### PR TITLE
refactor(connlib): move `TunnelError` into the tunnel crate

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -24,8 +24,7 @@ use tunnel::messages::gateway::{
 };
 use tunnel::messages::{self, RelaysPresence, SnownetCapabilities};
 use tunnel::{
-    GatewayTunnel, GatewayTunnelEvent, IPV4_TUNNEL, IPV6_TUNNEL, IpConfig, ResolveDnsRequest,
-    TunnelError,
+    GatewayEvent, GatewayTunnel, IPV4_TUNNEL, IPV6_TUNNEL, IpConfig, ResolveDnsRequest, TunnelError,
 };
 
 use crate::RELEASE;
@@ -121,7 +120,7 @@ impl Eventloop {
 
 enum CombinedEvent {
     SigIntTerm,
-    Tunnel(GatewayTunnelEvent),
+    Tunnel(Result<GatewayEvent, TunnelError>),
     Portal(Option<Result<PortalEvent, phoenix_channel::Error>>),
     DomainResolved((Result<Vec<IpAddr>, Arc<anyhow::Error>>, ResolveDnsRequest)),
 }
@@ -242,10 +241,13 @@ impl Eventloop {
         Ok(())
     }
 
-    async fn handle_tunnel_event(&mut self, event: GatewayTunnelEvent) -> Result<()> {
+    async fn handle_tunnel_event(
+        &mut self,
+        event: Result<GatewayEvent, TunnelError>,
+    ) -> Result<()> {
         let event = match event {
-            GatewayTunnelEvent::State(event) => event,
-            GatewayTunnelEvent::Error(error) => return self.handle_tunnel_error(error),
+            Ok(event) => event,
+            Err(error) => return self.handle_tunnel_error(error),
         };
 
         match event {

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -245,16 +245,11 @@ impl Eventloop {
         &mut self,
         event: Result<GatewayEvent, TunnelError>,
     ) -> Result<()> {
-        let event = match event {
-            Ok(event) => event,
-            Err(error) => return self.handle_tunnel_error(error),
-        };
-
         match event {
-            tunnel::GatewayEvent::AddedIceCandidates {
+            Ok(GatewayEvent::AddedIceCandidates {
                 conn_id: client,
                 candidates,
-            } => {
+            }) => {
                 self.portal_cmd_tx
                     .send(PortalCommand::Send(EgressMessages::BroadcastIceCandidates(
                         ClientsIceCandidates {
@@ -264,10 +259,10 @@ impl Eventloop {
                     )))
                     .await?;
             }
-            tunnel::GatewayEvent::RemovedIceCandidates {
+            Ok(GatewayEvent::RemovedIceCandidates {
                 conn_id: client,
                 candidates,
-            } => {
+            }) => {
                 self.portal_cmd_tx
                     .send(PortalCommand::Send(
                         EgressMessages::BroadcastInvalidatedIceCandidates(ClientsIceCandidates {
@@ -277,7 +272,7 @@ impl Eventloop {
                     ))
                     .await?;
             }
-            tunnel::GatewayEvent::ResolveDns(setup_nat) => {
+            Ok(GatewayEvent::ResolveDns(setup_nat)) => {
                 if self
                     .resolve_tasks
                     .try_push(self.resolve(setup_nat.domain().clone()), setup_nat)
@@ -286,12 +281,13 @@ impl Eventloop {
                     tracing::warn!("Too many dns resolution requests, dropping existing one");
                 };
             }
-            tunnel::GatewayEvent::NoRelays => {
+            Ok(GatewayEvent::NoRelays) => {
                 self.portal_cmd_tx
                     .send(PortalCommand::Send(EgressMessages::NoRelays {}))
                     .await
                     .context("Failed to send message to portal")?;
             }
+            Err(error) => self.handle_tunnel_error(error)?,
         }
 
         Ok(())

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -24,7 +24,8 @@ use tunnel::messages::gateway::{
 };
 use tunnel::messages::{self, RelaysPresence, SnownetCapabilities};
 use tunnel::{
-    GatewayEvent, GatewayTunnel, IPV4_TUNNEL, IPV6_TUNNEL, IpConfig, ResolveDnsRequest, TunnelError,
+    GatewayTunnel, GatewayTunnelEvent, IPV4_TUNNEL, IPV6_TUNNEL, IpConfig, ResolveDnsRequest,
+    TunnelError,
 };
 
 use crate::RELEASE;
@@ -120,7 +121,7 @@ impl Eventloop {
 
 enum CombinedEvent {
     SigIntTerm,
-    Tunnel(GatewayEvent),
+    Tunnel(GatewayTunnelEvent),
     Portal(Option<Result<PortalEvent, phoenix_channel::Error>>),
     DomainResolved((Result<Vec<IpAddr>, Arc<anyhow::Error>>, ResolveDnsRequest)),
 }
@@ -241,7 +242,12 @@ impl Eventloop {
         Ok(())
     }
 
-    async fn handle_tunnel_event(&mut self, event: tunnel::GatewayEvent) -> Result<()> {
+    async fn handle_tunnel_event(&mut self, event: GatewayTunnelEvent) -> Result<()> {
+        let event = match event {
+            GatewayTunnelEvent::State(event) => event,
+            GatewayTunnelEvent::Error(error) => return self.handle_tunnel_error(error),
+        };
+
         match event {
             tunnel::GatewayEvent::AddedIceCandidates {
                 conn_id: client,
@@ -284,7 +290,6 @@ impl Eventloop {
                     .await
                     .context("Failed to send message to portal")?;
             }
-            GatewayEvent::Error(error) => self.handle_tunnel_error(error)?,
         }
 
         Ok(())

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -27,10 +27,7 @@ use tunnel::messages::client::{
     ResourceFiltersUpdated,
 };
 use tunnel::messages::{IngestToken, RelaysPresence, SnownetCapabilities};
-use tunnel::{
-    ClientEvent, ClientTunnel, ClientTunnelEvent, DnsResourceRecord, IpConfig, TunConfig,
-    TunnelError,
-};
+use tunnel::{ClientEvent, ClientTunnel, DnsResourceRecord, IpConfig, TunConfig, TunnelError};
 
 /// In-memory cache for DNS resource records.
 ///
@@ -188,7 +185,7 @@ impl Eventloop {
 
 enum CombinedEvent {
     Command(Option<Command>),
-    Tunnel(ClientTunnelEvent),
+    Tunnel(Result<ClientEvent, TunnelError>),
     Portal(Option<Result<PortalEvent, phoenix_channel::Error>>),
 }
 
@@ -309,10 +306,10 @@ impl Eventloop {
         Ok(ControlFlow::Continue(()))
     }
 
-    async fn handle_tunnel_event(&mut self, event: ClientTunnelEvent) -> Result<()> {
+    async fn handle_tunnel_event(&mut self, event: Result<ClientEvent, TunnelError>) -> Result<()> {
         let event = match event {
-            ClientTunnelEvent::State(event) => event,
-            ClientTunnelEvent::Error(error) => return self.handle_tunnel_error(error),
+            Ok(event) => event,
+            Err(error) => return self.handle_tunnel_error(error),
         };
 
         match event {

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -27,7 +27,10 @@ use tunnel::messages::client::{
     ResourceFiltersUpdated,
 };
 use tunnel::messages::{IngestToken, RelaysPresence, SnownetCapabilities};
-use tunnel::{ClientEvent, ClientTunnel, DnsResourceRecord, IpConfig, TunConfig, TunnelError};
+use tunnel::{
+    ClientEvent, ClientTunnel, ClientTunnelEvent, DnsResourceRecord, IpConfig, TunConfig,
+    TunnelError,
+};
 
 /// In-memory cache for DNS resource records.
 ///
@@ -185,7 +188,7 @@ impl Eventloop {
 
 enum CombinedEvent {
     Command(Option<Command>),
-    Tunnel(ClientEvent),
+    Tunnel(ClientTunnelEvent),
     Portal(Option<Result<PortalEvent, phoenix_channel::Error>>),
 }
 
@@ -306,7 +309,12 @@ impl Eventloop {
         Ok(ControlFlow::Continue(()))
     }
 
-    async fn handle_tunnel_event(&mut self, event: ClientEvent) -> Result<()> {
+    async fn handle_tunnel_event(&mut self, event: ClientTunnelEvent) -> Result<()> {
+        let event = match event {
+            ClientTunnelEvent::State(event) => event,
+            ClientTunnelEvent::Error(error) => return self.handle_tunnel_error(error),
+        };
+
         match event {
             ClientEvent::AddedIceCandidates {
                 conn_id: ClientOrGatewayId::Gateway(gid),
@@ -426,7 +434,6 @@ impl Eventloop {
                     .await
                     .context("Failed to send message to portal")?;
             }
-            ClientEvent::Error(error) => self.handle_tunnel_error(error)?,
         }
 
         Ok(())

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -307,16 +307,11 @@ impl Eventloop {
     }
 
     async fn handle_tunnel_event(&mut self, event: Result<ClientEvent, TunnelError>) -> Result<()> {
-        let event = match event {
-            Ok(event) => event,
-            Err(error) => return self.handle_tunnel_error(error),
-        };
-
         match event {
-            ClientEvent::AddedIceCandidates {
+            Ok(ClientEvent::AddedIceCandidates {
                 conn_id: ClientOrGatewayId::Gateway(gid),
                 candidates,
-            } => {
+            }) => {
                 tracing::debug!(%gid, ?candidates, "Sending new ICE candidates to gateway");
 
                 self.portal_cmd_tx
@@ -329,10 +324,10 @@ impl Eventloop {
                     .await
                     .context("Failed to send message to portal")?;
             }
-            ClientEvent::RemovedIceCandidates {
+            Ok(ClientEvent::RemovedIceCandidates {
                 conn_id: ClientOrGatewayId::Gateway(gid),
                 candidates,
-            } => {
+            }) => {
                 tracing::debug!(%gid, ?candidates, "Sending invalidated ICE candidates to gateway");
 
                 self.portal_cmd_tx
@@ -345,10 +340,10 @@ impl Eventloop {
                     .await
                     .context("Failed to send message to portal")?;
             }
-            ClientEvent::AddedIceCandidates {
+            Ok(ClientEvent::AddedIceCandidates {
                 conn_id: ClientOrGatewayId::Client(cid),
                 candidates,
-            } => {
+            }) => {
                 tracing::debug!(%cid, ?candidates, "Sending new ICE candidates to client");
 
                 self.portal_cmd_tx
@@ -361,10 +356,10 @@ impl Eventloop {
                     .await
                     .context("Failed to send message to portal")?;
             }
-            ClientEvent::RemovedIceCandidates {
+            Ok(ClientEvent::RemovedIceCandidates {
                 conn_id: ClientOrGatewayId::Client(cid),
                 candidates,
-            } => {
+            }) => {
                 tracing::debug!(%cid, ?candidates, "Sending invalidated ICE candidates to client");
 
                 self.portal_cmd_tx
@@ -377,11 +372,11 @@ impl Eventloop {
                     .await
                     .context("Failed to send message to portal")?;
             }
-            ClientEvent::ResourceConnectionIntent {
+            Ok(ClientEvent::ResourceConnectionIntent {
                 preferred_gateways,
                 resource,
                 ip,
-            } => {
+            }) => {
                 let (ipv4, ipv6) = match ip {
                     None => (None, None),
                     Some(IpAddr::V4(v4)) => (Some(v4), None),
@@ -398,10 +393,10 @@ impl Eventloop {
                     .await
                     .context("Failed to send message to portal")?;
             }
-            ClientEvent::DevicePoolDomainQueried {
+            Ok(ClientEvent::DevicePoolDomainQueried {
                 resource_id,
                 domain,
-            } => {
+            }) => {
                 self.portal_cmd_tx
                     .send(PortalCommand::Send(
                         EgressMessages::ResolveDevicePoolDomain {
@@ -412,25 +407,26 @@ impl Eventloop {
                     .await
                     .context("Failed to send message to portal")?;
             }
-            ClientEvent::ResourcesChanged { resources } => {
+            Ok(ClientEvent::ResourcesChanged { resources }) => {
                 self.resource_list_sender
                     .send(resources)
                     .context("Failed to emit event")?;
             }
-            ClientEvent::TunInterfaceUpdated(config) => {
+            Ok(ClientEvent::TunInterfaceUpdated(config)) => {
                 self.tun_config_sender
                     .send(Some(config))
                     .context("Failed to emit event")?;
             }
-            ClientEvent::DnsRecordsChanged { records } => {
+            Ok(ClientEvent::DnsRecordsChanged { records }) => {
                 *DNS_RESOURCE_RECORDS_CACHE.lock() = records;
             }
-            ClientEvent::NoRelays => {
+            Ok(ClientEvent::NoRelays) => {
                 self.portal_cmd_tx
                     .send(PortalCommand::Send(EgressMessages::NoRelays {}))
                     .await
                     .context("Failed to send message to portal")?;
             }
+            Err(error) => self.handle_tunnel_error(error)?,
         }
 
         Ok(())

--- a/rust/libs/connlib/tunnel-proto/src/lib.rs
+++ b/rust/libs/connlib/tunnel-proto/src/lib.rs
@@ -16,7 +16,6 @@ use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use logging::DisplayBTreeSet;
 use std::{
     collections::BTreeSet,
-    mem,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
@@ -95,7 +94,6 @@ pub enum ClientEvent {
     TunInterfaceUpdated(TunConfig),
     /// We ran out of relays and need a new set from the portal.
     NoRelays,
-    Error(TunnelError),
 }
 
 #[derive(Clone, derive_more::Debug, PartialEq, Eq, Hash)]
@@ -142,49 +140,6 @@ pub enum GatewayEvent {
     ResolveDns(ResolveDnsRequest),
     /// We ran out of relays and need a new set from the portal.
     NoRelays,
-    Error(TunnelError),
-}
-
-/// A collection of errors that occurred during a single event-loop tick.
-///
-/// This type purposely doesn't provide a `From` implementation for any errors.
-/// We want compile-time safety inside the event-loop that we don't abort processing in the middle of a packet batch.
-#[derive(Debug, Default)]
-pub struct TunnelError {
-    errors: Vec<anyhow::Error>,
-}
-
-impl TunnelError {
-    pub fn single(e: impl Into<anyhow::Error>) -> Self {
-        Self {
-            errors: vec![e.into()],
-        }
-    }
-
-    pub fn push(&mut self, e: impl Into<anyhow::Error>) {
-        self.errors.push(e.into());
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.errors.is_empty()
-    }
-
-    pub fn drain(&mut self) -> impl Iterator<Item = anyhow::Error> {
-        mem::take(&mut self.errors).into_iter()
-    }
-}
-
-impl Drop for TunnelError {
-    fn drop(&mut self) {
-        debug_assert!(
-            self.errors.is_empty(),
-            "should never drop `TunnelError` without consuming errors"
-        );
-
-        if !self.errors.is_empty() {
-            tracing::error!("should never drop `TunnelError` without consuming errors")
-        }
-    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -50,20 +50,6 @@ const MAX_EVENTLOOP_ITERS: u32 = 5000;
 pub type GatewayTunnel = Tunnel<GatewayState>;
 pub type ClientTunnel = Tunnel<ClientState>;
 
-/// The events a [`ClientTunnel`] emits.
-#[derive(Debug)]
-pub enum ClientTunnelEvent {
-    State(ClientEvent),
-    Error(TunnelError),
-}
-
-/// The events a [`GatewayTunnel`] emits.
-#[derive(Debug)]
-pub enum GatewayTunnelEvent {
-    State(GatewayEvent),
-    Error(TunnelError),
-}
-
 /// A collection of errors that occurred during a single event-loop tick.
 ///
 /// This type purposely doesn't provide a `From` implementation for any errors.
@@ -218,7 +204,7 @@ impl ClientTunnel {
         &mut self,
         cx: &mut Context<'_>,
         now: Instant,
-    ) -> Poll<ClientTunnelEvent> {
+    ) -> Poll<Result<ClientEvent, TunnelError>> {
         let mut budget = Budget::new(cx.waker(), MAX_EVENTLOOP_ITERS, "client-tunnel");
 
         while let Some(mut tick) = budget.next() {
@@ -243,7 +229,7 @@ impl ClientTunnel {
                     }
                 }
 
-                return Poll::Ready(ClientTunnelEvent::State(event));
+                return Poll::Ready(Ok(event));
             }
 
             // Drain all buffered IP packets.
@@ -349,7 +335,7 @@ impl ClientTunnel {
                 }
 
                 if !error.is_empty() {
-                    return Poll::Ready(ClientTunnelEvent::Error(error));
+                    return Poll::Ready(Err(error));
                 }
             }
         }
@@ -417,7 +403,7 @@ impl GatewayTunnel {
         &mut self,
         cx: &mut Context<'_>,
         now: Instant,
-    ) -> Poll<GatewayTunnelEvent> {
+    ) -> Poll<Result<GatewayEvent, TunnelError>> {
         let mut budget = Budget::new(cx.waker(), MAX_EVENTLOOP_ITERS, "gateway-tunnel");
 
         while let Some(mut tick) = budget.next() {
@@ -432,7 +418,7 @@ impl GatewayTunnel {
 
             // Pass up existing events.
             if let Some(other) = self.role_state.poll_event() {
-                return Poll::Ready(GatewayTunnelEvent::State(other));
+                return Poll::Ready(Ok(other));
             }
 
             // Drain all buffered transmits.
@@ -620,7 +606,7 @@ impl GatewayTunnel {
                 }
 
                 if !error.is_empty() {
-                    return Poll::Ready(GatewayTunnelEvent::Error(error));
+                    return Poll::Ready(Err(error));
                 }
             }
         }

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -20,7 +20,7 @@ use io::Io;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::{
     collections::BTreeSet,
-    future,
+    future, mem,
     net::{IpAddr, SocketAddr},
     sync::Arc,
     task::{Context, Poll},
@@ -49,6 +49,62 @@ const MAX_EVENTLOOP_ITERS: u32 = 5000;
 
 pub type GatewayTunnel = Tunnel<GatewayState>;
 pub type ClientTunnel = Tunnel<ClientState>;
+
+/// The events a [`ClientTunnel`] emits.
+#[derive(Debug)]
+pub enum ClientTunnelEvent {
+    State(ClientEvent),
+    Error(TunnelError),
+}
+
+/// The events a [`GatewayTunnel`] emits.
+#[derive(Debug)]
+pub enum GatewayTunnelEvent {
+    State(GatewayEvent),
+    Error(TunnelError),
+}
+
+/// A collection of errors that occurred during a single event-loop tick.
+///
+/// This type purposely doesn't provide a `From` implementation for any errors.
+/// We want compile-time safety inside the event-loop that we don't abort processing in the middle of a packet batch.
+#[derive(Debug, Default)]
+pub struct TunnelError {
+    errors: Vec<anyhow::Error>,
+}
+
+impl TunnelError {
+    pub fn single(e: impl Into<anyhow::Error>) -> Self {
+        Self {
+            errors: vec![e.into()],
+        }
+    }
+
+    pub fn push(&mut self, e: impl Into<anyhow::Error>) {
+        self.errors.push(e.into());
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.errors.is_empty()
+    }
+
+    pub fn drain(&mut self) -> impl Iterator<Item = anyhow::Error> {
+        mem::take(&mut self.errors).into_iter()
+    }
+}
+
+impl Drop for TunnelError {
+    fn drop(&mut self) {
+        debug_assert!(
+            self.errors.is_empty(),
+            "should never drop `TunnelError` without consuming errors"
+        );
+
+        if !self.errors.is_empty() {
+            tracing::error!("should never drop `TunnelError` without consuming errors")
+        }
+    }
+}
 
 /// [`Tunnel`] glues together connlib's [`Io`] component and the respective (pure) state of a client or gateway.
 ///
@@ -158,7 +214,11 @@ impl ClientTunnel {
         .boxed()
     }
 
-    pub fn poll_next_event(&mut self, cx: &mut Context<'_>, now: Instant) -> Poll<ClientEvent> {
+    pub fn poll_next_event(
+        &mut self,
+        cx: &mut Context<'_>,
+        now: Instant,
+    ) -> Poll<ClientTunnelEvent> {
         let mut budget = Budget::new(cx.waker(), MAX_EVENTLOOP_ITERS, "client-tunnel");
 
         while let Some(mut tick) = budget.next() {
@@ -183,7 +243,7 @@ impl ClientTunnel {
                     }
                 }
 
-                return Poll::Ready(event);
+                return Poll::Ready(ClientTunnelEvent::State(event));
             }
 
             // Drain all buffered IP packets.
@@ -289,7 +349,7 @@ impl ClientTunnel {
                 }
 
                 if !error.is_empty() {
-                    return Poll::Ready(ClientEvent::Error(error));
+                    return Poll::Ready(ClientTunnelEvent::Error(error));
                 }
             }
         }
@@ -353,7 +413,11 @@ impl GatewayTunnel {
         .boxed()
     }
 
-    pub fn poll_next_event(&mut self, cx: &mut Context<'_>, now: Instant) -> Poll<GatewayEvent> {
+    pub fn poll_next_event(
+        &mut self,
+        cx: &mut Context<'_>,
+        now: Instant,
+    ) -> Poll<GatewayTunnelEvent> {
         let mut budget = Budget::new(cx.waker(), MAX_EVENTLOOP_ITERS, "gateway-tunnel");
 
         while let Some(mut tick) = budget.next() {
@@ -368,7 +432,7 @@ impl GatewayTunnel {
 
             // Pass up existing events.
             if let Some(other) = self.role_state.poll_event() {
-                return Poll::Ready(other);
+                return Poll::Ready(GatewayTunnelEvent::State(other));
             }
 
             // Drain all buffered transmits.
@@ -556,7 +620,7 @@ impl GatewayTunnel {
                 }
 
                 if !error.is_empty() {
-                    return Poll::Ready(GatewayEvent::Error(error));
+                    return Poll::Ready(GatewayTunnelEvent::Error(error));
                 }
             }
         }

--- a/rust/tests/fuzz/expected-coverage/tunnel-proto.json
+++ b/rust/tests/fuzz/expected-coverage/tunnel-proto.json
@@ -1,4 +1,4 @@
 {
-  "covered": 5920,
-  "total": 8028
+  "covered": 5919,
+  "total": 7999
 }

--- a/rust/tests/fuzz/src/sut.rs
+++ b/rust/tests/fuzz/src/sut.rs
@@ -1388,7 +1388,6 @@ impl TunnelTest {
 
                 Ok(())
             }
-            ClientEvent::Error(_) => unreachable!("ClientState never emits `TunnelError`"),
             ClientEvent::DevicePoolDomainQueried {
                 resource_id,
                 domain,
@@ -1594,7 +1593,6 @@ fn on_gateway_event(
             // Mimic the portal: reply with the current set of relays.
             gateway.exec_mut(|g| g.update_relays(iter::empty(), relays.iter(), now));
         }
-        GatewayEvent::Error(_) => unreachable!("GatewayState never emits `TunnelError`"),
     }
 }
 
@@ -1609,6 +1607,5 @@ fn is_portal_bound_event(event: &ClientEvent) -> bool {
         ClientEvent::DnsRecordsChanged { .. } => false,
         ClientEvent::TunInterfaceUpdated(_) => false,
         ClientEvent::NoRelays => true,
-        ClientEvent::Error(_) => false,
     }
 }


### PR DESCRIPTION
`TunnelError` collects the errors that occur while the event-loop drives IO. The sans-IO state machines never emit one, which is why the fuzz harness had to match the event variant with `unreachable!`.

Moving the type into `tunnel` and surfacing it as the error half of what `poll_next_event` returns leaves `tunnel-proto` exposing just the state-machine API, and stops dead error-handling code from counting against the fuzz coverage of the sans-IO crate.
