### PR TITLE
feat(client-ffi): expose uploader, thread spool dir

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -340,6 +340,7 @@ class TunnelService : VpnService() {
                             deviceName = getDeviceName(),
                             logDir = getLogDir(),
                             logFilter = config.logFilter,
+                            flowLogsDir = getFlowLogsDir(),
                             isInternetResourceActive = resourceState.isEnabled(),
                             protectSocket = protectSocket,
                             deviceInfo = deviceInfo,
@@ -540,6 +541,15 @@ class TunnelService : VpnService() {
         val logDir = cacheDir.absolutePath + "/logs"
         Files.createDirectories(Paths.get(logDir))
         return logDir
+    }
+
+    // Spool directory for flow logs the tunnel writes and the uploader drains. Under
+    // `filesDir` (persistent, unlike `cacheDir`) and outside the log directory so an
+    // exported log bundle never sweeps it up.
+    private fun getFlowLogsDir(): String {
+        val flowLogsDir = filesDir.absolutePath + "/flow_logs"
+        Files.createDirectories(Paths.get(flowLogsDir))
+        return flowLogsDir
     }
 
     fun startConnectedNotification() {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -543,9 +543,8 @@ class TunnelService : VpnService() {
         return logDir
     }
 
-    // Spool directory for flow logs the tunnel writes and the uploader drains. Under
-    // `filesDir` (persistent, unlike `cacheDir`) and outside the log directory so an
-    // exported log bundle never sweeps it up.
+    // Under `filesDir` (persistent) and outside the log directory so exported
+    // log bundles never sweep the spool up.
     private fun getFlowLogsDir(): String {
         val flowLogsDir = filesDir.absolutePath + "/flow_logs"
         Files.createDirectories(Paths.get(flowLogsDir))

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -340,7 +340,7 @@ class TunnelService : VpnService() {
                             deviceName = getDeviceName(),
                             logDir = getLogDir(),
                             logFilter = config.logFilter,
-                            flowLogsDir = getFlowLogsDir(),
+                            flowLogsDir = flowLogsDir(this@TunnelService),
                             isInternetResourceActive = resourceState.isEnabled(),
                             protectSocket = protectSocket,
                             deviceInfo = deviceInfo,
@@ -541,14 +541,6 @@ class TunnelService : VpnService() {
         val logDir = cacheDir.absolutePath + "/logs"
         Files.createDirectories(Paths.get(logDir))
         return logDir
-    }
-
-    // Under `filesDir` (persistent) and outside the log directory so exported
-    // log bundles never sweep the spool up.
-    private fun getFlowLogsDir(): String {
-        val flowLogsDir = filesDir.absolutePath + "/flow_logs"
-        Files.createDirectories(Paths.get(flowLogsDir))
-        return flowLogsDir
     }
 
     fun startConnectedNotification() {
@@ -808,6 +800,14 @@ class TunnelService : VpnService() {
         private const val MTU: Int = 1280
         private const val TAG: String = "TunnelService"
         private const val FEATURE_FLAG_POLL_INTERVAL_MS: Long = 5_000
+
+        // Under `filesDir` (persistent) and outside the log directory so exported
+        // log bundles never sweep the spool up.
+        fun flowLogsDir(context: Context): String {
+            val flowLogsDir = context.filesDir.absolutePath + "/flow_logs"
+            Files.createDirectories(Paths.get(flowLogsDir))
+            return flowLogsDir
+        }
 
         private val MANAGED_CONFIGURATIONS =
             arrayOf("token", "allowedApplications", "disallowedApplications", "deviceName")

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1230,6 +1230,7 @@ dependencies = [
  "backoff",
  "client-shared",
  "connlib-model",
+ "flow-log-upload",
  "ip-packet",
  "ip_network",
  "itertools",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1231,6 +1231,7 @@ dependencies = [
  "client-shared",
  "connlib-model",
  "flow-log-upload",
+ "flow-log-writer",
  "ip-packet",
  "ip_network",
  "itertools",

--- a/rust/client-ffi/Cargo.toml
+++ b/rust/client-ffi/Cargo.toml
@@ -15,6 +15,7 @@ backoff = { workspace = true }
 client-shared = { workspace = true }
 connlib-model = { workspace = true }
 flow-log-upload = { workspace = true }
+flow-log-writer = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true }
 itertools = { workspace = true }

--- a/rust/client-ffi/Cargo.toml
+++ b/rust/client-ffi/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = { workspace = true }
 backoff = { workspace = true }
 client-shared = { workspace = true }
 connlib-model = { workspace = true }
+flow-log-upload = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true }
 itertools = { workspace = true }

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -487,7 +487,7 @@ impl Drop for Session {
         // Android's app process outlives the session, so waiting would only
         // delay the disconnect.
         if let Some(uploader) = self.uploader.take() {
-            let flush = (!cfg!(target_os = "android")).then_some(Duration::from_secs(5));
+            let flush = (!cfg!(target_os = "android")).then_some(FLOW_LOG_DRAIN_TIMEOUT);
 
             uploader.stop(flush);
         }
@@ -770,9 +770,14 @@ pub fn drain_flow_logs(spool_dir: String) {
     // Outside the registry lock, so a concurrent `connect` is never blocked on
     // our bounded wait.
     if let Some(one_shot) = one_shot {
-        one_shot.stop(Some(Duration::from_secs(10)));
+        one_shot.stop(Some(FLOW_LOG_DRAIN_TIMEOUT));
     }
 }
+
+/// Longest we block for a flow-log drain: the one-shot in [`drain_flow_logs`]
+/// and the final flush when a session drops. Well within the 15-30s the OS
+/// grants `stopTunnel` on Apple.
+const FLOW_LOG_DRAIN_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// The one live uploader thread, if any: the session's while one exists, else
 /// the latest one-shot. Serializes drains: at most one thread uploads at a time.

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -194,6 +194,7 @@ impl Session {
         device_name: String,
         log_dir: String,
         log_filter: String,
+        flow_logs_dir: Option<String>,
         device_info: DeviceInfo,
         is_internet_resource_active: bool,
         protect_socket: Arc<dyn ProtectSocket>,
@@ -209,6 +210,7 @@ impl Session {
             Some(device_name),
             log_dir,
             log_filter,
+            flow_logs_dir,
             device_info,
             is_internet_resource_active,
             tcp_socket_factory,
@@ -233,6 +235,7 @@ impl Session {
         device_name: Option<String>,
         log_dir: String,
         log_filter: String,
+        flow_logs_dir: Option<String>,
         device_info: DeviceInfo,
         is_internet_resource_active: bool,
     ) -> Result<Self, ConnlibError> {
@@ -248,6 +251,7 @@ impl Session {
             device_name,
             log_dir,
             log_filter,
+            flow_logs_dir,
             device_info,
             is_internet_resource_active,
             tcp_socket_factory,
@@ -278,6 +282,7 @@ impl Session {
         device_name: Option<String>,
         log_dir: String,
         log_filter: String,
+        flow_logs_dir: Option<String>,
         device_info: DeviceInfo,
         is_internet_resource_active: bool,
     ) -> Result<Self, ConnlibError> {
@@ -292,6 +297,7 @@ impl Session {
             device_name,
             log_dir,
             log_filter,
+            flow_logs_dir,
             device_info,
             is_internet_resource_active,
             tcp_socket_factory,
@@ -484,6 +490,7 @@ fn connect(
     device_name: Option<String>,
     log_dir: String,
     log_filter: String,
+    flow_logs_dir: Option<String>,
     device_info: DeviceInfo,
     is_internet_resource_active: bool,
     tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
@@ -540,14 +547,22 @@ fn connect(
         },
         tcp_socket_factory.clone(),
     );
+    // The tunnel process on these platforms (iOS Network Extension, Android
+    // foreground service, macOS System Extension) is session-scoped, so the
+    // session only *writes* the spool. Uploading it is driven separately, for
+    // the provider / service process lifetime plus app-triggered drains, via
+    // `start_flow_log_uploader` / `run_flow_log_upload`.
+    let flow_logs_dir = flow_logs_dir
+        .filter(|dir| !dir.is_empty())
+        .map(PathBuf::from);
+
     let (session, events) = client_shared::Session::connect(
         tcp_socket_factory,
         udp_socket_factory,
         portal,
         is_internet_resource_active,
         Vec::default(),
-        // Mobile flow-log wiring (spool dir + uploader) comes separately.
-        None,
+        flow_logs_dir,
         false,
         runtime.handle().clone(),
     );
@@ -692,6 +707,136 @@ pub fn log_cleanup_default_interval_secs() -> u64 {
 #[uniffi::export]
 pub fn hash_device_id(id: String) -> String {
     telemetry::hash_device_id(id)
+}
+
+// Flow-log uploads go through a tunnel-bypassing socket factory so they never
+// traverse an active tunnel: on Apple the NetworkExtension's own sockets are
+// excluded from its tunnel, so plain sockets suffice; on Android we must
+// `protect()` the sockets via the `ProtectSocket` callback whenever a VPN is up.
+// So the functions that run alongside an active/​tearing-down tunnel are split by
+// platform (Android variants take a `ProtectSocket`). `run_flow_log_upload` is
+// plain on every platform: it's only invoked when no tunnel is active (Android's
+// app-launch drain), where there is nothing to bypass. The work lives in the
+// shared `do_*` helpers below.
+
+/// Starts the process-lifetime flow-log uploader thread over the spool at
+/// `spool_dir`, decoupled from any connlib session (the provider process on
+/// macOS/iOS, the foreground service on Android). Idempotent.
+#[uniffi::export]
+#[cfg(target_os = "android")]
+pub fn start_flow_log_uploader(spool_dir: String, protect_socket: Arc<dyn ProtectSocket>) {
+    do_start_flow_log_uploader(
+        spool_dir,
+        Arc::new(protected_tcp_socket_factory(protect_socket)),
+    );
+}
+
+#[uniffi::export]
+#[cfg(not(target_os = "android"))]
+pub fn start_flow_log_uploader(spool_dir: String) {
+    do_start_flow_log_uploader(spool_dir, Arc::new(socket_factory::tcp));
+}
+
+/// Runs a single flow-log upload pass over the spool at `spool_dir`, reusing the
+/// same parsing / request logic as the gateway and desktop clients. Needs no live
+/// session. Returns `true` when a backlog remained (more than one batch pending).
+///
+/// Uses plain (unprotected) sockets, so call it only when no tunnel is active —
+/// there is nothing to bypass then. While a tunnel is up, drain via the protected
+/// uploader thread / `run_flow_log_upload_timeboxed` instead.
+#[uniffi::export]
+pub fn run_flow_log_upload(spool_dir: String) -> bool {
+    do_run_flow_log_upload(spool_dir, Arc::new(socket_factory::tcp))
+}
+
+/// Runs a flow-log upload pass bounded to `timeout_secs`, for a best-effort final
+/// flush at disconnect: returns once the pass finishes or the timeout elapses,
+/// whichever comes first.
+#[uniffi::export]
+#[cfg(target_os = "android")]
+pub fn run_flow_log_upload_timeboxed(
+    spool_dir: String,
+    timeout_secs: u64,
+    protect_socket: Arc<dyn ProtectSocket>,
+) -> bool {
+    do_run_flow_log_upload_timeboxed(
+        spool_dir,
+        timeout_secs,
+        Arc::new(protected_tcp_socket_factory(protect_socket)),
+    )
+}
+
+#[uniffi::export]
+#[cfg(not(target_os = "android"))]
+pub fn run_flow_log_upload_timeboxed(spool_dir: String, timeout_secs: u64) -> bool {
+    do_run_flow_log_upload_timeboxed(spool_dir, timeout_secs, Arc::new(socket_factory::tcp))
+}
+
+/// Starts the uploader thread; it prunes the spool on start. Idempotent while
+/// the thread is alive; a dead thread (e.g. its runtime failed to build) is
+/// restarted on the next call.
+fn do_start_flow_log_uploader(spool_dir: String, tcp: Arc<dyn SocketFactory<TcpSocket>>) {
+    static UPLOADER: std::sync::Mutex<Option<std::thread::JoinHandle<()>>> =
+        std::sync::Mutex::new(None);
+
+    let mut uploader = UPLOADER
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    if uploader
+        .as_ref()
+        .is_some_and(|handle| !handle.is_finished())
+    {
+        return;
+    }
+
+    // The uploader may run without `connect` ever being called, so ensure the
+    // rustls crypto provider its TLS needs is installed (idempotent).
+    install_rustls_crypto_provider();
+
+    *uploader = Some(flow_log_upload::spawn(PathBuf::from(spool_dir), tcp));
+}
+
+/// Runs a single upload pass.
+fn do_run_flow_log_upload(spool_dir: String, tcp: Arc<dyn SocketFactory<TcpSocket>>) -> bool {
+    install_rustls_crypto_provider();
+
+    block_on_upload_pass(std::path::Path::new(&spool_dir), tcp)
+}
+
+/// Runs a single upload pass bounded to `timeout_secs`; the pass keeps running on
+/// its own thread if it overruns (best-effort flush at disconnect).
+fn do_run_flow_log_upload_timeboxed(
+    spool_dir: String,
+    timeout_secs: u64,
+    tcp: Arc<dyn SocketFactory<TcpSocket>>,
+) -> bool {
+    install_rustls_crypto_provider();
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let backlog = block_on_upload_pass(std::path::Path::new(&spool_dir), tcp);
+        let _ = tx.send(backlog);
+    });
+
+    rx.recv_timeout(Duration::from_secs(timeout_secs))
+        .unwrap_or(false)
+}
+
+/// Drives [`flow_log_upload::upload_once`] to completion on a fresh runtime.
+fn block_on_upload_pass(spool_dir: &Path, tcp: Arc<dyn SocketFactory<TcpSocket>>) -> bool {
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            tracing::error!("Failed to build flow-log upload runtime: {e:#}");
+            return false;
+        }
+    };
+
+    runtime.block_on(flow_log_upload::upload_once(spool_dir, tcp))
 }
 
 /// Returns whether log streaming is currently active.

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -375,7 +375,7 @@ impl Session {
     }
 
     pub fn set_log_directives(&self, directives: String) -> Result<(), ConnlibError> {
-        let (_, reload_handle) = LOGGER_STATE.get().context("Logger not yet initialised")?;
+        let (_, reload_handle, _) = LOGGER_STATE.get().context("Logger not yet initialised")?;
 
         reload_handle
             .reload(&directives)
@@ -479,6 +479,10 @@ impl Drop for Session {
         });
 
         runtime.shutdown_timeout(Duration::from_secs(1)); // Ensure we don't block forever on a task in the blocking pool.
+
+        // The event loop spooled its open flows on the way out; flush them
+        // before the OS may reap the process.
+        flush_flow_logs_on_disconnect();
     }
 }
 
@@ -514,7 +518,11 @@ fn connect(
 
     install_rustls_crypto_provider();
 
-    init_logging(&PathBuf::from(log_dir), log_filter)?;
+    let flow_logs_dir = flow_logs_dir
+        .filter(|dir| !dir.is_empty())
+        .map(PathBuf::from);
+
+    init_logging(&PathBuf::from(log_dir), log_filter, flow_logs_dir.clone())?;
 
     tunnel_bypass_resolver::configure(tcp_socket_factory.clone(), udp_socket_factory.clone());
 
@@ -551,11 +559,8 @@ fn connect(
     // foreground service, macOS System Extension) is session-scoped, so the
     // session only *writes* the spool. Uploading it is driven separately, for
     // the provider / service process lifetime plus app-triggered drains, via
-    // `start_flow_log_uploader` / `run_flow_log_upload`.
-    let flow_logs_dir = flow_logs_dir
-        .filter(|dir| !dir.is_empty())
-        .map(PathBuf::from);
-
+    // `ensure_flow_log_uploader` / `run_flow_log_upload`; the session nudges a
+    // flush when it drops.
     let (session, events) = client_shared::Session::connect(
         tcp_socket_factory,
         udp_socket_factory,
@@ -604,11 +609,14 @@ pub fn stop_telemetry() {
     telemetry::stop();
 }
 
-static LOGGER_STATE: OnceLock<(logging::file::Handle, logging::FilterReloadHandle)> =
-    OnceLock::new();
+static LOGGER_STATE: OnceLock<(
+    logging::file::Handle,
+    logging::FilterReloadHandle,
+    Option<flow_log_writer::Guard>,
+)> = OnceLock::new();
 
-fn init_logging(log_dir: &Path, log_filter: String) -> Result<()> {
-    if let Some((_, reload_handle)) = LOGGER_STATE.get() {
+fn init_logging(log_dir: &Path, log_filter: String, flow_logs_dir: Option<PathBuf>) -> Result<()> {
+    if let Some((_, reload_handle, _)) = LOGGER_STATE.get() {
         reload_handle
             .reload(&log_filter)
             .context("Failed to apply new log-filter")?;
@@ -618,6 +626,8 @@ fn init_logging(log_dir: &Path, log_filter: String) -> Result<()> {
     let (file_log_filter, file_reload_handle) = logging::try_filter(&log_filter)?;
     let (platform_log_filter, platform_reload_handle) = logging::try_filter(&log_filter)?;
     let (file_layer, handle) = logging::file::layer(log_dir, "connlib");
+    // Spools flow-log reports for the uploader, like the desktop entrypoints do.
+    let (flow_log_layer, flow_log_guard) = flow_logs_dir.map(flow_log_writer::layer).unzip();
 
     let subscriber = tracing_subscriber::registry()
         .with(file_layer.with_filter(file_log_filter))
@@ -628,6 +638,7 @@ fn init_logging(log_dir: &Path, log_filter: String) -> Result<()> {
                 .with_writer(platform::MakeWriter::default())
                 .with_filter(platform_log_filter),
         )
+        .with(flow_log_layer)
         .with(sentry_layer());
 
     let reload_handle = file_reload_handle.merge(platform_reload_handle);
@@ -635,7 +646,7 @@ fn init_logging(log_dir: &Path, log_filter: String) -> Result<()> {
     logging::init(subscriber)?;
 
     LOGGER_STATE
-        .set((handle, reload_handle))
+        .set((handle, reload_handle, flow_log_guard))
         .map_err(|_| anyhow!("Logging guard should never be initialized twice"))?;
 
     Ok(())
@@ -716,16 +727,17 @@ pub fn hash_device_id(id: String) -> String {
 // So the functions that run alongside an active/​tearing-down tunnel are split by
 // platform (Android variants take a `ProtectSocket`). `run_flow_log_upload` is
 // plain on every platform: it's only invoked when no tunnel is active (Android's
-// app-launch drain), where there is nothing to bypass. The work lives in the
-// shared `do_*` helpers below.
+// app-launch drain), where there is nothing to bypass.
 
-/// Starts the process-lifetime flow-log uploader thread over the spool at
-/// `spool_dir`, decoupled from any connlib session (the provider process on
-/// macOS/iOS, the foreground service on Android). Idempotent.
+/// Ensures the process-lifetime flow-log uploader thread is running over the
+/// spool at `spool_dir` and kicks a pass: a dead thread (e.g. its runtime
+/// failed to build) is respawned and uploads immediately, a live one is nudged
+/// to skip its interval. Needs no connlib session, so it also serves the
+/// app-foreground drain while disconnected.
 #[uniffi::export]
 #[cfg(target_os = "android")]
-pub fn start_flow_log_uploader(spool_dir: String, protect_socket: Arc<dyn ProtectSocket>) {
-    do_start_flow_log_uploader(
+pub fn ensure_flow_log_uploader(spool_dir: String, protect_socket: Arc<dyn ProtectSocket>) {
+    do_ensure_flow_log_uploader(
         spool_dir,
         Arc::new(protected_tcp_socket_factory(protect_socket)),
     );
@@ -733,8 +745,8 @@ pub fn start_flow_log_uploader(spool_dir: String, protect_socket: Arc<dyn Protec
 
 #[uniffi::export]
 #[cfg(not(target_os = "android"))]
-pub fn start_flow_log_uploader(spool_dir: String) {
-    do_start_flow_log_uploader(spool_dir, Arc::new(socket_factory::tcp));
+pub fn ensure_flow_log_uploader(spool_dir: String) {
+    do_ensure_flow_log_uploader(spool_dir, Arc::new(socket_factory::tcp));
 }
 
 /// Runs a single flow-log upload pass over the spool at `spool_dir`, reusing the
@@ -742,85 +754,62 @@ pub fn start_flow_log_uploader(spool_dir: String) {
 /// session. Returns `true` when a backlog remained (more than one batch pending).
 ///
 /// Uses plain (unprotected) sockets, so call it only when no tunnel is active —
-/// there is nothing to bypass then. While a tunnel is up, drain via the protected
-/// uploader thread / `run_flow_log_upload_timeboxed` instead.
+/// there is nothing to bypass then. While a tunnel is up, drain via
+/// `ensure_flow_log_uploader` instead.
 #[uniffi::export]
 pub fn run_flow_log_upload(spool_dir: String) -> bool {
-    do_run_flow_log_upload(spool_dir, Arc::new(socket_factory::tcp))
-}
+    install_rustls_crypto_provider();
 
-/// Runs a flow-log upload pass bounded to `timeout_secs`, for a best-effort final
-/// flush at disconnect: returns once the pass finishes or the timeout elapses,
-/// whichever comes first.
-#[uniffi::export]
-#[cfg(target_os = "android")]
-pub fn run_flow_log_upload_timeboxed(
-    spool_dir: String,
-    timeout_secs: u64,
-    protect_socket: Arc<dyn ProtectSocket>,
-) -> bool {
-    do_run_flow_log_upload_timeboxed(
-        spool_dir,
-        timeout_secs,
-        Arc::new(protected_tcp_socket_factory(protect_socket)),
+    block_on_upload_pass(
+        std::path::Path::new(&spool_dir),
+        Arc::new(socket_factory::tcp),
     )
 }
 
-#[uniffi::export]
-#[cfg(not(target_os = "android"))]
-pub fn run_flow_log_upload_timeboxed(spool_dir: String, timeout_secs: u64) -> bool {
-    do_run_flow_log_upload_timeboxed(spool_dir, timeout_secs, Arc::new(socket_factory::tcp))
-}
+/// The uploader thread, once a caller ensured it; sessions flush through it on
+/// disconnect.
+static UPLOADER: std::sync::Mutex<Option<flow_log_upload::Uploader>> = std::sync::Mutex::new(None);
 
-/// Starts the uploader thread; it prunes the spool on start. Idempotent while
-/// the thread is alive; a dead thread (e.g. its runtime failed to build) is
-/// restarted on the next call.
-fn do_start_flow_log_uploader(spool_dir: String, tcp: Arc<dyn SocketFactory<TcpSocket>>) {
-    static UPLOADER: std::sync::Mutex<Option<std::thread::JoinHandle<()>>> =
-        std::sync::Mutex::new(None);
-
+fn do_ensure_flow_log_uploader(spool_dir: String, tcp: Arc<dyn SocketFactory<TcpSocket>>) {
     let mut uploader = UPLOADER
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-    if uploader
-        .as_ref()
-        .is_some_and(|handle| !handle.is_finished())
-    {
+    match uploader.as_ref() {
+        Some(uploader) if !uploader.is_finished() => uploader.nudge(),
+        _ => {
+            // The uploader may run without `connect` ever being called, so ensure the
+            // rustls crypto provider its TLS needs is installed (idempotent).
+            install_rustls_crypto_provider();
+
+            *uploader = Some(flow_log_upload::spawn(PathBuf::from(spool_dir), tcp));
+        }
+    }
+}
+
+/// Flushes the spool when a session ends: connlib finalized its open flows on
+/// shutdown, and on Apple the provider process may be reaped shortly after
+/// `stopTunnel` returns, so block briefly for an upload pass. Android's app
+/// process outlives the session, so a wake-up suffices and keeps the disconnect
+/// prompt.
+fn flush_flow_logs_on_disconnect() {
+    let uploader = UPLOADER
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    let Some(uploader) = uploader.as_ref() else {
+        return;
+    };
+
+    if uploader.is_finished() {
         return;
     }
 
-    // The uploader may run without `connect` ever being called, so ensure the
-    // rustls crypto provider its TLS needs is installed (idempotent).
-    install_rustls_crypto_provider();
-
-    *uploader = Some(flow_log_upload::spawn(PathBuf::from(spool_dir), tcp));
-}
-
-/// Runs a single upload pass.
-fn do_run_flow_log_upload(spool_dir: String, tcp: Arc<dyn SocketFactory<TcpSocket>>) -> bool {
-    install_rustls_crypto_provider();
-
-    block_on_upload_pass(std::path::Path::new(&spool_dir), tcp)
-}
-
-/// Runs a single upload pass bounded to `timeout_secs`; the pass keeps running on
-/// its own thread if it overruns (best-effort flush at disconnect).
-fn do_run_flow_log_upload_timeboxed(
-    spool_dir: String,
-    timeout_secs: u64,
-    tcp: Arc<dyn SocketFactory<TcpSocket>>,
-) -> bool {
-    install_rustls_crypto_provider();
-
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let backlog = block_on_upload_pass(std::path::Path::new(&spool_dir), tcp);
-        let _ = tx.send(backlog);
-    });
-
-    rx.recv_timeout(Duration::from_secs(timeout_secs))
-        .unwrap_or(false)
+    if cfg!(target_os = "android") {
+        uploader.nudge();
+    } else {
+        uploader.nudge_and_wait(Duration::from_secs(5));
+    }
 }
 
 /// Drives [`flow_log_upload::upload_once`] to completion on a fresh runtime.

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -557,10 +557,13 @@ fn connect(
     );
     // The tunnel process on these platforms (iOS Network Extension, Android
     // foreground service, macOS System Extension) is session-scoped, so the
-    // session only *writes* the spool. Uploading it is driven separately, for
-    // the provider / service process lifetime plus app-triggered drains, via
-    // `ensure_flow_log_uploader` / `run_flow_log_upload`; the session nudges a
-    // flush when it drops.
+    // session only *writes* the spool. The uploader thread outlives it
+    // (`ensure_flow_log_uploader`); the session lends it its tunnel-bypassing
+    // socket factory while it lives and flushes it on drop.
+    if let Some(dir) = flow_logs_dir.clone() {
+        install_session_socket_factory(dir, tcp_socket_factory.clone());
+    }
+
     let (session, events) = client_shared::Session::connect(
         tcp_socket_factory,
         udp_socket_factory,
@@ -722,58 +725,19 @@ pub fn hash_device_id(id: String) -> String {
 
 // Flow-log uploads go through a tunnel-bypassing socket factory so they never
 // traverse an active tunnel: on Apple the NetworkExtension's own sockets are
-// excluded from its tunnel, so plain sockets suffice; on Android we must
-// `protect()` the sockets via the `ProtectSocket` callback whenever a VPN is up.
-// So the functions that run alongside an active/​tearing-down tunnel are split by
-// platform (Android variants take a `ProtectSocket`). `run_flow_log_upload` is
-// plain on every platform: it's only invoked when no tunnel is active (Android's
-// app-launch drain), where there is nothing to bypass.
+// excluded from its tunnel, so plain sockets always suffice; on Android the
+// session installs its VPN-protected factory into the uploader on connect and
+// drop resets it to plain sockets, so the thread opens connections correctly
+// no matter who started it or when.
 
 /// Ensures the process-lifetime flow-log uploader thread is running over the
 /// spool at `spool_dir` and kicks a pass: a dead thread (e.g. its runtime
 /// failed to build) is respawned and uploads immediately, a live one is nudged
-/// to skip its interval. Needs no connlib session, so it also serves the
-/// app-foreground drain while disconnected.
+/// to skip its interval. Needs no connlib session, so it serves process boot
+/// and the app-foreground drain while disconnected.
 #[uniffi::export]
-#[cfg(target_os = "android")]
-pub fn ensure_flow_log_uploader(spool_dir: String, protect_socket: Arc<dyn ProtectSocket>) {
-    do_ensure_flow_log_uploader(
-        spool_dir,
-        Arc::new(protected_tcp_socket_factory(protect_socket)),
-    );
-}
-
-#[uniffi::export]
-#[cfg(not(target_os = "android"))]
 pub fn ensure_flow_log_uploader(spool_dir: String) {
-    do_ensure_flow_log_uploader(spool_dir, Arc::new(socket_factory::tcp));
-}
-
-/// Runs a single flow-log upload pass over the spool at `spool_dir`, reusing the
-/// same parsing / request logic as the gateway and desktop clients. Needs no live
-/// session. Returns `true` when a backlog remained (more than one batch pending).
-///
-/// Uses plain (unprotected) sockets, so call it only when no tunnel is active —
-/// there is nothing to bypass then. While a tunnel is up, drain via
-/// `ensure_flow_log_uploader` instead.
-#[uniffi::export]
-pub fn run_flow_log_upload(spool_dir: String) -> bool {
-    install_rustls_crypto_provider();
-
-    block_on_upload_pass(
-        std::path::Path::new(&spool_dir),
-        Arc::new(socket_factory::tcp),
-    )
-}
-
-/// The uploader thread, once a caller ensured it; sessions flush through it on
-/// disconnect.
-static UPLOADER: std::sync::Mutex<Option<flow_log_upload::Uploader>> = std::sync::Mutex::new(None);
-
-fn do_ensure_flow_log_uploader(spool_dir: String, tcp: Arc<dyn SocketFactory<TcpSocket>>) {
-    let mut uploader = UPLOADER
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut uploader = lock_uploader();
 
     match uploader.as_ref() {
         Some(uploader) if !uploader.is_finished() => uploader.nudge(),
@@ -782,8 +746,31 @@ fn do_ensure_flow_log_uploader(spool_dir: String, tcp: Arc<dyn SocketFactory<Tcp
             // rustls crypto provider its TLS needs is installed (idempotent).
             install_rustls_crypto_provider();
 
-            *uploader = Some(flow_log_upload::spawn(PathBuf::from(spool_dir), tcp));
+            *uploader = Some(flow_log_upload::spawn(
+                PathBuf::from(spool_dir),
+                Arc::new(socket_factory::tcp),
+            ));
         }
+    }
+}
+
+/// The uploader thread, once a caller ensured it; sessions steer and flush it.
+static UPLOADER: std::sync::Mutex<Option<flow_log_upload::Uploader>> = std::sync::Mutex::new(None);
+
+fn lock_uploader() -> std::sync::MutexGuard<'static, Option<flow_log_upload::Uploader>> {
+    UPLOADER
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Points the uploader at the session's tunnel-bypassing socket factory for the
+/// session's lifetime, spawning it if it isn't running.
+fn install_session_socket_factory(spool_dir: PathBuf, tcp: Arc<dyn SocketFactory<TcpSocket>>) {
+    let mut uploader = lock_uploader();
+
+    match uploader.as_ref() {
+        Some(uploader) if !uploader.is_finished() => uploader.set_socket_factory(tcp),
+        _ => *uploader = Some(flow_log_upload::spawn(spool_dir, tcp)),
     }
 }
 
@@ -793,9 +780,7 @@ fn do_ensure_flow_log_uploader(spool_dir: String, tcp: Arc<dyn SocketFactory<Tcp
 /// process outlives the session, so a wake-up suffices and keeps the disconnect
 /// prompt.
 fn flush_flow_logs_on_disconnect() {
-    let uploader = UPLOADER
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let uploader = lock_uploader();
 
     let Some(uploader) = uploader.as_ref() else {
         return;
@@ -805,27 +790,15 @@ fn flush_flow_logs_on_disconnect() {
         return;
     }
 
+    // The session's protected factory dies with it; plain sockets are correct
+    // again until the next session installs its own.
+    uploader.set_socket_factory(Arc::new(socket_factory::tcp));
+
     if cfg!(target_os = "android") {
         uploader.nudge();
     } else {
         uploader.nudge_and_wait(Duration::from_secs(5));
     }
-}
-
-/// Drives [`flow_log_upload::upload_once`] to completion on a fresh runtime.
-fn block_on_upload_pass(spool_dir: &Path, tcp: Arc<dyn SocketFactory<TcpSocket>>) -> bool {
-    let runtime = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(runtime) => runtime,
-        Err(e) => {
-            tracing::error!("Failed to build flow-log upload runtime: {e:#}");
-            return false;
-        }
-    };
-
-    runtime.block_on(flow_log_upload::upload_once(spool_dir, tcp))
 }
 
 /// Returns whether log streaming is currently active.

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -566,11 +566,15 @@ fn connect(
     // The uploader thread lives and dies with the session: its interval only
     // makes sense while flows are being produced, and a resident thread in an
     // idle app process would poll and dial for nothing. It uses the session's
-    // tunnel-bypassing socket factory; out-of-session spool is drained by the
-    // one-shot `run_flow_log_upload` instead.
-    let uploader = flow_logs_dir
-        .clone()
-        .map(|dir| flow_log_upload::spawn(dir, tcp_socket_factory.clone()));
+    // tunnel-bypassing socket factory, and registers itself so `drain_flow_logs`
+    // nudges it instead of spawning a second drain.
+    let uploader = flow_logs_dir.clone().map(|dir| {
+        let uploader = flow_log_upload::spawn(dir, tcp_socket_factory.clone());
+
+        *lock_uploader() = Some(uploader.clone());
+
+        uploader
+    });
 
     let (session, events) = client_shared::Session::connect(
         tcp_socket_factory,
@@ -732,34 +736,52 @@ pub fn hash_device_id(id: String) -> String {
     telemetry::hash_device_id(id)
 }
 
-/// Runs a single flow-log upload pass over the spool at `spool_dir` and
-/// returns whether a backlog remained (more than one batch pending). For
-/// draining spool left behind while no session is running (app launch on
-/// Android, the app-foreground nudge on Apple); the interval uploader lives
-/// inside the session, so out of session there is nothing else draining.
+/// Drains the flow-log spool at `spool_dir`. Call whenever a prompt upload is
+/// wanted, e.g. on app foreground or launch.
 ///
-/// Uses plain sockets: without a session there is no tunnel of ours to bypass
-/// on Android, and Apple's NetworkExtension sockets are always excluded from
-/// its tunnel.
+/// A live session's uploader is nudged to upload now; the caller returns
+/// immediately, since that thread sticks around to see the upload through.
+/// Without one, a one-shot pass runs over plain sockets (no session means no
+/// tunnel of ours to bypass) and the call blocks until it completes, bounded to
+/// 10 seconds; the pass finishes in the background if it overruns.
 #[uniffi::export]
-pub fn run_flow_log_upload(spool_dir: String) -> bool {
+pub fn drain_flow_logs(spool_dir: String) {
     install_rustls_crypto_provider();
 
-    let runtime = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(runtime) => runtime,
-        Err(e) => {
-            tracing::error!("Failed to build flow-log upload runtime: {e:#}");
-            return false;
+    let one_shot = {
+        let mut uploader = lock_uploader();
+
+        match uploader.as_ref() {
+            Some(uploader) if !uploader.is_finished() => {
+                uploader.nudge();
+                None
+            }
+            _ => {
+                let one_shot =
+                    flow_log_upload::spawn(PathBuf::from(spool_dir), Arc::new(socket_factory::tcp));
+
+                *uploader = Some(one_shot.clone());
+
+                Some(one_shot)
+            }
         }
     };
 
-    runtime.block_on(flow_log_upload::upload_once(
-        std::path::Path::new(&spool_dir),
-        Arc::new(socket_factory::tcp),
-    ))
+    // Outside the registry lock, so a concurrent `connect` is never blocked on
+    // our bounded wait.
+    if let Some(one_shot) = one_shot {
+        one_shot.stop(Some(Duration::from_secs(10)));
+    }
+}
+
+/// The one live uploader thread, if any: the session's while one exists, else
+/// the latest one-shot. Serializes drains: at most one thread uploads at a time.
+static UPLOADER: std::sync::Mutex<Option<flow_log_upload::Uploader>> = std::sync::Mutex::new(None);
+
+fn lock_uploader() -> std::sync::MutexGuard<'static, Option<flow_log_upload::Uploader>> {
+    UPLOADER
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 /// Returns whether log streaming is currently active.

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -36,6 +36,7 @@ pub struct Session {
     inner: client_shared::Session,
     events: Mutex<client_shared::EventStream>,
     runtime: Option<tokio::runtime::Runtime>,
+    uploader: Option<flow_log_upload::Uploader>,
 }
 
 #[derive(uniffi::Object, thiserror::Error, Debug)]
@@ -480,9 +481,16 @@ impl Drop for Session {
 
         runtime.shutdown_timeout(Duration::from_secs(1)); // Ensure we don't block forever on a task in the blocking pool.
 
-        // The event loop spooled its open flows on the way out; flush them
-        // before the OS may reap the process.
-        flush_flow_logs_on_disconnect();
+        // The event loop spooled its open flows on the way out; run one final
+        // upload pass, then let the uploader thread exit. Apple blocks briefly
+        // because the provider process may be reaped right after `stopTunnel`;
+        // Android's app process outlives the session, so waiting would only
+        // delay the disconnect.
+        if let Some(uploader) = self.uploader.take() {
+            let flush = (!cfg!(target_os = "android")).then_some(Duration::from_secs(5));
+
+            uploader.stop(flush);
+        }
     }
 }
 
@@ -555,14 +563,14 @@ fn connect(
         },
         tcp_socket_factory.clone(),
     );
-    // The tunnel process on these platforms (iOS Network Extension, Android
-    // foreground service, macOS System Extension) is session-scoped, so the
-    // session only *writes* the spool. The uploader thread outlives it
-    // (`ensure_flow_log_uploader`); the session lends it its tunnel-bypassing
-    // socket factory while it lives and flushes it on drop.
-    if let Some(dir) = flow_logs_dir.clone() {
-        install_session_socket_factory(dir, tcp_socket_factory.clone());
-    }
+    // The uploader thread lives and dies with the session: its interval only
+    // makes sense while flows are being produced, and a resident thread in an
+    // idle app process would poll and dial for nothing. It uses the session's
+    // tunnel-bypassing socket factory; out-of-session spool is drained by the
+    // one-shot `run_flow_log_upload` instead.
+    let uploader = flow_logs_dir
+        .clone()
+        .map(|dir| flow_log_upload::spawn(dir, tcp_socket_factory.clone()));
 
     let (session, events) = client_shared::Session::connect(
         tcp_socket_factory,
@@ -581,6 +589,7 @@ fn connect(
         inner: session,
         events: Mutex::new(events),
         runtime: Some(runtime),
+        uploader,
     })
 }
 
@@ -723,82 +732,34 @@ pub fn hash_device_id(id: String) -> String {
     telemetry::hash_device_id(id)
 }
 
-// Flow-log uploads go through a tunnel-bypassing socket factory so they never
-// traverse an active tunnel: on Apple the NetworkExtension's own sockets are
-// excluded from its tunnel, so plain sockets always suffice; on Android the
-// session installs its VPN-protected factory into the uploader on connect and
-// drop resets it to plain sockets, so the thread opens connections correctly
-// no matter who started it or when.
-
-/// Ensures the process-lifetime flow-log uploader thread is running over the
-/// spool at `spool_dir` and kicks a pass: a dead thread (e.g. its runtime
-/// failed to build) is respawned and uploads immediately, a live one is nudged
-/// to skip its interval. Needs no connlib session, so it serves process boot
-/// and the app-foreground drain while disconnected.
+/// Runs a single flow-log upload pass over the spool at `spool_dir` and
+/// returns whether a backlog remained (more than one batch pending). For
+/// draining spool left behind while no session is running (app launch on
+/// Android, the app-foreground nudge on Apple); the interval uploader lives
+/// inside the session, so out of session there is nothing else draining.
+///
+/// Uses plain sockets: without a session there is no tunnel of ours to bypass
+/// on Android, and Apple's NetworkExtension sockets are always excluded from
+/// its tunnel.
 #[uniffi::export]
-pub fn ensure_flow_log_uploader(spool_dir: String) {
-    let mut uploader = lock_uploader();
+pub fn run_flow_log_upload(spool_dir: String) -> bool {
+    install_rustls_crypto_provider();
 
-    match uploader.as_ref() {
-        Some(uploader) if !uploader.is_finished() => uploader.nudge(),
-        _ => {
-            // The uploader may run without `connect` ever being called, so ensure the
-            // rustls crypto provider its TLS needs is installed (idempotent).
-            install_rustls_crypto_provider();
-
-            *uploader = Some(flow_log_upload::spawn(
-                PathBuf::from(spool_dir),
-                Arc::new(socket_factory::tcp),
-            ));
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            tracing::error!("Failed to build flow-log upload runtime: {e:#}");
+            return false;
         }
-    }
-}
-
-/// The uploader thread, once a caller ensured it; sessions steer and flush it.
-static UPLOADER: std::sync::Mutex<Option<flow_log_upload::Uploader>> = std::sync::Mutex::new(None);
-
-fn lock_uploader() -> std::sync::MutexGuard<'static, Option<flow_log_upload::Uploader>> {
-    UPLOADER
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-}
-
-/// Points the uploader at the session's tunnel-bypassing socket factory for the
-/// session's lifetime, spawning it if it isn't running.
-fn install_session_socket_factory(spool_dir: PathBuf, tcp: Arc<dyn SocketFactory<TcpSocket>>) {
-    let mut uploader = lock_uploader();
-
-    match uploader.as_ref() {
-        Some(uploader) if !uploader.is_finished() => uploader.set_socket_factory(tcp),
-        _ => *uploader = Some(flow_log_upload::spawn(spool_dir, tcp)),
-    }
-}
-
-/// Flushes the spool when a session ends: connlib finalized its open flows on
-/// shutdown, and on Apple the provider process may be reaped shortly after
-/// `stopTunnel` returns, so block briefly for an upload pass. Android's app
-/// process outlives the session, so a wake-up suffices and keeps the disconnect
-/// prompt.
-fn flush_flow_logs_on_disconnect() {
-    let uploader = lock_uploader();
-
-    let Some(uploader) = uploader.as_ref() else {
-        return;
     };
 
-    if uploader.is_finished() {
-        return;
-    }
-
-    // The session's protected factory dies with it; plain sockets are correct
-    // again until the next session installs its own.
-    uploader.set_socket_factory(Arc::new(socket_factory::tcp));
-
-    if cfg!(target_os = "android") {
-        uploader.nudge();
-    } else {
-        uploader.nudge_and_wait(Duration::from_secs(5));
-    }
+    runtime.block_on(flow_log_upload::upload_once(
+        std::path::Path::new(&spool_dir),
+        Arc::new(socket_factory::tcp),
+    ))
 }
 
 /// Returns whether log streaming is currently active.

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -481,18 +481,12 @@ impl Drop for Session {
 
         runtime.shutdown_timeout(Duration::from_secs(1)); // Ensure we don't block forever on a task in the blocking pool.
 
-        // The event loop spooled its open flows on the way out; run one final
-        // upload pass, then let the uploader thread exit. Apple blocks briefly
-        // because the provider process may be reaped right after `stopTunnel`;
-        // Android's app process outlives the session, so waiting would only
-        // delay the disconnect.
+        // The event loop spooled its open flows on the way out; flush them.
         if let Some(uploader) = self.uploader.take() {
-            // Android's app process outlives the session; not waiting keeps
-            // the disconnect prompt.
+            // The app process outlives the session; don't delay the disconnect.
             #[cfg(target_os = "android")]
             let flush = None;
-            // The provider process may be reaped right after `stopTunnel`;
-            // block until the flush lands.
+            // The provider may be reaped right after `stopTunnel`; wait.
             #[cfg(not(target_os = "android"))]
             let flush = Some(FLOW_LOG_DRAIN_TIMEOUT);
 
@@ -571,11 +565,8 @@ fn connect(
         },
         tcp_socket_factory.clone(),
     );
-    // The uploader thread lives and dies with the session: its interval only
-    // makes sense while flows are being produced, and a resident thread in an
-    // idle app process would poll and dial for nothing. It uses the session's
-    // tunnel-bypassing socket factory, and registers itself so `drain_flow_logs`
-    // nudges it instead of spawning a second drain.
+    // The uploader lives and dies with the session (idle, it would only poll
+    // and dial); registered so `drain_flow_logs` nudges it instead of racing it.
     let uploader = flow_logs_dir.clone().map(|dir| {
         let uploader = flow_log_upload::spawn(dir, tcp_socket_factory.clone());
 
@@ -744,19 +735,12 @@ pub fn hash_device_id(id: String) -> String {
     telemetry::hash_device_id(id)
 }
 
-/// Drains the flow-log spool at `spool_dir`. Call whenever a prompt upload is
-/// wanted, e.g. on app foreground or launch.
+/// Drains the flow-log spool at `spool_dir`, e.g. on app foreground or launch.
 ///
-/// A live session's uploader is nudged to upload now; the caller returns
-/// immediately, since that thread sticks around to see the upload through.
-/// Without one, a one-shot pass runs and the call blocks until it completes,
-/// bounded to [`FLOW_LOG_DRAIN_TIMEOUT`]; the pass finishes in the background
-/// if it overruns.
-///
-/// Sockets always use the platform's tunnel bypass, so a drain can never loop
-/// uploads through a tunnel: Apple's NetworkExtension sockets are excluded
-/// from its tunnel, and on Android the `ProtectSocket` callback `protect()`s
-/// each socket.
+/// Nudges a live session's uploader and returns; without one, runs a one-shot
+/// pass, blocking for it up to [`FLOW_LOG_DRAIN_TIMEOUT`]. Sockets always use
+/// the platform's tunnel bypass (Apple's NE sockets are excluded, Android
+/// `protect()`s each one), so a drain can never loop through a tunnel.
 #[uniffi::export]
 #[cfg(target_os = "android")]
 pub fn drain_flow_logs(spool_dir: String, protect_socket: Arc<dyn ProtectSocket>) {
@@ -787,18 +771,16 @@ fn do_drain_flow_logs(spool_dir: String, tcp: Arc<dyn SocketFactory<TcpSocket>>)
     *uploader = Some(one_shot.clone());
     drop(uploader);
 
-    // Outside the registry lock, so a concurrent `connect` is never blocked on
-    // our bounded wait.
+    // Wait outside the registry lock so a concurrent `connect` isn't blocked.
     one_shot.stop(Some(FLOW_LOG_DRAIN_TIMEOUT));
 }
 
-/// Longest we block for a flow-log drain: the one-shot in [`drain_flow_logs`]
-/// and the final flush when a session drops. Well within the 15-30s the OS
-/// grants `stopTunnel` on Apple.
+/// Longest a drain blocks (one-shot and session-drop flush); well within the
+/// 15-30s the OS grants `stopTunnel` on Apple.
 const FLOW_LOG_DRAIN_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// The one live uploader thread, if any: the session's while one exists, else
-/// the latest one-shot. Serializes drains: at most one thread uploads at a time.
+/// The one live uploader thread: the session's, else the latest one-shot.
+/// Serializes drains.
 static UPLOADER: std::sync::Mutex<Option<flow_log_upload::Uploader>> = std::sync::Mutex::new(None);
 
 fn lock_uploader() -> std::sync::MutexGuard<'static, Option<flow_log_upload::Uploader>> {

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -487,8 +487,16 @@ impl Drop for Session {
         // Android's app process outlives the session, so waiting would only
         // delay the disconnect.
         if let Some(uploader) = self.uploader.take() {
-            let flush = (!cfg!(target_os = "android")).then_some(FLOW_LOG_DRAIN_TIMEOUT);
+            // Android's app process outlives the session; not waiting keeps
+            // the disconnect prompt.
+            #[cfg(target_os = "android")]
+            let flush = None;
+            // The provider process may be reaped right after `stopTunnel`;
+            // block until the flush lands.
+            #[cfg(not(target_os = "android"))]
+            let flush = Some(FLOW_LOG_DRAIN_TIMEOUT);
 
+            uploader.nudge();
             uploader.stop(flush);
         }
     }
@@ -741,37 +749,47 @@ pub fn hash_device_id(id: String) -> String {
 ///
 /// A live session's uploader is nudged to upload now; the caller returns
 /// immediately, since that thread sticks around to see the upload through.
-/// Without one, a one-shot pass runs over plain sockets (no session means no
-/// tunnel of ours to bypass) and the call blocks until it completes, bounded to
-/// 10 seconds; the pass finishes in the background if it overruns.
+/// Without one, a one-shot pass runs and the call blocks until it completes,
+/// bounded to [`FLOW_LOG_DRAIN_TIMEOUT`]; the pass finishes in the background
+/// if it overruns.
+///
+/// Sockets always use the platform's tunnel bypass, so a drain can never loop
+/// uploads through a tunnel: Apple's NetworkExtension sockets are excluded
+/// from its tunnel, and on Android the `ProtectSocket` callback `protect()`s
+/// each socket.
 #[uniffi::export]
+#[cfg(target_os = "android")]
+pub fn drain_flow_logs(spool_dir: String, protect_socket: Arc<dyn ProtectSocket>) {
+    do_drain_flow_logs(
+        spool_dir,
+        Arc::new(protected_tcp_socket_factory(protect_socket)),
+    );
+}
+
+#[uniffi::export]
+#[cfg(not(target_os = "android"))]
 pub fn drain_flow_logs(spool_dir: String) {
+    do_drain_flow_logs(spool_dir, Arc::new(socket_factory::tcp));
+}
+
+fn do_drain_flow_logs(spool_dir: String, tcp: Arc<dyn SocketFactory<TcpSocket>>) {
     install_rustls_crypto_provider();
 
-    let one_shot = {
-        let mut uploader = lock_uploader();
+    let mut uploader = lock_uploader();
 
-        match uploader.as_ref() {
-            Some(uploader) if !uploader.is_finished() => {
-                uploader.nudge();
-                None
-            }
-            _ => {
-                let one_shot =
-                    flow_log_upload::spawn(PathBuf::from(spool_dir), Arc::new(socket_factory::tcp));
+    if let Some(uploader) = uploader.as_ref()
+        && uploader.nudge()
+    {
+        return;
+    }
 
-                *uploader = Some(one_shot.clone());
-
-                Some(one_shot)
-            }
-        }
-    };
+    let one_shot = flow_log_upload::spawn(PathBuf::from(spool_dir), tcp);
+    *uploader = Some(one_shot.clone());
+    drop(uploader);
 
     // Outside the registry lock, so a concurrent `connect` is never blocked on
     // our bounded wait.
-    if let Some(one_shot) = one_shot {
-        one_shot.stop(Some(FLOW_LOG_DRAIN_TIMEOUT));
-    }
+    one_shot.stop(Some(FLOW_LOG_DRAIN_TIMEOUT));
 }
 
 /// Longest we block for a flow-log drain: the one-shot in [`drain_flow_logs`]

--- a/rust/libs/flow-log-upload/Cargo.toml
+++ b/rust/libs/flow-log-upload/Cargo.toml
@@ -16,7 +16,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 socket-factory = { workspace = true }
-tokio = { workspace = true, features = ["rt", "net", "time"] }
+tokio = { workspace = true, features = ["macros", "rt", "net", "time", "sync"] }
 tracing = { workspace = true }
 tunnel-bypass-resolver = { workspace = true }
 url = { workspace = true }

--- a/rust/libs/flow-log-upload/Cargo.toml
+++ b/rust/libs/flow-log-upload/Cargo.toml
@@ -16,7 +16,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 socket-factory = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt", "net", "time", "sync"] }
+tokio = { workspace = true, features = ["rt", "net", "time"] }
 tracing = { workspace = true }
 tunnel-bypass-resolver = { workspace = true }
 url = { workspace = true }

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -12,10 +12,10 @@
 //! ambiguous failures retry the whole batch.
 //!
 //! Two drivers share this logic:
-//! - [`spawn`] runs a long-lived thread (gateway and desktop clients, whose tunnel
-//!   service is always running).
-//! - [`upload_once`] runs a single pass for platforms that drive uploads from an
-//!   OS background task via FFI.
+//! - [`spawn`] runs a long-lived thread that uploads on the portal's interval;
+//!   [`Uploader::nudge`] wakes it early for prompt drains.
+//! - [`upload_once`] runs a single pass for callers that have no uploader thread
+//!   (the Android app-launch drain).
 //!
 //! The async fns offload all disk IO to the blocking pool: the HTTP/2 connection
 //! driver shares their runtime, so stalling it would starve the connection.
@@ -24,7 +24,7 @@
 
 use std::{
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Condvar, Mutex, PoisonError},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -110,33 +110,86 @@ pub fn configure_uploads(
     Ok(())
 }
 
+/// Handle to a spawned uploader thread.
+///
+/// Dropping it detaches the thread; it keeps running until the process exits.
+pub struct Uploader {
+    thread: std::thread::JoinHandle<()>,
+    nudge: Arc<tokio::sync::Notify>,
+    passes: Arc<(Mutex<u64>, Condvar)>,
+}
+
+impl Uploader {
+    /// Whether the thread has exited (e.g. its runtime failed to build).
+    pub fn is_finished(&self) -> bool {
+        self.thread.is_finished()
+    }
+
+    /// Wakes the uploader to run a pass now instead of waiting out its interval.
+    ///
+    /// A nudge during a running pass is remembered and triggers another pass
+    /// right after it.
+    pub fn nudge(&self) {
+        self.nudge.notify_one();
+    }
+
+    /// [`Self::nudge`], then blocks until a pass completes or `timeout` elapses;
+    /// returns whether one completed.
+    ///
+    /// Best effort: a pass already in flight when this is called counts, and it
+    /// may have started before the caller's spool writes landed.
+    pub fn nudge_and_wait(&self, timeout: Duration) -> bool {
+        let (lock, condvar) = &*self.passes;
+        let guard = lock.lock().unwrap_or_else(PoisonError::into_inner);
+        let observed = *guard;
+
+        self.nudge();
+
+        match condvar.wait_timeout_while(guard, timeout, |passes| *passes <= observed) {
+            Ok((_, result)) => !result.timed_out(),
+            Err(poisoned) => *poisoned.into_inner().0 > observed,
+        }
+    }
+}
+
 /// Spawns the long-lived uploader thread.
 ///
 /// Prunes stale spool directories on start, re-reads the persisted config each
 /// pass and runs until the process exits.
-pub fn spawn(
-    spool_root: PathBuf,
-    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
-) -> std::thread::JoinHandle<()> {
-    std::thread::Builder::new()
+pub fn spawn(spool_root: PathBuf, socket_factory: Arc<dyn SocketFactory<TcpSocket>>) -> Uploader {
+    let nudge = Arc::new(tokio::sync::Notify::new());
+    let passes = Arc::new((Mutex::new(0_u64), Condvar::new()));
+
+    let thread = std::thread::Builder::new()
         .name("flow-log-uploader".to_owned())
-        .spawn(move || {
-            prune(&spool_root);
+        .spawn({
+            let nudge = nudge.clone();
+            let passes = passes.clone();
 
-            let runtime = match tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-            {
-                Ok(runtime) => runtime,
-                Err(e) => {
-                    tracing::error!("Failed to build flow-log uploader runtime: {e:#}");
-                    return;
-                }
-            };
+            move || {
+                prune(&spool_root);
 
-            runtime.block_on(run(&spool_root, socket_factory));
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(e) => {
+                        tracing::error!("Failed to build flow-log uploader runtime: {e:#}");
+                        return;
+                    }
+                };
+
+                runtime.block_on(run(&spool_root, socket_factory, &nudge, &passes));
+            }
         })
-        .expect("Failed to spawn flow-log uploader thread")
+        .expect("Failed to spawn flow-log uploader thread");
+
+    Uploader {
+        thread,
+        nudge,
+        passes,
+    }
 }
 
 /// Runs a single upload pass on the caller's runtime, for platforms that drive
@@ -388,7 +441,12 @@ fn ingest_endpoint(base_url: &str) -> Result<String> {
     Ok(url.to_string())
 }
 
-async fn run(spool_root: &Path, socket_factory: Arc<dyn SocketFactory<TcpSocket>>) {
+async fn run(
+    spool_root: &Path,
+    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+    nudge: &tokio::sync::Notify,
+    passes: &(Mutex<u64>, Condvar),
+) {
     tracing::info!("Flow-log uploader started");
 
     loop {
@@ -410,7 +468,16 @@ async fn run(spool_root: &Path, socket_factory: Arc<dyn SocketFactory<TcpSocket>
             }
         };
 
-        tokio::time::sleep(delay).await;
+        {
+            let (lock, condvar) = passes;
+            *lock.lock().unwrap_or_else(PoisonError::into_inner) += 1;
+            condvar.notify_all();
+        }
+
+        tokio::select! {
+            () = tokio::time::sleep(delay) => {}
+            () = nudge.notified() => {}
+        }
     }
 }
 
@@ -1112,6 +1179,16 @@ mod tests {
         assert_eq!(classify_response(StatusCode::BAD_REQUEST), Drop);
         assert_eq!(classify_response(StatusCode::UNAUTHORIZED), Drop);
         assert_eq!(classify_response(StatusCode::FORBIDDEN), Drop);
+    }
+
+    #[test]
+    fn nudge_and_wait_completes_a_pass_before_the_timeout() {
+        let root = tempfile::tempdir().unwrap();
+        let uploader = spawn(root.path().to_owned(), Arc::new(socket_factory::tcp));
+
+        // Unconfigured spool: without a nudge the next pass is DISABLED_POLL away.
+        assert!(uploader.nudge_and_wait(Duration::from_secs(10)));
+        assert!(!uploader.is_finished());
     }
 
     #[test]

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -11,11 +11,10 @@
 //! what it sent; submits are idempotent (the portal upserts by flow identity), so
 //! ambiguous failures retry the whole batch.
 //!
-//! Two drivers share this logic:
-//! - [`spawn`] runs a long-lived thread that uploads on the portal's interval;
-//!   [`Uploader::nudge`] wakes it early for prompt drains.
-//! - [`upload_once`] runs a single pass for callers that have no uploader thread
-//!   (the Android app-launch drain).
+//! [`spawn`] runs a long-lived thread that uploads on the portal's interval;
+//! [`Uploader::nudge`] wakes it early for prompt drains and
+//! [`Uploader::set_socket_factory`] swaps how it opens connections (e.g. to
+//! VPN-protected sockets while an Android session is up).
 //!
 //! The async fns offload all disk IO to the blocking pool: the HTTP/2 connection
 //! driver shares their runtime, so stalling it would starve the connection.
@@ -117,6 +116,7 @@ pub struct Uploader {
     thread: std::thread::JoinHandle<()>,
     nudge: Arc<tokio::sync::Notify>,
     passes: Arc<(Mutex<u64>, Condvar)>,
+    socket_factory: Arc<Mutex<Arc<dyn SocketFactory<TcpSocket>>>>,
 }
 
 impl Uploader {
@@ -131,6 +131,15 @@ impl Uploader {
     /// right after it.
     pub fn nudge(&self) {
         self.nudge.notify_one();
+    }
+
+    /// Swaps the socket factory used for subsequent passes; a pass in flight
+    /// finishes on the old one.
+    pub fn set_socket_factory(&self, socket_factory: Arc<dyn SocketFactory<TcpSocket>>) {
+        *self
+            .socket_factory
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = socket_factory;
     }
 
     /// [`Self::nudge`], then blocks until a pass completes or `timeout` elapses;
@@ -159,12 +168,14 @@ impl Uploader {
 pub fn spawn(spool_root: PathBuf, socket_factory: Arc<dyn SocketFactory<TcpSocket>>) -> Uploader {
     let nudge = Arc::new(tokio::sync::Notify::new());
     let passes = Arc::new((Mutex::new(0_u64), Condvar::new()));
+    let socket_factory = Arc::new(Mutex::new(socket_factory));
 
     let thread = std::thread::Builder::new()
         .name("flow-log-uploader".to_owned())
         .spawn({
             let nudge = nudge.clone();
             let passes = passes.clone();
+            let socket_factory = socket_factory.clone();
 
             move || {
                 prune(&spool_root);
@@ -180,7 +191,7 @@ pub fn spawn(spool_root: PathBuf, socket_factory: Arc<dyn SocketFactory<TcpSocke
                     }
                 };
 
-                runtime.block_on(run(&spool_root, socket_factory, &nudge, &passes));
+                runtime.block_on(run(&spool_root, &socket_factory, &nudge, &passes));
             }
         })
         .expect("Failed to spawn flow-log uploader thread");
@@ -189,33 +200,7 @@ pub fn spawn(spool_root: PathBuf, socket_factory: Arc<dyn SocketFactory<TcpSocke
         thread,
         nudge,
         passes,
-    }
-}
-
-/// Runs a single upload pass on the caller's runtime, for platforms that drive
-/// uploads from an OS background task via FFI.
-///
-/// Returns `true` when a backlog remained, so the caller may schedule another pass
-/// sooner.
-pub async fn upload_once(
-    spool_root: &Path,
-    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
-) -> bool {
-    let config = match load_upload_config(spool_root).await {
-        Ok(Some(config)) => config,
-        Ok(None) => return false,
-        Err(e) => {
-            tracing::error!("Failed to load flow-log upload config: {e:#}");
-            return false;
-        }
-    };
-
-    match upload_pending(spool_root, &config, socket_factory).await {
-        Ok(backlog) => backlog,
-        Err(e) => {
-            tracing::error!("Flow-log upload pass failed: {e:#}");
-            false
-        }
+        socket_factory,
     }
 }
 
@@ -443,24 +428,27 @@ fn ingest_endpoint(base_url: &str) -> Result<String> {
 
 async fn run(
     spool_root: &Path,
-    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+    socket_factory: &Mutex<Arc<dyn SocketFactory<TcpSocket>>>,
     nudge: &tokio::sync::Notify,
     passes: &(Mutex<u64>, Condvar),
 ) {
     tracing::info!("Flow-log uploader started");
 
     loop {
+        let socket_factory = socket_factory
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone();
+
         let delay = match load_upload_config(spool_root).await {
-            Ok(Some(config)) => {
-                match upload_pending(spool_root, &config, socket_factory.clone()).await {
-                    Ok(true) => CATCHUP_POLL,
-                    Ok(false) => config.interval,
-                    Err(e) => {
-                        tracing::error!("Flow-log upload pass failed: {e:#}");
-                        config.interval
-                    }
+            Ok(Some(config)) => match upload_pending(spool_root, &config, socket_factory).await {
+                Ok(true) => CATCHUP_POLL,
+                Ok(false) => config.interval,
+                Err(e) => {
+                    tracing::error!("Flow-log upload pass failed: {e:#}");
+                    config.interval
                 }
-            }
+            },
             Ok(None) => DISABLED_POLL,
             Err(e) => {
                 tracing::error!("Failed to load flow-log upload config: {e:#}");

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -11,12 +11,12 @@
 //! what it sent; submits are idempotent (the portal upserts by flow identity), so
 //! ambiguous failures retry the whole batch.
 //!
-//! Two drivers share this logic:
-//! - [`spawn`] runs a thread that uploads on the portal's interval, for as long
-//!   as flows are being produced: the process lifetime on the gateway and
-//!   desktop clients, the session lifetime on mobile ([`Uploader::stop`]).
-//! - [`upload_once`] runs a single pass for draining a spool with no thread
-//!   around (mobile out-of-session drains).
+//! [`spawn`] runs a thread that uploads on the portal's interval, for as long
+//! as flows are being produced: the process lifetime on the gateway and desktop
+//! clients, the session lifetime on mobile. [`Uploader::nudge`] skips the
+//! current interval for prompt drains, and [`Uploader::stop`] ends the thread
+//! after one final pass; spawning and stopping right away yields a one-shot
+//! drain.
 //!
 //! The async fns offload all disk IO to the blocking pool: the HTTP/2 connection
 //! driver shares their runtime, so stalling it would starve the connection.
@@ -117,20 +117,32 @@ pub fn configure_uploads(
 /// Handle to a spawned uploader thread.
 ///
 /// Dropping it detaches the thread; it keeps running until the process exits.
+#[derive(Clone)]
 pub struct Uploader {
+    thread: Arc<std::thread::JoinHandle<()>>,
     nudge: Arc<tokio::sync::Notify>,
     passes: Arc<(Mutex<u64>, Condvar)>,
     stop: Arc<AtomicBool>,
 }
 
 impl Uploader {
+    /// Whether the thread has exited (stopped, or its runtime failed to build).
+    pub fn is_finished(&self) -> bool {
+        self.thread.is_finished()
+    }
+
+    /// Wakes the uploader to run a pass now instead of waiting out its interval.
+    pub fn nudge(&self) {
+        self.nudge.notify_one();
+    }
+
     /// Wakes the uploader for one final pass, after which the thread exits.
     ///
     /// With `flush`, blocks until that pass completes or the timeout elapses;
     /// returns whether one completed. Best effort: a pass already in flight when
     /// this is called counts, and it may have started before the caller's spool
     /// writes landed.
-    pub fn stop(self, flush: Option<Duration>) -> bool {
+    pub fn stop(&self, flush: Option<Duration>) -> bool {
         let (lock, condvar) = &*self.passes;
         let guard = lock.lock().unwrap_or_else(PoisonError::into_inner);
         let observed = *guard;
@@ -158,7 +170,7 @@ pub fn spawn(spool_root: PathBuf, socket_factory: Arc<dyn SocketFactory<TcpSocke
     let passes = Arc::new((Mutex::new(0_u64), Condvar::new()));
     let stop = Arc::new(AtomicBool::new(false));
 
-    std::thread::Builder::new()
+    let thread = std::thread::Builder::new()
         .name("flow-log-uploader".to_owned())
         .spawn({
             let nudge = nudge.clone();
@@ -185,36 +197,10 @@ pub fn spawn(spool_root: PathBuf, socket_factory: Arc<dyn SocketFactory<TcpSocke
         .expect("Failed to spawn flow-log uploader thread");
 
     Uploader {
+        thread: Arc::new(thread),
         nudge,
         passes,
         stop,
-    }
-}
-
-/// Runs a single upload pass on the caller's runtime, for draining a spool with
-/// no uploader thread around.
-///
-/// Returns `true` when a backlog remained, so the caller may schedule another pass
-/// sooner.
-pub async fn upload_once(
-    spool_root: &Path,
-    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
-) -> bool {
-    let config = match load_upload_config(spool_root).await {
-        Ok(Some(config)) => config,
-        Ok(None) => return false,
-        Err(e) => {
-            tracing::error!("Failed to load flow-log upload config: {e:#}");
-            return false;
-        }
-    };
-
-    match upload_pending(spool_root, &config, socket_factory).await {
-        Ok(backlog) => backlog,
-        Err(e) => {
-            tracing::error!("Flow-log upload pass failed: {e:#}");
-            false
-        }
     }
 }
 

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -11,10 +11,12 @@
 //! what it sent; submits are idempotent (the portal upserts by flow identity), so
 //! ambiguous failures retry the whole batch.
 //!
-//! [`spawn`] runs a long-lived thread that uploads on the portal's interval;
-//! [`Uploader::nudge`] wakes it early for prompt drains and
-//! [`Uploader::set_socket_factory`] swaps how it opens connections (e.g. to
-//! VPN-protected sockets while an Android session is up).
+//! Two drivers share this logic:
+//! - [`spawn`] runs a thread that uploads on the portal's interval, for as long
+//!   as flows are being produced: the process lifetime on the gateway and
+//!   desktop clients, the session lifetime on mobile ([`Uploader::stop`]).
+//! - [`upload_once`] runs a single pass for draining a spool with no thread
+//!   around (mobile out-of-session drains).
 //!
 //! The async fns offload all disk IO to the blocking pool: the HTTP/2 connection
 //! driver shares their runtime, so stalling it would starve the connection.
@@ -23,7 +25,10 @@
 
 use std::{
     path::{Path, PathBuf},
-    sync::{Arc, Condvar, Mutex, PoisonError},
+    sync::{
+        Arc, Condvar, Mutex, PoisonError,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -113,46 +118,29 @@ pub fn configure_uploads(
 ///
 /// Dropping it detaches the thread; it keeps running until the process exits.
 pub struct Uploader {
-    thread: std::thread::JoinHandle<()>,
     nudge: Arc<tokio::sync::Notify>,
     passes: Arc<(Mutex<u64>, Condvar)>,
-    socket_factory: Arc<Mutex<Arc<dyn SocketFactory<TcpSocket>>>>,
+    stop: Arc<AtomicBool>,
 }
 
 impl Uploader {
-    /// Whether the thread has exited (e.g. its runtime failed to build).
-    pub fn is_finished(&self) -> bool {
-        self.thread.is_finished()
-    }
-
-    /// Wakes the uploader to run a pass now instead of waiting out its interval.
+    /// Wakes the uploader for one final pass, after which the thread exits.
     ///
-    /// A nudge during a running pass is remembered and triggers another pass
-    /// right after it.
-    pub fn nudge(&self) {
-        self.nudge.notify_one();
-    }
-
-    /// Swaps the socket factory used for subsequent passes; a pass in flight
-    /// finishes on the old one.
-    pub fn set_socket_factory(&self, socket_factory: Arc<dyn SocketFactory<TcpSocket>>) {
-        *self
-            .socket_factory
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner) = socket_factory;
-    }
-
-    /// [`Self::nudge`], then blocks until a pass completes or `timeout` elapses;
-    /// returns whether one completed.
-    ///
-    /// Best effort: a pass already in flight when this is called counts, and it
-    /// may have started before the caller's spool writes landed.
-    pub fn nudge_and_wait(&self, timeout: Duration) -> bool {
+    /// With `flush`, blocks until that pass completes or the timeout elapses;
+    /// returns whether one completed. Best effort: a pass already in flight when
+    /// this is called counts, and it may have started before the caller's spool
+    /// writes landed.
+    pub fn stop(self, flush: Option<Duration>) -> bool {
         let (lock, condvar) = &*self.passes;
         let guard = lock.lock().unwrap_or_else(PoisonError::into_inner);
         let observed = *guard;
 
-        self.nudge();
+        self.stop.store(true, Ordering::Relaxed);
+        self.nudge.notify_one();
+
+        let Some(timeout) = flush else {
+            return false;
+        };
 
         match condvar.wait_timeout_while(guard, timeout, |passes| *passes <= observed) {
             Ok((_, result)) => !result.timed_out(),
@@ -161,21 +149,21 @@ impl Uploader {
     }
 }
 
-/// Spawns the long-lived uploader thread.
+/// Spawns the uploader thread.
 ///
-/// Prunes stale spool directories on start, re-reads the persisted config each
-/// pass and runs until the process exits.
+/// Prunes stale spool directories on start and re-reads the persisted config
+/// each pass. Runs until the process exits, or until [`Uploader::stop`].
 pub fn spawn(spool_root: PathBuf, socket_factory: Arc<dyn SocketFactory<TcpSocket>>) -> Uploader {
     let nudge = Arc::new(tokio::sync::Notify::new());
     let passes = Arc::new((Mutex::new(0_u64), Condvar::new()));
-    let socket_factory = Arc::new(Mutex::new(socket_factory));
+    let stop = Arc::new(AtomicBool::new(false));
 
-    let thread = std::thread::Builder::new()
+    std::thread::Builder::new()
         .name("flow-log-uploader".to_owned())
         .spawn({
             let nudge = nudge.clone();
             let passes = passes.clone();
-            let socket_factory = socket_factory.clone();
+            let stop = stop.clone();
 
             move || {
                 prune(&spool_root);
@@ -191,16 +179,42 @@ pub fn spawn(spool_root: PathBuf, socket_factory: Arc<dyn SocketFactory<TcpSocke
                     }
                 };
 
-                runtime.block_on(run(&spool_root, &socket_factory, &nudge, &passes));
+                runtime.block_on(run(&spool_root, socket_factory, &nudge, &passes, &stop));
             }
         })
         .expect("Failed to spawn flow-log uploader thread");
 
     Uploader {
-        thread,
         nudge,
         passes,
-        socket_factory,
+        stop,
+    }
+}
+
+/// Runs a single upload pass on the caller's runtime, for draining a spool with
+/// no uploader thread around.
+///
+/// Returns `true` when a backlog remained, so the caller may schedule another pass
+/// sooner.
+pub async fn upload_once(
+    spool_root: &Path,
+    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+) -> bool {
+    let config = match load_upload_config(spool_root).await {
+        Ok(Some(config)) => config,
+        Ok(None) => return false,
+        Err(e) => {
+            tracing::error!("Failed to load flow-log upload config: {e:#}");
+            return false;
+        }
+    };
+
+    match upload_pending(spool_root, &config, socket_factory).await {
+        Ok(backlog) => backlog,
+        Err(e) => {
+            tracing::error!("Flow-log upload pass failed: {e:#}");
+            false
+        }
     }
 }
 
@@ -428,27 +442,25 @@ fn ingest_endpoint(base_url: &str) -> Result<String> {
 
 async fn run(
     spool_root: &Path,
-    socket_factory: &Mutex<Arc<dyn SocketFactory<TcpSocket>>>,
+    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     nudge: &tokio::sync::Notify,
     passes: &(Mutex<u64>, Condvar),
+    stop: &AtomicBool,
 ) {
     tracing::info!("Flow-log uploader started");
 
     loop {
-        let socket_factory = socket_factory
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .clone();
-
         let delay = match load_upload_config(spool_root).await {
-            Ok(Some(config)) => match upload_pending(spool_root, &config, socket_factory).await {
-                Ok(true) => CATCHUP_POLL,
-                Ok(false) => config.interval,
-                Err(e) => {
-                    tracing::error!("Flow-log upload pass failed: {e:#}");
-                    config.interval
+            Ok(Some(config)) => {
+                match upload_pending(spool_root, &config, socket_factory.clone()).await {
+                    Ok(true) => CATCHUP_POLL,
+                    Ok(false) => config.interval,
+                    Err(e) => {
+                        tracing::error!("Flow-log upload pass failed: {e:#}");
+                        config.interval
+                    }
                 }
-            },
+            }
             Ok(None) => DISABLED_POLL,
             Err(e) => {
                 tracing::error!("Failed to load flow-log upload config: {e:#}");
@@ -460,6 +472,12 @@ async fn run(
             let (lock, condvar) = passes;
             *lock.lock().unwrap_or_else(PoisonError::into_inner) += 1;
             condvar.notify_all();
+        }
+
+        // Checked after the pass, so a stop always gets its final flush.
+        if stop.load(Ordering::Relaxed) {
+            tracing::info!("Flow-log uploader stopped");
+            return;
         }
 
         tokio::select! {
@@ -1170,13 +1188,21 @@ mod tests {
     }
 
     #[test]
-    fn nudge_and_wait_completes_a_pass_before_the_timeout() {
+    fn stop_flushes_a_final_pass_before_the_timeout() {
         let root = tempfile::tempdir().unwrap();
         let uploader = spawn(root.path().to_owned(), Arc::new(socket_factory::tcp));
 
-        // Unconfigured spool: without a nudge the next pass is DISABLED_POLL away.
-        assert!(uploader.nudge_and_wait(Duration::from_secs(10)));
-        assert!(!uploader.is_finished());
+        // Unconfigured spool: without the stop nudge the next pass is
+        // DISABLED_POLL away.
+        assert!(uploader.stop(Some(Duration::from_secs(10))));
+    }
+
+    #[test]
+    fn stop_without_flush_returns_immediately() {
+        let root = tempfile::tempdir().unwrap();
+        let uploader = spawn(root.path().to_owned(), Arc::new(socket_factory::tcp));
+
+        assert!(!uploader.stop(None));
     }
 
     #[test]

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -13,10 +13,10 @@
 //!
 //! [`spawn`] runs a thread that uploads on the portal's interval, for as long
 //! as flows are being produced: the process lifetime on the gateway and desktop
-//! clients, the session lifetime on mobile. [`Uploader::nudge`] skips the
-//! current interval for prompt drains, and [`Uploader::stop`] ends the thread
-//! after one final pass; spawning and stopping right away yields a one-shot
-//! drain.
+//! clients, the session lifetime on mobile. The thread is driven by messages:
+//! [`Uploader::nudge`] skips the current interval for a prompt drain, and
+//! [`Uploader::stop`] ends the thread once queued work is done; spawning and
+//! stopping right away yields a one-shot drain.
 //!
 //! The async fns offload all disk IO to the blocking pool: the HTTP/2 connection
 //! driver shares their runtime, so stalling it would starve the connection.
@@ -25,10 +25,7 @@
 
 use std::{
     path::{Path, PathBuf},
-    sync::{
-        Arc, Condvar, Mutex, PoisonError,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, mpsc},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -119,88 +116,131 @@ pub fn configure_uploads(
 /// Dropping it detaches the thread; it keeps running until the process exits.
 #[derive(Clone)]
 pub struct Uploader {
-    thread: Arc<std::thread::JoinHandle<()>>,
-    nudge: Arc<tokio::sync::Notify>,
-    passes: Arc<(Mutex<u64>, Condvar)>,
-    stop: Arc<AtomicBool>,
+    commands: mpsc::Sender<Command>,
+}
+
+enum Command {
+    /// Run an upload pass now instead of waiting out the interval.
+    Upload,
+    /// Exit the thread, acknowledging on `done` first.
+    Shutdown { done: mpsc::Sender<()> },
 }
 
 impl Uploader {
-    /// Whether the thread has exited (stopped, or its runtime failed to build).
-    pub fn is_finished(&self) -> bool {
-        self.thread.is_finished()
+    /// Wakes the uploader to run a pass now instead of waiting out its
+    /// interval; returns whether the thread was alive to see it. A nudge
+    /// during a running pass is handled right after it.
+    pub fn nudge(&self) -> bool {
+        self.commands.send(Command::Upload).is_ok()
     }
 
-    /// Wakes the uploader to run a pass now instead of waiting out its interval.
-    pub fn nudge(&self) {
-        self.nudge.notify_one();
-    }
-
-    /// Wakes the uploader for one final pass, after which the thread exits.
+    /// Stops the thread once it has worked off everything already queued, e.g.
+    /// a preceding [`Self::nudge`]'s pass.
     ///
-    /// With `flush`, blocks until that pass completes or the timeout elapses;
-    /// returns whether one completed. Best effort: a pass already in flight when
-    /// this is called counts, and it may have started before the caller's spool
-    /// writes landed.
+    /// With `flush`, blocks until the thread acknowledges or the timeout
+    /// elapses; returns whether it acknowledged.
     pub fn stop(&self, flush: Option<Duration>) -> bool {
-        let (lock, condvar) = &*self.passes;
-        let guard = lock.lock().unwrap_or_else(PoisonError::into_inner);
-        let observed = *guard;
+        let (done, acked) = mpsc::channel();
 
-        self.stop.store(true, Ordering::Relaxed);
-        self.nudge.notify_one();
+        if self.commands.send(Command::Shutdown { done }).is_err() {
+            return false;
+        }
 
         let Some(timeout) = flush else {
             return false;
         };
 
-        match condvar.wait_timeout_while(guard, timeout, |passes| *passes <= observed) {
-            Ok((_, result)) => !result.timed_out(),
-            Err(poisoned) => *poisoned.into_inner().0 > observed,
-        }
+        acked.recv_timeout(timeout).is_ok()
     }
 }
 
-/// Spawns the uploader thread.
+/// Spawns the uploader thread with an immediate first pass queued.
 ///
 /// Prunes stale spool directories on start and re-reads the persisted config
 /// each pass. Runs until the process exits, or until [`Uploader::stop`].
 pub fn spawn(spool_root: PathBuf, socket_factory: Arc<dyn SocketFactory<TcpSocket>>) -> Uploader {
-    let nudge = Arc::new(tokio::sync::Notify::new());
-    let passes = Arc::new((Mutex::new(0_u64), Condvar::new()));
-    let stop = Arc::new(AtomicBool::new(false));
+    let (commands, inbox) = mpsc::channel();
 
-    let thread = std::thread::Builder::new()
+    let uploader = Uploader { commands };
+    uploader.nudge();
+
+    std::thread::Builder::new()
         .name("flow-log-uploader".to_owned())
         .spawn({
-            let nudge = nudge.clone();
-            let passes = passes.clone();
-            let stop = stop.clone();
+            // The thread holds a sender too, so dropping the handle detaches
+            // the thread instead of stopping it (gateway and desktop clients
+            // drop it right away and rely on the process lifetime).
+            let keep_alive = uploader.clone();
 
             move || {
+                let _keep_alive = keep_alive;
+
                 prune(&spool_root);
-
-                let runtime = match tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                {
-                    Ok(runtime) => runtime,
-                    Err(e) => {
-                        tracing::error!("Failed to build flow-log uploader runtime: {e:#}");
-                        return;
-                    }
-                };
-
-                runtime.block_on(run(&spool_root, socket_factory, &nudge, &passes, &stop));
+                run(&spool_root, socket_factory, &inbox);
             }
         })
         .expect("Failed to spawn flow-log uploader thread");
 
-    Uploader {
-        thread: Arc::new(thread),
-        nudge,
-        passes,
-        stop,
+    uploader
+}
+
+/// The uploader's event loop: sleeps until the next interval or an earlier
+/// [`Command`], then acts on whichever arrived.
+fn run(
+    spool_root: &Path,
+    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+    commands: &mpsc::Receiver<Command>,
+) {
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            tracing::error!("Failed to build flow-log uploader runtime: {e:#}");
+            return;
+        }
+    };
+
+    tracing::info!("Flow-log uploader started");
+
+    let mut delay = DISABLED_POLL;
+
+    loop {
+        match commands.recv_timeout(delay) {
+            Ok(Command::Upload) | Err(mpsc::RecvTimeoutError::Timeout) => {
+                delay = runtime.block_on(upload_pass(spool_root, socket_factory.clone()));
+            }
+            Ok(Command::Shutdown { done }) => {
+                let _ = done.send(());
+                tracing::info!("Flow-log uploader stopped");
+                return;
+            }
+            // Unreachable while the thread holds its own sender.
+            Err(mpsc::RecvTimeoutError::Disconnected) => return,
+        }
+    }
+}
+
+/// Runs one upload pass; returns how long to wait before the next.
+async fn upload_pass(
+    spool_root: &Path,
+    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+) -> Duration {
+    match load_upload_config(spool_root).await {
+        Ok(Some(config)) => match upload_pending(spool_root, &config, socket_factory).await {
+            Ok(true) => CATCHUP_POLL,
+            Ok(false) => config.interval,
+            Err(e) => {
+                tracing::error!("Flow-log upload pass failed: {e:#}");
+                config.interval
+            }
+        },
+        Ok(None) => DISABLED_POLL,
+        Err(e) => {
+            tracing::error!("Failed to load flow-log upload config: {e:#}");
+            DISABLED_POLL
+        }
     }
 }
 
@@ -424,53 +464,6 @@ fn ingest_endpoint(base_url: &str) -> Result<String> {
         .with_context(|| format!("Invalid flow-log API URL `{base_url}`"))?;
 
     Ok(url.to_string())
-}
-
-async fn run(
-    spool_root: &Path,
-    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
-    nudge: &tokio::sync::Notify,
-    passes: &(Mutex<u64>, Condvar),
-    stop: &AtomicBool,
-) {
-    tracing::info!("Flow-log uploader started");
-
-    loop {
-        let delay = match load_upload_config(spool_root).await {
-            Ok(Some(config)) => {
-                match upload_pending(spool_root, &config, socket_factory.clone()).await {
-                    Ok(true) => CATCHUP_POLL,
-                    Ok(false) => config.interval,
-                    Err(e) => {
-                        tracing::error!("Flow-log upload pass failed: {e:#}");
-                        config.interval
-                    }
-                }
-            }
-            Ok(None) => DISABLED_POLL,
-            Err(e) => {
-                tracing::error!("Failed to load flow-log upload config: {e:#}");
-                DISABLED_POLL
-            }
-        };
-
-        {
-            let (lock, condvar) = passes;
-            *lock.lock().unwrap_or_else(PoisonError::into_inner) += 1;
-            condvar.notify_all();
-        }
-
-        // Checked after the pass, so a stop always gets its final flush.
-        if stop.load(Ordering::Relaxed) {
-            tracing::info!("Flow-log uploader stopped");
-            return;
-        }
-
-        tokio::select! {
-            () = tokio::time::sleep(delay) => {}
-            () = nudge.notified() => {}
-        }
-    }
 }
 
 /// Opens a tunnel-bypassing HTTP client to the ingest host, re-resolved each pass
@@ -1174,12 +1167,10 @@ mod tests {
     }
 
     #[test]
-    fn stop_flushes_a_final_pass_before_the_timeout() {
+    fn stop_acks_after_queued_passes_before_the_timeout() {
         let root = tempfile::tempdir().unwrap();
         let uploader = spawn(root.path().to_owned(), Arc::new(socket_factory::tcp));
 
-        // Unconfigured spool: without the stop nudge the next pass is
-        // DISABLED_POLL away.
         assert!(uploader.stop(Some(Duration::from_secs(10))));
     }
 
@@ -1189,6 +1180,25 @@ mod tests {
         let uploader = spawn(root.path().to_owned(), Arc::new(socket_factory::tcp));
 
         assert!(!uploader.stop(None));
+    }
+
+    #[test]
+    fn nudge_reports_whether_the_thread_is_alive() {
+        let root = tempfile::tempdir().unwrap();
+        let uploader = spawn(root.path().to_owned(), Arc::new(socket_factory::tcp));
+
+        assert!(uploader.nudge());
+        assert!(uploader.stop(Some(Duration::from_secs(10))));
+
+        // The ack precedes the thread dropping its receiver by an instant.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while uploader.nudge() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "thread should exit after stop"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
     }
 
     #[test]

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -12,11 +12,10 @@
 //! ambiguous failures retry the whole batch.
 //!
 //! [`spawn`] runs a thread that uploads on the portal's interval, for as long
-//! as flows are being produced: the process lifetime on the gateway and desktop
-//! clients, the session lifetime on mobile. The thread is driven by messages:
-//! [`Uploader::nudge`] skips the current interval for a prompt drain, and
-//! [`Uploader::stop`] ends the thread once queued work is done; spawning and
-//! stopping right away yields a one-shot drain.
+//! as flows are being produced: process lifetime on the gateway and desktop
+//! clients, session lifetime on mobile. [`Uploader::nudge`] skips the current
+//! interval; [`Uploader::stop`] ends the thread; spawning and stopping right
+//! away yields a one-shot drain.
 //!
 //! The async fns offload all disk IO to the blocking pool: the HTTP/2 connection
 //! driver shares their runtime, so stalling it would starve the connection.
@@ -127,18 +126,14 @@ enum Command {
 }
 
 impl Uploader {
-    /// Wakes the uploader to run a pass now instead of waiting out its
-    /// interval; returns whether the thread was alive to see it. A nudge
-    /// during a running pass is handled right after it.
+    /// Wakes the uploader to run a pass now; returns whether the thread was
+    /// alive to see it.
     pub fn nudge(&self) -> bool {
         self.commands.send(Command::Upload).is_ok()
     }
 
-    /// Stops the thread once it has worked off everything already queued, e.g.
-    /// a preceding [`Self::nudge`]'s pass.
-    ///
-    /// With `flush`, blocks until the thread acknowledges or the timeout
-    /// elapses; returns whether it acknowledged.
+    /// Stops the thread once already-queued work (e.g. a nudge's pass) is done.
+    /// With `flush`, blocks until it acknowledges or the timeout elapses.
     pub fn stop(&self, flush: Option<Duration>) -> bool {
         let (done, acked) = mpsc::channel();
 
@@ -154,10 +149,8 @@ impl Uploader {
     }
 }
 
-/// Spawns the uploader thread with an immediate first pass queued.
-///
-/// Prunes stale spool directories on start and re-reads the persisted config
-/// each pass. Runs until the process exits, or until [`Uploader::stop`].
+/// Spawns the uploader thread with an immediate first pass queued; it prunes
+/// the spool on start and re-reads the persisted config each pass.
 pub fn spawn(spool_root: PathBuf, socket_factory: Arc<dyn SocketFactory<TcpSocket>>) -> Uploader {
     let (commands, inbox) = mpsc::channel();
 
@@ -168,8 +161,7 @@ pub fn spawn(spool_root: PathBuf, socket_factory: Arc<dyn SocketFactory<TcpSocke
         .name("flow-log-uploader".to_owned())
         .spawn({
             // The thread holds a sender too, so dropping the handle detaches
-            // the thread instead of stopping it (gateway and desktop clients
-            // drop it right away and rely on the process lifetime).
+            // rather than stops it (gateway and desktop drop it right away).
             let keep_alive = uploader.clone();
 
             move || {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
@@ -83,6 +83,20 @@ public struct SharedAccess {
     return nil
   }
 
+  // Spool directory for flow logs the tunnel writes and uploads. Kept under
+  // Application Support (persistent state, not cache) and outside the log folder so
+  // an exported log bundle never sweeps it up.
+  public static var flowLogsFolderURL: URL? {
+    if let url = applicationSupportFolderURL?.appendingPathComponent("flow_logs") {
+      guard ensureDirectoryExists(at: url.path) else {
+        return nil
+      }
+      return url
+    }
+    NSLog("Can't access applicationSupportFolderURL to create flowLogsFolderURL")
+    return nil
+  }
+
   public static var providerStopReasonURL: URL {
     baseFolderURL.appendingPathComponent("reason")
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
@@ -83,9 +83,8 @@ public struct SharedAccess {
     return nil
   }
 
-  // Spool directory for flow logs the tunnel writes and uploads. Kept under
-  // Application Support (persistent state, not cache) and outside the log folder so
-  // an exported log bundle never sweeps it up.
+  // Under Application Support (persistent) and outside the log folder so
+  // exported log bundles never sweep the spool up.
   public static var flowLogsFolderURL: URL? {
     if let url = applicationSupportFolderURL?.appendingPathComponent("flow_logs") {
       guard ensureDirectoryExists(at: url.path) else {

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -167,6 +167,7 @@ actor Adapter {
     #endif
 
     let logDir = SharedAccess.connlibLogFolderURL?.path ?? "/tmp/firezone"
+    let flowLogsDir = SharedAccess.flowLogsFolderURL?.path
 
     #if os(iOS)
       let deviceInfo = DeviceInfo(
@@ -195,6 +196,7 @@ actor Adapter {
         deviceName: deviceName,
         logDir: logDir,
         logFilter: logFilter,
+        flowLogsDir: flowLogsDir,
         deviceInfo: deviceInfo,
         isInternetResourceActive: internetResourceEnabled
       )


### PR DESCRIPTION
The gateway and desktop clients already spool flow logs and upload them. The mobile apps couldn't: client-ffi never passed a spool directory to the session, never installed the layer that writes reports to the spool, and didn't expose the uploader.

The session constructors now take a flow-logs directory and the writer layer is installed, so the Apple and Android tunnels spool reports. The uploader thread lives and dies with the session and is driven by a command channel: connect spawns it with the session's tunnel-bypassing sockets, and dropping the session nudges one final upload pass before the thread exits, blocking briefly on Apple where the provider process may be reaped right after stopTunnel.

The only other entry point is drain_flow_logs, called when the app foregrounds: it nudges the session's uploader to upload now, or runs a one-shot pass bounded to ten seconds when no thread is alive. Drains always use the platform's tunnel bypass (plain sockets on Apple, the ProtectSocket callback on Android), and a registry of the one live thread keeps drains serialized.

Supersedes #13921 with its review feedback applied.