### PR TITLE
feat(portal): mark flow log reporting as new

### DIFF
--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -537,7 +537,15 @@ defmodule PortalWeb.Policies.Components do
     <div>
       <div class="flex items-center justify-between py-1">
         <div>
-          <p class="text-sm font-medium text-body">Flow log reporting</p>
+          <div class="flex items-center gap-2">
+            <p class="text-sm font-medium text-body">Flow log reporting</p>
+            <span
+              data-flow-logs-new-badge="true"
+              class="px-1 py-px rounded text-[9px] font-semibold tracking-wider bg-brand-muted text-brand"
+            >
+              NEW
+            </span>
+          </div>
           <p class="text-[11px] text-subtle">
             Report flow logs for connections created by this Policy
           </p>

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -231,6 +231,7 @@ defmodule PortalWeb.PoliciesTest do
         |> live(~p"/#{account}/policies/new")
 
       assert html =~ "Flow log reporting"
+      assert has_element?(lv, "[data-flow-logs-new-badge]", "NEW")
 
       html =
         lv


### PR DESCRIPTION
## Summary

- add a sidebar-styled `NEW` badge immediately after the Flow log reporting label in Policy forms
- cover the badge in the Policy LiveView test

## Testing

- `mise exec -- mix format --check-formatted lib/portal_web/live/policies/components.ex test/portal_web/live/policies_test.exs`
- `mise exec -- mix test test/portal_web/live/policies_test.exs:219`