### PR TITLE
feat(portal): persist attested device fields on session flush

### DIFF
--- a/elixir/lib/portal/device.ex
+++ b/elixir/lib/portal/device.ex
@@ -23,6 +23,7 @@ defmodule Portal.Device do
     last_seen_remote_ip_location_lon
     last_seen_version
     last_seen_at
+    last_attested_at
     client_token_id
     gateway_token_id
   ]a
@@ -64,6 +65,7 @@ defmodule Portal.Device do
           last_attested_mdm_device_id: String.t() | nil,
           last_attested_cert_serial: String.t() | nil,
           last_attested_cert_fingerprint: String.t() | nil,
+          last_attested_at: DateTime.t() | nil,
           verified_at: DateTime.t() | nil,
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
@@ -97,6 +99,11 @@ defmodule Portal.Device do
     field :last_attested_mdm_device_id, :string
     field :last_attested_cert_serial, :string
     field :last_attested_cert_fingerprint, :string
+    # When the device last proved possession of an MDM-provisioned client
+    # certificate. Point-in-time history, never cleared by the flush; whether
+    # the CURRENT session proved possession is live connection state (the
+    # `attested?` presence attribute).
+    field :last_attested_at, :utc_datetime_usec
     field :verified_at, :utc_datetime_usec
 
     # Gateway-only

--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -2593,6 +2593,12 @@ defmodule PortalAPI.Client.Channel.Shared do
       # the flush's coalesce keeps the row's current value on nil, and the
       # conflict probe then runs only for real merges instead of every flush.
       firezone_id: if(client.firezone_id_merged?, do: client.firezone_id),
+      last_attested_device_serial: client.last_attested_device_serial,
+      last_attested_device_uuid: client.last_attested_device_uuid,
+      last_attested_mdm_device_id: client.last_attested_mdm_device_id,
+      last_attested_cert_serial: client.last_attested_cert_serial,
+      last_attested_cert_fingerprint: client.last_attested_cert_fingerprint,
+      last_attested_at: client.last_attested_at,
       client_token_id: client.client_token_id,
       public_key: client.public_key,
       user_agent: client.last_seen_user_agent,

--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -2528,7 +2528,11 @@ defmodule PortalAPI.Client.Channel.Shared do
         if is_nil(current_pid) do
           Portal.Queue.enqueue(
             :client_session_queue,
-            session_attrs(socket.assigns.client, socket.assigns.session_ref),
+            session_attrs(
+              socket.assigns.client,
+              socket.assigns.session_ref,
+              socket.assigns[:attested?] || false
+            ),
             metadata: %{
               subject: Authentication.Subject.to_map(socket.assigns.subject),
               timestamp: DateTime.utc_now()
@@ -2583,7 +2587,26 @@ defmodule PortalAPI.Client.Channel.Shared do
     end
   end
 
-  defp session_attrs(%Portal.Device{} = client, session_ref) do
+  defp session_attrs(%Portal.Device{} = client, session_ref, attested?) do
+    # The attested snapshot is carried only when THIS session proved
+    # possession (the v3 challenge sets the assign). Copying it off the row
+    # for every session would re-assert a stale snapshot and race a fresher
+    # proof flushing from another session; the flush's recency guard keeps
+    # the row's values when the entry carries none.
+    attested_attrs =
+      if attested? do
+        %{
+          last_attested_device_serial: client.last_attested_device_serial,
+          last_attested_device_uuid: client.last_attested_device_uuid,
+          last_attested_mdm_device_id: client.last_attested_mdm_device_id,
+          last_attested_cert_serial: client.last_attested_cert_serial,
+          last_attested_cert_fingerprint: client.last_attested_cert_fingerprint,
+          last_attested_at: client.last_attested_at
+        }
+      else
+        %{}
+      end
+
     %{
       session_ref: session_ref,
       account_id: client.account_id,
@@ -2593,12 +2616,6 @@ defmodule PortalAPI.Client.Channel.Shared do
       # the flush's coalesce keeps the row's current value on nil, and the
       # conflict probe then runs only for real merges instead of every flush.
       firezone_id: if(client.firezone_id_merged?, do: client.firezone_id),
-      last_attested_device_serial: client.last_attested_device_serial,
-      last_attested_device_uuid: client.last_attested_device_uuid,
-      last_attested_mdm_device_id: client.last_attested_mdm_device_id,
-      last_attested_cert_serial: client.last_attested_cert_serial,
-      last_attested_cert_fingerprint: client.last_attested_cert_fingerprint,
-      last_attested_at: client.last_attested_at,
       client_token_id: client.client_token_id,
       public_key: client.public_key,
       user_agent: client.last_seen_user_agent,
@@ -2609,6 +2626,7 @@ defmodule PortalAPI.Client.Channel.Shared do
       remote_ip_location_lon: client.last_seen_remote_ip_location_lon,
       version: client.last_seen_version
     }
+    |> Map.merge(attested_attrs)
   end
 
   defp abnormal_exit?(:normal), do: false

--- a/elixir/lib/portal_api/client/device_trust.ex
+++ b/elixir/lib/portal_api/client/device_trust.ex
@@ -32,6 +32,11 @@ defmodule PortalAPI.Client.DeviceTrust do
   @max_cert_bytes 16_384
   @max_signature_bytes 1_024
   @max_chain_depth 4
+  # Real device identifiers top out around 40 characters (UUIDs, UDIDs,
+  # serials); anything longer is garbage and would otherwise overflow the
+  # varchar(255) device columns during the bulk session flush, which bypasses
+  # changeset validation.
+  @max_identifier_bytes 64
 
   # Typed URI SAN idtypes: firezone://<idtype>/<value>
   @idtype_columns %{
@@ -204,9 +209,22 @@ defmodule PortalAPI.Client.DeviceTrust do
         {:ok,
          %{
            identifiers: identifiers,
-           last_attested_cert_serial: leaf_otp |> X509.serial_number() |> Integer.to_string(16),
+           last_attested_cert_serial: format_cert_serial(leaf_otp),
            last_attested_cert_fingerprint: sha256_hex(leaf_der)
          }}
+    end
+  end
+
+  # RFC 5280 caps serial numbers at 20 octets (40 hex chars); an out-of-spec
+  # serial is dropped rather than overflowing the varchar(255) device column
+  # during the bulk session flush. The fingerprint remains the pin.
+  defp format_cert_serial(leaf_otp) do
+    serial = leaf_otp |> X509.serial_number() |> Integer.to_string(16)
+
+    if byte_size(serial) <= @max_identifier_bytes do
+      serial
+    else
+      nil
     end
   end
 
@@ -434,6 +452,7 @@ defmodule PortalAPI.Client.DeviceTrust do
     value = String.trim(value)
 
     cond do
+      byte_size(value) > @max_identifier_bytes -> nil
       not Regex.match?(@printable_ascii_regex, value) -> nil
       column == :last_attested_device_serial -> normalize_serial(value)
       column == :last_attested_device_uuid -> normalize_uuid(value)

--- a/elixir/lib/portal_api/client/device_trust.ex
+++ b/elixir/lib/portal_api/client/device_trust.ex
@@ -32,11 +32,11 @@ defmodule PortalAPI.Client.DeviceTrust do
   @max_cert_bytes 16_384
   @max_signature_bytes 1_024
   @max_chain_depth 4
-  # Real device identifiers top out around 40 characters (UUIDs, UDIDs,
-  # serials); anything longer is garbage and would otherwise overflow the
-  # varchar(255) device columns during the bulk session flush, which bypasses
-  # changeset validation.
-  @max_identifier_bytes 64
+  # Matches the varchar(255) device columns: the bulk session flush bypasses
+  # changeset validation, so an oversized value would abort the whole batch.
+  # This bound only protects the columns; garbage screening is the
+  # blocklists' job.
+  @max_identifier_bytes 255
 
   # Typed URI SAN idtypes: firezone://<idtype>/<value>
   @idtype_columns %{
@@ -215,9 +215,9 @@ defmodule PortalAPI.Client.DeviceTrust do
     end
   end
 
-  # RFC 5280 caps serial numbers at 20 octets (40 hex chars); an out-of-spec
-  # serial is dropped rather than overflowing the varchar(255) device column
-  # during the bulk session flush. The fingerprint remains the pin.
+  # A conforming serial is at most 20 octets (RFC 5280), but the column is
+  # the real bound: a serial that cannot fit varchar(255) is dropped rather
+  # than aborting the bulk session flush. The fingerprint remains the pin.
   defp format_cert_serial(leaf_otp) do
     serial = leaf_otp |> X509.serial_number() |> Integer.to_string(16)
 

--- a/elixir/lib/portal_api/controllers/client_json.ex
+++ b/elixir/lib/portal_api/controllers/client_json.ex
@@ -38,6 +38,7 @@ defmodule PortalAPI.ClientJSON do
       last_attested_mdm_device_id: device.last_attested_mdm_device_id,
       last_attested_cert_serial: device.last_attested_cert_serial,
       last_attested_cert_fingerprint: device.last_attested_cert_fingerprint,
+      last_attested_at: device.last_attested_at,
       verified_at: device.verified_at,
       public_key: device.public_key,
       last_seen_at: device.last_seen_at,

--- a/elixir/lib/portal_api/schemas/client_schema.ex
+++ b/elixir/lib/portal_api/schemas/client_schema.ex
@@ -81,6 +81,13 @@ defmodule PortalAPI.Schemas.Client do
           readOnly: true,
           description: "SHA-256 fingerprint of the client certificate used for device verification"
         },
+        last_attested_at: %Schema{
+          type: :string,
+          nullable: true,
+          readOnly: true,
+          description:
+            "When the device last proved possession of an MDM-provisioned client certificate"
+        },
         verified_at: %Schema{
           type: :string,
           description: "Client verification timestamp"
@@ -168,6 +175,7 @@ defmodule PortalAPI.Schemas.Client do
         "last_attested_mdm_device_id" => "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3",
         "last_attested_cert_serial" => "4A:2F:00:8C:11:03:9E:5B",
         "last_attested_cert_fingerprint" => "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+        "last_attested_at" => "2025-01-01T00:00:00Z",
         "verified_at" => "2025-01-01T00:00:00Z",
         "public_key" => "WdKAyoA45xJllRUYnFhI5+Y4EjSTs50MzYYHfrIhVAc=",
         "last_seen_at" => "2025-01-01T00:00:00Z",
@@ -257,6 +265,7 @@ defmodule PortalAPI.Schemas.Client do
           "last_attested_mdm_device_id" => "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3",
           "last_attested_cert_serial" => "4A:2F:00:8C:11:03:9E:5B",
           "last_attested_cert_fingerprint" => "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+          "last_attested_at" => "2025-01-01T00:00:00Z",
           "verified_at" => "2025-01-01T00:00:00Z",
           "created_at" => "2025-01-01T00:00:00Z",
           "updated_at" => "2025-01-01T00:00:00Z"
@@ -321,6 +330,7 @@ defmodule PortalAPI.Schemas.Client do
             "last_attested_mdm_device_id" => nil,
             "last_attested_cert_serial" => nil,
             "last_attested_cert_fingerprint" => nil,
+            "last_attested_at" => nil,
             "verified_at" => nil,
             "created_at" => "2025-01-01T00:00:00Z",
             "updated_at" => "2025-01-01T00:00:00Z"

--- a/elixir/lib/portal_api/sockets/latest_session.ex
+++ b/elixir/lib/portal_api/sockets/latest_session.ex
@@ -59,6 +59,12 @@ defmodule PortalAPI.Sockets.LatestSession do
         device_id: attrs.device_id,
         actor_id: attrs[:actor_id],
         firezone_id: attrs[:firezone_id],
+        last_attested_device_serial: attrs[:last_attested_device_serial],
+        last_attested_device_uuid: attrs[:last_attested_device_uuid],
+        last_attested_mdm_device_id: attrs[:last_attested_mdm_device_id],
+        last_attested_cert_serial: attrs[:last_attested_cert_serial],
+        last_attested_cert_fingerprint: attrs[:last_attested_cert_fingerprint],
+        last_attested_at: attrs[:last_attested_at],
         token_id: Map.fetch!(attrs, token_field),
         public_key: attrs[:public_key],
         user_agent: attrs[:user_agent],
@@ -109,6 +115,12 @@ defmodule PortalAPI.Sockets.LatestSession do
       device_id: Ecto.UUID,
       actor_id: Ecto.UUID,
       firezone_id: :string,
+      last_attested_device_serial: :string,
+      last_attested_device_uuid: :string,
+      last_attested_mdm_device_id: :string,
+      last_attested_cert_serial: :string,
+      last_attested_cert_fingerprint: :string,
+      last_attested_at: :utc_datetime_usec,
       token_id: Ecto.UUID,
       public_key: :string,
       user_agent: :string,
@@ -204,8 +216,29 @@ defmodule PortalAPI.Sockets.LatestSession do
           # connect merges a reinstalled client (new firezone_id, same attested
           # identity) onto its existing row in memory, and this flush persists
           # the new firezone_id. Entries that carry none (gateways) keep the
-          # row's current value.
+          # row's current value. The same discipline applies to the verified
+          # device-trust fields below: identity facts only ever strengthen
+          # here, clearing them is an explicit admin action.
           firezone_id: dynamic([d, v], coalesce(v.firezone_id, d.firezone_id)),
+          last_attested_device_serial:
+            dynamic([d, v], coalesce(v.last_attested_device_serial, d.last_attested_device_serial)),
+          last_attested_device_uuid:
+            dynamic([d, v], coalesce(v.last_attested_device_uuid, d.last_attested_device_uuid)),
+          last_attested_mdm_device_id:
+            dynamic([d, v], coalesce(v.last_attested_mdm_device_id, d.last_attested_mdm_device_id)),
+          last_attested_cert_serial:
+            dynamic([d, v], coalesce(v.last_attested_cert_serial, d.last_attested_cert_serial)),
+          last_attested_cert_fingerprint:
+            dynamic(
+              [d, v],
+              coalesce(v.last_attested_cert_fingerprint, d.last_attested_cert_fingerprint)
+            ),
+          # last_attested_at records when the device last proved possession -
+          # a point-in-time fact that only ever strengthens, like the other
+          # last_attested_* columns. Whether the CURRENT session proved
+          # possession is live connection state (the `attested?` presence
+          # attribute), never row state.
+          last_attested_at: dynamic([d, v], coalesce(v.last_attested_at, d.last_attested_at)),
           public_key: dynamic([d, v], v.public_key),
           last_seen_user_agent: dynamic([d, v], v.user_agent),
           last_seen_remote_ip: dynamic([d, v], v.remote_ip),
@@ -288,22 +321,28 @@ defmodule PortalAPI.Sockets.LatestSession do
     end
 
     # A merged firezone_id can collide with another device row of the same
-    # actor (e.g. an unattested row created before the attested merge). The
-    # colliding entry keeps its session but skips the identity change, so one
-    # poisoned entry cannot fail the whole batch; the merge retries on the
-    # device's next connect. Entries carry a firezone_id only when their
-    # connect actually adopted a new one, so in the steady state this probe
-    # has nothing to check and issues no query. The probe-then-update window
-    # is not atomic: a collision that appears in between still raises
-    # unique_violation, which the caller's rescue turns into failed entries
-    # that reconnect and retry.
+    # actor (e.g. an unattested row created before the device started
+    # attesting). The colliding entry keeps its session but skips the identity
+    # change, so one poisoned entry cannot fail the whole batch; the merge
+    # retries on the device's next connect. Entries carry a firezone_id only
+    # when their connect actually adopted a new one, so in the steady state
+    # this probe has nothing to check and issues no query. The
+    # probe-then-update window is not atomic: a collision that appears in
+    # between still raises unique_violation, which the caller's rescue turns
+    # into failed entries that reconnect and retry.
+    #
+    # NOTE (deferred, pending design decision): the intended end state is
+    # attested-row-wins with the stale unattested row absorbed/deleted, rather
+    # than skip-forever. Until that lands, a device whose attested identity
+    # displaced an older row will keep this firezone_id split until the stale
+    # row is removed; the log line below is the actionable signal.
     defp strip_conflicting_firezone_ids(rows, probe_repo) do
       probe_rows =
         for row <- rows, not is_nil(row.firezone_id), not is_nil(row.actor_id) do
           Map.take(row, [:account_id, :actor_id, :device_id, :firezone_id])
         end
 
-      conflicted =
+      conflicts =
         if probe_rows == [] do
           MapSet.new()
         else
@@ -313,14 +352,19 @@ defmodule PortalAPI.Sockets.LatestSession do
               d.account_id == v.account_id and d.actor_id == v.actor_id and
                 d.firezone_id == v.firezone_id and d.id != v.device_id,
             where: d.type == :client,
-            select: v.device_id
+            select: %{device_id: v.device_id, conflicting_id: d.id, firezone_id: v.firezone_id}
           )
           |> probe(probe_repo)
         end
 
-      if MapSet.size(conflicted) > 0 do
-        Logger.info(
-          "Skipped #{MapSet.size(conflicted)} firezone_id merges during flush due to conflicting device rows"
+      conflicted = MapSet.new(conflicts, & &1.device_id)
+
+      for conflict <- conflicts do
+        Logger.warning(
+          "Skipping firezone_id merge during flush: another device row already holds this firezone_id",
+          device_id: conflict.device_id,
+          conflicting_device_id: conflict.conflicting_id,
+          firezone_id: conflict.firezone_id
         )
       end
 

--- a/elixir/lib/portal_api/sockets/latest_session.ex
+++ b/elixir/lib/portal_api/sockets/latest_session.ex
@@ -53,18 +53,19 @@ defmodule PortalAPI.Sockets.LatestSession do
     |> Enum.group_by(fn {attrs, _metadata} -> {attrs.account_id, attrs.device_id} end)
     |> Enum.map(fn {_key, device_entries} ->
       {attrs, metadata} = Enum.max_by(device_entries, &connected_at/1, DateTime)
+      attested = latest_attested_attrs(device_entries)
 
       %{
         account_id: attrs.account_id,
         device_id: attrs.device_id,
         actor_id: attrs[:actor_id],
         firezone_id: attrs[:firezone_id],
-        last_attested_device_serial: attrs[:last_attested_device_serial],
-        last_attested_device_uuid: attrs[:last_attested_device_uuid],
-        last_attested_mdm_device_id: attrs[:last_attested_mdm_device_id],
-        last_attested_cert_serial: attrs[:last_attested_cert_serial],
-        last_attested_cert_fingerprint: attrs[:last_attested_cert_fingerprint],
-        last_attested_at: attrs[:last_attested_at],
+        last_attested_device_serial: attested[:last_attested_device_serial],
+        last_attested_device_uuid: attested[:last_attested_device_uuid],
+        last_attested_mdm_device_id: attested[:last_attested_mdm_device_id],
+        last_attested_cert_serial: attested[:last_attested_cert_serial],
+        last_attested_cert_fingerprint: attested[:last_attested_cert_fingerprint],
+        last_attested_at: attested[:last_attested_at],
         token_id: Map.fetch!(attrs, token_field),
         public_key: attrs[:public_key],
         user_agent: attrs[:user_agent],
@@ -78,6 +79,21 @@ defmodule PortalAPI.Sockets.LatestSession do
       }
     end)
     |> Enum.sort_by(&{&1.account_id, &1.device_id})
+  end
+
+  # The newest entry wins the session fields above, but the attested snapshot
+  # folds independently: an attested connect followed by an unattested
+  # reconnect in the same batch must not drop the proof, because the
+  # in-database coalesce can only preserve values that already flushed. The
+  # snapshot with the most recent proof time wins, as a unit.
+  defp latest_attested_attrs(device_entries) do
+    device_entries
+    |> Enum.map(fn {attrs, _metadata} -> attrs end)
+    |> Enum.filter(& &1[:last_attested_at])
+    |> case do
+      [] -> %{}
+      attested -> Enum.max_by(attested, & &1.last_attested_at, DateTime)
+    end
   end
 
   # Connect time from the queue entry's metadata; entries that carry none
@@ -140,6 +156,18 @@ defmodule PortalAPI.Sockets.LatestSession do
       actor_id: Ecto.UUID,
       device_id: Ecto.UUID,
       firezone_id: :string
+    }
+
+    @attested_identifier_fields ~w[last_attested_device_serial last_attested_device_uuid last_attested_mdm_device_id]a
+    @attested_fields @attested_identifier_fields ++
+                       ~w[last_attested_cert_serial last_attested_cert_fingerprint last_attested_at]a
+    @attested_probe_types %{
+      account_id: Ecto.UUID,
+      actor_id: Ecto.UUID,
+      device_id: Ecto.UUID,
+      last_attested_device_serial: :string,
+      last_attested_device_uuid: :string,
+      last_attested_mdm_device_id: :string
     }
 
     @token_schemas %{
@@ -209,6 +237,8 @@ defmodule PortalAPI.Sockets.LatestSession do
         rows
         |> dedupe_proposed_firezone_ids()
         |> strip_conflicting_firezone_ids(probe_repo)
+        |> dedupe_proposed_attested_identities()
+        |> strip_conflicting_attested_identities(probe_repo)
 
       set =
         [
@@ -216,29 +246,22 @@ defmodule PortalAPI.Sockets.LatestSession do
           # connect merges a reinstalled client (new firezone_id, same attested
           # identity) onto its existing row in memory, and this flush persists
           # the new firezone_id. Entries that carry none (gateways) keep the
-          # row's current value. The same discipline applies to the verified
-          # device-trust fields below: identity facts only ever strengthen
-          # here, clearing them is an explicit admin action.
+          # row's current value.
           firezone_id: dynamic([d, v], coalesce(v.firezone_id, d.firezone_id)),
-          last_attested_device_serial:
-            dynamic([d, v], coalesce(v.last_attested_device_serial, d.last_attested_device_serial)),
-          last_attested_device_uuid:
-            dynamic([d, v], coalesce(v.last_attested_device_uuid, d.last_attested_device_uuid)),
-          last_attested_mdm_device_id:
-            dynamic([d, v], coalesce(v.last_attested_mdm_device_id, d.last_attested_mdm_device_id)),
-          last_attested_cert_serial:
-            dynamic([d, v], coalesce(v.last_attested_cert_serial, d.last_attested_cert_serial)),
-          last_attested_cert_fingerprint:
-            dynamic(
-              [d, v],
-              coalesce(v.last_attested_cert_fingerprint, d.last_attested_cert_fingerprint)
-            ),
-          # last_attested_at records when the device last proved possession -
-          # a point-in-time fact that only ever strengthens, like the other
-          # last_attested_* columns. Whether the CURRENT session proved
+          # The attested fields move as one snapshot, keyed by
+          # last_attested_at (when the device last proved possession).
+          # Entries that carry no snapshot keep the row's current values, and
+          # a snapshot never replaces a fresher one: batches can flush out of
+          # proof order across nodes. Whether the CURRENT session proved
           # possession is live connection state (the `attested?` presence
-          # attribute), never row state.
-          last_attested_at: dynamic([d, v], coalesce(v.last_attested_at, d.last_attested_at)),
+          # attribute), never row state. Clearing the fields is an explicit
+          # admin action.
+          last_attested_device_serial: attested_field(:last_attested_device_serial),
+          last_attested_device_uuid: attested_field(:last_attested_device_uuid),
+          last_attested_mdm_device_id: attested_field(:last_attested_mdm_device_id),
+          last_attested_cert_serial: attested_field(:last_attested_cert_serial),
+          last_attested_cert_fingerprint: attested_field(:last_attested_cert_fingerprint),
+          last_attested_at: attested_field(:last_attested_at),
           public_key: dynamic([d, v], v.public_key),
           last_seen_user_agent: dynamic([d, v], v.user_agent),
           last_seen_remote_ip: dynamic([d, v], v.remote_ip),
@@ -273,6 +296,25 @@ defmodule PortalAPI.Sockets.LatestSession do
 
     defp unique_violation?(%Postgrex.Error{postgres: %{code: :unique_violation}}), do: true
     defp unique_violation?(_error), do: false
+
+    # The proposed snapshot is applied only when it is at least as fresh as
+    # the row's (v's last_attested_at is NULL when the entry carries no
+    # snapshot, so the CASE keeps the row's value, like the firezone_id
+    # coalesce).
+    defp attested_field(field) do
+      dynamic(
+        [d, v],
+        fragment(
+          "CASE WHEN ? IS NOT NULL AND (? IS NULL OR ? >= ?) THEN ? ELSE ? END",
+          v.last_attested_at,
+          d.last_attested_at,
+          v.last_attested_at,
+          d.last_attested_at,
+          field(v, ^field),
+          field(d, ^field)
+        )
+      )
+    end
 
     # Two rows in the same batch can propose the same previously unused
     # {account_id, actor_id, firezone_id}: both would pass the persisted-row
@@ -371,6 +413,102 @@ defmodule PortalAPI.Sockets.LatestSession do
       Enum.map(rows, fn row ->
         if MapSet.member?(conflicted, row.device_id) do
           %{row | firezone_id: nil}
+        else
+          row
+        end
+      end)
+    end
+
+    # Two rows in the same batch can propose the same attested identifier for
+    # different devices of one actor (a cloned certificate, or two machines
+    # whose MDM stamped the same identity), which would violate the partial
+    # unique indexes and fail every session in the batch. The snapshot with
+    # the freshest proof wins; losers keep their session but skip the
+    # attested update entirely, since the snapshot is all-or-nothing.
+    defp dedupe_proposed_attested_identities(rows) do
+      losers =
+        for field <- @attested_identifier_fields,
+            {_key, contenders} <-
+              rows
+              |> Enum.filter(&(not is_nil(Map.fetch!(&1, field)) and not is_nil(&1.actor_id)))
+              |> Enum.group_by(&{&1.account_id, &1.actor_id, Map.fetch!(&1, field)}),
+            loser <- contenders |> sort_freshest_proof_first() |> tl(),
+            uniq: true do
+          %{device_id: loser.device_id, field: field}
+        end
+
+      loser_ids = MapSet.new(losers, & &1.device_id)
+
+      for loser <- losers do
+        Logger.warning(
+          "Skipping attested identity during flush: another device in the same batch claims this identifier",
+          device_id: loser.device_id,
+          field: loser.field
+        )
+      end
+
+      strip_attested_fields(rows, loser_ids)
+    end
+
+    defp sort_freshest_proof_first(contenders) do
+      Enum.sort(contenders, fn a, b ->
+        case DateTime.compare(a.last_attested_at, b.last_attested_at) do
+          :gt -> true
+          :lt -> false
+          :eq -> a.device_id >= b.device_id
+        end
+      end)
+    end
+
+    # A proposed attested identifier can already sit on another device row of
+    # the same actor: the connect-time adoption check refuses that, but a
+    # concurrent adoption on another node can land in between. As with
+    # firezone_id, the conflicting entry keeps its session and skips the
+    # attested update; a conflict that appears between this probe and the
+    # UPDATE still raises unique_violation, which the retry (re-probing the
+    # primary) resolves at the entry level.
+    defp strip_conflicting_attested_identities(rows, probe_repo) do
+      probe_rows =
+        for row <- rows,
+            not is_nil(row.actor_id),
+            Enum.any?(@attested_identifier_fields, &(not is_nil(Map.fetch!(row, &1)))) do
+          Map.take(row, [:account_id, :actor_id, :device_id | @attested_identifier_fields])
+        end
+
+      conflicts =
+        if probe_rows == [] do
+          MapSet.new()
+        else
+          from(d in Device,
+            join: v in values(probe_rows, @attested_probe_types),
+            on: d.account_id == v.account_id and d.actor_id == v.actor_id and d.id != v.device_id,
+            where:
+              d.type == :client and
+                (d.last_attested_device_serial == v.last_attested_device_serial or
+                   d.last_attested_device_uuid == v.last_attested_device_uuid or
+                   d.last_attested_mdm_device_id == v.last_attested_mdm_device_id),
+            select: %{device_id: v.device_id, conflicting_id: d.id}
+          )
+          |> probe(probe_repo)
+        end
+
+      for conflict <- conflicts do
+        Logger.warning(
+          "Skipping attested identity during flush: another device row already holds this identifier",
+          device_id: conflict.device_id,
+          conflicting_device_id: conflict.conflicting_id
+        )
+      end
+
+      strip_attested_fields(rows, MapSet.new(conflicts, & &1.device_id))
+    end
+
+    defp strip_attested_fields(rows, device_ids) do
+      nils = Map.new(@attested_fields, &{&1, nil})
+
+      Enum.map(rows, fn row ->
+        if MapSet.member?(device_ids, row.device_id) do
+          Map.merge(row, nils)
         else
           row
         end

--- a/elixir/priv/repo/migrations/20260722000000_add_last_attested_at_to_devices.exs
+++ b/elixir/priv/repo/migrations/20260722000000_add_last_attested_at_to_devices.exs
@@ -1,0 +1,17 @@
+defmodule Portal.Repo.Migrations.AddLastAttestedAtToDevices do
+  @moduledoc """
+  Adds `last_attested_at`: when the device last proved possession of an
+  MDM-provisioned client certificate. Like the other `last_attested_*`
+  columns it records point-in-time history and is never cleared by the
+  session flush; whether the CURRENT session proved possession is live
+  connection state (the `attested?` presence attribute), not row state.
+  Nullable with no default, so the column add is metadata-only.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:devices) do
+      add(:last_attested_at, :timestamptz)
+    end
+  end
+end

--- a/elixir/test/portal/queue/callbacks_test.exs
+++ b/elixir/test/portal/queue/callbacks_test.exs
@@ -160,6 +160,47 @@ defmodule Portal.Queue.CallbacksTest do
       assert_receive {:confirm_session_durability, ^ref_b}
     end
 
+    test "an unattested session preserves last_attested_at history" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      attested_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+      client =
+        client_fixture(account: account, actor: actor)
+        |> Ecto.Changeset.change(last_attested_at: attested_at)
+        |> Repo.update!()
+
+      token = client_token_fixture(account: account, actor: actor)
+      session_ref = make_ref()
+
+      :ok = PG.register(client.id)
+
+      attrs = %{
+        session_ref: session_ref,
+        account_id: account.id,
+        device_id: client.id,
+        actor_id: actor.id,
+        client_token_id: token.id,
+        public_key: generate_public_key(),
+        user_agent: "test-client/1.0",
+        remote_ip: {100, 64, 0, 1},
+        version: "1.3.0",
+        inserted_at: DateTime.utc_now()
+      }
+
+      on_flush = Keyword.fetch!(PortalAPI.Client.Socket.client_session_queue_opts(), :on_flush)
+      metadata = %{subject: %{"actor_id" => actor.id}, timestamp: DateTime.utc_now()}
+
+      # The entry carries no last_attested_at: this session did not prove
+      # possession, but the record of the last successful proof is history
+      # and is kept. Whether the CURRENT session is attested lives in
+      # presence metadata, not on the row.
+      assert 1 = on_flush.([{attrs, metadata}])
+
+      device = Repo.get_by!(Device, id: client.id, account_id: account.id)
+      assert DateTime.compare(device.last_attested_at, attested_at) == :eq
+    end
+
     test "skips a conflicting firezone_id merge but keeps the session" do
       account = account_fixture()
       actor = actor_fixture(account: account)

--- a/elixir/test/portal/queue/callbacks_test.exs
+++ b/elixir/test/portal/queue/callbacks_test.exs
@@ -201,6 +201,225 @@ defmodule Portal.Queue.CallbacksTest do
       assert DateTime.compare(device.last_attested_at, attested_at) == :eq
     end
 
+    test "a batch keeps the attested snapshot when an unattested reconnect follows" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      client = client_fixture(account: account, actor: actor)
+      token = client_token_fixture(account: account, actor: actor)
+      ref_attested = make_ref()
+      ref_reconnect = make_ref()
+
+      :ok = PG.register(client.id)
+
+      older = DateTime.add(DateTime.utc_now(), -60, :second)
+      newer = DateTime.utc_now()
+
+      base = %{
+        account_id: account.id,
+        device_id: client.id,
+        actor_id: actor.id,
+        client_token_id: token.id,
+        public_key: generate_public_key(),
+        user_agent: "test-client/1.0",
+        remote_ip: {100, 64, 0, 1},
+        version: "1.3.0"
+      }
+
+      attested_entry =
+        {Map.merge(base, %{
+           session_ref: ref_attested,
+           last_attested_device_serial: "C02XK1ZGJGH5",
+           last_attested_device_uuid: "7a461ff9-0be2-64a9-a418-539d9a21827b",
+           last_attested_cert_fingerprint:
+             "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+           last_attested_at: older,
+           version: "1.2.9",
+           inserted_at: older
+         }), %{subject: %{"actor_id" => actor.id}, timestamp: older}}
+
+      reconnect_entry =
+        {Map.merge(base, %{session_ref: ref_reconnect, inserted_at: newer}),
+         %{subject: %{"actor_id" => actor.id}, timestamp: newer}}
+
+      on_flush = Keyword.fetch!(PortalAPI.Client.Socket.client_session_queue_opts(), :on_flush)
+
+      assert 2 = on_flush.([attested_entry, reconnect_entry])
+
+      device = Repo.get_by!(Device, id: client.id, account_id: account.id)
+
+      # The newest entry wins the session fields, but the attested snapshot
+      # from the earlier entry is not dropped: it never reached the database,
+      # so the in-database coalesce alone could not have preserved it.
+      assert device.last_attested_device_serial == "C02XK1ZGJGH5"
+      assert device.last_attested_device_uuid == "7a461ff9-0be2-64a9-a418-539d9a21827b"
+      assert device.last_attested_cert_fingerprint
+      assert DateTime.compare(device.last_attested_at, older) == :eq
+      assert device.last_seen_version == "1.3.0"
+      assert device.last_seen_at == newer
+      assert_receive {:confirm_session_durability, ^ref_attested}
+      assert_receive {:confirm_session_durability, ^ref_reconnect}
+    end
+
+    test "a stale attested snapshot does not regress a fresher proof" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      fresh_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+      stale_at = DateTime.add(fresh_at, -3600, :second)
+
+      client =
+        client_fixture(account: account, actor: actor)
+        |> Ecto.Changeset.change(
+          last_attested_device_serial: "SN-FRESH",
+          last_attested_at: fresh_at
+        )
+        |> Repo.update!()
+
+      token = client_token_fixture(account: account, actor: actor)
+      session_ref = make_ref()
+
+      :ok = PG.register(client.id)
+
+      attrs = %{
+        session_ref: session_ref,
+        account_id: account.id,
+        device_id: client.id,
+        actor_id: actor.id,
+        last_attested_device_serial: "SN-STALE",
+        last_attested_at: stale_at,
+        client_token_id: token.id,
+        public_key: generate_public_key(),
+        user_agent: "test-client/1.0",
+        remote_ip: {100, 64, 0, 1},
+        version: "1.3.0",
+        inserted_at: DateTime.utc_now()
+      }
+
+      on_flush = Keyword.fetch!(PortalAPI.Client.Socket.client_session_queue_opts(), :on_flush)
+      metadata = %{subject: %{"actor_id" => actor.id}, timestamp: DateTime.utc_now()}
+
+      # Batches can flush out of proof order across nodes; an older proof
+      # never replaces a newer one already on the row.
+      assert 1 = on_flush.([{attrs, metadata}])
+
+      device = Repo.get_by!(Device, id: client.id, account_id: account.id)
+      assert device.last_attested_device_serial == "SN-FRESH"
+      assert DateTime.compare(device.last_attested_at, fresh_at) == :eq
+    end
+
+    test "a same-batch attested identity collision skips only the losing snapshot" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      client_a = client_fixture(account: account, actor: actor)
+      client_b = client_fixture(account: account, actor: actor)
+      token_a = client_token_fixture(account: account, actor: actor)
+      token_b = client_token_fixture(account: account, actor: actor)
+      ref_a = make_ref()
+      ref_b = make_ref()
+
+      :ok = PG.register(client_a.id)
+      :ok = PG.register(client_b.id)
+
+      older = DateTime.add(DateTime.utc_now(), -60, :second)
+      newer = DateTime.utc_now()
+
+      base = %{
+        account_id: account.id,
+        actor_id: actor.id,
+        # A cloned certificate: both entries prove the same serial.
+        last_attested_device_serial: "SN-CLONED",
+        public_key: generate_public_key(),
+        user_agent: "test-client/1.0",
+        remote_ip: {100, 64, 0, 1},
+        version: "1.3.0"
+      }
+
+      entry_a =
+        {Map.merge(base, %{
+           session_ref: ref_a,
+           device_id: client_a.id,
+           client_token_id: token_a.id,
+           last_attested_at: older,
+           inserted_at: older
+         }), %{subject: %{"actor_id" => actor.id}, timestamp: older}}
+
+      entry_b =
+        {Map.merge(base, %{
+           session_ref: ref_b,
+           device_id: client_b.id,
+           client_token_id: token_b.id,
+           last_attested_at: newer,
+           inserted_at: newer
+         }), %{subject: %{"actor_id" => actor.id}, timestamp: newer}}
+
+      on_flush = Keyword.fetch!(PortalAPI.Client.Socket.client_session_queue_opts(), :on_flush)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert 2 = on_flush.([entry_a, entry_b])
+        end)
+
+      assert log =~ "another device in the same batch claims this identifier"
+
+      device_a = Repo.get_by!(Device, id: client_a.id, account_id: account.id)
+      device_b = Repo.get_by!(Device, id: client_b.id, account_id: account.id)
+
+      # The freshest proof wins the identifier; the loser keeps its session
+      # but skips the attested update.
+      assert device_b.last_attested_device_serial == "SN-CLONED"
+      assert is_nil(device_a.last_attested_device_serial)
+      assert is_nil(device_a.last_attested_at)
+      assert device_a.client_token_id == token_a.id
+      assert_receive {:confirm_session_durability, ^ref_a}
+      assert_receive {:confirm_session_durability, ^ref_b}
+    end
+
+    test "skips an attested identity another device row already holds" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      client = client_fixture(account: account, actor: actor)
+
+      _other =
+        client_fixture(account: account, actor: actor)
+        |> Ecto.Changeset.change(last_attested_device_serial: "SN-TAKEN")
+        |> Repo.update!()
+
+      token = client_token_fixture(account: account, actor: actor)
+      session_ref = make_ref()
+
+      :ok = PG.register(client.id)
+
+      attrs = %{
+        session_ref: session_ref,
+        account_id: account.id,
+        device_id: client.id,
+        actor_id: actor.id,
+        last_attested_device_serial: "SN-TAKEN",
+        last_attested_at: DateTime.utc_now(),
+        client_token_id: token.id,
+        public_key: generate_public_key(),
+        user_agent: "test-client/1.0",
+        remote_ip: {100, 64, 0, 1},
+        version: "1.3.0",
+        inserted_at: DateTime.utc_now()
+      }
+
+      on_flush = Keyword.fetch!(PortalAPI.Client.Socket.client_session_queue_opts(), :on_flush)
+      metadata = %{subject: %{"actor_id" => actor.id}, timestamp: DateTime.utc_now()}
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert 1 = on_flush.([{attrs, metadata}])
+        end)
+
+      assert log =~ "another device row already holds this identifier"
+
+      device = Repo.get_by!(Device, id: client.id, account_id: account.id)
+      assert is_nil(device.last_attested_device_serial)
+      assert is_nil(device.last_attested_at)
+      assert device.client_token_id == token.id
+      assert_receive {:confirm_session_durability, ^session_ref}
+    end
+
     test "skips a conflicting firezone_id merge but keeps the session" do
       account = account_fixture()
       actor = actor_fixture(account: account)

--- a/elixir/test/portal_api/client/device_trust_test.exs
+++ b/elixir/test/portal_api/client/device_trust_test.exs
@@ -104,6 +104,46 @@ defmodule PortalAPI.Client.DeviceTrustTest do
       assert {:error, :verification_failed} = DeviceTrust.verify_response([entry], nonce, anchors)
     end
 
+    test "drops an out-of-spec certificate serial but still verifies", %{
+      pki: pki,
+      nonce: nonce,
+      anchors: anchors
+    } do
+      huge_serial = 64 |> :crypto.strong_rand_bytes() |> :binary.decode_unsigned()
+
+      entry =
+        response_entry(
+          pki,
+          [
+            serial: huge_serial,
+            sans: [{:uniformResourceIdentifier, ~c"firezone://serial/C02XK1ZGJGH5"}]
+          ],
+          nonce
+        )
+
+      assert {:ok, verified} = DeviceTrust.verify_response([entry], nonce, anchors)
+      assert verified.identifiers.last_attested_device_serial == "C02XK1ZGJGH5"
+      assert is_nil(verified.last_attested_cert_serial)
+      assert is_binary(verified.last_attested_cert_fingerprint)
+    end
+
+    test "rejects a cert whose only identifier exceeds the length bound", %{
+      pki: pki,
+      nonce: nonce,
+      anchors: anchors
+    } do
+      long_serial = String.duplicate("AB", 40)
+
+      entry =
+        response_entry(
+          pki,
+          [sans: [{:uniformResourceIdentifier, ~c"firezone://serial/#{long_serial}"}]],
+          nonce
+        )
+
+      assert {:error, :verification_failed} = DeviceTrust.verify_response([entry], nonce, anchors)
+    end
+
     test "rejects a leaf without client-auth EKU", %{pki: pki, nonce: nonce, anchors: anchors} do
       entry = response_entry(pki, :no_eku, nonce)
       assert {:error, :verification_failed} = DeviceTrust.verify_response([entry], nonce, anchors)
@@ -249,6 +289,16 @@ defmodule PortalAPI.Client.DeviceTrustTest do
 
     test "trims and rejects empty values" do
       assert DeviceTrust.normalize_identifier(:last_attested_device_serial, "   ") == nil
+    end
+
+    test "rejects identifiers longer than 64 bytes" do
+      at_bound = String.duplicate("AB", 32)
+      over_bound = String.duplicate("AB", 33)
+
+      assert DeviceTrust.normalize_identifier(:last_attested_device_serial, at_bound) == at_bound
+      assert DeviceTrust.normalize_identifier(:last_attested_device_serial, over_bound) == nil
+      assert DeviceTrust.normalize_identifier(:last_attested_device_uuid, over_bound) == nil
+      assert DeviceTrust.normalize_identifier(:last_attested_mdm_device_id, over_bound) == nil
     end
   end
 end

--- a/elixir/test/portal_api/client/device_trust_test.exs
+++ b/elixir/test/portal_api/client/device_trust_test.exs
@@ -104,12 +104,12 @@ defmodule PortalAPI.Client.DeviceTrustTest do
       assert {:error, :verification_failed} = DeviceTrust.verify_response([entry], nonce, anchors)
     end
 
-    test "drops an out-of-spec certificate serial but still verifies", %{
+    test "drops a certificate serial exceeding the column limit but still verifies", %{
       pki: pki,
       nonce: nonce,
       anchors: anchors
     } do
-      huge_serial = 64 |> :crypto.strong_rand_bytes() |> :binary.decode_unsigned()
+      huge_serial = 192 |> :crypto.strong_rand_bytes() |> :binary.decode_unsigned()
 
       entry =
         response_entry(
@@ -132,7 +132,7 @@ defmodule PortalAPI.Client.DeviceTrustTest do
       nonce: nonce,
       anchors: anchors
     } do
-      long_serial = String.duplicate("AB", 40)
+      long_serial = String.duplicate("AB", 130)
 
       entry =
         response_entry(
@@ -291,9 +291,9 @@ defmodule PortalAPI.Client.DeviceTrustTest do
       assert DeviceTrust.normalize_identifier(:last_attested_device_serial, "   ") == nil
     end
 
-    test "rejects identifiers longer than 64 bytes" do
-      at_bound = String.duplicate("AB", 32)
-      over_bound = String.duplicate("AB", 33)
+    test "rejects identifiers longer than the 255-char column limit" do
+      at_bound = "C" <> String.duplicate("AB", 127)
+      over_bound = String.duplicate("AB", 128)
 
       assert DeviceTrust.normalize_identifier(:last_attested_device_serial, at_bound) == at_bound
       assert DeviceTrust.normalize_identifier(:last_attested_device_serial, over_bound) == nil

--- a/elixir/test/portal_api/controllers/client_controller_test.exs
+++ b/elixir/test/portal_api/controllers/client_controller_test.exs
@@ -155,6 +155,7 @@ defmodule PortalAPI.ClientControllerTest do
 
     test "renders device trust fields", %{conn: conn, actor: actor, account: account} do
       client_actor = actor_fixture(account: account)
+      attested_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
 
       client =
         client_fixture(
@@ -164,7 +165,8 @@ defmodule PortalAPI.ClientControllerTest do
           last_attested_device_uuid: "7A461FF9-0BE2-64A9-A418-539D9A21827B",
           last_attested_mdm_device_id: "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3",
           last_attested_cert_serial: "4A:2F:00:8C",
-          last_attested_cert_fingerprint: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+          last_attested_cert_fingerprint: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+          last_attested_at: attested_at
         )
 
       conn =
@@ -180,6 +182,8 @@ defmodule PortalAPI.ClientControllerTest do
       assert data["last_attested_cert_serial"] == "4A:2F:00:8C"
       assert data["last_attested_cert_fingerprint"] ==
                "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+
+      assert data["last_attested_at"] == DateTime.to_iso8601(attested_at)
     end
 
     test "renders hostname when set", %{conn: conn, actor: actor, account: account} do

--- a/elixir/test/support/fixtures/device_fixtures.ex
+++ b/elixir/test/support/fixtures/device_fixtures.ex
@@ -142,6 +142,7 @@ defmodule Portal.DeviceFixtures do
         :last_attested_mdm_device_id,
         :last_attested_cert_serial,
         :last_attested_cert_fingerprint,
+        :last_attested_at,
         :verified_at
       ])
       |> Ecto.Changeset.put_change(:type, :client)

--- a/elixir/test/support/fixtures/device_trust_challenge_fixtures.ex
+++ b/elixir/test/support/fixtures/device_trust_challenge_fixtures.ex
@@ -71,7 +71,7 @@ defmodule Portal.DeviceTrustChallengeFixtures do
   `:no_digital_signature` (keyAgreement-only Key Usage), `:expired`,
   `:not_yet_valid`, and `:no_identifiers` (SAN-less, subject-only). A keyword
   list mints a custom leaf under the trusted CA (`:cn`, `:ous`, `:sans`,
-  `:eku`, `:key_usage`, `:validity`, `:key`).
+  `:eku`, `:key_usage`, `:validity`, `:key`, `:serial`).
   """
   def leaf(pki, opts) when is_list(opts), do: issue_leaf(pki.ca, opts)
 
@@ -156,7 +156,17 @@ defmodule Portal.DeviceTrustChallengeFixtures do
           usages -> [{:Extension, @key_usage_oid, true, usages}]
         end
 
-    cert_der = sign_cert(issuer.subject, issuer.key, subject, spki(key), extensions, validity)
+    cert_der =
+      sign_cert(
+        issuer.subject,
+        issuer.key,
+        subject,
+        spki(key),
+        extensions,
+        validity,
+        Keyword.get(opts, :serial) || serial_number()
+      )
+
     {cert_der, key}
   end
 
@@ -167,11 +177,11 @@ defmodule Portal.DeviceTrustChallengeFixtures do
     ]
   end
 
-  defp sign_cert(issuer_rdn, issuer_key, subject_rdn, spki, extensions, {from_days, to_days}) do
+  defp sign_cert(issuer_rdn, issuer_key, subject_rdn, spki, extensions, {from_days, to_days}, serial \\ nil) do
     now = DateTime.utc_now()
 
     tbs =
-      {:OTPTBSCertificate, :v3, serial_number(),
+      {:OTPTBSCertificate, :v3, serial || serial_number(),
        {:SignatureAlgorithm, @ecdsa_sha256_oid, :asn1_NOVALUE}, issuer_rdn,
        {:Validity, utc_time(DateTime.add(now, from_days, :day)),
         utc_time(DateTime.add(now, to_days, :day))}, subject_rdn, spki, :asn1_NOVALUE,


### PR DESCRIPTION
Device rows get a new last_attested_at column: when the device last proved possession of an MDM-provisioned certificate. The batched session flush now carries it and the other attested fields onto the row.

Like firezone_id, these fields only strengthen: a session that carries no attested values keeps the row's current ones, so an unattested connect never erases attestation history. The firezone_id conflict probe also logs each skipped merge with the conflicting device ids now, since a stale row can hold a merged firezone_id until an admin removes it.

Related: #14291 #14254