### PR TITLE
fix(fuzz): make Ctrl+C stop `-fork`, `cmin` and `tmin` runs

### DIFF
--- a/rust/tests/fuzz/interruptible.sh
+++ b/rust/tests/fuzz/interruptible.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Runs a command so that Ctrl+C stops it.
+#
+# libFuzzer's out-of-process modes (`-fork`, `-merge`, `-minimize_crash`) start
+# each worker with system(3), which ignores SIGINT in the caller for as long as
+# that worker runs. The driver therefore never sees the Ctrl+C: the signal
+# reaches only the worker, and the driver starts a replacement for it. The run
+# outlives every process that was supervising it and has to be killed by hand.
+#
+# SIGTERM is not ignored, so translate the interrupt into one of those. Job
+# control puts the command in a process group of its own, both so that
+# signalling all of it does not also signal us and so that the terminal
+# delivers Ctrl+C here rather than straight to the workers.
+
+set -euo pipefail
+
+set -m
+"$@" &
+child=$!
+set +m
+
+trap 'kill -TERM -"$child" 2>/dev/null || true' HUP INT QUIT TERM
+
+# Each trap that runs cuts `wait` short, so keep waiting until the command is
+# really gone.
+status=0
+while :; do
+  wait "$child" && status=0 || status=$?
+  kill -0 "$child" 2>/dev/null || break
+done
+
+exit "$status"

--- a/rust/tests/fuzz/mise.toml
+++ b/rust/tests/fuzz/mise.toml
@@ -60,7 +60,7 @@ if [ "$target" = "tunnel-proto" ]; then
   set -- -max_len=8192 -len_control=0 "$@"
 fi
 
-cargo fuzz run --target x86_64-unknown-linux-gnu --fuzz-dir . --target-dir ../../target "$target" -- "$@"
+./interruptible.sh cargo fuzz run --target x86_64-unknown-linux-gnu --fuzz-dir . --target-dir ../../target "$target" -- "$@"
 '''
 
 [tasks.cmin]
@@ -76,7 +76,7 @@ env = { ASAN_OPTIONS = "detect_leaks=0" }
 run = '''
 set -euo pipefail
 
-cargo fuzz cmin --target x86_64-unknown-linux-gnu --fuzz-dir . --target-dir ../../target "$usage_target"
+./interruptible.sh cargo fuzz cmin --target x86_64-unknown-linux-gnu --fuzz-dir . --target-dir ../../target "$usage_target"
 '''
 
 [tasks.pack-corpus]
@@ -140,7 +140,7 @@ arg "<target>"
 arg "<testcase>"
 '''
 raw = true
-run = 'cargo fuzz tmin --target x86_64-unknown-linux-gnu --fuzz-dir . --target-dir ../../target "$usage_target" "$usage_testcase"'
+run = './interruptible.sh cargo fuzz tmin --target x86_64-unknown-linux-gnu --fuzz-dir . --target-dir ../../target "$usage_target" "$usage_testcase"'
 
 [tasks.repro]
 description = "Replay one fuzz input with tracing; override RUST_LOG for more detail"


### PR DESCRIPTION
libFuzzer starts each out-of-process worker with `system(3)`, which ignores SIGINT in the caller for as long as that worker runs. The driver therefore never sees a Ctrl+C: the signal reaches only the worker, and the driver immediately starts a replacement for it. An interrupted run outlives every process that was supervising it and has to be tracked down and killed by hand.

This affects the three tasks that use libFuzzer's out-of-process modes (`-fork`, `-merge` and `-minimize_crash`). The rest drive libFuzzer in-process and already stop cleanly, so they are left alone.

SIGTERM is not ignored, so the fix is to translate the interrupt into one of those for the command's own process group.