### PR TITLE
feat(connlib): hold back ICE candidates while portal is down

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -152,19 +152,21 @@ impl Eventloop {
 
                 Ok(ControlFlow::Continue(()))
             }
-            CombinedEvent::Portal(Some(Ok(event))) => {
-                match event {
-                    PortalEvent::Message(msg) => self.handle_portal_message(msg).await?,
-                    PortalEvent::Connected => {
-                        if let Some(tunnel) = self.tunnel.as_mut() {
-                            tunnel.state_mut().set_portal_connected(true);
-                        }
-                    }
-                    PortalEvent::Disconnected => {
-                        if let Some(tunnel) = self.tunnel.as_mut() {
-                            tunnel.state_mut().set_portal_connected(false);
-                        }
-                    }
+            CombinedEvent::Portal(Some(Ok(PortalEvent::Message(msg)))) => {
+                self.handle_portal_message(msg).await?;
+
+                Ok(ControlFlow::Continue(()))
+            }
+            CombinedEvent::Portal(Some(Ok(PortalEvent::Connected))) => {
+                if let Some(tunnel) = self.tunnel.as_mut() {
+                    tunnel.state_mut().set_portal_connected(true);
+                }
+
+                Ok(ControlFlow::Continue(()))
+            }
+            CombinedEvent::Portal(Some(Ok(PortalEvent::Disconnected))) => {
+                if let Some(tunnel) = self.tunnel.as_mut() {
+                    tunnel.state_mut().set_portal_connected(false);
                 }
 
                 Ok(ControlFlow::Continue(()))

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -51,7 +51,7 @@ pub struct Eventloop {
         Result<Vec<IpAddr>, Arc<anyhow::Error>>,
         ResolveDnsRequest,
     >,
-    portal_event_rx: mpsc::Receiver<Result<IngressMessages, phoenix_channel::Error>>,
+    portal_event_rx: mpsc::Receiver<Result<PortalEvent, phoenix_channel::Error>>,
     portal_cmd_tx: mpsc::Sender<PortalCommand>,
 
     sigint: signals::Terminate,
@@ -65,6 +65,15 @@ pub struct Eventloop {
 enum PortalCommand {
     Send(EgressMessages),
     Close,
+}
+
+/// An update from the portal connection task to the main event-loop.
+enum PortalEvent {
+    Message(IngressMessages),
+    /// The portal connection (re)established.
+    Connected,
+    /// The portal connection dropped and is being re-established.
+    Disconnected,
 }
 
 impl Eventloop {
@@ -112,7 +121,7 @@ impl Eventloop {
 enum CombinedEvent {
     SigIntTerm,
     Tunnel(GatewayEvent),
-    Portal(Option<Result<IngressMessages, phoenix_channel::Error>>),
+    Portal(Option<Result<PortalEvent, phoenix_channel::Error>>),
     DomainResolved((Result<Vec<IpAddr>, Arc<anyhow::Error>>, ResolveDnsRequest)),
 }
 
@@ -143,8 +152,20 @@ impl Eventloop {
 
                 Ok(ControlFlow::Continue(()))
             }
-            CombinedEvent::Portal(Some(Ok(msg))) => {
-                self.handle_portal_message(msg).await?;
+            CombinedEvent::Portal(Some(Ok(event))) => {
+                match event {
+                    PortalEvent::Message(msg) => self.handle_portal_message(msg).await?,
+                    PortalEvent::Connected => {
+                        if let Some(tunnel) = self.tunnel.as_mut() {
+                            tunnel.state_mut().set_portal_connected(true);
+                        }
+                    }
+                    PortalEvent::Disconnected => {
+                        if let Some(tunnel) = self.tunnel.as_mut() {
+                            tunnel.state_mut().set_portal_connected(false);
+                        }
+                    }
+                }
 
                 Ok(ControlFlow::Continue(()))
             }
@@ -540,7 +561,7 @@ async fn resolve_record(
 async fn phoenix_channel_event_loop(
     mut portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
     public_key: PublicKeyParam,
-    event_tx: mpsc::Sender<Result<IngressMessages, phoenix_channel::Error>>,
+    event_tx: mpsc::Sender<Result<PortalEvent, phoenix_channel::Error>>,
     mut cmd_rx: mpsc::Receiver<PortalCommand>,
     resolver: TokioResolver,
 ) {
@@ -555,7 +576,7 @@ async fn phoenix_channel_event_loop(
     loop {
         match select(poll_fn(|cx| portal.poll(cx)), pin!(cmd_rx.recv())).await {
             Either::Left((Ok(phoenix_channel::Event::Message { msg, .. }), _)) => {
-                if event_tx.send(Ok(msg)).await.is_err() {
+                if event_tx.send(Ok(PortalEvent::Message(msg))).await.is_err() {
                     tracing::debug!("Event channel closed: exiting phoenix-channel event-loop");
                     break;
                 }
@@ -580,6 +601,8 @@ async fn phoenix_channel_event_loop(
                 );
                 hiccups.add(1, &telemetry::otel::error_layers(&error));
 
+                let _ = event_tx.send(Ok(PortalEvent::Disconnected)).await;
+
                 let ips = resolve_portal_host_ips(&resolver, portal.host()).await;
                 portal.connect(ips, backoff, public_key.clone());
             }
@@ -590,6 +613,8 @@ async fn phoenix_channel_event_loop(
                 ) {
                     tracing::debug!(?msg, "Failed to send snownet capabilities: Not connected");
                 }
+
+                let _ = event_tx.send(Ok(PortalEvent::Connected)).await;
             }
             Either::Left((Err(e), _)) => {
                 let _ = event_tx.send(Err(e)).await; // We don't care about the result because we are exiting anyway.

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -68,7 +68,7 @@ pub struct Eventloop {
     tun_config_sender: watch::Sender<Option<TunConfig>>,
     user_notification_sender: mpsc::Sender<UserNotification>,
 
-    portal_event_rx: mpsc::Receiver<Result<IngressMessages, phoenix_channel::Error>>,
+    portal_event_rx: mpsc::Receiver<Result<PortalEvent, phoenix_channel::Error>>,
     portal_cmd_tx: mpsc::Sender<PortalCommand>,
 
     logged_permission_denied: bool,
@@ -95,6 +95,15 @@ enum PortalCommand {
     Connect(PublicKeyParam),
     Send(EgressMessages),
     UpdateDnsServers(Vec<IpAddr>),
+}
+
+/// An update from the portal connection task to the main event-loop.
+enum PortalEvent {
+    Message(IngressMessages),
+    /// The portal connection (re)established.
+    Connected,
+    /// The portal connection dropped and is being re-established.
+    Disconnected,
 }
 
 /// Unified error type to use across connlib.
@@ -177,7 +186,7 @@ impl Eventloop {
 enum CombinedEvent {
     Command(Option<Command>),
     Tunnel(ClientEvent),
-    Portal(Option<Result<IngressMessages, phoenix_channel::Error>>),
+    Portal(Option<Result<PortalEvent, phoenix_channel::Error>>),
 }
 
 impl Eventloop {
@@ -218,8 +227,19 @@ impl Eventloop {
                 Ok(ControlFlow::Continue(()))
             }
             CombinedEvent::Portal(Some(event)) => {
-                let msg = event.context("Connection to portal failed")?;
-                self.handle_portal_message(msg).await?;
+                match event.context("Connection to portal failed")? {
+                    PortalEvent::Message(msg) => self.handle_portal_message(msg).await?,
+                    PortalEvent::Connected => {
+                        if let Some(tunnel) = self.tunnel.as_mut() {
+                            tunnel.state_mut().set_portal_connected(true);
+                        }
+                    }
+                    PortalEvent::Disconnected => {
+                        if let Some(tunnel) = self.tunnel.as_mut() {
+                            tunnel.state_mut().set_portal_connected(false);
+                        }
+                    }
+                }
 
                 Ok(ControlFlow::Continue(()))
             }
@@ -823,7 +843,7 @@ fn persist_ingest_token(spool_root: Option<&std::path::Path>, token: &IngestToke
 async fn phoenix_channel_event_loop(
     mut portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
     mut public_key: PublicKeyParam,
-    event_tx: mpsc::Sender<Result<IngressMessages, phoenix_channel::Error>>,
+    event_tx: mpsc::Sender<Result<PortalEvent, phoenix_channel::Error>>,
     mut cmd_rx: mpsc::Receiver<PortalCommand>,
     udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
     tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
@@ -875,7 +895,7 @@ async fn phoenix_channel_event_loop(
                 break;
             }
             Either::Right((Ok(phoenix_channel::Event::Message { msg, .. }), _)) => {
-                if event_tx.send(Ok(msg)).await.is_err() {
+                if event_tx.send(Ok(PortalEvent::Message(msg))).await.is_err() {
                     tracing::debug!("Event channel closed: exiting phoenix-channel event-loop");
 
                     break;
@@ -900,6 +920,8 @@ async fn phoenix_channel_event_loop(
                 );
                 hiccups.add(1, &telemetry::otel::error_layers(&error));
 
+                let _ = event_tx.send(Ok(PortalEvent::Disconnected)).await;
+
                 let ips = resolve_portal_host_ips(&bootstrap_dns_client, portal.host()).await;
                 portal.connect(ips, backoff, public_key.clone());
             }
@@ -910,6 +932,8 @@ async fn phoenix_channel_event_loop(
                 ) {
                     tracing::debug!(?msg, "Failed to send snownet capabilities: Not connected");
                 }
+
+                let _ = event_tx.send(Ok(PortalEvent::Connected)).await;
             }
             Either::Right((Err(e), _)) => {
                 let _ = event_tx.send(Err(e)).await; // We don't care about the result because we are exiting anyway.

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -226,23 +226,28 @@ impl Eventloop {
 
                 Ok(ControlFlow::Continue(()))
             }
-            CombinedEvent::Portal(Some(event)) => {
-                match event.context("Connection to portal failed")? {
-                    PortalEvent::Message(msg) => self.handle_portal_message(msg).await?,
-                    PortalEvent::Connected => {
-                        if let Some(tunnel) = self.tunnel.as_mut() {
-                            tunnel.state_mut().set_portal_connected(true);
-                        }
-                    }
-                    PortalEvent::Disconnected => {
-                        if let Some(tunnel) = self.tunnel.as_mut() {
-                            tunnel.state_mut().set_portal_connected(false);
-                        }
-                    }
+            CombinedEvent::Portal(Some(Ok(PortalEvent::Message(msg)))) => {
+                self.handle_portal_message(msg).await?;
+
+                Ok(ControlFlow::Continue(()))
+            }
+            CombinedEvent::Portal(Some(Ok(PortalEvent::Connected))) => {
+                if let Some(tunnel) = self.tunnel.as_mut() {
+                    tunnel.state_mut().set_portal_connected(true);
                 }
 
                 Ok(ControlFlow::Continue(()))
             }
+            CombinedEvent::Portal(Some(Ok(PortalEvent::Disconnected))) => {
+                if let Some(tunnel) = self.tunnel.as_mut() {
+                    tunnel.state_mut().set_portal_connected(false);
+                }
+
+                Ok(ControlFlow::Continue(()))
+            }
+            CombinedEvent::Portal(Some(Err(e))) => Err(DisconnectError(
+                anyhow::Error::new(e).context("Connection to portal failed"),
+            )),
             CombinedEvent::Portal(None) => Err(DisconnectError(anyhow::Error::msg(
                 "portal task exited unexpectedly",
             ))),

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -3022,6 +3022,37 @@ mod tests {
         assert!(state.poll_event().is_none());
     }
 
+    #[test]
+    fn held_candidates_flush_to_peer_on_portal_reconnect() {
+        let mut state = ClientState::for_test();
+        let gateway = ClientOrGatewayId::Gateway(GatewayId::from_u128(1));
+
+        // While the portal is down, candidate changes are held back rather than emitted.
+        state.set_portal_connected(false);
+        state
+            .held_added_ice_candidates
+            .entry(gateway)
+            .or_default()
+            .insert("added".to_owned().into());
+        state
+            .held_removed_ice_candidates
+            .entry(gateway)
+            .or_default()
+            .insert("removed".to_owned().into());
+        assert!(state.poll_event().is_none());
+
+        // On reconnect, both the additions and the removals are flushed to the peer.
+        state.set_portal_connected(true);
+        let events = std::iter::from_fn(|| state.poll_event()).collect::<Vec<_>>();
+
+        assert!(events.iter().any(|e| matches!(e,
+            ClientEvent::AddedIceCandidates { conn_id, candidates }
+                if *conn_id == gateway && candidates.len() == 1)));
+        assert!(events.iter().any(|e| matches!(e,
+            ClientEvent::RemovedIceCandidates { conn_id, candidates }
+                if *conn_id == gateway && candidates.len() == 1)));
+    }
+
     impl ClientState {
         pub fn for_test() -> ClientState {
             ClientState::new(

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -33,6 +33,7 @@ use crate::messages::{
     client::{DevicePoolMember, FailReason},
 };
 use crate::peer_store::{Peer, PeerStore};
+use crate::portal_connection::PortalConnection;
 use crate::unique_packet_buffer::UniquePacketBuffer;
 use crate::unix_ts::UnixTsClock;
 use crate::unroutable_packet::UnroutablePacket;
@@ -182,22 +183,8 @@ pub struct ClientState {
     buffered_packets: VecDeque<IpPacket>,
     buffered_transmits: snownet::TransmitBuffer,
 
-    /// Whether we currently have a live connection to the portal.
-    ///
-    /// ICE candidates are signalled to peers through the portal, so while it is
-    /// disconnected any candidate change we emit would be lost. We therefore hold
-    /// candidate changes back until the portal reconnects.
-    portal_connected: bool,
-    /// New candidates gathered while the portal was disconnected, per connection.
-    ///
-    /// Flushed to the peer as soon as the portal reconnects (see
-    /// [`ClientState::set_portal_connected`]).
-    held_added_ice_candidates: BTreeMap<ClientOrGatewayId, BTreeSet<IceCandidate>>,
-    /// Previously-signalled candidates invalidated while the portal was disconnected.
-    ///
-    /// Flushed to the peer on reconnect so it stops using an address that is no longer
-    /// reachable (e.g. a replaced relay allocation).
-    held_removed_ice_candidates: BTreeMap<ClientOrGatewayId, BTreeSet<IceCandidate>>,
+    /// Our connection to the portal, holding back ICE candidates while it is down.
+    portal: PortalConnection<ClientOrGatewayId>,
 
     unix_ts_clock: UnixTsClock,
     buffered_dns_queries: VecDeque<dns::RecursiveQuery>,
@@ -224,9 +211,7 @@ impl ClientState {
             buffered_packets: Default::default(),
             node: Node::new(seed, now, unix_ts),
             flow_tracker: flow_tracker::Tracker::new(now, unix_ts),
-            portal_connected: true,
-            held_added_ice_candidates: Default::default(),
-            held_removed_ice_candidates: Default::default(),
+            portal: Default::default(),
             sites_status: Default::default(),
             gateways_by_site: Default::default(),
             resource_stub_resolver: ResourceStubResolver::new(records),
@@ -1460,10 +1445,8 @@ impl ClientState {
             .remove(&ClientOrGatewayId::Gateway(*disconnected_gateway));
         self.pending_peer_packets
             .remove(&ClientOrGatewayId::Gateway(*disconnected_gateway));
-        self.held_added_ice_candidates
-            .remove(&ClientOrGatewayId::Gateway(*disconnected_gateway));
-        self.held_removed_ice_candidates
-            .remove(&ClientOrGatewayId::Gateway(*disconnected_gateway));
+        self.portal
+            .forget(&ClientOrGatewayId::Gateway(*disconnected_gateway));
         self.update_site_status_by_gateway(disconnected_gateway, ResourceStatus::Unknown, now);
         self.gateways.remove(disconnected_gateway);
         for _ in self
@@ -1479,10 +1462,8 @@ impl ClientState {
             .remove(&ClientOrGatewayId::Client(*disconnected_client));
         self.pending_peer_packets
             .remove(&ClientOrGatewayId::Client(*disconnected_client));
-        self.held_added_ice_candidates
-            .remove(&ClientOrGatewayId::Client(*disconnected_client));
-        self.held_removed_ice_candidates
-            .remove(&ClientOrGatewayId::Client(*disconnected_client));
+        self.portal
+            .forget(&ClientOrGatewayId::Client(*disconnected_client));
         if self.clients.remove(disconnected_client).is_some() {
             self.resource_list.update(self.resource_list_snapshot());
         }
@@ -2116,37 +2097,16 @@ impl ClientState {
                 snownet::Event::NewIceCandidate {
                     connection,
                     candidate,
-                } if !self.portal_connected => {
+                } if !self.portal.is_connected() => {
                     // Portal is down: hold the candidate back until it reconnects
                     // instead of emitting an event that would be lost.
-                    let candidate = candidate.into();
-                    if let Some(removed) = self.held_removed_ice_candidates.get_mut(&connection) {
-                        removed.remove(&candidate);
-                    }
-                    self.held_added_ice_candidates
-                        .entry(connection)
-                        .or_default()
-                        .insert(candidate);
+                    self.portal.hold_added(connection, candidate.into());
                 }
                 snownet::Event::InvalidateIceCandidate {
                     connection,
                     candidate,
-                } if !self.portal_connected => {
-                    let candidate = candidate.into();
-                    let was_held_add = self
-                        .held_added_ice_candidates
-                        .get_mut(&connection)
-                        .is_some_and(|added| added.remove(&candidate));
-
-                    // Only signal the removal for candidates the peer already learned.
-                    // One we were still holding back was never signalled, so cancelling
-                    // it locally is enough.
-                    if !was_held_add {
-                        self.held_removed_ice_candidates
-                            .entry(connection)
-                            .or_default()
-                            .insert(candidate);
-                    }
+                } if !self.portal.is_connected() => {
+                    self.portal.hold_removed(connection, candidate.into());
                 }
                 snownet::Event::NewIceCandidate {
                     connection,
@@ -2310,14 +2270,14 @@ impl ClientState {
     /// connection, so a peer we roamed away from learns our new addresses and forgets
     /// the ones that became unreachable.
     pub fn set_portal_connected(&mut self, connected: bool) {
-        let reconnected = connected && !self.portal_connected;
-        self.portal_connected = connected;
-
-        if !reconnected {
+        if !connected {
+            self.portal.disconnect();
             return;
         }
 
-        for (conn_id, candidates) in std::mem::take(&mut self.held_added_ice_candidates) {
+        let held = self.portal.connect();
+
+        for (conn_id, candidates) in held.added {
             if candidates.is_empty() {
                 continue;
             }
@@ -2329,7 +2289,7 @@ impl ClientState {
                 });
         }
 
-        for (conn_id, candidates) in std::mem::take(&mut self.held_removed_ice_candidates) {
+        for (conn_id, candidates) in held.removed {
             if candidates.is_empty() {
                 continue;
             }
@@ -3020,37 +2980,6 @@ mod tests {
             &(ResourceStatus::Offline, offline_at)
         );
         assert!(state.poll_event().is_none());
-    }
-
-    #[test]
-    fn held_candidates_flush_to_peer_on_portal_reconnect() {
-        let mut state = ClientState::for_test();
-        let gateway = ClientOrGatewayId::Gateway(GatewayId::from_u128(1));
-
-        // While the portal is down, candidate changes are held back rather than emitted.
-        state.set_portal_connected(false);
-        state
-            .held_added_ice_candidates
-            .entry(gateway)
-            .or_default()
-            .insert("added".to_owned().into());
-        state
-            .held_removed_ice_candidates
-            .entry(gateway)
-            .or_default()
-            .insert("removed".to_owned().into());
-        assert!(state.poll_event().is_none());
-
-        // On reconnect, both the additions and the removals are flushed to the peer.
-        state.set_portal_connected(true);
-        let events = std::iter::from_fn(|| state.poll_event()).collect::<Vec<_>>();
-
-        assert!(events.iter().any(|e| matches!(e,
-            ClientEvent::AddedIceCandidates { conn_id, candidates }
-                if *conn_id == gateway && candidates.len() == 1)));
-        assert!(events.iter().any(|e| matches!(e,
-            ClientEvent::RemovedIceCandidates { conn_id, candidates }
-                if *conn_id == gateway && candidates.len() == 1)));
     }
 
     impl ClientState {

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -185,14 +185,19 @@ pub struct ClientState {
     /// Whether we currently have a live connection to the portal.
     ///
     /// ICE candidates are signalled to peers through the portal, so while it is
-    /// disconnected any candidate we emit would be lost. We therefore hold candidates
-    /// back in [`Self::held_ice_candidates`] until the portal reconnects.
+    /// disconnected any candidate change we emit would be lost. We therefore hold
+    /// candidate changes back until the portal reconnects.
     portal_connected: bool,
-    /// Candidates gathered while the portal was disconnected, per connection.
+    /// New candidates gathered while the portal was disconnected, per connection.
     ///
     /// Flushed to the peer as soon as the portal reconnects (see
     /// [`ClientState::set_portal_connected`]).
-    held_ice_candidates: BTreeMap<ClientOrGatewayId, BTreeSet<IceCandidate>>,
+    held_added_ice_candidates: BTreeMap<ClientOrGatewayId, BTreeSet<IceCandidate>>,
+    /// Previously-signalled candidates invalidated while the portal was disconnected.
+    ///
+    /// Flushed to the peer on reconnect so it stops using an address that is no longer
+    /// reachable (e.g. a replaced relay allocation).
+    held_removed_ice_candidates: BTreeMap<ClientOrGatewayId, BTreeSet<IceCandidate>>,
 
     unix_ts_clock: UnixTsClock,
     buffered_dns_queries: VecDeque<dns::RecursiveQuery>,
@@ -220,7 +225,8 @@ impl ClientState {
             node: Node::new(seed, now, unix_ts),
             flow_tracker: flow_tracker::Tracker::new(now, unix_ts),
             portal_connected: true,
-            held_ice_candidates: Default::default(),
+            held_added_ice_candidates: Default::default(),
+            held_removed_ice_candidates: Default::default(),
             sites_status: Default::default(),
             gateways_by_site: Default::default(),
             resource_stub_resolver: ResourceStubResolver::new(records),
@@ -1454,7 +1460,9 @@ impl ClientState {
             .remove(&ClientOrGatewayId::Gateway(*disconnected_gateway));
         self.pending_peer_packets
             .remove(&ClientOrGatewayId::Gateway(*disconnected_gateway));
-        self.held_ice_candidates
+        self.held_added_ice_candidates
+            .remove(&ClientOrGatewayId::Gateway(*disconnected_gateway));
+        self.held_removed_ice_candidates
             .remove(&ClientOrGatewayId::Gateway(*disconnected_gateway));
         self.update_site_status_by_gateway(disconnected_gateway, ResourceStatus::Unknown, now);
         self.gateways.remove(disconnected_gateway);
@@ -1471,7 +1479,9 @@ impl ClientState {
             .remove(&ClientOrGatewayId::Client(*disconnected_client));
         self.pending_peer_packets
             .remove(&ClientOrGatewayId::Client(*disconnected_client));
-        self.held_ice_candidates
+        self.held_added_ice_candidates
+            .remove(&ClientOrGatewayId::Client(*disconnected_client));
+        self.held_removed_ice_candidates
             .remove(&ClientOrGatewayId::Client(*disconnected_client));
         if self.clients.remove(disconnected_client).is_some() {
             self.resource_list.update(self.resource_list_snapshot());
@@ -2109,18 +2119,33 @@ impl ClientState {
                 } if !self.portal_connected => {
                     // Portal is down: hold the candidate back until it reconnects
                     // instead of emitting an event that would be lost.
-                    self.held_ice_candidates
+                    let candidate = candidate.into();
+                    if let Some(removed) = self.held_removed_ice_candidates.get_mut(&connection) {
+                        removed.remove(&candidate);
+                    }
+                    self.held_added_ice_candidates
                         .entry(connection)
                         .or_default()
-                        .insert(candidate.into());
+                        .insert(candidate);
                 }
                 snownet::Event::InvalidateIceCandidate {
                     connection,
                     candidate,
                 } if !self.portal_connected => {
-                    // Never signalled while held, so just drop it from the pending set.
-                    if let Some(held) = self.held_ice_candidates.get_mut(&connection) {
-                        held.remove(&candidate.into());
+                    let candidate = candidate.into();
+                    let was_held_add = self
+                        .held_added_ice_candidates
+                        .get_mut(&connection)
+                        .is_some_and(|added| added.remove(&candidate));
+
+                    // Only signal the removal for candidates the peer already learned.
+                    // One we were still holding back was never signalled, so cancelling
+                    // it locally is enough.
+                    if !was_held_add {
+                        self.held_removed_ice_candidates
+                            .entry(connection)
+                            .or_default()
+                            .insert(candidate);
                     }
                 }
                 snownet::Event::NewIceCandidate {
@@ -2280,10 +2305,10 @@ impl ClientState {
 
     /// Records whether we currently have a live connection to the portal.
     ///
-    /// While disconnected, ICE candidates are held back (see [`Self::held_ice_candidates`]).
-    /// On the disconnected -> connected edge, the held candidates are flushed to their peers
-    /// as a single `AddedIceCandidates` per connection so a peer we roamed away from learns
-    /// our new addresses.
+    /// While disconnected, ICE candidate changes are held back. On the disconnected ->
+    /// connected edge, the held changes are flushed to their peers, one batch per
+    /// connection, so a peer we roamed away from learns our new addresses and forgets
+    /// the ones that became unreachable.
     pub fn set_portal_connected(&mut self, connected: bool) {
         let reconnected = connected && !self.portal_connected;
         self.portal_connected = connected;
@@ -2292,13 +2317,25 @@ impl ClientState {
             return;
         }
 
-        for (conn_id, candidates) in std::mem::take(&mut self.held_ice_candidates) {
+        for (conn_id, candidates) in std::mem::take(&mut self.held_added_ice_candidates) {
             if candidates.is_empty() {
                 continue;
             }
 
             self.buffered_events
                 .push_back(ClientEvent::AddedIceCandidates {
+                    conn_id,
+                    candidates,
+                });
+        }
+
+        for (conn_id, candidates) in std::mem::take(&mut self.held_removed_ice_candidates) {
+            if candidates.is_empty() {
+                continue;
+            }
+
+            self.buffered_events
+                .push_back(ClientEvent::RemovedIceCandidates {
                     conn_id,
                     candidates,
                 });

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -182,6 +182,18 @@ pub struct ClientState {
     buffered_packets: VecDeque<IpPacket>,
     buffered_transmits: snownet::TransmitBuffer,
 
+    /// Whether we currently have a live connection to the portal.
+    ///
+    /// ICE candidates are signalled to peers through the portal, so while it is
+    /// disconnected any candidate we emit would be lost. We therefore hold candidates
+    /// back in [`Self::held_ice_candidates`] until the portal reconnects.
+    portal_connected: bool,
+    /// Candidates gathered while the portal was disconnected, per connection.
+    ///
+    /// Flushed to the peer as soon as the portal reconnects (see
+    /// [`ClientState::set_portal_connected`]).
+    held_ice_candidates: BTreeMap<ClientOrGatewayId, BTreeSet<IceCandidate>>,
+
     unix_ts_clock: UnixTsClock,
     buffered_dns_queries: VecDeque<dns::RecursiveQuery>,
     dns_lookup_duration: opentelemetry::metrics::Histogram<f64>,
@@ -207,6 +219,8 @@ impl ClientState {
             buffered_packets: Default::default(),
             node: Node::new(seed, now, unix_ts),
             flow_tracker: flow_tracker::Tracker::new(now, unix_ts),
+            portal_connected: true,
+            held_ice_candidates: Default::default(),
             sites_status: Default::default(),
             gateways_by_site: Default::default(),
             resource_stub_resolver: ResourceStubResolver::new(records),
@@ -1440,6 +1454,8 @@ impl ClientState {
             .remove(&ClientOrGatewayId::Gateway(*disconnected_gateway));
         self.pending_peer_packets
             .remove(&ClientOrGatewayId::Gateway(*disconnected_gateway));
+        self.held_ice_candidates
+            .remove(&ClientOrGatewayId::Gateway(*disconnected_gateway));
         self.update_site_status_by_gateway(disconnected_gateway, ResourceStatus::Unknown, now);
         self.gateways.remove(disconnected_gateway);
         for _ in self
@@ -1454,6 +1470,8 @@ impl ClientState {
         self.pending_routed_packets
             .remove(&ClientOrGatewayId::Client(*disconnected_client));
         self.pending_peer_packets
+            .remove(&ClientOrGatewayId::Client(*disconnected_client));
+        self.held_ice_candidates
             .remove(&ClientOrGatewayId::Client(*disconnected_client));
         if self.clients.remove(disconnected_client).is_some() {
             self.resource_list.update(self.resource_list_snapshot());
@@ -2088,6 +2106,26 @@ impl ClientState {
                 snownet::Event::NewIceCandidate {
                     connection,
                     candidate,
+                } if !self.portal_connected => {
+                    // Portal is down: hold the candidate back until it reconnects
+                    // instead of emitting an event that would be lost.
+                    self.held_ice_candidates
+                        .entry(connection)
+                        .or_default()
+                        .insert(candidate.into());
+                }
+                snownet::Event::InvalidateIceCandidate {
+                    connection,
+                    candidate,
+                } if !self.portal_connected => {
+                    // Never signalled while held, so just drop it from the pending set.
+                    if let Some(held) = self.held_ice_candidates.get_mut(&connection) {
+                        held.remove(&candidate.into());
+                    }
+                }
+                snownet::Event::NewIceCandidate {
+                    connection,
+                    candidate,
                 } => {
                     added_ice_candidates
                         .entry(connection)
@@ -2238,6 +2276,33 @@ impl ClientState {
         }
 
         self.buffered_events.pop_front()
+    }
+
+    /// Records whether we currently have a live connection to the portal.
+    ///
+    /// While disconnected, ICE candidates are held back (see [`Self::held_ice_candidates`]).
+    /// On the disconnected -> connected edge, the held candidates are flushed to their peers
+    /// as a single `AddedIceCandidates` per connection so a peer we roamed away from learns
+    /// our new addresses.
+    pub fn set_portal_connected(&mut self, connected: bool) {
+        let reconnected = connected && !self.portal_connected;
+        self.portal_connected = connected;
+
+        if !reconnected {
+            return;
+        }
+
+        for (conn_id, candidates) in std::mem::take(&mut self.held_ice_candidates) {
+            if candidates.is_empty() {
+                continue;
+            }
+
+            self.buffered_events
+                .push_back(ClientEvent::AddedIceCandidates {
+                    conn_id,
+                    candidates,
+                });
+        }
     }
 
     pub(crate) fn reset(&mut self, now: Instant, reason: &str) {

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -7,6 +7,7 @@ use crate::gateway::client_on_gateway::TranslateOutboundResult;
 use crate::messages::gateway::{Client, ResourceDescription};
 use crate::messages::{IceCredentials, IngestToken, ResolveRequest};
 use crate::peer_store::PeerStore;
+use crate::portal_connection::PortalConnection;
 use crate::unix_ts::UnixTsClock;
 use crate::unroutable_packet::UnroutablePacket;
 use crate::{FailedToDecapsulate, GatewayEvent, IpConfig, p2p_control, packet_kind};
@@ -50,15 +51,8 @@ pub struct GatewayState {
     buffered_events: VecDeque<GatewayEvent>,
     buffered_transmits: snownet::TransmitBuffer,
 
-    /// Whether we currently have a live connection to the portal.
-    ///
-    /// ICE candidate changes are signalled to clients through the portal, so while it is
-    /// disconnected we hold them back rather than emit events that would be lost.
-    portal_connected: bool,
-    /// New candidates gathered while the portal was disconnected, per client.
-    held_added_ice_candidates: BTreeMap<ClientId, BTreeSet<IceCandidate>>,
-    /// Previously-signalled candidates invalidated while the portal was disconnected, per client.
-    held_removed_ice_candidates: BTreeMap<ClientId, BTreeSet<IceCandidate>>,
+    /// Our connection to the portal, holding back ICE candidates while it is down.
+    portal: PortalConnection<ClientId>,
 }
 
 #[derive(Debug)]
@@ -83,9 +77,7 @@ impl GatewayState {
         Self {
             peers: Default::default(),
             node: Node::new(seed, now, unix_ts),
-            portal_connected: true,
-            held_added_ice_candidates: Default::default(),
-            held_removed_ice_candidates: Default::default(),
+            portal: Default::default(),
             buffered_events: VecDeque::default(),
             buffered_transmits: snownet::TransmitBuffer::default(),
             flow_tracker: flow_tracker::Tracker::new(now, unix_ts),
@@ -487,38 +479,19 @@ impl GatewayState {
                     // We purposely don't clear the peer-state here.
                     // The Client might re-establish the connection but if it hasn't cleared its local state too,
                     // it will consider all its access authorizations to be still valid.
-                    self.held_added_ice_candidates.remove(&id);
-                    self.held_removed_ice_candidates.remove(&id);
+                    self.portal.forget(&id);
                 }
                 snownet::Event::NewIceCandidate {
                     connection,
                     candidate,
-                } if !self.portal_connected => {
-                    let candidate = candidate.into();
-                    if let Some(removed) = self.held_removed_ice_candidates.get_mut(&connection) {
-                        removed.remove(&candidate);
-                    }
-                    self.held_added_ice_candidates
-                        .entry(connection)
-                        .or_default()
-                        .insert(candidate);
+                } if !self.portal.is_connected() => {
+                    self.portal.hold_added(connection, candidate.into());
                 }
                 snownet::Event::InvalidateIceCandidate {
                     connection,
                     candidate,
-                } if !self.portal_connected => {
-                    let candidate = candidate.into();
-                    let was_held_add = self
-                        .held_added_ice_candidates
-                        .get_mut(&connection)
-                        .is_some_and(|added| added.remove(&candidate));
-
-                    if !was_held_add {
-                        self.held_removed_ice_candidates
-                            .entry(connection)
-                            .or_default()
-                            .insert(candidate);
-                    }
+                } if !self.portal.is_connected() => {
+                    self.portal.hold_removed(connection, candidate.into());
                 }
                 snownet::Event::NewIceCandidate {
                     connection,
@@ -588,14 +561,14 @@ impl GatewayState {
     /// connected edge, the held changes are flushed to their clients, one batch per
     /// connection.
     pub fn set_portal_connected(&mut self, connected: bool) {
-        let reconnected = connected && !self.portal_connected;
-        self.portal_connected = connected;
-
-        if !reconnected {
+        if !connected {
+            self.portal.disconnect();
             return;
         }
 
-        for (conn_id, candidates) in std::mem::take(&mut self.held_added_ice_candidates) {
+        let held = self.portal.connect();
+
+        for (conn_id, candidates) in held.added {
             if candidates.is_empty() {
                 continue;
             }
@@ -607,7 +580,7 @@ impl GatewayState {
                 });
         }
 
-        for (conn_id, candidates) in std::mem::take(&mut self.held_removed_ice_candidates) {
+        for (conn_id, candidates) in held.removed {
             if candidates.is_empty() {
                 continue;
             }

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -49,6 +49,16 @@ pub struct GatewayState {
 
     buffered_events: VecDeque<GatewayEvent>,
     buffered_transmits: snownet::TransmitBuffer,
+
+    /// Whether we currently have a live connection to the portal.
+    ///
+    /// ICE candidate changes are signalled to clients through the portal, so while it is
+    /// disconnected we hold them back rather than emit events that would be lost.
+    portal_connected: bool,
+    /// New candidates gathered while the portal was disconnected, per client.
+    held_added_ice_candidates: BTreeMap<ClientId, BTreeSet<IceCandidate>>,
+    /// Previously-signalled candidates invalidated while the portal was disconnected, per client.
+    held_removed_ice_candidates: BTreeMap<ClientId, BTreeSet<IceCandidate>>,
 }
 
 #[derive(Debug)]
@@ -73,6 +83,9 @@ impl GatewayState {
         Self {
             peers: Default::default(),
             node: Node::new(seed, now, unix_ts),
+            portal_connected: true,
+            held_added_ice_candidates: Default::default(),
+            held_removed_ice_candidates: Default::default(),
             buffered_events: VecDeque::default(),
             buffered_transmits: snownet::TransmitBuffer::default(),
             flow_tracker: flow_tracker::Tracker::new(now, unix_ts),
@@ -470,10 +483,42 @@ impl GatewayState {
 
         while let Some(event) = self.node.poll_event() {
             match event {
-                snownet::Event::ConnectionFailed(_) | snownet::Event::ConnectionClosed(_) => {
+                snownet::Event::ConnectionFailed(id) | snownet::Event::ConnectionClosed(id) => {
                     // We purposely don't clear the peer-state here.
                     // The Client might re-establish the connection but if it hasn't cleared its local state too,
                     // it will consider all its access authorizations to be still valid.
+                    self.held_added_ice_candidates.remove(&id);
+                    self.held_removed_ice_candidates.remove(&id);
+                }
+                snownet::Event::NewIceCandidate {
+                    connection,
+                    candidate,
+                } if !self.portal_connected => {
+                    let candidate = candidate.into();
+                    if let Some(removed) = self.held_removed_ice_candidates.get_mut(&connection) {
+                        removed.remove(&candidate);
+                    }
+                    self.held_added_ice_candidates
+                        .entry(connection)
+                        .or_default()
+                        .insert(candidate);
+                }
+                snownet::Event::InvalidateIceCandidate {
+                    connection,
+                    candidate,
+                } if !self.portal_connected => {
+                    let candidate = candidate.into();
+                    let was_held_add = self
+                        .held_added_ice_candidates
+                        .get_mut(&connection)
+                        .is_some_and(|added| added.remove(&candidate));
+
+                    if !was_held_add {
+                        self.held_removed_ice_candidates
+                            .entry(connection)
+                            .or_default()
+                            .insert(candidate);
+                    }
                 }
                 snownet::Event::NewIceCandidate {
                     connection,
@@ -535,6 +580,44 @@ impl GatewayState {
         }
 
         None
+    }
+
+    /// Records whether we currently have a live connection to the portal.
+    ///
+    /// While disconnected, ICE candidate changes are held back. On the disconnected ->
+    /// connected edge, the held changes are flushed to their clients, one batch per
+    /// connection.
+    pub fn set_portal_connected(&mut self, connected: bool) {
+        let reconnected = connected && !self.portal_connected;
+        self.portal_connected = connected;
+
+        if !reconnected {
+            return;
+        }
+
+        for (conn_id, candidates) in std::mem::take(&mut self.held_added_ice_candidates) {
+            if candidates.is_empty() {
+                continue;
+            }
+
+            self.buffered_events
+                .push_back(GatewayEvent::AddedIceCandidates {
+                    conn_id,
+                    candidates,
+                });
+        }
+
+        for (conn_id, candidates) in std::mem::take(&mut self.held_removed_ice_candidates) {
+            if candidates.is_empty() {
+                continue;
+            }
+
+            self.buffered_events
+                .push_back(GatewayEvent::RemovedIceCandidates {
+                    conn_id,
+                    candidates,
+                });
+        }
     }
 
     pub fn update_relays(

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -44,6 +44,7 @@ mod otel;
 mod p2p_control;
 mod packet_kind;
 mod peer_store;
+mod portal_connection;
 #[cfg(all(test, feature = "proptest"))]
 mod proptest;
 mod routing_table;

--- a/rust/libs/connlib/tunnel/src/portal_connection.rs
+++ b/rust/libs/connlib/tunnel/src/portal_connection.rs
@@ -1,0 +1,141 @@
+use connlib_model::IceCandidate;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Tracks whether we currently have a live connection to the portal.
+///
+/// ICE candidates are signalled to peers through the portal, so while it is
+/// disconnected any candidate change would be lost. In that state we hold the
+/// changes back per connection and flush them once the portal reconnects, so a
+/// peer we roamed away from learns our new addresses and forgets the ones that
+/// became unreachable.
+#[derive(Default)]
+pub(crate) enum PortalConnection<Id> {
+    #[default]
+    Connected,
+    Disconnected(HeldCandidates<Id>),
+}
+
+/// Candidate changes held back per connection while the portal is disconnected.
+pub(crate) struct HeldCandidates<Id> {
+    /// New candidates gathered while disconnected, to signal as added on reconnect.
+    pub(crate) added: BTreeMap<Id, BTreeSet<IceCandidate>>,
+    /// Previously-signalled candidates invalidated while disconnected, to signal as
+    /// removed on reconnect.
+    pub(crate) removed: BTreeMap<Id, BTreeSet<IceCandidate>>,
+}
+
+impl<Id> Default for HeldCandidates<Id> {
+    fn default() -> Self {
+        Self {
+            added: BTreeMap::new(),
+            removed: BTreeMap::new(),
+        }
+    }
+}
+
+impl<Id: Ord> PortalConnection<Id> {
+    pub(crate) fn is_connected(&self) -> bool {
+        matches!(self, Self::Connected)
+    }
+
+    /// Records a newly gathered candidate to signal on reconnect.
+    ///
+    /// Only has an effect while disconnected; when connected the candidate is signalled
+    /// immediately by the caller instead.
+    pub(crate) fn hold_added(&mut self, connection: Id, candidate: IceCandidate) {
+        let Self::Disconnected(held) = self else {
+            return;
+        };
+
+        if let Some(removed) = held.removed.get_mut(&connection) {
+            removed.remove(&candidate);
+        }
+        held.added.entry(connection).or_default().insert(candidate);
+    }
+
+    /// Records an invalidated candidate to signal on reconnect.
+    pub(crate) fn hold_removed(&mut self, connection: Id, candidate: IceCandidate) {
+        let Self::Disconnected(held) = self else {
+            return;
+        };
+
+        // A candidate we were still holding back was never signalled, so cancelling it
+        // locally is enough; only signal the removal for ones the peer already learned.
+        let was_held_add = held
+            .added
+            .get_mut(&connection)
+            .is_some_and(|added| added.remove(&candidate));
+
+        if !was_held_add {
+            held.removed
+                .entry(connection)
+                .or_default()
+                .insert(candidate);
+        }
+    }
+
+    /// Drops any candidates held for a connection that no longer exists.
+    pub(crate) fn forget(&mut self, connection: &Id) {
+        let Self::Disconnected(held) = self else {
+            return;
+        };
+
+        held.added.remove(connection);
+        held.removed.remove(connection);
+    }
+
+    /// Marks the portal disconnected, starting to hold candidate changes back.
+    ///
+    /// Keeps any already-held candidates if we were already disconnected.
+    pub(crate) fn disconnect(&mut self) {
+        if let Self::Connected = self {
+            *self = Self::Disconnected(HeldCandidates::default());
+        }
+    }
+
+    /// Marks the portal connected, returning the candidates held during the outage so
+    /// the caller can flush them to their peers.
+    ///
+    /// Returns an empty set if we were already connected.
+    pub(crate) fn connect(&mut self) -> HeldCandidates<Id> {
+        match std::mem::replace(self, Self::Connected) {
+            Self::Connected => HeldCandidates::default(),
+            Self::Disconnected(held) => held,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn holds_candidate_changes_and_flushes_them_on_reconnect() {
+        let mut portal = PortalConnection::<u8>::default();
+        assert!(portal.is_connected());
+
+        portal.disconnect();
+        assert!(!portal.is_connected());
+
+        portal.hold_added(1, "added".to_owned().into());
+        portal.hold_removed(1, "removed".to_owned().into());
+
+        let held = portal.connect();
+        assert!(portal.is_connected());
+        assert_eq!(held.added[&1].len(), 1);
+        assert_eq!(held.removed[&1].len(), 1);
+    }
+
+    #[test]
+    fn invalidating_a_still_held_addition_cancels_it() {
+        let mut portal = PortalConnection::<u8>::default();
+        portal.disconnect();
+
+        portal.hold_added(1, "c".to_owned().into());
+        portal.hold_removed(1, "c".to_owned().into());
+
+        let held = portal.connect();
+        assert!(held.added.get(&1).is_none_or(BTreeSet::is_empty));
+        assert!(held.removed.get(&1).is_none_or(BTreeSet::is_empty));
+    }
+}

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -450,6 +450,7 @@ impl TunnelTest {
                 debug_assert!(added);
                 client.exec_mut(|c| {
                     c.sut.reset(now, "roam");
+                    c.sut.set_portal_connected(false);
                 });
 
                 let portal_until = now + portal_window;
@@ -464,6 +465,7 @@ impl TunnelTest {
                 let ref_client = ref_state.clients.get(&client_id).unwrap();
                 let client = state.clients.get_mut(&client_id).unwrap();
                 client.exec_mut(|c| {
+                    c.sut.set_portal_connected(true);
                     c.update_relays(iter::empty(), state.relays.iter(), now);
                     c.sut.set_resources(ref_client.inner().all_resources(), now);
                 });


### PR DESCRIPTION
ICE candidates are signalled to peers through the portal, so while the portal connection is down (for example mid-roam) any candidate change `connlib` emits is lost. This leaves a peer we roamed away from unable to learn our new address, so the connection cannot repair. There are no ACKs for these kind of messages and therefore also no re-transmits.

To fix this, we hold candidate additions and invalidations back per connection while the portal is disconnected, then flush them once it reconnects: the peer learns our new addresses and forgets the ones that became unreachable. The portal-connection state is tracked explicitly in the sans-IO layer for both Client and Gateway, driven from the phoenix-channel lifecycle so a connection blip flips it even without a network reset.