### PR TITLE
test(connlib): schedule the simulated TCP DNS client

### DIFF
--- a/rust/tests/fuzz/src/sim_net.rs
+++ b/rust/tests/fuzz/src/sim_net.rs
@@ -399,7 +399,14 @@ pub(crate) trait PollTimeout {
 
 impl PollTimeout for SimClient {
     fn poll_timeout(&mut self) -> Option<(Instant, &'static str)> {
-        self.sut.poll_timeout()
+        iter::empty()
+            .chain(self.sut.poll_timeout())
+            .chain(
+                self.tcp_dns_client
+                    .poll_timeout()
+                    .map(|instant| (instant, "Application TCP DNS client")),
+            )
+            .min_by_key(|(instant, _)| *instant)
     }
 }
 


### PR DESCRIPTION
`SimClient::poll_timeout` only reported connlib's deadlines, so the simulated application's TCP stack never had a say in when the simulation clock advanced. The loop would jump straight to connlib's next deadline, skipping the point at which that stack needed servicing.

A small DNS response survives this because it needs no further round trip. One spanning several segments does not: it stalls until the query deadline expires, and the model then reports a missing response that the product would have delivered.