### PR TITLE
fix(portal): scope joined rows by account

### DIFF
--- a/elixir/.credo.exs
+++ b/elixir/.credo.exs
@@ -47,7 +47,8 @@
         ".credo/check/warning/action_fallback_usage.ex",
         ".credo/check/warning/missing_changeset_function.ex",
         ".credo/check/warning/unsafe_template_html.ex",
-        ".credo/check/warning/missing_handle_info_catch_all.ex"
+        ".credo/check/warning/missing_handle_info_catch_all.ex",
+        ".credo/check/warning/missing_account_id_in_join.ex"
       ],
       #
       # If you want to enforce a style guide and need a more traditional linting
@@ -169,7 +170,8 @@
           {Credo.Check.Warning.MissingDatabaseAlias, []},
           {Credo.Check.Warning.CrossModuleDatabaseCall, []},
           {Credo.Check.Warning.UnsafeTemplateHTML, []},
-          {Credo.Check.Warning.MissingHandleInfoCatchAll, []}
+          {Credo.Check.Warning.MissingHandleInfoCatchAll, []},
+          {Credo.Check.Warning.MissingAccountIdInJoin, []}
         ],
         disabled: [
           {Credo.Check.Readability.AliasOrder, []},

--- a/elixir/.credo/README.md
+++ b/elixir/.credo/README.md
@@ -55,6 +55,12 @@ Ensures proper Portal.Safe aliasing in modules that need it.
 
 Prevents cross-module database operations to maintain proper boundaries.
 
+### Warning.MissingAccountIdInJoin
+
+Requires Ecto join conditions to reference `account_id`, because `Portal.Safe`
+scopes only the root query binding. Joins to `Portal.Account` and
+`assoc(..., :account)` are exempt.
+
 ## Running Checks
 
 ```bash

--- a/elixir/.credo/check/warning/missing_account_id_in_join.ex
+++ b/elixir/.credo/check/warning/missing_account_id_in_join.ex
@@ -1,0 +1,157 @@
+defmodule Credo.Check.Warning.MissingAccountIdInJoin do
+  use Credo.Check,
+    base_priority: :high,
+    category: :warning,
+    explanations: [
+      check: """
+      Ecto join conditions should reference `account_id`.
+
+      Portal.Safe scopes only the root query binding. It does not add account
+      predicates to joined tables, so tenant-owned rows must be joined with an
+      explicit account condition.
+
+      Joins to Portal.Account and `assoc(..., :account)` are exempt because the
+      accounts table is not tenant-owned. Intentional joins that do not need an
+      account condition should use a targeted Credo disable comment.
+      """,
+      params: []
+    ]
+
+  @join_options [
+    :join,
+    :inner_join,
+    :cross_join,
+    :cross_lateral_join,
+    :left_join,
+    :right_join,
+    :full_join,
+    :inner_lateral_join,
+    :left_lateral_join
+  ]
+
+  @doc false
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    source_file
+    |> Credo.Code.prewalk(&traverse(&1, &2, issue_meta), [])
+    |> Enum.reverse()
+  end
+
+  defp traverse({:from, _meta, args} = ast, issues, issue_meta) when is_list(args) do
+    {ast, issues_for_from(args, issues, issue_meta)}
+  end
+
+  defp traverse({:join, meta, args} = ast, issues, issue_meta) when is_list(args) do
+    {ast, issues_for_join_call(args, meta[:line], issues, issue_meta)}
+  end
+
+  defp traverse(
+         {{:., _dot_meta, [_module, function]}, meta, args} = ast,
+         issues,
+         issue_meta
+       )
+       when function in [:from, :join] and is_list(args) do
+    issues =
+      case function do
+        :from -> issues_for_from(args, issues, issue_meta)
+        :join -> issues_for_join_call(args, meta[:line], issues, issue_meta)
+      end
+
+    {ast, issues}
+  end
+
+  defp traverse(ast, issues, _issue_meta), do: {ast, issues}
+
+  defp issues_for_from(args, issues, issue_meta) do
+    case Enum.find(Enum.reverse(args), &keyword_list?/1) do
+      nil ->
+        issues
+
+      options ->
+        options
+        |> Enum.with_index()
+        |> Enum.reduce(issues, fn
+          {{join_type, source}, index}, issues when join_type in @join_options ->
+            on =
+              options
+              |> Enum.drop(index + 1)
+              |> Enum.take_while(fn {option, _value} -> option not in @join_options end)
+              |> Keyword.get(:on)
+
+            maybe_add_issue(
+              join_type,
+              source,
+              on,
+              ast_line(source),
+              issues,
+              issue_meta
+            )
+
+          _option, issues ->
+            issues
+        end)
+    end
+  end
+
+  defp issues_for_join_call(args, line_no, issues, issue_meta) do
+    case Enum.split_while(args, &(not join_source?(&1))) do
+      {_before_source, [source | after_source]} ->
+        options = Enum.find(after_source, &keyword_list?/1) || []
+        on = Keyword.get(options, :on)
+        maybe_add_issue(:join, source, on, line_no || ast_line(source), issues, issue_meta)
+
+      {_before_source, []} ->
+        issues
+    end
+  end
+
+  defp maybe_add_issue(join_type, source, on, line_no, issues, issue_meta) do
+    if account_source?(source) or contains_account_id?(on) do
+      issues
+    else
+      [issue_for(join_type, line_no, issue_meta) | issues]
+    end
+  end
+
+  defp join_source?({:in, _meta, [_binding, _source]}), do: true
+  defp join_source?(_ast), do: false
+
+  defp account_source?({:in, _meta, [_binding, source]}), do: account_source?(source)
+  defp account_source?({:assoc, _meta, [_parent, :account]}), do: true
+  defp account_source?({:__aliases__, _meta, parts}), do: List.last(parts) == :Account
+  defp account_source?("accounts"), do: true
+  defp account_source?(_ast), do: false
+
+  defp contains_account_id?(nil), do: false
+
+  defp contains_account_id?(ast) do
+    {_ast, found?} =
+      Macro.prewalk(ast, false, fn
+        node, true -> {node, true}
+        :account_id = node, false -> {node, true}
+        {:account_id, _meta, _context} = node, false -> {node, true}
+        node, false -> {node, false}
+      end)
+
+    found?
+  end
+
+  defp keyword_list?(value), do: is_list(value) and Keyword.keyword?(value)
+
+  defp ast_line({_name, meta, _args}) when is_list(meta), do: meta[:line]
+  defp ast_line(_ast), do: nil
+
+  defp issue_for(join_type, line_no, issue_meta) do
+    trigger = to_string(join_type)
+
+    format_issue(
+      issue_meta,
+      message:
+        "Join condition does not reference account_id. " <>
+          "Portal.Safe scopes only the root query binding; add an account_id condition to this join.",
+      trigger: trigger,
+      line_no: line_no
+    )
+  end
+end

--- a/elixir/lib/portal/authentication.ex
+++ b/elixir/lib/portal/authentication.ex
@@ -644,7 +644,10 @@ defmodule Portal.Authentication do
 
       from(tokens in ClientToken, as: :tokens)
       |> join(:inner, [tokens: tokens], account in assoc(tokens, :account), as: :account)
-      |> join(:inner, [tokens: tokens], actor in assoc(tokens, :actor), as: :actor)
+      |> join(:inner, [tokens: tokens], actor in assoc(tokens, :actor),
+        on: actor.account_id == tokens.account_id,
+        as: :actor
+      )
       |> where([tokens: tokens], tokens.expires_at > ^now or is_nil(tokens.expires_at))
       |> where([tokens: tokens], tokens.id == ^token_id)
       |> where([tokens: tokens], tokens.account_id == ^account_id)
@@ -665,7 +668,10 @@ defmodule Portal.Authentication do
 
       from(tokens in Portal.APIToken, as: :tokens)
       |> join(:inner, [tokens: tokens], account in assoc(tokens, :account), as: :account)
-      |> join(:inner, [tokens: tokens], actor in assoc(tokens, :actor), as: :actor)
+      |> join(:inner, [tokens: tokens], actor in assoc(tokens, :actor),
+        on: actor.account_id == tokens.account_id,
+        as: :actor
+      )
       |> where([tokens: tokens], tokens.expires_at > ^now or is_nil(tokens.expires_at))
       |> where([tokens: tokens], tokens.id == ^token_id)
       |> where([tokens: tokens], tokens.account_id == ^account_id)
@@ -702,6 +708,7 @@ defmodule Portal.Authentication do
     def consume_one_time_passcode_attempt(account_id, actor_id, id) do
       from(otp in OneTimePasscode,
         join: a in assoc(otp, :actor),
+        on: a.account_id == otp.account_id,
         where: otp.account_id == ^account_id,
         where: otp.actor_id == ^actor_id,
         where: otp.id == ^id,
@@ -777,6 +784,7 @@ defmodule Portal.Authentication do
 
       from(ps in PortalSession,
         join: a in assoc(ps, :actor),
+        on: a.account_id == ps.account_id,
         where: ps.account_id == ^account_id,
         where: ps.id == ^id,
         where: ps.expires_at > ^DateTime.utc_now(),

--- a/elixir/lib/portal/cache/client.ex
+++ b/elixir/lib/portal/cache/client.ex
@@ -1062,8 +1062,14 @@ defmodule Portal.Cache.Client do
     def all_member_ips(resource_ids, subject) do
       from(r in Portal.Resource, as: :resources)
       |> where([resources: r], r.id in ^resource_ids)
-      |> join(:inner, [resources: r], m in assoc(r, :static_pool_members), as: :members)
-      |> join(:inner, [members: m], c in assoc(m, :client), as: :clients)
+      |> join(:inner, [resources: r], m in assoc(r, :static_pool_members),
+        on: m.account_id == r.account_id,
+        as: :members
+      )
+      |> join(:inner, [members: m], c in assoc(m, :client),
+        on: c.account_id == m.account_id,
+        as: :clients
+      )
       |> where([clients: c], c.type == :client)
       |> select(
         [resources: r, members: m, clients: c],

--- a/elixir/lib/portal/entra/sync.ex
+++ b/elixir/lib/portal/entra/sync.ex
@@ -1255,7 +1255,7 @@ defmodule Portal.Entra.Sync do
       query =
         from(m in Portal.Membership,
           join: g in Portal.Group,
-          on: m.group_id == g.id,
+          on: m.group_id == g.id and m.account_id == g.account_id,
           where: g.account_id == ^account_id,
           where: g.directory_id == ^directory_id,
           where:

--- a/elixir/lib/portal/google/sync.ex
+++ b/elixir/lib/portal/google/sync.ex
@@ -1479,7 +1479,7 @@ defmodule Portal.Google.Sync do
       query =
         from(m in Portal.Membership,
           join: g in Portal.Group,
-          on: m.group_id == g.id,
+          on: m.group_id == g.id and m.account_id == g.account_id,
           where: g.account_id == ^account_id,
           where: g.directory_id == ^directory_id,
           where:

--- a/elixir/lib/portal/okta/sync.ex
+++ b/elixir/lib/portal/okta/sync.ex
@@ -1182,7 +1182,7 @@ defmodule Portal.Okta.Sync do
       query =
         from(m in Portal.Membership,
           join: g in Portal.Group,
-          on: m.group_id == g.id,
+          on: m.group_id == g.id and m.account_id == g.account_id,
           where: g.account_id == ^account_id,
           where: g.directory_id == ^directory_id,
           where:

--- a/elixir/lib/portal_api/gateway/socket.ex
+++ b/elixir/lib/portal_api/gateway/socket.ex
@@ -368,6 +368,7 @@ defmodule PortalAPI.Gateway.Socket do
           where: d.id == ^id,
           where: d.type == :gateway,
           join: s in assoc(d, :site),
+          on: s.account_id == d.account_id,
           preload: [site: s]
         )
         |> Safe.unscoped(:replica)

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -1162,6 +1162,7 @@ defmodule PortalWeb.OIDCController do
     def fetch_active_identity_by_idp(account_id, issuer, idp_id) do
       from(identity in ExternalIdentity,
         join: actor in assoc(identity, :actor),
+        on: actor.account_id == identity.account_id,
         where: identity.account_id == ^account_id,
         where: identity.issuer == ^issuer,
         where: identity.idp_id == ^idp_id,
@@ -1398,7 +1399,7 @@ defmodule PortalWeb.OIDCController do
       existing_identity_cte =
         from(ei in "external_identities",
           join: a in "actors",
-          on: a.id == ei.actor_id,
+          on: a.id == ei.actor_id and a.account_id == ei.account_id,
           where:
             ei.account_id == ^account_id_bytes and
               ei.issuer == ^issuer and
@@ -1519,6 +1520,7 @@ defmodule PortalWeb.OIDCController do
     defp fetch_pending_passcode_for_update(%PendingIdentity{} = pending_identity) do
       from(passcode in OneTimePasscode,
         join: actor in assoc(passcode, :actor),
+        on: actor.account_id == passcode.account_id,
         where: passcode.account_id == ^pending_identity.account_id,
         where: passcode.actor_id == ^pending_identity.actor_id,
         where: passcode.id == ^pending_identity.one_time_passcode_id,

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -1415,8 +1415,11 @@ defmodule PortalWeb.OIDCController do
 
       base_query =
         from(d in fragment("SELECT 1"),
+          # Both CTEs return at most one row and are already scoped by account_id.
+          # credo:disable-for-next-line Credo.Check.Warning.MissingAccountIdInJoin
           left_join: al in "actor_lookup",
           on: true,
+          # credo:disable-for-next-line Credo.Check.Warning.MissingAccountIdInJoin
           left_join: ei in "existing_identity",
           on: true,
           where: not is_nil(al.id) or not is_nil(ei.actor_id),

--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -1389,11 +1389,11 @@ defmodule PortalWeb.Actors do
         from(d in Directory,
           where: d.account_id == ^subject.account.id,
           left_join: google in Portal.Google.Directory,
-          on: google.id == d.id and d.type == :google,
+          on: google.id == d.id and google.account_id == d.account_id and d.type == :google,
           left_join: entra in Portal.Entra.Directory,
-          on: entra.id == d.id and d.type == :entra,
+          on: entra.id == d.id and entra.account_id == d.account_id and d.type == :entra,
           left_join: okta in Portal.Okta.Directory,
-          on: okta.id == d.id and d.type == :okta,
+          on: okta.id == d.id and okta.account_id == d.account_id and d.type == :okta,
           select: %{
             id: d.id,
             name: fragment("COALESCE(?, ?, ?)", google.name, entra.name, okta.name),
@@ -1539,17 +1539,20 @@ defmodule PortalWeb.Actors do
     def get_identities_for_actor(actor_id, subject) do
       from(i in ExternalIdentity, as: :identities)
       |> where([identities: i], i.actor_id == ^actor_id)
-      |> join(:left, [identities: i], d in assoc(i, :directory), as: :directory)
+      |> join(:left, [identities: i], d in assoc(i, :directory),
+        on: d.account_id == i.account_id,
+        as: :directory
+      )
       |> join(:left, [directory: d], gd in Portal.Google.Directory,
-        on: gd.id == d.id and d.type == :google,
+        on: gd.id == d.id and gd.account_id == d.account_id and d.type == :google,
         as: :google_directory
       )
       |> join(:left, [directory: d], ed in Portal.Entra.Directory,
-        on: ed.id == d.id and d.type == :entra,
+        on: ed.id == d.id and ed.account_id == d.account_id and d.type == :entra,
         as: :entra_directory
       )
       |> join(:left, [directory: d], od in Portal.Okta.Directory,
-        on: od.id == d.id and d.type == :okta,
+        on: od.id == d.id and od.account_id == d.account_id and d.type == :okta,
         as: :okta_directory
       )
       |> join(:left, [identities: i], ss in Portal.ExternalIdentitySyncState,
@@ -1633,7 +1636,10 @@ defmodule PortalWeb.Actors do
     def get_portal_sessions_for_actor(actor_id, subject) do
       from(ps in PortalSession, as: :portal_sessions)
       |> where([portal_sessions: ps], ps.actor_id == ^actor_id)
-      |> join(:left, [portal_sessions: ps], ap in assoc(ps, :auth_provider), as: :auth_provider)
+      |> join(:left, [portal_sessions: ps], ap in assoc(ps, :auth_provider),
+        on: ap.account_id == ps.account_id,
+        as: :auth_provider
+      )
       |> select_merge([auth_provider: ap], %{
         auth_provider_type: type(ap.type, :string),
         auth_provider_name:
@@ -1677,17 +1683,20 @@ defmodule PortalWeb.Actors do
         on: m.group_id == g.id and m.account_id == g.account_id,
         as: :membership
       )
-      |> join(:left, [groups: g], d in assoc(g, :directory), as: :directory)
+      |> join(:left, [groups: g], d in assoc(g, :directory),
+        on: d.account_id == g.account_id,
+        as: :directory
+      )
       |> join(:left, [directory: d], gd in Portal.Google.Directory,
-        on: gd.id == d.id and d.type == :google,
+        on: gd.id == d.id and gd.account_id == d.account_id and d.type == :google,
         as: :google_directory
       )
       |> join(:left, [directory: d], ed in Portal.Entra.Directory,
-        on: ed.id == d.id and d.type == :entra,
+        on: ed.id == d.id and ed.account_id == d.account_id and d.type == :entra,
         as: :entra_directory
       )
       |> join(:left, [directory: d], od in Portal.Okta.Directory,
-        on: od.id == d.id and d.type == :okta,
+        on: od.id == d.id and od.account_id == d.account_id and d.type == :okta,
         as: :okta_directory
       )
       |> where([membership: m], m.actor_id == ^actor_id)

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -780,7 +780,10 @@ defmodule PortalWeb.Clients do
         if has_named_binding?(queryable, :actors) do
           queryable
         else
-          join(queryable, :inner, [devices: d], a in assoc(d, :actor), as: :actors)
+          join(queryable, :inner, [devices: d], a in assoc(d, :actor),
+            on: a.account_id == d.account_id,
+            as: :actors
+          )
         end
 
       {queryable,
@@ -822,23 +825,23 @@ defmodule PortalWeb.Clients do
         pa.initiating_device_id == ^client.id or pa.receiving_device_id == ^client.id
       )
       |> join(:inner, [policy_authorizations: pa], p in Policy,
-        on: p.id == pa.policy_id,
+        on: p.id == pa.policy_id and p.account_id == pa.account_id,
         as: :policies
       )
       |> join(:left, [policies: p], g in Group,
-        on: g.id == p.group_id,
+        on: g.id == p.group_id and g.account_id == p.account_id,
         as: :groups
       )
       |> join(:inner, [policies: p], r in Resource,
-        on: r.id == p.resource_id,
+        on: r.id == p.resource_id and r.account_id == p.account_id,
         as: :resources
       )
       |> join(:left, [policy_authorizations: pa], id in Device,
-        on: id.id == pa.initiating_device_id,
+        on: id.id == pa.initiating_device_id and id.account_id == pa.account_id,
         as: :initiating_devices
       )
       |> join(:left, [policy_authorizations: pa], rd in Device,
-        on: rd.id == pa.receiving_device_id,
+        on: rd.id == pa.receiving_device_id and rd.account_id == pa.account_id,
         as: :receiving_devices
       )
       |> select(

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -1355,8 +1355,9 @@ defmodule PortalWeb.Groups do
     defp joined_group_query(query) do
       member_counts_query =
         from(m in Portal.Membership,
-          group_by: m.group_id,
+          group_by: [m.account_id, m.group_id],
           select: %{
+            account_id: m.account_id,
             group_id: m.group_id,
             count: count(m.actor_id)
           }
@@ -1365,8 +1366,9 @@ defmodule PortalWeb.Groups do
       policy_counts_query =
         from(p in Portal.Policy,
           where: is_nil(p.disabled_at),
-          group_by: p.group_id,
+          group_by: [p.account_id, p.group_id],
           select: %{
+            account_id: p.account_id,
             group_id: p.group_id,
             count: count(p.id)
           }
@@ -1374,11 +1376,11 @@ defmodule PortalWeb.Groups do
 
       query
       |> join(:left, [groups: g], mc in subquery(member_counts_query),
-        on: mc.group_id == g.id,
+        on: mc.group_id == g.id and mc.account_id == g.account_id,
         as: :member_counts
       )
       |> join(:left, [groups: g], pc in subquery(policy_counts_query),
-        on: pc.group_id == g.id,
+        on: pc.group_id == g.id and pc.account_id == g.account_id,
         as: :policy_counts
       )
       |> join(:left, [groups: g], d in Directory,
@@ -1386,15 +1388,15 @@ defmodule PortalWeb.Groups do
         as: :directory
       )
       |> join(:left, [directory: d], gd in Portal.Google.Directory,
-        on: gd.id == d.id and d.type == :google,
+        on: gd.id == d.id and gd.account_id == d.account_id and d.type == :google,
         as: :google_directory
       )
       |> join(:left, [directory: d], ed in Portal.Entra.Directory,
-        on: ed.id == d.id and d.type == :entra,
+        on: ed.id == d.id and ed.account_id == d.account_id and d.type == :entra,
         as: :entra_directory
       )
       |> join(:left, [directory: d], od in Portal.Okta.Directory,
-        on: od.id == d.id and d.type == :okta,
+        on: od.id == d.id and od.account_id == d.account_id and d.type == :okta,
         as: :okta_directory
       )
     end
@@ -1506,13 +1508,13 @@ defmodule PortalWeb.Groups do
     def count_total_members(subject) do
       member_counts_query =
         from(m in Portal.Membership,
-          group_by: m.group_id,
-          select: %{group_id: m.group_id, count: count(m.actor_id)}
+          group_by: [m.account_id, m.group_id],
+          select: %{account_id: m.account_id, group_id: m.group_id, count: count(m.actor_id)}
         )
 
       from(g in Portal.Group, as: :groups)
       |> join(:left, [groups: g], mc in subquery(member_counts_query),
-        on: mc.group_id == g.id,
+        on: mc.group_id == g.id and mc.account_id == g.account_id,
         as: :member_counts
       )
       |> where(
@@ -1564,11 +1566,11 @@ defmodule PortalWeb.Groups do
         from(d in Directory,
           where: d.account_id == ^subject.account.id,
           left_join: google in Portal.Google.Directory,
-          on: google.id == d.id and d.type == :google,
+          on: google.id == d.id and google.account_id == d.account_id and d.type == :google,
           left_join: entra in Portal.Entra.Directory,
-          on: entra.id == d.id and d.type == :entra,
+          on: entra.id == d.id and entra.account_id == d.account_id and d.type == :entra,
           left_join: okta in Portal.Okta.Directory,
-          on: okta.id == d.id and d.type == :okta,
+          on: okta.id == d.id and okta.account_id == d.account_id and d.type == :okta,
           select: %{
             id: d.id,
             name: fragment("COALESCE(?, ?, ?)", google.name, entra.name, okta.name),
@@ -1664,7 +1666,9 @@ defmodule PortalWeb.Groups do
       base =
         from(a in Portal.Actor, as: :actors)
         |> join(:inner, [actors: a], m in Portal.Membership,
-          on: m.actor_id == a.id and m.group_id == ^group.id,
+          on:
+            m.actor_id == a.id and m.account_id == a.account_id and
+              m.group_id == ^group.id,
           as: :memberships
         )
         |> order_by([actors: a], asc: a.name)
@@ -1773,7 +1777,9 @@ defmodule PortalWeb.Groups do
     def list_resources_for_group(group, subject, repo \\ :replica) do
       from(r in Portal.Resource, as: :resources)
       |> join(:inner, [resources: r], p in Portal.Policy,
-        on: p.resource_id == r.id and p.group_id == ^group.id,
+        on:
+          p.resource_id == r.id and p.account_id == r.account_id and
+            p.group_id == ^group.id,
         as: :policies
       )
       |> select([resources: r, policies: p], %{
@@ -1796,21 +1802,30 @@ defmodule PortalWeb.Groups do
       query =
         from(g in Portal.Group, as: :groups)
         |> where([groups: groups], groups.id == ^id)
-        |> join(:left, [groups: g], d in assoc(g, :directory), as: :directory)
+        |> join(:left, [groups: g], d in assoc(g, :directory),
+          on: d.account_id == g.account_id,
+          as: :directory
+        )
         |> join(:left, [directory: d], gd in Portal.Google.Directory,
-          on: gd.id == d.id and d.type == :google,
+          on: gd.id == d.id and gd.account_id == d.account_id and d.type == :google,
           as: :google_directory
         )
         |> join(:left, [directory: d], ed in Portal.Entra.Directory,
-          on: ed.id == d.id and d.type == :entra,
+          on: ed.id == d.id and ed.account_id == d.account_id and d.type == :entra,
           as: :entra_directory
         )
         |> join(:left, [directory: d], od in Portal.Okta.Directory,
-          on: od.id == d.id and d.type == :okta,
+          on: od.id == d.id and od.account_id == d.account_id and d.type == :okta,
           as: :okta_directory
         )
-        |> join(:left, [groups: g], m in assoc(g, :memberships), as: :memberships)
-        |> join(:left, [memberships: m], a in assoc(m, :actor), as: :actors)
+        |> join(:left, [groups: g], m in assoc(g, :memberships),
+          on: m.account_id == g.account_id,
+          as: :memberships
+        )
+        |> join(:left, [memberships: m], a in assoc(m, :actor),
+          on: a.account_id == m.account_id,
+          as: :actors
+        )
         |> join(:left, [groups: g], gss in Portal.GroupSyncState,
           on: gss.group_id == g.id and gss.account_id == g.account_id,
           as: :sync_state

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -1178,17 +1178,20 @@ defmodule PortalWeb.Policies do
       row =
         from(g in Group, as: :groups)
         |> where([groups: g], g.id == ^id)
-        |> join(:left, [groups: g], d in assoc(g, :directory), as: :directory)
+        |> join(:left, [groups: g], d in assoc(g, :directory),
+          on: d.account_id == g.account_id,
+          as: :directory
+        )
         |> join(:left, [directory: d], gd in Portal.Google.Directory,
-          on: gd.id == d.id and d.type == :google,
+          on: gd.id == d.id and gd.account_id == d.account_id and d.type == :google,
           as: :google_directory
         )
         |> join(:left, [directory: d], ed in Portal.Entra.Directory,
-          on: ed.id == d.id and d.type == :entra,
+          on: ed.id == d.id and ed.account_id == d.account_id and d.type == :entra,
           as: :entra_directory
         )
         |> join(:left, [directory: d], od in Portal.Okta.Directory,
-          on: od.id == d.id and d.type == :okta,
+          on: od.id == d.id and od.account_id == d.account_id and d.type == :okta,
           as: :okta_directory
         )
         |> select(
@@ -1208,17 +1211,20 @@ defmodule PortalWeb.Policies do
     def list_group_options(search_query_or_nil, subject) do
       query =
         from(g in Group, as: :groups)
-        |> join(:left, [groups: g], d in assoc(g, :directory), as: :directory)
+        |> join(:left, [groups: g], d in assoc(g, :directory),
+          on: d.account_id == g.account_id,
+          as: :directory
+        )
         |> join(:left, [directory: d], gd in Portal.Google.Directory,
-          on: gd.id == d.id and d.type == :google,
+          on: gd.id == d.id and gd.account_id == d.account_id and d.type == :google,
           as: :google_directory
         )
         |> join(:left, [directory: d], ed in Portal.Entra.Directory,
-          on: ed.id == d.id and d.type == :entra,
+          on: ed.id == d.id and ed.account_id == d.account_id and d.type == :entra,
           as: :entra_directory
         )
         |> join(:left, [directory: d], od in Portal.Okta.Directory,
-          on: od.id == d.id and d.type == :okta,
+          on: od.id == d.id and od.account_id == d.account_id and d.type == :okta,
           as: :okta_directory
         )
         |> select(
@@ -1403,7 +1409,10 @@ defmodule PortalWeb.Policies do
       if has_named_binding?(queryable, :group) do
         queryable
       else
-        join(queryable, :left, [policies: p], g in assoc(p, :group), as: :group)
+        join(queryable, :left, [policies: p], g in assoc(p, :group),
+          on: g.account_id == p.account_id,
+          as: :group
+        )
       end
     end
 
@@ -1411,7 +1420,10 @@ defmodule PortalWeb.Policies do
       if has_named_binding?(queryable, :resource) do
         queryable
       else
-        join(queryable, :inner, [policies: p], r in assoc(p, :resource), as: :resource)
+        join(queryable, :inner, [policies: p], r in assoc(p, :resource),
+          on: r.account_id == p.account_id,
+          as: :resource
+        )
       end
     end
 
@@ -1428,19 +1440,19 @@ defmodule PortalWeb.Policies do
       from(pa in PolicyAuthorization, as: :policy_authorizations)
       |> where([policy_authorizations: pa], pa.policy_id == ^policy.id)
       |> join(:inner, [policy_authorizations: pa], t in ClientToken,
-        on: t.id == pa.token_id,
+        on: t.id == pa.token_id and t.account_id == pa.account_id,
         as: :tokens
       )
       |> join(:left, [tokens: t], a in Actor,
-        on: a.id == t.actor_id,
+        on: a.id == t.actor_id and a.account_id == t.account_id,
         as: :actors
       )
       |> join(:left, [policy_authorizations: pa], id in Device,
-        on: id.id == pa.initiating_device_id,
+        on: id.id == pa.initiating_device_id and id.account_id == pa.account_id,
         as: :initiating_devices
       )
       |> join(:left, [policy_authorizations: pa], rd in Device,
-        on: rd.id == pa.receiving_device_id,
+        on: rd.id == pa.receiving_device_id and rd.account_id == pa.account_id,
         as: :receiving_devices
       )
       |> select(

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -2853,17 +2853,20 @@ defmodule PortalWeb.Policies.Components do
       group =
         from(g in Portal.Group, as: :groups)
         |> where([groups: g], g.id == ^id)
-        |> join(:left, [groups: g], d in assoc(g, :directory), as: :directory)
+        |> join(:left, [groups: g], d in assoc(g, :directory),
+          on: d.account_id == g.account_id,
+          as: :directory
+        )
         |> join(:left, [directory: d], gd in Portal.Google.Directory,
-          on: gd.id == d.id and d.type == :google,
+          on: gd.id == d.id and gd.account_id == d.account_id and d.type == :google,
           as: :google_directory
         )
         |> join(:left, [directory: d], ed in Portal.Entra.Directory,
-          on: ed.id == d.id and d.type == :entra,
+          on: ed.id == d.id and ed.account_id == d.account_id and d.type == :entra,
           as: :entra_directory
         )
         |> join(:left, [directory: d], od in Portal.Okta.Directory,
-          on: od.id == d.id and d.type == :okta,
+          on: od.id == d.id and od.account_id == d.account_id and d.type == :okta,
           as: :okta_directory
         )
         |> select(
@@ -2889,17 +2892,20 @@ defmodule PortalWeb.Policies.Components do
     def list_group_options(search_query_or_nil, subject) do
       query =
         from(g in Portal.Group, as: :groups)
-        |> join(:left, [groups: g], d in assoc(g, :directory), as: :directory)
+        |> join(:left, [groups: g], d in assoc(g, :directory),
+          on: d.account_id == g.account_id,
+          as: :directory
+        )
         |> join(:left, [directory: d], gd in Portal.Google.Directory,
-          on: gd.id == d.id and d.type == :google,
+          on: gd.id == d.id and gd.account_id == d.account_id and d.type == :google,
           as: :google_directory
         )
         |> join(:left, [directory: d], ed in Portal.Entra.Directory,
-          on: ed.id == d.id and d.type == :entra,
+          on: ed.id == d.id and ed.account_id == d.account_id and d.type == :entra,
           as: :entra_directory
         )
         |> join(:left, [directory: d], od in Portal.Okta.Directory,
-          on: od.id == d.id and d.type == :okta,
+          on: od.id == d.id and od.account_id == d.account_id and d.type == :okta,
           as: :okta_directory
         )
         |> select(
@@ -3169,6 +3175,7 @@ defmodule PortalWeb.Policies.Components do
           :inner,
           [policy_authorizations: policy_authorizations],
           policy in assoc(policy_authorizations, ^binding),
+          on: policy.account_id == policy_authorizations.account_id,
           as: ^binding
         )
       end)
@@ -3181,6 +3188,7 @@ defmodule PortalWeb.Policies.Components do
           :inner,
           [policy_authorizations: policy_authorizations],
           client in assoc(policy_authorizations, ^binding),
+          on: client.account_id == policy_authorizations.account_id,
           as: ^binding
         )
       end)
@@ -3190,7 +3198,10 @@ defmodule PortalWeb.Policies.Components do
       queryable
       |> with_joined_gateway()
       |> with_policy_authorization_named_binding(:site, fn queryable, binding ->
-        join(queryable, :inner, [gateway: gateway], site in assoc(gateway, :site), as: ^binding)
+        join(queryable, :inner, [gateway: gateway], site in assoc(gateway, :site),
+          on: site.account_id == gateway.account_id,
+          as: ^binding
+        )
       end)
     end
 
@@ -3201,6 +3212,7 @@ defmodule PortalWeb.Policies.Components do
           :inner,
           [policy_authorizations: policy_authorizations],
           gateway in assoc(policy_authorizations, ^binding),
+          on: gateway.account_id == policy_authorizations.account_id,
           as: ^binding
         )
       end)

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -1653,7 +1653,9 @@ defmodule PortalWeb.Resources do
     def list_groups_for_resource(resource, subject, repo \\ :replica) do
       from(g in Group, as: :groups)
       |> join(:inner, [groups: g], p in Policy,
-        on: p.group_id == g.id and p.resource_id == ^resource.id,
+        on:
+          p.group_id == g.id and p.account_id == g.account_id and
+            p.resource_id == ^resource.id,
         as: :policies
       )
       |> join(:left, [groups: g], d in Directory,
@@ -1688,27 +1690,27 @@ defmodule PortalWeb.Resources do
       from(pa in PolicyAuthorization, as: :policy_authorizations)
       |> where([policy_authorizations: pa], pa.resource_id == ^resource.id)
       |> join(:inner, [policy_authorizations: pa], p in Policy,
-        on: p.id == pa.policy_id,
+        on: p.id == pa.policy_id and p.account_id == pa.account_id,
         as: :policies
       )
       |> join(:left, [policies: p], g in Group,
-        on: g.id == p.group_id,
+        on: g.id == p.group_id and g.account_id == p.account_id,
         as: :groups
       )
       |> join(:inner, [policy_authorizations: pa], t in ClientToken,
-        on: t.id == pa.token_id,
+        on: t.id == pa.token_id and t.account_id == pa.account_id,
         as: :tokens
       )
       |> join(:left, [tokens: t], a in Actor,
-        on: a.id == t.actor_id,
+        on: a.id == t.actor_id and a.account_id == t.account_id,
         as: :actors
       )
       |> join(:left, [policy_authorizations: pa], id in Device,
-        on: id.id == pa.initiating_device_id,
+        on: id.id == pa.initiating_device_id and id.account_id == pa.account_id,
         as: :initiating_devices
       )
       |> join(:left, [policy_authorizations: pa], rd in Device,
-        on: rd.id == pa.receiving_device_id,
+        on: rd.id == pa.receiving_device_id and rd.account_id == pa.account_id,
         as: :receiving_devices
       )
       |> select(

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -2166,7 +2166,10 @@ defmodule PortalWeb.Resources.Components do
       query =
         from(c in Device, as: :clients)
         |> where([clients: c], c.type == :client)
-        |> join(:inner, [clients: c], a in assoc(c, :actor), as: :actors)
+        |> join(:inner, [clients: c], a in assoc(c, :actor),
+          on: a.account_id == c.account_id,
+          as: :actors
+        )
         |> where([clients: c], c.id not in ^selected_ids)
         |> where(^client_search_filter(pattern))
         |> order_by([clients: c], desc: c.id in ^online_ids)

--- a/elixir/lib/portal_web/live/settings/api_clients/index.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/index.ex
@@ -15,7 +15,10 @@ defmodule PortalWeb.Settings.ApiClients.Index do
     def list_actors_with_token(subject) do
       from(a in Portal.Actor, as: :actors)
       |> where([actors: a], a.type == :api_client)
-      |> join(:left, [actors: a], t in Portal.APIToken, on: t.actor_id == a.id, as: :tokens)
+      |> join(:left, [actors: a], t in Portal.APIToken,
+        on: t.actor_id == a.id and t.account_id == a.account_id,
+        as: :tokens
+      )
       |> order_by([actors: a, tokens: t], asc: a.inserted_at, asc: a.id, desc: t.inserted_at)
       |> distinct([actors: a], a.id)
       |> select([actors: a, tokens: t], {a, t})

--- a/elixir/test/credo/check/warning/missing_account_id_in_join_test.exs
+++ b/elixir/test/credo/check/warning/missing_account_id_in_join_test.exs
@@ -1,0 +1,145 @@
+defmodule Credo.Check.Warning.MissingAccountIdInJoinTest do
+  use ExUnit.Case, async: true
+
+  alias Credo.Check.Warning.MissingAccountIdInJoin
+
+  setup_all do
+    Application.ensure_all_started(:credo)
+    :ok
+  end
+
+  test "reports a piped join without an account_id condition" do
+    issues =
+      """
+      query
+      |> join(:left, [actors: actor], token in Portal.APIToken,
+        on: token.actor_id == actor.id
+      )
+      """
+      |> issues()
+
+    assert [%{trigger: "join", line_no: 2}] = issues
+  end
+
+  test "allows a piped join with an account_id condition" do
+    issues =
+      """
+      query
+      |> join(:left, [actors: actor], token in Portal.APIToken,
+        on: token.actor_id == actor.id and token.account_id == actor.account_id
+      )
+      """
+      |> issues()
+
+    assert issues == []
+  end
+
+  test "reports only unsafe joins in a from expression with multiple joins" do
+    issues =
+      """
+      from(actor in Portal.Actor,
+        join: token in Portal.APIToken,
+        on: token.actor_id == actor.id and token.account_id == actor.account_id,
+        left_join: identity in Portal.ExternalIdentity,
+        on: identity.actor_id == actor.id
+      )
+      """
+      |> issues()
+
+    assert [%{trigger: "left_join", line_no: 4}] = issues
+  end
+
+  test "reports a join without an explicit on condition" do
+    issues =
+      """
+      query
+      |> join(:inner, [actors: actor], identity in assoc(actor, :identities))
+      """
+      |> issues()
+
+    assert [%{trigger: "join", line_no: 2}] = issues
+  end
+
+  test "allows account association joins without an explicit on condition" do
+    issues =
+      """
+      query
+      |> join(:inner, [tokens: token], account in assoc(token, :account))
+      """
+      |> issues()
+
+    assert issues == []
+  end
+
+  test "allows direct Portal.Account joins without an account_id condition" do
+    issues =
+      """
+      from(directory in Portal.Directory,
+        join: account in Portal.Account,
+        on: account.id == directory.account_id
+      )
+      """
+      |> issues()
+
+    assert issues == []
+  end
+
+  test "allows a join scoped to a pinned account_id" do
+    issues =
+      """
+      from(actor in Portal.Actor,
+        join: identity in Portal.ExternalIdentity,
+        on: identity.actor_id == actor.id and identity.account_id == ^account_id
+      )
+      """
+      |> issues()
+
+    assert issues == []
+  end
+
+  test "reports an intentional on true join so it must be explicitly suppressed" do
+    issues =
+      """
+      from(row in fragment("SELECT 1"),
+        left_join: lookup in "actor_lookup",
+        on: true
+      )
+      """
+      |> issues()
+
+    assert [%{trigger: "left_join", line_no: 2}] = issues
+  end
+
+  test "supports qualified Ecto.Query calls" do
+    issues =
+      """
+      Ecto.Query.join(
+        query,
+        :left,
+        [actors: actor],
+        token in Portal.APIToken,
+        on: token.actor_id == actor.id
+      )
+      """
+      |> issues()
+
+    assert [%{trigger: "join", line_no: 1}] = issues
+  end
+
+  test "ignores unrelated join functions" do
+    issues =
+      """
+      Enum.join(values, ",")
+      join(values)
+      """
+      |> issues()
+
+    assert issues == []
+  end
+
+  defp issues(source) do
+    source
+    |> Credo.SourceFile.parse("lib/portal/example.ex")
+    |> MissingAccountIdInJoin.run()
+  end
+end

--- a/elixir/test/portal_web/live/settings/api_clients/index_test.exs
+++ b/elixir/test/portal_web/live/settings/api_clients/index_test.exs
@@ -3,6 +3,7 @@ defmodule PortalWeb.Settings.ApiClients.IndexTest do
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
+  import Portal.SubjectFixtures
   import Portal.TokenFixtures
 
   alias Portal.Actor
@@ -55,6 +56,44 @@ defmodule PortalWeb.Settings.ApiClients.IndexTest do
   end
 
   describe "index (default action)" do
+    test "does not join tokens from another account when actor IDs match", %{
+      account: account,
+      actor: admin_actor
+    } do
+      shared_id = Ecto.UUID.generate()
+
+      Repo.insert!(%Actor{
+        id: shared_id,
+        account_id: account.id,
+        type: :api_client,
+        name: "Local API Client"
+      })
+
+      other_account = account_fixture()
+
+      other_actor =
+        Repo.insert!(%Actor{
+          id: shared_id,
+          account_id: other_account.id,
+          type: :api_client,
+          name: "Other API Client"
+        })
+
+      _other_token = api_token_fixture(account: other_account, actor: other_actor)
+      subject = subject_fixture(account: account, actor: admin_actor)
+
+      assert [
+               {%Actor{
+                  id: ^shared_id,
+                  account_id: account_id,
+                  name: "Local API Client"
+                }, nil}
+             ] =
+               PortalWeb.Settings.ApiClients.Index.Database.list_actors_with_token(subject)
+
+      assert account_id == account.id
+    end
+
     test "redirects to beta page when rest api is disabled", %{conn: conn} do
       account = account_fixture(features: %{rest_api: false})
       actor = admin_actor_fixture(account: account)


### PR DESCRIPTION
Safe.scoped/2 applies the account predicate to the root query binding, but it does not automatically scope every joined table. Because tenant-owned tables use composite `(account_id, id)` keys, joining only on an ID can associate a row from another account when UUIDs collide.

This PR:

- adds matching `account_id` predicates to tenant-owned joins across Portal, PortalAPI, and PortalWeb
- makes group member/policy aggregate subqueries group and join by both `account_id` and `group_id`
- adds `Credo.Check.Warning.MissingAccountIdInJoin` to prevent future omissions in piped and keyword Ecto joins
- exempts account-table joins and documents targeted suppressions for two derived one-row CTE joins
- adds a regression test proving an API client does not join a token from another account with the same actor UUID

Testing:

- focused affected test suite: 696 tests, 0 failures
- `test/portal_web/live/settings/api_clients/index_test.exs`: 15 tests, 0 failures
- custom Credo checks: 20 tests, 0 failures
- new Credo rule across 476 application source files: 0 issues
- `mix credo --strict`
- `mix format --check-formatted`
- `git diff --check`

---