### PR TITLE
docs(rust): extract coding guidelines from agent rules

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,6 +38,8 @@ To maximize your chances of getting your pull request approved, please abide by
 the following general guidelines:
 
 1. Please adhere to our [code of conduct](CODE_OF_CONDUCT.md).
+1. For Rust code, follow the
+   [Rust coding guidelines](../rust/CODING_GUIDELINES.md).
 1. Please test your code and include unit tests when possible.
 1. It is up to you, the contributor, to make a case for why your change is a
    good idea.

--- a/rust/AGENT.md
+++ b/rust/AGENT.md
@@ -1,22 +1,6 @@
 # AI agent rules for Firezone Rust code
 
-## Code style
-
-- Do not generate excessive comments
-- Document the code, not the change that introduced it. A comment should read the
-  same a year later to someone who never saw the diff: describe what the code does
-  and why it must work that way, not how it differs from what it replaced. Avoid
-  change-relative wording like "instead of", "now", "no longer", or "previously".
-  The reason a change is made belongs in the commit message — and, at a high level,
-  in the PR description, which becomes the squash-merge commit message — not in a
-  code comment.
-- Prefer a functional style (i.e. Iterators) over imperative code
-- Prefer turbofish over explicit type-hints
-- Prefer early-returns in functions to keep the indentation of the happy-path minimal, i.e. use `let-else` instead of `if let`
-- When writing tests, focus on the public API of the module
-- Follow the arrange - act - assert pattern
-- Order functions within a module from high to low priority: Public API first, then sorted roughly in order of how they are called.
-  Scrolling further down should be roughly equivalent to drilling down into details as to how the module works.
+Follow the [Rust coding guidelines](CODING_GUIDELINES.md).
 
 ## Use of log levels
 

--- a/rust/CODING_GUIDELINES.md
+++ b/rust/CODING_GUIDELINES.md
@@ -10,7 +10,7 @@ Rules for all Rust code in this repository.
   If possible, write code where the compiler can infer the type.
 - Prefer early-returns to keep the indentation of the happy-path minimal, i.e. use `let-else` instead of `if let`.
 - Write one match-arm per distinct case, even if the bodies are identical or create slight duplication.
-  Separate arms format better and read clearer than combined `A | B` patterns or `matches!` guards.
+  Separate arms format better and are easier to read than combined `A | B` patterns or `matches!` guards.
 - Order functions within a module from high to low priority: Public API first, then sorted roughly in order of how they are called.
   Scrolling further down should be roughly equivalent to drilling down into details as to how the module works.
   This also applies to test modules:

--- a/rust/CODING_GUIDELINES.md
+++ b/rust/CODING_GUIDELINES.md
@@ -1,0 +1,37 @@
+# Rust coding guidelines
+
+Rules for all Rust code in this repository.
+
+## Code style
+
+- Prefer a functional style (i.e. iterators) over imperative code, especially when you are expressing data transformations.
+  For side-effects, imperative loops may be easier to understand.
+- Prefer turbofish over explicit type-hints where the compiler cannot infer the type.
+  If possible, write code where the compiler can infer the type.
+- Prefer early-returns to keep the indentation of the happy-path minimal, i.e. use `let-else` instead of `if let`.
+- Write one match-arm per distinct case, even if the bodies are identical or create slight duplication.
+  Separate arms format better and read clearer than combined `A | B` patterns or `matches!` guards.
+- Order functions within a module from high to low priority: Public API first, then sorted roughly in order of how they are called.
+  Scrolling further down should be roughly equivalent to drilling down into details as to how the module works.
+  This also applies to test modules:
+  Helper functions inside test modules should always be below their usage.
+  The tests are important, the helpers are not.
+- Don't end functions with expressions that evaluate to `Result`.
+  Instead, assign it to another variable, use `?` and end the function with `Ok(T)`.
+  This ensures error handling and failure paths are always clearly visible.
+
+## Comments
+
+- Default to no comments; let the code speak.
+  Types, function and variable names give a lot of opportunity for naming.
+  Comment only a non-obvious "why" such as a hack, a workaround or an invariant, and explain it in exactly one place.
+- Document the code, not the change that introduced it.
+  A comment should read the same a year later to someone who never saw the diff, so avoid change-relative wording like "instead of", "now", "no longer", or "previously".
+  The reason for a change belongs in the commit message, not in a code comment.
+- Style doc comments after the [rustdoc guide](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html#documenting-components): a third-person, one-sentence summary (e.g. "Returns the tidied title"), followed by a blank line and further detail, with `# Examples`, `# Panics`, `# Errors` and `# Safety` sections where they apply.
+
+## Tests
+
+- Focus on the public API of the module.
+- Cover the behaviour a change introduces, not every path: one or two focused tests are usually enough.
+- Follow the arrange - act - assert pattern.


### PR DESCRIPTION
I noticed that I am repeating myself a lot in Rust code reviews. Hopefully, these coding guidelines should capture some of those points so future reviews can focus more on the actual change.