### PR TITLE
ci: retry Docker static binary download

### DIFF
--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -48,7 +48,7 @@ runs:
         DOCKER_URL="https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz"
 
         echo "Downloading Docker ${DOCKER_VERSION} for ${DOCKER_ARCH}..."
-        curl -fsSL "${DOCKER_URL}" -o /tmp/docker.tgz
+        curl -fsSL --retry 5 --retry-all-errors --connect-timeout 30 "${DOCKER_URL}" -o /tmp/docker.tgz
 
         echo "Extracting Docker binaries..."
         tar -xzf /tmp/docker.tgz -C /tmp


### PR DESCRIPTION
The `setup-docker` action downloads the Docker static tarball with a single-shot `curl`, so a transient connection reset from `download.docker.com` fails the step and cascades into `Cannot connect to the Docker daemon` errors across the whole integration test job. Retrying with backoff on any transport error means a single network blip no longer fails the run.

Example failure: https://github.com/firezone/firezone/actions/runs/29971142779/job/89094087371