### PR TITLE
ci: skip the disk-space reclaim when the runner has room

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: "Keep the preinstalled Android SDK and NDK (the kotlin jobs build against them)"
     required: false
     default: "false"
+  required-gb:
+    description: "Skip the reclaim when the root filesystem already has at least this much free space"
+    required: false
+    default: "60"
 runs:
   using: "composite"
   steps:
@@ -15,6 +19,14 @@ runs:
       run: |
         # Reclaim ~25 GB from pre-installed toolchains we don't use, so the
         # instrumented coverage builds have headroom on leaner hosted runners.
+        # The hosted images currently leave 87-109 GB free, which is already
+        # ample, so the reclaim only has to run if that ever shrinks again.
+        available_gb=$(df --output=avail --block-size=1G / | tail -1)
+        if (( available_gb >= ${{ inputs.required-gb }} )); then
+          echo "${available_gb} GB available, skipping reclaim"
+          exit 0
+        fi
+
         if [[ "${{ inputs.keep-android }}" != "true" ]]; then
           sudo rm -rf /usr/local/lib/android
         fi


### PR DESCRIPTION
The hosted Linux runners now leave far more room than this action reclaims. Sampling the four labels we use showed 88 GB free on `ubuntu-24.04` and `ubuntu-latest`, 87 GB on `ubuntu-22.04` and 109 GB on `ubuntu-24.04-arm`, against a reclaim that frees roughly 21 GB. Deleting those toolchains costs 40-80s per job for headroom we already have.

The reclaim now runs only when the root filesystem is below `required-gb`, so it stays available if the images ever shrink again rather than being dropped outright. Runner disk size is undocumented and has been reduced without notice before, so this keeps the safety net at no cost.

Related: #13508
Related: #14309