### PR TITLE
ci: turn off mise debug logging

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -17,8 +17,6 @@ runs:
     - shell: bash
       run: echo "MISE_LOCKED=1" >> "$GITHUB_ENV"
     - shell: bash
-      run: echo "MISE_DEBUG=1" >> "$GITHUB_ENV"
-    - shell: bash
       if: ${{ runner.os == 'Windows' }}
       run: |
         echo "MISE_INSTALLS_DIR=C:\.mise-installs" >> "$GITHUB_ENV"


### PR DESCRIPTION
Debug logging was enabled to diagnose flaky mise installs. It is no longer needed and only makes the setup step noisy.