### PR TITLE
ci(rust): report fuzz coverage only for our own sources

### DIFF
--- a/rust/tests/fuzz/mise.toml
+++ b/rust/tests/fuzz/mise.toml
@@ -312,6 +312,11 @@ profile="coverage/$crate/coverage.profdata"
 binary="../../target/x86_64-unknown-linux-gnu/release/$crate"
 llvm_cov="$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov"
 
+if [ ! -f "$profile" ]; then
+  echo "error: coverage profile is missing; run mise run //rust/tests/fuzz:coverage $crate first" >&2
+  exit 1
+fi
+
 # Fuzz builds instrument every dependency, including a from-source standard
 # library. Their regions would otherwise dominate what we report to Coveralls.
 "$llvm_cov" export \

--- a/rust/tests/fuzz/mise.toml
+++ b/rust/tests/fuzz/mise.toml
@@ -299,12 +299,28 @@ exit 1
 '''
 
 [tasks.lcov]
-description = "Export an existing fuzz coverage profile as lcov"
+description = "Export an existing fuzz coverage profile as lcov, restricted to our own sources"
 shell = "bash -c"
 depends = ["install-toolchain"]
 usage = 'arg "<crate>"'
 raw = true
-run = '"$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov" export -format=lcov -instr-profile=coverage/$usage_crate/coverage.profdata ../../target/x86_64-unknown-linux-gnu/release/$usage_crate'
+run = '''
+set -euo pipefail
+
+crate="$usage_crate"
+profile="coverage/$crate/coverage.profdata"
+binary="../../target/x86_64-unknown-linux-gnu/release/$crate"
+llvm_cov="$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov"
+
+# Fuzz builds instrument every dependency, including a from-source standard
+# library. Their regions would otherwise dominate what we report to Coveralls.
+"$llvm_cov" export \
+  -format=lcov \
+  -instr-profile="$profile" \
+  -ignore-filename-regex="^${CARGO_HOME:-$HOME/.cargo}/" \
+  -ignore-filename-regex="^${RUSTUP_HOME:-$HOME/.rustup}/" \
+  "$binary"
+'''
 
 [tasks.llvm-cov]
 description = "Run the nightly toolchain's llvm-cov, e.g. to post-process coverage.profdata"


### PR DESCRIPTION
Fuzz builds instrument the entire dependency tree, including a from-source standard library. Exporting that profile verbatim meant Coveralls counted registry crates, git checkouts and the standard library as project code, which diluted the reported number to a small fraction of the real one.

Replaying the committed `tunnel-proto` corpus, the export goes from 2750 files at 10.24% to 147 files at 69.46%, the latter being exactly the `rust/` subtree Coveralls already shows separately.
