### PR TITLE
chore(loadtest): use operating system TCP connect timeouts

### DIFF
--- a/rust/tests/loadtest/loadtest.example.toml
+++ b/rust/tests/loadtest/loadtest.example.toml
@@ -29,8 +29,6 @@ addresses = [
 concurrent = "5..50"
 # How long to hold connections (seconds)
 duration_secs = "30..300"
-# Connection timeout (seconds)
-timeout_secs = "10..10"
 # Enable echo mode for round-trip verification
 echo_mode = false
 # Payload size for echo messages (bytes)

--- a/rust/tests/loadtest/src/config.rs
+++ b/rust/tests/loadtest/src/config.rs
@@ -132,8 +132,6 @@ pub struct TcpConfig {
     pub concurrent: Range,
     /// How long to hold connections in seconds.
     pub duration_secs: Range,
-    /// Connection timeout in seconds.
-    pub timeout_secs: Range,
     /// Enable echo mode for payload verification.
     pub echo_mode: bool,
     /// Echo payload size in bytes.

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -343,7 +343,6 @@ impl TestSelector {
 
         let concurrent = self.rng.random_range(config.concurrent) as usize;
         let duration = Duration::from_secs(self.rng.random_range(config.duration_secs));
-        let timeout = Duration::from_secs(self.rng.random_range(config.timeout_secs));
         let echo_mode = config.echo_mode;
         let echo_payload_size = self.rng.random_range(config.echo_payload_size) as usize;
         let echo_interval = Some(Duration::from_secs(
@@ -356,7 +355,6 @@ impl TestSelector {
             target: address.to_owned(),
             concurrent,
             hold_duration: duration,
-            connect_timeout: timeout,
             echo_mode,
             echo_payload_size,
             echo_interval,

--- a/rust/tests/loadtest/src/tcp.rs
+++ b/rust/tests/loadtest/src/tcp.rs
@@ -23,9 +23,6 @@ const DEFAULT_CONCURRENT: usize = 10;
 /// Default connection hold duration.
 const DEFAULT_HOLD_DURATION: Duration = Duration::from_secs(30);
 
-/// Default connection timeout.
-const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
-
 /// Default timeout for reading echo responses.
 const DEFAULT_ECHO_READ_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -38,8 +35,6 @@ pub struct TestConfig {
     pub concurrent: usize,
     /// How long to hold each connection open
     pub hold_duration: Duration,
-    /// Connection timeout
-    pub connect_timeout: Duration,
     /// Enable echo mode: send timestamped payloads and verify responses
     pub echo_mode: bool,
     /// Size of echo payload in bytes (minimum 16 for header)
@@ -122,10 +117,6 @@ pub struct Args {
     #[arg(short = 'd', long, value_parser = crate::cli::parse_duration)]
     duration: Option<Duration>,
 
-    /// Connection timeout for establishing connections
-    #[arg(long, value_parser = crate::cli::parse_duration)]
-    timeout: Option<Duration>,
-
     /// Enable echo mode: send timestamped payloads and verify responses
     #[arg(long)]
     echo: bool,
@@ -161,10 +152,6 @@ pub fn merge(args: Args, base: Option<TestConfig>) -> Result<TestConfig> {
         .duration
         .or_else(|| base.map(|b| b.hold_duration))
         .unwrap_or(DEFAULT_HOLD_DURATION);
-    let connect_timeout = args
-        .timeout
-        .or_else(|| base.map(|b| b.connect_timeout))
-        .unwrap_or(DEFAULT_CONNECT_TIMEOUT);
     let echo_mode = args.echo || base.is_some_and(|b| b.echo_mode);
     let echo_payload_size = args
         .echo_payload_size
@@ -182,7 +169,6 @@ pub fn merge(args: Args, base: Option<TestConfig>) -> Result<TestConfig> {
         target,
         concurrent,
         hold_duration,
-        connect_timeout,
         echo_mode,
         echo_payload_size,
         echo_interval,
@@ -348,8 +334,8 @@ async fn run_single_connection(
 ) -> ConnectionResult {
     let connect_start = Instant::now();
 
-    match timeout(config.connect_timeout, TcpStream::connect(&config.target)).await {
-        Ok(Ok(stream)) => {
+    match TcpStream::connect(&config.target).await {
+        Ok(stream) => {
             let connect_latency = connect_start.elapsed();
             let current = active.fetch_add(1, Ordering::SeqCst) + 1;
             // Update peak if this is a new high water mark
@@ -379,17 +365,8 @@ async fn run_single_connection(
                 echo_stats,
             }
         }
-        Ok(Err(e)) => {
+        Err(e) => {
             tracing::debug!(connection = connection_id, target = %config.target, error = %e, "TCP connection failed");
-            ConnectionResult {
-                success: false,
-                connect_latency: connect_start.elapsed(),
-                held_duration: Duration::ZERO,
-                echo_stats: EchoStats::default(),
-            }
-        }
-        Err(_) => {
-            tracing::debug!(connection = connection_id, target = %config.target, "TCP connection timed out");
             ConnectionResult {
                 success: false,
                 connect_latency: connect_start.elapsed(),


### PR DESCRIPTION
`tcp::run_single_connection` wrapped every call to `TcpStream::connect` in a `tokio::time::timeout`. That gave the loadtest behavior unrelated to the TCP stack it is meant to exercise: the QA configuration cuts connection attempts off after a random one or two seconds, before Windows has made its first SYN retransmission.

The timeout configuration, CLI flag, default and wrapper are removed, so the TCP test now waits for the operating system's connect state machine. A short loss during direct-path migration is therefore modeled as the OS models it, rather than as a test-specific deadline.