### PR TITLE
perf(connlib): prefetch packet payloads ahead of processing

### DIFF
--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -9,7 +9,7 @@ mod udp_gso_queue;
 pub use device::{Device, TunChannelClosed};
 pub(crate) use udp_gso_queue::{GSO_BUFFER_SIZE, UdpGsoQueue};
 
-use crate::prefetch::{LOOKAHEAD, PrefetchExt as _};
+use crate::prefetch::PrefetchExt as _;
 use crate::{TunnelError, dns, io::timeout::Timeout, otel, sockets::Sockets};
 use anyhow::{ErrorExt, Result};
 use bootstrap_dns_client::BootstrapDnsClient;
@@ -84,6 +84,12 @@ pub struct Input {
     pub error: TunnelError,
 }
 
+/// How many items ahead of consumption to prefetch.
+///
+/// Processing one packet takes several times longer than fetching one from another
+/// core's cache, so two items hide the fetch latency entirely.
+const PREFETCH_LOOKAHEAD: usize = 2;
+
 /// The IP packets read from the TUN device during one poll.
 pub struct DevicePackets {
     batch: tun::PacketBatch,
@@ -93,7 +99,7 @@ impl DevicePackets {
     /// Removes all packets, in order, prefetching their payloads ahead of the
     /// caller's processing.
     pub fn drain(&mut self) -> impl Iterator<Item = IpPacket> + '_ {
-        self.batch.drain().prefetch_ahead::<LOOKAHEAD>()
+        self.batch.drain().prefetch_ahead::<PREFETCH_LOOKAHEAD>()
     }
 }
 
@@ -109,7 +115,7 @@ impl NetworkDatagrams {
         self.batches
             .iter_mut()
             .flat_map(|batch| batch.drain())
-            .prefetch_ahead::<LOOKAHEAD>()
+            .prefetch_ahead::<PREFETCH_LOOKAHEAD>()
     }
 }
 

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -9,6 +9,7 @@ mod udp_gso_queue;
 pub use device::{Device, TunChannelClosed};
 pub(crate) use udp_gso_queue::{GSO_BUFFER_SIZE, UdpGsoQueue};
 
+use crate::prefetch::{LOOKAHEAD, PrefetchExt as _};
 use crate::{TunnelError, dns, io::timeout::Timeout, otel, sockets::Sockets};
 use anyhow::{ErrorExt, Result};
 use bootstrap_dns_client::BootstrapDnsClient;
@@ -18,7 +19,7 @@ use futures_bounded::{FuturesMap, FuturesTupleSet};
 use http_client::HttpClient;
 use ip_packet::{Ecn, IpPacket};
 use nameserver_set::NameserverSet;
-use socket_factory::{DatagramBatch, SocketFactory, TcpSocket, UdpSocket};
+use socket_factory::{DatagramBatch, DatagramIn, SocketFactory, TcpSocket, UdpSocket};
 use std::{
     collections::{BTreeMap, BTreeSet},
     io,
@@ -75,12 +76,41 @@ struct DnsQueryMetaData {
 /// handling them one at a time, improving fairness and preventing starvation.
 pub struct Input {
     pub timeout: bool,
-    pub device: Option<tun::PacketBatch>,
-    pub network: Option<Buffer<VecBuf<DatagramBatch>>>,
+    pub device: Option<DevicePackets>,
+    pub network: Option<NetworkDatagrams>,
     pub tcp_dns_queries: Vec<l4_tcp_dns_server::Query>,
     pub udp_dns_queries: Vec<l4_udp_dns_server::Query>,
     pub dns_response: Option<dns::RecursiveResponse>,
     pub error: TunnelError,
+}
+
+/// The IP packets read from the TUN device during one poll.
+pub struct DevicePackets {
+    batch: tun::PacketBatch,
+}
+
+impl DevicePackets {
+    /// Removes all packets, in order, prefetching their payloads ahead of the
+    /// caller's processing.
+    pub fn drain(&mut self) -> impl Iterator<Item = IpPacket> + '_ {
+        self.batch.drain().prefetch_ahead::<LOOKAHEAD>()
+    }
+}
+
+/// The UDP datagrams received from the network during one poll.
+pub struct NetworkDatagrams {
+    batches: Buffer<VecBuf<DatagramBatch>>,
+}
+
+impl NetworkDatagrams {
+    /// Removes all datagrams across all batches, in order, prefetching their
+    /// payloads ahead of the caller's processing.
+    pub fn drain(&mut self) -> impl Iterator<Item = DatagramIn<'_>> {
+        self.batches
+            .iter_mut()
+            .flat_map(|batch| batch.drain())
+            .prefetch_ahead::<LOOKAHEAD>()
+    }
 }
 
 impl Input {
@@ -246,7 +276,10 @@ impl Io {
             }
         }
 
-        let network = self.sockets.poll_recv_from(cx);
+        let network = self
+            .sockets
+            .poll_recv_from(cx)
+            .map(|batches| NetworkDatagrams { batches });
 
         while let Poll::Ready(e) = self.sockets.poll_error(cx) {
             error.push(e);
@@ -271,7 +304,7 @@ impl Io {
                 ],
             );
 
-            batch
+            DevicePackets { batch }
         });
 
         let udp_dns_queries = self

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -16,7 +16,6 @@ use connlib_model::PublicKey;
 use eventloop_budget::Budget;
 use futures::{FutureExt, future::BoxFuture};
 use io::Io;
-use prefetch::PrefetchExt as _;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::{
     collections::BTreeSet,
@@ -278,7 +277,7 @@ impl ClientTunnel {
                 }
 
                 if let Some(mut packets) = device {
-                    for packet in packets.drain().prefetch_ahead::<2>() {
+                    for packet in packets.drain() {
                         match self
                             .role_state
                             .handle_tun_input(packet, now, self.io.gso_queue_mut())
@@ -299,12 +298,8 @@ impl ClientTunnel {
                     tick.want_continue();
                 }
 
-                if let Some(mut batches) = network {
-                    for received in batches
-                        .iter_mut()
-                        .flat_map(|batch| batch.drain())
-                        .prefetch_ahead::<2>()
-                    {
+                if let Some(mut datagrams) = network {
+                    for received in datagrams.drain() {
                         self.packet_counter.add(
                             1,
                             &[
@@ -482,7 +477,7 @@ impl GatewayTunnel {
                 }
 
                 if let Some(mut packets) = device {
-                    for packet in packets.drain().prefetch_ahead::<2>() {
+                    for packet in packets.drain() {
                         match self
                             .role_state
                             .handle_tun_input(packet, now, self.io.gso_queue_mut())
@@ -516,12 +511,8 @@ impl GatewayTunnel {
                     tick.want_continue();
                 }
 
-                if let Some(mut batches) = network {
-                    for received in batches
-                        .iter_mut()
-                        .flat_map(|batch| batch.drain())
-                        .prefetch_ahead::<2>()
-                    {
+                if let Some(mut datagrams) = network {
+                    for received in datagrams.drain() {
                         self.packet_counter.add(
                             1,
                             &[

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -16,6 +16,7 @@ use connlib_model::PublicKey;
 use eventloop_budget::Budget;
 use futures::{FutureExt, future::BoxFuture};
 use io::Io;
+use prefetch::PrefetchExt as _;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::{
     collections::BTreeSet,
@@ -29,6 +30,7 @@ use tun::Tun;
 use tunnel_proto::unroutable_packet::RoutingError;
 
 mod io;
+mod prefetch;
 mod sockets;
 mod utils;
 
@@ -276,7 +278,7 @@ impl ClientTunnel {
                 }
 
                 if let Some(mut packets) = device {
-                    for packet in packets.drain() {
+                    for packet in packets.drain().prefetch_ahead::<2>() {
                         match self
                             .role_state
                             .handle_tun_input(packet, now, self.io.gso_queue_mut())
@@ -298,7 +300,11 @@ impl ClientTunnel {
                 }
 
                 if let Some(mut batches) = network {
-                    for received in batches.iter_mut().flat_map(|batch| batch.drain()) {
+                    for received in batches
+                        .iter_mut()
+                        .flat_map(|batch| batch.drain())
+                        .prefetch_ahead::<2>()
+                    {
                         self.packet_counter.add(
                             1,
                             &[
@@ -476,7 +482,7 @@ impl GatewayTunnel {
                 }
 
                 if let Some(mut packets) = device {
-                    for packet in packets.drain() {
+                    for packet in packets.drain().prefetch_ahead::<2>() {
                         match self
                             .role_state
                             .handle_tun_input(packet, now, self.io.gso_queue_mut())
@@ -511,7 +517,11 @@ impl GatewayTunnel {
                 }
 
                 if let Some(mut batches) = network {
-                    for received in batches.iter_mut().flat_map(|batch| batch.drain()) {
+                    for received in batches
+                        .iter_mut()
+                        .flat_map(|batch| batch.drain())
+                        .prefetch_ahead::<2>()
+                    {
                         self.packet_counter.add(
                             1,
                             &[

--- a/rust/libs/connlib/tunnel/src/prefetch.rs
+++ b/rust/libs/connlib/tunnel/src/prefetch.rs
@@ -1,25 +1,13 @@
-//! An experiment in prefetching packet payloads ahead of processing.
+//! Prefetching of packet payloads ahead of processing.
 //!
 //! Packets arrive on the main thread with their payload bytes last written by an IO
 //! thread on another core, so the first access during en- / decryption stalls on a
 //! cache miss per line. Processing one packet takes several times longer than fetching
 //! one from another core's cache, so a lookahead of two items is enough to hide that
 //! latency entirely.
-//!
-//! Disabled by default; enable per process with `FIREZONE_PREFETCH_PACKETS=1` so
-//! identical builds can be benchmarked with and without it.
-
-use std::sync::LazyLock;
 
 use ip_packet::IpPacket;
 use socket_factory::DatagramIn;
-
-static ENABLED: LazyLock<bool> = LazyLock::new(|| {
-    matches!(
-        std::env::var("FIREZONE_PREFETCH_PACKETS").as_deref(),
-        Ok("1") | Ok("true")
-    )
-});
 
 /// An item whose backing memory can be pulled into cache ahead of use.
 pub(crate) trait Prefetch {
@@ -46,7 +34,7 @@ pub(crate) trait PrefetchExt: Iterator + Sized {
     where
         Self::Item: Prefetch,
     {
-        PrefetchAhead::new(self, *ENABLED)
+        PrefetchAhead::new(self)
     }
 }
 
@@ -55,11 +43,8 @@ impl<I> PrefetchExt for I where I: Iterator + Sized {}
 pub(crate) struct PrefetchAhead<I: Iterator, const K: usize> {
     inner: I,
     /// FIFO of items pulled ahead of consumption; `head` is the oldest slot.
-    ///
-    /// Stays empty (and unused) while the experiment is disabled.
     lookahead: [Option<I::Item>; K],
     head: usize,
-    enabled: bool,
 }
 
 impl<I, const K: usize> PrefetchAhead<I, K>
@@ -67,12 +52,8 @@ where
     I: Iterator,
     I::Item: Prefetch,
 {
-    fn new(mut inner: I, enabled: bool) -> Self {
+    fn new(mut inner: I) -> Self {
         let lookahead = std::array::from_fn(|_| {
-            if !enabled {
-                return None;
-            }
-
             let item = inner.next();
 
             if let Some(item) = &item {
@@ -86,7 +67,6 @@ where
             inner,
             lookahead,
             head: 0,
-            enabled,
         }
     }
 }
@@ -99,10 +79,6 @@ where
     type Item = I::Item;
 
     fn next(&mut self) -> Option<I::Item> {
-        if !self.enabled {
-            return self.inner.next();
-        }
-
         let fresh = self.inner.next();
 
         if let Some(item) = &fresh {
@@ -159,7 +135,7 @@ mod tests {
     fn yields_all_items_in_order() {
         let items = (0..5).map(Plain);
 
-        let result = PrefetchAhead::<_, 2>::new(items, true)
+        let result = PrefetchAhead::<_, 2>::new(items)
             .map(|p| p.0)
             .collect::<Vec<_>>();
 
@@ -170,7 +146,7 @@ mod tests {
     fn yields_fewer_items_than_lookahead() {
         let items = std::iter::once(Plain(7));
 
-        let result = PrefetchAhead::<_, 2>::new(items, true)
+        let result = PrefetchAhead::<_, 2>::new(items)
             .map(|p| p.0)
             .collect::<Vec<_>>();
 

--- a/rust/libs/connlib/tunnel/src/prefetch.rs
+++ b/rust/libs/connlib/tunnel/src/prefetch.rs
@@ -91,13 +91,17 @@ where
     }
 }
 
-/// Issues a prefetch for every cacheline of `bytes`.
+/// The stride between prefetch hints.
 ///
-/// A 64-byte stride is correct on x86-64 and common ARM cores; Apple Silicon uses
-/// 128-byte lines, where it merely issues one redundant hint per line.
-fn prefetch_slice(bytes: &[u8]) {
-    const CACHE_LINE: usize = 64;
+/// Apple Silicon uses 128-byte cachelines; everything else we target, including
+/// Intel Macs and Android's Cortex cores, uses 64 bytes.
+const CACHE_LINE: usize = cfg_select! {
+    all(target_arch = "aarch64", target_vendor = "apple") => { 128 }
+    _ => { 64 }
+};
 
+/// Issues a prefetch for every cacheline of `bytes`.
+fn prefetch_slice(bytes: &[u8]) {
     for line_start in (0..bytes.len()).step_by(CACHE_LINE) {
         prefetch_addr(&bytes[line_start]);
     }

--- a/rust/libs/connlib/tunnel/src/prefetch.rs
+++ b/rust/libs/connlib/tunnel/src/prefetch.rs
@@ -2,15 +2,11 @@
 //!
 //! Packets arrive on the main thread with their payload bytes last written by an IO
 //! thread on another core, so the first access during en- / decryption stalls on a
-//! cache miss per line. Processing one packet takes several times longer than fetching
-//! one from another core's cache, so a lookahead of two items is enough to hide that
-//! latency entirely.
+//! cache miss per line. A small lookahead over the receive iterators is enough to
+//! hide that latency entirely.
 
 use ip_packet::IpPacket;
 use socket_factory::DatagramIn;
-
-/// How many items ahead of consumption to prefetch.
-pub(crate) const LOOKAHEAD: usize = 2;
 
 /// An item whose backing memory can be pulled into cache ahead of use.
 pub(crate) trait Prefetch {

--- a/rust/libs/connlib/tunnel/src/prefetch.rs
+++ b/rust/libs/connlib/tunnel/src/prefetch.rs
@@ -9,6 +9,9 @@
 use ip_packet::IpPacket;
 use socket_factory::DatagramIn;
 
+/// How many items ahead of consumption to prefetch.
+pub(crate) const LOOKAHEAD: usize = 2;
+
 /// An item whose backing memory can be pulled into cache ahead of use.
 pub(crate) trait Prefetch {
     /// Requests the item's payload to be loaded into cache; returns without waiting.

--- a/rust/libs/connlib/tunnel/src/prefetch.rs
+++ b/rust/libs/connlib/tunnel/src/prefetch.rs
@@ -1,0 +1,185 @@
+//! An experiment in prefetching packet payloads ahead of processing.
+//!
+//! Packets arrive on the main thread with their payload bytes last written by an IO
+//! thread on another core, so the first access during en- / decryption stalls on a
+//! cache miss per line. Processing one packet takes several times longer than fetching
+//! one from another core's cache, so a lookahead of two items is enough to hide that
+//! latency entirely.
+//!
+//! Disabled by default; enable per process with `FIREZONE_PREFETCH_PACKETS=1` so
+//! identical builds can be benchmarked with and without it.
+
+use std::sync::LazyLock;
+
+use ip_packet::IpPacket;
+use socket_factory::DatagramIn;
+
+static ENABLED: LazyLock<bool> = LazyLock::new(|| {
+    matches!(
+        std::env::var("FIREZONE_PREFETCH_PACKETS").as_deref(),
+        Ok("1") | Ok("true")
+    )
+});
+
+/// An item whose backing memory can be pulled into cache ahead of use.
+pub(crate) trait Prefetch {
+    /// Requests the item's payload to be loaded into cache; returns without waiting.
+    fn prefetch(&self);
+}
+
+impl Prefetch for IpPacket {
+    fn prefetch(&self) {
+        prefetch_slice(self.packet());
+    }
+}
+
+impl Prefetch for DatagramIn<'_> {
+    fn prefetch(&self) {
+        prefetch_slice(self.packet);
+    }
+}
+
+pub(crate) trait PrefetchExt: Iterator + Sized {
+    /// Pulls up to `K` items ahead of consumption, prefetching each item's payload as
+    /// it enters the lookahead window.
+    fn prefetch_ahead<const K: usize>(self) -> PrefetchAhead<Self, K>
+    where
+        Self::Item: Prefetch,
+    {
+        PrefetchAhead::new(self, *ENABLED)
+    }
+}
+
+impl<I> PrefetchExt for I where I: Iterator + Sized {}
+
+pub(crate) struct PrefetchAhead<I: Iterator, const K: usize> {
+    inner: I,
+    /// FIFO of items pulled ahead of consumption; `head` is the oldest slot.
+    ///
+    /// Stays empty (and unused) while the experiment is disabled.
+    lookahead: [Option<I::Item>; K],
+    head: usize,
+    enabled: bool,
+}
+
+impl<I, const K: usize> PrefetchAhead<I, K>
+where
+    I: Iterator,
+    I::Item: Prefetch,
+{
+    fn new(mut inner: I, enabled: bool) -> Self {
+        let lookahead = std::array::from_fn(|_| {
+            if !enabled {
+                return None;
+            }
+
+            let item = inner.next();
+
+            if let Some(item) = &item {
+                item.prefetch();
+            }
+
+            item
+        });
+
+        Self {
+            inner,
+            lookahead,
+            head: 0,
+            enabled,
+        }
+    }
+}
+
+impl<I, const K: usize> Iterator for PrefetchAhead<I, K>
+where
+    I: Iterator,
+    I::Item: Prefetch,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<I::Item> {
+        if !self.enabled {
+            return self.inner.next();
+        }
+
+        let fresh = self.inner.next();
+
+        if let Some(item) = &fresh {
+            item.prefetch();
+        }
+
+        let item = std::mem::replace(&mut self.lookahead[self.head], fresh);
+        self.head = (self.head + 1) % K;
+
+        item
+    }
+}
+
+/// Issues a prefetch for every cacheline of `bytes`.
+///
+/// A 64-byte stride is correct on x86-64 and common ARM cores; Apple Silicon uses
+/// 128-byte lines, where it merely issues one redundant hint per line.
+fn prefetch_slice(bytes: &[u8]) {
+    const CACHE_LINE: usize = 64;
+
+    for line_start in (0..bytes.len()).step_by(CACHE_LINE) {
+        prefetch_addr(&bytes[line_start]);
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+fn prefetch_addr(byte: &u8) {
+    use std::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+
+    // SAFETY: `_mm_prefetch` is a hint and cannot fault, regardless of the address.
+    unsafe { _mm_prefetch::<_MM_HINT_T0>(std::ptr::from_ref(byte).cast()) }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn prefetch_addr(byte: &u8) {
+    // SAFETY: `prfm` is a hint and cannot fault, regardless of the address.
+    unsafe {
+        std::arch::asm!(
+            "prfm pldl1keep, [{p}]",
+            p = in(reg) byte,
+            options(nostack, preserves_flags, readonly)
+        );
+    }
+}
+
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+fn prefetch_addr(_byte: &u8) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yields_all_items_in_order() {
+        let items = (0..5).map(Plain);
+
+        let result = PrefetchAhead::<_, 2>::new(items, true)
+            .map(|p| p.0)
+            .collect::<Vec<_>>();
+
+        assert_eq!(result, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn yields_fewer_items_than_lookahead() {
+        let items = std::iter::once(Plain(7));
+
+        let result = PrefetchAhead::<_, 2>::new(items, true)
+            .map(|p| p.0)
+            .collect::<Vec<_>>();
+
+        assert_eq!(result, vec![7]);
+    }
+
+    struct Plain(u32);
+
+    impl Prefetch for Plain {
+        fn prefetch(&self) {}
+    }
+}


### PR DESCRIPTION
Packet payloads arrive on the main thread with their bytes last written by an IO thread on another core, so the first access during en- / decryption stalls on a cache miss per line. This adds a small lookahead combinator on the receive iterators that prefetches each item's payload as it is pulled, two items ahead of consumption, giving each fetch roughly one packet's worth of processing time to complete in the background.

Related: #14405