### PR TITLE
chore(deps): bump boringtun to remove per-session locking

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.7.0"
-source = "git+https://github.com/firezone/boringtun?branch=master#cf83e8bca2fdd7cd1565ba358ec96c66b7ecac17"
+source = "git+https://github.com/firezone/boringtun?branch=master#b275f9028dc529165b05c6dd87157b1e7ea49693"
 dependencies = [
  "aead",
  "blake2",


### PR DESCRIPTION
Bumps the `boringtun` dependency to pull in firezone/boringtun#222, which removes the per-`Session` `Mutex` and `AtomicU64` from the WireGuard data path now that every access to a session is already exclusive.

Related: firezone/boringtun#222