### PR TITLE
feat(connlib): enable URO on Windows until proven broken

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6972,6 +6972,7 @@ dependencies = [
  "gat-lending-iterator",
  "ip-packet",
  "libc",
+ "memchr",
  "opentelemetry",
  "otel-instruments",
  "parking_lot",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -144,6 +144,7 @@ libc = "0.2.186"
 libfuzzer-sys = "0.4.13"
 logging = { path = "libs/logging" }
 lru = "0.18.0"
+memchr = "2.7.4"
 mimalloc = { version = "0.1.52" }
 mio = "1.2.1"
 moka = "0.12.15"

--- a/rust/libs/connlib/socket-factory/Cargo.toml
+++ b/rust/libs/connlib/socket-factory/Cargo.toml
@@ -10,6 +10,7 @@ bufferpool = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
 gat-lending-iterator = { workspace = true }
 ip-packet = { workspace = true }
+memchr = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 otel-instruments = { workspace = true }
 quinn-udp = { workspace = true }

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -20,7 +20,7 @@ use tokio::io::Interest;
 mod buffer_sizes;
 mod pool;
 #[cfg(windows)]
-pub mod uro;
+mod uro;
 
 pub use buffer_sizes::{MAX_RECV_BATCH_MEMORY, RECV_BUFFER_SIZE, SEND_BUFFER_SIZE};
 
@@ -441,7 +441,9 @@ impl PerfUdpSocket {
         })?;
 
         #[cfg(windows)]
-        enforce_uro_invariant(&socket, batch.metas.iter().take(len));
+        if uro::detect_broken_coalescing(batch.metas.iter().take(len)) {
+            socket.disable_gro();
+        }
 
         let iter = DatagramSegmentIter::new(batch.buffers, batch.metas, self.port, len);
 
@@ -862,27 +864,6 @@ async fn wait_for_send_capacity(socket: &tokio::net::UdpSocket) {
 
     let timeout = std::time::Duration::from_millis(10);
     let _ = tokio::time::timeout(timeout, socket.writable()).await;
-}
-
-/// Disables URO once a receive proves that datagram coalescing is broken.
-///
-/// Correct coalescing reports the size of the original datagrams as the segment size, and no
-/// Firezone peer sends a datagram larger than [`ip_packet::MAX_FZ_PAYLOAD`], so a segment above
-/// that bound means datagrams were merged without split metadata (see [`crate::uro`]).
-///
-/// A socket opts out when it observes a violation; sockets created afterwards never opt in.
-/// The oversized receives themselves are dropped by [`DatagramSegmentIter`].
-#[cfg(windows)]
-fn enforce_uro_invariant<'a>(
-    socket: &Socket<'_>,
-    mut metas: impl Iterator<Item = &'a quinn_udp::RecvMeta>,
-) {
-    let Some(meta) = metas.find(|meta| meta.stride > ip_packet::MAX_FZ_PAYLOAD) else {
-        return;
-    };
-
-    uro::trip(meta);
-    socket.disable_gro();
 }
 
 /// The pools backing a batched receive: scratch space for the datagrams themselves

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -1047,6 +1047,15 @@ where
                 }
             }
 
+            // A zero stride would never advance past the segment below; nothing sane
+            // reports one, so drop the receive.
+            if meta.stride == 0 && meta.len > 0 {
+                tracing::warn!(len = %meta.len, "Dropping receive with a zero segment size");
+
+                self.buf_index += 1;
+                continue;
+            }
+
             // No Firezone peer sends a datagram this large; the receive is either broken
             // coalescing (see `uro`) or junk from an unrelated sender.
             if meta.stride > ip_packet::MAX_FZ_PAYLOAD {
@@ -1175,6 +1184,41 @@ mod tests {
         assert_eq!(iter.next().unwrap().packet, b"baz3");
         assert_eq!(iter.next().unwrap().packet, b"baz4");
         assert_eq!(iter.next().unwrap().packet, b"baz5");
+        assert_eq!(iter.next().unwrap().packet, b"foo");
+        assert!(iter.next().is_none());
+    }
+
+    /// A zero stride on a non-empty buffer must not stall the iterator: the receive
+    /// is dropped and iteration moves on to the next buffer.
+    #[test]
+    fn zero_stride_buffer_is_skipped() {
+        let buffer_pool = BufferPool::<VecBuf<DummyBuffer>>::new(2, "test");
+        let meta_pool = BufferPool::<VecBuf<quinn_udp::RecvMeta>>::new(2, "test");
+
+        let mut buffers = buffer_pool.pull();
+        buffers.extend([
+            DummyBuffer(b"garbage    ".to_vec()),
+            DummyBuffer(b"foo        ".to_vec()),
+        ]);
+
+        let mut metas = meta_pool.pull();
+        metas.extend([
+            recv_meta(
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                7,
+                0,
+            ),
+            recv_meta(
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                3,
+                3,
+            ),
+        ]);
+
+        let mut iter = DatagramSegmentIter::new(buffers, metas, 0, 2);
+
         assert_eq!(iter.next().unwrap().packet, b"foo");
         assert!(iter.next().is_none());
     }

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -19,6 +19,8 @@ use tokio::io::Interest;
 
 mod buffer_sizes;
 mod pool;
+#[cfg(windows)]
+pub mod uro;
 
 pub use buffer_sizes::{MAX_RECV_BATCH_MEMORY, RECV_BUFFER_SIZE, SEND_BUFFER_SIZE};
 
@@ -437,6 +439,9 @@ impl PerfUdpSocket {
                 }
             }
         })?;
+
+        #[cfg(windows)]
+        enforce_uro_invariant(&socket, batch.metas.iter().take(len));
 
         let iter = DatagramSegmentIter::new(batch.buffers, batch.metas, self.port, len);
 
@@ -859,6 +864,35 @@ async fn wait_for_send_capacity(socket: &tokio::net::UdpSocket) {
     let _ = tokio::time::timeout(timeout, socket.writable()).await;
 }
 
+/// Disables URO for the process once a receive proves that datagram coalescing is broken.
+///
+/// Correct coalescing reports the size of the original datagrams as the segment size, and no
+/// Firezone peer sends a datagram larger than [`ip_packet::MAX_FZ_PAYLOAD`], so a segment above
+/// that bound means datagrams were merged without split metadata (see [`crate::uro`]).
+///
+/// Sockets shed URO lazily: each one opts out when it processes its first batch after the trip.
+/// The oversized receives themselves are dropped by [`DatagramSegmentIter`].
+#[cfg(windows)]
+fn enforce_uro_invariant<'a>(
+    socket: &Socket<'_>,
+    mut metas: impl Iterator<Item = &'a quinn_udp::RecvMeta>,
+) {
+    if let Some(meta) = metas.find(|meta| meta.stride > ip_packet::MAX_FZ_PAYLOAD)
+        && uro::trip()
+    {
+        tracing::warn!(
+            stride = %meta.stride,
+            len = %meta.len,
+            interface_index = ?meta.interface_index,
+            "Received a datagram segment larger than any Firezone peer sends; disabling URO to work around broken receive coalescing"
+        );
+    }
+
+    if uro::is_tripped() {
+        socket.disable_gro();
+    }
+}
+
 /// The pools backing a batched receive: scratch space for the datagrams themselves
 /// plus containers for the buffers and metas that make up one batch.
 ///
@@ -1033,6 +1067,15 @@ where
                 }
             }
 
+            // No Firezone peer sends a datagram this large; the receive is either broken
+            // coalescing (see `uro`) or junk from an unrelated sender.
+            if meta.stride > ip_packet::MAX_FZ_PAYLOAD {
+                tracing::trace!(stride = %meta.stride, len = %meta.len, "Dropping receive with an impossibly large segment size");
+
+                self.buf_index += 1;
+                continue;
+            }
+
             if self.segment_index >= meta.len {
                 self.buf_index += 1;
                 self.segment_index = 0;
@@ -1169,6 +1212,41 @@ mod tests {
         ];
 
         assert_eq!(metas.iter().map(num_segments).sum::<usize>(), 12);
+    }
+
+    #[test]
+    fn datagram_iter_drops_segments_larger_than_max_fz_payload() {
+        let buffer_pool = BufferPool::<VecBuf<DummyBuffer>>::new(2, "test");
+        let meta_pool = BufferPool::<VecBuf<quinn_udp::RecvMeta>>::new(2, "test");
+
+        let oversized = 2 * ip_packet::MAX_FZ_PAYLOAD;
+
+        let mut buffers = buffer_pool.pull();
+        buffers.extend([
+            DummyBuffer(vec![0; oversized]),
+            DummyBuffer(b"foobar1".to_vec()),
+        ]);
+
+        let mut metas = meta_pool.pull();
+        metas.extend([
+            recv_meta(
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                oversized,
+                oversized,
+            ),
+            recv_meta(
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                7,
+                7,
+            ),
+        ]);
+
+        let mut iter = DatagramSegmentIter::new(buffers, metas, 0, 2);
+
+        assert_eq!(iter.next().unwrap().packet, b"foobar1");
+        assert!(iter.next().is_none());
     }
 
     #[test]

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -864,33 +864,25 @@ async fn wait_for_send_capacity(socket: &tokio::net::UdpSocket) {
     let _ = tokio::time::timeout(timeout, socket.writable()).await;
 }
 
-/// Disables URO for the process once a receive proves that datagram coalescing is broken.
+/// Disables URO once a receive proves that datagram coalescing is broken.
 ///
 /// Correct coalescing reports the size of the original datagrams as the segment size, and no
 /// Firezone peer sends a datagram larger than [`ip_packet::MAX_FZ_PAYLOAD`], so a segment above
 /// that bound means datagrams were merged without split metadata (see [`crate::uro`]).
 ///
-/// Sockets shed URO lazily: each one opts out when it processes its first batch after the trip.
+/// A socket opts out when it observes a violation; sockets created afterwards never opt in.
 /// The oversized receives themselves are dropped by [`DatagramSegmentIter`].
 #[cfg(windows)]
 fn enforce_uro_invariant<'a>(
     socket: &Socket<'_>,
     mut metas: impl Iterator<Item = &'a quinn_udp::RecvMeta>,
 ) {
-    if let Some(meta) = metas.find(|meta| meta.stride > ip_packet::MAX_FZ_PAYLOAD)
-        && uro::trip()
-    {
-        tracing::warn!(
-            stride = %meta.stride,
-            len = %meta.len,
-            interface_index = ?meta.interface_index,
-            "Received a datagram segment larger than any Firezone peer sends; disabling URO to work around broken receive coalescing"
-        );
-    }
+    let Some(meta) = metas.find(|meta| meta.stride > ip_packet::MAX_FZ_PAYLOAD) else {
+        return;
+    };
 
-    if uro::is_tripped() {
-        socket.disable_gro();
-    }
+    uro::trip(meta);
+    socket.disable_gro();
 }
 
 /// The pools backing a batched receive: scratch space for the datagrams themselves

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -19,7 +19,7 @@ use tokio::io::Interest;
 
 mod buffer_sizes;
 mod pool;
-#[cfg(windows)]
+#[cfg(any(windows, test))]
 mod uro;
 
 pub use buffer_sizes::{MAX_RECV_BATCH_MEMORY, RECV_BUFFER_SIZE, SEND_BUFFER_SIZE};
@@ -441,7 +441,14 @@ impl PerfUdpSocket {
         })?;
 
         #[cfg(windows)]
-        if uro::detect_broken_coalescing(batch.metas.iter().take(len)) {
+        if uro::detect_broken_coalescing(
+            batch
+                .buffers
+                .iter()
+                .map(|b| b.as_slice())
+                .zip(batch.metas.iter_mut())
+                .take(len),
+        ) {
             socket.disable_gro();
         }
 

--- a/rust/libs/connlib/socket-factory/src/pool.rs
+++ b/rust/libs/connlib/socket-factory/src/pool.rs
@@ -115,7 +115,7 @@ impl OwnedSocket {
 /// Opts a socket into URO unless broken coalescing has been observed (see [`crate::uro`]).
 #[cfg(windows)]
 fn enable_gro(socket: &tokio::net::UdpSocket, state: &quinn_udp::UdpSocketState) {
-    if crate::uro::is_tripped() {
+    if crate::uro::is_broken() {
         return;
     }
 

--- a/rust/libs/connlib/socket-factory/src/pool.rs
+++ b/rust/libs/connlib/socket-factory/src/pool.rs
@@ -17,6 +17,8 @@ pub(crate) use apple::SocketPool;
 #[cfg(not(apple))]
 pub(crate) use fallback::SocketPool;
 
+#[cfg(windows)]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     io::{self, IoSliceMut},
     task::{Context, Poll},
@@ -35,6 +37,8 @@ pub(crate) struct Socket<'a> {
     pub(crate) state: &'a quinn_udp::UdpSocketState,
     /// Whether the socket is `connect`ed to a fixed peer and thus takes Darwin's fast path.
     pub(crate) connected: bool,
+    #[cfg(windows)]
+    gro_enabled: &'a AtomicBool,
 }
 
 impl Socket<'_> {
@@ -46,6 +50,18 @@ impl Socket<'_> {
     ) -> io::Result<usize> {
         self.state.recv(UdpSockRef::from(self.inner), bufs, meta)
     }
+
+    /// Opts the socket out of URO; repeated calls are no-ops.
+    #[cfg(windows)]
+    pub(crate) fn disable_gro(&self) {
+        if !self.gro_enabled.swap(false, Ordering::Relaxed) {
+            return;
+        }
+
+        if let Err(e) = self.state.set_gro(UdpSockRef::from(self.inner), false) {
+            tracing::warn!("Failed to disable URO: {e}");
+        }
+    }
 }
 
 /// A UDP socket and its quinn state, owned. The unit a [`SocketPool`] is made of.
@@ -53,6 +69,8 @@ pub(crate) struct OwnedSocket {
     socket: tokio::net::UdpSocket,
     state: quinn_udp::UdpSocketState,
     connected: bool,
+    #[cfg(windows)]
+    gro_enabled: AtomicBool,
 }
 
 impl OwnedSocket {
@@ -61,10 +79,15 @@ impl OwnedSocket {
         state: quinn_udp::UdpSocketState,
         connected: bool,
     ) -> Self {
+        #[cfg(windows)]
+        let gro_enabled = AtomicBool::new(enable_gro(&socket, &state));
+
         Self {
             socket,
             state,
             connected,
+            #[cfg(windows)]
+            gro_enabled,
         }
     }
 
@@ -73,6 +96,8 @@ impl OwnedSocket {
             inner: &self.socket,
             state: &self.state,
             connected: self.connected,
+            #[cfg(windows)]
+            gro_enabled: &self.gro_enabled,
         }
     }
 
@@ -99,6 +124,24 @@ impl OwnedSocket {
 
         tracing::debug!(requested_send_buffer_size = %send, %send_buffer_size, requested_recv_buffer_size = %recv, %recv_buffer_size, %port, "UDP socket buffer sizes");
     }
+}
+
+/// Opts a socket into URO unless broken coalescing has been observed (see [`crate::uro`]).
+#[cfg(windows)]
+fn enable_gro(socket: &tokio::net::UdpSocket, state: &quinn_udp::UdpSocketState) -> bool {
+    if crate::uro::is_tripped() {
+        return false;
+    }
+
+    if let Err(e) = state.set_gro(UdpSockRef::from(socket), true) {
+        tracing::debug!("Failed to enable URO: {e}");
+
+        return false;
+    }
+
+    tracing::debug!("Enabled URO");
+
+    true
 }
 
 /// Polls a single socket for readiness and, when ready, tries to receive a batch.

--- a/rust/libs/connlib/socket-factory/src/pool.rs
+++ b/rust/libs/connlib/socket-factory/src/pool.rs
@@ -17,8 +17,6 @@ pub(crate) use apple::SocketPool;
 #[cfg(not(apple))]
 pub(crate) use fallback::SocketPool;
 
-#[cfg(windows)]
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     io::{self, IoSliceMut},
     task::{Context, Poll},
@@ -37,8 +35,6 @@ pub(crate) struct Socket<'a> {
     pub(crate) state: &'a quinn_udp::UdpSocketState,
     /// Whether the socket is `connect`ed to a fixed peer and thus takes Darwin's fast path.
     pub(crate) connected: bool,
-    #[cfg(windows)]
-    gro_enabled: &'a AtomicBool,
 }
 
 impl Socket<'_> {
@@ -51,13 +47,9 @@ impl Socket<'_> {
         self.state.recv(UdpSockRef::from(self.inner), bufs, meta)
     }
 
-    /// Opts the socket out of URO; repeated calls are no-ops.
+    /// Opts the socket out of URO.
     #[cfg(windows)]
     pub(crate) fn disable_gro(&self) {
-        if !self.gro_enabled.swap(false, Ordering::Relaxed) {
-            return;
-        }
-
         if let Err(e) = self.state.set_gro(UdpSockRef::from(self.inner), false) {
             tracing::warn!("Failed to disable URO: {e}");
         }
@@ -69,8 +61,6 @@ pub(crate) struct OwnedSocket {
     socket: tokio::net::UdpSocket,
     state: quinn_udp::UdpSocketState,
     connected: bool,
-    #[cfg(windows)]
-    gro_enabled: AtomicBool,
 }
 
 impl OwnedSocket {
@@ -80,14 +70,12 @@ impl OwnedSocket {
         connected: bool,
     ) -> Self {
         #[cfg(windows)]
-        let gro_enabled = AtomicBool::new(enable_gro(&socket, &state));
+        enable_gro(&socket, &state);
 
         Self {
             socket,
             state,
             connected,
-            #[cfg(windows)]
-            gro_enabled,
         }
     }
 
@@ -96,8 +84,6 @@ impl OwnedSocket {
             inner: &self.socket,
             state: &self.state,
             connected: self.connected,
-            #[cfg(windows)]
-            gro_enabled: &self.gro_enabled,
         }
     }
 
@@ -128,20 +114,18 @@ impl OwnedSocket {
 
 /// Opts a socket into URO unless broken coalescing has been observed (see [`crate::uro`]).
 #[cfg(windows)]
-fn enable_gro(socket: &tokio::net::UdpSocket, state: &quinn_udp::UdpSocketState) -> bool {
+fn enable_gro(socket: &tokio::net::UdpSocket, state: &quinn_udp::UdpSocketState) {
     if crate::uro::is_tripped() {
-        return false;
+        return;
     }
 
     if let Err(e) = state.set_gro(UdpSockRef::from(socket), true) {
         tracing::debug!("Failed to enable URO: {e}");
 
-        return false;
+        return;
     }
 
     tracing::debug!("Enabled URO");
-
-    true
 }
 
 /// Polls a single socket for readiness and, when ready, tries to receive a batch.

--- a/rust/libs/connlib/socket-factory/src/uro.rs
+++ b/rust/libs/connlib/socket-factory/src/uro.rs
@@ -39,7 +39,7 @@ pub(crate) fn detect_broken_coalescing<'a>(
         stride = %meta.stride,
         len = %meta.len,
         interface_index = ?meta.interface_index,
-        "Disabling URO"
+        "Received a datagram segment larger than any Firezone peer sends; disabling URO"
     );
 
     true

--- a/rust/libs/connlib/socket-factory/src/uro.rs
+++ b/rust/libs/connlib/socket-factory/src/uro.rs
@@ -5,12 +5,24 @@
 //! turning every packet train into one unusable blob
 //! (<https://github.com/quinn-rs/quinn/issues/2041>).
 //!
-//! No Firezone peer sends a datagram larger than [`ip_packet::MAX_FZ_PAYLOAD`] and
-//! correct coalescing reports the size of the original datagrams as the segment size,
-//! so receiving a segment above that bound proves that coalescing on this machine is
-//! broken. Once that happens, URO stays off for the remainder of the process.
+//! Correct coalescing reports the size of the original datagrams as the segment size,
+//! so a receive that violates that proves that coalescing on this machine is broken:
+//! either a segment is larger than [`MAX_FZ_PAYLOAD`] (no Firezone peer sends a
+//! datagram that big) or a receive reported as a single datagram is provably a train
+//! of several Firezone datagrams. Once either happens, URO stays off for the
+//! remainder of the process.
+//!
+//! Firezone sockets only ever receive WireGuard messages (direct traffic) and STUN /
+//! TURN channel-data messages (relay traffic), all of which leave the datagram
+//! boundaries of a merged train recoverable: WireGuard handshake messages have fixed
+//! sizes, WireGuard data packets have a recognizable header, and STUN and
+//! channel-data messages carry their own length. Where the boundaries can be
+//! recovered, the receive is salvaged by reporting the recovered segment size;
+//! otherwise it is dropped and the tunneled protocols retransmit.
 
 use std::sync::atomic::{AtomicBool, Ordering};
+
+use ip_packet::{DATA_CHANNEL_OVERHEAD, MAX_FZ_PAYLOAD, WG_OVERHEAD};
 
 static BROKEN: AtomicBool = AtomicBool::new(false);
 
@@ -21,28 +33,243 @@ pub(crate) fn is_broken() -> bool {
 
 /// Detects receives that prove coalescing on this machine is broken.
 ///
-/// Returns `true` if any of the receives has a segment size above
-/// [`ip_packet::MAX_FZ_PAYLOAD`], meaning the socket should opt out of URO.
+/// Returns `true` if any of the receives proves broken coalescing, meaning the socket
+/// should opt out of URO. Receives whose datagram boundaries can be recovered from
+/// the payload are salvaged by rewriting their segment size to the recovered one.
 /// The first detection is logged; later ones are silent.
 pub(crate) fn detect_broken_coalescing<'a>(
-    mut metas: impl Iterator<Item = &'a quinn_udp::RecvMeta>,
+    receives: impl Iterator<Item = (&'a [u8], &'a mut quinn_udp::RecvMeta)>,
 ) -> bool {
-    let Some(meta) = metas.find(|meta| meta.stride > ip_packet::MAX_FZ_PAYLOAD) else {
-        return false;
-    };
+    let mut any_broken = false;
 
-    if BROKEN.swap(true, Ordering::Relaxed) {
-        return true;
+    for (buf, meta) in receives {
+        let Some(datagram) = buf.get(..meta.len) else {
+            continue;
+        };
+        let Some(detection) = classify(datagram, meta.stride) else {
+            continue;
+        };
+
+        any_broken = true;
+
+        if !BROKEN.swap(true, Ordering::Relaxed) {
+            tracing::info!(
+                stride = %meta.stride,
+                len = %meta.len,
+                interface_index = ?meta.interface_index,
+                reason = ?detection.reason,
+                salvaged_segment_size = ?detection.segment_size,
+                "Received a datagram that proves broken coalescing; disabling URO"
+            );
+        }
+
+        if let Some(segment_size) = detection.segment_size {
+            meta.stride = segment_size;
+        }
     }
 
-    tracing::info!(
-        stride = %meta.stride,
-        len = %meta.len,
-        interface_index = ?meta.interface_index,
-        "Received a datagram segment larger than any Firezone peer sends; disabling URO"
-    );
+    any_broken
+}
 
-    true
+/// Proof that coalescing on this machine is broken, derived from a single receive.
+#[derive(Debug, PartialEq)]
+struct Detection {
+    reason: Reason,
+    /// The segment size recovered from the payload, if the receive is salvageable.
+    segment_size: Option<usize>,
+}
+
+#[derive(Debug, PartialEq)]
+enum Reason {
+    OversizedSegment,
+    MergedWgHandshakes,
+    MergedWgDataPackets,
+    MergedStunMessages,
+    MergedChannelData,
+}
+
+fn classify(datagram: &[u8], stride: usize) -> Option<Detection> {
+    // A receive with coalescing metadata (stride < len) is already split correctly;
+    // only a receive reported as a single datagram can be an unsplit train.
+    if stride == datagram.len()
+        && let Some(detection) = detect_merged_datagrams(datagram)
+    {
+        return Some(detection);
+    }
+
+    (stride > MAX_FZ_PAYLOAD).then_some(Detection {
+        reason: Reason::OversizedSegment,
+        segment_size: None,
+    })
+}
+
+/// Detects a receive whose payload is a train of several Firezone datagrams.
+fn detect_merged_datagrams(datagram: &[u8]) -> Option<Detection> {
+    let (reason, segment_size) = wg_handshake_train(datagram)
+        .map(|s| (Reason::MergedWgHandshakes, s))
+        .or_else(|| wg_data_train(datagram).map(|s| (Reason::MergedWgDataPackets, s)))
+        .or_else(|| stun_train(datagram).map(|s| (Reason::MergedStunMessages, s)))
+        .or_else(|| channel_data_train(datagram).map(|s| (Reason::MergedChannelData, s)))?;
+
+    Some(Detection {
+        reason,
+        segment_size: Some(segment_size),
+    })
+}
+
+/// A train of WireGuard handshake messages: a fixed-size handshake message with more
+/// payload after it, every segment starting like a WireGuard message.
+fn wg_handshake_train(datagram: &[u8]) -> Option<usize> {
+    let segment_size = wg_handshake_size(wg_message_type(datagram)?)?;
+
+    if datagram.len() <= segment_size {
+        return None;
+    }
+
+    segment_starts(datagram, segment_size)
+        .all(|s| wg_message_type(&datagram[s..]).is_some())
+        .then_some(segment_size)
+}
+
+/// A train of WireGuard data packets: data-packet headers repeating at a fixed
+/// distance.
+///
+/// Unlike the other trains, the segment size is not known up front, so we scan for
+/// the second packet's header. The header check is strong enough (see
+/// [`starts_wg_data_packet`]) that random ciphertext practically never produces a
+/// false boundary.
+fn wg_data_train(datagram: &[u8]) -> Option<usize> {
+    if !starts_wg_data_packet(datagram) {
+        return None;
+    }
+
+    let max_segment_size = std::cmp::min(MAX_FZ_PAYLOAD, datagram.len() - MIN_WG_DATA_PACKET);
+
+    if max_segment_size < MIN_WG_DATA_PACKET {
+        return None;
+    }
+
+    memchr::memchr_iter(4, &datagram[MIN_WG_DATA_PACKET..=max_segment_size])
+        .map(|candidate| MIN_WG_DATA_PACKET + candidate)
+        .find(|&segment_size| {
+            segment_starts(datagram, segment_size).all(|s| starts_wg_data_packet(&datagram[s..]))
+        })
+}
+
+/// A train of STUN messages: a STUN message with more payload after it.
+fn stun_train(datagram: &[u8]) -> Option<usize> {
+    message_train(datagram, stun_message_size)
+}
+
+/// A train of TURN channel-data messages: a channel-data message with more payload
+/// after it.
+fn channel_data_train(datagram: &[u8]) -> Option<usize> {
+    message_train(datagram, channel_data_message_size)
+}
+
+/// A train of self-delimiting messages: the first message's size is the segment size
+/// (coalescing only merges equal-sized datagrams; only the last may be shorter) and
+/// every further segment is a whole message, either `segment_size` long or closing
+/// the train exactly.
+fn message_train(datagram: &[u8], message_size: impl Fn(&[u8]) -> Option<usize>) -> Option<usize> {
+    let segment_size = message_size(datagram)?;
+
+    if datagram.len() <= segment_size {
+        return None;
+    }
+
+    segment_starts(datagram, segment_size)
+        .all(|s| {
+            let Some(size) = message_size(&datagram[s..]) else {
+                return false;
+            };
+
+            size == segment_size || s + size == datagram.len()
+        })
+        .then_some(segment_size)
+}
+
+/// The start offsets of all segments after the first, splitting `datagram` every
+/// `segment_size` bytes.
+fn segment_starts(datagram: &[u8], segment_size: usize) -> impl Iterator<Item = usize> {
+    (segment_size..datagram.len()).step_by(segment_size)
+}
+
+/// The message type of a WireGuard message: the first byte, followed by three
+/// reserved zero bytes.
+fn wg_message_type(buf: &[u8]) -> Option<u8> {
+    match buf {
+        [t @ 1..=4, 0, 0, 0, ..] => Some(*t),
+        _ => None,
+    }
+}
+
+/// The fixed wire sizes of the WireGuard handshake messages.
+fn wg_handshake_size(message_type: u8) -> Option<usize> {
+    match message_type {
+        1 => Some(148), // Handshake initiation.
+        2 => Some(92),  // Handshake response.
+        3 => Some(64),  // Cookie reply.
+        _ => None,
+    }
+}
+
+/// The smallest WireGuard data packet: a 16-byte header plus the AEAD tag of an empty
+/// payload, i.e. a keepalive.
+const MIN_WG_DATA_PACKET: usize = WG_OVERHEAD;
+
+/// Whether the buffer starts like a WireGuard data packet: the type-4 header and a
+/// zero upper half of the little-endian packet counter.
+///
+/// Sessions rekey long before 2^32 packets, so the upper counter half of a genuine
+/// data packet is always zero. Together with the header this makes 8 fixed bytes;
+/// without the counter check, random ciphertext would produce a false packet boundary
+/// (and thus needlessly disable URO) every few million data packets.
+fn starts_wg_data_packet(buf: &[u8]) -> bool {
+    if buf.len() < MIN_WG_DATA_PACKET {
+        return false;
+    }
+
+    buf[..4] == [4, 0, 0, 0] && buf[12..16] == [0, 0, 0, 0]
+}
+
+const STUN_MAGIC_COOKIE: [u8; 4] = [0x21, 0x12, 0xA4, 0x42];
+const STUN_HEADER_LEN: usize = 20;
+
+/// The wire size of the STUN message at the start of the buffer, if it plausibly is
+/// one: zero upper type bits, the magic cookie and an attribute length that is a
+/// multiple of four (attributes are padded), bounded by what Firezone peers send.
+fn stun_message_size(buf: &[u8]) -> Option<usize> {
+    if buf.len() < STUN_HEADER_LEN || buf[0] & 0b1100_0000 != 0 || buf[4..8] != STUN_MAGIC_COOKIE {
+        return None;
+    }
+
+    let attribute_len = u16::from_be_bytes([buf[2], buf[3]]) as usize;
+
+    if !attribute_len.is_multiple_of(4) {
+        return None;
+    }
+
+    let size = STUN_HEADER_LEN + attribute_len;
+
+    (size <= MAX_FZ_PAYLOAD).then_some(size)
+}
+
+/// The wire size of the TURN channel-data message at the start of the buffer, if it
+/// plausibly is one: a channel number in the 0x4000..=0x7FFF range plus the length of
+/// the application data it carries, bounded by what Firezone peers send.
+fn channel_data_message_size(buf: &[u8]) -> Option<usize> {
+    let &[channel, _, l1, l2, ..] = buf else {
+        return None;
+    };
+
+    if !(0x40..=0x7F).contains(&channel) {
+        return None;
+    }
+
+    let size = DATA_CHANNEL_OVERHEAD + u16::from_be_bytes([l1, l2]) as usize;
+
+    (size <= MAX_FZ_PAYLOAD).then_some(size)
 }
 
 #[cfg(test)]
@@ -50,25 +277,227 @@ mod tests {
     use super::*;
 
     #[test]
-    fn detects_broken_coalescing_from_oversized_segment() {
-        let ok = meta_with_stride(ip_packet::MAX_FZ_PAYLOAD);
-        let oversized = meta_with_stride(ip_packet::MAX_FZ_PAYLOAD + 1);
+    fn single_wg_data_packet_is_not_merged() {
+        assert_eq!(classify(&wg_data_packet(1312), 1312), None);
+    }
 
-        // `BROKEN` is process-global: reset it so this test neither observes nor leaks state.
+    #[test]
+    fn merged_wg_data_packets_are_salvaged() {
+        let blob = merged(&[&wg_data_packet(1312), &wg_data_packet(1312)]);
+
+        assert_eq!(
+            classify(&blob, blob.len()),
+            Some(Detection {
+                reason: Reason::MergedWgDataPackets,
+                segment_size: Some(1312),
+            })
+        );
+    }
+
+    #[test]
+    fn merged_keepalives_are_salvaged() {
+        let blob = merged(&[
+            &wg_data_packet(32),
+            &wg_data_packet(32),
+            &wg_data_packet(32),
+        ]);
+
+        assert_eq!(
+            classify(&blob, blob.len()),
+            Some(Detection {
+                reason: Reason::MergedWgDataPackets,
+                segment_size: Some(32),
+            })
+        );
+    }
+
+    #[test]
+    fn fake_boundary_in_ciphertext_does_not_confuse_the_scan() {
+        let mut first = wg_data_packet(100);
+        first[40..44].copy_from_slice(&[4, 0, 0, 0]);
+        first[52..56].copy_from_slice(&[0, 0, 0, 0]);
+
+        let blob = merged(&[&first, &wg_data_packet(100)]);
+
+        assert_eq!(
+            classify(&blob, blob.len()),
+            Some(Detection {
+                reason: Reason::MergedWgDataPackets,
+                segment_size: Some(100),
+            })
+        );
+    }
+
+    #[test]
+    fn single_wg_handshake_initiation_is_not_merged() {
+        assert_eq!(classify(&wg_handshake(1, 148), 148), None);
+    }
+
+    #[test]
+    fn merged_wg_handshake_initiations_are_salvaged() {
+        let blob = merged(&[&wg_handshake(1, 148), &wg_handshake(1, 148)]);
+
+        assert_eq!(
+            classify(&blob, blob.len()),
+            Some(Detection {
+                reason: Reason::MergedWgHandshakes,
+                segment_size: Some(148),
+            })
+        );
+    }
+
+    #[test]
+    fn wg_handshake_with_trailing_junk_is_not_merged() {
+        let blob = merged(&[&wg_handshake(1, 148), &[0xEE; 5]]);
+
+        assert_eq!(classify(&blob, blob.len()), None);
+    }
+
+    #[test]
+    fn single_stun_message_is_not_merged() {
+        let message = stun_message(8);
+
+        assert_eq!(classify(&message, message.len()), None);
+    }
+
+    #[test]
+    fn merged_stun_messages_are_salvaged() {
+        let blob = merged(&[&stun_message(8), &stun_message(8)]);
+
+        assert_eq!(
+            classify(&blob, blob.len()),
+            Some(Detection {
+                reason: Reason::MergedStunMessages,
+                segment_size: Some(28),
+            })
+        );
+    }
+
+    #[test]
+    fn stun_message_with_unaligned_length_is_not_merged() {
+        let mut message = stun_message(8);
+        message[3] = 6; // Claim 6 bytes of attributes, leaving 2 trailing bytes.
+
+        assert_eq!(classify(&message, message.len()), None);
+    }
+
+    #[test]
+    fn merged_channel_data_messages_are_salvaged() {
+        let blob = merged(&[&channel_data(50), &channel_data(50)]);
+
+        assert_eq!(
+            classify(&blob, blob.len()),
+            Some(Detection {
+                reason: Reason::MergedChannelData,
+                segment_size: Some(54),
+            })
+        );
+    }
+
+    #[test]
+    fn channel_data_with_padding_is_not_merged() {
+        let blob = merged(&[&channel_data(50), &[0, 0]]);
+
+        assert_eq!(classify(&blob, blob.len()), None);
+    }
+
+    #[test]
+    fn oversized_junk_is_broken_without_salvage() {
+        assert_eq!(
+            classify(&vec![0xFF; 2000], 2000),
+            Some(Detection {
+                reason: Reason::OversizedSegment,
+                segment_size: None,
+            })
+        );
+    }
+
+    #[test]
+    fn receive_with_coalescing_metadata_is_not_merged() {
+        let blob = merged(&[&wg_data_packet(1312), &wg_data_packet(1312)]);
+
+        assert_eq!(classify(&blob, 1312), None);
+    }
+
+    #[test]
+    fn oversized_segment_with_coalescing_metadata_is_broken_without_salvage() {
+        assert_eq!(
+            classify(&vec![0xFF; 4000], 2000),
+            Some(Detection {
+                reason: Reason::OversizedSegment,
+                segment_size: None,
+            })
+        );
+    }
+
+    /// The only test that may call [`detect_broken_coalescing`]: it touches the
+    /// process-global `BROKEN` flag, so a second such test would race with this one.
+    #[test]
+    fn detect_flips_the_kill_switch_and_salvages() {
         BROKEN.store(false, Ordering::Relaxed);
 
-        assert!(!detect_broken_coalescing([&ok].into_iter()));
-        assert!(!is_broken());
+        let single = wg_data_packet(1312);
+        let mut single_meta = meta(single.len(), single.len());
 
-        assert!(detect_broken_coalescing([&ok, &oversized].into_iter()));
+        assert!(!detect_broken_coalescing(
+            [(single.as_slice(), &mut single_meta)].into_iter()
+        ));
+        assert!(!is_broken());
+        assert_eq!(single_meta.stride, 1312);
+
+        let blob = merged(&[&wg_data_packet(1312), &wg_data_packet(1312)]);
+        let mut blob_meta = meta(blob.len(), blob.len());
+
+        assert!(detect_broken_coalescing(
+            [(blob.as_slice(), &mut blob_meta)].into_iter()
+        ));
         assert!(is_broken());
+        assert_eq!(blob_meta.stride, 1312);
 
         BROKEN.store(false, Ordering::Relaxed);
     }
 
-    fn meta_with_stride(stride: usize) -> quinn_udp::RecvMeta {
+    fn wg_data_packet(len: usize) -> Vec<u8> {
+        assert!(len >= MIN_WG_DATA_PACKET);
+
+        let mut packet = vec![0xAA; len];
+        packet[..4].copy_from_slice(&[4, 0, 0, 0]);
+        packet[8..16].copy_from_slice(&1234u64.to_le_bytes());
+
+        packet
+    }
+
+    fn wg_handshake(message_type: u8, len: usize) -> Vec<u8> {
+        let mut message = vec![0xCC; len];
+        message[..4].copy_from_slice(&[message_type, 0, 0, 0]);
+
+        message
+    }
+
+    fn stun_message(attribute_len: u8) -> Vec<u8> {
+        let mut message = vec![0xBB; STUN_HEADER_LEN + attribute_len as usize];
+        message[..2].copy_from_slice(&[0x00, 0x01]);
+        message[2..4].copy_from_slice(&[0x00, attribute_len]);
+        message[4..8].copy_from_slice(&STUN_MAGIC_COOKIE);
+
+        message
+    }
+
+    fn channel_data(data_len: u8) -> Vec<u8> {
+        let mut message = vec![0xDD; DATA_CHANNEL_OVERHEAD + data_len as usize];
+        message[..2].copy_from_slice(&[0x40, 0x01]);
+        message[2..4].copy_from_slice(&[0x00, data_len]);
+
+        message
+    }
+
+    fn merged(datagrams: &[&[u8]]) -> Vec<u8> {
+        datagrams.concat()
+    }
+
+    fn meta(len: usize, stride: usize) -> quinn_udp::RecvMeta {
         let mut meta = quinn_udp::RecvMeta::default();
-        meta.len = stride;
+        meta.len = len;
         meta.stride = stride;
 
         meta

--- a/rust/libs/connlib/socket-factory/src/uro.rs
+++ b/rust/libs/connlib/socket-factory/src/uro.rs
@@ -23,7 +23,7 @@ pub(crate) fn is_broken() -> bool {
 ///
 /// Returns `true` if any of the receives has a segment size above
 /// [`ip_packet::MAX_FZ_PAYLOAD`], meaning the socket should opt out of URO.
-/// The first detection logs a warning; later ones are silent.
+/// The first detection is logged; later ones are silent.
 pub(crate) fn detect_broken_coalescing<'a>(
     mut metas: impl Iterator<Item = &'a quinn_udp::RecvMeta>,
 ) -> bool {
@@ -35,11 +35,11 @@ pub(crate) fn detect_broken_coalescing<'a>(
         return true;
     }
 
-    tracing::warn!(
+    tracing::info!(
         stride = %meta.stride,
         len = %meta.len,
         interface_index = ?meta.interface_index,
-        "Received a datagram segment larger than any Firezone peer sends; disabling URO to work around broken receive coalescing"
+        "Disabling URO"
     );
 
     true

--- a/rust/libs/connlib/socket-factory/src/uro.rs
+++ b/rust/libs/connlib/socket-factory/src/uro.rs
@@ -1,0 +1,42 @@
+//! Process-wide kill switch for URO (UDP receive coalescing) on Windows.
+//!
+//! Some Windows machines coalesce received UDP datagrams without attaching the
+//! `UDP_COALESCED_INFO` metadata required to split the buffer back into datagrams,
+//! turning every packet train into one unusable blob
+//! (<https://github.com/quinn-rs/quinn/issues/2041>).
+//!
+//! No Firezone peer sends a datagram larger than [`ip_packet::MAX_FZ_PAYLOAD`] and
+//! correct coalescing reports the size of the original datagrams as the segment size,
+//! so receiving a segment above that bound proves that coalescing on this machine is
+//! broken. Once that happens, URO stays off for the remainder of the process.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static TRIPPED: AtomicBool = AtomicBool::new(false);
+
+/// Whether broken coalescing has been observed in this process.
+pub fn is_tripped() -> bool {
+    TRIPPED.load(Ordering::Relaxed)
+}
+
+/// Records an observation of broken coalescing.
+///
+/// Returns `true` for the observation that tripped the switch, `false` for all later ones.
+pub(crate) fn trip() -> bool {
+    !TRIPPED.swap(true, Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trips_once() {
+        assert!(!is_tripped());
+
+        assert!(trip());
+        assert!(!trip());
+
+        assert!(is_tripped());
+    }
+}

--- a/rust/libs/connlib/socket-factory/src/uro.rs
+++ b/rust/libs/connlib/socket-factory/src/uro.rs
@@ -438,7 +438,7 @@ mod tests {
     #[test]
     fn zero_stride_junk_is_delivered_as_one_datagram() {
         assert_eq!(
-            classify(&vec![0xFF; 100], 0),
+            classify(&[0xFF; 100], 0),
             Some(Detection {
                 reason: Reason::ZeroSizedSegment,
                 segment_size: Some(100),

--- a/rust/libs/connlib/socket-factory/src/uro.rs
+++ b/rust/libs/connlib/socket-factory/src/uro.rs
@@ -53,7 +53,7 @@ pub(crate) fn detect_broken_coalescing<'a>(
         any_broken = true;
 
         if !BROKEN.swap(true, Ordering::Relaxed) {
-            tracing::info!(
+            tracing::warn!(
                 stride = %meta.stride,
                 len = %meta.len,
                 interface_index = ?meta.interface_index,

--- a/rust/libs/connlib/socket-factory/src/uro.rs
+++ b/rust/libs/connlib/socket-factory/src/uro.rs
@@ -54,11 +54,16 @@ mod tests {
         let ok = meta_with_stride(ip_packet::MAX_FZ_PAYLOAD);
         let oversized = meta_with_stride(ip_packet::MAX_FZ_PAYLOAD + 1);
 
+        // `BROKEN` is process-global: reset it so this test neither observes nor leaks state.
+        BROKEN.store(false, Ordering::Relaxed);
+
         assert!(!detect_broken_coalescing([&ok].into_iter()));
         assert!(!is_broken());
 
         assert!(detect_broken_coalescing([&ok, &oversized].into_iter()));
         assert!(is_broken());
+
+        BROKEN.store(false, Ordering::Relaxed);
     }
 
     fn meta_with_stride(stride: usize) -> quinn_udp::RecvMeta {

--- a/rust/libs/connlib/socket-factory/src/uro.rs
+++ b/rust/libs/connlib/socket-factory/src/uro.rs
@@ -12,19 +12,27 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
-static TRIPPED: AtomicBool = AtomicBool::new(false);
+static BROKEN: AtomicBool = AtomicBool::new(false);
 
 /// Whether broken coalescing has been observed in this process.
-pub fn is_tripped() -> bool {
-    TRIPPED.load(Ordering::Relaxed)
+pub(crate) fn is_broken() -> bool {
+    BROKEN.load(Ordering::Relaxed)
 }
 
-/// Records an observation of broken coalescing.
+/// Detects receives that prove coalescing on this machine is broken.
 ///
-/// The first observation logs a warning; later ones are silent.
-pub(crate) fn trip(meta: &quinn_udp::RecvMeta) {
-    if TRIPPED.swap(true, Ordering::Relaxed) {
-        return;
+/// Returns `true` if any of the receives has a segment size above
+/// [`ip_packet::MAX_FZ_PAYLOAD`], meaning the socket should opt out of URO.
+/// The first detection logs a warning; later ones are silent.
+pub(crate) fn detect_broken_coalescing<'a>(
+    mut metas: impl Iterator<Item = &'a quinn_udp::RecvMeta>,
+) -> bool {
+    let Some(meta) = metas.find(|meta| meta.stride > ip_packet::MAX_FZ_PAYLOAD) else {
+        return false;
+    };
+
+    if BROKEN.swap(true, Ordering::Relaxed) {
+        return true;
     }
 
     tracing::warn!(
@@ -33,6 +41,8 @@ pub(crate) fn trip(meta: &quinn_udp::RecvMeta) {
         interface_index = ?meta.interface_index,
         "Received a datagram segment larger than any Firezone peer sends; disabling URO to work around broken receive coalescing"
     );
+
+    true
 }
 
 #[cfg(test)]
@@ -40,12 +50,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn trips_once() {
-        assert!(!is_tripped());
+    fn detects_broken_coalescing_from_oversized_segment() {
+        let ok = meta_with_stride(ip_packet::MAX_FZ_PAYLOAD);
+        let oversized = meta_with_stride(ip_packet::MAX_FZ_PAYLOAD + 1);
 
-        trip(&quinn_udp::RecvMeta::default());
-        trip(&quinn_udp::RecvMeta::default());
+        assert!(!detect_broken_coalescing([&ok].into_iter()));
+        assert!(!is_broken());
 
-        assert!(is_tripped());
+        assert!(detect_broken_coalescing([&ok, &oversized].into_iter()));
+        assert!(is_broken());
+    }
+
+    fn meta_with_stride(stride: usize) -> quinn_udp::RecvMeta {
+        let mut meta = quinn_udp::RecvMeta::default();
+        meta.len = stride;
+        meta.stride = stride;
+
+        meta
     }
 }

--- a/rust/libs/connlib/socket-factory/src/uro.rs
+++ b/rust/libs/connlib/socket-factory/src/uro.rs
@@ -21,9 +21,18 @@ pub fn is_tripped() -> bool {
 
 /// Records an observation of broken coalescing.
 ///
-/// Returns `true` for the observation that tripped the switch, `false` for all later ones.
-pub(crate) fn trip() -> bool {
-    !TRIPPED.swap(true, Ordering::Relaxed)
+/// The first observation logs a warning; later ones are silent.
+pub(crate) fn trip(meta: &quinn_udp::RecvMeta) {
+    if TRIPPED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+
+    tracing::warn!(
+        stride = %meta.stride,
+        len = %meta.len,
+        interface_index = ?meta.interface_index,
+        "Received a datagram segment larger than any Firezone peer sends; disabling URO to work around broken receive coalescing"
+    );
 }
 
 #[cfg(test)]
@@ -34,8 +43,8 @@ mod tests {
     fn trips_once() {
         assert!(!is_tripped());
 
-        assert!(trip());
-        assert!(!trip());
+        trip(&quinn_udp::RecvMeta::default());
+        trip(&quinn_udp::RecvMeta::default());
 
         assert!(is_tripped());
     }

--- a/rust/libs/connlib/socket-factory/src/uro.rs
+++ b/rust/libs/connlib/socket-factory/src/uro.rs
@@ -7,10 +7,10 @@
 //!
 //! Correct coalescing reports the size of the original datagrams as the segment size,
 //! so a receive that violates that proves that coalescing on this machine is broken:
-//! either a segment is larger than [`MAX_FZ_PAYLOAD`] (no Firezone peer sends a
-//! datagram that big) or a receive reported as a single datagram is provably a train
-//! of several Firezone datagrams. Once either happens, URO stays off for the
-//! remainder of the process.
+//! a segment size that is impossible (zero, or larger than [`MAX_FZ_PAYLOAD`], which
+//! no Firezone peer sends) or a receive reported as a single datagram that is
+//! provably a train of several Firezone datagrams. Once either happens, URO stays
+//! off for the remainder of the process.
 //!
 //! Firezone sockets only ever receive WireGuard messages (direct traffic) and STUN /
 //! TURN channel-data messages (relay traffic), all of which leave the datagram
@@ -82,6 +82,7 @@ struct Detection {
 #[derive(Debug, PartialEq)]
 enum Reason {
     OversizedSegment,
+    ZeroSizedSegment,
     MergedWgHandshakes,
     MergedWgDataPackets,
     MergedStunMessages,
@@ -89,18 +90,33 @@ enum Reason {
 }
 
 fn classify(datagram: &[u8], stride: usize) -> Option<Detection> {
-    // A receive with coalescing metadata (stride < len) is already split correctly;
-    // only a receive reported as a single datagram can be an unsplit train.
-    if stride == datagram.len()
+    // A receive with sane coalescing metadata (0 < stride < len) is already split
+    // correctly; only one reported as a single datagram (stride == len, which is also
+    // how quinn-udp reports the absence of metadata) or with a nonsensical zero
+    // segment size can be an unsplit train.
+    if (stride == datagram.len() || stride == 0)
         && let Some(detection) = detect_merged_datagrams(datagram)
     {
         return Some(detection);
     }
 
-    (stride > MAX_FZ_PAYLOAD).then_some(Detection {
-        reason: Reason::OversizedSegment,
-        segment_size: None,
-    })
+    if stride > MAX_FZ_PAYLOAD {
+        return Some(Detection {
+            reason: Reason::OversizedSegment,
+            segment_size: None,
+        });
+    }
+
+    if stride == 0 && !datagram.is_empty() {
+        // Boundaries are unrecoverable; reporting the whole payload as one segment
+        // delivers a plain datagram intact and leaves a blob to the upstream parsers.
+        return Some(Detection {
+            reason: Reason::ZeroSizedSegment,
+            segment_size: Some(datagram.len()),
+        });
+    }
+
+    None
 }
 
 /// Detects a receive whose payload is a train of several Firezone datagrams.
@@ -399,6 +415,35 @@ mod tests {
         let blob = merged(&[&channel_data(50), &[0, 0]]);
 
         assert_eq!(classify(&blob, blob.len()), None);
+    }
+
+    #[test]
+    fn empty_datagram_is_not_broken() {
+        assert_eq!(classify(&[], 0), None);
+    }
+
+    #[test]
+    fn zero_stride_train_is_salvaged() {
+        let blob = merged(&[&wg_data_packet(1312), &wg_data_packet(1312)]);
+
+        assert_eq!(
+            classify(&blob, 0),
+            Some(Detection {
+                reason: Reason::MergedWgDataPackets,
+                segment_size: Some(1312),
+            })
+        );
+    }
+
+    #[test]
+    fn zero_stride_junk_is_delivered_as_one_datagram() {
+        assert_eq!(
+            classify(&vec![0xFF; 100], 0),
+            Some(Detection {
+                reason: Reason::ZeroSizedSegment,
+                segment_size: Some(100),
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
URO is the only receive-path batching available on Windows but has been off since `quinn-udp` disabled it by default: some machines coalesce UDP datagrams without attaching the `UDP_COALESCED_INFO` metadata needed to split them apart again, most notably Windows on ARM with WSL2 installed and certain dock NIC drivers on Windows 11 24H2.

Nobody can identify the affected machines up front, but we do not have to: correct coalescing reports the original datagram size as the segment size, so a receive that violates that proves the machine's coalescing is broken. We opt every socket into URO and detect broken coalescing in two ways:

1. a segment larger than `MAX_FZ_PAYLOAD` (no Firezone peer sends a datagram that big)
2. a receive reported as a single datagram whose payload is provably a train of several Firezone datagrams. The latter works because everything our sockets receive leaves the datagram boundaries recoverable: WireGuard handshake messages have fixed sizes, WireGuard data packets have a recognizable header, and STUN / TURN channel-data messages carry their own length.
 
On detection we opt out of URO for the remainder of the process and salvage the offending receive by reporting the recovered segment size where possible; unsalvageable receives are dropped and the tunneled protocols retransmit their contents. On healthy machines, URO batches up to ~49 datagrams per `WSARecvMsg` call.

Related: https://github.com/quinn-rs/quinn/issues/2041