### PR TITLE
ci: retry apt downloads via shared apt-install action

### DIFF
--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -25,4 +25,8 @@ runs:
       run: sudo apt-get update
     - name: Install packages
       shell: bash
-      run: sudo apt-get --yes install ${{ inputs.packages }}
+      env:
+        PACKAGES: ${{ inputs.packages }}
+      run: |
+        read -ra packages <<< "$PACKAGES"
+        sudo apt-get --yes install -- "${packages[@]}"

--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -1,0 +1,28 @@
+name: "Install apt packages"
+description: "Installs apt packages with retry and timeout settings applied so a slow or stalling mirror is retried instead of hanging until the job times out."
+inputs:
+  packages:
+    description: "Space-separated list of apt packages to install."
+    required: true
+  update:
+    description: "Whether to run `apt-get update` first. Set to false to reuse an index already refreshed by an earlier call in the same job."
+    required: false
+    default: "true"
+runs:
+  using: "composite"
+  steps:
+    - name: Configure apt retries and timeouts
+      shell: bash
+      run: |
+        sudo tee /etc/apt/apt.conf.d/99firezone-retries >/dev/null <<'EOF'
+        Acquire::Retries "5";
+        Acquire::http::Timeout "30";
+        Acquire::https::Timeout "30";
+        EOF
+    - name: Update package index
+      if: ${{ inputs.update == 'true' }}
+      shell: bash
+      run: sudo apt-get update
+    - name: Install packages
+      shell: bash
+      run: sudo apt-get --yes install ${{ inputs.packages }}

--- a/.github/actions/setup-azure-cli/action.yml
+++ b/.github/actions/setup-azure-cli/action.yml
@@ -3,11 +3,14 @@ description: "Installs the latest Azure CLI version"
 runs:
   using: "composite"
   steps:
-    - run: |
-        sudo apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
+    - uses: ./.github/actions/apt-install
+      with:
+        packages: ca-certificates curl apt-transport-https lsb-release gnupg
+    - shell: bash
+      run: |
         curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
         AZ_REPO=$(lsb_release -cs)
         echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
-        sudo apt-get update
-        sudo apt-get install -y azure-cli
-      shell: bash
+    - uses: ./.github/actions/apt-install
+      with:
+        packages: azure-cli

--- a/.github/actions/setup-musl/action.yml
+++ b/.github/actions/setup-musl/action.yml
@@ -9,9 +9,9 @@ runs:
   steps:
     - name: Setup musl for x86_64
       if: ${{ inputs.target == 'x86_64-unknown-linux-musl' }}
-      shell: bash
-      run: |
-        sudo apt-get install musl-tools
+      uses: ./.github/actions/apt-install
+      with:
+        packages: musl-tools
 
     - name: Setup musl for aarch64
       if: ${{ inputs.target == 'aarch64-unknown-linux-musl' }}

--- a/.github/actions/setup-tauri-v2/action.yml
+++ b/.github/actions/setup-tauri-v2/action.yml
@@ -27,19 +27,11 @@ runs:
 
     - name: Install Tauri build deps
       if: ${{ runner.os == 'Linux' }}
+      # `gnome-keyring` is only needed to launch the Tauri GUI, but installing it
+      # here keeps the non-GUI jobs on a single apt transaction.
       uses: ./.github/actions/apt-install
       with:
-        packages: build-essential curl file libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev libxdo-dev wget
-
-    - name: Install gnome-keyring
-      if: ${{ runner.os == 'Linux' }}
-      # This is only needed if we'll launch the Tauri GUI, so it's redundant for clippy / test
-      # This is what the Tauri CI tests use
-      # <https://github.com/tauri-apps/tauri/blob/3fb414b61ad7cfce67751230826fddfb39effec5/.github/workflows/bench.yml#L74>
-      uses: ./.github/actions/apt-install
-      with:
-        packages: gnome-keyring
-        update: "false"
+        packages: build-essential curl file libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev libxdo-dev wget gnome-keyring
 
     - name: Install Tauri runtime deps
       if: ${{ runner.os == 'Linux' && inputs.runtime == 'true' }}

--- a/.github/actions/setup-tauri-v2/action.yml
+++ b/.github/actions/setup-tauri-v2/action.yml
@@ -25,28 +25,28 @@ runs:
         sudo cp ~/apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
       shell: bash
 
-    - name: Apt-get update
-      if: ${{ runner.os == 'Linux' }}
-      run: sudo apt-get update
-      shell: bash
-
     - name: Install Tauri build deps
       if: ${{ runner.os == 'Linux' }}
-      run: sudo apt-get --yes install build-essential curl file libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev libxdo-dev wget
-      shell: bash
+      uses: ./.github/actions/apt-install
+      with:
+        packages: build-essential curl file libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev libxdo-dev wget
 
     - name: Install gnome-keyring
       if: ${{ runner.os == 'Linux' }}
-      run: sudo apt-get --yes install gnome-keyring
-      shell: bash
       # This is only needed if we'll launch the Tauri GUI, so it's redundant for clippy / test
       # This is what the Tauri CI tests use
       # <https://github.com/tauri-apps/tauri/blob/3fb414b61ad7cfce67751230826fddfb39effec5/.github/workflows/bench.yml#L74>
+      uses: ./.github/actions/apt-install
+      with:
+        packages: gnome-keyring
+        update: "false"
 
     - name: Install Tauri runtime deps
       if: ${{ runner.os == 'Linux' && inputs.runtime == 'true' }}
-      run: sudo apt-get --yes install at-spi2-core xvfb
-      shell: bash
+      uses: ./.github/actions/apt-install
+      with:
+        packages: at-spi2-core xvfb
+        update: "false"
 
     - name: Save apt packages to cache
       if: ${{ runner.os == 'Linux' && steps.apt-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -57,9 +57,9 @@ jobs:
 
       - name: Install dependencies (Linux)
         if: matrix.os == 'linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y musl-tools
+        uses: ./.github/actions/apt-install
+        with:
+          packages: musl-tools
 
       - name: Install Azure CLI (macOS)
         if: matrix.os == 'macos'

--- a/.github/workflows/_rpm.yml
+++ b/.github/workflows/_rpm.yml
@@ -21,9 +21,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install createrepo_c
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes createrepo-c rpm
+        uses: ./.github/actions/apt-install
+        with:
+          packages: createrepo-c rpm
 
       - uses: ./.github/actions/setup-azure-cli
 


### PR DESCRIPTION
Installing the Tauri build deps frequently times out when Ubuntu's apt mirror stalls mid-download, exhausting the step's 15-minute budget with no retry (e.g. [this run](https://github.com/firezone/firezone/actions/runs/30073906037/job/89420417559), where the 27 MB `libwebkit2gtk` package never finished).

A new `apt-install` composite action writes an apt retry/timeout config so a stalled mirror connection is dropped after 30s and retried instead of hanging, then updates and installs. Every apt call site now goes through it, so the config can't be forgotten as new ones are added.