### PR TITLE
ci: free disk space in Android build jobs

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,6 +1,11 @@
 ---
 name: "Free disk space"
 description: "Reclaim disk space by removing pre-installed toolchains we don't use"
+inputs:
+  keep-android:
+    description: "Keep the preinstalled Android SDK and NDK (the kotlin jobs build against them)"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -10,8 +15,10 @@ runs:
       run: |
         # Reclaim ~25 GB from pre-installed toolchains we don't use, so the
         # instrumented coverage builds have headroom on leaner hosted runners.
+        if [[ "${{ inputs.keep-android }}" != "true" ]]; then
+          sudo rm -rf /usr/local/lib/android
+        fi
         sudo rm -rf \
-          /usr/local/lib/android \
           /usr/share/dotnet \
           /opt/ghc \
           /usr/local/.ghcup \

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -75,6 +75,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-tags: true # Otherwise we cannot embed the correct version into the build.
+      - uses: ./.github/actions/free-disk-space
+        with:
+          keep-android: "true"
       - uses: ./.github/actions/setup-android
       - uses: ./.github/actions/setup-mise
         with:
@@ -174,6 +177,9 @@ jobs:
     name: build-debug
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/free-disk-space
+        with:
+          keep-android: "true"
       - uses: ./.github/actions/setup-android
       - name: Build debug APK
         run: |


### PR DESCRIPTION
The Android build jobs compile connlib for four ABIs and ran out of disk on a hosted runner. The free-disk-space action gains a keep-android input so these jobs reclaim the unused toolchains without deleting the preinstalled SDK and NDK they build against.

Related: #14295