### PR TITLE
fix(android): raise exception when `VpnService.protect` fails

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -791,12 +791,7 @@ class TunnelService : VpnService() {
         // Protects through the one live service; the session, telemetry, and
         // flow-log drains all share it. Without a running service our VPN cannot
         // be up, so the no-op is the correct bypass then too.
-        val protectSocketCallback: ProtectSocket =
-            object : ProtectSocket {
-                override fun protectSocket(fd: Int) {
-                    activeService?.protect(fd)
-                }
-            }
+        val protectSocketCallback: ProtectSocket = VpnProtectSocket { fd -> activeService?.protect(fd) }
 
         // FIXME: Find another way to check if we're running
         @SuppressWarnings("deprecation")

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/VpnProtectSocket.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/VpnProtectSocket.kt
@@ -1,0 +1,20 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.tunnel
+
+import uniffi.connlib.CallbackException
+import uniffi.connlib.ProtectSocket
+
+/**
+ * Excludes connlib's sockets from the VPN so its traffic isn't routed back into the tunnel.
+ *
+ * `protect` returns `null` when there is no service to protect through.
+ */
+internal class VpnProtectSocket(
+    private val protect: (Int) -> Boolean?,
+) : ProtectSocket {
+    override fun protectSocket(fd: Int) {
+        if (protect(fd) == false) {
+            throw CallbackException.Failed("`VpnService.protect` failed for fd $fd")
+        }
+    }
+}

--- a/kotlin/android/app/src/test/java/dev/firezone/android/tunnel/VpnProtectSocketTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/tunnel/VpnProtectSocketTest.kt
@@ -1,0 +1,22 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.tunnel
+
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import uniffi.connlib.CallbackException
+
+class VpnProtectSocketTest {
+    @Test
+    fun `throws when protect fails`() {
+        val protectSocket = VpnProtectSocket { false }
+
+        assertThrows(CallbackException::class.java) { protectSocket.protectSocket(42) }
+    }
+
+    @Test
+    fun `does not throw without a service`() {
+        val protectSocket = VpnProtectSocket { null }
+
+        protectSocket.protectSocket(42)
+    }
+}


### PR DESCRIPTION
`VpnService.protect` returns `false` when a socket cannot be excluded from the tunnel, and we were discarding that. connlib then keeps using a socket whose traffic is routed back into the VPN it is establishing, which presents as a silent connectivity failure rather than an error.

The `ProtectSocket` callback already models failure as `CallbackError`, so surface it and let connlib treat the socket as unusable. Having no live service to protect through remains a no-op, as before.