### PR TITLE
test(connlib): widen bootstrap_doh window to 10s

### DIFF
--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -631,8 +631,9 @@ mod tests {
             );
         }
 
-        // Hack: Advance for a bit but timeout after 2s. We don't emit an event when the client is bootstrapped so this will always be `Pending`.
-        let _ = tokio::time::timeout(Duration::from_secs(2), io.next()).await;
+        // Hack: Advance for a bit but timeout after 10s. We don't emit an event when the client is bootstrapped so this will always be `Pending`.
+        // The window has to comfortably cover a real DNS resolution plus TLS handshake to the DoH server on slow CI runners.
+        let _ = tokio::time::timeout(Duration::from_secs(10), io.next()).await;
 
         {
             io.send_dns_query(example_com_recursive_query(), Instant::now());


### PR DESCRIPTION
The `bootstrap_doh` test resolves `cloudflare-dns.com` and completes a TLS handshake against the real DoH server within a fixed window. A 2s window is too tight on slow macOS CI runners, where the handshake can outlast it and the second query re-returns the bootstrapping placeholder, panicking on `unwrap`. Widening the window to 10s comfortably covers a real resolution plus handshake while keeping the test pointed at a real DoH server.

Fixes: #14401