### PR TITLE
docs(rust): record why release builds pin codegen-units

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -291,8 +291,14 @@ tracing = "0.1.41"
 # Full link-time optimization. Reduces binaries by up to 3x on some platforms.
 lto = "fat"
 
-# Increases the compiler's ability to produce smaller, optimized code
-# at the expense of compilation time
+# Combined with `lto = "fat"`, this is not the usual smaller-code-for-compile-time
+# trade-off: every extra codegen unit is another bitcode module the LTO step has to
+# merge. Measured on `firezone-gateway` and `firezone-headless-client`, raising this
+# from 1 to 16 grew peak `rustc` memory by 27-34% and the stripped binaries by ~10%,
+# with no build time saved.
+#
+# `ebpf-turn-router` does not link at all above 1, because `handle_turn` then exceeds
+# the 512-byte BPF stack limit.
 codegen-units = 1
 
 [profile.release.package.firezone-gui-client]


### PR DESCRIPTION
The existing comment framed `codegen-units = 1` as buying smaller code in exchange for compile time. Benchmarking the release profile showed that is not what it does here: under `lto = "fat"` the setting costs nothing in build time and is what keeps peak compiler memory and binary size down, and the eBPF TURN router does not link without it at all.

Recording the measurements next to the setting so the next person to reach for it knows what it is holding up.