### PR TITLE
fix(anyhow-ext): find custom errors inside `io::Error`

### DIFF
--- a/rust/libs/anyhow-ext/lib.rs
+++ b/rust/libs/anyhow-ext/lib.rs
@@ -139,6 +139,18 @@ mod tests {
     }
 
     #[test]
+    fn any_downcast_ref_works_for_custom_error_inside_io_error() {
+        let error = Result::<(), _>::Err(io::Error::other(FooError))
+            .context("Foobar")
+            .unwrap_err();
+
+        assert_eq!(
+            error.any_downcast_ref::<FooError>().unwrap().to_string(),
+            "Foo"
+        )
+    }
+
+    #[test]
     fn any_downcast_ref_works_for_custom_error_with_source() {
         let error = Result::<(), _>::Err(BazError(BarError(FooError)))
             .context("Foobar")

--- a/rust/libs/anyhow-ext/lib.rs
+++ b/rust/libs/anyhow-ext/lib.rs
@@ -10,15 +10,11 @@ pub trait ErrorExt {
 }
 
 impl ErrorExt for anyhow::Error {
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "We are implementing the alternative."
-    )]
     fn any_is<T>(&self) -> bool
     where
         T: std::error::Error + Send + Sync + 'static,
     {
-        self.is::<T>() || self.chain().any(|e| e.is::<T>())
+        self.any_downcast_ref::<T>().is_some()
     }
 
     #[expect(
@@ -32,8 +28,23 @@ impl ErrorExt for anyhow::Error {
         std::iter::empty()
             .chain(self.downcast_ref::<T>())
             .chain(self.chain().flat_map(|e| e.downcast_ref::<T>()))
+            .chain(
+                self.chain()
+                    .filter_map(custom_io_error)
+                    .flat_map(|e| e.downcast_ref::<T>()),
+            )
             .next()
     }
+}
+
+/// Returns the custom error `error` carries, if it is an [`std::io::Error`] built from one.
+///
+/// [`std::io::Error::source`] reports the source of its custom error rather than that error
+/// itself, so walking sources alone never observes it.
+fn custom_io_error<'a>(
+    error: &'a (dyn std::error::Error + 'static),
+) -> Option<&'a (dyn std::error::Error + Send + Sync + 'static)> {
+    error.downcast_ref::<std::io::Error>()?.get_ref()
 }
 
 #[cfg(test)]
@@ -80,6 +91,15 @@ mod tests {
         assert!(error.any_is::<BazError>());
         assert!(error.any_is::<BarError>());
         assert!(error.any_is::<FooError>());
+    }
+
+    #[test]
+    fn any_is_works_for_custom_error_inside_io_error() {
+        let error = Result::<(), _>::Err(io::Error::other(FooError))
+            .context("Foobar")
+            .unwrap_err();
+
+        assert!(error.any_is::<FooError>())
     }
 
     #[test]

--- a/rust/libs/anyhow-ext/lib.rs
+++ b/rust/libs/anyhow-ext/lib.rs
@@ -39,8 +39,8 @@ impl ErrorExt for anyhow::Error {
 
 /// Returns the custom error `error` carries, if it is an [`std::io::Error`] built from one.
 ///
-/// [`std::io::Error::source`] reports the source of its custom error rather than that error
-/// itself, so walking sources alone never observes it.
+/// [`std::error::Error::source`] on an [`std::io::Error`] reports the source of its custom
+/// error rather than that error itself, so walking sources alone never observes it.
 fn custom_io_error<'a>(
     error: &'a (dyn std::error::Error + 'static),
 ) -> Option<&'a (dyn std::error::Error + Send + Sync + 'static)> {


### PR DESCRIPTION
`io::Error` reports the source of its custom error rather than that error itself, so a typed error boxed into one is invisible to anything walking `Error::source`. Callers had to know that and reach for `get_ref` by hand, which is exactly the sharp edge `any_is` and `any_downcast_ref` exist to hide.

Related: #14369