### PR TITLE
test(tunnel): only expect pings to connected gateways

### DIFF
--- a/rust/libs/connlib/tunnel/src/tests/ref_client.rs
+++ b/rust/libs/connlib/tunnel/src/tests/ref_client.rs
@@ -571,6 +571,18 @@ impl RefClient {
             };
             tracing::Span::current().record("gateway", tracing::field::display(gateway));
 
+            // A gateway's tunnel IP is only routable once we are connected to it:
+            // connlib learns the IP as part of the connection setup and drops
+            // packets to unknown peers.
+            if !self
+                .connected_resources()
+                .filter_map(&gateway_by_resource)
+                .any(|g| g == gateway)
+            {
+                tracing::debug!(%gateway, "Not connected to gateway; packet to its tunnel IP is unroutable");
+                return;
+            }
+
             gateway
         } else {
             let Some(resource) = self.resource_by_dst(&dst, proto) else {


### PR DESCRIPTION
The proptest reference model registered an expected handshake for a packet sent to any Gateway's tunnel IP, even one the client is no longer connected to. The ping strategy samples a *connected* Gateway's tunnel IP, but the connection can be torn down before the packet is applied (a filter change, a roam, a deauthorization in between). At that point `connlib` correctly drops the packet as an unknown resource while the model still expected the handshake.

Only register the expectation for Gateways the client is still connected to.