### PR TITLE
build(rust): remove unused `--cfg tokio_unstable`

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -13,7 +13,7 @@ permissions:
   security-events: "write" # trivy SARIF upload from setup-mise
 
 env:
-  RUSTFLAGS: "--cfg tokio_unstable --deny warnings"
+  RUSTFLAGS: "--deny warnings"
   RUSTDOCFLAGS: "--deny warnings"
 
 jobs:

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -5,10 +5,6 @@
 [settings]
 auto_install = false
 
-[env]
-# Match CI environment - enables tokio unstable features and denies warnings
-RUSTFLAGS = "--cfg tokio_unstable"
-
 [tools]
 "github:aya-rs/bpf-linker" = { version = "0.10.3", os = ["linux"] }
 "cargo:cargo-deb" = { version = "3.7.0", os = ["linux"] }


### PR DESCRIPTION
`--cfg tokio_unstable` was set for CI and the `mise` dev environment but no longer gates anything the workspace uses: the task-ID APIs the proptest harvester relies on were stabilised in tokio 1.41, and the release builds (nix, Android) never set the flag. Removing it brings CI and local dev in line with the release builds.

Dropping the `mise` `RUSTFLAGS` override additionally lets local builds inherit `force-frame-pointers=yes` from `.cargo/config.toml`, which the env var previously masked.