### PR TITLE
fix(connlib): exit on unrecoverable UDP bind failures

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6961,6 +6961,7 @@ dependencies = [
  "quinn-udp",
  "smallvec",
  "socket2",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -674,7 +674,7 @@ fn protected_tcp_socket_factory(callback: Arc<dyn ProtectSocket>) -> impl Socket
         use std::os::fd::AsRawFd;
         callback
             .protect_socket(socket.as_raw_fd())
-            .map_err(std::io::Error::other)?;
+            .map_err(socket_factory::fatal)?;
 
         Ok(socket)
     }
@@ -687,7 +687,7 @@ fn protected_udp_socket_factory(callback: Arc<dyn ProtectSocket>) -> impl Socket
         use std::os::fd::AsRawFd;
         callback
             .protect_socket(socket.as_raw_fd())
-            .map_err(std::io::Error::other)?;
+            .map_err(socket_factory::fatal)?;
 
         Ok(socket)
     }

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -674,7 +674,7 @@ fn protected_tcp_socket_factory(callback: Arc<dyn ProtectSocket>) -> impl Socket
         use std::os::fd::AsRawFd;
         callback
             .protect_socket(socket.as_raw_fd())
-            .map_err(socket_factory::fatal)?;
+            .map_err(socket_factory::RoutingLoopPreventionFailed::new)?;
 
         Ok(socket)
     }
@@ -687,7 +687,7 @@ fn protected_udp_socket_factory(callback: Arc<dyn ProtectSocket>) -> impl Socket
         use std::os::fd::AsRawFd;
         callback
             .protect_socket(socket.as_raw_fd())
-            .map_err(socket_factory::fatal)?;
+            .map_err(socket_factory::RoutingLoopPreventionFailed::new)?;
 
         Ok(socket)
     }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -309,8 +309,7 @@ impl Eventloop {
 
             if e.any_is::<tunnel::UdpSocketThreadStopped>()
                 || e.any_is::<tunnel::TunChannelClosed>()
-                || e.any_downcast_ref::<io::Error>()
-                    .is_some_and(socket_factory::RoutingLoopPreventionFailed::is_cause_of)
+                || e.any_is::<socket_factory::RoutingLoopPreventionFailed>()
             {
                 return Err(e);
             }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -309,6 +309,8 @@ impl Eventloop {
 
             if e.any_is::<tunnel::UdpSocketThreadStopped>()
                 || e.any_is::<tunnel::TunChannelClosed>()
+                || e.any_downcast_ref::<io::Error>()
+                    .is_some_and(socket_factory::is_fatal)
             {
                 return Err(e);
             }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -310,7 +310,7 @@ impl Eventloop {
             if e.any_is::<tunnel::UdpSocketThreadStopped>()
                 || e.any_is::<tunnel::TunChannelClosed>()
                 || e.any_downcast_ref::<io::Error>()
-                    .is_some_and(socket_factory::is_fatal)
+                    .is_some_and(socket_factory::RoutingLoopPreventionFailed::is_cause_of)
             {
                 return Err(e);
             }

--- a/rust/libs/bin-shared/src/linux.rs
+++ b/rust/libs/bin-shared/src/linux.rs
@@ -2,11 +2,11 @@ use std::{io, net::SocketAddr};
 
 use crate::FIREZONE_MARK;
 use nix::sys::socket::{setsockopt, sockopt};
-use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
+use socket_factory::{RoutingLoopPreventionFailed, SocketFactory, TcpSocket, UdpSocket};
 
 pub fn tcp_socket_factory(socket_addr: SocketAddr) -> io::Result<TcpSocket> {
     let socket = socket_factory::tcp(socket_addr)?;
-    setsockopt(&socket, sockopt::Mark, &FIREZONE_MARK)?;
+    setsockopt(&socket, sockopt::Mark, &FIREZONE_MARK).map_err(RoutingLoopPreventionFailed::new)?;
     Ok(socket)
 }
 
@@ -16,7 +16,8 @@ pub struct UdpSocketFactory {}
 impl SocketFactory<UdpSocket> for UdpSocketFactory {
     fn bind(&self, local: SocketAddr) -> io::Result<UdpSocket> {
         let socket = socket_factory::udp(local)?;
-        setsockopt(&socket, sockopt::Mark, &FIREZONE_MARK)?;
+        setsockopt(&socket, sockopt::Mark, &FIREZONE_MARK)
+            .map_err(RoutingLoopPreventionFailed::new)?;
         Ok(socket)
     }
 

--- a/rust/libs/bin-shared/src/windows.rs
+++ b/rust/libs/bin-shared/src/windows.rs
@@ -2,6 +2,7 @@ use crate::TUNNEL_NAME;
 use anyhow::Result;
 use dashmap::DashMap;
 use logging::err_with_src;
+use socket_factory::RoutingLoopPreventionFailed;
 use socket_factory::SocketFactory;
 use socket_factory::{TcpSocket, UdpSocket};
 use std::{
@@ -100,7 +101,8 @@ pub fn tcp_socket_factory(addr: SocketAddr) -> io::Result<TcpSocket> {
     // To avoid routing loops, all TCP sockets are bound to the "best" source IP.
     // Additionally, we add a dedicated route for the given address to route via the default interface.
     socket.bind((route.addr, 0).into())?;
-    let entry = RoutingTableEntry::create(addr.ip(), route.original)?;
+    let entry = RoutingTableEntry::create(addr.ip(), route.original)
+        .map_err(RoutingLoopPreventionFailed::new)?;
 
     socket.pack(entry);
 

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -451,6 +451,8 @@ impl Eventloop {
 
             if e.any_is::<tunnel::UdpSocketThreadStopped>()
                 || e.any_is::<tunnel::TunChannelClosed>()
+                || e.any_downcast_ref::<io::Error>()
+                    .is_some_and(socket_factory::is_fatal)
             {
                 return Err(e);
             }

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -451,8 +451,7 @@ impl Eventloop {
 
             if e.any_is::<tunnel::UdpSocketThreadStopped>()
                 || e.any_is::<tunnel::TunChannelClosed>()
-                || e.any_downcast_ref::<io::Error>()
-                    .is_some_and(socket_factory::RoutingLoopPreventionFailed::is_cause_of)
+                || e.any_is::<socket_factory::RoutingLoopPreventionFailed>()
             {
                 return Err(e);
             }

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -452,7 +452,7 @@ impl Eventloop {
             if e.any_is::<tunnel::UdpSocketThreadStopped>()
                 || e.any_is::<tunnel::TunChannelClosed>()
                 || e.any_downcast_ref::<io::Error>()
-                    .is_some_and(socket_factory::is_fatal)
+                    .is_some_and(socket_factory::RoutingLoopPreventionFailed::is_cause_of)
             {
                 return Err(e);
             }

--- a/rust/libs/connlib/socket-factory/Cargo.toml
+++ b/rust/libs/connlib/socket-factory/Cargo.toml
@@ -15,6 +15,7 @@ otel-instruments = { workspace = true }
 quinn-udp = { workspace = true }
 smallvec = { workspace = true, features = ["const_generics"] }
 socket2 = { workspace = true, features = ["all"] }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt", "time"] }
 tracing = { workspace = true }
 

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -29,30 +29,42 @@ pub trait SocketFactory<S>: Send + Sync + 'static {
     fn reset(&self);
 }
 
-/// Marks `error` as an unrecoverable bind failure, i.e. binding again will fail the same way.
+/// A socket could not be excluded from our own tunnel, so its traffic would loop back into it.
 ///
-/// Most bind failures say something about the network: a family that isn't available, an
-/// address that isn't up yet. Retrying those is how a session survives roaming. Some say
-/// something about the process instead - Android's `protect` callback failing means every
-/// socket we make would route back into our own tunnel - and no amount of retrying fixes
-/// them. [`SocketFactory`] implementations mark the latter so consumers can give up rather
-/// than rebind forever, which they detect with [`is_fatal`].
-pub fn fatal(error: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> io::Error {
-    io::Error::other(Fatal {
-        source: error.into(),
-    })
-}
-
-/// Returns whether `error` was marked unrecoverable by [`fatal`].
-pub fn is_fatal(error: &io::Error) -> bool {
-    error.get_ref().is_some_and(|e| e.is::<Fatal>())
-}
-
-/// The marker [`fatal`] attaches. Named `source` so the underlying cause stays in the chain.
+/// Platforms that route their own traffic around the tunnel - Android's `VpnService.protect`,
+/// and anything equivalent elsewhere - report a failure of that mechanism this way. Unlike a
+/// family that won't bind or an address that isn't up yet, this does not pass: every socket
+/// bound afterwards loops the same way, so consumers give up instead of rebinding forever.
 #[derive(thiserror::Error, Debug)]
-#[error("{source}")]
-struct Fatal {
-    source: Box<dyn std::error::Error + Send + Sync>,
+#[error("Failed to prevent a routing loop")]
+pub struct RoutingLoopPreventionFailed {
+    #[source]
+    cause: Box<dyn std::error::Error + Send + Sync>,
+}
+
+impl RoutingLoopPreventionFailed {
+    pub fn new(cause: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Self {
+        Self {
+            cause: cause.into(),
+        }
+    }
+
+    /// Returns whether `error` carries a [`RoutingLoopPreventionFailed`].
+    ///
+    /// `io::Error` omits a custom error from its own `source` chain and only exposes that
+    /// error's source, so walking sources never finds this: it has to be read back out of
+    /// the `io::Error` directly.
+    pub fn is_cause_of(error: &io::Error) -> bool {
+        error
+            .get_ref()
+            .is_some_and(|e| e.is::<RoutingLoopPreventionFailed>())
+    }
+}
+
+impl From<RoutingLoopPreventionFailed> for io::Error {
+    fn from(value: RoutingLoopPreventionFailed) -> Self {
+        io::Error::other(value)
+    }
 }
 
 /// How many times we at most try to re-send a packet if we encounter ENOBUFS on MacOS / iOS or 10055 on Windows.
@@ -1069,21 +1081,31 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
     #[test]
-    fn only_marked_bind_errors_are_fatal() {
-        assert!(is_fatal(&fatal(io::Error::from(
-            io::ErrorKind::PermissionDenied
-        ))));
-        assert!(!is_fatal(&io::Error::from(io::ErrorKind::AddrNotAvailable)));
+    fn only_routing_loop_failures_are_recognised() {
+        let error = io::Error::from(RoutingLoopPreventionFailed::new(io::Error::from(
+            io::ErrorKind::PermissionDenied,
+        )));
+
+        assert!(RoutingLoopPreventionFailed::is_cause_of(&error));
+        assert!(!RoutingLoopPreventionFailed::is_cause_of(&io::Error::from(
+            io::ErrorKind::AddrNotAvailable
+        )));
     }
 
-    /// Consumers see bind failures as a wrapped, contextualised [`anyhow::Error`], so the
-    /// marker has to stay discoverable through those layers.
+    /// Consumers see bind failures as a wrapped, contextualised [`anyhow::Error`], so this has
+    /// to stay recognisable through those layers.
     #[test]
-    fn fatal_bind_errors_stay_fatal_once_wrapped() {
-        let error = anyhow::Error::new(fatal(io::Error::from(io::ErrorKind::PermissionDenied)))
-            .context("Failed to bind UDP socket on 0.0.0.0:1234");
+    fn routing_loop_failures_survive_wrapping() {
+        let error = anyhow::Error::new(io::Error::from(RoutingLoopPreventionFailed::new(
+            io::Error::from(io::ErrorKind::PermissionDenied),
+        )))
+        .context("Failed to bind UDP socket on 0.0.0.0:1234");
 
-        assert!(error.any_downcast_ref::<io::Error>().is_some_and(is_fatal));
+        assert!(
+            error
+                .any_downcast_ref::<io::Error>()
+                .is_some_and(RoutingLoopPreventionFailed::is_cause_of)
+        );
     }
 
     #[test]

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -48,16 +48,6 @@ impl RoutingLoopPreventionFailed {
             cause: cause.into(),
         }
     }
-
-    /// Returns whether `error` carries a [`RoutingLoopPreventionFailed`].
-    ///
-    /// For a bare [`io::Error`]; once one is wrapped in an [`anyhow::Error`], `any_is`
-    /// finds it.
-    pub fn is_cause_of(error: &io::Error) -> bool {
-        error
-            .get_ref()
-            .is_some_and(|e| e.is::<RoutingLoopPreventionFailed>())
-    }
 }
 
 impl From<RoutingLoopPreventionFailed> for io::Error {
@@ -1078,18 +1068,6 @@ mod tests {
     use gat_lending_iterator::LendingIterator as _;
     use quinn_udp::RecvMeta;
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
-
-    #[test]
-    fn only_routing_loop_failures_are_recognised() {
-        let error = io::Error::from(RoutingLoopPreventionFailed::new(io::Error::from(
-            io::ErrorKind::PermissionDenied,
-        )));
-
-        assert!(RoutingLoopPreventionFailed::is_cause_of(&error));
-        assert!(!RoutingLoopPreventionFailed::is_cause_of(&io::Error::from(
-            io::ErrorKind::AddrNotAvailable
-        )));
-    }
 
     /// Consumers see bind failures as a wrapped, contextualised [`anyhow::Error`], so this has
     /// to stay recognisable through those layers.

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -29,6 +29,32 @@ pub trait SocketFactory<S>: Send + Sync + 'static {
     fn reset(&self);
 }
 
+/// Marks `error` as an unrecoverable bind failure, i.e. binding again will fail the same way.
+///
+/// Most bind failures say something about the network: a family that isn't available, an
+/// address that isn't up yet. Retrying those is how a session survives roaming. Some say
+/// something about the process instead - Android's `protect` callback failing means every
+/// socket we make would route back into our own tunnel - and no amount of retrying fixes
+/// them. [`SocketFactory`] implementations mark the latter so consumers can give up rather
+/// than rebind forever, which they detect with [`is_fatal`].
+pub fn fatal(error: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> io::Error {
+    io::Error::other(Fatal {
+        source: error.into(),
+    })
+}
+
+/// Returns whether `error` was marked unrecoverable by [`fatal`].
+pub fn is_fatal(error: &io::Error) -> bool {
+    error.get_ref().is_some_and(|e| e.is::<Fatal>())
+}
+
+/// The marker [`fatal`] attaches. Named `source` so the underlying cause stays in the chain.
+#[derive(thiserror::Error, Debug)]
+#[error("{source}")]
+struct Fatal {
+    source: Box<dyn std::error::Error + Send + Sync>,
+}
+
 /// How many times we at most try to re-send a packet if we encounter ENOBUFS on MacOS / iOS or 10055 on Windows.
 #[cfg(any(apple, target_os = "windows"))]
 const MAX_ENOBUFS_RETRIES: u32 = 24;
@@ -1037,9 +1063,28 @@ where
 
 #[cfg(test)]
 mod tests {
+    use anyhow::ErrorExt as _;
     use gat_lending_iterator::LendingIterator as _;
     use quinn_udp::RecvMeta;
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
+
+    #[test]
+    fn only_marked_bind_errors_are_fatal() {
+        assert!(is_fatal(&fatal(io::Error::from(
+            io::ErrorKind::PermissionDenied
+        ))));
+        assert!(!is_fatal(&io::Error::from(io::ErrorKind::AddrNotAvailable)));
+    }
+
+    /// Consumers see bind failures as a wrapped, contextualised [`anyhow::Error`], so the
+    /// marker has to stay discoverable through those layers.
+    #[test]
+    fn fatal_bind_errors_stay_fatal_once_wrapped() {
+        let error = anyhow::Error::new(fatal(io::Error::from(io::ErrorKind::PermissionDenied)))
+            .context("Failed to bind UDP socket on 0.0.0.0:1234");
+
+        assert!(error.any_downcast_ref::<io::Error>().is_some_and(is_fatal));
+    }
 
     #[test]
     fn datagram_out_max_len_is_whole_segments_of_one_gso_send() {

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -51,9 +51,8 @@ impl RoutingLoopPreventionFailed {
 
     /// Returns whether `error` carries a [`RoutingLoopPreventionFailed`].
     ///
-    /// `io::Error` omits a custom error from its own `source` chain and only exposes that
-    /// error's source, so walking sources never finds this: it has to be read back out of
-    /// the `io::Error` directly.
+    /// For a bare [`io::Error`]; once one is wrapped in an [`anyhow::Error`], `any_is`
+    /// finds it.
     pub fn is_cause_of(error: &io::Error) -> bool {
         error
             .get_ref()
@@ -1101,11 +1100,7 @@ mod tests {
         )))
         .context("Failed to bind UDP socket on 0.0.0.0:1234");
 
-        assert!(
-            error
-                .any_downcast_ref::<io::Error>()
-                .is_some_and(RoutingLoopPreventionFailed::is_cause_of)
-        );
+        assert!(error.any_is::<RoutingLoopPreventionFailed>());
     }
 
     #[test]

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -1064,22 +1064,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use anyhow::ErrorExt as _;
     use gat_lending_iterator::LendingIterator as _;
     use quinn_udp::RecvMeta;
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
-
-    /// Consumers see bind failures as a wrapped, contextualised [`anyhow::Error`], so this has
-    /// to stay recognisable through those layers.
-    #[test]
-    fn routing_loop_failures_survive_wrapping() {
-        let error = anyhow::Error::new(io::Error::from(RoutingLoopPreventionFailed::new(
-            io::Error::from(io::ErrorKind::PermissionDenied),
-        )))
-        .context("Failed to bind UDP socket on 0.0.0.0:1234");
-
-        assert!(error.any_is::<RoutingLoopPreventionFailed>());
-    }
 
     #[test]
     fn datagram_out_max_len_is_whole_segments_of_one_gso_send() {

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -218,10 +218,6 @@ impl Io {
         )
     }
 
-    pub fn poll_has_sockets(&mut self, cx: &mut Context<'_>) -> Poll<()> {
-        self.sockets.poll_has_sockets(cx)
-    }
-
     pub fn fastest_nameserver(&self) -> Option<IpAddr> {
         self.nameservers.fastest()
     }

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -23,7 +23,7 @@ use std::{
     future,
     net::{IpAddr, SocketAddr},
     sync::Arc,
-    task::{Context, Poll, ready},
+    task::{Context, Poll},
     time::{Duration, Instant, SystemTime},
 };
 use tun::Tun;
@@ -186,8 +186,6 @@ impl ClientTunnel {
                 self.role_state.handle_timeout(now);
                 tick.want_continue();
             }
-
-            ready!(self.io.poll_has_sockets(cx)); // Suspend everything if we don't have any sockets.
 
             // Pass up existing events.
             if let Some(event) = self.role_state.poll_event() {
@@ -383,8 +381,6 @@ impl GatewayTunnel {
                 self.role_state.handle_timeout(now);
                 tick.want_continue();
             }
-
-            ready!(self.io.poll_has_sockets(cx)); // Suspend everything if we don't have any sockets.
 
             // Pass up existing events.
             if let Some(other) = self.role_state.poll_event() {

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -2,9 +2,7 @@ use crate::otel;
 use anyhow::{Context as _, ErrorExt as _, Result};
 use futures::{SinkExt, ready};
 use gat_lending_iterator::LendingIterator;
-use socket_factory::{
-    DatagramIn, DatagramSegmentIter, RoutingLoopPreventionFailed, SocketFactory, UdpSocket,
-};
+use socket_factory::{DatagramIn, DatagramSegmentIter, SocketFactory, UdpSocket};
 use socket_factory::{DatagramOut, PerfUdpSocket};
 use std::collections::VecDeque;
 use std::env::VarError;
@@ -564,8 +562,6 @@ fn listen(
     for addr in addresses {
         match sf.bind(*addr).and_then(|s| s.into_perf()) {
             Ok(s) => return Ok(s),
-            // Another port cannot fix a failure that isn't about the address.
-            Err(e) if RoutingLoopPreventionFailed::is_cause_of(&e) => return Err(e),
             Err(e) => {
                 tracing::debug!(%addr, "Failed to listen on UDP socket: {e}");
 

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -4,13 +4,14 @@ use futures::{SinkExt, ready};
 use gat_lending_iterator::LendingIterator;
 use socket_factory::{DatagramIn, DatagramSegmentIter, SocketFactory, UdpSocket};
 use socket_factory::{DatagramOut, PerfUdpSocket};
+use std::collections::VecDeque;
 use std::env::VarError;
 use std::time::{Duration, Instant};
 use std::{
     io,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
     sync::Arc,
-    task::{Context, Poll, Waker},
+    task::{Context, Poll},
 };
 use tokio::sync::mpsc;
 use tokio_util::sync::PollSender;
@@ -53,10 +54,11 @@ const UNSPECIFIED_V6_SOCKET: SocketAddrV6 =
 
 #[derive(Default)]
 pub(crate) struct Sockets {
-    waker: Option<Waker>,
-
     socket_v4: Option<ThreadedUdpSocket>,
     socket_v6: Option<ThreadedUdpSocket>,
+
+    /// Bind failures, surfaced through [`Sockets::poll_error`] alongside runtime socket errors.
+    bind_errors: VecDeque<anyhow::Error>,
 }
 
 impl Sockets {
@@ -64,35 +66,27 @@ impl Sockets {
         self.socket_v4 = None;
         self.socket_v6 = None;
 
-        self.socket_v4 = ThreadedUdpSocket::new(
-            socket_factory.clone(),
-            SocketAddr::V4(UNSPECIFIED_V4_SOCKET),
-        )
-        .inspect_err(|e| tracing::info!("Failed to bind IPv4 socket: {e}"))
-        .ok();
-        self.socket_v6 =
-            ThreadedUdpSocket::new(socket_factory, SocketAddr::V6(UNSPECIFIED_V6_SOCKET))
-                .inspect_err(|e| tracing::info!("Failed to bind IPv6 socket: {e}"))
-                .ok();
-
-        if let Some(waker) = self.waker.take() {
-            waker.wake();
-        }
+        self.socket_v4 = self.bind(&socket_factory, SocketAddr::V4(UNSPECIFIED_V4_SOCKET));
+        self.socket_v6 = self.bind(&socket_factory, SocketAddr::V6(UNSPECIFIED_V6_SOCKET));
     }
 
-    pub fn poll_has_sockets(&mut self, cx: &mut Context<'_>) -> Poll<()> {
-        if self.socket_v4.is_none() && self.socket_v6.is_none() {
-            let previous = self.waker.replace(cx.waker().clone());
+    fn bind(
+        &mut self,
+        socket_factory: &Arc<dyn SocketFactory<UdpSocket>>,
+        addr: SocketAddr,
+    ) -> Option<ThreadedUdpSocket> {
+        match ThreadedUdpSocket::new(socket_factory.clone(), addr) {
+            Ok(socket) => Some(socket),
+            Err(e) => {
+                // A family we cannot bind is survivable on its own - the other one carries the
+                // session - so the event-loop decides what a failure means instead of us.
+                self.bind_errors.push_back(
+                    anyhow::Error::new(e).context(format!("Failed to bind UDP socket on {addr}")),
+                );
 
-            if previous.is_none() {
-                // If we didn't have a waker yet, it means we just lost our sockets. Let the user know everything will be suspended.
-                tracing::error!("No available UDP sockets")
+                None
             }
-
-            return Poll::Pending;
         }
-
-        Poll::Ready(())
     }
 
     pub fn poll_send_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
@@ -149,6 +143,10 @@ impl Sockets {
     }
 
     pub fn poll_error(&mut self, cx: &mut Context<'_>) -> Poll<anyhow::Error> {
+        if let Some(error) = self.bind_errors.pop_front() {
+            return Poll::Ready(error);
+        }
+
         if let Some(socket) = self.socket_v4.as_mut()
             && let Poll::Ready(e) = socket.poll_error(cx)
         {
@@ -564,6 +562,8 @@ fn listen(
     for addr in addresses {
         match sf.bind(*addr).and_then(|s| s.into_perf()) {
             Ok(s) => return Ok(s),
+            // Another port cannot fix a failure that isn't about the address.
+            Err(e) if socket_factory::is_fatal(&e) => return Err(e),
             Err(e) => {
                 tracing::debug!(%addr, "Failed to listen on UDP socket: {e}");
 

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -2,7 +2,9 @@ use crate::otel;
 use anyhow::{Context as _, ErrorExt as _, Result};
 use futures::{SinkExt, ready};
 use gat_lending_iterator::LendingIterator;
-use socket_factory::{DatagramIn, DatagramSegmentIter, SocketFactory, UdpSocket};
+use socket_factory::{
+    DatagramIn, DatagramSegmentIter, RoutingLoopPreventionFailed, SocketFactory, UdpSocket,
+};
 use socket_factory::{DatagramOut, PerfUdpSocket};
 use std::collections::VecDeque;
 use std::env::VarError;
@@ -563,7 +565,7 @@ fn listen(
         match sf.bind(*addr).and_then(|s| s.into_perf()) {
             Ok(s) => return Ok(s),
             // Another port cannot fix a failure that isn't about the address.
-            Err(e) if socket_factory::is_fatal(&e) => return Err(e),
+            Err(e) if RoutingLoopPreventionFailed::is_cause_of(&e) => return Err(e),
             Err(e) => {
                 tracing::debug!(%addr, "Failed to listen on UDP socket: {e}");
 


### PR DESCRIPTION
Losing every UDP socket used to suspend the event-loop indefinitely behind a single log line, leaving a session that looked connected but carried no traffic until a network change happened to rebind it.

Bind failures now travel the same error channel as runtime socket errors, so the event-loop sees them. Whether one is worth dying over is the socket factory's call rather than something `Sockets` can infer: a family that won't bind is survivable, but Android's `protect` callback failing means every socket we make would route back into our own tunnel. Factories mark the latter, and both event-loops shut down loudly when they see it.

Related: #14363