### PR TITLE
fix(connlib): drop hair-pinned Client-to-Client traffic

### DIFF
--- a/rust/libs/connlib/tunnel-proto/src/client/routing.rs
+++ b/rust/libs/connlib/tunnel-proto/src/client/routing.rs
@@ -98,6 +98,14 @@ impl RoutingTables {
             });
         }
 
+        // Firezone's tunnel range holds Clients and Gateways, so the Internet Resource must
+        // not claim it: only the Client table consulted by `resolve` routes there. Letting
+        // the catch-all below match would send Client-to-Client traffic to a Gateway, which
+        // hair-pins it back out of its TUN device.
+        if crate::is_peer(destination) {
+            return None;
+        }
+
         let resource_id = internet_resource?;
 
         tracing::trace!(
@@ -264,5 +272,52 @@ impl RouteEntry for DnsEntry {
     /// A more specific (i.e. *greater*) pattern wins over a less specific one.
     fn specificity(&self, other: &Self) -> Ordering {
         self.pattern.cmp(&other.pattern).reverse()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn internet_resource_does_not_route_to_another_client() {
+        let mut tables = RoutingTables::default();
+
+        let route = tables.resolve(
+            other_client_tun_ip(),
+            Protocol::Tcp(80),
+            Some(internet_resource_id()),
+        );
+
+        assert!(route.is_none());
+    }
+
+    #[test]
+    fn device_pool_routes_to_another_client() {
+        let mut tables = RoutingTables::default();
+        let client_id = ClientId::from_u128(3);
+        tables.upsert_client(
+            IpNetwork::from(other_client_tun_ip()),
+            ResourceId::from_u128(2),
+            client_id,
+            FilterEngine::PermitAll,
+        );
+
+        let route = tables.resolve(
+            other_client_tun_ip(),
+            Protocol::Tcp(80),
+            Some(internet_resource_id()),
+        );
+
+        assert!(matches!(route, Some(Route::Client { client_id: c, .. }) if c == client_id));
+    }
+
+    fn other_client_tun_ip() -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(100, 64, 0, 3))
+    }
+
+    fn internet_resource_id() -> ResourceId {
+        ResourceId::from_u128(1)
     }
 }

--- a/rust/libs/connlib/tunnel-proto/src/gateway/client_on_gateway.rs
+++ b/rust/libs/connlib/tunnel-proto/src/gateway/client_on_gateway.rs
@@ -350,6 +350,8 @@ impl ClientOnGateway {
         let packet = self.transform_tun_to_network(packet, now)?;
 
         self.ensure_client_ip(packet.destination())?;
+        ensure_not_peer_ip(packet.source())
+            .with_context(|| UnroutablePacket::not_allowed(&packet))?;
 
         // Always allow ICMP errors to pass through, even in the presence of filters that don't allow ICMP.
         if packet.icmp_error().is_ok_and(|e| e.is_some()) {
@@ -465,6 +467,8 @@ impl ClientOnGateway {
         if self.gateway_tun.is_ip(packet.destination()) {
             return Ok(());
         }
+
+        ensure_not_peer_ip(packet.destination())?;
 
         let rid = self.classify_resource(packet.destination(), packet.destination_protocol())?;
 
@@ -647,6 +651,21 @@ impl TranslationState {
 
 fn is_dns_addr(addr: IpAddr) -> bool {
     IpNetwork::from(IPV4_RESOURCES).contains(addr) || IpNetwork::from(IPV6_RESOURCES).contains(addr)
+}
+
+/// Rejects addresses within Firezone's tunnel range.
+///
+/// A Client's counterpart is always a resource or this Gateway's own TUN device, never
+/// another Client. Admitting a tunnel address here would let the Internet Resource's
+/// catch-all in [`ClientOnGateway::classify_resource`] carry traffic between two Clients
+/// of this Gateway, hair-pinning through the TUN device and side-stepping the device pool
+/// authorization that governs Client-to-Client access.
+fn ensure_not_peer_ip(ip: IpAddr) -> anyhow::Result<()> {
+    if crate::is_peer(ip) {
+        return Err(anyhow::Error::new(NotAllowedResource(ip)));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -918,6 +937,51 @@ mod tests {
         .unwrap();
 
         assert!(peer.translate_outbound(pkt, Instant::now()).is_ok());
+    }
+
+    #[test]
+    fn internet_resource_does_not_allow_traffic_to_another_client() {
+        let mut peer = ClientOnGateway::new(client_id(), client_tun(), gateway_tun());
+        peer.add_resource(internet_resource(), None, Instant::now());
+
+        let request = ip_packet::make::udp_packet(
+            client_tun_ipv4(),
+            other_client_tun_ipv4(),
+            5401,
+            80,
+            &[0u8; 8],
+        )
+        .unwrap();
+
+        assert!(matches!(
+            peer.translate_outbound(request, Instant::now()).unwrap(),
+            TranslateOutboundResult::Filtered(_)
+        ));
+    }
+
+    #[test]
+    fn internet_resource_does_not_allow_traffic_from_another_client() {
+        let now = Instant::now();
+        let mut peer = ClientOnGateway::new(client_id(), client_tun(), gateway_tun());
+        peer.add_resource(internet_resource(), None, now);
+
+        let hairpinned = ip_packet::make::udp_packet(
+            other_client_tun_ipv4(),
+            client_tun_ipv4(),
+            80,
+            5401,
+            &[0u8; 8],
+        )
+        .unwrap();
+
+        #[expect(clippy::disallowed_methods, reason = "This is a test.")]
+        let error = peer
+            .translate_inbound(hairpinned, now)
+            .unwrap_err()
+            .downcast::<UnroutablePacket>()
+            .unwrap();
+
+        assert_eq!(error.reason(), RoutingError::NotAllowed);
     }
 
     #[test]
@@ -1397,6 +1461,10 @@ mod tests {
 
     fn client_tun_ipv6() -> Ipv6Addr {
         "fd00:2021:1111::1".parse().unwrap()
+    }
+
+    fn other_client_tun_ipv4() -> Ipv4Addr {
+        "100.64.0.3".parse().unwrap()
     }
 
     pub fn gateway_tun() -> IpConfig {

--- a/rust/libs/connlib/tunnel-proto/src/lib.rs
+++ b/rust/libs/connlib/tunnel-proto/src/lib.rs
@@ -169,4 +169,16 @@ mod unittests {
     fn mldv2_routers_are_not_peers() {
         assert!(!is_peer("ff02::16".parse().unwrap()))
     }
+
+    #[test]
+    fn tunnel_ips_of_both_families_are_peers() {
+        assert!(is_peer("100.64.0.3".parse().unwrap()));
+        assert!(is_peer("fd00:2021:1111::3".parse().unwrap()));
+    }
+
+    #[test]
+    fn addresses_outside_the_tunnel_ranges_are_not_peers() {
+        assert!(!is_peer("100.96.0.1".parse().unwrap()));
+        assert!(!is_peer("fd00:2021:1111:8000::1".parse().unwrap()));
+    }
 }

--- a/rust/tests/fuzz/expected-coverage/tunnel-proto.json
+++ b/rust/tests/fuzz/expected-coverage/tunnel-proto.json
@@ -1,4 +1,4 @@
 {
-  "covered": 5919,
-  "total": 7999
+  "covered": 5936,
+  "total": 8021
 }


### PR DESCRIPTION
The Internet Resource's catch-all matched Firezone's own tunnel range, so two Clients authorized for it on the same Gateway could reach each other on any port: the Gateway forwarded the packet to its TUN device, the kernel routed it straight back in, and the Gateway then delivered it to the second Client. That side-steps the device pool authorization which otherwise governs Client-to-Client access.

Gateways only ever serve DNS, CIDR and Internet resources, so an address in the tunnel range is never a resource. It is now rejected on the Gateway in both directions, and on the Client too so such a packet never leaves the device.