### PR TITLE
fix(portal): exclude ingestion from REST redirects

### DIFF
--- a/elixir/lib/portal_api/endpoint.ex
+++ b/elixir/lib/portal_api/endpoint.ex
@@ -87,6 +87,9 @@ defmodule PortalAPI.Endpoint do
 
   plug Sentry.PlugContext
 
+  # Ingestion has its own configured hostname and is not part of the REST API.
+  def redirect_to_rest_api_url(%Plug.Conn{path_info: ["ingestion" | _]} = conn, _opts), do: conn
+
   def redirect_to_rest_api_url(%Plug.Conn{} = conn, _opts) do
     case Portal.Config.get_env(:portal, :rest_api_url) do
       nil -> conn

--- a/elixir/test/portal_api/redirect_to_rest_api_url_test.exs
+++ b/elixir/test/portal_api/redirect_to_rest_api_url_test.exs
@@ -31,6 +31,17 @@ defmodule PortalAPI.RedirectToRestApiUrlTest do
       assert result == conn
     end
 
+    test "passes flow-log ingestion requests through on the dedicated host" do
+      Portal.Config.put_env_override(:rest_api_url, "https://rest-api.firezone.dev/")
+
+      conn = conn(:post, "https://flow-api.firezone.dev/ingestion/flow_logs", "")
+
+      result = call(conn)
+
+      refute result.halted
+      assert result == conn
+    end
+
     test "permanent-redirects requests on any other host preserving path and query" do
       Portal.Config.put_env_override(:rest_api_url, "https://rest-api.firezone.dev/")
 


### PR DESCRIPTION
The dedicated flow API shares PortalAPI.Endpoint with the REST API. The redirect_to_rest_api_url plug runs before the router and was canonicalizing every ordinary HTTP request to rest_api_url, so POSTs to /ingestion/flow_logs received a 308 instead of reaching the ingestion pipeline.

Skip REST host canonicalization for /ingestion routes, whose hostname is configured separately.

Tests:
- mix test test/portal_api/redirect_to_rest_api_url_test.exs
- mix format --check-formatted lib/portal_api/endpoint.ex test/portal_api/redirect_to_rest_api_url_test.exs

---