### PR TITLE
ci(nix): build each package on its own runner

### DIFF
--- a/.github/workflows/_nix.yml
+++ b/.github/workflows/_nix.yml
@@ -76,9 +76,6 @@ jobs:
             extra-substituters = https://artifacts.firezone.dev/nix
             extra-trusted-public-keys = artifacts.firezone.dev/nix-1:T4LHdL1HeA6LE9qgu0Po0j3RIlelKZz8pzqnzEAIRfI=
       - name: Check flake
-        # Evaluation covers the whole flake regardless of what this leg
-        # builds, so one leg per system is enough.
-        if: ${{ matrix.package == 'firezone-gateway' }}
         run: nix flake check --no-build
       - name: Build package
         id: build

--- a/.github/workflows/_nix.yml
+++ b/.github/workflows/_nix.yml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   build:
-    name: build-${{ matrix.system }}
+    name: build-${{ matrix.package }}-${{ matrix.system }}
     # The nix-cache-publish environment holds NIX_CACHE_SIGNING_KEY and is
     # restricted to main and release tags; PR builds never push or sign.
     environment: ${{ inputs.push_to_cache && 'nix-cache-publish' || '' }}
@@ -51,6 +51,14 @@ jobs:
         # (non-matching include entries become new combinations), so the
         # runner is derived from the system instead.
         system: ${{ fromJSON(inputs.systems) }}
+        # One runner per package: each derivation compiles the whole Rust
+        # dependency graph, so a shared runner leaves the three contending
+        # for its cores. Runner minutes are free on public repos, wall-clock
+        # time is not.
+        package:
+          - firezone-gateway
+          - firezone-headless-client
+          - firezone-gui-client
     runs-on: ${{ matrix.system == 'aarch64-linux' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -68,8 +76,11 @@ jobs:
             extra-substituters = https://artifacts.firezone.dev/nix
             extra-trusted-public-keys = artifacts.firezone.dev/nix-1:T4LHdL1HeA6LE9qgu0Po0j3RIlelKZz8pzqnzEAIRfI=
       - name: Check flake
+        # Evaluation covers the whole flake regardless of what this leg
+        # builds, so one leg per system is enough.
+        if: ${{ matrix.package == 'firezone-gateway' }}
         run: nix flake check --no-build
-      - name: Build packages
+      - name: Build package
         id: build
         shell: bash
         run: |
@@ -77,9 +88,7 @@ jobs:
 
           build() {
             nix build \
-              .#firezone-gateway \
-              .#firezone-headless-client \
-              .#firezone-gui-client \
+              .#${{ matrix.package }} \
               --print-build-logs 2>&1 | tee build.log
           }
 
@@ -105,14 +114,16 @@ jobs:
       - name: Set up GnuPG for the bump commit
         # Only the cache-publish context (main / release tags) is trusted with
         # the bot credentials, and one matrix leg is enough to open the PR.
-        if: ${{ inputs.push_to_cache && steps.build.outputs.hash_changed == 'true' && matrix.system == 'x86_64-linux' }}
+        # The GUI client is the only package with a pnpm-deps input, so its
+        # leg is the only one that can set hash_changed.
+        if: ${{ inputs.push_to_cache && steps.build.outputs.hash_changed == 'true' && matrix.package == 'firezone-gui-client' && matrix.system == 'x86_64-linux' }}
         uses: ./.github/actions/setup-gpg
         id: setup-gpg
         with:
           key: ${{ secrets.RELEASE_PR_BOT_GPG_KEY }}
           email: github-bot@firezone.dev
       - name: Open pnpm-deps hash bump PR
-        if: ${{ inputs.push_to_cache && steps.build.outputs.hash_changed == 'true' && matrix.system == 'x86_64-linux' }}
+        if: ${{ inputs.push_to_cache && steps.build.outputs.hash_changed == 'true' && matrix.package == 'firezone-gui-client' && matrix.system == 'x86_64-linux' }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PR_BOT_GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
The three Nix derivations each compile the whole Rust dependency graph. Sharing a single 4-vCPU runner leaves them contending for its cores, which makes the Nix job the longest in CI at roughly 21 minutes and puts it on the critical path for both PRs and the merge queue.

Building each package on its own matrix leg trades runner minutes, which are free on public repos, for wall-clock time. The `firezone-gui-client` leg becomes the new critical path at an estimated 12 to 13 minutes, since it carries both the most crates and the longest link-time-optimization tail.

Compiling the shared dependency graph once instead of three times is the larger win and is left for a follow-up.