### PR TITLE
fix(flow-log-upload): follow permanent redirects

### DIFF
--- a/rust/libs/flow-log-upload/src/ingest.rs
+++ b/rust/libs/flow-log-upload/src/ingest.rs
@@ -1,0 +1,230 @@
+//! The HTTP side of uploading: the connection to the portal's ingest API and the
+//! requests made over it.
+
+use std::{sync::Arc, time::Duration};
+
+use anyhow::{Context as _, Result};
+use bytes::Bytes;
+use http::header;
+use http_client::HttpClient;
+use socket_factory::{SocketFactory, TcpSocket};
+use url::Url;
+
+/// Prevent a broken or malicious endpoint from trapping an upload in a redirect loop.
+const MAX_REDIRECTS: usize = 5;
+const INGEST_PATH: &str = "/ingestion/flow_logs";
+
+/// An ingest connection and its current endpoint.
+///
+/// [`HttpClient`] is tied to one host, so following a cross-host redirect must
+/// also replace the underlying connection.
+pub struct IngestClient {
+    http: HttpClient,
+    url: Url,
+    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+    redirects: usize,
+}
+
+impl IngestClient {
+    pub async fn connect(
+        url: Url,
+        socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+    ) -> Result<Self> {
+        let http = connect(&url, socket_factory.clone()).await?;
+
+        Ok(Self {
+            http,
+            url,
+            socket_factory,
+            redirects: 0,
+        })
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.http.is_closed()
+    }
+
+    /// POSTs `body` to the current endpoint, authorized by `token`.
+    pub async fn send(&self, token: &str, body: Bytes) -> Result<http::Response<Bytes>> {
+        let request = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(self.url.as_str())
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .context("Failed to build flow-log request")?;
+        let response = self.http.send_request(request)?.await?;
+
+        Ok(response)
+    }
+
+    /// Points the client at the redirect's `Location`, reconnecting when it moves
+    /// to another host.
+    ///
+    /// Errs once [`MAX_REDIRECTS`] have been followed.
+    pub async fn follow_redirect(&mut self, response: &http::Response<Bytes>) -> Result<()> {
+        anyhow::ensure!(
+            self.redirects < MAX_REDIRECTS,
+            "Flow-log upload exceeded {MAX_REDIRECTS} redirects"
+        );
+
+        let redirected = redirect_url(&self.url, response)?;
+
+        if redirected.host_str() != self.url.host_str() {
+            self.http = connect(&redirected, self.socket_factory.clone()).await?;
+        }
+
+        tracing::info!(from = %self.url, to = %redirected, "Following flow-log upload redirect");
+
+        self.url = redirected;
+        self.redirects += 1;
+
+        Ok(())
+    }
+}
+
+/// Builds the ingest endpoint from the portal's base API URL.
+pub fn ingest_endpoint(base_url: &str) -> Result<Url> {
+    Url::parse(base_url)
+        .and_then(|base| base.join(INGEST_PATH))
+        .with_context(|| format!("Invalid flow-log API URL `{base_url}`"))
+}
+
+pub fn retry_after(response: &http::Response<Bytes>) -> Option<Duration> {
+    let seconds = response
+        .headers()
+        .get(header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .parse::<u64>()
+        .ok()?;
+
+    Some(Duration::from_secs(seconds))
+}
+
+pub fn body_string(response: &http::Response<Bytes>) -> String {
+    String::from_utf8_lossy(response.body()).into_owned()
+}
+
+/// Opens a tunnel-bypassing HTTP client to the ingest host, re-resolved on every
+/// connect so address changes are picked up.
+///
+/// Resolution goes through [`tunnel_bypass_resolver`]: while a session owns
+/// the system resolver, `getaddrinfo` would loop back through connlib.
+async fn connect(
+    url: &Url,
+    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+) -> Result<HttpClient> {
+    let host = url.host_str().context("Ingest URL has no host")?.to_owned();
+
+    let addresses = tunnel_bypass_resolver::resolve(&host).await?;
+
+    HttpClient::new(host, addresses, socket_factory)
+        .await
+        .context("Failed to connect to ingest host")
+}
+
+/// Resolves a redirect's `Location` against the current endpoint.
+///
+/// Only an origin we would have dialled ourselves is accepted: uploads carry a
+/// Bearer token, so a redirect must not downgrade the transport or hand the token
+/// to an endpoint the [`HttpClient`] could not have reached.
+fn redirect_url(current: &Url, response: &http::Response<Bytes>) -> Result<Url> {
+    let location = response
+        .headers()
+        .get(header::LOCATION)
+        .context("Flow-log upload redirect has no Location header")?
+        .to_str()
+        .context("Flow-log upload redirect has an invalid Location header")?;
+    let mut redirected = current
+        .join(location)
+        .context("Invalid flow-log upload redirect URL")?;
+
+    anyhow::ensure!(
+        redirected.scheme() == "https",
+        "Flow-log upload redirect must use HTTPS"
+    );
+    anyhow::ensure!(
+        redirected.port_or_known_default() == Some(443),
+        "Flow-log upload redirect must use port 443"
+    );
+    anyhow::ensure!(
+        redirected.username().is_empty() && redirected.password().is_none(),
+        "Flow-log upload redirect must not contain credentials"
+    );
+
+    redirected.set_fragment(None);
+
+    Ok(redirected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn current_url() -> Url {
+        Url::parse("https://flow-api.firezone.dev/ingestion/flow_logs").unwrap()
+    }
+
+    fn response(headers: &[(header::HeaderName, &str)]) -> http::Response<Bytes> {
+        headers
+            .iter()
+            .fold(http::Response::builder(), |builder, (name, value)| {
+                builder.header(name, *value)
+            })
+            .body(Bytes::new())
+            .unwrap()
+    }
+
+    fn redirect_to(location: &str) -> Result<Url> {
+        redirect_url(&current_url(), &response(&[(header::LOCATION, location)]))
+    }
+
+    #[test]
+    fn ingest_endpoint_appends_the_ingest_path() {
+        assert_eq!(
+            ingest_endpoint("https://flow-api.firezone.dev/")
+                .unwrap()
+                .as_str(),
+            "https://flow-api.firezone.dev/ingestion/flow_logs"
+        );
+        assert!(ingest_endpoint("not a url").is_err());
+    }
+
+    #[test]
+    fn redirect_url_resolves_absolute_and_relative_locations() {
+        assert_eq!(
+            redirect_to("https://rest-api.firezone.dev/ingestion/flow_logs")
+                .unwrap()
+                .as_str(),
+            "https://rest-api.firezone.dev/ingestion/flow_logs"
+        );
+        assert_eq!(
+            redirect_to("/v2/flow_logs").unwrap().as_str(),
+            "https://flow-api.firezone.dev/v2/flow_logs"
+        );
+    }
+
+    #[test]
+    fn redirect_url_rejects_missing_or_unsafe_locations() {
+        assert!(redirect_url(&current_url(), &response(&[])).is_err());
+        assert!(redirect_to("http://rest-api.firezone.dev/ingestion/flow_logs").is_err());
+        assert!(redirect_to("https://rest-api.firezone.dev:8443/ingestion/flow_logs").is_err());
+        assert!(
+            redirect_to("https://user:secret@rest-api.firezone.dev/ingestion/flow_logs").is_err()
+        );
+    }
+
+    #[test]
+    fn retry_after_parses_the_seconds_header() {
+        assert_eq!(
+            retry_after(&response(&[(header::RETRY_AFTER, "30")])),
+            Some(Duration::from_secs(30))
+        );
+        assert_eq!(retry_after(&response(&[])), None);
+        assert_eq!(
+            retry_after(&response(&[(header::RETRY_AFTER, "soon")])),
+            None
+        );
+    }
+}

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -760,7 +760,7 @@ enum ResponseAction {
     RateLimited,
     /// Transient failure (408 / 5xx); back off, then retry the same batch.
     Retry,
-    /// Permanently redirected (308); reconnect if needed and replay the POST.
+    /// Redirected (301 / 302 / 307 / 308); reconnect if needed and replay the POST.
     Redirect,
     /// Permanently rejected (422 / other 4xx); log and drop the batch. The portal
     /// upserts by flow identity, so a dropped batch is never a partial write.
@@ -774,7 +774,11 @@ fn classify_response(status: StatusCode) -> ResponseAction {
         StatusCode::TOO_MANY_REQUESTS => ResponseAction::RateLimited,
         StatusCode::REQUEST_TIMEOUT => ResponseAction::Retry,
         s if s.is_server_error() => ResponseAction::Retry,
-        StatusCode::PERMANENT_REDIRECT => ResponseAction::Redirect,
+        // 303 is absent: it mandates a GET, which cannot carry the batch.
+        StatusCode::MOVED_PERMANENTLY
+        | StatusCode::FOUND
+        | StatusCode::TEMPORARY_REDIRECT
+        | StatusCode::PERMANENT_REDIRECT => ResponseAction::Redirect,
         _ => ResponseAction::Drop,
     }
 }
@@ -1087,7 +1091,11 @@ mod tests {
         assert_eq!(classify_response(StatusCode::REQUEST_TIMEOUT), Retry);
         assert_eq!(classify_response(StatusCode::INTERNAL_SERVER_ERROR), Retry);
         assert_eq!(classify_response(StatusCode::SERVICE_UNAVAILABLE), Retry);
+        assert_eq!(classify_response(StatusCode::MOVED_PERMANENTLY), Redirect);
+        assert_eq!(classify_response(StatusCode::FOUND), Redirect);
+        assert_eq!(classify_response(StatusCode::TEMPORARY_REDIRECT), Redirect);
         assert_eq!(classify_response(StatusCode::PERMANENT_REDIRECT), Redirect);
+        assert_eq!(classify_response(StatusCode::SEE_OTHER), Drop);
         assert_eq!(classify_response(StatusCode::UNPROCESSABLE_ENTITY), Drop);
         assert_eq!(classify_response(StatusCode::BAD_REQUEST), Drop);
         assert_eq!(classify_response(StatusCode::UNAUTHORIZED), Drop);

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -33,12 +33,14 @@ use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 use base64::Engine as _;
 use bytes::Bytes;
 use flow_log_spool::deserialize;
-use http::{StatusCode, header};
-use http_client::HttpClient;
+use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_with::{DurationSeconds, serde_as};
 use socket_factory::{SocketFactory, TcpSocket};
-use url::Url;
+
+mod ingest;
+
+use ingest::{IngestClient, body_string, ingest_endpoint, retry_after};
 
 /// Default flows per upload when the portal doesn't specify one.
 const DEFAULT_BATCH_SIZE: usize = 1_000;
@@ -51,9 +53,6 @@ const DISABLED_POLL: Duration = Duration::from_secs(30);
 /// Total time spent retrying one batch on transient failures before deferring it
 /// to the next pass.
 const MAX_UPLOAD_RETRY: Duration = Duration::from_secs(5 * 60);
-/// Prevent a broken or malicious endpoint from trapping an upload in a redirect loop.
-const MAX_REDIRECTS: usize = 5;
-const INGEST_PATH: &str = "/ingestion/flow_logs";
 const CONFIG_FILE: &str = "upload.json";
 const START_SUFFIX: &str = ".start.json";
 const END_SUFFIX: &str = ".end.json";
@@ -452,85 +451,6 @@ fn apply_dacl(path: &Path, dacl: &windows_security::pipe_dacl::PipeDacl) -> std:
         .map_err(|e| std::io::Error::other(format!("{e:#}")))
 }
 
-fn ingest_endpoint(base_url: &str) -> Result<String> {
-    let url = Url::parse(base_url)
-        .and_then(|base| base.join(INGEST_PATH))
-        .with_context(|| format!("Invalid flow-log API URL `{base_url}`"))?;
-
-    Ok(url.to_string())
-}
-
-/// Opens a tunnel-bypassing HTTP client to the ingest host, re-resolved each pass
-/// so address changes are picked up.
-///
-/// Resolution goes through [`tunnel_bypass_resolver`]: while a session owns
-/// the system resolver, `getaddrinfo` would loop back through connlib.
-async fn connect(
-    ingest_url: &str,
-    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
-) -> Result<HttpClient> {
-    let url = Url::parse(ingest_url).context("Invalid ingest URL")?;
-    let host = url.host_str().context("Ingest URL has no host")?.to_owned();
-
-    let addresses = tunnel_bypass_resolver::resolve(&host).await?;
-
-    HttpClient::new(host, addresses, socket_factory)
-        .await
-        .context("Failed to connect to ingest host")
-}
-
-/// An ingest connection and its current endpoint.
-///
-/// [`HttpClient`] is tied to one host, so following a cross-host redirect must
-/// also replace the underlying connection.
-struct IngestClient {
-    http: HttpClient,
-    url: String,
-    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
-}
-
-impl IngestClient {
-    async fn connect(
-        url: String,
-        socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
-    ) -> Result<Self> {
-        let http = connect(&url, socket_factory.clone()).await?;
-
-        Ok(Self {
-            http,
-            url,
-            socket_factory,
-        })
-    }
-
-    fn is_closed(&self) -> bool {
-        self.http.is_closed()
-    }
-
-    async fn follow_redirect(&mut self, response: &http::Response<Bytes>) -> Result<()> {
-        let redirected_url = redirect_url(&self.url, response)?;
-        let current_host = Url::parse(&self.url)
-            .context("Invalid current ingest URL")?
-            .host_str()
-            .context("Current ingest URL has no host")?
-            .to_owned();
-        let redirected_host = Url::parse(&redirected_url)
-            .context("Invalid redirected ingest URL")?
-            .host_str()
-            .context("Redirected ingest URL has no host")?
-            .to_owned();
-
-        if redirected_host != current_host {
-            self.http = connect(&redirected_url, self.socket_factory.clone()).await?;
-        }
-
-        tracing::info!(from = %self.url, to = %redirected_url, "Following flow-log upload redirect");
-        self.url = redirected_url;
-
-        Ok(())
-    }
-}
-
 /// One flow to upload: the record to send and the files to delete once it lands.
 struct Pending {
     payload: serde_json::Value,
@@ -782,10 +702,9 @@ async fn submit(client: &mut IngestClient, token: &str, batch: &[Pending]) -> Re
     let body = Bytes::from(body);
 
     let mut backoff = upload_backoff();
-    let mut redirects = 0;
 
     loop {
-        let response = match send(client, token, body.clone()).await {
+        let response = match client.send(token, body.clone()).await {
             Ok(response) => response,
             Err(e) => {
                 tracing::info!("Flow-log upload request failed: {e:#}");
@@ -819,14 +738,7 @@ async fn submit(client: &mut IngestClient, token: &str, batch: &[Pending]) -> Re
                     return Ok(());
                 }
             }
-            ResponseAction::Redirect => {
-                anyhow::ensure!(
-                    redirects < MAX_REDIRECTS,
-                    "Flow-log upload exceeded {MAX_REDIRECTS} redirects"
-                );
-                client.follow_redirect(&response).await?;
-                redirects += 1;
-            }
+            ResponseAction::Redirect => client.follow_redirect(&response).await?,
             ResponseAction::Drop => {
                 let body = body_string(&response);
                 tracing::info!(%status, %body, "Flow-log upload rejected; dropping batch");
@@ -865,52 +777,6 @@ fn classify_response(status: StatusCode) -> ResponseAction {
         StatusCode::PERMANENT_REDIRECT => ResponseAction::Redirect,
         _ => ResponseAction::Drop,
     }
-}
-
-async fn send(client: &IngestClient, token: &str, body: Bytes) -> Result<http::Response<Bytes>> {
-    let request = http::Request::builder()
-        .method(http::Method::POST)
-        .uri(&client.url)
-        .header(header::AUTHORIZATION, format!("Bearer {token}"))
-        .header(header::CONTENT_TYPE, "application/json")
-        .body(body)
-        .context("Failed to build flow-log request")?;
-
-    client.http.send_request(request)?.await
-}
-
-fn redirect_url(current_url: &str, response: &http::Response<Bytes>) -> Result<String> {
-    let location = response
-        .headers()
-        .get(header::LOCATION)
-        .context("Flow-log upload redirect has no Location header")?
-        .to_str()
-        .context("Flow-log upload redirect has an invalid Location header")?;
-    let mut redirected = Url::parse(current_url)
-        .context("Invalid current ingest URL")?
-        .join(location)
-        .context("Invalid flow-log upload redirect URL")?;
-
-    anyhow::ensure!(
-        redirected.scheme() == "https",
-        "Flow-log upload redirect must use HTTPS"
-    );
-    anyhow::ensure!(
-        redirected.port_or_known_default() == Some(443),
-        "Flow-log upload redirect must use port 443"
-    );
-    anyhow::ensure!(
-        redirected.username().is_empty() && redirected.password().is_none(),
-        "Flow-log upload redirect must not contain credentials"
-    );
-
-    redirected.set_fragment(None);
-
-    Ok(redirected.to_string())
-}
-
-fn body_string(response: &http::Response<Bytes>) -> String {
-    String::from_utf8_lossy(response.body()).into_owned()
 }
 
 /// Splits an over-sized batch in half and submits each.
@@ -952,18 +818,6 @@ fn delete_files(files: Vec<PathBuf>) {
     }
 
     tracing::debug!(count, "Deleted uploaded flow-log reports");
-}
-
-fn retry_after(response: &http::Response<Bytes>) -> Option<Duration> {
-    let seconds = response
-        .headers()
-        .get(header::RETRY_AFTER)?
-        .to_str()
-        .ok()?
-        .parse::<u64>()
-        .ok()?;
-
-    Some(Duration::from_secs(seconds))
 }
 
 fn upload_backoff() -> ExponentialBackoff {
@@ -1024,15 +878,6 @@ mod tests {
         assert_eq!(config.api_url, "https://flow-api.firezone.dev/");
         assert_eq!(config.interval, Duration::from_secs(90));
         assert_eq!(config.batch_size, 500);
-    }
-
-    #[test]
-    fn ingest_endpoint_appends_the_ingest_path() {
-        assert_eq!(
-            ingest_endpoint("https://flow-api.firezone.dev/").unwrap(),
-            "https://flow-api.firezone.dev/ingestion/flow_logs"
-        );
-        assert!(ingest_endpoint("not a url").is_err());
     }
 
     #[test]
@@ -1250,65 +1095,6 @@ mod tests {
     }
 
     #[test]
-    fn redirect_url_resolves_absolute_and_relative_locations() {
-        let absolute = http::Response::builder()
-            .header(
-                header::LOCATION,
-                "https://rest-api.firezone.dev/ingestion/flow_logs",
-            )
-            .body(Bytes::new())
-            .unwrap();
-        assert_eq!(
-            redirect_url(
-                "https://flow-api.firezone.dev/ingestion/flow_logs",
-                &absolute
-            )
-            .unwrap(),
-            "https://rest-api.firezone.dev/ingestion/flow_logs"
-        );
-
-        let relative = http::Response::builder()
-            .header(header::LOCATION, "/v2/flow_logs")
-            .body(Bytes::new())
-            .unwrap();
-        assert_eq!(
-            redirect_url(
-                "https://flow-api.firezone.dev/ingestion/flow_logs",
-                &relative
-            )
-            .unwrap(),
-            "https://flow-api.firezone.dev/v2/flow_logs"
-        );
-    }
-
-    #[test]
-    fn redirect_url_rejects_missing_or_insecure_locations() {
-        let missing = http::Response::builder().body(Bytes::new()).unwrap();
-        assert!(
-            redirect_url(
-                "https://flow-api.firezone.dev/ingestion/flow_logs",
-                &missing
-            )
-            .is_err()
-        );
-
-        let insecure = http::Response::builder()
-            .header(
-                header::LOCATION,
-                "http://rest-api.firezone.dev/ingestion/flow_logs",
-            )
-            .body(Bytes::new())
-            .unwrap();
-        assert!(
-            redirect_url(
-                "https://flow-api.firezone.dev/ingestion/flow_logs",
-                &insecure
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
     fn stop_acks_after_queued_passes_before_the_timeout() {
         let root = tempfile::tempdir().unwrap();
         let uploader = spawn(root.path().to_owned(), Arc::new(socket_factory::tcp));
@@ -1341,23 +1127,5 @@ mod tests {
             );
             std::thread::sleep(Duration::from_millis(10));
         }
-    }
-
-    #[test]
-    fn retry_after_parses_the_seconds_header() {
-        let with_header = http::Response::builder()
-            .header(header::RETRY_AFTER, "30")
-            .body(Bytes::new())
-            .unwrap();
-        assert_eq!(retry_after(&with_header), Some(Duration::from_secs(30)));
-
-        let no_header = http::Response::builder().body(Bytes::new()).unwrap();
-        assert_eq!(retry_after(&no_header), None);
-
-        let non_numeric = http::Response::builder()
-            .header(header::RETRY_AFTER, "soon")
-            .body(Bytes::new())
-            .unwrap();
-        assert_eq!(retry_after(&non_numeric), None);
     }
 }

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -739,6 +739,10 @@ async fn submit(client: &mut IngestClient, token: &str, batch: &[Pending]) -> Re
                 }
             }
             ResponseAction::Redirect => client.follow_redirect(&response).await?,
+            ResponseAction::Defer => {
+                tracing::warn!(%status, "Flow-log upload redirected somewhere we cannot follow");
+                return Ok(()); // the files remain on disk
+            }
             ResponseAction::Drop => {
                 let body = body_string(&response);
                 tracing::info!(%status, %body, "Flow-log upload rejected; dropping batch");
@@ -762,6 +766,10 @@ enum ResponseAction {
     Retry,
     /// Redirected (301 / 302 / 307 / 308); reconnect if needed and replay the POST.
     Redirect,
+    /// A redirect we cannot follow (303 and other 3xx); keep the batch on disk.
+    /// The portal never stored it, and replaying the POST would only be redirected
+    /// again, so a later pass tries afresh.
+    Defer,
     /// Permanently rejected (422 / other 4xx); log and drop the batch. The portal
     /// upserts by flow identity, so a dropped batch is never a partial write.
     Drop,
@@ -779,6 +787,7 @@ fn classify_response(status: StatusCode) -> ResponseAction {
         | StatusCode::FOUND
         | StatusCode::TEMPORARY_REDIRECT
         | StatusCode::PERMANENT_REDIRECT => ResponseAction::Redirect,
+        s if s.is_redirection() => ResponseAction::Defer,
         _ => ResponseAction::Drop,
     }
 }
@@ -1095,7 +1104,8 @@ mod tests {
         assert_eq!(classify_response(StatusCode::FOUND), Redirect);
         assert_eq!(classify_response(StatusCode::TEMPORARY_REDIRECT), Redirect);
         assert_eq!(classify_response(StatusCode::PERMANENT_REDIRECT), Redirect);
-        assert_eq!(classify_response(StatusCode::SEE_OTHER), Drop);
+        assert_eq!(classify_response(StatusCode::SEE_OTHER), Defer);
+        assert_eq!(classify_response(StatusCode::NOT_MODIFIED), Defer);
         assert_eq!(classify_response(StatusCode::UNPROCESSABLE_ENTITY), Drop);
         assert_eq!(classify_response(StatusCode::BAD_REQUEST), Drop);
         assert_eq!(classify_response(StatusCode::UNAUTHORIZED), Drop);

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -51,6 +51,8 @@ const DISABLED_POLL: Duration = Duration::from_secs(30);
 /// Total time spent retrying one batch on transient failures before deferring it
 /// to the next pass.
 const MAX_UPLOAD_RETRY: Duration = Duration::from_secs(5 * 60);
+/// Prevent a broken or malicious endpoint from trapping an upload in a redirect loop.
+const MAX_REDIRECTS: usize = 5;
 const INGEST_PATH: &str = "/ingestion/flow_logs";
 const CONFIG_FILE: &str = "upload.json";
 const START_SUFFIX: &str = ".start.json";
@@ -477,6 +479,58 @@ async fn connect(
         .context("Failed to connect to ingest host")
 }
 
+/// An ingest connection and its current endpoint.
+///
+/// [`HttpClient`] is tied to one host, so following a cross-host redirect must
+/// also replace the underlying connection.
+struct IngestClient {
+    http: HttpClient,
+    url: String,
+    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+}
+
+impl IngestClient {
+    async fn connect(
+        url: String,
+        socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+    ) -> Result<Self> {
+        let http = connect(&url, socket_factory.clone()).await?;
+
+        Ok(Self {
+            http,
+            url,
+            socket_factory,
+        })
+    }
+
+    fn is_closed(&self) -> bool {
+        self.http.is_closed()
+    }
+
+    async fn follow_redirect(&mut self, response: &http::Response<Bytes>) -> Result<()> {
+        let redirected_url = redirect_url(&self.url, response)?;
+        let current_host = Url::parse(&self.url)
+            .context("Invalid current ingest URL")?
+            .host_str()
+            .context("Current ingest URL has no host")?
+            .to_owned();
+        let redirected_host = Url::parse(&redirected_url)
+            .context("Invalid redirected ingest URL")?
+            .host_str()
+            .context("Redirected ingest URL has no host")?
+            .to_owned();
+
+        if redirected_host != current_host {
+            self.http = connect(&redirected_url, self.socket_factory.clone()).await?;
+        }
+
+        tracing::info!(from = %self.url, to = %redirected_url, "Following flow-log upload redirect");
+        self.url = redirected_url;
+
+        Ok(())
+    }
+}
+
 /// One flow to upload: the record to send and the files to delete once it lands.
 struct Pending {
     payload: serde_json::Value,
@@ -504,7 +558,7 @@ async fn upload_pending(
     }
 
     // Routine while the device is offline or roaming; try again next pass.
-    let client = match connect(&url, socket_factory).await {
+    let mut client = match IngestClient::connect(url, socket_factory).await {
         Ok(client) => client,
         Err(e) => {
             tracing::info!("Failed to open flow-log ingest connection: {e:#}");
@@ -532,7 +586,7 @@ async fn upload_pending(
             return Ok(true);
         }
 
-        match upload_authz_batch(&client, &dir, &url, config.batch_size).await {
+        match upload_authz_batch(&mut client, &dir, config.batch_size).await {
             Ok(more) => backlog |= more,
             // One broken directory must not block the others.
             Err(e) => tracing::warn!(?dir, "Failed to upload flow-log batch: {e:#}"),
@@ -574,9 +628,8 @@ fn read_dir_or_empty(dir: &Path) -> Result<Vec<PathBuf>> {
 /// Uploads one batch from one authorization's spool. Returns whether more than one
 /// batch was pending (a backlog).
 async fn upload_authz_batch(
-    client: &HttpClient,
+    client: &mut IngestClient,
     dir: &Path,
-    url: &str,
     batch_size: usize,
 ) -> Result<bool> {
     let collected = {
@@ -589,7 +642,7 @@ async fn upload_authz_batch(
         return Ok(false);
     };
 
-    submit(client, url, &token, &batch).await?;
+    submit(client, &token, &batch).await?;
 
     Ok(backlog)
 }
@@ -716,7 +769,7 @@ fn read_report(path: &Path) -> Result<Option<serde_json::Value>> {
 
 /// Submits one batch with response-specific handling. Idempotent, so transient
 /// failures retry the whole batch.
-async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) -> Result<()> {
+async fn submit(client: &mut IngestClient, token: &str, batch: &[Pending]) -> Result<()> {
     if batch.is_empty() {
         return Ok(());
     }
@@ -729,9 +782,10 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
     let body = Bytes::from(body);
 
     let mut backoff = upload_backoff();
+    let mut redirects = 0;
 
     loop {
-        let response = match send(client, url, token, body.clone()).await {
+        let response = match send(client, token, body.clone()).await {
             Ok(response) => response,
             Err(e) => {
                 tracing::info!("Flow-log upload request failed: {e:#}");
@@ -751,7 +805,7 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
                 return Ok(());
             }
             ResponseAction::Partition => {
-                return partition(client, url, token, batch).await;
+                return partition(client, token, batch).await;
             }
             ResponseAction::RateLimited => {
                 let wait = retry_after(&response).unwrap_or(CATCHUP_POLL);
@@ -764,6 +818,14 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
                 if !sleep_backoff(&mut backoff).await {
                     return Ok(());
                 }
+            }
+            ResponseAction::Redirect => {
+                anyhow::ensure!(
+                    redirects < MAX_REDIRECTS,
+                    "Flow-log upload exceeded {MAX_REDIRECTS} redirects"
+                );
+                client.follow_redirect(&response).await?;
+                redirects += 1;
             }
             ResponseAction::Drop => {
                 let body = body_string(&response);
@@ -786,6 +848,8 @@ enum ResponseAction {
     RateLimited,
     /// Transient failure (408 / 5xx); back off, then retry the same batch.
     Retry,
+    /// Permanently redirected (308); reconnect if needed and replay the POST.
+    Redirect,
     /// Permanently rejected (422 / other 4xx); log and drop the batch. The portal
     /// upserts by flow identity, so a dropped batch is never a partial write.
     Drop,
@@ -798,25 +862,51 @@ fn classify_response(status: StatusCode) -> ResponseAction {
         StatusCode::TOO_MANY_REQUESTS => ResponseAction::RateLimited,
         StatusCode::REQUEST_TIMEOUT => ResponseAction::Retry,
         s if s.is_server_error() => ResponseAction::Retry,
+        StatusCode::PERMANENT_REDIRECT => ResponseAction::Redirect,
         _ => ResponseAction::Drop,
     }
 }
 
-async fn send(
-    client: &HttpClient,
-    url: &str,
-    token: &str,
-    body: Bytes,
-) -> Result<http::Response<Bytes>> {
+async fn send(client: &IngestClient, token: &str, body: Bytes) -> Result<http::Response<Bytes>> {
     let request = http::Request::builder()
         .method(http::Method::POST)
-        .uri(url)
+        .uri(&client.url)
         .header(header::AUTHORIZATION, format!("Bearer {token}"))
         .header(header::CONTENT_TYPE, "application/json")
         .body(body)
         .context("Failed to build flow-log request")?;
 
-    client.send_request(request)?.await
+    client.http.send_request(request)?.await
+}
+
+fn redirect_url(current_url: &str, response: &http::Response<Bytes>) -> Result<String> {
+    let location = response
+        .headers()
+        .get(header::LOCATION)
+        .context("Flow-log upload redirect has no Location header")?
+        .to_str()
+        .context("Flow-log upload redirect has an invalid Location header")?;
+    let mut redirected = Url::parse(current_url)
+        .context("Invalid current ingest URL")?
+        .join(location)
+        .context("Invalid flow-log upload redirect URL")?;
+
+    anyhow::ensure!(
+        redirected.scheme() == "https",
+        "Flow-log upload redirect must use HTTPS"
+    );
+    anyhow::ensure!(
+        redirected.port_or_known_default() == Some(443),
+        "Flow-log upload redirect must use port 443"
+    );
+    anyhow::ensure!(
+        redirected.username().is_empty() && redirected.password().is_none(),
+        "Flow-log upload redirect must not contain credentials"
+    );
+
+    redirected.set_fragment(None);
+
+    Ok(redirected.to_string())
 }
 
 fn body_string(response: &http::Response<Bytes>) -> String {
@@ -824,7 +914,7 @@ fn body_string(response: &http::Response<Bytes>) -> String {
 }
 
 /// Splits an over-sized batch in half and submits each.
-async fn partition(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) -> Result<()> {
+async fn partition(client: &mut IngestClient, token: &str, batch: &[Pending]) -> Result<()> {
     if batch.len() <= 1 {
         tracing::error!("A single flow exceeds the upload size limit; dropping");
         delete_all(batch).await;
@@ -832,8 +922,8 @@ async fn partition(client: &HttpClient, url: &str, token: &str, batch: &[Pending
     }
 
     let mid = batch.len() / 2;
-    Box::pin(submit(client, url, token, &batch[..mid])).await?;
-    Box::pin(submit(client, url, token, &batch[mid..])).await?;
+    Box::pin(submit(client, token, &batch[..mid])).await?;
+    Box::pin(submit(client, token, &batch[mid..])).await?;
 
     Ok(())
 }
@@ -1152,10 +1242,70 @@ mod tests {
         assert_eq!(classify_response(StatusCode::REQUEST_TIMEOUT), Retry);
         assert_eq!(classify_response(StatusCode::INTERNAL_SERVER_ERROR), Retry);
         assert_eq!(classify_response(StatusCode::SERVICE_UNAVAILABLE), Retry);
+        assert_eq!(classify_response(StatusCode::PERMANENT_REDIRECT), Redirect);
         assert_eq!(classify_response(StatusCode::UNPROCESSABLE_ENTITY), Drop);
         assert_eq!(classify_response(StatusCode::BAD_REQUEST), Drop);
         assert_eq!(classify_response(StatusCode::UNAUTHORIZED), Drop);
         assert_eq!(classify_response(StatusCode::FORBIDDEN), Drop);
+    }
+
+    #[test]
+    fn redirect_url_resolves_absolute_and_relative_locations() {
+        let absolute = http::Response::builder()
+            .header(
+                header::LOCATION,
+                "https://rest-api.firezone.dev/ingestion/flow_logs",
+            )
+            .body(Bytes::new())
+            .unwrap();
+        assert_eq!(
+            redirect_url(
+                "https://flow-api.firezone.dev/ingestion/flow_logs",
+                &absolute
+            )
+            .unwrap(),
+            "https://rest-api.firezone.dev/ingestion/flow_logs"
+        );
+
+        let relative = http::Response::builder()
+            .header(header::LOCATION, "/v2/flow_logs")
+            .body(Bytes::new())
+            .unwrap();
+        assert_eq!(
+            redirect_url(
+                "https://flow-api.firezone.dev/ingestion/flow_logs",
+                &relative
+            )
+            .unwrap(),
+            "https://flow-api.firezone.dev/v2/flow_logs"
+        );
+    }
+
+    #[test]
+    fn redirect_url_rejects_missing_or_insecure_locations() {
+        let missing = http::Response::builder().body(Bytes::new()).unwrap();
+        assert!(
+            redirect_url(
+                "https://flow-api.firezone.dev/ingestion/flow_logs",
+                &missing
+            )
+            .is_err()
+        );
+
+        let insecure = http::Response::builder()
+            .header(
+                header::LOCATION,
+                "http://rest-api.firezone.dev/ingestion/flow_logs",
+            )
+            .body(Bytes::new())
+            .unwrap();
+        assert!(
+            redirect_url(
+                "https://flow-api.firezone.dev/ingestion/flow_logs",
+                &insecure
+            )
+            .is_err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
A 308 response previously fell through to the catch-all Drop action, deleting the batch from the flow-log spool without delivering it.

Treat 308 as a redirect and replay the POST at its Location, including reconnecting through the tunnel-bypass socket factory when the host changes. The redirected connection is reused for the rest of the pass. Redirects are limited to five and restricted to HTTPS on port 443 without URL credentials; invalid redirects return an error and leave the spool untouched.

Related: #14360