### PR TITLE
fix(apple): drain flow logs at launch, not on foreground

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -72,9 +72,6 @@ enum IPCClient {
     _ = try await sendProviderMessage(session: session, message: message)
   }
 
-  // Asks the provider to drain the flow-log spool. Delivering the message
-  // starts the provider if it isn't running (macOS cycle-starts it in
-  // `sendProviderMessage`, iOS launches the appex to deliver the message).
   @MainActor
   static func drainFlowLogs(session: any TunnelSessionProtocol) async throws {
     let message = ProviderMessage.drainFlowLogs

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -249,10 +249,10 @@ public final class Store: ObservableObject {
       }
     }
 
-    observeForegroundForFlowLogDrain()
-    // Nudge a drain on launch too, not just on subsequent foregrounds; not
-    // awaited so startup never waits on the IPC round-trip.
-    Task { await drainFlowLogs() }
+    #if os(iOS)
+      observeForegroundForFlowLogDrain()
+      Task { await drainFlowLogs() }
+    #endif
 
     // Handle initial status to ensure resources start loading if already connected
     try await handleVPNStatusChange(newVPNStatus: session.status)
@@ -324,6 +324,10 @@ public final class Store: ObservableObject {
         Log.debug("Startup: initVPNConfiguration")
         try await initVPNConfiguration()
         Telemetry.setEnvironmentOrClose(configuration.apiURL)
+        #if os(macOS)
+          Log.debug("Startup: drainFlowLogsOnLaunch")
+          await drainFlowLogsOnLaunch()
+        #endif
         Log.debug("Startup: setupTunnelObservers")
         try await setupTunnelObservers()
         Log.debug("Startup: maybeAutoConnect")
@@ -629,27 +633,15 @@ public final class Store: ObservableObject {
     Log.setStreamingActive(false)
   }
 
-  /// Subscribes to app-foreground events to nudge a best-effort flow-log drain.
-  ///
-  /// The provider pokes a connected session's uploader, or runs a bounded
-  /// one-shot pass while disconnected, when the user opening the app may be the
-  /// only chance to upload. Delivering the message while disconnected also
-  /// starts the provider on both platforms (macOS via an explicit cycle-start,
-  /// iOS by launching the appex to deliver it). Best effort: nothing happens
-  /// once the app quits.
-  private func observeForegroundForFlowLogDrain() {
-    #if os(iOS)
-      let didBecomeActive = UIApplication.didBecomeActiveNotification
-    #elseif os(macOS)
-      let didBecomeActive = NSApplication.didBecomeActiveNotification
-    #endif
-
-    NotificationCenter.default.publisher(for: didBecomeActive)
-      .sink { [weak self] _ in
-        Task { @MainActor in await self?.drainFlowLogs() }
-      }
-      .store(in: &cancellables)
-  }
+  #if os(iOS)
+    private func observeForegroundForFlowLogDrain() {
+      NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
+        .sink { [weak self] _ in
+          Task { @MainActor in await self?.drainFlowLogs() }
+        }
+        .store(in: &cancellables)
+    }
+  #endif
 
   /// Nudges the provider to run a best-effort flow-log upload pass.
   private func drainFlowLogs() async {
@@ -660,6 +652,18 @@ public final class Store: ObservableObject {
       Log.debug("Failed to nudge flow-log uploader: \(error)")
     }
   }
+
+  #if os(macOS)
+    // `vpnStatus == nil` means no Sign In button yet, so the cycle start can't race one.
+    private func drainFlowLogsOnLaunch() async {
+      guard vpnStatus == nil,
+        let session = try? manager().session(),
+        session.status == .disconnected
+      else { return }
+
+      await drainFlowLogs()
+    }
+  #endif
 
   private func pollStateOnce() async throws {
     guard let session = try self.manager().session() else { return }

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/IPCClientTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/IPCClientTests.swift
@@ -1,0 +1,83 @@
+//
+//  IPCClientTests.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Foundation
+import NetworkExtension
+import Testing
+
+@testable import FirezoneKit
+
+// `@unchecked Sendable`: IPCClient and these tests are `@MainActor`, so all access is too.
+private final class RecordingTunnelSession: TunnelSessionProtocol, @unchecked Sendable {
+  let status: NEVPNStatus
+
+  private(set) var startTunnelCallCount = 0
+  private(set) var stopTunnelCallCount = 0
+  private(set) var sentMessages: [ProviderMessage] = []
+
+  init(status: NEVPNStatus) {
+    self.status = status
+  }
+
+  // swiftlint:disable:next discouraged_optional_collection
+  func startTunnel(options: [String: Any]?) throws {
+    startTunnelCallCount += 1
+  }
+
+  func stopTunnel() {
+    stopTunnelCallCount += 1
+  }
+
+  func sendProviderMessage(_ messageData: Data, responseHandler: ((Data?) -> Void)?) throws {
+    sentMessages.append(try PropertyListDecoder().decode(ProviderMessage.self, from: messageData))
+    responseHandler?(nil)
+  }
+
+  func fetchLastDisconnectError(completionHandler: @escaping @Sendable (Error?) -> Void) {
+    completionHandler(nil)
+  }
+}
+
+@Suite("IPCClient flow-log drain")
+@MainActor
+struct IPCClientTests {
+  @Test("A running tunnel is left alone")
+  func drainDoesNotCycleRunningTunnel() async throws {
+    for status in [NEVPNStatus.connected, .connecting, .reasserting] {
+      let session = RecordingTunnelSession(status: status)
+
+      try await IPCClient.drainFlowLogs(session: session)
+
+      #expect(session.sentMessages.count == 1)
+      #expect(session.startTunnelCallCount == 0)
+      #expect(session.stopTunnelCallCount == 0)
+    }
+  }
+
+  @Test("An invalid session is refused rather than started")
+  func drainRefusesInvalidSession() async {
+    let session = RecordingTunnelSession(status: .invalid)
+
+    await #expect(throws: IPCClient.Error.self) {
+      try await IPCClient.drainFlowLogs(session: session)
+    }
+
+    #expect(session.startTunnelCallCount == 0)
+  }
+
+  #if os(macOS)
+    @Test("A stopped tunnel is cycle-started and stopped again")
+    func drainCycleStartsStoppedTunnel() async throws {
+      let session = RecordingTunnelSession(status: .disconnected)
+
+      try await IPCClient.drainFlowLogs(session: session)
+
+      #expect(session.sentMessages.count == 1)
+      #expect(session.startTunnelCallCount == 1)
+      #expect(session.stopTunnelCallCount == 1)
+    }
+  #endif
+}

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -264,16 +264,14 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
         exportLogs(handler)
       case .drainFlowLogs:
-        // The app nudges this on foreground/launch. `drainFlowLogs` pokes a
-        // connected session's uploader, or runs a bounded one-shot pass while
-        // disconnected. Delivering this while disconnected also starts the
-        // provider (macOS via `maybeCycleStart`, iOS by launching the appex to
-        // deliver the message). Ack right away; the drain runs in the background.
+        // Ack after the drain: the app stops the tunnel on the response, reaping us.
         Task.detached(priority: .utility) { @Sendable in
-          guard let spoolDir = SharedAccess.flowLogsFolderURL?.path else { return }
-          drainFlowLogs(spoolDir: spoolDir)
+          if let spoolDir = SharedAccess.flowLogsFolderURL?.path {
+            drainFlowLogs(spoolDir: spoolDir)
+          }
+
+          completionHandler?(nil)
         }
-        completionHandler?(nil)
       }
     } catch {
       Log.error(error)


### PR DESCRIPTION
Opening the app nudged the tunnel to upload any flow logs it had saved to disk. On macOS that nudge has to wake the network extension, and waking it means briefly starting and stopping the tunnel so the utun the system creates gets cleaned up again.

Signing in returns from the browser at the same moment the app comes to the foreground, so the nudge and the sign-in raced. The tunnel briefly looked connected, the real start was ignored, and the nudge then stopped everything. The tunnel never came up.

The nudge now happens once during startup, before the app has read the VPN status and before the menu offers a Sign In button. Nothing can try to start the tunnel underneath it, so no coordination is needed. iOS still drains on every foreground, where delivering the message just launches the extension and costs nothing.

The extension also answered the drain request before doing the work, so the app stopped the tunnel while the upload was still running. It now answers once the upload is done.

Related: #14294 #10580