### PR TITLE
fix(portal): route session flush probes to the replica

### DIFF
--- a/elixir/lib/portal/safe.ex
+++ b/elixir/lib/portal/safe.ex
@@ -182,27 +182,29 @@ defmodule Portal.Safe do
   def one!(repo, queryable) when repo == Repo,
     do: safe_repo!(fn -> Repo.one!(queryable) end, queryable)
 
-  # all/1
-  @spec all(Scoped.t()) :: [Ecto.Schema.t()] | {:error, :unauthorized}
-  def all(%Scoped{
-        subject: %Subject{account: %{id: account_id}} = subject,
-        queryable: queryable,
-        repo: repo
-      }) do
+  # all/1,2
+  def all(ctx, opts \\ [])
+
+  @spec all(Scoped.t(), Keyword.t()) :: [Ecto.Schema.t()] | {:error, :unauthorized}
+  def all(
+        %Scoped{
+          subject: %Subject{account: %{id: account_id}} = subject,
+          queryable: queryable,
+          repo: repo
+        },
+        opts
+      ) do
     schema = get_schema_module(queryable)
 
     with :ok <- permit(:read, schema, subject) do
-      safe_repo(fn ->
-        queryable
-        |> apply_account_filter(schema, account_id)
-        |> repo.all()
-      end) || []
+      filtered_query = apply_account_filter(queryable, schema, account_id)
+      fetch_all_with_primary_fallback(repo, filtered_query, opts[:fallback_to_primary])
     end
   end
 
-  @spec all(Unscoped.t()) :: [Ecto.Schema.t()]
-  def all(%Unscoped{queryable: queryable, repo: repo}),
-    do: safe_repo(fn -> repo.all(queryable) end) || []
+  @spec all(Unscoped.t(), Keyword.t()) :: [Ecto.Schema.t()]
+  def all(%Unscoped{queryable: queryable, repo: repo}, opts),
+    do: fetch_all_with_primary_fallback(repo, queryable, opts[:fallback_to_primary])
 
   @spec all(Portal.Repo, Ecto.Queryable.t()) :: [Ecto.Schema.t()]
   def all(repo, queryable) when repo == Repo, do: safe_repo(fn -> Repo.all(queryable) end) || []
@@ -754,6 +756,17 @@ defmodule Portal.Safe do
 
       result ->
         result
+    end
+  end
+
+  # Unlike one/2, an empty list is a legitimate result, so fallback_to_primary
+  # only covers replica connection errors, never empty replica reads; callers
+  # that must not miss rows due to replication lag re-probe the primary.
+  defp fetch_all_with_primary_fallback(repo, query, retry?) do
+    case read_replica(fn -> repo.all(query) end, retry?) do
+      :fallback -> safe_repo(fn -> Repo.all(query) end) || []
+      nil -> []
+      result -> result
     end
   end
 

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -392,7 +392,7 @@ defmodule PortalAPI.Client.Socket do
           order_by: [asc: d.inserted_at]
         )
         |> Safe.unscoped(:replica)
-        |> Safe.all()
+        |> Safe.all(fallback_to_primary: true)
         |> classify_attested_rows(Map.new(filters))
       end
     end

--- a/elixir/lib/portal_api/sockets/latest_session.ex
+++ b/elixir/lib/portal_api/sockets/latest_session.ex
@@ -144,27 +144,45 @@ defmodule PortalAPI.Sockets.LatestSession do
         |> Enum.uniq()
 
       schema = Map.fetch!(@token_schemas, token_field)
+      existing = existing_token_ids(schema, probe_rows, :replica)
+      misses = Enum.reject(probe_rows, &MapSet.member?(existing, &1.token_id))
 
-      existing =
-        from(t in schema,
-          join: v in values(probe_rows, @token_probe_types),
-          on: t.account_id == v.account_id and t.id == v.token_id,
-          select: t.id
-        )
-        |> Safe.unscoped()
-        |> Safe.all()
+      # Replica lag can hide a token created moments before the flush; a token
+      # is only declared dead (disconnecting its session) once the primary
+      # confirms the miss. Steady state issues no primary query.
+      if misses == [] do
+        MapSet.new()
+      else
+        existing_on_primary = existing_token_ids(schema, misses, :primary)
+
+        misses
+        |> Enum.map(& &1.token_id)
+        |> Enum.reject(&MapSet.member?(existing_on_primary, &1))
         |> MapSet.new()
+      end
+    end
 
-      probe_rows
-      |> Enum.map(& &1.token_id)
-      |> Enum.reject(&MapSet.member?(existing, &1))
-      |> MapSet.new()
+    defp existing_token_ids(schema, probe_rows, repo) do
+      from(t in schema,
+        join: v in values(probe_rows, @token_probe_types),
+        on: t.account_id == v.account_id and t.id == v.token_id,
+        select: t.id
+      )
+      |> probe(repo)
+    end
+
+    defp probe(queryable, :replica) do
+      queryable |> Safe.unscoped(:replica) |> Safe.all(fallback_to_primary: true) |> MapSet.new()
+    end
+
+    defp probe(queryable, :primary) do
+      queryable |> Safe.unscoped() |> Safe.all() |> MapSet.new()
     end
 
     def update_devices([], _token_field), do: MapSet.new()
 
     def update_devices(rows, token_field) do
-      do_update_devices(rows, token_field, _retries_left = 1)
+      do_update_devices(rows, token_field, _retries_left = 1, :replica)
     end
 
     # The probe-then-update window is not atomic: a flush on another node can
@@ -172,12 +190,13 @@ defmodule PortalAPI.Sockets.LatestSession do
     # the unique index. Re-probing (which then sees the winner and strips the
     # loser) and retrying once resolves the collision at the entry level
     # instead of failing every session in the batch; anything beyond that is
-    # left to the caller's batch-level rescue.
-    defp do_update_devices(rows, token_field, retries_left) do
+    # left to the caller's batch-level rescue. The retry probes the primary:
+    # the winning write just landed and may not have replicated yet.
+    defp do_update_devices(rows, token_field, retries_left, probe_repo) do
       rows =
         rows
         |> dedupe_proposed_firezone_ids()
-        |> strip_conflicting_firezone_ids()
+        |> strip_conflicting_firezone_ids(probe_repo)
 
       set =
         [
@@ -213,7 +232,7 @@ defmodule PortalAPI.Sockets.LatestSession do
     rescue
       error in Postgrex.Error ->
         if retries_left > 0 and unique_violation?(error) do
-          do_update_devices(rows, token_field, retries_left - 1)
+          do_update_devices(rows, token_field, retries_left - 1, :primary)
         else
           reraise error, __STACKTRACE__
         end
@@ -278,7 +297,7 @@ defmodule PortalAPI.Sockets.LatestSession do
     # is not atomic: a collision that appears in between still raises
     # unique_violation, which the caller's rescue turns into failed entries
     # that reconnect and retry.
-    defp strip_conflicting_firezone_ids(rows) do
+    defp strip_conflicting_firezone_ids(rows, probe_repo) do
       probe_rows =
         for row <- rows, not is_nil(row.firezone_id), not is_nil(row.actor_id) do
           Map.take(row, [:account_id, :actor_id, :device_id, :firezone_id])
@@ -296,9 +315,7 @@ defmodule PortalAPI.Sockets.LatestSession do
             where: d.type == :client,
             select: v.device_id
           )
-          |> Safe.unscoped()
-          |> Safe.all()
-          |> MapSet.new()
+          |> probe(probe_repo)
         end
 
       if MapSet.size(conflicted) > 0 do
@@ -316,17 +333,27 @@ defmodule PortalAPI.Sockets.LatestSession do
       end)
     end
 
+    # A device missing here fails its entry (disconnecting the session), so a
+    # replica miss is confirmed against the primary before it counts.
     def existing_device_ids(rows) do
       probe_rows = Enum.map(rows, &Map.take(&1, [:account_id, :device_id]))
+      existing = probe_device_ids(probe_rows, :replica)
+      misses = Enum.reject(probe_rows, &MapSet.member?(existing, &1.device_id))
 
+      if misses == [] do
+        existing
+      else
+        MapSet.union(existing, probe_device_ids(misses, :primary))
+      end
+    end
+
+    defp probe_device_ids(probe_rows, repo) do
       from(d in Device,
         join: v in values(probe_rows, @probe_types),
         on: d.account_id == v.account_id and d.id == v.device_id,
         select: d.id
       )
-      |> Safe.unscoped()
-      |> Safe.all()
-      |> MapSet.new()
+      |> probe(repo)
     end
   end
 end


### PR DESCRIPTION
The batched session flush probed the primary on every flush: for deleted tokens, for missing devices, and for conflicting firezone_ids. Reads should go to the replica so the primary is left to handle writes.

The probes now go to the replica first. A miss on the replica can just be replication lag, and wrongly declaring a token or device missing would disconnect a healthy session. So a miss only counts once the primary confirms it, and in the steady state the primary sees no queries at all. The retry after a unique violation also probes the primary, because the conflicting write just landed and may not have replicated yet.

Safe.all gains the same fallback_to_primary option Safe.one already had: it retries on the primary when the replica connection fails. The attested-device lookup on the client socket now uses it, so a replica outage falls back instead of breaking client connects.

Related: #14254