### PR TITLE
ci: cache the `firezone-cli` and loadtest binaries

### DIFF
--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -262,6 +262,14 @@ jobs:
         with:
           path: rust/target/${{ matrix.arch.target }}/${{ inputs.profile }}/${{ matrix.name.package }}
           key: ${{ matrix.name.package }}-${{ matrix.arch.target }}-${{ inputs.profile }}
+      # `firezone-cli` ships as an asset of the gateway's `.deb`, so it is built
+      # separately below and needs its own entry.
+      - uses: ./.github/actions/setup-rust-binary-cache
+        id: cli-binary-cache
+        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-gateway' }}
+        with:
+          path: rust/target/${{ matrix.arch.target }}/release/firezone-cli
+          key: firezone-cli-${{ matrix.arch.target }}-release
       - uses: ./.github/actions/setup-mise
         with:
           install_args: --cd rust
@@ -336,10 +344,12 @@ jobs:
             --auth-mode login \
             --account-name firezoneartifacts
 
+      - name: Build firezone-cli
+        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-gateway' && steps.cli-binary-cache.outputs.cache-hit != 'true' }}
+        run: cargo build --bin firezone-cli --release --target ${{ matrix.arch.target }}
       - name: Create Firezone Gateway .deb package
         if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-gateway' }}
         run: |
-          cargo build --bin firezone-cli --release --target ${{ matrix.arch.target }}
           cargo deb --package firezone-gateway --target ${{ matrix.arch.target }} --no-build --no-strip
           cp target/debian/*.deb "$BINARY_DEST_PATH".deb
       - name: Upload Release Assets

--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -54,8 +54,14 @@ jobs:
         with:
           azure-connection-string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
 
+      - uses: ./.github/actions/setup-rust-binary-cache
+        id: binary-cache
+        with:
+          path: rust/target/${{ matrix.target }}/release/${{ matrix.binary }}
+          key: firezone-loadtest-${{ matrix.target }}-release
+
       - name: Install dependencies (Linux)
-        if: matrix.os == 'linux'
+        if: matrix.os == 'linux' && steps.binary-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/apt-install
         with:
           packages: musl-tools
@@ -72,6 +78,7 @@ jobs:
           Write-Host "Event Log source 'FirezoneLoadtest' registered (or already exists)"
 
       - name: Build loadtest binary
+        if: steps.binary-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
           set -e
@@ -80,7 +87,9 @@ jobs:
             --target ${{ matrix.target }} \
             --package firezone-loadtest
 
-          cp target/${{ matrix.target }}/release/${{ matrix.binary }} ${{ matrix.binary }}
+      - name: Package binary
+        shell: bash
+        run: cp target/${{ matrix.target }}/release/${{ matrix.binary }} ${{ matrix.binary }}
 
       - name: Generate checksum (Linux/Windows)
         if: matrix.os != 'macos'


### PR DESCRIPTION
Two binaries the Rust binary cache does not cover yet.

`firezone-cli` ships as an asset of the gateway's `.deb` and is produced by its own `cargo build`, which the gateway's cache entry does not include. A run that restored the gateway binary and skipped its build still spent ~40s rebuilding the CLI.

The loadtest jobs are on `sccache` alone, which cannot cache linking or turn a no-change build into a no-op. Even with the workspace `target` cache they previously had, the Windows build took 2m23s and macOS 1m47s, so keying the built binary on the Rust inputs suits them better.

Related: #14374
Related: #14303
