### PR TITLE
feat(android): run flow-log uploader from tunnel service

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -194,6 +194,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.11.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.11.0")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.11.0")
+    implementation("androidx.lifecycle:lifecycle-process:2.11.0")
 
     // Navigation
     implementation("androidx.navigation:navigation-fragment-ktx:2.9.7")

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
@@ -6,9 +6,7 @@ import android.content.Context
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.HiltAndroidApp
 import dev.firezone.android.BuildConfig
-import dev.firezone.android.tunnel.TunnelService
-import uniffi.connlib.runFlowLogUpload
-import kotlin.concurrent.thread
+import uniffi.connlib.ensureFlowLogUploader
 
 @HiltAndroidApp
 class FirezoneApp : Application() {
@@ -28,14 +26,10 @@ class FirezoneApp : Application() {
         // Wires connlib's TLS stack (rustls) to Android's trust store; required before any TLS handshake.
         initRustlsPlatformVerifier(this)
 
-        // Best-effort flow-log drain on launch for spool a previous session left behind.
-        // Only when the tunnel isn't running: there's then no VPN to bypass, so plain
-        // (unprotected) sockets are fine. While connected, the TunnelService's protected
-        // uploader owns draining.
-        if (!TunnelService.isRunning(this)) {
-            val flowLogsDir = filesDir.absolutePath + "/flow_logs"
-            thread(isDaemon = true) { runFlowLogUpload(flowLogsDir) }
-        }
+        // Run the flow-log uploader for the app-process lifetime so spool a previous
+        // session left behind uploads promptly. Safe in every state: connlib sessions
+        // install their VPN-protected sockets into it while they live.
+        ensureFlowLogUploader(filesDir.absolutePath + "/flow_logs")
     }
 
     companion object {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
@@ -6,7 +6,8 @@ import android.content.Context
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.HiltAndroidApp
 import dev.firezone.android.BuildConfig
-import uniffi.connlib.ensureFlowLogUploader
+import uniffi.connlib.runFlowLogUpload
+import kotlin.concurrent.thread
 
 @HiltAndroidApp
 class FirezoneApp : Application() {
@@ -26,10 +27,12 @@ class FirezoneApp : Application() {
         // Wires connlib's TLS stack (rustls) to Android's trust store; required before any TLS handshake.
         initRustlsPlatformVerifier(this)
 
-        // Run the flow-log uploader for the app-process lifetime so spool a previous
-        // session left behind uploads promptly. Safe in every state: connlib sessions
-        // install their VPN-protected sockets into it while they live.
-        ensureFlowLogUploader(filesDir.absolutePath + "/flow_logs")
+        // Drain flow logs a previous session left spooled. One-shot on purpose: the
+        // interval uploader lives inside connlib sessions, and with no session there
+        // is nothing producing flows, so a resident thread would poll and dial for
+        // nothing. Plain sockets are fine because no VPN of ours is up yet.
+        val flowLogsDir = filesDir.absolutePath + "/flow_logs"
+        thread(isDaemon = true) { runFlowLogUpload(flowLogsDir) }
     }
 
     companion object {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
@@ -6,6 +6,9 @@ import android.content.Context
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.HiltAndroidApp
 import dev.firezone.android.BuildConfig
+import dev.firezone.android.tunnel.TunnelService
+import uniffi.connlib.runFlowLogUpload
+import kotlin.concurrent.thread
 
 @HiltAndroidApp
 class FirezoneApp : Application() {
@@ -24,6 +27,15 @@ class FirezoneApp : Application() {
 
         // Wires connlib's TLS stack (rustls) to Android's trust store; required before any TLS handshake.
         initRustlsPlatformVerifier(this)
+
+        // Best-effort flow-log drain on launch for spool a previous session left behind.
+        // Only when the tunnel isn't running: there's then no VPN to bypass, so plain
+        // (unprotected) sockets are fine. While connected, the TunnelService's protected
+        // uploader owns draining.
+        if (!TunnelService.isRunning(this)) {
+            val flowLogsDir = filesDir.absolutePath + "/flow_logs"
+            thread(isDaemon = true) { runFlowLogUpload(flowLogsDir) }
+        }
     }
 
     companion object {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
@@ -3,10 +3,13 @@ package dev.firezone.android.core
 
 import android.app.Application
 import android.content.Context
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.HiltAndroidApp
 import dev.firezone.android.BuildConfig
-import uniffi.connlib.runFlowLogUpload
+import uniffi.connlib.drainFlowLogs
 import kotlin.concurrent.thread
 
 @HiltAndroidApp
@@ -27,12 +30,18 @@ class FirezoneApp : Application() {
         // Wires connlib's TLS stack (rustls) to Android's trust store; required before any TLS handshake.
         initRustlsPlatformVerifier(this)
 
-        // Drain flow logs a previous session left spooled. One-shot on purpose: the
-        // interval uploader lives inside connlib sessions, and with no session there
-        // is nothing producing flows, so a resident thread would poll and dial for
-        // nothing. Plain sockets are fine because no VPN of ours is up yet.
+        // Drain flow logs whenever the app comes to the foreground (including this
+        // launch): pokes the session's uploader while connected, or runs a bounded
+        // one-shot pass to sweep up spool a previous session left behind. Off the
+        // main thread because the one-shot case blocks for up to ten seconds.
         val flowLogsDir = filesDir.absolutePath + "/flow_logs"
-        thread(isDaemon = true) { runFlowLogUpload(flowLogsDir) }
+        ProcessLifecycleOwner.get().lifecycle.addObserver(
+            object : DefaultLifecycleObserver {
+                override fun onStart(owner: LifecycleOwner) {
+                    thread(isDaemon = true) { drainFlowLogs(flowLogsDir) }
+                }
+            },
+        )
     }
 
     companion object {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.HiltAndroidApp
 import dev.firezone.android.BuildConfig
+import dev.firezone.android.tunnel.TunnelService
 import uniffi.connlib.drainFlowLogs
 import kotlin.concurrent.thread
 
@@ -38,7 +39,9 @@ class FirezoneApp : Application() {
         ProcessLifecycleOwner.get().lifecycle.addObserver(
             object : DefaultLifecycleObserver {
                 override fun onStart(owner: LifecycleOwner) {
-                    thread(isDaemon = true) { drainFlowLogs(flowLogsDir) }
+                    thread(isDaemon = true) {
+                        drainFlowLogs(flowLogsDir, TunnelService.protectSocketCallback)
+                    }
                 }
             },
         )

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
@@ -35,7 +35,7 @@ class FirezoneApp : Application() {
         // launch): pokes the session's uploader while connected, or runs a bounded
         // one-shot pass to sweep up spool a previous session left behind. Off the
         // main thread because the one-shot case blocks for up to ten seconds.
-        val flowLogsDir = filesDir.absolutePath + "/flow_logs"
+        val flowLogsDir = TunnelService.flowLogsDir(this)
         ProcessLifecycleOwner.get().lifecycle.addObserver(
             object : DefaultLifecycleObserver {
                 override fun onStart(owner: LifecycleOwner) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -246,12 +246,14 @@ class TunnelService : VpnService() {
 
     override fun onCreate() {
         super.onCreate()
+        activeService = this
         registerReceiver(restrictionsReceiver, restrictionsFilter)
 
         startTelemetry(protectSocket)
     }
 
     override fun onDestroy() {
+        activeService = null
         unregisterReceiver(restrictionsReceiver)
         serviceScope.cancel()
 
@@ -789,6 +791,18 @@ class TunnelService : VpnService() {
 
         private val MANAGED_CONFIGURATIONS =
             arrayOf("token", "allowedApplications", "disallowedApplications", "deviceName")
+
+        @Volatile
+        private var activeService: TunnelService? = null
+
+        // protect() marks a socket to bypass our VPN. Without a running service our
+        // VPN cannot be up, so the no-op is the correct bypass then too.
+        val protectSocketCallback: ProtectSocket =
+            object : ProtectSocket {
+                override fun protectSocket(fd: Int) {
+                    activeService?.protect(fd)
+                }
+            }
 
         // FIXME: Find another way to check if we're running
         @SuppressWarnings("deprecation")

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -55,12 +55,15 @@ import uniffi.connlib.enforceLogSizeCap
 import uniffi.connlib.isLogStreamingActive
 import uniffi.connlib.logCleanupDefaultIntervalSecs
 import uniffi.connlib.logCleanupDefaultMaxSizeMb
+import uniffi.connlib.runFlowLogUploadTimeboxed
+import uniffi.connlib.startFlowLogUploader
 import uniffi.connlib.startTelemetry
 import uniffi.connlib.stopTelemetry
 import uniffi.connlib.use
 import java.nio.file.Files
 import java.nio.file.Paths
 import javax.inject.Inject
+import kotlin.concurrent.thread
 import kotlin.coroutines.cancellation.CancellationException
 
 @AndroidEntryPoint
@@ -249,6 +252,12 @@ class TunnelService : VpnService() {
         registerReceiver(restrictionsReceiver, restrictionsFilter)
 
         startTelemetry(protectSocket)
+
+        // Run the flow-log uploader for the app-process lifetime, decoupled from any
+        // connlib session, so spooled flows keep uploading across connect/disconnect
+        // cycles while the process is alive. Idempotent across service restarts. Uses
+        // protected (tunnel-bypassing) sockets so uploads never loop through the VPN.
+        startFlowLogUploader(getFlowLogsDir(), protectSocket)
     }
 
     override fun onDestroy() {
@@ -366,6 +375,14 @@ class TunnelService : VpnService() {
                 } finally {
                     commandChannel = null
                     tunnelState = State.DOWN
+
+                    // Best-effort: connlib has finalized any open flows into the spool,
+                    // so kick a prompt, timeboxed drain over protected sockets (the tunnel
+                    // may still be tearing down). The process-lifetime uploader also keeps
+                    // draining while the app process is alive.
+                    val flowLogsDir = getFlowLogsDir()
+                    val protect = protectSocket
+                    thread(isDaemon = true) { runFlowLogUploadTimeboxed(flowLogsDir, 5UL, protect) }
 
                     stopNetworkMonitoring()
                     stopFeatureFlagPoll()

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -239,12 +239,14 @@ class TunnelService : VpnService() {
 
     override fun onCreate() {
         super.onCreate()
+        activeService = this
         registerReceiver(restrictionsReceiver, restrictionsFilter)
 
         startTelemetry(protectSocketCallback)
     }
 
     override fun onDestroy() {
+        activeService = null
         unregisterReceiver(restrictionsReceiver)
         serviceScope.cancel()
 
@@ -783,16 +785,16 @@ class TunnelService : VpnService() {
         private val MANAGED_CONFIGURATIONS =
             arrayOf("token", "allowedApplications", "disallowedApplications", "deviceName")
 
-        // protect() reads no service state: it marks the socket via netd, gated on
-        // Firezone being the user's chosen VPN app. A bare instance therefore works
-        // with or without a running service, so this one callback serves the
-        // session, telemetry, and flow-log drains alike.
-        private object SocketProtector : VpnService()
+        @Volatile
+        private var activeService: TunnelService? = null
 
+        // Protects through the one live service; the session, telemetry, and
+        // flow-log drains all share it. Without a running service our VPN cannot
+        // be up, so the no-op is the correct bypass then too.
         val protectSocketCallback: ProtectSocket =
             object : ProtectSocket {
                 override fun protectSocket(fd: Int) {
-                    SocketProtector.protect(fd)
+                    activeService?.protect(fd)
                 }
             }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -135,13 +135,6 @@ class TunnelService : VpnService() {
             binder
         }
 
-    private val protectSocket: ProtectSocket =
-        object : ProtectSocket {
-            override fun protectSocket(fd: Int) {
-                protect(fd)
-            }
-        }
-
     private fun buildVpnService() {
         fun handleApplications(
             appRestrictions: Bundle,
@@ -248,7 +241,7 @@ class TunnelService : VpnService() {
         super.onCreate()
         registerReceiver(restrictionsReceiver, restrictionsFilter)
 
-        startTelemetry(protectSocket)
+        startTelemetry(protectSocketCallback)
     }
 
     override fun onDestroy() {
@@ -344,7 +337,7 @@ class TunnelService : VpnService() {
                             logFilter = config.logFilter,
                             flowLogsDir = flowLogsDir(this@TunnelService),
                             isInternetResourceActive = resourceState.isEnabled(),
-                            protectSocket = protectSocket,
+                            protectSocket = protectSocketCallback,
                             deviceInfo = deviceInfo,
                         ).use { session ->
                             startNetworkMonitoring()
@@ -792,7 +785,8 @@ class TunnelService : VpnService() {
 
         // protect() reads no service state: it marks the socket via netd, gated on
         // Firezone being the user's chosen VPN app. A bare instance therefore works
-        // without a running service, so drains can always protect their sockets.
+        // with or without a running service, so this one callback serves the
+        // session, telemetry, and flow-log drains alike.
         private object SocketProtector : VpnService()
 
         val protectSocketCallback: ProtectSocket =

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -246,14 +246,12 @@ class TunnelService : VpnService() {
 
     override fun onCreate() {
         super.onCreate()
-        activeService = this
         registerReceiver(restrictionsReceiver, restrictionsFilter)
 
         startTelemetry(protectSocket)
     }
 
     override fun onDestroy() {
-        activeService = null
         unregisterReceiver(restrictionsReceiver)
         serviceScope.cancel()
 
@@ -792,15 +790,15 @@ class TunnelService : VpnService() {
         private val MANAGED_CONFIGURATIONS =
             arrayOf("token", "allowedApplications", "disallowedApplications", "deviceName")
 
-        @Volatile
-        private var activeService: TunnelService? = null
+        // protect() reads no service state: it marks the socket via netd, gated on
+        // Firezone being the user's chosen VPN app. A bare instance therefore works
+        // without a running service, so drains can always protect their sockets.
+        private object SocketProtector : VpnService()
 
-        // protect() marks a socket to bypass our VPN. Without a running service our
-        // VPN cannot be up, so the no-op is the correct bypass then too.
         val protectSocketCallback: ProtectSocket =
             object : ProtectSocket {
                 override fun protectSocket(fd: Int) {
-                    activeService?.protect(fd)
+                    SocketProtector.protect(fd)
                 }
             }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -52,18 +52,16 @@ import uniffi.connlib.ProtectSocket
 import uniffi.connlib.Session
 import uniffi.connlib.SessionInterface
 import uniffi.connlib.enforceLogSizeCap
+import uniffi.connlib.ensureFlowLogUploader
 import uniffi.connlib.isLogStreamingActive
 import uniffi.connlib.logCleanupDefaultIntervalSecs
 import uniffi.connlib.logCleanupDefaultMaxSizeMb
-import uniffi.connlib.runFlowLogUploadTimeboxed
-import uniffi.connlib.startFlowLogUploader
 import uniffi.connlib.startTelemetry
 import uniffi.connlib.stopTelemetry
 import uniffi.connlib.use
 import java.nio.file.Files
 import java.nio.file.Paths
 import javax.inject.Inject
-import kotlin.concurrent.thread
 import kotlin.coroutines.cancellation.CancellationException
 
 @AndroidEntryPoint
@@ -257,7 +255,8 @@ class TunnelService : VpnService() {
         // connlib session, so spooled flows keep uploading across connect/disconnect
         // cycles while the process is alive. Idempotent across service restarts. Uses
         // protected (tunnel-bypassing) sockets so uploads never loop through the VPN.
-        startFlowLogUploader(getFlowLogsDir(), protectSocket)
+        // connlib wakes it when a session ends, so disconnects drain promptly too.
+        ensureFlowLogUploader(getFlowLogsDir(), protectSocket)
     }
 
     override fun onDestroy() {
@@ -375,14 +374,6 @@ class TunnelService : VpnService() {
                 } finally {
                     commandChannel = null
                     tunnelState = State.DOWN
-
-                    // Best-effort: connlib has finalized any open flows into the spool,
-                    // so kick a prompt, timeboxed drain over protected sockets (the tunnel
-                    // may still be tearing down). The process-lifetime uploader also keeps
-                    // draining while the app process is alive.
-                    val flowLogsDir = getFlowLogsDir()
-                    val protect = protectSocket
-                    thread(isDaemon = true) { runFlowLogUploadTimeboxed(flowLogsDir, 5UL, protect) }
 
                     stopNetworkMonitoring()
                     stopFeatureFlagPoll()

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -52,7 +52,6 @@ import uniffi.connlib.ProtectSocket
 import uniffi.connlib.Session
 import uniffi.connlib.SessionInterface
 import uniffi.connlib.enforceLogSizeCap
-import uniffi.connlib.ensureFlowLogUploader
 import uniffi.connlib.isLogStreamingActive
 import uniffi.connlib.logCleanupDefaultIntervalSecs
 import uniffi.connlib.logCleanupDefaultMaxSizeMb
@@ -250,13 +249,6 @@ class TunnelService : VpnService() {
         registerReceiver(restrictionsReceiver, restrictionsFilter)
 
         startTelemetry(protectSocket)
-
-        // Run the flow-log uploader for the app-process lifetime, decoupled from any
-        // connlib session, so spooled flows keep uploading across connect/disconnect
-        // cycles while the process is alive. Idempotent across service restarts. Uses
-        // protected (tunnel-bypassing) sockets so uploads never loop through the VPN.
-        // connlib wakes it when a session ends, so disconnects drain promptly too.
-        ensureFlowLogUploader(getFlowLogsDir(), protectSocket)
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
The app drains flow logs on every foreground, including launch: the drain pokes the session's uploader while connected, or runs a bounded one-shot pass to sweep up spool a previous session left behind. Sessions upload on the portal's interval and flush on disconnect from inside connlib, so the tunnel service has no uploader code.

Supersedes: #13923
Related: #14292