### PR TITLE
refactor(connlib): align `DatagramBatch` with `PacketBatch`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -691,7 +691,6 @@ dependencies = [
  "dashmap",
  "dns-types",
  "futures",
- "gat-lending-iterator",
  "hex",
  "hex-literal",
  "hmac 0.13.0",
@@ -2531,7 +2530,6 @@ dependencies = [
  "bytecodec",
  "clap",
  "futures",
- "gat-lending-iterator",
  "ip-packet",
  "known-dirs",
  "logging",
@@ -2897,12 +2895,6 @@ dependencies = [
  "tracing-subscriber",
  "tunnel-proto",
 ]
-
-[[package]]
-name = "gat-lending-iterator"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "750117b6c895c40a8feee97fc95da9b5eb4b531ad772af2640a810ea1e4d2102"
 
 [[package]]
 name = "gdk"
@@ -6979,7 +6971,6 @@ dependencies = [
  "anyhow-ext",
  "bufferpool",
  "derive_more",
- "gat-lending-iterator",
  "ip-packet",
  "libc",
  "memchr",
@@ -8480,7 +8471,6 @@ dependencies = [
  "eventloop-budget",
  "futures",
  "futures-bounded",
- "gat-lending-iterator",
  "http-client",
  "ip-packet",
  "itertools",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -112,7 +112,6 @@ flow-log-writer = { path = "libs/flow-log-writer" }
 flow-tracker = { path = "libs/connlib/flow-tracker" }
 futures = { version = "0.3.32" }
 futures-bounded = "0.3.0"
-gat-lending-iterator = "0.1.8"
 glob = "0.3.3"
 hex = "0.4.3"
 hex-display = "0.4.0"

--- a/rust/libs/bin-shared/Cargo.toml
+++ b/rust/libs/bin-shared/Cargo.toml
@@ -82,7 +82,6 @@ features = [
 
 [dev-dependencies]
 bufferpool = { workspace = true }
-gat-lending-iterator = { workspace = true }
 http = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs"] }

--- a/rust/libs/bin-shared/tests/no_packet_loops_udp.rs
+++ b/rust/libs/bin-shared/tests/no_packet_loops_udp.rs
@@ -2,7 +2,6 @@
 
 use bin_shared::{TunDeviceManager, platform::UdpSocketFactory};
 use bufferpool::BufferPool;
-use gat_lending_iterator::LendingIterator as _;
 use ip_network::Ipv4Network;
 use ip_packet::Ecn;
 use socket_factory::DatagramOut;
@@ -60,7 +59,7 @@ async fn no_packet_loops_udp() {
         .unwrap();
 
     let task = async {
-        socket.recv_from().await.unwrap().next().unwrap();
+        socket.recv_from().await.unwrap().drain().next().unwrap();
     };
 
     tokio::time::timeout(Duration::from_secs(10), task)

--- a/rust/libs/connlib/socket-factory/Cargo.toml
+++ b/rust/libs/connlib/socket-factory/Cargo.toml
@@ -8,7 +8,6 @@ license = { workspace = true }
 anyhow = { workspace = true }
 bufferpool = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
-gat-lending-iterator = { workspace = true }
 ip-packet = { workspace = true }
 memchr = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
@@ -33,6 +32,5 @@ parking_lot = { workspace = true }
 [dev-dependencies]
 bufferpool = { workspace = true }
 derive_more = { workspace = true, features = ["deref"] }
-gat-lending-iterator = { workspace = true }
 ip-packet = { workspace = true }
 tokio = { workspace = true, features = ["macros", "net", "rt", "time"] }

--- a/rust/libs/connlib/socket-factory/src/buffer_sizes.rs
+++ b/rust/libs/connlib/socket-factory/src/buffer_sizes.rs
@@ -1,4 +1,4 @@
-use crate::DatagramSegmentIter;
+use crate::DatagramBatch;
 use bufferpool::Buffer;
 use std::mem::size_of;
 use std::time::Duration;
@@ -26,14 +26,14 @@ pub const RECV_BUFFER_SIZE: usize = recv_buffer_size_for_service_gap(
     RECV_SERVICE_GAP.saturating_mul(RECV_SERVICE_GAP_WINDOWS as u32),
 );
 
-/// Worst-case heap that a single received batch ([`DatagramSegmentIter`]) pins.
+/// Worst-case heap that a single received batch ([`DatagramBatch`]) pins.
 ///
 /// A batch owns [`quinn_udp::BATCH_SIZE`] receive buffers plus their handles and metadata. Each buffer
 /// is sized to hold a full coalesced batch - up to `MAX_RECV_BUFFER_SEGMENTS` datagrams of at most
 /// [`ip_packet::MAX_FZ_PAYLOAD`] bytes - so on Linux / Android and Windows a single buffer is 64x the
 /// size of the datagram it might actually carry. That factor dominates this figure even on Windows,
 /// where Quinn currently leaves URO disabled but allocates URO-capable buffers.
-pub const MAX_RECV_BATCH_MEMORY: usize = size_of::<DatagramSegmentIter>()
+pub const MAX_RECV_BATCH_MEMORY: usize = size_of::<DatagramBatch>()
     + quinn_udp::BATCH_SIZE
         * (ip_packet::MAX_FZ_PAYLOAD * MAX_RECV_BUFFER_SEGMENTS
             + size_of::<Buffer<Vec<u8>>>()

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context as _, Result};
 use bufferpool::{Buffer, BufferPool, VecBuf};
-use gat_lending_iterator::LendingIterator;
 use ip_packet::{Ecn, Ipv4HeaderSlice, Ipv6HeaderSlice, UdpSlice};
 use opentelemetry::KeyValue;
 use quinn_udp::{EcnCodepoint, Transmit, UdpSockRef};
@@ -406,7 +405,7 @@ impl DatagramOut {
 
 impl PerfUdpSocket {
     /// Receives a batch of datagrams from whichever of our sockets becomes ready first.
-    pub async fn recv_from(&self) -> Result<DatagramSegmentIter> {
+    pub async fn recv_from(&self) -> Result<DatagramBatch> {
         std::future::poll_fn(|cx| {
             self.pool
                 .poll_recv(cx, |socket| self.try_recv_batch(socket))
@@ -418,7 +417,7 @@ impl PerfUdpSocket {
     ///
     /// Returns `WouldBlock` if the socket is not readable, clearing tokio's cached
     /// readiness in the process so that waiting for readiness actually suspends.
-    fn try_recv_batch(&self, socket: Socket<'_>) -> io::Result<DatagramSegmentIter> {
+    fn try_recv_batch(&self, socket: Socket<'_>) -> io::Result<DatagramBatch> {
         let mut batch = self.recv_buffers.pull_batch();
 
         let len = socket.inner.try_io(Interest::READABLE, || {
@@ -452,19 +451,19 @@ impl PerfUdpSocket {
             socket.disable_gro();
         }
 
-        let iter = DatagramSegmentIter::new(batch.buffers, batch.metas, self.port, len);
+        let batch = DatagramBatch::new(batch.buffers, batch.metas, self.port, len);
 
         // `len` only counts the buffers the syscall filled; with GRO a single buffer holds
         // several datagrams, so the segments across all buffers are what we want here.
         self.batch_histogram.record(
-            iter.num_packets() as u64,
+            batch.len() as u64,
             &[
                 KeyValue::new("network.transport", "udp"),
                 KeyValue::new("network.io.direction", "receive"),
             ],
         );
 
-        Ok(iter)
+        Ok(batch)
     }
 
     pub async fn send(&self, datagram: DatagramOut) -> Result<()> {
@@ -877,9 +876,8 @@ async fn wait_for_send_capacity(socket: &tokio::net::UdpSocket) {
 /// plus containers for the buffers and metas that make up one batch.
 ///
 /// The buffers and metas live in pooled, heap-allocated `Vec`s rather than inline in
-/// [`DatagramSegmentIter`]: the iterator is sent over a channel and inline storage
-/// would make every channel slot (and thus tokio's block allocations) carry the full
-/// batch size.
+/// [`DatagramBatch`]: the batch is sent over a channel and inline storage would make
+/// every channel slot (and thus tokio's block allocations) carry the full batch size.
 pub(crate) struct RecvBuffers {
     bytes: BufferPool<Vec<u8>>,
     buffers: BufferPool<VecBuf<Buffer<Vec<u8>>>>,
@@ -896,7 +894,7 @@ impl RecvBatch {
     /// The batch's datagram buffers as scatter slices, paired with the meta array the
     /// kernel fills in — the two arguments a `recvmmsg`-style read expects. Borrows the
     /// batch for the duration of the read; afterwards the buffers are handed to a
-    /// [`DatagramSegmentIter`].
+    /// [`DatagramBatch`].
     fn recv_slices(
         &mut self,
     ) -> (
@@ -934,24 +932,17 @@ impl RecvBuffers {
     }
 }
 
-/// An iterator that segments a batch of buffers into individual datagrams.
+/// A batch of datagrams, received from the socket in a single syscall and exchanged
+/// over the socket channels as a single item.
 ///
-/// This iterator is generic over its buffer type to allow easier testing without a buffer pool.
+/// The datagrams stay in the receive buffers the kernel filled; the buffers and metas
+/// live in pooled, heap-allocated `Vec`s (see [`RecvBuffers`]), so moving a batch only
+/// copies a couple of pointers. Callers consume a batch with [`DatagramBatch::drain`],
+/// which segments buffers holding several GRO / URO-coalesced datagrams apart again.
 ///
-/// This implementation might look like dark arts but it is actually quite simple.
-/// Its design is driven by two main ideas:
-///
-/// - We want the return a single `Iterator`-like type from a `recv` call on the socket.
-/// - We want to avoid copying buffers around.
-///
-/// To achieve this, this type doesn't implement `Iterator` but `LendingIterator` instead.
-/// A `LendingIterator` adds a lifetime to the `Item` type, allowing us to return a reference to something the iterator owns.
-///
-/// Composing `LendingIterator`s itself is difficult which is why we implement the entire segmentation of the buffers within a single type.
-/// When [`quinn_udp`] returns us the buffers, it will have populated the [`quinn_udp::RecvMeta`]s accordingly.
-/// Thus, our main job within this iterator is to loop over the `buffers` and `meta` pair-wise, inspect the `meta` and segment the data within the buffer accordingly.
+/// The batch is generic over its buffer type to allow easier testing without a buffer pool.
 #[derive(derive_more::Debug)]
-pub struct DatagramSegmentIter<B = Buffer<Vec<u8>>> {
+pub struct DatagramBatch<B = Buffer<Vec<u8>>> {
     #[debug(skip)]
     buffers: Buffer<VecBuf<B>>,
     #[debug(skip)]
@@ -959,14 +950,11 @@ pub struct DatagramSegmentIter<B = Buffer<Vec<u8>>> {
 
     port: u16,
 
-    buf_index: usize,
-    segment_index: usize,
-
     _total_bytes: usize,
     num_packets: usize,
 }
 
-impl<B> DatagramSegmentIter<B> {
+impl<B> DatagramBatch<B> {
     pub(crate) fn new(
         mut buffers: Buffer<VecBuf<B>>,
         mut metas: Buffer<VecBuf<quinn_udp::RecvMeta>>,
@@ -984,16 +972,36 @@ impl<B> DatagramSegmentIter<B> {
             buffers,
             metas,
             port,
-            buf_index: 0,
-            segment_index: 0,
             _total_bytes: total_bytes,
             num_packets,
         }
     }
 
     /// How many datagrams this batch carries in total.
-    pub(crate) fn num_packets(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.num_packets
+    }
+
+    /// Whether this batch carries no datagrams at all.
+    pub fn is_empty(&self) -> bool {
+        self.num_packets == 0
+    }
+
+    /// Yields all datagrams in the batch, in order.
+    ///
+    /// When [`quinn_udp`] returns us the buffers, it will have populated the
+    /// [`quinn_udp::RecvMeta`]s accordingly. Thus, our main job here is to loop over the
+    /// `buffers` and `metas` pair-wise, inspect the `meta` and segment the data within
+    /// the buffer accordingly.
+    pub fn drain(&mut self) -> impl Iterator<Item = DatagramIn<'_>>
+    where
+        B: Deref<Target = Vec<u8>>,
+    {
+        Drain {
+            batch: self,
+            buf_index: 0,
+            segment_index: 0,
+        }
     }
 }
 
@@ -1006,20 +1014,29 @@ fn num_segments(meta: &quinn_udp::RecvMeta) -> usize {
     meta.len.div_ceil(meta.stride.max(1))
 }
 
-impl<B> LendingIterator for DatagramSegmentIter<B>
-where
-    B: Deref<Target = Vec<u8>> + 'static,
-{
-    type Item<'a> = DatagramIn<'a>;
+/// The iterator behind [`DatagramBatch::drain`].
+struct Drain<'a, B> {
+    batch: &'a DatagramBatch<B>,
+    buf_index: usize,
+    segment_index: usize,
+}
 
-    fn next(&mut self) -> Option<Self::Item<'_>> {
+impl<'a, B> Iterator for Drain<'a, B>
+where
+    B: Deref<Target = Vec<u8>>,
+{
+    type Item = DatagramIn<'a>;
+
+    fn next(&mut self) -> Option<DatagramIn<'a>> {
+        let batch = self.batch;
+
         loop {
-            if self.buf_index >= self.buffers.len() {
+            if self.buf_index >= batch.buffers.len() {
                 return None;
             }
 
-            let buf = &self.buffers[self.buf_index];
-            let meta = &self.metas[self.buf_index];
+            let buf = &batch.buffers[self.buf_index];
+            let meta = &batch.metas[self.buf_index];
 
             if meta.len == 0 {
                 self.buf_index += 1;
@@ -1071,12 +1088,12 @@ where
                 continue;
             }
 
-            let local = SocketAddr::new(local_ip, self.port);
+            let local = SocketAddr::new(local_ip, batch.port);
 
             let segment_size = meta.stride;
 
             #[cfg(debug_assertions)]
-            tracing::trace!(target: "wire::net::recv", num_p = %self.num_packets, tot_b = %self._total_bytes, src = %meta.addr, dst = %local, ecn = ?meta.ecn, len = %segment_size);
+            tracing::trace!(target: "wire::net::recv", num_p = %batch.num_packets, tot_b = %batch._total_bytes, src = %meta.addr, dst = %local, ecn = ?meta.ecn, len = %segment_size);
 
             let segment_start = self.segment_index;
             let segment_end = std::cmp::min(segment_start + segment_size, meta.len);
@@ -1100,7 +1117,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use gat_lending_iterator::LendingIterator as _;
     use quinn_udp::RecvMeta;
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
@@ -1132,18 +1148,18 @@ mod tests {
         }
     }
 
-    /// The iterator is the item of the channel to the main thread; keeping it small is
-    /// the whole point of storing the batch in pooled `Vec`s rather than inline. tokio
+    /// The batch is the item of the channel to the main thread; keeping it small is
+    /// the whole point of storing its buffers in pooled `Vec`s rather than inline. tokio
     /// allocates channel slots in blocks, so a large item would cross musl's mmap
     /// threshold and thrash the allocator (see the pooling that produced this type).
     #[cfg(target_pointer_width = "64")]
     #[test]
-    fn iter_is_a_small_channel_item() {
-        assert_eq!(size_of::<DatagramSegmentIter>(), 104);
+    fn batch_is_a_small_channel_item() {
+        assert_eq!(size_of::<DatagramBatch>(), 88);
     }
 
     #[test]
-    fn datagram_iter_segments_buffer_correctly() {
+    fn drain_segments_buffers_correctly() {
         let buffer_pool = BufferPool::<VecBuf<DummyBuffer>>::new(3, "test");
         let meta_pool = BufferPool::<VecBuf<quinn_udp::RecvMeta>>::new(3, "test");
 
@@ -1171,7 +1187,8 @@ mod tests {
             quinn_udp::RecvMeta::default(),
         ]);
 
-        let mut iter = DatagramSegmentIter::new(buffers, metas, 0, 3);
+        let mut batch = DatagramBatch::new(buffers, metas, 0, 3);
+        let mut iter = batch.drain();
 
         assert_eq!(iter.next().unwrap().packet, b"foobar1");
         assert_eq!(iter.next().unwrap().packet, b"foobar2");
@@ -1217,7 +1234,8 @@ mod tests {
             ),
         ]);
 
-        let mut iter = DatagramSegmentIter::new(buffers, metas, 0, 2);
+        let mut batch = DatagramBatch::new(buffers, metas, 0, 2);
+        let mut iter = batch.drain();
 
         assert_eq!(iter.next().unwrap().packet, b"foo");
         assert!(iter.next().is_none());
@@ -1226,7 +1244,7 @@ mod tests {
     /// Both buffers end in a segment shorter than their stride, so counting whole strides
     /// would miss one datagram each.
     #[test]
-    fn num_packets_counts_segments_across_buffers() {
+    fn len_counts_segments_across_buffers() {
         let localhost = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
 
         let metas = [
@@ -1239,7 +1257,7 @@ mod tests {
     }
 
     #[test]
-    fn datagram_iter_drops_segments_larger_than_max_fz_payload() {
+    fn drain_drops_segments_larger_than_max_fz_payload() {
         let buffer_pool = BufferPool::<VecBuf<DummyBuffer>>::new(2, "test");
         let meta_pool = BufferPool::<VecBuf<quinn_udp::RecvMeta>>::new(2, "test");
 
@@ -1267,7 +1285,8 @@ mod tests {
             ),
         ]);
 
-        let mut iter = DatagramSegmentIter::new(buffers, metas, 0, 2);
+        let mut batch = DatagramBatch::new(buffers, metas, 0, 2);
+        let mut iter = batch.drain();
 
         assert_eq!(iter.next().unwrap().packet, b"foobar1");
         assert!(iter.next().is_none());

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -949,6 +949,7 @@ pub struct DatagramBatch<B = Buffer<Vec<u8>>> {
     metas: Buffer<VecBuf<quinn_udp::RecvMeta>>,
 
     port: u16,
+    drained: bool,
 
     _total_bytes: usize,
     num_packets: usize,
@@ -972,22 +973,30 @@ impl<B> DatagramBatch<B> {
             buffers,
             metas,
             port,
+            drained: false,
             _total_bytes: total_bytes,
             num_packets,
         }
     }
 
-    /// How many datagrams this batch carries in total.
+    /// How many datagrams this batch carries, as counted from the kernel's receive metadata.
+    ///
+    /// [`DatagramBatch::drain`] may yield fewer datagrams than this: receives with
+    /// nonsensical metadata are dropped during iteration. A drained batch reports zero.
     pub fn len(&self) -> usize {
+        if self.drained {
+            return 0;
+        }
+
         self.num_packets
     }
 
     /// Whether this batch carries no datagrams at all.
     pub fn is_empty(&self) -> bool {
-        self.num_packets == 0
+        self.len() == 0
     }
 
-    /// Yields all datagrams in the batch, in order.
+    /// Removes all datagrams from the batch, in order; draining again yields nothing.
     ///
     /// When [`quinn_udp`] returns us the buffers, it will have populated the
     /// [`quinn_udp::RecvMeta`]s accordingly. Thus, our main job here is to loop over the
@@ -997,9 +1006,12 @@ impl<B> DatagramBatch<B> {
     where
         B: Deref<Target = Vec<u8>>,
     {
+        let buf_index = if self.drained { self.buffers.len() } else { 0 };
+        self.drained = true;
+
         Drain {
             batch: self,
-            buf_index: 0,
+            buf_index,
             segment_index: 0,
         }
     }
@@ -1203,6 +1215,30 @@ mod tests {
         assert_eq!(iter.next().unwrap().packet, b"baz5");
         assert_eq!(iter.next().unwrap().packet, b"foo");
         assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn drained_batch_yields_nothing() {
+        let buffer_pool = BufferPool::<VecBuf<DummyBuffer>>::new(1, "test");
+        let meta_pool = BufferPool::<VecBuf<quinn_udp::RecvMeta>>::new(1, "test");
+
+        let mut buffers = buffer_pool.pull();
+        buffers.extend([DummyBuffer(b"foo".to_vec())]);
+
+        let mut metas = meta_pool.pull();
+        metas.extend([recv_meta(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            3,
+            3,
+        )]);
+
+        let mut batch = DatagramBatch::new(buffers, metas, 0, 1);
+
+        assert_eq!(batch.drain().count(), 1);
+
+        assert_eq!(batch.drain().count(), 0);
+        assert!(batch.is_empty());
     }
 
     /// A zero stride on a non-empty buffer must not stall the iterator: the receive

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -936,7 +936,7 @@ impl RecvBuffers {
 /// over the socket channels as a single item.
 ///
 /// The datagrams stay in the receive buffers the kernel filled; the buffers and metas
-/// live in pooled, heap-allocated `Vec`s (see [`RecvBuffers`]), so moving a batch only
+/// live in pooled, heap-allocated `Vec`s (see `RecvBuffers`), so moving a batch only
 /// copies a couple of pointers. Callers consume a batch with [`DatagramBatch::drain`],
 /// which segments buffers holding several GRO / URO-coalesced datagrams apart again.
 ///

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -941,7 +941,7 @@ impl RecvBuffers {
 /// which segments buffers holding several GRO / URO-coalesced datagrams apart again.
 ///
 /// The batch is generic over its buffer type to allow easier testing without a buffer pool.
-#[derive(derive_more::Debug)]
+#[derive(Clone, derive_more::Debug)]
 pub struct DatagramBatch<B = Buffer<Vec<u8>>> {
     #[debug(skip)]
     buffers: Buffer<VecBuf<B>>,

--- a/rust/libs/connlib/socket-factory/src/pool.rs
+++ b/rust/libs/connlib/socket-factory/src/pool.rs
@@ -25,7 +25,7 @@ use std::{
 use anyhow::{Context as _, Result};
 use quinn_udp::UdpSockRef;
 
-use crate::{DatagramSegmentIter, apply_buffer_size};
+use crate::{DatagramBatch, apply_buffer_size};
 
 /// A borrowed handle to a UDP socket and its quinn state - the currency the send and receive
 /// paths operate on, regardless of which [`SocketPool`] member it came from.
@@ -135,9 +135,9 @@ pub(crate) fn poll_recv_ready<F>(
     cx: &mut Context<'_>,
     socket: Socket<'_>,
     try_recv: &mut F,
-) -> Poll<Result<DatagramSegmentIter>>
+) -> Poll<Result<DatagramBatch>>
 where
-    F: FnMut(Socket<'_>) -> io::Result<DatagramSegmentIter>,
+    F: FnMut(Socket<'_>) -> io::Result<DatagramBatch>,
 {
     loop {
         match socket.inner.poll_recv_ready(cx) {

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -43,7 +43,7 @@ use anyhow::Result;
 use parking_lot::{Mutex, MutexGuard};
 use quinn_udp::UdpSockRef;
 
-use crate::{DatagramSegmentIter, RecvBuffers};
+use crate::{DatagramBatch, RecvBuffers};
 
 use super::{OwnedSocket, Socket, poll_recv_ready};
 
@@ -103,7 +103,7 @@ struct Inner {
     flow_sockets_supported: bool,
     buffer_sizes: Option<(usize, usize)>,
     /// Datagrams rescued from an evicted socket's receive buffer just before closing it.
-    drained: VecDeque<DatagramSegmentIter>,
+    drained: VecDeque<DatagramBatch>,
     /// Waker of the receive task; woken when new sockets or drained datagrams appear.
     recv_waker: Option<Waker>,
     /// Counter to rotate the polling order of sockets, ensuring receive fairness.
@@ -170,9 +170,9 @@ impl SocketPool {
         &self,
         cx: &mut Context<'_>,
         mut try_recv: F,
-    ) -> Poll<Result<DatagramSegmentIter>>
+    ) -> Poll<Result<DatagramBatch>>
     where
-        F: FnMut(Socket<'_>) -> io::Result<DatagramSegmentIter>,
+        F: FnMut(Socket<'_>) -> io::Result<DatagramBatch>,
     {
         let mut inner = self.lock();
 
@@ -184,8 +184,8 @@ impl SocketPool {
         }
 
         // Datagrams rescued from an evicted flow socket are the oldest; yield them first.
-        if let Some(iter) = inner.drained.pop_front() {
-            return Poll::Ready(Ok(iter));
+        if let Some(batch) = inner.drained.pop_front() {
+            return Poll::Ready(Ok(batch));
         }
 
         // Rotate the polling order by one slot per call so no socket can starve the others
@@ -429,12 +429,7 @@ fn eviction_rank(last_received: Option<Instant>, created_at: Instant) -> (bool, 
 /// A connected socket captures inbound for its 4-tuple; whatever is already queued would be
 /// discarded by the kernel on close. Packets arriving after the close are delivered to the
 /// catch-all socket instead.
-fn drain(
-    victim: &Flow,
-    port: u16,
-    recv_buffers: &RecvBuffers,
-    out: &mut VecDeque<DatagramSegmentIter>,
-) {
+fn drain(victim: &Flow, port: u16, recv_buffers: &RecvBuffers, out: &mut VecDeque<DatagramBatch>) {
     let socket = victim.socket.as_socket();
 
     loop {
@@ -449,12 +444,7 @@ fn drain(
             }
         };
 
-        out.push_back(DatagramSegmentIter::new(
-            batch.buffers,
-            batch.metas,
-            port,
-            len,
-        ));
+        out.push_back(DatagramBatch::new(batch.buffers, batch.metas, port, len));
     }
 }
 

--- a/rust/libs/connlib/socket-factory/src/pool/fallback.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/fallback.rs
@@ -12,7 +12,7 @@ use std::{
 
 use anyhow::Result;
 
-use crate::DatagramSegmentIter;
+use crate::DatagramBatch;
 
 use super::{OwnedSocket, Socket, poll_recv_ready};
 
@@ -41,9 +41,9 @@ impl SocketPool {
         &self,
         cx: &mut Context<'_>,
         mut try_recv: F,
-    ) -> Poll<Result<DatagramSegmentIter>>
+    ) -> Poll<Result<DatagramBatch>>
     where
-        F: FnMut(Socket<'_>) -> io::Result<DatagramSegmentIter>,
+        F: FnMut(Socket<'_>) -> io::Result<DatagramBatch>,
     {
         poll_recv_ready(cx, self.wildcard.as_socket(), &mut try_recv)
     }

--- a/rust/libs/connlib/socket-factory/tests/perf_udp_socket.rs
+++ b/rust/libs/connlib/socket-factory/tests/perf_udp_socket.rs
@@ -1,7 +1,6 @@
 //! Integration tests for [`socket_factory::PerfUdpSocket`], exercising it through its public API.
 
 use bufferpool::BufferPool;
-use gat_lending_iterator::LendingIterator as _;
 use ip_packet::Ecn;
 use socket_factory::{DatagramOut, udp};
 
@@ -53,8 +52,8 @@ async fn sends_and_receives_a_datagram() {
     // The reply matches the (connected) socket's 4-tuple exactly and must be delivered via it.
     peer.send_to(b"world", from).await.unwrap();
 
-    let mut iter = socket.recv_from().await.unwrap();
-    let datagram = iter.next().unwrap();
+    let mut batch = socket.recv_from().await.unwrap();
+    let datagram = batch.drain().next().unwrap();
 
     assert_eq!(datagram.packet, b"world");
     assert_eq!(datagram.from, peer_addr);

--- a/rust/libs/connlib/tunnel/Cargo.toml
+++ b/rust/libs/connlib/tunnel/Cargo.toml
@@ -13,7 +13,6 @@ dns-types = { workspace = true }
 eventloop-budget = { workspace = true }
 futures = { workspace = true }
 futures-bounded = { workspace = true, features = ["tokio"] }
-gat-lending-iterator = { workspace = true }
 http-client = { workspace = true }
 ip-packet = { workspace = true }
 itertools = { workspace = true, features = ["use_std"] }

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -14,11 +14,10 @@ use anyhow::{ErrorExt, Result};
 use bootstrap_dns_client::BootstrapDnsClient;
 use dns_types::DoHUrl;
 use futures_bounded::{FuturesMap, FuturesTupleSet};
-use gat_lending_iterator::LendingIterator;
 use http_client::HttpClient;
-use ip_packet::{Ecn, IpPacket, MAX_FZ_PAYLOAD};
+use ip_packet::{Ecn, IpPacket};
 use nameserver_set::NameserverSet;
-use socket_factory::{DatagramIn, SocketFactory, TcpSocket, UdpSocket};
+use socket_factory::{DatagramBatch, SocketFactory, TcpSocket, UdpSocket};
 use std::{
     collections::{BTreeMap, BTreeSet},
     io,
@@ -73,17 +72,17 @@ struct DnsQueryMetaData {
 ///
 /// This structure allows us to batch-process multiple ready sources rather than
 /// handling them one at a time, improving fairness and preventing starvation.
-pub struct Input<D, I> {
+pub struct Input {
     pub timeout: bool,
-    pub device: Option<D>,
-    pub network: Option<I>,
+    pub device: Option<tun::PacketBatch>,
+    pub network: Option<Vec<DatagramBatch>>,
     pub tcp_dns_queries: Vec<l4_tcp_dns_server::Query>,
     pub udp_dns_queries: Vec<l4_udp_dns_server::Query>,
     pub dns_response: Option<dns::RecursiveResponse>,
     pub error: TunnelError,
 }
 
-impl<D, I> Input<D, I> {
+impl Input {
     fn error(e: impl Into<anyhow::Error>) -> Self {
         Self {
             timeout: false,
@@ -222,12 +221,7 @@ impl Io {
         self.nameservers.fastest()
     }
 
-    pub fn poll(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<
-        Input<tun::PacketBatch, impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + use<>>,
-    > {
+    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Input> {
         if let Err(e) = ready!(self.flush(cx)) {
             return Poll::Ready(Input::error(e));
         }
@@ -251,10 +245,7 @@ impl Io {
             }
         }
 
-        let network = self
-            .sockets
-            .poll_recv_from(cx)
-            .map(|network| network.filter(is_max_wg_packet_size));
+        let network = self.sockets.poll_recv_from(cx);
 
         while let Poll::Ready(e) = self.sockets.poll_error(cx) {
             error.push(e);
@@ -591,15 +582,6 @@ impl Io {
     }
 }
 
-fn is_max_wg_packet_size(d: &DatagramIn) -> bool {
-    let len = d.packet.len();
-    if len > MAX_FZ_PAYLOAD {
-        return false;
-    }
-
-    true
-}
-
 #[cfg(test)]
 mod tests {
     use std::{future::poll_fn, net::Ipv4Addr};
@@ -737,10 +719,7 @@ mod tests {
             io
         }
 
-        async fn next(
-            &mut self,
-        ) -> Input<tun::PacketBatch, impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>>>
-        {
+        async fn next(&mut self) -> Input {
             poll_fn(|cx| self.poll(cx)).await
         }
     }

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -12,6 +12,7 @@ pub(crate) use udp_gso_queue::{GSO_BUFFER_SIZE, UdpGsoQueue};
 use crate::{TunnelError, dns, io::timeout::Timeout, otel, sockets::Sockets};
 use anyhow::{ErrorExt, Result};
 use bootstrap_dns_client::BootstrapDnsClient;
+use bufferpool::{Buffer, VecBuf};
 use dns_types::DoHUrl;
 use futures_bounded::{FuturesMap, FuturesTupleSet};
 use http_client::HttpClient;
@@ -75,7 +76,7 @@ struct DnsQueryMetaData {
 pub struct Input {
     pub timeout: bool,
     pub device: Option<tun::PacketBatch>,
-    pub network: Option<Vec<DatagramBatch>>,
+    pub network: Option<Buffer<VecBuf<DatagramBatch>>>,
     pub tcp_dns_queries: Vec<l4_tcp_dns_server::Query>,
     pub udp_dns_queries: Vec<l4_udp_dns_server::Query>,
     pub dns_response: Option<dns::RecursiveResponse>,

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -16,8 +16,7 @@ use connlib_model::PublicKey;
 use eventloop_budget::Budget;
 use futures::{FutureExt, future::BoxFuture};
 use io::Io;
-use ip_packet::MAX_FZ_PAYLOAD;
-use socket_factory::{DatagramIn, SocketFactory, TcpSocket, UdpSocket};
+use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::{
     collections::BTreeSet,
     future, mem,
@@ -299,11 +298,7 @@ impl ClientTunnel {
                 }
 
                 if let Some(mut batches) = network {
-                    for received in batches
-                        .iter_mut()
-                        .flat_map(|batch| batch.drain())
-                        .filter(is_max_wg_packet_size)
-                    {
+                    for received in batches.iter_mut().flat_map(|batch| batch.drain()) {
                         self.packet_counter.add(
                             1,
                             &[
@@ -516,11 +511,7 @@ impl GatewayTunnel {
                 }
 
                 if let Some(mut batches) = network {
-                    for received in batches
-                        .iter_mut()
-                        .flat_map(|batch| batch.drain())
-                        .filter(is_max_wg_packet_size)
-                    {
+                    for received in batches.iter_mut().flat_map(|batch| batch.drain()) {
                         self.packet_counter.add(
                             1,
                             &[
@@ -634,13 +625,4 @@ impl GatewayTunnel {
 pub struct FailedToHandleNetworkPacket {
     local: SocketAddr,
     from: SocketAddr,
-}
-
-fn is_max_wg_packet_size(d: &DatagramIn) -> bool {
-    let len = d.packet.len();
-    if len > MAX_FZ_PAYLOAD {
-        return false;
-    }
-
-    true
 }

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -15,9 +15,9 @@ use anyhow::{Context as _, ErrorExt as _, Result};
 use connlib_model::PublicKey;
 use eventloop_budget::Budget;
 use futures::{FutureExt, future::BoxFuture};
-use gat_lending_iterator::LendingIterator;
 use io::Io;
-use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
+use ip_packet::MAX_FZ_PAYLOAD;
+use socket_factory::{DatagramIn, SocketFactory, TcpSocket, UdpSocket};
 use std::{
     collections::BTreeSet,
     future, mem,
@@ -298,8 +298,12 @@ impl ClientTunnel {
                     tick.want_continue();
                 }
 
-                if let Some(mut packets) = network {
-                    while let Some(received) = packets.next() {
+                if let Some(mut batches) = network {
+                    for received in batches
+                        .iter_mut()
+                        .flat_map(|batch| batch.drain())
+                        .filter(is_max_wg_packet_size)
+                    {
                         self.packet_counter.add(
                             1,
                             &[
@@ -511,8 +515,12 @@ impl GatewayTunnel {
                     tick.want_continue();
                 }
 
-                if let Some(mut packets) = network {
-                    while let Some(received) = packets.next() {
+                if let Some(mut batches) = network {
+                    for received in batches
+                        .iter_mut()
+                        .flat_map(|batch| batch.drain())
+                        .filter(is_max_wg_packet_size)
+                    {
                         self.packet_counter.add(
                             1,
                             &[
@@ -626,4 +634,13 @@ impl GatewayTunnel {
 pub struct FailedToHandleNetworkPacket {
     local: SocketAddr,
     from: SocketAddr,
+}
+
+fn is_max_wg_packet_size(d: &DatagramIn) -> bool {
+    let len = d.packet.len();
+    if len > MAX_FZ_PAYLOAD {
+        return false;
+    }
+
+    true
 }

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -1,5 +1,6 @@
 use crate::otel;
 use anyhow::{Context as _, ErrorExt as _, Result};
+use bufferpool::{Buffer, BufferPool, VecBuf};
 use futures::{SinkExt, ready};
 use socket_factory::{DatagramBatch, DatagramOut, PerfUdpSocket, SocketFactory, UdpSocket};
 use std::collections::VecDeque;
@@ -8,7 +9,7 @@ use std::time::{Duration, Instant};
 use std::{
     io,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
-    sync::Arc,
+    sync::{Arc, LazyLock},
     task::{Context, Poll},
 };
 use tokio::sync::mpsc;
@@ -44,6 +45,14 @@ const UDP_RECV_BATCH_LIMIT: usize = cfg_select! {
     target_os = "android" => { 1 }
     _ => { 8 }
 };
+
+/// Pool for the `Vec`s that collect one poll's worth of received datagram batches.
+///
+/// Sized to hold a full drain of both sockets, so collecting into it never reallocates.
+/// Dropping the collection after processing returns it to the pool, keeping the
+/// receive path free of allocations.
+static BATCHES_POOL: LazyLock<BufferPool<VecBuf<DatagramBatch>>> =
+    LazyLock::new(|| BufferPool::new(2 * UDP_RECV_BATCH_LIMIT, "udp-recv-batches"));
 
 const UNSPECIFIED_V4_SOCKET: SocketAddrV4 =
     SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, DEFAULT_LISTEN_PORT);
@@ -120,8 +129,8 @@ impl Sockets {
     }
 
     /// Polls for batches of received UDP datagrams, at most [`UDP_RECV_BATCH_LIMIT`] per socket.
-    pub fn poll_recv_from(&mut self, cx: &mut Context<'_>) -> Poll<Vec<DatagramBatch>> {
-        let mut batches = Vec::with_capacity(2 * UDP_RECV_BATCH_LIMIT);
+    pub fn poll_recv_from(&mut self, cx: &mut Context<'_>) -> Poll<Buffer<VecBuf<DatagramBatch>>> {
+        let mut batches = BATCHES_POOL.pull();
 
         if let Some(socket) = self.socket_v4.as_mut() {
             socket.poll_recv_from(cx, &mut batches);

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -1,9 +1,7 @@
 use crate::otel;
 use anyhow::{Context as _, ErrorExt as _, Result};
 use futures::{SinkExt, ready};
-use gat_lending_iterator::LendingIterator;
-use socket_factory::{DatagramIn, DatagramSegmentIter, SocketFactory, UdpSocket};
-use socket_factory::{DatagramOut, PerfUdpSocket};
+use socket_factory::{DatagramBatch, DatagramOut, PerfUdpSocket, SocketFactory, UdpSocket};
 use std::collections::VecDeque;
 use std::env::VarError;
 use std::time::{Duration, Instant};
@@ -121,25 +119,23 @@ impl Sockets {
         Ok(())
     }
 
-    pub fn poll_recv_from(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + use<>> {
-        let mut iter = PacketIter::new();
+    /// Polls for batches of received UDP datagrams, at most [`UDP_RECV_BATCH_LIMIT`] per socket.
+    pub fn poll_recv_from(&mut self, cx: &mut Context<'_>) -> Poll<Vec<DatagramBatch>> {
+        let mut batches = Vec::with_capacity(2 * UDP_RECV_BATCH_LIMIT);
 
-        if let Some(Poll::Ready(packets)) = self.socket_v4.as_mut().map(|s| s.poll_recv_from(cx)) {
-            iter.ip4 = Some(packets);
+        if let Some(socket) = self.socket_v4.as_mut() {
+            socket.poll_recv_from(cx, &mut batches);
         }
 
-        if let Some(Poll::Ready(packets)) = self.socket_v6.as_mut().map(|s| s.poll_recv_from(cx)) {
-            iter.ip6 = Some(packets);
+        if let Some(socket) = self.socket_v6.as_mut() {
+            socket.poll_recv_from(cx, &mut batches);
         }
 
-        if iter.is_empty() {
+        if batches.is_empty() {
             return Poll::Pending;
         }
 
-        Poll::Ready(iter)
+        Poll::Ready(batches)
     }
 
     pub fn poll_error(&mut self, cx: &mut Context<'_>) -> Poll<anyhow::Error> {
@@ -160,74 +156,6 @@ impl Sockets {
         }
 
         Poll::Pending
-    }
-}
-
-struct PacketIter<T4, T6> {
-    ip4: Option<T4>,
-    ip6: Option<T6>,
-}
-
-impl<T4, T6> PacketIter<T4, T6> {
-    fn new() -> Self {
-        Self {
-            ip4: None,
-            ip6: None,
-        }
-    }
-
-    fn is_empty(&self) -> bool {
-        self.ip4.is_none() && self.ip6.is_none()
-    }
-}
-
-impl<T4, T6> LendingIterator for PacketIter<T4, T6>
-where
-    T4: 'static + for<'a> LendingIterator<Item<'a> = DatagramIn<'a>>,
-    T6: 'static + for<'a> LendingIterator<Item<'a> = DatagramIn<'a>>,
-{
-    type Item<'a> = DatagramIn<'a>;
-
-    fn next(&mut self) -> Option<Self::Item<'_>> {
-        if let Some(packet) = self.ip4.as_mut().and_then(|i| i.next()) {
-            return Some(packet);
-        }
-
-        if let Some(packet) = self.ip6.as_mut().and_then(|i| i.next()) {
-            return Some(packet);
-        }
-
-        None
-    }
-}
-
-/// Chains up to [`UDP_RECV_BATCH_LIMIT`] datagram batches from a single `poll` into one iterator.
-///
-/// A linked list (not a `Vec`) so `next` can fall back from the drained `current` batch to `rest` as
-/// separate fields — the disjoint borrow that lets a runtime-length chain of lending iterators
-/// compile on stable Rust.
-struct ChainedDatagrams {
-    current: DatagramSegmentIter,
-    rest: Option<Box<ChainedDatagrams>>,
-}
-
-impl ChainedDatagrams {
-    fn new(batches: Vec<DatagramSegmentIter>) -> Option<Self> {
-        let mut rest = None;
-
-        for current in batches.into_iter().rev() {
-            rest = Some(Box::new(ChainedDatagrams { current, rest }));
-        }
-
-        rest.map(|boxed| *boxed)
-    }
-}
-
-impl LendingIterator for ChainedDatagrams {
-    type Item<'a> = DatagramIn<'a>;
-
-    fn next(&mut self) -> Option<Self::Item<'_>> {
-        self.current.next().or_else(|| self.rest.as_mut()?.next())
     }
 }
 
@@ -288,7 +216,7 @@ struct ThreadedUdpSocket {
 
 struct Channels {
     outbound_tx: PollSender<DatagramOut>,
-    inbound_rx: mpsc::Receiver<DatagramSegmentIter>,
+    inbound_rx: mpsc::Receiver<DatagramBatch>,
     /// Send/receive errors, plus a final [`UdpSocketThreadStopped`] when a thread dies.
     error_rx: mpsc::Receiver<anyhow::Error>,
 }
@@ -418,8 +346,8 @@ impl ThreadedUdpSocket {
 
                     async move {
                         loop {
-                            let datagrams = match socket.recv_from().await {
-                                Ok(datagrams) => datagrams,
+                            let batch = match socket.recv_from().await {
+                                Ok(batch) => batch,
                                 Err(e) => {
                                     if let Some(io) = e.any_downcast_ref::<io::Error>() {
                                         io_error_counter.add(
@@ -444,7 +372,7 @@ impl ThreadedUdpSocket {
                                 }
                             };
 
-                            if inbound_tx.send(datagrams).await.is_err() {
+                            if inbound_tx.send(batch).await.is_err() {
                                 tracing::debug!(
                                     "Channel for inbound datagrams closed; exiting UDP recv task"
                                 );
@@ -493,26 +421,20 @@ impl ThreadedUdpSocket {
         Ok(())
     }
 
-    fn poll_recv_from(&mut self, cx: &mut Context<'_>) -> Poll<ChainedDatagrams> {
+    /// Appends the batches received from the socket thread to `batches`, at most
+    /// [`UDP_RECV_BATCH_LIMIT`] per call.
+    ///
+    /// Appending nothing means the channel is either empty or closed, i.e. the thread
+    /// stopped (reported via `poll_error`); no waker is registered on close, since
+    /// we'll be shutting down anyway.
+    fn poll_recv_from(&mut self, cx: &mut Context<'_>, batches: &mut Vec<DatagramBatch>) {
         let Some(channels) = self.channels.as_mut() else {
-            return Poll::Pending;
+            return;
         };
 
-        let mut batches = Vec::with_capacity(UDP_RECV_BATCH_LIMIT);
-        ready!(
-            channels
-                .inbound_rx
-                .poll_recv_many(cx, &mut batches, UDP_RECV_BATCH_LIMIT)
-        );
-
-        let Some(datagrams) = ChainedDatagrams::new(batches) else {
-            // An empty read means a closed channel, i.e. the thread stopped (reported via
-            // `poll_error`). `Pending` avoids dropping the other socket's datagrams; no waker on
-            // close, since we'll be shutting down anyway.
-            return Poll::Pending;
-        };
-
-        Poll::Ready(datagrams)
+        let _ = channels
+            .inbound_rx
+            .poll_recv_many(cx, batches, UDP_RECV_BATCH_LIMIT);
     }
 
     fn poll_error(&mut self, cx: &mut Context<'_>) -> Poll<anyhow::Error> {

--- a/rust/tests/loadtest/Cargo.toml
+++ b/rust/tests/loadtest/Cargo.toml
@@ -17,7 +17,6 @@ bufferpool = { workspace = true }
 bytecodec = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 futures = { workspace = true }
-gat-lending-iterator = { workspace = true }
 ip-packet = { workspace = true }
 known-dirs = { workspace = true }
 logging = { workspace = true }

--- a/rust/tests/loadtest/src/turn.rs
+++ b/rust/tests/loadtest/src/turn.rs
@@ -25,7 +25,6 @@ use anyhow::{Context as _, ErrorExt as _, Result, anyhow, bail};
 use bufferpool::BufferPool;
 use bytecodec::{DecodeExt as _, EncodeExt as _};
 use clap::Parser;
-use gat_lending_iterator::LendingIterator as _;
 use ip_packet::Ecn;
 use rand::random;
 use serde::Serialize;
@@ -708,15 +707,15 @@ async fn receive(
 
             () = tokio::time::sleep_until(deadline) => break,
             result = socket.recv_from() => {
-                let mut datagrams = match result {
-                    Ok(datagrams) => datagrams,
+                let mut batch = match result {
+                    Ok(batch) => batch,
                     Err(e) => {
                         tracing::warn!(error = %e, "Failed to receive on peer socket");
                         break;
                     }
                 };
 
-                while let Some(datagram) = datagrams.next() {
+                for datagram in batch.drain() {
                     record_datagram(&mut stats, &counters, datagram.packet, payload_size);
                 }
             }
@@ -1152,9 +1151,9 @@ async fn request_response(
 /// Receive the next datagram originating from `server`, copied out of the socket buffer.
 async fn recv_response(socket: &PerfUdpSocket, server: SocketAddr) -> Result<Vec<u8>> {
     loop {
-        let mut datagrams = socket.recv_from().await?;
+        let mut batch = socket.recv_from().await?;
 
-        while let Some(datagram) = datagrams.next() {
+        for datagram in batch.drain() {
             if datagram.from == server {
                 return Ok(datagram.packet.to_vec());
             }


### PR DESCRIPTION
Both IO paths hand batches of packets over channels to the main thread, but the two channel items shared neither naming nor API: the TUN side sends a `PacketBatch` while the UDP side sent a `DatagramSegmentIter`, a `LendingIterator` with the iteration cursor baked into the channel item itself.

This renames `DatagramSegmentIter` to `DatagramBatch` and shapes its API after `PacketBatch`: a plain batch with `len`, `is_empty` and a `drain` method that yields the individual datagrams.

With the iteration state in a borrowing iterator, `drain` can return a std `Iterator`, so the bespoke lending-iterator plumbing (`ChainedDatagrams`, `PacketIter`) and the `gat-lending-iterator` dependency go away. The per-poll collections of batches are pulled from a `BufferPool`, keeping the UDP receive path allocation-free.