### PR TITLE
ci: upload Sentry symbols for shipped binaries only

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -126,6 +126,7 @@ jobs:
       # mark:next-gui-version
       FIREZONE_GUI_VERSION: 1.5.16
       RENAME_SCRIPT: ../../scripts/build/tauri-rename-${{ matrix.os }}.sh
+      SYMBOLS_SCRIPT: ../../scripts/build/tauri-symbols-${{ matrix.os }}.sh
       TEST_INSTALL_SCRIPT: ../../scripts/tests/gui-client-install-${{ matrix.os }}-${{ matrix.pkg-extension }}
       TARGET_DIR: ../target
       UPLOAD_SCRIPT: ../../scripts/build/tauri-upload-${{ matrix.os }}.sh
@@ -229,8 +230,8 @@ jobs:
 
       - name: Upload debug symbols to Sentry
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
-        run: |
-          sentry-cli debug-files upload --log-level info --project gui-client --include-sources ../target
+        shell: bash
+        run: ${{ env.SYMBOLS_SCRIPT }}
 
       - name: Upload Release Assets
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"

--- a/scripts/build/tauri-symbols-linux.sh
+++ b/scripts/build/tauri-symbols-linux.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Runs from `rust/gui-client`
+
+set -euox pipefail
+
+# Only the binaries we ship. Scanning all of `target` also picks up intermediate
+# object files, whose debug info can reference a directory instead of a source
+# file, which aborts the upload.
+sentry-cli debug-files upload --log-level info --project gui-client --include-sources \
+    "$TARGET_DIR/release/firezone-client-gui" \
+    "$TARGET_DIR/release/firezone-client-tunnel"

--- a/scripts/build/tauri-symbols-windows.sh
+++ b/scripts/build/tauri-symbols-windows.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Runs from `rust/gui-client`
+
+set -euox pipefail
+
+# Only the binaries we ship. Scanning all of `target` also picks up intermediate
+# object files, whose debug info can reference a directory instead of a source
+# file, which aborts the upload.
+sentry-cli debug-files upload --log-level info --project gui-client --include-sources \
+    "$TARGET_DIR/release/Firezone.exe" \
+    "$TARGET_DIR/release/firezone_gui_client.pdb" \
+    "$TARGET_DIR/release/firezone-client-tunnel.exe" \
+    "$TARGET_DIR/release/firezone_client_tunnel.pdb" \
+    "$TARGET_DIR/release/register-sparse.exe" \
+    "$TARGET_DIR/release/register_sparse.pdb"


### PR DESCRIPTION
Release builds upload debug symbols to Sentry so crash reports can show source code. That upload has been failing and blocking the Linux GUI builds.

We install the newest sentry-cli on every run, so version 3.6.1 arrived on its own. It bumped the `symbolic` library from 13.1.1 to 13.8.0, which changed how the source files a binary points to are read: paths used to be skipped when they could not be read as a file, and now they are opened first. Opening a folder on Linux succeeds, so a folder no longer gets skipped.

That matters because we pointed sentry-cli at the whole `target` folder, which holds much more than the app: build scripts, proc macros, and half-finished object files. One object left behind by the `ring` crate says its source lives at a folder rather than a file. sentry-cli opens it, gets "Is a directory", and gives up on the entire upload.

Now we hand Sentry only the binaries we actually ship. The bad object is never opened, and we stop uploading symbols for tools that only ever ran on the build machine.
