### PR TITLE
fix(connlib): round up the packet count in the GSO send trace

### DIFF
--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -535,7 +535,7 @@ impl PerfUdpSocket {
             };
 
             #[cfg(debug_assertions)]
-            tracing::trace!(target: "wire::net::send", ?src, %dst, ecn = ?chunk.ecn, num_packets = %(contents.len() / segment_size), %segment_size, connected = %socket.connected);
+            tracing::trace!(target: "wire::net::send", ?src, %dst, ecn = ?chunk.ecn, num_packets = %contents.len().div_ceil(segment_size), %segment_size, connected = %socket.connected);
 
             let result = if socket.connected {
                 // Connected sockets never return `EWOULDBLOCK` on Darwin; issue the syscall


### PR DESCRIPTION
Counting the datagrams in a GSO batch has to round up, because the last segment may be shorter than `segment_size`. The `wire::net::send` trace floored instead, so it under-reported by one whenever a batch ended in a short segment, and logged zero for a chunk carrying a single short datagram. Everywhere else that derives this count already rounds up.