### PR TITLE
feat(relay): patch release SHA into binary after linking

### DIFF
--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -279,6 +279,13 @@ jobs:
 
           # Used for Docker images
           cp target/${{ matrix.arch.target }}/${{ inputs.profile }}/${{ matrix.name.package }} ${{ matrix.name.package }}
+
+          # Stamp the commit SHA into the relay's placeholder before checksum and
+          # upload; the binary is otherwise SHA-independent and cache-restorable.
+          if [[ "${{ matrix.name.package }}" == "firezone-relay" ]]; then
+            mise run //rust:patch-relay-release "$PWD/${{ matrix.name.package }}" "${{ env.RESOLVED_SHA }}"
+          fi
+
           sha256sum ${{ matrix.name.package }} > ${{ matrix.name.package }}.sha256sum.txt
 
           # Used for release artifact

--- a/rust/mise-tasks/patch-relay-release
+++ b/rust/mise-tasks/patch-relay-release
@@ -10,12 +10,13 @@ marker="firezone-git-sha:"
   echo "error: $binary not found" >&2
   exit 1
 }
-[[ "${#sha}" -eq 40 ]] || {
-  echo "error: expected a 40-char SHA, got '$sha' (${#sha} chars)" >&2
+[[ "$sha" =~ ^[0-9a-fA-F]{40}$ ]] || {
+  echo "error: expected a 40-char hex SHA, got '$sha'" >&2
   exit 1
 }
 
-hits=$(grep -F -a -b -o "$marker" "$binary" || true)
+# LC_ALL=C keeps grep byte-oriented (offsets, not multibyte characters).
+hits=$(LC_ALL=C grep -F -a -b -o "$marker" "$binary" || true)
 count=$(printf '%s' "$hits" | grep -c . || true)
 [[ "$count" -eq 1 ]] || {
   echo "error: '$marker' must appear exactly once in $binary (found $count)" >&2

--- a/rust/mise-tasks/patch-relay-release
+++ b/rust/mise-tasks/patch-relay-release
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#MISE description="Stamp a 40-char commit SHA into a built relay binary's release placeholder"
+set -euo pipefail
+
+binary="${1:?usage: mise run //rust:patch-relay-release <binary> <sha>}"
+sha="${2:?usage: mise run //rust:patch-relay-release <binary> <sha>}"
+marker="firezone-git-sha:"
+
+[[ -f "$binary" ]] || {
+  echo "error: $binary not found" >&2
+  exit 1
+}
+[[ "${#sha}" -eq 40 ]] || {
+  echo "error: expected a 40-char SHA, got '$sha' (${#sha} chars)" >&2
+  exit 1
+}
+
+hits=$(grep -F -a -b -o "$marker" "$binary" || true)
+count=$(printf '%s' "$hits" | grep -c . || true)
+[[ "$count" -eq 1 ]] || {
+  echo "error: '$marker' must appear exactly once in $binary (found $count)" >&2
+  exit 1
+}
+
+offset=$(printf '%s' "$hits" | cut -d: -f1)
+printf '%s' "$sha" | dd of="$binary" bs=1 seek=$((offset + ${#marker})) conv=notrunc status=none
+
+echo "Patched $binary with release $sha"

--- a/rust/relay/server/src/lib.rs
+++ b/rust/relay/server/src/lib.rs
@@ -28,7 +28,16 @@ use std::{
     sync::LazyLock,
 };
 
-pub const VERSION: Option<&str> = option_env!("GITHUB_SHA");
+/// The commit SHA this binary was built from, patched into the placeholder
+/// after linking. An all-zero field means the patch step did not run.
+#[used]
+static RELEASE: [u8; 57] = *b"firezone-git-sha:0000000000000000000000000000000000000000";
+
+pub static VERSION: LazyLock<Option<&'static str>> = LazyLock::new(|| {
+    // The 40-char SHA follows the 17-byte "firezone-git-sha:" marker.
+    let sha = std::str::from_utf8(&RELEASE[17..]).unwrap_or_default();
+    (!sha.bytes().all(|b| b == b'0')).then_some(sha)
+});
 pub static SOFTWARE: LazyLock<Software> = LazyLock::new(|| {
     Software::new(format!(
         "firezone-relay; rev={}",

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -144,12 +144,10 @@ fn main() -> ExitCode {
         .expect("Failed to build tokio runtime");
 
     if args.telemetry {
+        let release = VERSION
+            .expect("relay binary was not patched with a release SHA before enabling telemetry");
         telemetry::configure(std::sync::Arc::new(socket_factory::tcp));
-        telemetry::start(
-            args.api_url.as_str(),
-            VERSION.unwrap_or("unknown"),
-            RELAY_DSN,
-        );
+        telemetry::start(args.api_url.as_str(), release, RELAY_DSN);
     }
 
     let code = match runtime.block_on(try_main(args)) {
@@ -228,7 +226,7 @@ async fn try_main(args: Args) -> Result<()> {
         let is_connected = is_connected.clone();
         http_health_check::serve_with_version(
             args.health_check.health_check_addr,
-            firezone_relay::VERSION,
+            *firezone_relay::VERSION,
             move || is_connected.load(Ordering::Relaxed),
         )
     });

--- a/scripts/tests/bats/patch_relay_release.bats
+++ b/scripts/tests/bats/patch_relay_release.bats
@@ -20,10 +20,14 @@ setup() {
   grep -F -q "FOOTER" "$BINARY"
 }
 
-@test "rejects a sha that is not 40 characters" {
+@test "rejects a sha that is not 40 hex characters" {
   run "$PATCHER" "$BINARY" "tooshort"
   [ "$status" -ne 0 ]
   [[ "$output" == *"40-char"* ]]
+
+  # 40 characters but not hex (would be >40 bytes if multibyte) must be rejected.
+  run "$PATCHER" "$BINARY" "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+  [ "$status" -ne 0 ]
 }
 
 @test "fails when the marker is missing" {

--- a/scripts/tests/bats/patch_relay_release.bats
+++ b/scripts/tests/bats/patch_relay_release.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+setup() {
+  PATCHER="$BATS_TEST_DIRNAME/../../../rust/mise-tasks/patch-relay-release"
+  BINARY="$BATS_TEST_TMPDIR/relay"
+  # A stand-in binary: arbitrary bytes around the marker + 40-zero placeholder.
+  printf 'HEADER\0firezone-git-sha:0000000000000000000000000000000000000000\0FOOTER' >"$BINARY"
+}
+
+@test "stamps the sha into the placeholder without changing the size" {
+  local before after sha="1234567890abcdef1234567890abcdef12345678"
+  before=$(wc -c <"$BINARY")
+
+  run "$PATCHER" "$BINARY" "$sha"
+  [ "$status" -eq 0 ]
+
+  after=$(wc -c <"$BINARY")
+  [ "$before" -eq "$after" ]
+  grep -F -q "firezone-git-sha:$sha" "$BINARY"
+  grep -F -q "FOOTER" "$BINARY"
+}
+
+@test "rejects a sha that is not 40 characters" {
+  run "$PATCHER" "$BINARY" "tooshort"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"40-char"* ]]
+}
+
+@test "fails when the marker is missing" {
+  printf 'no marker here' >"$BINARY"
+  run "$PATCHER" "$BINARY" "1234567890abcdef1234567890abcdef12345678"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"exactly once"* ]]
+}


### PR DESCRIPTION
The relay embedded its commit SHA at compile time via `option_env!("GITHUB_SHA")`, so the binary changed on every commit and could not be cached. It now carries a fixed placeholder that the data-plane build patches with the real SHA after linking: the binary stays SHA-independent and cache-restorable while still shipping the correct release, and a telemetry-enabled relay refuses to start if the placeholder was never patched.

Related: #14261