### PR TITLE
feat(relay): read release SHA from env at runtime

### DIFF
--- a/rust/relay/server/src/lib.rs
+++ b/rust/relay/server/src/lib.rs
@@ -28,11 +28,17 @@ use std::{
     sync::LazyLock,
 };
 
-pub const VERSION: Option<&str> = option_env!("GITHUB_SHA");
+/// The deployed release identifier (the commit SHA), read from the
+/// `FIREZONE_RELEASE` environment variable at startup.
+pub static VERSION: LazyLock<Option<String>> =
+    LazyLock::new(|| std::env::var("FIREZONE_RELEASE").ok());
 pub static SOFTWARE: LazyLock<Software> = LazyLock::new(|| {
     Software::new(format!(
         "firezone-relay; rev={}",
-        VERSION.map(|rev| &rev[..8]).unwrap_or("xxxx")
+        VERSION
+            .as_deref()
+            .map(|rev| rev.get(..8).unwrap_or(rev))
+            .unwrap_or("xxxx")
     ))
     .expect("less than 128 chars")
 });

--- a/rust/relay/server/src/lib.rs
+++ b/rust/relay/server/src/lib.rs
@@ -29,15 +29,18 @@ use std::{
 };
 
 /// The deployed release identifier (the commit SHA), read from the
-/// `FIREZONE_RELEASE` environment variable at startup.
-pub static VERSION: LazyLock<Option<String>> =
-    LazyLock::new(|| std::env::var("FIREZONE_RELEASE").ok());
+/// `FIREZONE_RELEASE` environment variable.
+pub static VERSION: LazyLock<Option<String>> = LazyLock::new(|| {
+    std::env::var("FIREZONE_RELEASE")
+        .ok()
+        .filter(|release| !release.trim().is_empty())
+});
 pub static SOFTWARE: LazyLock<Software> = LazyLock::new(|| {
     Software::new(format!(
         "firezone-relay; rev={}",
         VERSION
             .as_deref()
-            .map(|rev| rev.get(..8).unwrap_or(rev))
+            .and_then(|rev| rev.get(..8))
             .unwrap_or("xxxx")
     ))
     .expect("less than 128 chars")

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -147,7 +147,7 @@ fn main() -> ExitCode {
         telemetry::configure(std::sync::Arc::new(socket_factory::tcp));
         telemetry::start(
             args.api_url.as_str(),
-            VERSION.unwrap_or("unknown"),
+            VERSION.as_deref().unwrap_or("unknown"),
             RELAY_DSN,
         );
     }
@@ -228,7 +228,7 @@ async fn try_main(args: Args) -> Result<()> {
         let is_connected = is_connected.clone();
         http_health_check::serve_with_version(
             args.health_check.health_check_addr,
-            firezone_relay::VERSION,
+            firezone_relay::VERSION.as_deref(),
             move || is_connected.load(Ordering::Relaxed),
         )
     });


### PR DESCRIPTION
The relay embedded the commit SHA at compile time via `option_env!("GITHUB_SHA")`, so its binary changed on every commit and could not be cached or restored across builds. It now reads the SHA from the `FIREZONE_RELEASE` environment variable at startup, degrading to `unknown` when the variable is unset (e.g. local or container runs).

Related: firezone/infra#774