### PR TITLE
feat(portal): count presences by region

### DIFF
--- a/elixir/lib/portal/ops.ex
+++ b/elixir/lib/portal/ops.ex
@@ -64,9 +64,43 @@ defmodule Portal.Ops do
 
   """
   def count_local_presences do
+    count_presences_on_nodes([node()])
+  end
+
+  @doc """
+  Counts presences hosted by nodes in `region`, grouped by topic prefix.
+
+  The region is read from each connected node's runtime configuration.
+
+  ## Examples
+
+      iex> count_regional_presences("centralus")
+      [
+        {"presences:account_clients", 215},
+        {"presences:account_gateways", 210},
+        {"presences:actor_clients", 215},
+        {"presences:global_relays", 17},
+        {"presences:portal_sessions", 4},
+        {"presences:sites", 210}
+      ]
+
+  """
+  def count_regional_presences(region) when is_binary(region) do
+    nodes =
+      [node() | Node.list()]
+      |> Enum.filter(&(node_region(&1) == region))
+
+    count_presences_on_nodes(nodes)
+  end
+
+  defp count_presences_on_nodes(nodes) do
+    nodes = MapSet.new(nodes)
+
     Portal.Presence_shard0
     |> :ets.tab2list()
-    |> Enum.filter(fn {{_topic, pid, _id}, _meta, _clock} -> node(pid) == node() end)
+    |> Enum.filter(fn {{_topic, pid, _id}, _meta, _clock} ->
+      MapSet.member?(nodes, node(pid))
+    end)
     |> Enum.map(fn {{topic, _pid, id}, _meta, _clock} -> {topic, id} end)
     |> Enum.uniq()
     |> Enum.map(fn {topic, _id} ->
@@ -74,6 +108,17 @@ defmodule Portal.Ops do
       {prefix, 1}
     end)
     |> sum_presence_counts()
+  end
+
+  defp node_region(node) do
+    if node == node() do
+      Portal.Config.get_env(:portal, :region)
+    else
+      case :rpc.call(node, Portal.Config, :get_env, [:portal, :region], 1_000) do
+        {:badrpc, _reason} -> nil
+        region -> region
+      end
+    end
   end
 
   defp sum_presence_counts(presences) do

--- a/elixir/test/portal/ops_test.exs
+++ b/elixir/test/portal/ops_test.exs
@@ -66,6 +66,21 @@ defmodule Portal.OpsTest do
     end
   end
 
+  describe "count_regional_presences/1" do
+    test "returns presence counts for nodes in the requested region" do
+      unique_id = Ecto.UUID.generate()
+      region = "centralus-#{unique_id}"
+      prefix = "presences:regional_clients_#{unique_id}"
+      Portal.Config.put_env_override(:portal, :region, region)
+
+      {:ok, _} = Portal.Presence.track(self(), "#{prefix}:account", "client1", %{})
+      {:ok, _} = Portal.Presence.track(self(), "#{prefix}:account", "client2", %{})
+
+      assert {prefix, 2} in count_regional_presences(region)
+      refute {prefix, 2} in count_regional_presences("another-region")
+    end
+  end
+
   describe "sync_pricing_plans/0" do
     test "applies current Stripe product features and limits to accounts" do
       account =


### PR DESCRIPTION
Adds a regional presence-count helper for inspecting all connections hosted across every Portal node in a deployment region.

- Adds `Portal.Ops.count_regional_presences/1`.
- Discovers currently connected cluster nodes whose runtime `REGION` matches the requested value.
- Aggregates and deduplicates presence counts owned by those nodes.
- Reuses the node-scoped implementation for `count_local_presences/0`.

For Central US, run:

```elixir
Portal.Ops.count_regional_presences("centralus")
```

Testing:

- `mix test test/portal/ops_test.exs` (17 tests, 0 failures)

---