### PR TITLE
ci: pull buildkit and base images via mirror.gcr.io

### DIFF
--- a/.github/actions/setup-buildx/action.yml
+++ b/.github/actions/setup-buildx/action.yml
@@ -1,0 +1,14 @@
+name: "Set up Docker Buildx"
+description: "Sets up Docker Buildx with the BuildKit image and Docker Hub base-image pulls routed through the mirror.gcr.io pull-through cache, so booting the builder and building images don't hit Docker Hub's anonymous rate limits."
+runs:
+  using: "composite"
+  steps:
+    - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      with:
+        # Boot BuildKit from the mirror instead of registry-1.docker.io, whose
+        # anonymous pulls from shared runner IPs frequently time out.
+        driver-opts: image=mirror.gcr.io/moby/buildkit:buildx-stable-1
+        # Route `FROM docker.io/...` pulls during builds through the same mirror.
+        buildkitd-config-inline: |
+          [registry."docker.io"]
+            mirrors = ["mirror.gcr.io"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,6 +61,7 @@ updates:
       - "/.github/actions/setup-android"
       - "/.github/actions/setup-azure-cli"
       - "/.github/actions/setup-azure-sign-tool"
+      - "/.github/actions/setup-buildx"
       - "/.github/actions/setup-docker"
       - "/.github/actions/setup-elixir"
       - "/.github/actions/setup-gpg"

--- a/.github/workflows/_control-plane.yml
+++ b/.github/workflows/_control-plane.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           ref: ${{ inputs.sha }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: ./.github/actions/setup-buildx
       - uses: ./.github/actions/ghcr-docker-login
         id: login
         with:

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -364,7 +364,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: ./.github/actions/setup-buildx
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
@@ -480,7 +480,7 @@ jobs:
       - name: Display structure of downloaded artifacts
         run: ls -R /tmp/digests
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: ./.github/actions/setup-buildx
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -63,7 +63,7 @@ jobs:
           echo "major_minor_version=$MAJOR_MINOR_VERSION" >> "$GITHUB_OUTPUT"
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: ./.github/actions/setup-buildx
       - name: Pull and push
         run: |
           set -xe


### PR DESCRIPTION
Booting Buildx pulls `moby/buildkit` from Docker Hub, and its anonymous pulls from shared GitHub-runner IPs frequently time out, failing the image build jobs (e.g. [this run](https://github.com/firezone/firezone/actions/runs/30173290056/job/89717907619), where the buildkit pull from `registry-1.docker.io` timed out during builder bootstrap).

Route those pulls through Google's `mirror.gcr.io` pull-through cache, which isn't subject to Docker Hub's anonymous rate limits. A small `setup-buildx` action wraps `docker/setup-buildx-action` to boot BuildKit from the mirror and to route `docker.io` base-image pulls during builds through it too; every buildx call site now goes through it so the mirror config can't be forgotten.

Resolves: #14338