### PR TITLE
feat(portal): allow flow logs for internet resource

### DIFF
--- a/elixir/lib/portal/policy.ex
+++ b/elixir/lib/portal/policy.ex
@@ -68,37 +68,38 @@ defmodule Portal.Policy do
   @doc """
   Defaults `flow_log_uploads_enabled` to false for Internet Resource policies.
 
-  The schema and database default remain true for all other resources. An
-  explicit value is always honored, including when a policy is created for or
-  moved onto the Internet Resource.
+  The raw attributes are needed to distinguish an omitted value from an
+  explicit value equal to the schema default, which `cast/4` intentionally
+  excludes from the changes. `fetch_change/2` limits the resource lookup and
+  defaulting to policy creation or an actual resource change.
   """
   def default_flow_log_uploads_for_internet_resource(
         %Ecto.Changeset{} = changeset,
+        %{"flow_log_uploads_enabled" => _value},
+        %Authentication.Subject{}
+      ) do
+    changeset
+  end
+
+  def default_flow_log_uploads_for_internet_resource(
+        %Ecto.Changeset{} = changeset,
+        _attrs,
         %Authentication.Subject{} = subject
       ) do
-    resource_id = get_field(changeset, :resource_id)
-
-    needs_default? =
-      not flow_log_uploads_provided?(changeset) and
-        not is_nil(resource_id) and
-        (new_record?(changeset) or Map.has_key?(changeset.changes, :resource_id))
-
-    if needs_default? and Database.internet_resource?(resource_id, subject) do
+    with {:ok, resource_id} <- fetch_change(changeset, :resource_id),
+         %Portal.Resource{} = resource <- Database.fetch_resource(resource_id, subject),
+         false <- flow_log_uploads_enabled_by_default?(resource) do
       put_change(changeset, :flow_log_uploads_enabled, false)
     else
-      changeset
+      _ -> changeset
     end
   end
 
-  defp flow_log_uploads_provided?(%Ecto.Changeset{params: nil}), do: false
-
-  defp flow_log_uploads_provided?(%Ecto.Changeset{params: params}) do
-    Map.has_key?(params, "flow_log_uploads_enabled") or
-      Map.has_key?(params, :flow_log_uploads_enabled)
-  end
-
-  defp new_record?(%Ecto.Changeset{data: %{__meta__: %{state: :built}}}), do: true
-  defp new_record?(%Ecto.Changeset{}), do: false
+  @doc """
+  Returns whether flow log uploads are enabled by default for a resource.
+  """
+  def flow_log_uploads_enabled_by_default?(%Portal.Resource{type: :internet}), do: false
+  def flow_log_uploads_enabled_by_default?(%Portal.Resource{}), do: true
 
   # A policy may carry at most one condition per property. Each operator accepts
   # a list of values, so multiple conditions on the same property are always
@@ -125,15 +126,12 @@ defmodule Portal.Policy do
     alias Portal.Policy
     alias Portal.Safe
 
-    @spec internet_resource?(Ecto.UUID.t(), Portal.Authentication.Subject.t()) :: boolean()
-    def internet_resource?(resource_id, subject) do
+    @spec fetch_resource(Ecto.UUID.t(), Portal.Authentication.Subject.t()) ::
+            Portal.Resource.t() | nil
+    def fetch_resource(resource_id, subject) do
       from(r in Portal.Resource, where: r.id == ^resource_id)
       |> Safe.scoped(subject, :replica)
       |> Safe.one(fallback_to_primary: true)
-      |> case do
-        %Portal.Resource{type: :internet} -> true
-        _ -> false
-      end
     end
 
     @spec reconnect_orphaned_policies(Ecto.UUID.t()) :: non_neg_integer()

--- a/elixir/lib/portal/policy.ex
+++ b/elixir/lib/portal/policy.ex
@@ -87,19 +87,12 @@ defmodule Portal.Policy do
         %Authentication.Subject{} = subject
       ) do
     with {:ok, resource_id} <- fetch_change(changeset, :resource_id),
-         %Portal.Resource{} = resource <- Database.fetch_resource(resource_id, subject),
-         false <- flow_log_uploads_enabled_by_default?(resource) do
+         %Portal.Resource{type: :internet} <- Database.fetch_resource(resource_id, subject) do
       put_change(changeset, :flow_log_uploads_enabled, false)
     else
       _ -> changeset
     end
   end
-
-  @doc """
-  Returns whether flow log uploads are enabled by default for a resource.
-  """
-  def flow_log_uploads_enabled_by_default?(%Portal.Resource{type: :internet}), do: false
-  def flow_log_uploads_enabled_by_default?(%Portal.Resource{}), do: true
 
   # A policy may carry at most one condition per property. Each operator accepts
   # a list of values, so multiple conditions on the same property are always

--- a/elixir/lib/portal/policy.ex
+++ b/elixir/lib/portal/policy.ex
@@ -66,32 +66,35 @@ defmodule Portal.Policy do
   end
 
   @doc """
-  Forces `flow_log_uploads_enabled` off on policies for the Internet Resource.
+  Defaults `flow_log_uploads_enabled` to false for Internet Resource policies.
 
-  Flow logs attribute traffic to a specific resource; for the Internet Resource
-  that would mean uploading logs for every destination the client talks to, so
-  it is not supported. The flag is coerced to false rather than rejected: it
-  defaults to true, so rejecting would break every write that never set it.
-  Hits the database only when the flag would end up enabled on an insert or on
-  an update that changes the flag or the resource.
+  The schema and database default remain true for all other resources. An
+  explicit value is always honored, including when a policy is created for or
+  moved onto the Internet Resource.
   """
-  def disable_flow_log_uploads_for_internet_resource(
+  def default_flow_log_uploads_for_internet_resource(
         %Ecto.Changeset{} = changeset,
         %Authentication.Subject{} = subject
       ) do
     resource_id = get_field(changeset, :resource_id)
 
-    needs_check? =
-      get_field(changeset, :flow_log_uploads_enabled) == true and not is_nil(resource_id) and
-        (new_record?(changeset) or
-           Map.has_key?(changeset.changes, :flow_log_uploads_enabled) or
-           Map.has_key?(changeset.changes, :resource_id))
+    needs_default? =
+      not flow_log_uploads_provided?(changeset) and
+        not is_nil(resource_id) and
+        (new_record?(changeset) or Map.has_key?(changeset.changes, :resource_id))
 
-    if needs_check? and Database.internet_resource?(resource_id, subject) do
+    if needs_default? and Database.internet_resource?(resource_id, subject) do
       put_change(changeset, :flow_log_uploads_enabled, false)
     else
       changeset
     end
+  end
+
+  defp flow_log_uploads_provided?(%Ecto.Changeset{params: nil}), do: false
+
+  defp flow_log_uploads_provided?(%Ecto.Changeset{params: params}) do
+    Map.has_key?(params, "flow_log_uploads_enabled") or
+      Map.has_key?(params, :flow_log_uploads_enabled)
   end
 
   defp new_record?(%Ecto.Changeset{data: %{__meta__: %{state: :built}}}), do: true

--- a/elixir/lib/portal_api/controllers/policy_controller.ex
+++ b/elixir/lib/portal_api/controllers/policy_controller.ex
@@ -196,7 +196,7 @@ defmodule PortalAPI.PolicyController do
       policy
       |> changeset(attrs)
       |> populate_group_idp_id(subject)
-      |> Policy.disable_flow_log_uploads_for_internet_resource(subject)
+      |> Policy.default_flow_log_uploads_for_internet_resource(subject)
       |> Safe.scoped(subject)
       |> Safe.update()
     end
@@ -233,7 +233,7 @@ defmodule PortalAPI.PolicyController do
       changeset =
         create_changeset(attrs, subject)
         |> populate_group_idp_id(subject)
-        |> Policy.disable_flow_log_uploads_for_internet_resource(subject)
+        |> Policy.default_flow_log_uploads_for_internet_resource(subject)
 
       Safe.scoped(changeset, subject)
       |> Safe.insert()

--- a/elixir/lib/portal_api/controllers/policy_controller.ex
+++ b/elixir/lib/portal_api/controllers/policy_controller.ex
@@ -196,7 +196,7 @@ defmodule PortalAPI.PolicyController do
       policy
       |> changeset(attrs)
       |> populate_group_idp_id(subject)
-      |> Policy.default_flow_log_uploads_for_internet_resource(subject)
+      |> Policy.default_flow_log_uploads_for_internet_resource(attrs, subject)
       |> Safe.scoped(subject)
       |> Safe.update()
     end
@@ -233,7 +233,7 @@ defmodule PortalAPI.PolicyController do
       changeset =
         create_changeset(attrs, subject)
         |> populate_group_idp_id(subject)
-        |> Policy.default_flow_log_uploads_for_internet_resource(subject)
+        |> Policy.default_flow_log_uploads_for_internet_resource(attrs, subject)
 
       Safe.scoped(changeset, subject)
       |> Safe.insert()

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -353,7 +353,15 @@ defmodule PortalWeb.Groups do
 
     {:noreply,
      socket
-     |> merge_state(:group_resources, grant_selected_resource_ids: updated)
+     |> merge_state(:group_resources,
+       grant_selected_resource_ids: updated,
+       grant_resource_form:
+         to_grant_resource_form(
+           Enum.any?(socket.assigns.group_resources.available_resources, fn resource ->
+             resource.id in updated and resource.type == :internet
+           end)
+         )
+     )
      |> merge_state(:grant_conditions, active_conditions: active)}
   end
 
@@ -1253,8 +1261,8 @@ defmodule PortalWeb.Groups do
   end
 
   @spec to_grant_resource_form() :: Phoenix.HTML.Form.t()
-  defp to_grant_resource_form do
-    %Portal.Policy{}
+  defp to_grant_resource_form(internet_resource_selected? \\ false) do
+    %Portal.Policy{flow_log_uploads_enabled: not internet_resource_selected?}
     |> Ecto.Changeset.change()
     |> to_form(as: :policy)
   end
@@ -1723,7 +1731,7 @@ defmodule PortalWeb.Groups do
         |> Portal.Policy.changeset()
         |> put_change(:account_id, subject.account.id)
         |> populate_group_idp_id(subject)
-        |> Portal.Policy.disable_flow_log_uploads_for_internet_resource(subject)
+        |> Portal.Policy.default_flow_log_uploads_for_internet_resource(subject)
 
       Safe.scoped(changeset, subject)
       |> Safe.insert()

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -354,7 +354,7 @@ defmodule PortalWeb.Groups do
     flow_log_uploads_enabled? =
       socket.assigns.group_resources.available_resources
       |> Enum.filter(&(&1.id in updated))
-      |> Enum.all?(&Portal.Policy.flow_log_uploads_enabled_by_default?/1)
+      |> Enum.all?(&(&1.type != :internet))
 
     {:noreply,
      socket

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -351,16 +351,16 @@ defmodule PortalWeb.Groups do
     active =
       Enum.filter(socket.assigns.grant_conditions.active_conditions, &(&1 in allowed))
 
+    flow_log_uploads_enabled? =
+      socket.assigns.group_resources.available_resources
+      |> Enum.filter(&(&1.id in updated))
+      |> Enum.all?(&Portal.Policy.flow_log_uploads_enabled_by_default?/1)
+
     {:noreply,
      socket
      |> merge_state(:group_resources,
        grant_selected_resource_ids: updated,
-       grant_resource_form:
-         to_grant_resource_form(
-           Enum.any?(socket.assigns.group_resources.available_resources, fn resource ->
-             resource.id in updated and resource.type == :internet
-           end)
-         )
+       grant_resource_form: to_grant_resource_form(flow_log_uploads_enabled?)
      )
      |> merge_state(:grant_conditions, active_conditions: active)}
   end
@@ -1261,8 +1261,8 @@ defmodule PortalWeb.Groups do
   end
 
   @spec to_grant_resource_form() :: Phoenix.HTML.Form.t()
-  defp to_grant_resource_form(internet_resource_selected? \\ false) do
-    %Portal.Policy{flow_log_uploads_enabled: not internet_resource_selected?}
+  defp to_grant_resource_form(flow_log_uploads_enabled? \\ true) do
+    %Portal.Policy{flow_log_uploads_enabled: flow_log_uploads_enabled?}
     |> Ecto.Changeset.change()
     |> to_form(as: :policy)
   end
@@ -1731,7 +1731,7 @@ defmodule PortalWeb.Groups do
         |> Portal.Policy.changeset()
         |> put_change(:account_id, subject.account.id)
         |> populate_group_idp_id(subject)
-        |> Portal.Policy.default_flow_log_uploads_for_internet_resource(subject)
+        |> Portal.Policy.default_flow_log_uploads_for_internet_resource(attrs, subject)
 
       Safe.scoped(changeset, subject)
       |> Safe.insert()

--- a/elixir/lib/portal_web/live/groups/components.ex
+++ b/elixir/lib/portal_web/live/groups/components.ex
@@ -762,7 +762,10 @@ defmodule PortalWeb.Groups.Components do
             </div>
           </div>
           <div :if={@flow_logs_feature_enabled?} class="border-t border-border pt-4">
-            <.flow_log_uploads_toggle form={@grant_resource_form} />
+            <.flow_log_uploads_toggle
+              form={@grant_resource_form}
+              internet_resource?={Enum.any?(selected_resources, &(&1.type == :internet))}
+            />
           </div>
         </div>
       </div>

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -647,7 +647,10 @@ defmodule PortalWeb.Policies do
       changeset =
         change_policy(policy, params)
         |> validate_internet_resource_allowed(socket.assigns.subject)
-        |> Policy.default_flow_log_uploads_for_internet_resource(socket.assigns.subject)
+        |> Policy.default_flow_log_uploads_for_internet_resource(
+          params,
+          socket.assigns.subject
+        )
 
       case Database.update_policy(changeset, socket.assigns.subject) do
         {:ok, updated} ->
@@ -882,7 +885,7 @@ defmodule PortalWeb.Policies do
         (socket.assigns.live_action == :new or resource.type == :internet)
 
     if should_default? do
-      enabled? = resource.type != :internet
+      enabled? = Policy.flow_log_uploads_enabled_by_default?(resource)
 
       merge_state(socket, :policy_panel,
         form:
@@ -908,7 +911,7 @@ defmodule PortalWeb.Policies do
     attrs
     |> new_policy(subject)
     |> validate_internet_resource_allowed(subject)
-    |> Policy.default_flow_log_uploads_for_internet_resource(subject)
+    |> Policy.default_flow_log_uploads_for_internet_resource(attrs, subject)
     |> Database.insert_policy(subject)
   end
 

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -647,7 +647,7 @@ defmodule PortalWeb.Policies do
       changeset =
         change_policy(policy, params)
         |> validate_internet_resource_allowed(socket.assigns.subject)
-        |> Policy.disable_flow_log_uploads_for_internet_resource(socket.assigns.subject)
+        |> Policy.default_flow_log_uploads_for_internet_resource(socket.assigns.subject)
 
       case Database.update_policy(changeset, socket.assigns.subject) do
         {:ok, updated} ->
@@ -860,6 +860,7 @@ defmodule PortalWeb.Policies do
 
     {:noreply,
      socket
+     |> maybe_default_flow_log_uploads(resource)
      |> merge_state(:policy_panel, selected_resource: resource)
      |> merge_state(:policy_conditions, active_conditions: filtered)}
   end
@@ -870,6 +871,28 @@ defmodule PortalWeb.Policies do
 
   def on_panel_resource_change({_id, _name, resource}) do
     send(self(), {:panel_change_resource, resource})
+  end
+
+  defp maybe_default_flow_log_uploads(socket, resource) do
+    previous_resource = socket.assigns.policy_panel.selected_resource
+    resource_changed? = is_nil(previous_resource) or previous_resource.id != resource.id
+
+    should_default? =
+      resource_changed? and
+        (socket.assigns.live_action == :new or resource.type == :internet)
+
+    if should_default? do
+      enabled? = resource.type != :internet
+
+      merge_state(socket, :policy_panel,
+        form:
+          socket.assigns.policy_panel.form.source
+          |> put_change(:flow_log_uploads_enabled, enabled?)
+          |> to_form()
+      )
+    else
+      socket
+    end
   end
 
   defp new_policy(attrs, %Authentication.Subject{} = subject) do
@@ -885,7 +908,7 @@ defmodule PortalWeb.Policies do
     attrs
     |> new_policy(subject)
     |> validate_internet_resource_allowed(subject)
-    |> Policy.disable_flow_log_uploads_for_internet_resource(subject)
+    |> Policy.default_flow_log_uploads_for_internet_resource(subject)
     |> Database.insert_policy(subject)
   end
 

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -885,12 +885,10 @@ defmodule PortalWeb.Policies do
         (socket.assigns.live_action == :new or resource.type == :internet)
 
     if should_default? do
-      enabled? = Policy.flow_log_uploads_enabled_by_default?(resource)
-
       merge_state(socket, :policy_panel,
         form:
           socket.assigns.policy_panel.form.source
-          |> put_change(:flow_log_uploads_enabled, enabled?)
+          |> put_change(:flow_log_uploads_enabled, resource.type != :internet)
           |> to_form()
       )
     else

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -495,19 +495,16 @@ defmodule PortalWeb.Policies.Components do
 
   def policy_flow_log_uploads_field(assigns) do
     ~H"""
-    <div :if={@flow_logs_feature_enabled? and not internet_resource?(@panel_selected_resource)}>
-      <.flow_log_uploads_toggle form={@panel_form} />
+    <div :if={@flow_logs_feature_enabled?}>
+      <.flow_log_uploads_toggle
+        form={@panel_form}
+        internet_resource?={internet_resource?(@panel_selected_resource)}
+      />
       <p :if={flow_log_uploads_changed?(@panel_form)} class="mt-1 text-xs text-warning">
         Changing this setting expires all active connections created by this Policy;
         users may experience a few seconds of interrupted connectivity.
       </p>
     </div>
-    <p
-      :if={@flow_logs_feature_enabled? and internet_resource?(@panel_selected_resource)}
-      class="text-xs text-subtle"
-    >
-      Flow log uploads are not available for the Internet Resource.
-    </p>
     """
   end
 
@@ -521,39 +518,61 @@ defmodule PortalWeb.Policies.Components do
 
   @doc """
   The flow-log reporting toggle shared by every form that creates or edits a
-  policy. On by default (uploads default to on); posts the schema field
-  directly. Callers gate it behind the `flow_logs` feature flag, which each
-  LiveView checks once at mount.
+  policy. Callers initialize the form with the appropriate resource-specific
+  default and gate the component behind the `flow_logs` feature flag.
   """
   attr :form, :any, required: true
+  attr :internet_resource?, :boolean, default: false
 
   def flow_log_uploads_toggle(assigns) do
+    assigns =
+      assigns
+      |> assign(:checked?, flow_log_uploads_checked?(assigns.form))
+      |> assign(
+        :internet_resource_warning_id,
+        "#{assigns.form[:flow_log_uploads_enabled].id}-internet-resource-warning"
+      )
+
     ~H"""
-    <div class="flex items-center justify-between py-1">
-      <div>
-        <p class="text-sm font-medium text-body">Flow log reporting</p>
-        <p class="text-[11px] text-subtle">
-          Report flow logs for connections created by this Policy
-        </p>
+    <div>
+      <div class="flex items-center justify-between py-1">
+        <div>
+          <p class="text-sm font-medium text-body">Flow log reporting</p>
+          <p class="text-[11px] text-subtle">
+            Report flow logs for connections created by this Policy
+          </p>
+        </div>
+        <input type="hidden" name={@form[:flow_log_uploads_enabled].name} value="false" />
+        <.toggle
+          id={@form[:flow_log_uploads_enabled].id}
+          name={@form[:flow_log_uploads_enabled].name}
+          value="true"
+          checked={@checked?}
+          phx-click={
+            @internet_resource? &&
+              JS.toggle_class("hidden", to: "##{@internet_resource_warning_id}")
+          }
+        />
       </div>
-      <input type="hidden" name={@form[:flow_log_uploads_enabled].name} value="false" />
-      <.toggle
-        id={@form[:flow_log_uploads_enabled].id}
-        name={@form[:flow_log_uploads_enabled].name}
-        value="true"
-        checked={flow_log_uploads_checked?(@form)}
-      />
+      <p
+        :if={@internet_resource?}
+        id={@internet_resource_warning_id}
+        class={[
+          "mt-1 items-start gap-1 text-[11px] text-warning",
+          if(@checked?, do: "flex", else: "hidden")
+        ]}
+      >
+        <.icon name="ri-error-warning-line" class="mt-px h-3.5 w-3.5 shrink-0" />
+        <span>
+          Enabling flow log collection for the internet resource can result in substantial log volume.
+        </span>
+      </p>
     </div>
     """
   end
 
-  # A map-backed form (the grant panels before first submit) has no value for
-  # the field; absent means the schema default, which is enabled.
   defp flow_log_uploads_checked?(form) do
-    case form[:flow_log_uploads_enabled].value do
-      nil -> true
-      value -> Phoenix.HTML.Form.normalize_value("checkbox", value)
-    end
+    Phoenix.HTML.Form.normalize_value("checkbox", form[:flow_log_uploads_enabled].value)
   end
 
   defp internet_resource?(%{type: :internet}), do: true

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -1761,7 +1761,7 @@ defmodule PortalWeb.Resources do
         |> Portal.Policy.changeset()
         |> put_change(:account_id, subject.account.id)
         |> populate_group_idp_id(subject)
-        |> Portal.Policy.default_flow_log_uploads_for_internet_resource(subject)
+        |> Portal.Policy.default_flow_log_uploads_for_internet_resource(attrs, subject)
 
       Safe.scoped(changeset, subject)
       |> Safe.insert()

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -18,7 +18,7 @@ defmodule PortalWeb.Resources do
       resource_status_badge: 1,
       resource_type_label: 1,
       type_badge_class: 1,
-      to_grant_form: 0
+      to_grant_form: 1
     ]
 
   alias Portal.Changes.Change
@@ -895,7 +895,7 @@ defmodule PortalWeb.Resources do
          base_resource_grant(socket,
            available_groups: available,
            providers: providers,
-           grant_form: to_grant_form()
+           grant_form: to_grant_form(resource)
          )
      )
      |> assign(resource_ui: base_resource_ui())}
@@ -1761,7 +1761,7 @@ defmodule PortalWeb.Resources do
         |> Portal.Policy.changeset()
         |> put_change(:account_id, subject.account.id)
         |> populate_group_idp_id(subject)
-        |> Portal.Policy.disable_flow_log_uploads_for_internet_resource(subject)
+        |> Portal.Policy.default_flow_log_uploads_for_internet_resource(subject)
 
       Safe.scoped(changeset, subject)
       |> Safe.insert()

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -2038,9 +2038,7 @@ defmodule PortalWeb.Resources.Components do
 
   @spec to_grant_form(Portal.Resource.t()) :: Phoenix.HTML.Form.t()
   def to_grant_form(resource) do
-    %Portal.Policy{
-      flow_log_uploads_enabled: Portal.Policy.flow_log_uploads_enabled_by_default?(resource)
-    }
+    %Portal.Policy{flow_log_uploads_enabled: resource.type != :internet}
     |> Ecto.Changeset.change()
     |> to_form(as: :policy)
   end

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1698,10 +1698,13 @@ defmodule PortalWeb.Resources.Components do
             <% end %>
           </div>
           <div
-            :if={@resource.type != :internet and @flow_logs_feature_enabled?}
+            :if={@flow_logs_feature_enabled?}
             class="border-t border-border pt-4"
           >
-            <.flow_log_uploads_toggle form={@grant_form} />
+            <.flow_log_uploads_toggle
+              form={@grant_form}
+              internet_resource?={@resource.type == :internet}
+            />
           </div>
         </div>
       </div>
@@ -2033,9 +2036,9 @@ defmodule PortalWeb.Resources.Components do
   def format_filter(%{protocol: protocol, ports: ports}),
     do: "#{String.upcase("#{protocol}")}: #{Enum.join(ports, ", ")}"
 
-  @spec to_grant_form() :: Phoenix.HTML.Form.t()
-  def to_grant_form do
-    %Portal.Policy{}
+  @spec to_grant_form(Portal.Resource.t()) :: Phoenix.HTML.Form.t()
+  def to_grant_form(resource) do
+    %Portal.Policy{flow_log_uploads_enabled: resource.type != :internet}
     |> Ecto.Changeset.change()
     |> to_form(as: :policy)
   end

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -2038,7 +2038,9 @@ defmodule PortalWeb.Resources.Components do
 
   @spec to_grant_form(Portal.Resource.t()) :: Phoenix.HTML.Form.t()
   def to_grant_form(resource) do
-    %Portal.Policy{flow_log_uploads_enabled: resource.type != :internet}
+    %Portal.Policy{
+      flow_log_uploads_enabled: Portal.Policy.flow_log_uploads_enabled_by_default?(resource)
+    }
     |> Ecto.Changeset.change()
     |> to_form(as: :policy)
   end

--- a/elixir/priv/repo/migrations/20260707000000_add_flow_log_uploads_enabled_to_policies.exs
+++ b/elixir/priv/repo/migrations/20260707000000_add_flow_log_uploads_enabled_to_policies.exs
@@ -6,8 +6,8 @@ defmodule Portal.Repo.Migrations.AddFlowLogUploadsEnabledToPolicies do
       add(:flow_log_uploads_enabled, :boolean, null: false, default: true)
     end
 
-    # Flow log uploads are never allowed for the Internet Resource, so existing
-    # internet policies must not pick up the enabled-by-default value.
+    # Internet Resource policies default to disabled, so existing policies must
+    # not pick up the enabled-by-default value used by all other resources.
     execute("""
     UPDATE policies
     SET flow_log_uploads_enabled = FALSE

--- a/elixir/test/portal_api/controllers/policy_controller_test.exs
+++ b/elixir/test/portal_api/controllers/policy_controller_test.exs
@@ -652,6 +652,24 @@ defmodule PortalAPI.PolicyControllerTest do
       assert resp["data"]["flow_log_uploads_enabled"] == true
     end
 
+    test "preserves enabled flow logs when an internet resource_id is unchanged", %{conn: conn} do
+      account = account_fixture(features: %{internet_resource: true})
+      actor = api_client_fixture(account: account)
+      resource = internet_resource_fixture(account: account)
+      policy = policy_fixture(account: account, resource: resource, flow_log_uploads_enabled: true)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/policies/#{policy.id}",
+          policy: %{"resource_id" => resource.id, "description" => "updated"}
+        )
+
+      assert resp = json_response(conn, 200)
+      assert resp["data"]["flow_log_uploads_enabled"] == true
+    end
+
     test "disables flow log uploads when moving a policy onto the internet resource", %{conn: conn} do
       account = account_fixture(features: %{internet_resource: true})
       actor = api_client_fixture(account: account)

--- a/elixir/test/portal_api/controllers/policy_controller_test.exs
+++ b/elixir/test/portal_api/controllers/policy_controller_test.exs
@@ -502,6 +502,7 @@ defmodule PortalAPI.PolicyControllerTest do
       assert resp = json_response(conn, 201)
       assert resp["data"]["resource_id"] == resource.id
       assert resp["data"]["group_id"] == group.id
+      assert resp["data"]["flow_log_uploads_enabled"] == false
     end
 
     test "creates a policy with flow log uploads disabled", %{
@@ -547,7 +548,7 @@ defmodule PortalAPI.PolicyControllerTest do
       assert resp["data"]["flow_log_uploads_enabled"] == true
     end
 
-    test "forces flow_log_uploads_enabled off for an internet resource policy", %{conn: conn} do
+    test "allows flow_log_uploads_enabled for an internet resource policy", %{conn: conn} do
       account = account_fixture(features: %{internet_resource: true})
       actor = api_client_fixture(account: account)
       resource = internet_resource_fixture(account: account)
@@ -566,7 +567,7 @@ defmodule PortalAPI.PolicyControllerTest do
         |> post("/policies", policy: attrs)
 
       assert resp = json_response(conn, 201)
-      assert resp["data"]["flow_log_uploads_enabled"] == false
+      assert resp["data"]["flow_log_uploads_enabled"] == true
     end
   end
 
@@ -633,7 +634,7 @@ defmodule PortalAPI.PolicyControllerTest do
       assert resp["data"]["flow_log_uploads_enabled"] == true
     end
 
-    test "forces flow_log_uploads_enabled off when enabling it on an internet resource policy", %{
+    test "enables flow_log_uploads_enabled on an internet resource policy", %{
       conn: conn
     } do
       account = account_fixture(features: %{internet_resource: true})
@@ -648,7 +649,7 @@ defmodule PortalAPI.PolicyControllerTest do
         |> put("/policies/#{policy.id}", policy: %{"flow_log_uploads_enabled" => true})
 
       assert resp = json_response(conn, 200)
-      assert resp["data"]["flow_log_uploads_enabled"] == false
+      assert resp["data"]["flow_log_uploads_enabled"] == true
     end
 
     test "disables flow log uploads when moving a policy onto the internet resource", %{conn: conn} do
@@ -665,6 +666,28 @@ defmodule PortalAPI.PolicyControllerTest do
 
       assert resp = json_response(conn, 200)
       assert resp["data"]["flow_log_uploads_enabled"] == false
+    end
+
+    test "keeps flow log uploads enabled when explicitly enabled while moving a policy onto the internet resource",
+         %{conn: conn} do
+      account = account_fixture(features: %{internet_resource: true})
+      actor = api_client_fixture(account: account)
+      internet_resource = internet_resource_fixture(account: account)
+      policy = policy_fixture(account: account, flow_log_uploads_enabled: true)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/policies/#{policy.id}",
+          policy: %{
+            "resource_id" => internet_resource.id,
+            "flow_log_uploads_enabled" => true
+          }
+        )
+
+      assert resp = json_response(conn, 200)
+      assert resp["data"]["flow_log_uploads_enabled"] == true
     end
 
     test "preserves conditions when conditions are omitted", %{

--- a/elixir/test/portal_web/live/groups_test.exs
+++ b/elixir/test/portal_web/live/groups_test.exs
@@ -248,6 +248,35 @@ defmodule PortalWeb.GroupsTest do
       assert policy.flow_log_uploads_enabled == false
     end
 
+    test "defaults flow log reporting off when granting access to the Internet Resource",
+         %{conn: conn} do
+      enable_feature(:flow_logs)
+      account = account_fixture(features: %{internet_resource: true})
+      actor = admin_actor_fixture(account: account)
+      group = group_fixture(account: account)
+      resource = internet_resource_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/groups/#{group}?tab=resources")
+
+      render_click(lv, "open_grant_resource_form")
+
+      html = render_click(lv, "toggle_grant_resource", %{"resource_id" => resource.id})
+      assert html =~ "Flow log reporting"
+
+      assert html =~
+               "Enabling flow log collection for the internet resource can result in substantial log volume."
+
+      lv
+      |> form("#grant-resource-form")
+      |> render_submit()
+
+      policy = Repo.get_by!(Policy, group_id: group.id, resource_id: resource.id)
+      assert policy.flow_log_uploads_enabled == false
+    end
+
     test "grants access to multiple resources at once", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -286,7 +286,7 @@ defmodule PortalWeb.PoliciesTest do
       refute html =~ "Flow log reporting"
     end
 
-    test "forces flow log reporting off for Internet Resource policies", %{conn: conn} do
+    test "defaults flow log reporting off for Internet Resource policies", %{conn: conn} do
       enable_feature(:flow_logs)
       account = account_fixture(features: %{internet_resource: true})
       actor = admin_actor_fixture(account: account)
@@ -297,6 +297,67 @@ defmodule PortalWeb.PoliciesTest do
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/policies/new")
+
+      lv
+      |> form("[phx-change='change_policy_form']",
+        policy: %{
+          group_id: group.id,
+          resource_id: internet_resource.id
+        }
+      )
+      |> render_change()
+
+      html =
+        lv
+        |> form("[phx-submit='submit_policy_form']",
+          policy: %{
+            group_id: group.id,
+            resource_id: internet_resource.id
+          }
+        )
+        |> render_submit()
+
+      assert html =~ "created successfully"
+
+      policy = Repo.get_by!(Policy, group_id: group.id, resource_id: internet_resource.id)
+      assert policy.flow_log_uploads_enabled == false
+    end
+
+    test "allows flow log reporting for Internet Resource policies and shows a volume warning",
+         %{conn: conn} do
+      enable_feature(:flow_logs)
+      account = account_fixture(features: %{internet_resource: true})
+      actor = admin_actor_fixture(account: account)
+      group = group_fixture(account: account)
+      internet_resource = internet_resource_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies/new")
+
+      lv
+      |> form("[phx-change='change_policy_form']",
+        policy: %{
+          group_id: group.id,
+          resource_id: internet_resource.id
+        }
+      )
+      |> render_change()
+
+      html =
+        lv
+        |> form("[phx-change='change_policy_form']",
+          policy: %{
+            group_id: group.id,
+            resource_id: internet_resource.id,
+            flow_log_uploads_enabled: true
+          }
+        )
+        |> render_change()
+
+      assert html =~
+               "Enabling flow log collection for the internet resource can result in substantial log volume."
 
       html =
         lv
@@ -312,7 +373,7 @@ defmodule PortalWeb.PoliciesTest do
       assert html =~ "created successfully"
 
       policy = Repo.get_by!(Policy, group_id: group.id, resource_id: internet_resource.id)
-      assert policy.flow_log_uploads_enabled == false
+      assert policy.flow_log_uploads_enabled == true
     end
   end
 
@@ -497,7 +558,7 @@ defmodule PortalWeb.PoliciesTest do
       refute html =~ ~s(phx-click="remove_condition")
     end
 
-    test "hides flow log reporting checkbox when editing an Internet Resource policy", %{
+    test "shows flow log reporting checkbox when editing an Internet Resource policy", %{
       conn: conn
     } do
       enable_feature(:flow_logs)
@@ -512,8 +573,10 @@ defmodule PortalWeb.PoliciesTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/policies/#{policy.id}/edit")
 
-      assert html =~ "Flow log uploads are not available for the Internet Resource."
-      refute html =~ "policy[flow_log_uploads_enabled]"
+      assert html =~ "Flow log reporting"
+      assert html =~ "policy[flow_log_uploads_enabled]"
+      assert html =~
+               "Enabling flow log collection for the internet resource can result in substantial log volume."
     end
 
     test "warns when changing flow log reporting on an existing policy", %{
@@ -561,6 +624,15 @@ defmodule PortalWeb.PoliciesTest do
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/policies/#{policy.id}/edit")
+
+      lv
+      |> form("[phx-change='change_policy_form']",
+        policy: %{
+          group_id: group.id,
+          resource_id: internet_resource.id
+        }
+      )
+      |> render_change()
 
       html =
         lv

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -564,6 +564,49 @@ defmodule PortalWeb.ResourcesTest do
       assert policy.flow_log_uploads_enabled == false
     end
 
+    test "defaults Internet Resource flow logs off and allows enabling them", %{conn: conn} do
+      enable_feature(:flow_logs)
+      account = account_fixture(features: %{internet_resource: true})
+      actor = admin_actor_fixture(account: account)
+      resource = internet_resource_fixture(account: account)
+      default_group = group_fixture(account: account)
+      enabled_group = group_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}")
+
+      html = render_click(lv, "open_grant_form")
+      assert html =~ "Flow log reporting"
+
+      assert html =~
+               "Enabling flow log collection for the internet resource can result in substantial log volume."
+
+      render_click(lv, "toggle_grant_group", %{"group_id" => default_group.id})
+
+      lv
+      |> form("#grant-form")
+      |> render_submit()
+
+      default_policy =
+        Repo.get_by!(Policy, resource_id: resource.id, group_id: default_group.id)
+
+      assert default_policy.flow_log_uploads_enabled == false
+
+      render_click(lv, "open_grant_form")
+      render_click(lv, "toggle_grant_group", %{"group_id" => enabled_group.id})
+
+      lv
+      |> form("#grant-form", policy: %{flow_log_uploads_enabled: true})
+      |> render_submit()
+
+      enabled_policy =
+        Repo.get_by!(Policy, resource_id: resource.id, group_id: enabled_group.id)
+
+      assert enabled_policy.flow_log_uploads_enabled == true
+    end
+
     test "shows blurred upgrade state in grant access form for starter accounts without policy conditions",
          %{conn: conn} do
       account =


### PR DESCRIPTION
## Summary

- keep flow log collection disabled by default for Internet Resource policies
- allow callers and admins to explicitly enable flow logs for Internet Resource policies
- show an inline caution when Internet Resource flow logging is enabled across policy and grant forms

## Testing

- `mix compile --warnings-as-errors`
- `mix test` (4,299 tests)
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer --format dialyxir`

---