### PR TITLE
chore(portal): exempt global features join from credo check

### DIFF
--- a/elixir/lib/portal_api/client/device_trust.ex
+++ b/elixir/lib/portal_api/client/device_trust.ex
@@ -500,6 +500,8 @@ defmodule PortalAPI.Client.DeviceTrust do
     # check and verification material come from the same query.
     def fetch_enabled_anchors(subject) do
       from(c in Portal.TrustAnchorCertificate,
+        # The features table is global per-deployment state with no account_id.
+        # credo:disable-for-next-line Credo.Check.Warning.MissingAccountIdInJoin
         join: f in Portal.Features,
         on: f.feature == :trust_anchors and f.enabled == true,
         select: c.pem


### PR DESCRIPTION
The trust-anchor query joins the features table, which is global per-deployment state with no account_id column, so the account-scoping credo check added in #14398 flags it. #14291 merged after that check landed, so the warning reached main unnoticed since credo is not in CI. This adds the documented suppression comment to the join.

Related: #14291, #14398