### PR TITLE
test(connlib): retry bootstrap-dns port bind on macOS

### DIFF
--- a/rust/libs/connlib/bootstrap-dns-client/lib.rs
+++ b/rust/libs/connlib/bootstrap-dns-client/lib.rs
@@ -413,14 +413,8 @@ mod tests {
             let addr = tcp.local_addr().unwrap();
             match tokio::net::UdpSocket::bind(addr).await {
                 Ok(udp) => return (tcp, udp, addr),
-                Err(e)
-                    if matches!(
-                        e.kind(),
-                        std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::AddrInUse
-                    ) =>
-                {
-                    continue;
-                }
+                Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => continue,
+                Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => continue,
                 Err(e) => panic!("Failed to bind UDP socket: {e}"),
             }
         }

--- a/rust/libs/connlib/bootstrap-dns-client/lib.rs
+++ b/rust/libs/connlib/bootstrap-dns-client/lib.rs
@@ -402,17 +402,25 @@ mod tests {
 
     /// Binds a TCP listener and a UDP socket to the same loopback port.
     ///
-    /// On Windows, TCP and UDP have independent excluded-port ranges (Hyper-V /
-    /// WinNAT reserve blocks of the ephemeral range, and the runners differ for
-    /// each protocol), so a port the OS hands out for TCP may be forbidden for
-    /// UDP, yielding `WSAEACCES` (10013). Retry until a port binds for both.
+    /// A port the OS hands out for TCP may be unusable for UDP, so retry until
+    /// one binds for both. Windows reserves blocks of the ephemeral range per
+    /// protocol (Hyper-V / WinNAT), yielding `WSAEACCES` (`PermissionDenied`);
+    /// on macOS the TCP port can already be held by a concurrent test's UDP
+    /// socket, yielding `EADDRINUSE` (`AddrInUse`). Both mean "try another port".
     async fn bind_tcp_and_udp() -> (tokio::net::TcpListener, tokio::net::UdpSocket, SocketAddr) {
         loop {
             let tcp = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
             let addr = tcp.local_addr().unwrap();
             match tokio::net::UdpSocket::bind(addr).await {
                 Ok(udp) => return (tcp, udp, addr),
-                Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => continue,
+                Err(e)
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::AddrInUse
+                    ) =>
+                {
+                    continue;
+                }
                 Err(e) => panic!("Failed to bind UDP socket: {e}"),
             }
         }


### PR DESCRIPTION
`skips_tcp_fallback_when_udp_already_returned_ips` flakes on the macOS runner: its `bind_tcp_and_udp` helper binds a TCP listener to an ephemeral port then binds a UDP socket to the same port, but the retry loop only tolerated Windows' `WSAEACCES`. Tests in the crate run concurrently, and on macOS the TCP-assigned port can already be held by another test's UDP socket, so the UDP bind returns `EADDRINUSE`, which fell through to a panic and failed the whole run.

Retry on `AddrInUse` as well, so the helper just picks another port like it already does on Windows.

Fixes: #14342