### PR TITLE
feat(portal): add /client/v3 device-trust challenge

### DIFF
--- a/elixir/lib/portal/safe.ex
+++ b/elixir/lib/portal/safe.ex
@@ -966,13 +966,16 @@ defmodule Portal.Safe do
   # Oban.Job permissions - admin only
   def permit(:read, Oban.Job, :account_admin_user), do: :ok
 
-  # Device permissions (union of Client + Gateway)
+  # Device permissions (union of Client + Gateway); non-admin actors can
+  # insert because clients create their own device row at first connect
   def permit(_action, Portal.Device, :account_admin_user), do: :ok
   def permit(_action, Portal.Device, :api_client), do: :ok
   def permit(:read, Portal.Device, :account_user), do: :ok
   def permit(:update, Portal.Device, :account_user), do: :ok
+  def permit(:insert, Portal.Device, :account_user), do: :ok
   def permit(:read, Portal.Device, :service_account), do: :ok
   def permit(:update, Portal.Device, :service_account), do: :ok
+  def permit(:insert, Portal.Device, :service_account), do: :ok
 
   # PolicyAuthorization permissions - all actor types can read and create policy_authorizations
   def permit(:read, Portal.PolicyAuthorization, _), do: :ok

--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -2564,7 +2564,10 @@ defmodule PortalAPI.Client.Channel.Shared do
           psk_base: socket.assigns.client.psk_base,
           remote_ip: socket.assigns.client.last_seen_remote_ip,
           version: socket.assigns.client.last_seen_version,
-          user_agent: socket.assigns.client.last_seen_user_agent
+          user_agent: socket.assigns.client.last_seen_user_agent,
+          # Whether THIS session proved possession of an MDM-provisioned
+          # certificate (v3 challenge). v1/v2 sessions never set the assign.
+          attested?: socket.assigns[:attested?] || false
         }
 
         :ok =

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -2,6 +2,7 @@ defmodule PortalAPI.Client.Socket do
   use Phoenix.Socket
   alias Portal.{Authentication, Device, PG, SessionLog, Version}
   alias Portal.Repo.Batch
+  alias PortalAPI.Client.DeviceTrust
   alias PortalAPI.Sockets
   alias Portal.Types.LogId
   alias __MODULE__.Database
@@ -29,6 +30,51 @@ defmodule PortalAPI.Client.Socket do
 
   @impl true
   def connect(attrs, socket, connect_info) do
+    handle_connect(attrs, socket, connect_info, :resolve)
+  end
+
+  @doc false
+  # Entry point for /client/v3 sockets: token auth as usual, but on accounts
+  # with the device-trust gate enabled the device resolution is deferred until
+  # after the channel's challenge round trip (see PortalAPI.Client.V3.Channel).
+  def connect_deferring(attrs, socket, connect_info) do
+    handle_connect(attrs, socket, connect_info, :defer_if_enabled)
+  end
+
+  @impl true
+  def id(socket) do
+    Portal.Sockets.socket_id(socket.assigns.subject.credential.id)
+  end
+
+  @doc false
+  # Resolves a deferred device after the challenge round trip (or its
+  # timeout). `verified` is the DeviceTrust verification result or nil when
+  # the challenge failed, timed out, or produced no usable certificate.
+  def resolve_deferred_client(socket, verified) do
+    %{
+      changeset: changeset,
+      attrs: attrs,
+      token_id: token_id,
+      public_key: public_key,
+      version: version
+    } = socket.assigns.pending_device
+
+    with {:ok, client} <- Database.resolve_client(changeset, attrs, verified) do
+      client = apply_session(client, token_id, public_key, socket.assigns.subject, version)
+      set_connect_attributes(token_id, client, socket.assigns.subject, version)
+
+      socket =
+        socket
+        |> assign(:client, client)
+        |> assign(:pending_device, nil)
+
+      {:ok, socket}
+    end
+  end
+
+  ## Private functions
+
+  defp handle_connect(attrs, socket, connect_info, mode) do
     unless Application.get_env(:portal, :sql_sandbox) do
       Portal.Repo.put_dynamic_repo(Portal.Repo.Api)
       Portal.Repo.Replica.put_dynamic_repo(Portal.Repo.Replica.Api)
@@ -39,19 +85,12 @@ defmodule PortalAPI.Client.Socket do
     OpenTelemetry.Tracer.with_span "client.connect" do
       with {:ok, token} <- PortalAPI.Sockets.extract_token(attrs, connect_info),
            :ok <- PortalAPI.Sockets.RateLimit.check(connect_info, token: token) do
-        do_connect(token, attrs, socket, connect_info)
+        do_connect(token, attrs, socket, connect_info, mode)
       end
     end
   end
 
-  @impl true
-  def id(socket) do
-    Portal.Sockets.socket_id(socket.assigns.subject.credential.id)
-  end
-
-  ## Private functions
-
-  defp do_connect(token, attrs, socket, connect_info) do
+  defp do_connect(token, attrs, socket, connect_info, mode) do
     context = PortalAPI.Sockets.auth_context(connect_info, :client)
     attrs = normalize_device_attrs(attrs)
 
@@ -61,13 +100,29 @@ defmodule PortalAPI.Client.Socket do
          {:ok, public_key} <- validate_public_key(attrs),
          changeset = insert_changeset(subject.actor, subject, attrs),
          {:ok, _} <- apply_action(changeset, :validate),
-         {:ok, client} <- Database.find_or_create_client(changeset, attrs) do
+         {:ok, outcome} <- resolve_or_defer(changeset, attrs, subject, mode) do
       version = derive_version(subject.context.user_agent)
       {context, version} = PortalAPI.Sockets.truncate_session_fields(subject.context, version)
       subject = %{subject | context: context}
-      client = apply_session(client, token_id, public_key, subject, version)
-      set_connect_attributes(token_id, client, subject, version)
-      {:ok, assign_connect(socket, subject, client, version)}
+
+      case outcome do
+        {:resolved, client} ->
+          client = apply_session(client, token_id, public_key, subject, version)
+          set_connect_attributes(token_id, client, subject, version)
+          {:ok, assign_connect(socket, subject, client, version)}
+
+        {:deferred, anchors} ->
+          pending = %{
+            changeset: changeset,
+            attrs: attrs,
+            token_id: token_id,
+            public_key: public_key,
+            version: version,
+            anchors: anchors
+          }
+
+          {:ok, assign_connect_deferred(socket, subject, pending)}
+      end
     else
       {:error, :invalid_token} ->
         OpenTelemetry.Tracer.set_status(:error, "invalid_token")
@@ -82,6 +137,22 @@ defmodule PortalAPI.Client.Socket do
         OpenTelemetry.Tracer.set_status(:error, inspect(changeset))
         Logger.debug("Error connecting client websocket: #{inspect(changeset)}")
         {:error, changeset}
+    end
+  end
+
+  # One query decides the gate AND fetches the verification material: empty
+  # anchors (feature off or none uploaded) resolve at connect exactly as
+  # before, non-empty anchors ride the pending state so the challenge
+  # response never re-fetches them.
+  defp resolve_or_defer(changeset, attrs, subject, mode) do
+    with :defer_if_enabled <- mode,
+         [_ | _] = anchors <- DeviceTrust.fetch_enabled_anchors(subject.account.id) do
+      {:ok, {:deferred, anchors}}
+    else
+      _resolve_now ->
+        with {:ok, client} <- Database.find_or_create_client(changeset, attrs) do
+          {:ok, {:resolved, client}}
+        end
     end
   end
 
@@ -228,6 +299,16 @@ defmodule PortalAPI.Client.Socket do
     |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
   end
 
+  defp assign_connect_deferred(socket, subject, pending) do
+    socket
+    |> assign(:subject, subject)
+    |> assign(:pending_device, pending)
+    |> assign(:session_ref, make_ref())
+    |> assign(:client_version, pending.version)
+    |> assign(:opentelemetry_span_ctx, OpenTelemetry.Tracer.current_span_ctx())
+    |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
+  end
+
   defp insert_changeset(actor, subject, attrs) do
     required_fields = ~w[firezone_id name]a
 
@@ -324,34 +405,69 @@ defmodule PortalAPI.Client.Socket do
 
     @hardware_id_fields ~w[device_serial device_uuid identifier_for_vendor firebase_installation_id]a
     @attested_id_fields ~w[last_attested_device_serial last_attested_device_uuid last_attested_mdm_device_id]a
+    @verified_fields @attested_id_fields ++ ~w[last_attested_cert_serial last_attested_cert_fingerprint last_attested_at]a
 
-    @dialyzer {:no_opaque, [find_or_create_client: 2, find_by_attested_ids: 3]}
+    @dialyzer {:no_opaque,
+               [find_or_create_client: 2, resolve_client: 3, find_by_attested_ids: 3]}
     def find_or_create_client(changeset, attrs) do
+      resolve_client(changeset, attrs, nil)
+    end
+
+    # Resolves the connecting device. `verified` carries the DeviceTrust
+    # challenge result (attested identifiers + pinned cert) or nil for
+    # unattested connects, in which case this behaves exactly like the classic
+    # firezone_id find-or-create.
+    def resolve_client(changeset, attrs, verified) do
       account_id = Ecto.Changeset.get_field(changeset, :account_id)
       actor_id = Ecto.Changeset.get_field(changeset, :actor_id)
       firezone_id = Ecto.Changeset.get_field(changeset, :firezone_id)
 
+      changeset = put_verified_changes(changeset, verified)
+
       case find_by_attested_ids(changeset, account_id, actor_id) do
         {:ok, client} ->
           check_hardware_id_mismatch(client, attrs)
-          {:ok, merge_firezone_id(client, firezone_id)}
+
+          client =
+            client
+            |> merge_firezone_id(firezone_id)
+            |> merge_verified(verified)
+
+          {:ok, client}
 
         :identity_conflict ->
-          # Refuse to guess which device this is: fall back to the plain
-          # firezone_id path with the attested fields stripped, so a fallback
-          # insert cannot collide with the split rows' unique indexes.
+          # Identity conflict - the identifiers split across rows, or a
+          # matched row disagrees on another identifier: refuse to adopt any
+          # attested identity for this connect and fall back to the plain
+          # firezone_id path, keeping the verified fields off the row and off
+          # the changeset so a fallback insert cannot collide with the
+          # conflicting rows' unique indexes.
           changeset
-          |> strip_attested_changes()
-          |> resolve_by_firezone_id(attrs, account_id, actor_id, firezone_id)
+          |> strip_verified_changes()
+          |> resolve_by_firezone_id(attrs, account_id, actor_id, firezone_id, nil)
 
         nil ->
-          resolve_by_firezone_id(changeset, attrs, account_id, actor_id, firezone_id)
+          resolve_by_firezone_id(changeset, attrs, account_id, actor_id, firezone_id, verified)
       end
     end
 
-    defp resolve_by_firezone_id(changeset, attrs, account_id, actor_id, firezone_id) do
+    defp resolve_by_firezone_id(changeset, attrs, account_id, actor_id, firezone_id, verified) do
       if client = find_by_firezone_id(account_id, actor_id, firezone_id) do
         check_hardware_id_mismatch(client, attrs)
+
+        client =
+          cond do
+            is_nil(verified) ->
+              client
+
+            consistent_attested?(client, verified.identifiers) ->
+              merge_verified(client, verified)
+
+            true ->
+              log_attested_mismatch([client], verified.identifiers)
+              client
+          end
+
         {:ok, client}
       else
         changeset
@@ -363,12 +479,11 @@ defmodule PortalAPI.Client.Socket do
     # Attested identifiers anchor a physical device, so they take precedence
     # over the client-reported firezone_id: a reinstalled client (new
     # firezone_id, same attested identity) merges back onto its existing device
-    # row instead of creating a duplicate. The per-column partial unique
-    # indexes guarantee each identifier maps to at most one row, so when all
-    # supplied identifiers resolve to one device the query returns exactly one
-    # row. More than one distinct row means the identifiers split across
-    # devices; adopting either would merge the connection onto an arbitrary
-    # device, so adoption is refused instead.
+    # row instead of creating a duplicate. Adoption requires the identifiers
+    # to agree: all supplied identifiers must resolve to exactly one row (the
+    # per-column unique indexes guarantee each identifier maps to at most
+    # one), and every identifier that is non-NULL on both the row and the
+    # certificate must match. Anything else is an identity conflict.
     defp find_by_attested_ids(changeset, account_id, actor_id) do
       filters =
         for field <- @attested_id_fields,
@@ -398,8 +513,18 @@ defmodule PortalAPI.Client.Socket do
     end
 
     defp classify_attested_rows([], _cert_identifiers), do: nil
-    defp classify_attested_rows([client], _cert_identifiers), do: {:ok, client}
 
+    defp classify_attested_rows([client], cert_identifiers) do
+      if consistent_attested?(client, cert_identifiers) do
+        {:ok, client}
+      else
+        log_attested_mismatch([client], cert_identifiers)
+        :identity_conflict
+      end
+    end
+
+    # More than one distinct row means the identifiers split across devices;
+    # adopting any of them would merge the connection onto an arbitrary device.
     defp classify_attested_rows(clients, cert_identifiers) do
       Logger.warning(
         "Attested identifiers split across multiple devices: refusing to adopt device identity",
@@ -411,8 +536,62 @@ defmodule PortalAPI.Client.Socket do
       :identity_conflict
     end
 
-    defp strip_attested_changes(changeset) do
-      Enum.reduce(@attested_id_fields, changeset, &Ecto.Changeset.delete_change(&2, &1))
+    defp consistent_attested?(client, cert_identifiers) do
+      Enum.all?(@attested_id_fields, fn field ->
+        row_value = Map.get(client, field)
+        cert_value = Map.get(cert_identifiers, field)
+
+        is_nil(row_value) or is_nil(cert_value) or row_value == cert_value
+      end)
+    end
+
+    defp log_attested_mismatch(clients, cert_identifiers) do
+      Logger.warning(
+        "Attested identifier mismatch: refusing to adopt device identity",
+        client_ids: Enum.map(clients, & &1.id),
+        cert_identifiers: inspect(cert_identifiers),
+        row_identifiers:
+          inspect(
+            Enum.map(clients, fn client ->
+              Map.take(client, @attested_id_fields)
+            end)
+          )
+      )
+    end
+
+    defp put_verified_changes(changeset, nil), do: changeset
+
+    defp put_verified_changes(changeset, verified) do
+      verified.identifiers
+      |> Enum.reduce(changeset, fn {field, value}, cs ->
+        Ecto.Changeset.put_change(cs, field, value)
+      end)
+      |> Ecto.Changeset.put_change(:last_attested_cert_serial, verified.last_attested_cert_serial)
+      |> Ecto.Changeset.put_change(:last_attested_cert_fingerprint, verified.last_attested_cert_fingerprint)
+      |> Ecto.Changeset.put_change(:last_attested_at, DateTime.utc_now())
+    end
+
+    # Unconditional: an identity conflict must clear the verified fields even
+    # when they arrived on the changeset rather than via `verified` (the
+    # dormant unattested path), so a fallback insert can never collide with
+    # the conflicting rows' unique indexes.
+    defp strip_verified_changes(changeset) do
+      Enum.reduce(@verified_fields, changeset, &Ecto.Changeset.delete_change(&2, &1))
+    end
+
+    # In-memory only, like merge_firezone_id: the verified identifiers and
+    # pinned cert are persisted by the batched client session flush.
+    # last_attested_at records when the device last proved possession; whether
+    # the CURRENT session proved it is live connection state (the `attested?`
+    # socket assign / presence attribute), not row state.
+    defp merge_verified(client, nil), do: client
+
+    defp merge_verified(client, verified) do
+      client
+      |> Map.merge(Map.new(verified.identifiers))
+      |> Map.put(:last_attested_cert_serial, verified.last_attested_cert_serial)
+      |> Map.put(:last_attested_cert_fingerprint, verified.last_attested_cert_fingerprint)
+      |> Map.put(:last_attested_at, DateTime.utc_now())
     end
 
     defp find_by_firezone_id(_account_id, _actor_id, nil), do: nil

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -146,7 +146,7 @@ defmodule PortalAPI.Client.Socket do
   # response never re-fetches them.
   defp resolve_or_defer(changeset, attrs, subject, mode) do
     with :defer_if_enabled <- mode,
-         [_ | _] = anchors <- DeviceTrust.fetch_enabled_anchors(subject.account.id) do
+         [_ | _] = anchors <- DeviceTrust.fetch_enabled_anchors(subject) do
       {:ok, {:deferred, anchors}}
     else
       _resolve_now ->

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -50,6 +50,9 @@ defmodule PortalAPI.Client.Socket do
   # Resolves a deferred device after the challenge round trip (or its
   # timeout). `verified` is the DeviceTrust verification result or nil when
   # the challenge failed, timed out, or produced no usable certificate.
+  # The `:attested?` assign (live connection state, rides presence metadata)
+  # is true only when the resolved row adopted the proven identity: possession
+  # alone does not vouch for a row whose adoption was refused as a conflict.
   def resolve_deferred_client(socket, verified) do
     %{
       changeset: changeset,
@@ -66,6 +69,7 @@ defmodule PortalAPI.Client.Socket do
       socket =
         socket
         |> assign(:client, client)
+        |> assign(:attested?, identity_adopted?(client, verified))
         |> assign(:pending_device, nil)
 
       {:ok, socket}
@@ -154,6 +158,12 @@ defmodule PortalAPI.Client.Socket do
           {:ok, {:resolved, client}}
         end
     end
+  end
+
+  defp identity_adopted?(_client, nil), do: false
+
+  defp identity_adopted?(client, verified) do
+    client.last_attested_cert_fingerprint == verified.last_attested_cert_fingerprint
   end
 
   # The connection snapshot lives directly on the device struct: these are the

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -48,12 +48,12 @@ defmodule PortalAPI.Client.Socket do
 
   @doc false
   # Resolves a deferred device after the challenge round trip (or its
-  # timeout). `verified` is the DeviceTrust verification result or nil when
-  # the challenge failed, timed out, or produced no usable certificate.
+  # timeout). `proof` is the DeviceTrust possession proof or nil when the
+  # challenge failed, timed out, or produced no usable certificate.
   # The `:attested?` assign (live connection state, rides presence metadata)
   # is true only when the resolved row adopted the proven identity: possession
   # alone does not vouch for a row whose adoption was refused as a conflict.
-  def resolve_deferred_client(socket, verified) do
+  def resolve_deferred_client(socket, proof) do
     %{
       changeset: changeset,
       attrs: attrs,
@@ -62,14 +62,15 @@ defmodule PortalAPI.Client.Socket do
       version: version
     } = socket.assigns.pending_device
 
-    with {:ok, client} <- Database.resolve_client(changeset, attrs, verified) do
+    with {:ok, client} <-
+           Database.resolve_client(changeset, attrs, proof, socket.assigns.subject) do
       client = apply_session(client, token_id, public_key, socket.assigns.subject, version)
       set_connect_attributes(token_id, client, socket.assigns.subject, version)
 
       socket =
         socket
         |> assign(:client, client)
-        |> assign(:attested?, identity_adopted?(client, verified))
+        |> assign(:attested?, identity_adopted?(client, proof))
         |> assign(:pending_device, nil)
 
       {:ok, socket}
@@ -154,7 +155,7 @@ defmodule PortalAPI.Client.Socket do
       {:ok, {:deferred, anchors}}
     else
       _resolve_now ->
-        with {:ok, client} <- Database.find_or_create_client(changeset, attrs) do
+        with {:ok, client} <- Database.find_or_create_client(changeset, attrs, subject) do
           {:ok, {:resolved, client}}
         end
     end
@@ -162,8 +163,8 @@ defmodule PortalAPI.Client.Socket do
 
   defp identity_adopted?(_client, nil), do: false
 
-  defp identity_adopted?(client, verified) do
-    client.last_attested_cert_fingerprint == verified.last_attested_cert_fingerprint
+  defp identity_adopted?(client, proof) do
+    client.last_attested_cert_fingerprint == proof.last_attested_cert_fingerprint
   end
 
   # The connection snapshot lives directly on the device struct: these are the
@@ -415,33 +416,32 @@ defmodule PortalAPI.Client.Socket do
 
     @hardware_id_fields ~w[device_serial device_uuid identifier_for_vendor firebase_installation_id]a
     @attested_id_fields ~w[last_attested_device_serial last_attested_device_uuid last_attested_mdm_device_id]a
-    @verified_fields @attested_id_fields ++ ~w[last_attested_cert_serial last_attested_cert_fingerprint last_attested_at]a
+    @proof_fields @attested_id_fields ++ ~w[last_attested_cert_serial last_attested_cert_fingerprint last_attested_at]a
 
     @dialyzer {:no_opaque,
-               [find_or_create_client: 2, resolve_client: 3, find_by_attested_ids: 3]}
-    def find_or_create_client(changeset, attrs) do
-      resolve_client(changeset, attrs, nil)
+               [find_or_create_client: 3, resolve_client: 4, find_by_attested_ids: 3]}
+    def find_or_create_client(changeset, attrs, subject) do
+      resolve_client(changeset, attrs, nil, subject)
     end
 
-    # Resolves the connecting device. `verified` carries the DeviceTrust
-    # challenge result (attested identifiers + pinned cert) or nil for
+    # Resolves the connecting device. `proof` carries the DeviceTrust
+    # possession proof (attested identifiers + pinned cert) or nil for
     # unattested connects, in which case this behaves exactly like the classic
     # firezone_id find-or-create.
-    def resolve_client(changeset, attrs, verified) do
-      account_id = Ecto.Changeset.get_field(changeset, :account_id)
+    def resolve_client(changeset, attrs, proof, subject) do
       actor_id = Ecto.Changeset.get_field(changeset, :actor_id)
       firezone_id = Ecto.Changeset.get_field(changeset, :firezone_id)
 
-      changeset = put_verified_changes(changeset, verified)
+      changeset = put_proof_changes(changeset, proof)
 
-      case find_by_attested_ids(changeset, account_id, actor_id) do
+      case find_by_attested_ids(changeset, actor_id, subject) do
         {:ok, client} ->
           check_hardware_id_mismatch(client, attrs)
 
           client =
             client
             |> merge_firezone_id(firezone_id)
-            |> merge_verified(verified)
+            |> merge_proof(proof)
 
           {:ok, client}
 
@@ -449,39 +449,39 @@ defmodule PortalAPI.Client.Socket do
           # Identity conflict - the identifiers split across rows, or a
           # matched row disagrees on another identifier: refuse to adopt any
           # attested identity for this connect and fall back to the plain
-          # firezone_id path, keeping the verified fields off the row and off
+          # firezone_id path, keeping the proof fields off the row and off
           # the changeset so a fallback insert cannot collide with the
           # conflicting rows' unique indexes.
           changeset
-          |> strip_verified_changes()
-          |> resolve_by_firezone_id(attrs, account_id, actor_id, firezone_id, nil)
+          |> strip_proof_changes()
+          |> resolve_by_firezone_id(attrs, actor_id, firezone_id, nil, subject)
 
         nil ->
-          resolve_by_firezone_id(changeset, attrs, account_id, actor_id, firezone_id, verified)
+          resolve_by_firezone_id(changeset, attrs, actor_id, firezone_id, proof, subject)
       end
     end
 
-    defp resolve_by_firezone_id(changeset, attrs, account_id, actor_id, firezone_id, verified) do
-      if client = find_by_firezone_id(account_id, actor_id, firezone_id) do
+    defp resolve_by_firezone_id(changeset, attrs, actor_id, firezone_id, proof, subject) do
+      if client = find_by_firezone_id(actor_id, firezone_id, subject) do
         check_hardware_id_mismatch(client, attrs)
 
         client =
           cond do
-            is_nil(verified) ->
+            is_nil(proof) ->
               client
 
-            consistent_attested?(client, verified.identifiers) ->
-              merge_verified(client, verified)
+            consistent_attested?(client, proof.identifiers) ->
+              merge_proof(client, proof)
 
             true ->
-              log_attested_mismatch([client], verified.identifiers)
+              log_attested_mismatch([client], proof.identifiers)
               client
           end
 
         {:ok, client}
       else
         changeset
-        |> Safe.unscoped()
+        |> Safe.scoped(subject)
         |> Safe.insert()
       end
     end
@@ -494,7 +494,7 @@ defmodule PortalAPI.Client.Socket do
     # per-column unique indexes guarantee each identifier maps to at most
     # one), and every identifier that is non-NULL on both the row and the
     # certificate must match. Anything else is an identity conflict.
-    defp find_by_attested_ids(changeset, account_id, actor_id) do
+    defp find_by_attested_ids(changeset, actor_id, subject) do
       filters =
         for field <- @attested_id_fields,
             value = Ecto.Changeset.get_field(changeset, field),
@@ -510,13 +510,12 @@ defmodule PortalAPI.Client.Socket do
           end)
 
         from(d in Device,
-          where: d.account_id == ^account_id,
           where: d.actor_id == ^actor_id,
           where: d.type == :client,
           where: ^attested_match,
           order_by: [asc: d.inserted_at]
         )
-        |> Safe.unscoped(:replica)
+        |> Safe.scoped(subject, :replica)
         |> Safe.all(fallback_to_primary: true)
         |> classify_attested_rows(Map.new(filters))
       end
@@ -569,51 +568,50 @@ defmodule PortalAPI.Client.Socket do
       )
     end
 
-    defp put_verified_changes(changeset, nil), do: changeset
+    defp put_proof_changes(changeset, nil), do: changeset
 
-    defp put_verified_changes(changeset, verified) do
-      verified.identifiers
+    defp put_proof_changes(changeset, proof) do
+      proof.identifiers
       |> Enum.reduce(changeset, fn {field, value}, cs ->
         Ecto.Changeset.put_change(cs, field, value)
       end)
-      |> Ecto.Changeset.put_change(:last_attested_cert_serial, verified.last_attested_cert_serial)
-      |> Ecto.Changeset.put_change(:last_attested_cert_fingerprint, verified.last_attested_cert_fingerprint)
+      |> Ecto.Changeset.put_change(:last_attested_cert_serial, proof.last_attested_cert_serial)
+      |> Ecto.Changeset.put_change(:last_attested_cert_fingerprint, proof.last_attested_cert_fingerprint)
       |> Ecto.Changeset.put_change(:last_attested_at, DateTime.utc_now())
     end
 
-    # Unconditional: an identity conflict must clear the verified fields even
-    # when they arrived on the changeset rather than via `verified` (the
+    # Unconditional: an identity conflict must clear the proof fields even
+    # when they arrived on the changeset rather than via `proof` (the
     # dormant unattested path), so a fallback insert can never collide with
     # the conflicting rows' unique indexes.
-    defp strip_verified_changes(changeset) do
-      Enum.reduce(@verified_fields, changeset, &Ecto.Changeset.delete_change(&2, &1))
+    defp strip_proof_changes(changeset) do
+      Enum.reduce(@proof_fields, changeset, &Ecto.Changeset.delete_change(&2, &1))
     end
 
-    # In-memory only, like merge_firezone_id: the verified identifiers and
+    # In-memory only, like merge_firezone_id: the proven identifiers and
     # pinned cert are persisted by the batched client session flush.
     # last_attested_at records when the device last proved possession; whether
     # the CURRENT session proved it is live connection state (the `attested?`
     # socket assign / presence attribute), not row state.
-    defp merge_verified(client, nil), do: client
+    defp merge_proof(client, nil), do: client
 
-    defp merge_verified(client, verified) do
+    defp merge_proof(client, proof) do
       client
-      |> Map.merge(Map.new(verified.identifiers))
-      |> Map.put(:last_attested_cert_serial, verified.last_attested_cert_serial)
-      |> Map.put(:last_attested_cert_fingerprint, verified.last_attested_cert_fingerprint)
+      |> Map.merge(Map.new(proof.identifiers))
+      |> Map.put(:last_attested_cert_serial, proof.last_attested_cert_serial)
+      |> Map.put(:last_attested_cert_fingerprint, proof.last_attested_cert_fingerprint)
       |> Map.put(:last_attested_at, DateTime.utc_now())
     end
 
-    defp find_by_firezone_id(_account_id, _actor_id, nil), do: nil
+    defp find_by_firezone_id(_actor_id, nil, _subject), do: nil
 
-    defp find_by_firezone_id(account_id, actor_id, firezone_id) do
+    defp find_by_firezone_id(actor_id, firezone_id, subject) do
       from(d in Device,
-        where: d.account_id == ^account_id,
         where: d.actor_id == ^actor_id,
         where: d.firezone_id == ^firezone_id,
         where: d.type == :client
       )
-      |> Safe.unscoped(:replica)
+      |> Safe.scoped(subject, :replica)
       |> Safe.one(fallback_to_primary: true)
     end
 

--- a/elixir/lib/portal_api/client/v3/channel.ex
+++ b/elixir/lib/portal_api/client/v3/channel.ex
@@ -1,0 +1,135 @@
+defmodule PortalAPI.Client.V3.Channel do
+  use PortalAPI, :channel
+  alias PortalAPI.Client.Channel.Shared
+  alias PortalAPI.Client.DeviceTrust
+  alias PortalAPI.Client.Socket
+  require Logger
+
+  # On gated accounts the device is not resolved yet when the channel joins:
+  # the client is challenged to prove possession of an MDM-provisioned
+  # certificate first, and the device is resolved (attested-first) only after
+  # the response or the timeout. Failure never blocks the connect - it falls
+  # back to the plain firezone_id path, unverified.
+
+  @impl true
+  def join(topic, payload, socket) do
+    socket = assign(socket, :channel_protocol, __MODULE__)
+
+    if socket.assigns[:pending_device] do
+      send(self(), :push_device_trust_request)
+      {:ok, socket}
+    else
+      Shared.join(topic, payload, socket)
+    end
+  end
+
+  @impl true
+  defdelegate terminate(reason, socket), to: Shared
+
+  @impl true
+  def handle_info(:push_device_trust_request, socket) do
+    nonce = DeviceTrust.nonce()
+    push(socket, "device_trust_request", DeviceTrust.challenge_payload(nonce))
+    Process.send_after(self(), :device_trust_timeout, challenge_timeout_ms())
+
+    {:noreply, assign(socket, :device_trust_nonce, nonce)}
+  end
+
+  def handle_info(:device_trust_timeout, socket) do
+    if socket.assigns[:pending_device] do
+      Logger.info("Device trust challenge timed out; connecting without attestation",
+        account_id: socket.assigns.subject.account.id
+      )
+
+      socket = assign(socket, :device_trust_nonce, nil)
+      resolve_and_continue(socket, nil)
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_info(message, socket), do: Shared.handle_info(message, socket)
+
+  @impl true
+  def handle_in("device_trust_response", payload, socket) do
+    nonce = socket.assigns[:device_trust_nonce]
+    socket = assign(socket, :device_trust_nonce, nil)
+
+    cond do
+      is_nil(socket.assigns[:pending_device]) ->
+        Logger.debug("Ignoring late or duplicate device trust response")
+        {:noreply, socket}
+
+      is_nil(nonce) ->
+        Logger.debug("Ignoring device trust response without an outstanding challenge")
+        {:noreply, socket}
+
+      true ->
+        account_id = socket.assigns.subject.account.id
+        anchors = socket.assigns.pending_device.anchors
+
+        verified =
+          case DeviceTrust.verify_response(payload, nonce, anchors) do
+            {:ok, verified} ->
+              Logger.info("Device trust challenge succeeded",
+                account_id: account_id,
+                last_attested_cert_fingerprint: verified.last_attested_cert_fingerprint,
+                identifiers: inspect(verified.identifiers)
+              )
+
+              verified
+
+            {:error, :no_usable_cert} ->
+              Logger.info(
+                "Device trust challenge: no usable certificate presented (device not enrolled?)",
+                account_id: account_id
+              )
+
+              nil
+
+            {:error, :verification_failed} ->
+              Logger.warning(
+                "Device trust challenge failed verification (check trust anchor configuration)",
+                account_id: account_id
+              )
+
+              nil
+          end
+
+        resolve_and_continue(socket, verified)
+    end
+  end
+
+  def handle_in(message, payload, socket), do: Shared.handle_in(message, payload, socket)
+
+  @doc false
+  def authorization_created_event, do: "authorization_created"
+
+  @doc false
+  def authorization_creation_failed_event, do: "authorization_creation_failed"
+
+  defp resolve_and_continue(socket, verified) do
+    # Whether THIS session proved possession is live connection state, not row
+    # state: it rides the socket assigns and the presence metadata, while the
+    # last_attested_* columns record durable history.
+    socket = assign(socket, :attested?, not is_nil(verified))
+
+    case Socket.resolve_deferred_client(socket, verified) do
+      {:ok, socket} ->
+        send(self(), :after_join)
+        {:noreply, socket}
+
+      {:error, reason} ->
+        Logger.warning(
+          "Failed to resolve client after device trust challenge: #{inspect(reason)}",
+          account_id: socket.assigns.subject.account.id
+        )
+
+        {:stop, :shutdown, socket}
+    end
+  end
+
+  defp challenge_timeout_ms do
+    Portal.Config.get_env(:portal, :device_trust_challenge_timeout_ms, :timer.seconds(10))
+  end
+end

--- a/elixir/lib/portal_api/client/v3/channel.ex
+++ b/elixir/lib/portal_api/client/v3/channel.ex
@@ -109,11 +109,6 @@ defmodule PortalAPI.Client.V3.Channel do
   def authorization_creation_failed_event, do: "authorization_creation_failed"
 
   defp resolve_and_continue(socket, verified) do
-    # Whether THIS session proved possession is live connection state, not row
-    # state: it rides the socket assigns and the presence metadata, while the
-    # last_attested_* columns record durable history.
-    socket = assign(socket, :attested?, not is_nil(verified))
-
     case Socket.resolve_deferred_client(socket, verified) do
       {:ok, socket} ->
         send(self(), :after_join)

--- a/elixir/lib/portal_api/client/v3/channel.ex
+++ b/elixir/lib/portal_api/client/v3/channel.ex
@@ -9,7 +9,7 @@ defmodule PortalAPI.Client.V3.Channel do
   # the client is challenged to prove possession of an MDM-provisioned
   # certificate first, and the device is resolved (attested-first) only after
   # the response or the timeout. Failure never blocks the connect - it falls
-  # back to the plain firezone_id path, unverified.
+  # back to the plain firezone_id path, unattested.
 
   @impl true
   def join(topic, payload, socket) do
@@ -68,16 +68,16 @@ defmodule PortalAPI.Client.V3.Channel do
         account_id = socket.assigns.subject.account.id
         anchors = socket.assigns.pending_device.anchors
 
-        verified =
+        proof =
           case DeviceTrust.verify_response(payload, nonce, anchors) do
-            {:ok, verified} ->
+            {:ok, proof} ->
               Logger.info("Device trust challenge succeeded",
                 account_id: account_id,
-                last_attested_cert_fingerprint: verified.last_attested_cert_fingerprint,
-                identifiers: inspect(verified.identifiers)
+                last_attested_cert_fingerprint: proof.last_attested_cert_fingerprint,
+                identifiers: inspect(proof.identifiers)
               )
 
-              verified
+              proof
 
             {:error, :no_usable_cert} ->
               Logger.info(
@@ -96,7 +96,7 @@ defmodule PortalAPI.Client.V3.Channel do
               nil
           end
 
-        resolve_and_continue(socket, verified)
+        resolve_and_continue(socket, proof)
     end
   end
 
@@ -108,8 +108,8 @@ defmodule PortalAPI.Client.V3.Channel do
   @doc false
   def authorization_creation_failed_event, do: "authorization_creation_failed"
 
-  defp resolve_and_continue(socket, verified) do
-    case Socket.resolve_deferred_client(socket, verified) do
+  defp resolve_and_continue(socket, proof) do
+    case Socket.resolve_deferred_client(socket, proof) do
       {:ok, socket} ->
         send(self(), :after_join)
         {:noreply, socket}

--- a/elixir/lib/portal_api/client/v3/socket.ex
+++ b/elixir/lib/portal_api/client/v3/socket.ex
@@ -1,0 +1,17 @@
+defmodule PortalAPI.Client.V3.Socket do
+  use Phoenix.Socket
+
+  ## Channels
+
+  channel "client", PortalAPI.Client.V3.Channel
+
+  # v3 defers device resolution on accounts with the device-trust gate
+  # enabled: the channel resolves the device after the challenge round trip.
+  @impl true
+  def connect(attrs, socket, connect_info) do
+    PortalAPI.Client.Socket.connect_deferring(attrs, socket, connect_info)
+  end
+
+  @impl true
+  defdelegate id(socket), to: PortalAPI.Client.Socket
+end

--- a/elixir/lib/portal_api/endpoint.ex
+++ b/elixir/lib/portal_api/endpoint.ex
@@ -71,6 +71,16 @@ defmodule PortalAPI.Endpoint do
     longpoll: false,
     drainer: []
 
+  socket "/client/v3", PortalAPI.Client.V3.Socket,
+    websocket: [
+      check_origin: :conn,
+      connect_info: [:trace_context_headers, :user_agent, :peer_data, :x_headers],
+      error_handler: {PortalAPI.Sockets, :handle_error, []},
+      timeout: :timer.seconds(37)
+    ],
+    longpoll: false,
+    drainer: []
+
   socket "/relay", PortalAPI.Relay.Socket,
     websocket: [
       check_origin: :conn,

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -1,5 +1,8 @@
 defmodule PortalAPI.Client.ChannelTest do
-  use PortalAPI.ChannelCase, async: true
+  # Grouped with PortalAPI.Client.V3.ChannelTest: both register the globally
+  # named client session/policy-authorization queues, so the modules must
+  # not run concurrently with each other.
+  use PortalAPI.ChannelCase, async: true, group: :client_queues
   import Ecto.Query, only: [from: 2]
   import ExUnit.CaptureLog
   alias Portal.Changes

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -645,6 +645,117 @@ defmodule PortalAPI.Client.SocketTest do
     end
   end
 
+  describe "resolve_client/3 device-trust verification" do
+    setup do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      %{account: account, actor: actor}
+    end
+
+    test "persists verified identifiers and pinned cert onto the row", %{
+      account: account,
+      actor: actor
+    } do
+      changeset =
+        device_trust_changeset(account, actor, %{"name" => "New", "firezone_id" => "fz-1"})
+
+      verified = %{
+        identifiers: %{
+          last_attested_device_serial: "C02XK1ZGJGH5",
+          last_attested_mdm_device_id: "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3"
+        },
+        last_attested_cert_serial: "4A2F008C",
+        last_attested_cert_fingerprint: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+      }
+
+      assert {:ok, client} = Socket.Database.resolve_client(changeset, %{}, verified)
+      assert client.last_attested_device_serial == "C02XK1ZGJGH5"
+      assert client.last_attested_mdm_device_id == "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3"
+      assert client.last_attested_cert_fingerprint == verified.last_attested_cert_fingerprint
+    end
+
+    test "verified identifiers split across devices refuse adoption entirely", %{
+      account: account,
+      actor: actor
+    } do
+      device_a =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_device_serial: "SN-V-SPLIT",
+          firezone_id: "fz-a"
+        )
+
+      device_b =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_device_uuid: "uuid-v-split",
+          firezone_id: "fz-b"
+        )
+
+      changeset =
+        device_trust_changeset(account, actor, %{"name" => "New", "firezone_id" => "fz-new"})
+
+      verified = %{
+        identifiers: %{
+          last_attested_device_serial: "SN-V-SPLIT",
+          last_attested_device_uuid: "uuid-v-split"
+        },
+        last_attested_cert_serial: "AA",
+        last_attested_cert_fingerprint: "bb"
+      }
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:ok, client} = Socket.Database.resolve_client(changeset, %{}, verified)
+          assert client.id != device_a.id
+          assert client.id != device_b.id
+          assert is_nil(client.last_attested_device_serial)
+          assert is_nil(client.last_attested_device_uuid)
+          assert is_nil(client.last_attested_at)
+        end)
+
+      assert log =~ "split across multiple devices"
+    end
+
+    test "refuses to adopt identity when a non-null identifier disagrees", %{
+      account: account,
+      actor: actor
+    } do
+      # Existing row proved serial SN-1 and uuid UUID-1 previously.
+      existing =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_device_serial: "SN-1",
+          last_attested_device_uuid: "uuid-1",
+          firezone_id: "fz-old"
+        )
+
+      # New cert matches on serial but carries a conflicting uuid.
+      changeset =
+        device_trust_changeset(account, actor, %{"name" => "New", "firezone_id" => "fz-new"})
+
+      verified = %{
+        identifiers: %{last_attested_device_serial: "SN-1", last_attested_device_uuid: "uuid-2"},
+        last_attested_cert_serial: "AA",
+        last_attested_cert_fingerprint: "bb"
+      }
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:ok, client} = Socket.Database.resolve_client(changeset, %{}, verified)
+          # Adoption refused: a brand new row is inserted rather than merging
+          # onto the mismatched existing one.
+          assert client.id != existing.id
+          refute client.last_attested_device_uuid == "uuid-2"
+        end)
+
+      assert log =~ "Attested identifier mismatch"
+    end
+  end
+
   defp device_trust_changeset(account, actor, attrs) do
     %Portal.Device{}
     |> Ecto.Changeset.cast(attrs, [

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -508,16 +508,18 @@ defmodule PortalAPI.Client.SocketTest do
     end
   end
 
-  describe "find_or_create_client/2" do
+  describe "find_or_create_client/3" do
     setup do
       account = account_fixture()
       actor = actor_fixture(account: account)
-      %{account: account, actor: actor}
+      subject = subject_fixture(account: account, actor: actor)
+      %{account: account, actor: actor, subject: subject}
     end
 
     test "attested identifier match wins over firezone_id and merges it in memory", %{
       account: account,
-      actor: actor
+      actor: actor,
+      subject: subject
     } do
       existing =
         client_fixture(
@@ -534,7 +536,7 @@ defmodule PortalAPI.Client.SocketTest do
           "last_attested_device_serial" => "SN-ATT-1"
         })
 
-      assert {:ok, client} = Socket.Database.find_or_create_client(changeset, %{})
+      assert {:ok, client} = Socket.Database.find_or_create_client(changeset, %{}, subject)
       assert client.id == existing.id
       assert client.firezone_id == "fz-new"
       assert [_only_one] = Portal.Repo.all(actor_devices_query(account, actor))
@@ -547,7 +549,8 @@ defmodule PortalAPI.Client.SocketTest do
 
     test "attested identifiers with no match insert a new device", %{
       account: account,
-      actor: actor
+      actor: actor,
+      subject: subject
     } do
       changeset =
         device_trust_changeset(account, actor, %{
@@ -556,14 +559,15 @@ defmodule PortalAPI.Client.SocketTest do
           "last_attested_device_serial" => "SN-NEW-1"
         })
 
-      assert {:ok, client} = Socket.Database.find_or_create_client(changeset, %{})
+      assert {:ok, client} = Socket.Database.find_or_create_client(changeset, %{}, subject)
       assert client.last_attested_device_serial == "SN-NEW-1"
       assert client.firezone_id == "fz-1"
     end
 
     test "without attested identifiers the firezone_id lookup is unchanged", %{
       account: account,
-      actor: actor
+      actor: actor,
+      subject: subject
     } do
       existing = client_fixture(account: account, actor: actor, firezone_id: "fz-same")
 
@@ -573,7 +577,7 @@ defmodule PortalAPI.Client.SocketTest do
           "firezone_id" => "fz-same"
         })
 
-      assert {:ok, client} = Socket.Database.find_or_create_client(changeset, %{})
+      assert {:ok, client} = Socket.Database.find_or_create_client(changeset, %{}, subject)
       assert client.id == existing.id
     end
 
@@ -599,7 +603,8 @@ defmodule PortalAPI.Client.SocketTest do
 
     test "identifiers split across devices refuse adoption and fall back", %{
       account: account,
-      actor: actor
+      actor: actor,
+      subject: subject
     } do
       # Serial matches device A, UUID matches device B: nothing can prove
       # which physical device is connecting, so neither row is adopted.
@@ -629,7 +634,7 @@ defmodule PortalAPI.Client.SocketTest do
 
       log =
         ExUnit.CaptureLog.capture_log(fn ->
-          assert {:ok, client} = Socket.Database.find_or_create_client(changeset, %{})
+          assert {:ok, client} = Socket.Database.find_or_create_client(changeset, %{}, subject)
 
           # Falls back to the firezone_id path: a fresh row, with the attested
           # fields stripped so the insert cannot collide with A's or B's
@@ -645,21 +650,23 @@ defmodule PortalAPI.Client.SocketTest do
     end
   end
 
-  describe "resolve_client/3 device-trust verification" do
+  describe "resolve_client/4 device-trust proof" do
     setup do
       account = account_fixture()
       actor = actor_fixture(account: account)
-      %{account: account, actor: actor}
+      subject = subject_fixture(account: account, actor: actor)
+      %{account: account, actor: actor, subject: subject}
     end
 
-    test "persists verified identifiers and pinned cert onto the row", %{
+    test "persists proven identifiers and pinned cert onto the row", %{
       account: account,
-      actor: actor
+      actor: actor,
+      subject: subject
     } do
       changeset =
         device_trust_changeset(account, actor, %{"name" => "New", "firezone_id" => "fz-1"})
 
-      verified = %{
+      proof = %{
         identifiers: %{
           last_attested_device_serial: "C02XK1ZGJGH5",
           last_attested_mdm_device_id: "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3"
@@ -668,15 +675,16 @@ defmodule PortalAPI.Client.SocketTest do
         last_attested_cert_fingerprint: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
       }
 
-      assert {:ok, client} = Socket.Database.resolve_client(changeset, %{}, verified)
+      assert {:ok, client} = Socket.Database.resolve_client(changeset, %{}, proof, subject)
       assert client.last_attested_device_serial == "C02XK1ZGJGH5"
       assert client.last_attested_mdm_device_id == "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3"
-      assert client.last_attested_cert_fingerprint == verified.last_attested_cert_fingerprint
+      assert client.last_attested_cert_fingerprint == proof.last_attested_cert_fingerprint
     end
 
-    test "verified identifiers split across devices refuse adoption entirely", %{
+    test "proven identifiers split across devices refuse adoption entirely", %{
       account: account,
-      actor: actor
+      actor: actor,
+      subject: subject
     } do
       device_a =
         client_fixture(
@@ -697,7 +705,7 @@ defmodule PortalAPI.Client.SocketTest do
       changeset =
         device_trust_changeset(account, actor, %{"name" => "New", "firezone_id" => "fz-new"})
 
-      verified = %{
+      proof = %{
         identifiers: %{
           last_attested_device_serial: "SN-V-SPLIT",
           last_attested_device_uuid: "uuid-v-split"
@@ -708,7 +716,7 @@ defmodule PortalAPI.Client.SocketTest do
 
       log =
         ExUnit.CaptureLog.capture_log(fn ->
-          assert {:ok, client} = Socket.Database.resolve_client(changeset, %{}, verified)
+          assert {:ok, client} = Socket.Database.resolve_client(changeset, %{}, proof, subject)
           assert client.id != device_a.id
           assert client.id != device_b.id
           assert is_nil(client.last_attested_device_serial)
@@ -721,7 +729,8 @@ defmodule PortalAPI.Client.SocketTest do
 
     test "refuses to adopt identity when a non-null identifier disagrees", %{
       account: account,
-      actor: actor
+      actor: actor,
+      subject: subject
     } do
       # Existing row proved serial SN-1 and uuid UUID-1 previously.
       existing =
@@ -737,7 +746,7 @@ defmodule PortalAPI.Client.SocketTest do
       changeset =
         device_trust_changeset(account, actor, %{"name" => "New", "firezone_id" => "fz-new"})
 
-      verified = %{
+      proof = %{
         identifiers: %{last_attested_device_serial: "SN-1", last_attested_device_uuid: "uuid-2"},
         last_attested_cert_serial: "AA",
         last_attested_cert_fingerprint: "bb"
@@ -745,7 +754,7 @@ defmodule PortalAPI.Client.SocketTest do
 
       log =
         ExUnit.CaptureLog.capture_log(fn ->
-          assert {:ok, client} = Socket.Database.resolve_client(changeset, %{}, verified)
+          assert {:ok, client} = Socket.Database.resolve_client(changeset, %{}, proof, subject)
           # Adoption refused: a brand new row is inserted rather than merging
           # onto the mismatched existing one.
           assert client.id != existing.id

--- a/elixir/test/portal_api/client/v3/channel_test.exs
+++ b/elixir/test/portal_api/client/v3/channel_test.exs
@@ -1,0 +1,170 @@
+defmodule PortalAPI.Client.V3.ChannelTest do
+  use PortalAPI.ChannelCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.DeviceFixtures
+  import Portal.SubjectFixtures
+  import Portal.TokenFixtures
+  import Portal.TrustAnchorFixtures
+  import Portal.FeaturesFixtures
+  import Portal.DeviceTrustChallengeFixtures
+
+  alias PortalAPI.Client.DeviceTrust
+
+  setup do
+    start_supervised!(
+      {Portal.Queue,
+       Keyword.merge(PortalAPI.Client.Channel.policy_authorization_queue_opts(),
+         callers: [self()],
+         flush_on_terminate: false
+       )}
+    )
+
+    start_supervised!(
+      {Portal.Queue,
+       Keyword.merge(PortalAPI.Client.Socket.client_session_queue_opts(),
+         callers: [self()],
+         flush_on_terminate: false
+       )}
+    )
+
+    account = account_fixture()
+    enable_feature(:trust_anchors)
+    trust_anchor_fixture(account: account, certs: [ca_der()])
+
+    actor = actor_fixture(type: :account_admin_user, account: account)
+    token = client_token_fixture(account: account, actor: actor)
+
+    subject =
+      subject_fixture(
+        account: account,
+        actor: actor,
+        type: :client,
+        token_id: token.id,
+        user_agent: "Linux/24.04 connlib/1.3.0"
+      )
+
+    client = client_fixture(account: account, actor: actor, firezone_id: "fz-existing")
+
+    %{account: account, actor: actor, subject: subject, client: client, token: token}
+  end
+
+  # Builds a socket in the deferred (pending_device) state, as V3.Socket.connect
+  # leaves it on a gated account.
+  defp deferred_socket(%{account: account, actor: actor, subject: subject, token: token}) do
+    changeset =
+      %Portal.Device{}
+      |> Ecto.Changeset.cast(%{firezone_id: "fz-existing", name: "New Client"}, [
+        :firezone_id,
+        :name
+      ])
+      |> Ecto.Changeset.put_change(:type, :client)
+      |> Ecto.Changeset.put_change(:account_id, account.id)
+      |> Ecto.Changeset.put_change(:actor_id, actor.id)
+      |> Portal.Device.changeset()
+
+    pending = %{
+      changeset: changeset,
+      attrs: %{},
+      token_id: token.id,
+      public_key: generate_public_key(),
+      version: "1.3.0",
+      anchors: DeviceTrust.fetch_enabled_anchors(account.id)
+    }
+
+    PortalAPI.Client.V3.Socket
+    |> socket("client:#{subject.credential.id}", %{
+      subject: subject,
+      pending_device: pending,
+      session_ref: make_ref(),
+      client_version: "1.3.0"
+    })
+  end
+
+  defp join_v3(context) do
+    context
+    |> deferred_socket()
+    |> subscribe_and_join(PortalAPI.Client.V3.Channel, "client")
+  end
+
+  describe "device trust challenge" do
+    test "pushes a 32-byte nonce challenge before init", context do
+      {:ok, _reply, _socket} = join_v3(context)
+
+      assert_push "device_trust_request", %{nonce: nonce, subject_cn: "dev.firezone.device-trust"}
+      refute_push "init", _payload, 100
+      assert byte_size(Base.decode64!(nonce)) == 32
+    end
+
+    test "a valid response resolves the device, persists attested fields, and inits", context do
+      {:ok, _reply, socket} = join_v3(context)
+      assert_push "device_trust_request", %{nonce: nonce}
+
+      entry = response_entry(:rsa, Base.decode64!(nonce))
+      push(socket, "device_trust_response", [entry])
+
+      assert_push "init", _payload, 2_000
+
+      Portal.Queue.flush(:client_session_queue)
+
+      device =
+        Portal.Repo.get_by!(Portal.Device,
+          id: context.client.id,
+          account_id: context.account.id
+        )
+
+      assert device.last_attested_device_serial == "C02XK1ZGJGH5"
+      assert device.last_attested_device_uuid == "7a461ff9-0be2-64a9-a418-539d9a21827b"
+      assert device.last_attested_cert_fingerprint
+      assert device.last_attested_at
+
+      # The live session is marked attested in presence metadata.
+      presence = Portal.Presence.Clients.Account.list(context.account.id)
+      assert %{metas: [%{attested?: true}]} = Map.fetch!(presence, device.id)
+    end
+
+    test "a response with no usable certificate connects unverified", context do
+      {:ok, _reply, socket} = join_v3(context)
+      assert_push "device_trust_request", _payload
+
+      push(socket, "device_trust_response", [])
+      assert_push "init", _payload, 2_000
+
+      Portal.Queue.flush(:client_session_queue)
+
+      device =
+        Portal.Repo.get_by!(Portal.Device,
+          id: context.client.id,
+          account_id: context.account.id
+        )
+
+      assert is_nil(device.last_attested_device_serial)
+      assert is_nil(device.last_attested_cert_fingerprint)
+      assert is_nil(device.last_attested_at)
+
+      # The live session is explicitly unattested in presence metadata.
+      presence = Portal.Presence.Clients.Account.list(context.account.id)
+      assert %{metas: [%{attested?: false}]} = Map.fetch!(presence, device.id)
+    end
+
+    test "the challenge times out and connects unverified", context do
+      Application.put_env(:portal, :device_trust_challenge_timeout_ms, 50)
+      on_exit(fn -> Application.delete_env(:portal, :device_trust_challenge_timeout_ms) end)
+
+      {:ok, _reply, _socket} = join_v3(context)
+      assert_push "device_trust_request", _payload
+
+      # No response sent; the timeout fires and init is pushed anyway.
+      assert_push "init", _payload, 2_000
+    end
+  end
+
+  describe "gate off" do
+    test "without the feature the socket resolves at connect and does not challenge", context do
+      disable_feature(:trust_anchors)
+
+      assert DeviceTrust.fetch_enabled_anchors(context.account.id) == []
+    end
+  end
+end

--- a/elixir/test/portal_api/client/v3/channel_test.exs
+++ b/elixir/test/portal_api/client/v3/channel_test.exs
@@ -159,7 +159,7 @@ defmodule PortalAPI.Client.V3.ChannelTest do
       assert %{metas: [%{attested?: false}]} = Map.fetch!(presence, device.id)
     end
 
-    test "a response with no usable certificate connects unverified", context do
+    test "a response with no usable certificate connects unattested", context do
       {:ok, _reply, socket} = join_v3(context)
       assert_push "device_trust_request", _payload
 
@@ -183,7 +183,7 @@ defmodule PortalAPI.Client.V3.ChannelTest do
       assert %{metas: [%{attested?: false}]} = Map.fetch!(presence, device.id)
     end
 
-    test "the challenge times out and connects unverified", context do
+    test "the challenge times out and connects unattested", context do
       Application.put_env(:portal, :device_trust_challenge_timeout_ms, 50)
       on_exit(fn -> Application.delete_env(:portal, :device_trust_challenge_timeout_ms) end)
 

--- a/elixir/test/portal_api/client/v3/channel_test.exs
+++ b/elixir/test/portal_api/client/v3/channel_test.exs
@@ -1,5 +1,8 @@
 defmodule PortalAPI.Client.V3.ChannelTest do
-  use PortalAPI.ChannelCase, async: true
+  # Grouped with PortalAPI.Client.ChannelTest: both register the globally
+  # named client session/policy-authorization queues, so the modules must
+  # not run concurrently with each other.
+  use PortalAPI.ChannelCase, async: true, group: :client_queues
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures

--- a/elixir/test/portal_api/client/v3/channel_test.exs
+++ b/elixir/test/portal_api/client/v3/channel_test.exs
@@ -71,7 +71,7 @@ defmodule PortalAPI.Client.V3.ChannelTest do
       token_id: token.id,
       public_key: generate_public_key(),
       version: "1.3.0",
-      anchors: DeviceTrust.fetch_enabled_anchors(account.id)
+      anchors: DeviceTrust.fetch_enabled_anchors(subject)
     }
 
     PortalAPI.Client.V3.Socket
@@ -165,7 +165,7 @@ defmodule PortalAPI.Client.V3.ChannelTest do
     test "without the feature the socket resolves at connect and does not challenge", context do
       disable_feature(:trust_anchors)
 
-      assert DeviceTrust.fetch_enabled_anchors(context.account.id) == []
+      assert DeviceTrust.fetch_enabled_anchors(context.subject) == []
     end
   end
 end

--- a/elixir/test/portal_api/client/v3/channel_test.exs
+++ b/elixir/test/portal_api/client/v3/channel_test.exs
@@ -125,6 +125,40 @@ defmodule PortalAPI.Client.V3.ChannelTest do
       assert %{metas: [%{attested?: true}]} = Map.fetch!(presence, device.id)
     end
 
+    test "a response conflicting with another device's identity connects unattested", context do
+      client_fixture(
+        account: context.account,
+        actor: context.actor,
+        firezone_id: "fz-conflicting",
+        last_attested_device_serial: "C02XK1ZGJGH5",
+        last_attested_device_uuid: "11111111-2222-4333-8444-555555555555"
+      )
+
+      {:ok, _reply, socket} = join_v3(context)
+      assert_push "device_trust_request", %{nonce: nonce}
+
+      entry = response_entry(context.pki, :rsa, Base.decode64!(nonce))
+      push(socket, "device_trust_response", [entry])
+
+      assert_push "init", _payload, 2_000
+
+      Portal.Queue.flush(:client_session_queue)
+
+      # The proven identity conflicts with the other row's, so adoption is
+      # refused: the session lands on the firezone_id row unattested.
+      device =
+        Portal.Repo.get_by!(Portal.Device,
+          id: context.client.id,
+          account_id: context.account.id
+        )
+
+      assert is_nil(device.last_attested_device_serial)
+      assert is_nil(device.last_attested_at)
+
+      presence = Portal.Presence.Clients.Account.list(context.account.id)
+      assert %{metas: [%{attested?: false}]} = Map.fetch!(presence, device.id)
+    end
+
     test "a response with no usable certificate connects unverified", context do
       {:ok, _reply, socket} = join_v3(context)
       assert_push "device_trust_request", _payload

--- a/elixir/test/portal_api/client/v3/channel_test.exs
+++ b/elixir/test/portal_api/client/v3/channel_test.exs
@@ -31,7 +31,8 @@ defmodule PortalAPI.Client.V3.ChannelTest do
 
     account = account_fixture()
     enable_feature(:trust_anchors)
-    trust_anchor_fixture(account: account, certs: [ca_der()])
+    pki = pki()
+    trust_anchor_fixture(account: account, certs: [pki.ca_der])
 
     actor = actor_fixture(type: :account_admin_user, account: account)
     token = client_token_fixture(account: account, actor: actor)
@@ -47,7 +48,7 @@ defmodule PortalAPI.Client.V3.ChannelTest do
 
     client = client_fixture(account: account, actor: actor, firezone_id: "fz-existing")
 
-    %{account: account, actor: actor, subject: subject, client: client, token: token}
+    %{account: account, actor: actor, subject: subject, client: client, token: token, pki: pki}
   end
 
   # Builds a socket in the deferred (pending_device) state, as V3.Socket.connect
@@ -101,7 +102,7 @@ defmodule PortalAPI.Client.V3.ChannelTest do
       {:ok, _reply, socket} = join_v3(context)
       assert_push "device_trust_request", %{nonce: nonce}
 
-      entry = response_entry(:rsa, Base.decode64!(nonce))
+      entry = response_entry(context.pki, :rsa, Base.decode64!(nonce))
       push(socket, "device_trust_response", [entry])
 
       assert_push "init", _payload, 2_000

--- a/elixir/test/portal_api/endpoint_test.exs
+++ b/elixir/test/portal_api/endpoint_test.exs
@@ -10,6 +10,9 @@ defmodule PortalAPI.EndpointTest do
     assert {"/client/v2", PortalAPI.Client.V2.Socket, _opts} =
              Enum.find(sockets, fn {path, _socket, _opts} -> path == "/client/v2" end)
 
+    assert {"/client/v3", PortalAPI.Client.V3.Socket, _opts} =
+             Enum.find(sockets, fn {path, _socket, _opts} -> path == "/client/v3" end)
+
     assert {"/gateway", PortalAPI.Gateway.Socket, _opts} =
              Enum.find(sockets, fn {path, _socket, _opts} -> path == "/gateway" end)
 


### PR DESCRIPTION
On accounts with the trust_anchors flag on and at least one trust anchor uploaded, the new /client/v3 socket defers device resolution: after join the portal pushes a random nonce and the client proves possession of an MDM-provisioned certificate before the device row is resolved. Proven connects resolve the device by its attested identity first, so a reinstalled client lands back on its own row instead of creating a duplicate. If the certificate's identifiers disagree with existing rows we refuse to guess and connect the device unverified.

A failed, missing, or timed-out proof never blocks the connection: the client connects the ordinary way, unverified. Whether the CURRENT session proved itself rides presence metadata as attested?; the row columns only record history. The two failure kinds get distinct log lines: certificate rejected (likely a trust anchor misconfiguration) versus no usable certificate (likely a device not enrolled).

Existing /client and /client/v2 connections don't change, and when the flag is off or no anchors exist /client/v3 behaves exactly like /client/v2. The gate check and the anchor fetch are a single query per v3 connect.

Related: #14293 #14254