### PR TITLE
feat(gui-client): match portal styling

### DIFF
--- a/rust/gui-client/package.json
+++ b/rust/gui-client/package.json
@@ -17,6 +17,8 @@
   },
   "dependencies": {
     "@eslint/js": "^9.39.5",
+    "@fontsource-variable/roboto": "^5.3.0",
+    "@fontsource-variable/roboto-mono": "^5.3.0",
     "@fontsource-variable/source-sans-3": "^5.3.0",
     "@heroicons/react": "^2.2.0",
     "@sentry/core": "^10.66.0",
@@ -37,6 +39,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-router": "^8.3.0",
+    "remixicon": "4.9.1",
     "run-script-os": "^1.1.6",
     "tailwindcss": "^4.3.3",
     "tslib": "^2.8.1",

--- a/rust/gui-client/pnpm-lock.yaml
+++ b/rust/gui-client/pnpm-lock.yaml
@@ -19,6 +19,12 @@ importers:
       '@eslint/js':
         specifier: ^9.39.5
         version: 9.39.5
+      '@fontsource-variable/roboto':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource-variable/roboto-mono':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@fontsource-variable/source-sans-3':
         specifier: ^5.3.0
         version: 5.3.0
@@ -79,6 +85,9 @@ importers:
       react-router:
         specifier: ^8.3.0
         version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      remixicon:
+        specifier: 4.9.1
+        version: 4.9.1
       run-script-os:
         specifier: ^1.1.6
         version: 1.1.6
@@ -187,6 +196,12 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource-variable/roboto-mono@5.3.0':
+    resolution: {integrity: sha512-h5r+KY/6qy8JEOj33JgcrFO81YAnvrc1EAwMpl/EPJLb2OIvOy0/jmB5M7qs7x/uXk5JUP5Ux4LrkeOK7faHkQ==}
+
+  '@fontsource-variable/roboto@5.3.0':
+    resolution: {integrity: sha512-BoaaZiQf8fgtxv07KXkTwx1bKz/EoqIlTXq2OOKKXINxp6qXWdnlChqV+hSaDANS49yyUASFl3OVBMMDTCIHFA==}
 
   '@fontsource-variable/source-sans-3@5.3.0':
     resolution: {integrity: sha512-dpi0GZk7EQe2tYpg6Q0Fx0OmUgnuGu+0rHPgtXqtKhglYmJuP7jZ12Mu1uN+NfRaJRY1Emn8AQJEWzmoZ4wa9g==}
@@ -1884,6 +1899,9 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  remixicon@4.9.1:
+    resolution: {integrity: sha512-36gLSoujkabnCFZFDyP17VNh9piuBA/rsXUb4auSJWLGsHVXtmxLj/EM5FjaEAGnk8oIAj1Azob/DZ2N+90lAQ==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2262,6 +2280,10 @@ snapshots:
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource-variable/roboto-mono@5.3.0': {}
+
+  '@fontsource-variable/roboto@5.3.0': {}
 
   '@fontsource-variable/source-sans-3@5.3.0': {}
 
@@ -3926,6 +3948,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  remixicon@4.9.1: {}
 
   resolve-from@4.0.0: {}
 

--- a/rust/gui-client/src-frontend/components/AboutPage.tsx
+++ b/rust/gui-client/src-frontend/components/AboutPage.tsx
@@ -4,26 +4,28 @@ import logo from "../logo.png";
 
 export default function AboutPage() {
   return (
-    <div className="w-full h-full max-w-sm flex flex-col justify-center items-center mx-auto">
-      <img src={logo} alt="Firezone Logo" className="w-20 h-20 mb-6" />
-      <p className="text-neutral-600 mb-1">Version</p>
-      <p className="text-2xl font-bold mb-1">
-        <span>{__APP_VERSION__}</span>
-      </p>
-      <p className="text-neutral-400 text-sm mb-6">
-        (<span>{__GIT_VERSION__?.substring(0, 8)}</span>)
-      </p>
-      <button
-        onClick={() =>
-          openUrl("https://www.firezone.dev/kb?utm_source=product").catch((e) =>
-            console.error("Failed to open documentation URL", e)
-          )
-        }
-        role="link"
-        className="text-accent-450 hover:underline text-sm"
-      >
-        Documentation
-      </button>
+    <div className="flex min-h-full items-center justify-center bg-page p-6">
+      <div className="flex w-full max-w-sm flex-col items-center text-center">
+        <img src={logo} alt="Firezone Logo" className="mb-6 h-20 w-20" />
+        <p className="mb-1 text-body">Version</p>
+        <p className="mb-1 text-2xl font-bold text-heading">
+          <span>{__APP_VERSION__}</span>
+        </p>
+        <p className="mb-6 font-mono text-sm text-subtle">
+          (<span>{__GIT_VERSION__?.substring(0, 8)}</span>)
+        </p>
+        <button
+          onClick={() =>
+            openUrl("https://www.firezone.dev/kb?utm_source=product").catch(
+              (e) => console.error("Failed to open documentation URL", e)
+            )
+          }
+          role="link"
+          className="rounded px-2 py-1.5 text-sm font-medium text-brand transition-colors hover:bg-brand-muted hover:text-brand-dark"
+        >
+          Documentation
+        </button>
+      </div>
     </div>
   );
 }

--- a/rust/gui-client/src-frontend/components/AdvancedSettingsPage.tsx
+++ b/rust/gui-client/src-frontend/components/AdvancedSettingsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useId, useState } from "react";
-import { Button, Label } from "flowbite-react";
+import Button from "./Button";
 import { ManagedTextInput } from "./ManagedInput";
+import RemixIcon from "./RemixIcon";
 import { AdvancedSettingsViewModel } from "../generated/bindings";
 
 interface Props {
@@ -44,24 +45,27 @@ export default function AdvancedSettingsPage({
   const logFilterInput = useId();
 
   return (
-    <div className="container p-4">
-      <p className="text-neutral-900 mb-6">
-        <strong>WARNING</strong>: These settings are intended for internal debug
-        purposes <strong>only</strong>. Changing these is not supported and will
-        disrupt access to your resources.
-      </p>
+    <div className="page">
+      <div className="mb-4 flex max-w-xl gap-2.5 rounded border border-warning/30 bg-warning-light p-3 text-sm text-warning">
+        <RemixIcon className="mt-0.5 h-4 w-4" name="alert" />
+        <p>
+          <strong>WARNING</strong>: These settings are intended for internal
+          debug purposes <strong>only</strong>. Changing these is not supported
+          and will disrupt access to your resources.
+        </p>
+      </div>
 
       <form
         onSubmit={(e) => {
           e.preventDefault();
           saveSettings(localSettings);
         }}
-        className="max-w flex flex-col gap-2"
+        className="max-w-xl space-y-3"
       >
         <div>
-          <Label className="text-neutral-600" htmlFor={authBaseUrlId}>
+          <label className="form-label" htmlFor={authBaseUrlId}>
             Auth Base URL
-          </Label>
+          </label>
           <ManagedTextInput
             name="auth_base_url"
             id={authBaseUrlId}
@@ -78,9 +82,9 @@ export default function AdvancedSettingsPage({
         </div>
 
         <div>
-          <Label className="text-neutral-600" htmlFor={apiUrlId}>
+          <label className="form-label" htmlFor={apiUrlId}>
             API URL
-          </Label>
+          </label>
           <ManagedTextInput
             name="api_url"
             id={apiUrlId}
@@ -97,14 +101,15 @@ export default function AdvancedSettingsPage({
         </div>
 
         <div>
-          <Label className="text-neutral-600" htmlFor={logFilterInput}>
+          <label className="form-label" htmlFor={logFilterInput}>
             Log Filter
-          </Label>
+          </label>
           <ManagedTextInput
             name="log_filter"
             id={logFilterInput}
             managed={localSettings.log_filter_is_managed}
             value={localSettings.log_filter}
+            className="font-mono text-xs"
             onChange={(e) =>
               setLocalSettings({
                 ...localSettings,
@@ -115,11 +120,13 @@ export default function AdvancedSettingsPage({
           />
         </div>
 
-        <div className="flex justify-end gap-4 mt-4">
-          <Button type="reset" onClick={resetSettings} color="alternative">
+        <div className="flex justify-end gap-2 border-t border-border pt-3">
+          <Button type="reset" onClick={resetSettings}>
             Reset to Defaults
           </Button>
-          <Button type="submit">Apply</Button>
+          <Button type="submit" variant="primary">
+            Apply
+          </Button>
         </div>
       </form>
     </div>

--- a/rust/gui-client/src-frontend/components/App.tsx
+++ b/rust/gui-client/src-frontend/components/App.tsx
@@ -1,18 +1,3 @@
-import {
-  Bars3Icon,
-  CogIcon,
-  DocumentMagnifyingGlassIcon,
-  HomeIcon,
-  InformationCircleIcon,
-  SwatchIcon,
-  WrenchScrewdriverIcon,
-} from "@heroicons/react/24/solid";
-import {
-  Sidebar,
-  SidebarCollapse,
-  SidebarItemGroup,
-  SidebarItems,
-} from "flowbite-react";
 import React, { useEffect, useState } from "react";
 import { Route, Routes } from "react-router";
 import About from "./AboutPage";
@@ -22,6 +7,7 @@ import ColorPalette from "./ColorPalettePage";
 import Diagnostics from "./DiagnosticsPage";
 import GeneralSettingsPage from "./GeneralSettingsPage";
 import Overview from "./OverviewPage";
+import RemixIcon from "./RemixIcon";
 import {
   AdvancedSettingsViewModel,
   commands,
@@ -39,6 +25,7 @@ export default function App() {
     useState<GeneralSettingsViewModel | null>(null);
   const [advancedSettings, setAdvancedSettings] =
     useState<AdvancedSettingsViewModel | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(true);
 
   useEffect(() => {
     const sessionChangedUnlisten = events.sessionChanged.listen((e) => {
@@ -84,7 +71,7 @@ export default function App() {
   const isDev = import.meta.env.DEV;
 
   return (
-    <div className="h-screen flex flex-col rounded-lg border border-neutral-300 overflow-hidden">
+    <div className="app-shell">
       <Routes>
         <Route path="/overview" element={<Titlebar title={"Firezone"} />} />
         <Route
@@ -105,53 +92,78 @@ export default function App() {
           element={<Titlebar title={"Colour Palette"} />}
         />
       </Routes>
-      <div className="flex-1 bg-neutral-50 flex flex-row">
-        <Sidebar
-          aria-label="Sidebar"
-          className="w-52 flex-shrink-0 border-r border-neutral-200"
-        >
-          <SidebarItems>
-            <SidebarItemGroup>
-              <ReactRouterSidebarItem icon={HomeIcon} href="/overview">
-                Overview
-              </ReactRouterSidebarItem>
-              <SidebarCollapse label="Settings" open={true} icon={Bars3Icon}>
-                <ReactRouterSidebarItem icon={CogIcon} href="/general-settings">
-                  General
+
+      <div className="flex min-h-0 flex-1">
+        <aside className="flex w-56 shrink-0 flex-col border-r border-border bg-surface">
+          <nav
+            aria-label="Client navigation"
+            className="flex-1 overflow-y-auto px-2 py-3"
+          >
+            <ul className="space-y-0.5">
+              <li>
+                <ReactRouterSidebarItem icon="home" href="/overview">
+                  Overview
                 </ReactRouterSidebarItem>
-                <ReactRouterSidebarItem
-                  icon={WrenchScrewdriverIcon}
-                  href="/advanced-settings"
+              </li>
+              <li>
+                <button
+                  aria-expanded={settingsOpen}
+                  className="nav-item w-full"
+                  onClick={() => setSettingsOpen((open) => !open)}
+                  type="button"
                 >
-                  Advanced
+                  <RemixIcon className="h-4 w-4" name="settings" />
+                  <span className="flex-1 text-left">Settings</span>
+                  <RemixIcon
+                    className={`h-3.5 w-3.5 transition-transform ${
+                      settingsOpen ? "rotate-180" : ""
+                    }`}
+                    name="arrow-down"
+                  />
+                </button>
+                {settingsOpen && (
+                  <ul className="mt-0.5 space-y-0.5 pl-4">
+                    <li>
+                      <ReactRouterSidebarItem
+                        icon="settings"
+                        href="/general-settings"
+                      >
+                        General
+                      </ReactRouterSidebarItem>
+                    </li>
+                    <li>
+                      <ReactRouterSidebarItem
+                        icon="equalizer"
+                        href="/advanced-settings"
+                      >
+                        Advanced
+                      </ReactRouterSidebarItem>
+                    </li>
+                  </ul>
+                )}
+              </li>
+              <li>
+                <ReactRouterSidebarItem icon="database" href="/diagnostics">
+                  Diagnostics
                 </ReactRouterSidebarItem>
-              </SidebarCollapse>
-              <ReactRouterSidebarItem
-                icon={DocumentMagnifyingGlassIcon}
-                href="/diagnostics"
-              >
-                Diagnostics
-              </ReactRouterSidebarItem>
-              <ReactRouterSidebarItem
-                icon={InformationCircleIcon}
-                href="/about"
-              >
-                About
-              </ReactRouterSidebarItem>
-            </SidebarItemGroup>
-            {isDev && (
-              <SidebarItemGroup>
-                <ReactRouterSidebarItem
-                  icon={SwatchIcon}
-                  href="/colour-palette"
-                >
-                  Color Palette
+              </li>
+              <li>
+                <ReactRouterSidebarItem icon="information" href="/about">
+                  About
                 </ReactRouterSidebarItem>
-              </SidebarItemGroup>
-            )}
-          </SidebarItems>
-        </Sidebar>
-        <main className="flex-grow overflow-auto">
+              </li>
+              {isDev && (
+                <li className="mt-3 border-t border-border pt-3">
+                  <ReactRouterSidebarItem icon="palette" href="/colour-palette">
+                    Color Palette
+                  </ReactRouterSidebarItem>
+                </li>
+              )}
+            </ul>
+          </nav>
+        </aside>
+
+        <main className="min-w-0 flex-1 overflow-auto bg-page">
           <Routes>
             <Route
               path="/overview"

--- a/rust/gui-client/src-frontend/components/Button.tsx
+++ b/rust/gui-client/src-frontend/components/Button.tsx
@@ -1,0 +1,17 @@
+import React, { ButtonHTMLAttributes } from "react";
+
+type ButtonVariant = "primary" | "secondary" | "danger";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+}
+
+export default function Button({
+  variant = "secondary",
+  className = "",
+  ...props
+}: ButtonProps) {
+  return (
+    <button className={`button button-${variant} ${className}`} {...props} />
+  );
+}

--- a/rust/gui-client/src-frontend/components/ColorPalettePage.tsx
+++ b/rust/gui-client/src-frontend/components/ColorPalettePage.tsx
@@ -43,7 +43,7 @@ const neutralColors = [
 
 export default function ColorPalettePage() {
   return (
-    <div className="p-6 max-w-full mx-auto">
+    <div className="page">
       <ColorSection title="Primary Colors" colors={primaryColors} />
       <ColorSection title="Accent Colors" colors={accentColors} />
       <ColorSection title="Neutral Colors" colors={neutralColors} />
@@ -53,9 +53,9 @@ export default function ColorPalettePage() {
 
 function ColorSwatch({ colorClass }: { colorClass: string }) {
   return (
-    <div className="bg-white rounded-lg shadow overflow-hidden border border-neutral-200">
-      <div className={`h-14 ${colorClass}`}></div>
-      <div className="p-3 text-xs">{colorClass}</div>
+    <div className="overflow-hidden rounded border border-border bg-surface">
+      <div className={`h-14 border-b border-border ${colorClass}`}></div>
+      <div className="p-3 font-mono text-xs text-body">{colorClass}</div>
     </div>
   );
 }
@@ -63,10 +63,10 @@ function ColorSwatch({ colorClass }: { colorClass: string }) {
 function ColorSection({ title, colors }: { title: string; colors: string[] }) {
   return (
     <div className="mb-8">
-      <h2 className="text-xl font-semibold mb-4 pb-2 border-b border-neutral-200">
+      <h2 className="mb-4 border-b border-border pb-2 text-xl font-semibold text-heading">
         {title}
       </h2>
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
         {colors.map((color) => (
           <ColorSwatch key={color} colorClass={color} />
         ))}

--- a/rust/gui-client/src-frontend/components/DiagnosticsPage.tsx
+++ b/rust/gui-client/src-frontend/components/DiagnosticsPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { ShareIcon, TrashIcon } from "@heroicons/react/16/solid";
-import { Button } from "flowbite-react";
+import Button from "./Button";
+import RemixIcon from "./RemixIcon";
 import { FileCount } from "../generated/bindings";
 
 interface DiagnosticsPageProps {
@@ -20,21 +20,25 @@ export default function Diagnostics({
   const megabytes = Math.round(Number(bytes / 100000)) / 10;
 
   return (
-    <div className="container mx-auto p-4">
-      <div className="p-4 rounded-lg">
-        <div className="mt-8 flex justify-center">
-          <p className="mr-1">Log directory size:</p>
-          <p>{`${files} files, ${megabytes} MB`}</p>
+    <div className="page">
+      <div className="panel max-w-xl p-4">
+        <div className="mt-8 flex justify-center text-sm text-body">
+          <div className="flex items-center gap-2.5">
+            <RemixIcon className="h-4 w-4 text-subtle" name="database" />
+            <p className="mr-1">Log directory size:</p>
+            <p className="font-mono tabular-nums">
+              {`${files} files, ${megabytes} MB`}
+            </p>
+          </div>
         </div>
 
         <div className="mt-8 flex justify-center gap-4">
-          <Button onClick={exportLogs} color="alternative">
-            <ShareIcon className="mr-2 h-5 w-5" />
+          <Button onClick={exportLogs}>
+            <RemixIcon className="h-3.5 w-3.5" name="share-forward" />
             Export Logs
           </Button>
-
-          <Button onClick={clearLogs} color="alternative">
-            <TrashIcon className="mr-2 h-5 w-5" />
+          <Button onClick={clearLogs}>
+            <RemixIcon className="h-3.5 w-3.5" name="delete-bin" />
             Clear Logs
           </Button>
         </div>

--- a/rust/gui-client/src-frontend/components/GeneralSettingsPage.tsx
+++ b/rust/gui-client/src-frontend/components/GeneralSettingsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useId, useState } from "react";
-import { Button, Label, ToggleSwitch } from "flowbite-react";
+import Button from "./Button";
 import { ManagedToggleSwitch, ManagedTextInput } from "./ManagedInput";
 import { GeneralSettingsViewModel } from "../generated/bindings";
 
@@ -44,18 +44,18 @@ export default function GeneralSettingsPage({
   const startOnLoginInputId = useId();
   const connectOnStartInputId = useId();
   return (
-    <div className="container p-4">
+    <div className="page">
       <form
         onSubmit={(e) => {
           e.preventDefault();
           saveSettings(localSettings);
         }}
-        className="max-w flex flex-col gap-2"
+        className="max-w-xl space-y-5"
       >
         <div>
-          <Label className="text-neutral-600" htmlFor={accountSlugInputId}>
+          <label className="form-label" htmlFor={accountSlugInputId}>
             Account slug
-          </Label>
+          </label>
           <ManagedTextInput
             name="account_slug"
             id={accountSlugInputId}
@@ -70,14 +70,12 @@ export default function GeneralSettingsPage({
           />
         </div>
 
-        <div className="flex flex-col max-w-1/2 gap-4 mt-4">
-          <div className="flex justify-between items-center">
-            <Label className="text-neutral-600" htmlFor={startMinimizedInputId}>
-              Start minimized
-            </Label>
-            <ToggleSwitch
+        <div className="panel divide-y divide-border">
+          <SettingRow inputId={startMinimizedInputId} label="Start minimized">
+            <ManagedToggleSwitch
               name="start_minimized"
               id={startMinimizedInputId}
+              managed={false}
               checked={localSettings.start_minimized}
               onChange={(e) =>
                 setLocalSettings({
@@ -86,15 +84,13 @@ export default function GeneralSettingsPage({
                 })
               }
             />
-          </div>
+          </SettingRow>
 
-          <div className="flex justify-between items-center">
-            <Label className="text-neutral-600" htmlFor={startOnLoginInputId}>
-              Start on login
-            </Label>
-            <ToggleSwitch
+          <SettingRow inputId={startOnLoginInputId} label="Start on login">
+            <ManagedToggleSwitch
               name="start_on_login"
               id={startOnLoginInputId}
+              managed={false}
               checked={localSettings.start_on_login}
               onChange={(e) =>
                 setLocalSettings({
@@ -103,12 +99,9 @@ export default function GeneralSettingsPage({
                 })
               }
             />
-          </div>
+          </SettingRow>
 
-          <div className="flex justify-between items-center">
-            <Label className="text-neutral-600" htmlFor={connectOnStartInputId}>
-              Connect on start
-            </Label>
+          <SettingRow inputId={connectOnStartInputId} label="Connect on start">
             <ManagedToggleSwitch
               name="connect-on-start"
               id={connectOnStartInputId}
@@ -121,16 +114,37 @@ export default function GeneralSettingsPage({
                 })
               }
             />
-          </div>
+          </SettingRow>
         </div>
 
-        <div className="flex justify-end gap-4 mt-4">
-          <Button type="reset" onClick={resetSettings} color="alternative">
+        <div className="flex justify-end gap-2 border-t border-border pt-4">
+          <Button type="reset" onClick={resetSettings}>
             Reset to Defaults
           </Button>
-          <Button type="submit">Apply</Button>
+          <Button type="submit" variant="primary">
+            Apply
+          </Button>
         </div>
       </form>
+    </div>
+  );
+}
+
+interface SettingRowProps extends React.PropsWithChildren {
+  inputId: string;
+  label: string;
+}
+
+function SettingRow({ children, inputId, label }: SettingRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-6 px-4 py-3">
+      <label
+        className="block text-sm font-medium text-heading"
+        htmlFor={inputId}
+      >
+        {label}
+      </label>
+      {children}
     </div>
   );
 }

--- a/rust/gui-client/src-frontend/components/ManagedInput.tsx
+++ b/rust/gui-client/src-frontend/components/ManagedInput.tsx
@@ -1,51 +1,82 @@
-import {
-  TextInputProps,
-  Tooltip,
-  TextInput,
-  ToggleSwitch,
-  ToggleSwitchProps,
-} from "flowbite-react";
-import React, { PropsWithChildren } from "react";
+import React, { InputHTMLAttributes, PropsWithChildren } from "react";
 
-export function ManagedTextInput(props: TextInputProps & { managed: boolean }) {
-  const { managed, ...inputProps } = props;
+type ManagedTextInputProps = InputHTMLAttributes<HTMLInputElement> & {
+  managed: boolean;
+};
+
+export function ManagedTextInput(props: ManagedTextInputProps) {
+  const { managed, disabled, className = "", ...inputProps } = props;
+
+  const input = (
+    <input
+      aria-disabled={managed || undefined}
+      className={`form-input ${className}`}
+      disabled={managed || disabled}
+      {...inputProps}
+    />
+  );
 
   if (managed) {
-    return (
-      <ManagedTooltip>
-        <TextInput {...inputProps} disabled={true} />
-      </ManagedTooltip>
-    );
+    return <ManagedTooltip fullWidth>{input}</ManagedTooltip>;
   } else {
-    return <TextInput {...inputProps} />;
+    return input;
   }
 }
 
-export function ManagedToggleSwitch(
-  props: ToggleSwitchProps & { managed: boolean }
+interface ManagedToggleSwitchProps {
+  checked: boolean;
+  id?: string;
+  managed: boolean;
+  name?: string;
+  onChange: (checked: boolean) => void;
+}
+
+export function ManagedToggleSwitch(props: ManagedToggleSwitchProps) {
+  const { checked, id, managed, name, onChange } = props;
+
+  const toggle = (
+    <button
+      aria-checked={checked}
+      aria-disabled={managed || undefined}
+      className={`toggle ${
+        checked ? "border-brand bg-brand" : "border-border-emphasis bg-raised"
+      } ${managed ? "cursor-not-allowed opacity-40" : ""}`}
+      disabled={managed}
+      id={id}
+      name={name}
+      onClick={() => onChange(!checked)}
+      role="switch"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        className={`toggle-thumb ${checked ? "translate-x-2.5" : ""}`}
+      />
+    </button>
+  );
+
+  if (managed) {
+    return <ManagedTooltip>{toggle}</ManagedTooltip>;
+  } else {
+    return toggle;
+  }
+}
+
+function ManagedTooltip(
+  props: PropsWithChildren<{
+    fullWidth?: boolean;
+  }>
 ) {
-  const { managed, ...toggleSwitchProps } = props;
-
-  if (managed) {
-    return (
-      <ManagedTooltip>
-        <ToggleSwitch {...toggleSwitchProps} disabled={true} />
-      </ManagedTooltip>
-    );
-  } else {
-    return <ToggleSwitch {...toggleSwitchProps} />;
-  }
-}
-
-function ManagedTooltip(props: PropsWithChildren) {
-  const { children } = props;
+  const { children, fullWidth = false } = props;
 
   return (
-    <Tooltip
-      content="This setting is managed by your organisation."
-      clearTheme={{ target: true }}
+    <span
+      className={`group relative ${fullWidth ? "flex w-full" : "inline-flex"}`}
     >
       {children}
-    </Tooltip>
+      <span className="managed-tooltip" role="tooltip">
+        This setting is managed by your organisation.
+      </span>
+    </span>
   );
 }

--- a/rust/gui-client/src-frontend/components/OverviewPage.tsx
+++ b/rust/gui-client/src-frontend/components/OverviewPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import logo from "../logo.png";
-import { Button, Spinner } from "flowbite-react";
+import Button from "./Button";
 import { SessionViewModel } from "../generated/bindings";
 
 interface OverviewPageProps {
@@ -11,12 +11,14 @@ interface OverviewPageProps {
 
 export default function Overview(props: OverviewPageProps) {
   return (
-    <div className="flex flex-col items-center justify-center gap-4">
-      <img src={logo} alt="Firezone Logo" className="w-40 h-40" />
-
-      <h1 className="text-6xl font-bold">Firezone</h1>
-
-      <Session {...props} />
+    <div className="flex min-h-full items-center justify-center bg-page p-6">
+      <div className="flex w-full max-w-lg flex-col items-center gap-4 text-center">
+        <img alt="Firezone Logo" className="h-20 w-20" src={logo} />
+        <h1 className="text-xl font-semibold tracking-tight text-heading">
+          Firezone
+        </h1>
+        <Session {...props} />
+      </div>
     </div>
   );
 }
@@ -53,19 +55,19 @@ interface SignedOutProps {
 
 function SignedOut({ signIn }: SignedOutProps) {
   return (
-    <div>
-      <div className="flex flex-col items-center gap-4">
-        <p className="text-center">
-          You can sign in by clicking the Firezone icon in the taskbar or by
-          clicking &quot;Sign in&quot; below.
-        </p>
-        <Button onClick={signIn}>Sign in</Button>
-        <p className="text-xs text-center">
-          Firezone will continue running after this window is closed.
-          <br />
-          It is always available from the taskbar.
-        </p>
-      </div>
+    <div className="flex flex-col items-center gap-4">
+      <p className="text-sm text-body">
+        You can sign in by clicking the Firezone icon in the taskbar or by
+        clicking &quot;Sign in&quot; below.
+      </p>
+      <Button onClick={signIn} variant="primary">
+        Sign in
+      </Button>
+      <p className="text-xs text-subtle">
+        Firezone will continue running after this window is closed.
+        <br />
+        It is always available from the taskbar.
+      </p>
     </div>
   );
 }
@@ -78,36 +80,38 @@ interface SignedInProps {
 
 function SignedIn({ actorName, accountSlug, signOut }: SignedInProps) {
   return (
-    <div>
-      <div className="flex flex-col items-center gap-4">
-        <p className="text-center">
-          You are currently signed into&nbsp;
-          <span className="font-bold">{accountSlug}</span>
-          &nbsp;as&nbsp;
-          <span className="font-bold">{actorName}</span>
-          .<br />
-          Click the Firezone icon in the taskbar to see the list of Resources.
-        </p>
-        <Button onClick={signOut}>Sign out</Button>
-        <p className="text-xs text-center">
-          Firezone will continue running in the taskbar after this window is
-          closed.
-        </p>
-      </div>
+    <div className="flex flex-col items-center gap-4">
+      <p className="text-sm text-body">
+        You are currently signed into&nbsp;
+        <span className="font-bold text-heading">{accountSlug}</span>
+        &nbsp;as&nbsp;
+        <span className="font-bold text-heading">{actorName}</span>
+        .<br />
+        Click the Firezone icon in the taskbar to see the list of Resources.
+      </p>
+      <Button onClick={signOut} variant="primary">
+        Sign out
+      </Button>
+      <p className="text-xs text-subtle">
+        Firezone will continue running in the taskbar after this window is
+        closed.
+      </p>
     </div>
   );
 }
 
 function Loading() {
   return (
-    <div>
-      <div className="flex flex-col items-center gap-4">
-        <Spinner />
-        <p className="text-xs text-center">
-          Firezone will continue running in the taskbar after this window is
-          closed.
-        </p>
-      </div>
+    <div className="flex flex-col items-center gap-4">
+      <span
+        aria-label="Loading"
+        className="h-5 w-5 animate-spin rounded-full border-2 border-brand-muted border-t-brand"
+        role="status"
+      />
+      <p className="text-xs text-subtle">
+        Firezone will continue running in the taskbar after this window is
+        closed.
+      </p>
     </div>
   );
 }

--- a/rust/gui-client/src-frontend/components/ReactRouterSidebarItem.tsx
+++ b/rust/gui-client/src-frontend/components/ReactRouterSidebarItem.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import type { FC, ComponentProps } from "react";
 import { useNavigate, useLocation } from "react-router";
-import { SidebarItem } from "flowbite-react";
+import RemixIcon, { RemixIconName } from "./RemixIcon";
 
 export default function ReactRouterSidebarItem({
   href,
@@ -9,26 +8,29 @@ export default function ReactRouterSidebarItem({
   children,
 }: {
   href: string;
-  icon: FC<ComponentProps<"svg">>;
+  icon: RemixIconName;
   children: React.ReactNode;
 }) {
   const location = useLocation();
   const navigate = useNavigate();
 
   // Custom navigation handler for SidebarItems to avoid full page reloads
-  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();
     navigate(href);
   };
 
   return (
-    <SidebarItem
-      active={location.pathname.startsWith(href)}
+    <a
+      aria-current={location.pathname.startsWith(href) ? "page" : undefined}
+      className={`nav-item ${
+        location.pathname.startsWith(href) ? "nav-item-active" : ""
+      }`}
       href={href}
-      icon={icon}
       onClick={handleClick}
     >
-      {children}
-    </SidebarItem>
+      <RemixIcon className="h-4 w-4" name={icon} />
+      <span>{children}</span>
+    </a>
   );
 }

--- a/rust/gui-client/src-frontend/components/RemixIcon.tsx
+++ b/rust/gui-client/src-frontend/components/RemixIcon.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import arrowDown from "remixicon/icons/Arrows/arrow-down-s-line.svg";
+import home from "remixicon/icons/Buildings/home-line.svg";
+import palette from "remixicon/icons/Design/palette-line.svg";
+import database from "remixicon/icons/Device/database-2-line.svg";
+import equalizer from "remixicon/icons/Media/equalizer-line.svg";
+import alert from "remixicon/icons/System/alert-line.svg";
+import close from "remixicon/icons/System/close-line.svg";
+import deleteBin from "remixicon/icons/System/delete-bin-line.svg";
+import information from "remixicon/icons/System/information-line.svg";
+import settings from "remixicon/icons/System/settings-3-line.svg";
+import shareForward from "remixicon/icons/System/share-forward-line.svg";
+
+const icons = {
+  alert,
+  "arrow-down": arrowDown,
+  close,
+  database,
+  "delete-bin": deleteBin,
+  equalizer,
+  home,
+  information,
+  palette,
+  settings,
+  "share-forward": shareForward,
+} as const;
+
+export type RemixIconName = keyof typeof icons;
+
+interface RemixIconProps {
+  className?: string;
+  name: RemixIconName;
+}
+
+export default function RemixIcon({ className = "", name }: RemixIconProps) {
+  const source = `url("${icons[name]}")`;
+
+  return (
+    <span
+      aria-hidden="true"
+      className={`inline-block shrink-0 bg-current align-middle ${className}`}
+      style={{
+        maskImage: source,
+        maskPosition: "center",
+        maskRepeat: "no-repeat",
+        maskSize: "contain",
+        WebkitMaskImage: source,
+        WebkitMaskPosition: "center",
+        WebkitMaskRepeat: "no-repeat",
+        WebkitMaskSize: "contain",
+      }}
+    />
+  );
+}

--- a/rust/gui-client/src-frontend/components/Titlebar.tsx
+++ b/rust/gui-client/src-frontend/components/Titlebar.tsx
@@ -1,7 +1,6 @@
-import { XMarkIcon } from "@heroicons/react/16/solid";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { Navbar } from "flowbite-react";
 import React from "react";
+import RemixIcon from "./RemixIcon";
 
 export interface TitlebarProps {
   title?: string;
@@ -15,31 +14,21 @@ export default function Titlebar({ title }: TitlebarProps) {
   };
 
   return (
-    <div onMouseDown={handleMouseDown} className="select-none">
-      <Navbar
-        clearTheme={{
-          root: {
-            base: true,
-          },
-        }}
-        theme={{
-          root: {
-            base: "py-1 px-2 bg-gray-100 flex flex-row space-between",
-            inner: {
-              base: "max-w-full",
-            },
-          },
-        }}
+    <header
+      onMouseDown={handleMouseDown}
+      className="flex h-14 shrink-0 select-none items-center justify-between border-b border-border bg-surface px-4"
+    >
+      <h1 className="truncate text-sm font-semibold text-heading">{title}</h1>
+      <button
+        className="icon-button -mr-1"
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={() => getCurrentWindow().close()}
+        aria-label="Close window"
+        title="Close"
+        type="button"
       >
-        <h2 className="text-xl font-semibold">{title}</h2>
-        <div
-          className="justify-self-end"
-          onMouseDown={(e) => e.stopPropagation()}
-          onClick={() => getCurrentWindow().close()}
-        >
-          <XMarkIcon className="h-6 p-1 rounded-full hover:text-gray-700 hover:bg-gray-200" />
-        </div>
-      </Navbar>
-    </div>
+        <RemixIcon className="h-4 w-4" name="close" />
+      </button>
+    </header>
   );
 }

--- a/rust/gui-client/src-frontend/custom.d.ts
+++ b/rust/gui-client/src-frontend/custom.d.ts
@@ -2,3 +2,8 @@ declare module "*.png" {
   const value: string;
   export default value;
 }
+
+declare module "*.svg" {
+  const value: string;
+  export default value;
+}

--- a/rust/gui-client/src-frontend/main.css
+++ b/rust/gui-client/src-frontend/main.css
@@ -1,14 +1,62 @@
 @import "tailwindcss";
-@import "@fontsource-variable/source-sans-3";
-
 @import "flowbite-react/plugin/tailwindcss";
-@plugin 'flowbite/plugin';
-
 @source "../.flowbite-react/class-list.json";
-
-@custom-variant dark (&:where(.dark, .dark *));
+@import "@fontsource-variable/roboto";
+@import "@fontsource-variable/roboto-mono";
 
 @theme {
+  /* Brand */
+  --color-brand: var(--brand);
+  --color-brand-dark: var(--brand-hover);
+  --color-brand-light: var(--brand-secondary);
+  --color-brand-subtle: var(--brand-tertiary);
+  --color-brand-muted: var(--brand-muted);
+
+  /* Accent */
+  --color-accent: var(--accent);
+  --color-accent-dark: var(--accent-hover);
+  --color-accent-light: var(--accent-secondary);
+  --color-accent-subtle: var(--accent-tertiary);
+  --color-accent-muted: var(--accent-muted);
+
+  /* Text */
+  --color-heading: var(--text-primary);
+  --color-body: var(--text-secondary);
+  --color-subtle: var(--text-tertiary);
+  --color-muted: var(--text-muted);
+  --color-inverse: var(--text-inverse);
+
+  /* Background */
+  --color-page: var(--canvas);
+  --color-surface: var(--surface);
+  --color-elevated: var(--surface-overlay);
+  --color-raised: var(--surface-raised);
+
+  /* Border */
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-border-emphasis: var(--border-emphasis);
+  --color-border-focus: var(--control-focus);
+
+  /* Status */
+  --color-success: var(--success);
+  --color-success-light: var(--success-light);
+  --color-warning: var(--warning);
+  --color-warning-light: var(--warning-light);
+  --color-error: var(--error);
+  --color-error-light: var(--error-light);
+  --color-info: var(--info);
+  --color-info-light: var(--info-light);
+  --color-danger: var(--danger);
+  --color-danger-light: var(--danger-light);
+  --color-neutral-status: var(--neutral-status);
+  --color-neutral-status-light: var(--neutral-status-light);
+
+  /* Controls */
+  --color-input: var(--control-bg);
+  --color-input-border: var(--control-border);
+
+  /* Legacy palette utilities used by the development color palette. */
   --color-primary-50: #fff9f5;
   --color-primary-100: #fff1e5;
   --color-primary-200: #ffddc2;
@@ -33,34 +81,310 @@
   --color-accent-800: #28005c;
   --color-accent-900: #160033;
 
-  --color-neutral-50: #fcfcfc;
-  --color-neutral-100: #f8f7f7;
-  --color-neutral-200: #ebebea;
-  --color-neutral-300: #dfdedd;
-  --color-neutral-400: #c7c4c2;
-  --color-neutral-500: #a7a3a0;
-  --color-neutral-600: #90867f;
-  --color-neutral-700: #766a60;
-  --color-neutral-800: #4c3e33;
-  --color-neutral-900: #1b140e;
+  --color-neutral-50: #f6f6f6;
+  --color-neutral-100: #e7e7e7;
+  --color-neutral-200: #d1d1d1;
+  --color-neutral-300: #b0b0b0;
+  --color-neutral-400: #888888;
+  --color-neutral-500: #6d6d6d;
+  --color-neutral-600: #575757;
+  --color-neutral-700: #4f4f4f;
+  --color-neutral-800: #454545;
+  --color-neutral-900: #3d3d3d;
 
-  --default-font-family: "Source Sans 3 Variable", sans-serif;
+  --font-sans:
+    "Roboto Variable", "Roboto", ui-sans-serif, system-ui, -apple-system,
+    "Segoe UI", sans-serif;
+  --font-mono:
+    "Roboto Mono Variable", "Roboto Mono", ui-monospace, SFMono-Regular, Menlo,
+    Monaco, Consolas, monospace;
+  --default-font-family: var(--font-sans);
+  --default-mono-font-family: var(--font-mono);
 }
 
-/*
-  The default border color has changed to `currentColor` in Tailwind CSS v4,
-  so we've added these compatibility styles to make sure everything still
-  looks the same as it did with Tailwind CSS v3.
+:root {
+  color-scheme: light dark;
 
-  If we ever want to remove these styles, we need to add an explicit border
-  color utility to any element that depends on these defaults.
-*/
+  /* Brand — identical to the portal */
+  --brand: oklch(71.74% 0.192 48.75);
+  --brand-secondary: oklch(77.69% 0.154 56.87);
+  --brand-tertiary: oklch(96.59% 0.022 63.21);
+  --brand-muted: oklch(98.56% 0.0084 56.32);
+  --brand-hover: oklch(58.23% 0.1574 48.48);
+
+  /* Accent */
+  --accent: oklch(48.06% 0.2976 276);
+  --accent-secondary: oklch(81.3% 0.295 276);
+  --accent-tertiary: oklch(91.9% 0.193 276);
+  --accent-muted: oklch(97.9% 0.193 276);
+  --accent-hover: oklch(30.98% 0.1931 276);
+
+  /* Surfaces */
+  --canvas: oklch(95.73% 0.0074 260.73);
+  --surface: oklch(100% 0 0);
+  --surface-raised: oklch(98.14% 0.0045 258.32);
+  --surface-overlay: oklch(100% 0 0);
+
+  /* Borders */
+  --border: oklch(20.77% 0.0398 265.75 / 8%);
+  --border-strong: oklch(20.77% 0.0398 265.75 / 16%);
+  --border-emphasis: oklch(20.77% 0.0398 265.75 / 28%);
+
+  /* Text */
+  --text-primary: oklch(20.77% 0.0398 265.75);
+  --text-secondary: oklch(44.55% 0.0374 257.28);
+  --text-tertiary: oklch(59.6% 0.0404 252.26);
+  --text-muted: oklch(75.17% 0.019 245.46);
+  --text-inverse: oklch(98.42% 0.0034 247.86);
+
+  /* Status */
+  --success: oklch(62.71% 0.1699 149.21);
+  --success-light: oklch(62.71% 0.1699 149.21 / 10%);
+  --info: oklch(54.61% 0.2152 262.88);
+  --info-light: oklch(54.61% 0.2152 262.88 / 8%);
+  --warning: oklch(66.58% 0.1574 58.32);
+  --warning-light: oklch(66.58% 0.1574 58.32 / 10%);
+  --neutral-status: oklch(55.44% 0.0407 257.42);
+  --neutral-status-light: oklch(55.44% 0.0407 257.42 / 12%);
+  --danger: oklch(57.71% 0.2152 27.33);
+  --danger-light: oklch(57.71% 0.2152 27.33 / 10%);
+  --error: oklch(57.71% 0.2152 27.33);
+  --error-light: oklch(93.56% 0.0309 17.72);
+
+  /* Controls */
+  --control-bg: oklch(100% 0 0);
+  --control-border: oklch(20.77% 0.0398 265.75 / 16%);
+  --control-focus: oklch(71.74% 0.192 48.75);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* Surfaces */
+    --canvas: oklch(15.42% 0.0185 263.23);
+    --surface: oklch(20.01% 0.0284 262.33);
+    --surface-raised: oklch(24.42% 0.037 263.53);
+    --surface-overlay: oklch(28.45% 0.0423 261.22);
+
+    /* Borders */
+    --border: oklch(96.83% 0.0069 247.9 / 7%);
+    --border-strong: oklch(96.83% 0.0069 247.9 / 12%);
+    --border-emphasis: oklch(96.83% 0.0069 247.9 / 22%);
+
+    /* Text */
+    --text-primary: oklch(96.83% 0.0069 247.9);
+    --text-secondary: oklch(71.07% 0.0351 256.79);
+    --text-tertiary: oklch(49.17% 0.045 251.05);
+    --text-muted: oklch(36.07% 0.0404 250.33);
+    --text-inverse: oklch(20.77% 0.0398 265.75);
+
+    /* Brand */
+    --brand: oklch(77.69% 0.154 56.87);
+    --brand-secondary: oklch(71.74% 0.192 48.75 / 60%);
+    --brand-tertiary: oklch(71.74% 0.192 48.75 / 30%);
+    --brand-muted: oklch(71.74% 0.192 48.75 / 12%);
+    --brand-hover: oklch(82.64% 0.1259 64.15);
+
+    /* Status */
+    --success-light: oklch(80.03% 0.1821 151.71 / 10%);
+    --info: oklch(71.37% 0.1434 254.62);
+    --info-light: oklch(71.37% 0.1434 254.62 / 10%);
+    --warning-light: oklch(83.69% 0.1644 84.43 / 10%);
+    --neutral-status-light: oklch(55.44% 0.0407 257.42 / 16%);
+    --danger-light: oklch(57.71% 0.2152 27.33 / 12%);
+    --error: oklch(71.06% 0.1661 22.22);
+    --error-light: oklch(71.06% 0.1661 22.22 / 10%);
+
+    /* Controls */
+    --control-bg: oklch(24.42% 0.037 263.53);
+    --control-border: oklch(96.83% 0.0069 247.9 / 12%);
+    --control-focus: oklch(77.69% 0.154 56.87);
+  }
+}
+
 @layer base {
   *,
-  ::after,
   ::before,
-  ::backdrop,
-  ::file-selector-button {
-    border-color: var(--color-gray-200, currentColor);
+  ::after {
+    box-sizing: border-box;
+  }
+
+  html {
+    background: transparent;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-variant-ligatures: common-ligatures contextual;
+    text-rendering: optimizeLegibility;
+  }
+
+  html,
+  body,
+  #root {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+  }
+
+  body {
+    overflow: hidden;
+    background: transparent;
+    color: var(--text-secondary);
+    font-family: var(--font-sans);
+  }
+
+  button,
+  input {
+    font: inherit;
+  }
+
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]) {
+    cursor: pointer;
+  }
+
+  code,
+  kbd,
+  samp,
+  pre,
+  .font-mono {
+    font-family: var(--font-mono);
+    font-variant-ligatures: common-ligatures;
+  }
+
+  ::selection {
+    color: var(--text-primary);
+    background: var(--brand-tertiary);
+  }
+}
+
+@layer components {
+  .app-shell {
+    @apply flex h-screen flex-col overflow-hidden rounded-lg border border-border-strong bg-surface text-sm text-body;
+  }
+
+  .page {
+    @apply min-h-full bg-page p-5;
+  }
+
+  .page-header {
+    @apply mb-5;
+  }
+
+  .page-title {
+    @apply text-base font-semibold tracking-tight text-heading;
+  }
+
+  .page-description {
+    @apply mt-1 text-sm text-body;
+  }
+
+  .panel {
+    @apply rounded border border-border bg-surface;
+  }
+
+  .form-label {
+    @apply mb-1.5 block text-xs font-semibold text-body;
+  }
+
+  .form-input {
+    @apply block h-9 w-full rounded border border-input-border bg-input px-3 py-2 text-sm text-heading outline-none transition-colors;
+  }
+
+  .form-input::placeholder {
+    color: var(--text-muted);
+  }
+
+  .form-input:hover:not(:disabled) {
+    border-color: var(--border-emphasis);
+  }
+
+  .form-input:focus {
+    border-color: var(--control-focus);
+    box-shadow: 0 0 0 1px
+      color-mix(in oklch, var(--control-focus) 30%, transparent);
+  }
+
+  .form-input:disabled {
+    @apply cursor-not-allowed opacity-40;
+  }
+
+  .button {
+    @apply inline-flex items-center justify-center gap-1.5 rounded border px-3 py-2 text-sm font-medium leading-5 transition-colors;
+  }
+
+  .button:focus-visible,
+  .icon-button:focus-visible,
+  .nav-item:focus-visible,
+  .toggle:focus-visible {
+    outline: 2px solid var(--control-focus);
+    outline-offset: 2px;
+  }
+
+  .button-primary {
+    @apply border-brand bg-brand text-white;
+  }
+
+  .button-primary:hover {
+    @apply border-brand-dark bg-brand-dark;
+  }
+
+  .button-secondary {
+    @apply border-border-strong bg-surface text-body;
+  }
+
+  .button-secondary:hover {
+    @apply bg-raised text-heading;
+  }
+
+  .button-danger {
+    @apply border-danger/40 bg-surface text-danger;
+  }
+
+  .button-danger:hover {
+    @apply bg-danger-light;
+  }
+
+  .button:disabled {
+    @apply cursor-not-allowed border-border bg-transparent text-muted;
+  }
+
+  .icon-button {
+    @apply flex h-8 w-8 items-center justify-center rounded text-body transition-colors;
+  }
+
+  .icon-button:hover {
+    @apply bg-raised text-heading;
+  }
+
+  .nav-item {
+    @apply flex items-center gap-2.5 rounded px-2 py-1.5 text-sm text-body transition-colors;
+  }
+
+  .nav-item:hover {
+    @apply bg-raised text-heading;
+  }
+
+  .nav-item-active {
+    @apply bg-brand-muted font-medium text-brand;
+  }
+
+  .nav-item-active:hover {
+    @apply bg-brand-muted text-brand;
+  }
+
+  .toggle {
+    @apply relative inline-flex h-4 w-7 shrink-0 items-center rounded-full border px-0.5 transition-colors;
+  }
+
+  .toggle-thumb {
+    @apply h-3 w-3 rounded-full bg-white shadow-sm transition-transform;
+  }
+
+  .managed-tooltip {
+    @apply pointer-events-none absolute right-0 top-full z-20 mt-2 w-max max-w-56 translate-y-1 rounded border border-border bg-elevated px-2.5 py-1.5 text-xs text-body opacity-0 shadow-sm transition-all;
+  }
+
+  .group:hover > .managed-tooltip,
+  .group:focus-within > .managed-tooltip {
+    @apply translate-y-0 opacity-100;
   }
 }

--- a/scripts/nix/packages/firezone-gui-client/frontend.nix
+++ b/scripts/nix/packages/firezone-gui-client/frontend.nix
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # when it drifts (so CI/CD never fails on a stale pin) and opens a
     # firezone-bot PR to commit the new value; run
     # scripts/nix/update-pnpm-hash.sh to refresh it by hand.
-    hash = "sha256-bD0Ea3OTb1nmOQnCbyDa4u51hyKu9IdWET4uXtcy+v8=";
+    hash = "sha256-749YoSsjcS8cq+oaPZ6Ezaqs8h2zkNeLecwouYpHX3g=";
   };
 
   # nixpkgs packages pnpm by major version only, not the exact patch in
@@ -41,7 +41,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   # vite.config.ts falls back to `git rev-parse` when unset, which is
   # unavailable in the sandbox.
-  env.GITHUB_SHA = finalAttrs.version;
+  env = {
+    # pnpm must know that Nix builds are non-interactive before it refreshes
+    # node_modules from the fixed-output store.
+    CI = "true";
+    GITHUB_SHA = finalAttrs.version;
+  };
 
   buildPhase = ''
     runHook preBuild


### PR DESCRIPTION
## Summary

- restyle the Tauri GUI client to match the portal’s fonts, colors, spacing, iconography, and ligatures
- replace UI elements with theme-specific primitives while preserving the existing copy and behavior
- update the frontend dependency hash and make pnpm non-interactive in the Nix build

## Stack

- Styling only. Refactoring and legacy frontend-tool cleanup moved to #14403.

---

Fixes #14380