### PR TITLE
fix(gui-client): hide console windows during MSI install

### DIFF
--- a/rust/gui-client/src-tauri/src/bin/register-sparse.rs
+++ b/rust/gui-client/src-tauri/src/bin/register-sparse.rs
@@ -27,6 +27,13 @@
 //!   runtime crashes) + the `register-sparse.log` file the install
 //!   canary captures.
 
+// Console-subsystem binaries get a console window allocated on every
+// `CreateProcess`, so each MSI custom action flashes a terminal at the
+// user during install and uninstall. Release builds are only ever run
+// by MSI, which discards their stdout anyway; debug builds keep the
+// console for manual runs.
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 use anyhow::{Context, ErrorExt, Result};
 use clap::Parser;
 use firezone_gui_client::PACKAGE_FAMILY_NAME;
@@ -111,8 +118,9 @@ fn run() -> ExitCode {
 ///   (and a `latest` link). This is the authoritative source during
 ///   MSI installs, because MSI discards stdout/stderr from deferred
 ///   EXE custom actions — they don't land in `install.log`.
-/// - Stdout: useful only when invoking `register-sparse.exe`
-///   manually for diagnosis.
+/// - Stdout: reaches a terminal only in debug builds, where the
+///   binary still has a console. Release builds are
+///   `windows_subsystem = "windows"` and have nowhere to write.
 /// - Sentry: `tracing::error!` events propagate to Sentry via the
 ///   `sentry-tracing` layer that `setup_global_subscriber` installs.
 ///


### PR DESCRIPTION
`register-sparse.exe` is a console-subsystem binary, so Windows allocates a console for it on every `CreateProcess`. That means the sparse-MSIX custom actions flash terminal windows at the user during install and uninstall, which looks like something went wrong. Release builds now use the Windows subsystem so no console is ever allocated; debug builds keep theirs, since that is where the binary actually gets run by hand. Nothing is lost on the install path: MSI discards stdout from deferred EXE custom actions anyway, and the log file plus Sentry remain the sources of truth.