### PR TITLE
fix(portal): keep connection state on device row updates

### DIFF
--- a/elixir/lib/portal/cache/client.ex
+++ b/elixir/lib/portal/cache/client.ex
@@ -518,15 +518,18 @@ defmodule Portal.Cache.Client do
     end
   end
 
-  # Cached resources must carry a resolved site: the client view renders it and
-  # has no clause for nil. `to_cache/1` only carries one over when the source
-  # resource has its site association loaded, which a struct rebuilt from the
-  # WAL never does, so every cache writer fed by a change broadcast has to
-  # resolve it here rather than take what `to_cache/1` produced.
+  # Cached gateway-backed resources must carry a resolved site: the client view
+  # renders it and has no clause for nil. `to_cache/1` only carries one over
+  # when the source resource has its site association loaded, which a struct
+  # rebuilt from the WAL never does, so every cache writer fed by a change
+  # broadcast has to resolve it here rather than take what `to_cache/1` produced.
   #
-  # A nil site is still a legitimate outcome (the site was deleted, leaving
-  # `ON DELETE SET NULL` behind, or hydration failed to load it).
-  # `adapted_resources/3` drops those before anything renders them.
+  # Nil is the steady state for device pools, which connect without a gateway
+  # and have their site_id forced to nil by `Portal.Resource.changeset/1`;
+  # `adapted_resources/3` keeps those and their render clauses never ask for a
+  # site. For every other type nil means the site was deleted (`ON DELETE SET
+  # NULL`) or hydration missed it, and `adapted_resources/3` drops the resource
+  # before anything renders it.
   #
   # Returns whether the site changed as well, because older clients cannot
   # handle a resource moving between sites and need a delete/create instead.

--- a/elixir/lib/portal/cache/client.ex
+++ b/elixir/lib/portal/cache/client.ex
@@ -501,22 +501,7 @@ defmodule Portal.Cache.Client do
 
     if Map.has_key?(cache.resources, resource.id) do
       cached_resource = Map.get(cache.resources, resource.id)
-      site_id_bytes = if changed_resource.site_id, do: Ecto.UUID.dump!(changed_resource.site_id)
-
-      # Check if we can reuse the cached site or need to fetch from DB.
-      # site_id can be nil when site is deleted (ON DELETE SET NULL).
-      # cached site can be nil if hydration failed to load it.
-      {site, site_changed?} =
-        cond do
-          is_nil(site_id_bytes) ->
-            {nil, not is_nil(cached_resource.site)}
-
-          cached_resource.site && cached_resource.site.id == site_id_bytes ->
-            {cached_resource.site, false}
-
-          true ->
-            {fetch_site_for_resource(site_id_bytes, subject), not is_nil(cached_resource.site)}
-        end
+      {site, site_changed?} = resolve_site(cached_resource, changed_resource, subject)
 
       resource = %{resource | site: site}
 
@@ -530,6 +515,33 @@ defmodule Portal.Cache.Client do
       recompute_connectable_resources(cache, client, subject, toggle: toggle)
     else
       {:ok, [], [], cache}
+    end
+  end
+
+  # Cached resources must carry a resolved site: the client view renders it and
+  # has no clause for nil. `to_cache/1` only carries one over when the source
+  # resource has its site association loaded, which a struct rebuilt from the
+  # WAL never does, so every cache writer fed by a change broadcast has to
+  # resolve it here rather than take what `to_cache/1` produced.
+  #
+  # A nil site is still a legitimate outcome (the site was deleted, leaving
+  # `ON DELETE SET NULL` behind, or hydration failed to load it).
+  # `adapted_resources/3` drops those before anything renders them.
+  #
+  # Returns whether the site changed as well, because older clients cannot
+  # handle a resource moving between sites and need a delete/create instead.
+  defp resolve_site(cached_resource, %Portal.Resource{} = changed_resource, subject) do
+    site_id_bytes = if changed_resource.site_id, do: Ecto.UUID.dump!(changed_resource.site_id)
+
+    cond do
+      is_nil(site_id_bytes) ->
+        {nil, not is_nil(cached_resource.site)}
+
+      cached_resource.site && cached_resource.site.id == site_id_bytes ->
+        {cached_resource.site, false}
+
+      true ->
+        {fetch_site_for_resource(site_id_bytes, subject), not is_nil(cached_resource.site)}
     end
   end
 

--- a/elixir/lib/portal/device.ex
+++ b/elixir/lib/portal/device.ex
@@ -13,7 +13,7 @@ defmodule Portal.Device do
 
   # Columns rewritten by the connect flush; WAL consumers skip device updates
   # that touch nothing else so connects don't flood audit logs and broadcasts.
-  @latest_session_columns ~w[
+  @latest_session_fields ~w[
     public_key
     last_seen_user_agent
     last_seen_remote_ip
@@ -25,7 +25,9 @@ defmodule Portal.Device do
     last_seen_at
     client_token_id
     gateway_token_id
-  ]
+  ]a
+
+  @latest_session_columns Enum.map(@latest_session_fields, &Atom.to_string/1)
 
   @type t :: %__MODULE__{
           id: Ecto.UUID.t(),
@@ -151,6 +153,30 @@ defmodule Portal.Device do
     |> unique_constraint(:ipv6, name: :devices_account_id_ipv6_index)
     |> unique_constraint(:hostname, name: :devices_account_id_hostname_index)
     |> check_constraint(:hostname, name: :devices_hostname_length)
+  end
+
+  @doc """
+    Folds a device update broadcast from the WAL onto the copy a socket holds,
+    keeping the state that only exists in that socket.
+
+    The latest-session columns are written by the batched connect flush, so the
+    WAL row still carries the previous session's values (or NULL) for the
+    seconds between connect and flush. Virtual fields and associations are never
+    in the WAL row at all. Taking the broadcast struct wholesale would drop this
+    connection's public key, silently breaking every payload derived from it.
+  """
+  def merge_broadcast(%__MODULE__{id: id} = current, %__MODULE__{id: id} = broadcast) do
+    broadcast =
+      Enum.reduce(@latest_session_fields ++ __schema__(:virtual_fields), broadcast, fn field, device ->
+        Map.replace!(device, field, Map.fetch!(current, field))
+      end)
+
+    Enum.reduce(__schema__(:associations), broadcast, fn assoc, device ->
+      case Map.fetch!(current, assoc) do
+        %Ecto.Association.NotLoaded{} -> device
+        loaded -> Map.replace!(device, assoc, loaded)
+      end
+    end)
   end
 
   def reserved_ipv4_cidr, do: @reserved_ipv4_cidr

--- a/elixir/lib/portal/device.ex
+++ b/elixir/lib/portal/device.ex
@@ -156,27 +156,17 @@ defmodule Portal.Device do
   end
 
   @doc """
-    Folds a device update broadcast from the WAL onto the copy a socket holds,
-    keeping the state that only exists in that socket.
+    Folds a device update broadcast from the WAL onto the copy a socket holds.
 
-    The latest-session columns are written by the batched connect flush, so the
-    WAL row still carries the previous session's values (or NULL) for the
-    seconds between connect and flush. Virtual fields and associations are never
-    in the WAL row at all. Taking the broadcast struct wholesale would drop this
-    connection's public key, silently breaking every payload derived from it.
+    On top of what `Portal.SchemaHelpers.merge_broadcast/3` keeps, the
+    latest-session columns are preserved: they are written by the batched
+    connect flush, so the WAL row still carries the previous session's values
+    (or NULL) for the seconds between connect and flush. Taking the broadcast
+    struct wholesale would drop this connection's public key, silently breaking
+    every payload derived from it.
   """
   def merge_broadcast(%__MODULE__{id: id} = current, %__MODULE__{id: id} = broadcast) do
-    broadcast =
-      Enum.reduce(@latest_session_fields ++ __schema__(:virtual_fields), broadcast, fn field, device ->
-        Map.replace!(device, field, Map.fetch!(current, field))
-      end)
-
-    Enum.reduce(__schema__(:associations), broadcast, fn assoc, device ->
-      case Map.fetch!(current, assoc) do
-        %Ecto.Association.NotLoaded{} -> device
-        loaded -> Map.replace!(device, assoc, loaded)
-      end
-    end)
+    Portal.SchemaHelpers.merge_broadcast(current, broadcast, @latest_session_fields)
   end
 
   def reserved_ipv4_cidr, do: @reserved_ipv4_cidr

--- a/elixir/lib/portal/schema_helpers.ex
+++ b/elixir/lib/portal/schema_helpers.ex
@@ -22,6 +22,30 @@ defmodule Portal.SchemaHelpers do
     |> Ecto.Changeset.apply_changes()
   end
 
+  @doc """
+  Folds a struct rebuilt from the WAL onto the copy a process already holds,
+  keeping the state that only lives in that process.
+
+  `struct_from_params/2` casts persisted fields and embeds, so a broadcast
+  struct carries neither virtual fields (which are not in `__schema__(:fields)`)
+  nor associations (which arrive `NotLoaded`). Assigning one wholesale silently
+  resets both. `preserve` names any persisted columns the holder also owns, for
+  values written to the database later than they are known in memory.
+  """
+  def merge_broadcast(%module{} = current, %module{} = broadcast, preserve \\ []) do
+    broadcast =
+      Enum.reduce(module.__schema__(:virtual_fields) ++ preserve, broadcast, fn field, struct ->
+        Map.replace!(struct, field, Map.fetch!(current, field))
+      end)
+
+    Enum.reduce(module.__schema__(:associations), broadcast, fn assoc, struct ->
+      case Map.fetch!(current, assoc) do
+        %Ecto.Association.NotLoaded{} -> struct
+        loaded -> Map.replace!(struct, assoc, loaded)
+      end
+    end)
+  end
+
   # Cast all embedded fields
   defp cast_all_embeds(changeset, schema_module, embeds) do
     Enum.reduce(embeds, changeset, fn embed_field, acc ->

--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -1898,12 +1898,7 @@ defmodule PortalAPI.Client.Channel.Shared do
          %{assigns: %{client: %{id: id} = current_client}} = socket
        )
        when id == client_id do
-    # Update socket with the new client state, preserving associations from the current socket.
-    updated_client = %{
-      client
-      | account: current_client.account,
-        actor: current_client.actor
-    }
+    updated_client = Device.merge_broadcast(current_client, client)
 
     socket = assign(socket, :client, updated_client)
 

--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -11,6 +11,7 @@ defmodule PortalAPI.Client.Channel.Shared do
     Features,
     PubSub,
     Presence,
+    SchemaHelpers,
     Authentication
   }
 
@@ -1843,6 +1844,7 @@ defmodule PortalAPI.Client.Channel.Shared do
          socket
        ) do
     # Update our subject's account
+    account = SchemaHelpers.merge_broadcast(socket.assigns.subject.account, account)
     subject = %{socket.assigns.subject | account: account}
     socket = assign(socket, subject: subject)
 

--- a/elixir/lib/portal_api/gateway/channel/shared.ex
+++ b/elixir/lib/portal_api/gateway/channel/shared.ex
@@ -861,7 +861,7 @@ defmodule PortalAPI.Gateway.Channel.Shared do
            assigns: %{gateway: %{id: gateway_id} = current_gateway}
          } = socket
        ) do
-    gateway = %{gateway | site: current_gateway.site}
+    gateway = Device.merge_broadcast(current_gateway, gateway)
     socket = assign(socket, :gateway, gateway)
 
     socket =

--- a/elixir/lib/portal_api/gateway/channel/shared.ex
+++ b/elixir/lib/portal_api/gateway/channel/shared.ex
@@ -11,7 +11,8 @@ defmodule PortalAPI.Gateway.Channel.Shared do
     Changes.Change,
     PubSub,
     Resource,
-    Presence
+    Presence,
+    SchemaHelpers
   }
 
   require Logger
@@ -822,6 +823,7 @@ defmodule PortalAPI.Gateway.Channel.Shared do
          },
          socket
        ) do
+    account = SchemaHelpers.merge_broadcast(socket.assigns.account, account)
     socket = assign(socket, :account, account)
 
     if old_slug != slug do

--- a/elixir/test/portal/schema_helpers_test.exs
+++ b/elixir/test/portal/schema_helpers_test.exs
@@ -325,4 +325,65 @@ defmodule Portal.SchemaHelpersTest do
       assert datetime.time_zone == "Etc/UTC"
     end
   end
+
+  describe "merge_broadcast/3" do
+    # Portal.Device is used over a local schema because it has virtual fields
+    # and associations; the function itself touches no repo.
+    setup do
+      site = %Portal.Site{id: Ecto.UUID.generate(), name: "Site"}
+
+      current = %Portal.Device{
+        id: Ecto.UUID.generate(),
+        name: "Before",
+        public_key: "the-connection's-key",
+        firezone_id_merged?: true,
+        site: site
+      }
+
+      broadcast =
+        SchemaHelpers.struct_from_params(Portal.Device, %{
+          "id" => current.id,
+          "name" => "After",
+          "public_key" => nil
+        })
+
+      %{current: current, broadcast: broadcast, site: site}
+    end
+
+    test "takes persisted columns from the broadcast", %{current: current, broadcast: broadcast} do
+      assert SchemaHelpers.merge_broadcast(current, broadcast).name == "After"
+    end
+
+    test "keeps virtual fields, which the broadcast never carries", %{
+      current: current,
+      broadcast: broadcast
+    } do
+      refute broadcast.firezone_id_merged?
+
+      assert SchemaHelpers.merge_broadcast(current, broadcast).firezone_id_merged?
+    end
+
+    test "keeps loaded associations and leaves unloaded ones alone", %{
+      current: current,
+      broadcast: broadcast,
+      site: site
+    } do
+      merged = SchemaHelpers.merge_broadcast(current, broadcast)
+
+      assert merged.site == site
+      assert %Ecto.Association.NotLoaded{} = merged.actor
+    end
+
+    test "keeps only the persisted columns named in preserve", %{
+      current: current,
+      broadcast: broadcast
+    } do
+      assert SchemaHelpers.merge_broadcast(current, broadcast).public_key == nil
+
+      merged = SchemaHelpers.merge_broadcast(current, broadcast, [:public_key])
+
+      assert merged.public_key == current.public_key
+      assert merged.name == "After"
+    end
+  end
 end

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -67,6 +67,16 @@ defmodule PortalAPI.Client.ChannelTest do
     socket
   end
 
+  # Mirrors what Portal.Changes.Hooks.Devices builds from a WAL row: the
+  # latest-session columns still hold what the last flush persisted, and virtual
+  # fields and associations are not in the row at all.
+  defp broadcast_struct(client) do
+    Portal.SchemaHelpers.struct_from_params(
+      Portal.Device,
+      Map.from_struct(%{client | public_key: nil, client_token_id: nil, last_seen_version: nil})
+    )
+  end
+
   # Mirrors Socket.connect's apply_session: the connection snapshot lives on
   # the Device struct.
   defp with_session(client, subject, version) do
@@ -2068,6 +2078,36 @@ defmodule PortalAPI.Client.ChannelTest do
 
       assert client_id == client.id
       assert ipv4 == new_ipv4.address
+    end
+
+    test "for client updates keeps this connection's session state", %{
+      client: client,
+      subject: subject
+    } do
+      socket = join_channel(client, subject)
+      assert_push "init", _
+
+      %{assigns: %{client: connected}} = :sys.get_state(socket.channel_pid)
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: 100,
+        op: :update,
+        old_struct: broadcast_struct(client),
+        struct: broadcast_struct(%{client | name: "Updated Name"})
+      })
+
+      assert %{assigns: %{client: updated}} = :sys.get_state(socket.channel_pid)
+
+      assert updated.name == "Updated Name"
+      assert updated.public_key == connected.public_key
+      assert updated.client_token_id == connected.client_token_id
+      assert updated.last_seen_version == connected.last_seen_version
+      assert updated.last_seen_user_agent == connected.last_seen_user_agent
+      assert updated.last_seen_remote_ip == connected.last_seen_remote_ip
+      assert updated.last_seen_at == connected.last_seen_at
+      assert updated.firezone_id_merged? == connected.firezone_id_merged?
+      assert updated.account == connected.account
+      assert updated.actor == connected.actor
     end
 
     test "for client deletions disconnects socket", %{

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -107,6 +107,16 @@ defmodule PortalAPI.Gateway.ChannelTest do
     }
   end
 
+  # Mirrors what Portal.Changes.Hooks.Devices builds from a WAL row: the
+  # latest-session columns still hold what the last flush persisted, and virtual
+  # fields and associations are not in the row at all.
+  defp broadcast_struct(gateway) do
+    Portal.SchemaHelpers.struct_from_params(
+      Portal.Device,
+      Map.from_struct(%{gateway | public_key: nil, gateway_token_id: nil, last_seen_version: nil})
+    )
+  end
+
   defp send_create_authorization(socket, client, subject, resource, policy_authorization_id) do
     expires_at = DateTime.add(DateTime.utc_now(), 30, :second)
     preshared_key = "PSK"
@@ -1556,6 +1566,84 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
       assert %{assigns: %{gateway: %{name: "Renamed gateway"}}} =
                :sys.get_state(socket.channel_pid)
+    end
+
+    test "keeps this connection's session state when a device update is broadcast", %{
+      account: account,
+      actor: actor,
+      group: group,
+      client: client,
+      subject: subject,
+      resource: resource,
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
+
+      %{assigns: %{gateway: connected}} = :sys.get_state(socket.channel_pid)
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :update,
+        old_struct: broadcast_struct(gateway),
+        struct: broadcast_struct(%{gateway | name: "Renamed gateway"})
+      })
+
+      assert %{assigns: %{gateway: updated}} = :sys.get_state(socket.channel_pid)
+
+      assert updated.name == "Renamed gateway"
+      assert updated.public_key == connected.public_key
+      assert updated.gateway_token_id == connected.gateway_token_id
+      assert updated.last_seen_version == connected.last_seen_version
+      assert updated.last_seen_user_agent == connected.last_seen_user_agent
+      assert updated.last_seen_at == connected.last_seen_at
+      assert updated.site == connected.site
+
+      channel_pid = self()
+      socket_ref = make_ref()
+
+      policy_authorization =
+        policy_authorization_fixture(
+          account: account,
+          actor: actor,
+          client: client,
+          resource: resource,
+          gateway: gateway,
+          group: group
+        )
+
+      send(
+        socket.channel_pid,
+        {:create_authorization, {channel_pid, socket_ref},
+         %{
+           client:
+             PortalAPI.Gateway.Views.Client.render(
+               client,
+               Portal.DeviceFixtures.generate_public_key(),
+               "PSK",
+               @test_user_agent
+             ),
+           subject: PortalAPI.Gateway.Views.Subject.render(subject),
+           resource: PortalAPI.Gateway.Views.Resource.render(to_cache(resource)),
+           resource_id: to_cache(resource).id,
+           policy_authorization_id: policy_authorization.id,
+           authorization_expires_at: DateTime.add(DateTime.utc_now(), 30, :second),
+           ice_credentials: %{
+             initiator: %{username: "A", password: "B"},
+             receiver: %{username: "C", password: "D"}
+           },
+           preshared_key: "PSK"
+         }}
+      )
+
+      assert_push "authorize_flow", %{ref: ref}
+      push_ref = push(socket, "flow_authorized", %{"ref" => ref})
+      assert_reply push_ref, :ok
+
+      assert_receive {:connect, ^socket_ref, _, _, _, gateway_public_key, _, _, _, _, _}
+      assert gateway_public_key == connected.public_key
     end
 
     test "ignores DOWN messages from unrelated processes", %{


### PR DESCRIPTION
When a row changes in the database, the portal tells every connected client and gateway so they can update their copy of it. Each connection also holds things in memory that belong to that connection alone, most importantly the WireGuard public key the device sent when it connected. That key only reaches the database a few seconds later, written by a batched job.

The update replaced the connection's whole in-memory copy with the database row. When it arrived before the batched write landed, the connection lost its public key, along with the other connect-time details, its virtual fields, and its preloaded associations. Gateways then sent `flow_created` with a null `gateway_public_key`, and clients threw the message away and never connected.

The update now keeps everything the connection owns and takes only the columns that actually changed. The rule lives next to the code that builds these structs from the database log, since that is what drops the in-memory parts, so it is one shared helper rather than a per-handler list. The account handlers use it too; they had the same hole, just nothing reading through it yet.

Fixes #14382 
