### PR TITLE
test(connlib): stop bootstrap_doh flaking on packet loss

### DIFF
--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -618,7 +618,11 @@ mod tests {
             .unwrap();
 
         let mut io = Io::for_test();
-        io.update_system_resolvers(vec![IpAddr::from([1, 1, 1, 1])]);
+        // The bootstrap DNS client doesn't retransmit; production relies on outer
+        // retries. Listing the resolver several times makes `resolve` fan out that
+        // many concurrent queries, standing in for those retries so a single
+        // dropped UDP packet to the real server doesn't flake the test.
+        io.update_system_resolvers(vec![IpAddr::from([1, 1, 1, 1]); 5]);
 
         {
             io.send_dns_query(example_com_recursive_query(), Instant::now());


### PR DESCRIPTION
`io::tests::bootstrap_doh` occasionally fails on CI (seen on the Windows runner) when the bootstrap DNS query to the real resolver times out, leaving the DoH client un-bootstrapped inside the test's 2s window so the second query still returns "Bootstrapping DoH client" and the unwrap panics.

By design the bootstrap DNS client sends each query once and leaves recovery to outer retries rather than retransmitting. The test configured a single upstream, so it never exercised that redundancy and a lone dropped UDP packet was enough to fail it. Listing the resolver several times makes `resolve` fan out that many concurrent queries, standing in for the outer retries and surviving the occasional dropped packet.