### PR TITLE
chore(rust): unset codegen-units for release build

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -291,10 +291,6 @@ tracing = "0.1.41"
 # Full link-time optimization. Reduces binaries by up to 3x on some platforms.
 lto = "fat"
 
-# Increases the compiler's ability to produce smaller, optimized code
-# at the expense of compilation time
-codegen-units = 1
-
 [profile.release.package.firezone-gui-client]
 debug = "full"
 split-debuginfo = "packed"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -298,6 +298,9 @@ split-debuginfo = "packed"
 [profile.release.package.ebpf-turn-router]
 debug = 2
 
+# Anything above 1 makes `handle_turn` exceed the 512-byte BPF stack limit.
+codegen-units = 1
+
 # Override build settings just for the GUI client, so we get a pdb/dwp
 # Cargo ignores profile settings if they're not in the workspace's Cargo.toml
 [profile.dev.package.firezone-gui-client]


### PR DESCRIPTION
Falls back to Cargo's default `codegen-units` for the release profile, so we can benchmark how much the `codegen-units = 1` override actually buys us in binary size and runtime performance versus the compile time it costs.

Not intended to merge as-is: this is here to get CI numbers to compare against `main`.