### PR TITLE
fix(portal): keep regular Resources out of the Internet Site

### DIFF
--- a/elixir/lib/portal/resource.ex
+++ b/elixir/lib/portal/resource.ex
@@ -2,6 +2,8 @@ defmodule Portal.Resource do
   use Ecto.Schema
   import Ecto.Changeset
   import Portal.Changeset
+  alias Portal.Authentication
+  alias __MODULE__.Database
 
   @primary_key false
   @foreign_key_type :binary_id
@@ -82,6 +84,47 @@ defmodule Portal.Resource do
       message: "Internet resource already exists for this account"
     )
   end
+
+  @doc """
+  Validates that the Resource type and its Site agree with each other.
+
+  The Internet Resource belongs to the system managed Internet Site, every other
+  Resource belongs to a Site managed by the account. The Site is only looked up
+  when the pairing can change, so unrelated updates do not hit the database.
+  """
+  @spec validate_site_matches_type(Ecto.Changeset.t(), Authentication.Subject.t()) ::
+          Ecto.Changeset.t()
+  def validate_site_matches_type(
+        %Ecto.Changeset{} = changeset,
+        %Authentication.Subject{} = subject
+      ) do
+    type = get_field(changeset, :type)
+    site_id = get_field(changeset, :site_id)
+
+    if is_nil(type) or is_nil(site_id) or not site_pairing_changed?(changeset) do
+      changeset
+    else
+      validate_site_pairing(changeset, type, Database.fetch_site(site_id, subject))
+    end
+  end
+
+  defp site_pairing_changed?(changeset) do
+    Map.has_key?(changeset.changes, :type) or Map.has_key?(changeset.changes, :site_id)
+  end
+
+  defp validate_site_pairing(changeset, :internet, %Portal.Site{managed_by: :system}) do
+    changeset
+  end
+
+  defp validate_site_pairing(changeset, :internet, _site) do
+    add_error(changeset, :site_id, "must be the Internet Site for an Internet Resource")
+  end
+
+  defp validate_site_pairing(changeset, _type, %Portal.Site{managed_by: :system}) do
+    add_error(changeset, :site_id, "cannot be the Internet Site")
+  end
+
+  defp validate_site_pairing(changeset, _type, _site), do: changeset
 
   defp validate_address_format(changeset) do
     if has_errors?(changeset, :type) or has_errors?(changeset, :address) do
@@ -514,5 +557,17 @@ defmodule Portal.Resource do
       end)
 
     Regex.compile!("\\A" <> body <> "\\z")
+  end
+
+  defmodule Database do
+    import Ecto.Query
+    alias Portal.Safe
+
+    @spec fetch_site(Ecto.UUID.t(), Portal.Authentication.Subject.t()) :: Portal.Site.t() | nil
+    def fetch_site(site_id, subject) do
+      from(s in Portal.Site, where: s.id == ^site_id)
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one(fallback_to_primary: true)
+    end
   end
 end

--- a/elixir/lib/portal_api/controllers/resource_controller.ex
+++ b/elixir/lib/portal_api/controllers/resource_controller.ex
@@ -200,6 +200,7 @@ defmodule PortalAPI.ResourceController do
 
     changeset
     |> Ecto.Changeset.validate_required(required)
+    |> Portal.Resource.validate_site_matches_type(subject)
     |> Database.validate_static_device_pool_feature_enabled(subject.account)
     |> Database.validate_traffic_filters_feature_enabled(subject.account)
   end
@@ -299,6 +300,7 @@ defmodule PortalAPI.ResourceController do
 
       changeset
       |> Ecto.Changeset.validate_required(required_fields)
+      |> Portal.Resource.validate_site_matches_type(subject)
       |> validate_static_device_pool_feature_enabled(subject.account)
       |> validate_traffic_filters_feature_enabled(subject.account)
     end

--- a/elixir/lib/portal_api/schemas/resource_schema.ex
+++ b/elixir/lib/portal_api/schemas/resource_schema.ex
@@ -123,7 +123,8 @@ defmodule PortalAPI.Schemas.Resource do
             site_id: %Schema{
               title: "SiteID",
               description:
-                "Site to connect the Resource to. Required for all types except `static_device_pool`.",
+                "Site to connect the Resource to. Required for all types except `static_device_pool`. " <>
+                  "The Internet Site is reserved for the Internet Resource and cannot be used.",
               type: :string,
               format: :uuid,
               nullable: true
@@ -195,7 +196,8 @@ defmodule PortalAPI.Schemas.Resource do
             site_id: %Schema{
               title: "SiteID",
               description:
-                "Site to connect the Resource to. Required for all types except `static_device_pool`.",
+                "Site to connect the Resource to. Required for all types except `static_device_pool`. " <>
+                  "The Internet Site is reserved for the Internet Resource and cannot be used.",
               type: :string,
               format: :uuid,
               nullable: true

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -110,7 +110,7 @@ defmodule PortalWeb.Resources do
 
   def handle_params(params, uri, %{assigns: %{live_action: :new}} = socket) do
     sites = Database.all_sites(socket.assigns.subject)
-    changeset = Database.new_resource(socket.assigns.account)
+    changeset = Database.new_resource(socket.assigns.subject)
     socket = handle_live_tables_params(socket, params, uri)
 
     {:noreply,
@@ -131,7 +131,7 @@ defmodule PortalWeb.Resources do
 
       resource ->
         sites = Database.all_sites(socket.assigns.subject)
-        changeset = Database.change_resource(resource)
+        changeset = Database.change_resource(resource, socket.assigns.subject)
         selected_clients = Database.list_pool_members(resource, socket.assigns.subject)
 
         {:noreply,
@@ -712,9 +712,9 @@ defmodule PortalWeb.Resources do
 
     changeset =
       if socket.assigns.resource_panel.view == :new_form do
-        Database.new_resource(socket.assigns.account, attrs)
+        Database.new_resource(socket.assigns.subject, attrs)
       else
-        Database.change_resource(socket.assigns.selected_resource, attrs)
+        Database.change_resource(socket.assigns.selected_resource, socket.assigns.subject, attrs)
       end
       |> Map.put(:action, :validate)
 
@@ -1455,12 +1455,13 @@ defmodule PortalWeb.Resources do
       |> Safe.all()
     end
 
-    def new_resource(account, attrs \\ %{}) do
+    def new_resource(subject, attrs \\ %{}) do
       changeset =
         %Resource{}
         |> cast(attrs, [:name, :address, :address_description, :type, :ip_stack, :site_id])
-        |> put_change(:account_id, account.id)
+        |> put_change(:account_id, subject.account.id)
         |> Resource.changeset()
+        |> Resource.validate_site_matches_type(subject)
 
       if get_field(changeset, :type) == :static_device_pool do
         validate_required(changeset, [:name])
@@ -1471,7 +1472,7 @@ defmodule PortalWeb.Resources do
 
     def create_resource(attrs, selected_clients, subject) do
       changeset =
-        new_resource(subject.account, attrs)
+        new_resource(subject, attrs)
         |> maybe_validate_required_fields()
         |> Components.Database.validate_static_device_pool_feature_enabled(subject.account)
 
@@ -1501,13 +1502,14 @@ defmodule PortalWeb.Resources do
       end
     end
 
-    def change_resource(resource, attrs \\ %{}) do
+    def change_resource(resource, subject, attrs \\ %{}) do
       update_fields = ~w[address address_description name type ip_stack site_id]a
 
       changeset =
         resource
         |> cast(attrs, update_fields)
         |> Resource.changeset()
+        |> Resource.validate_site_matches_type(subject)
 
       if get_field(changeset, :type) == :static_device_pool do
         validate_required(changeset, [:name, :type])
@@ -1518,7 +1520,7 @@ defmodule PortalWeb.Resources do
 
     def update_resource(resource, attrs, selected_clients, subject) do
       changeset =
-        change_resource(resource, attrs)
+        change_resource(resource, subject, attrs)
         |> Components.Database.validate_static_device_pool_feature_enabled(subject.account)
 
       with {:ok, validated_clients} <-

--- a/elixir/lib/portal_web/live/sites.ex
+++ b/elixir/lib/portal_web/live/sites.ex
@@ -921,8 +921,16 @@ defmodule PortalWeb.Sites do
      |> put_state(:site_deploy, base_site_deploy_state())}
   end
 
+  def handle_event(
+        "add_resource",
+        _params,
+        %{assigns: %{selected_site: %{managed_by: :system}}} = socket
+      ) do
+    {:noreply, socket}
+  end
+
   def handle_event("add_resource", _params, socket) do
-    changeset = Database.new_resource_changeset(socket.assigns.account)
+    changeset = Database.new_resource_changeset(socket.assigns.subject)
 
     {:noreply,
      socket
@@ -947,7 +955,7 @@ defmodule PortalWeb.Sites do
       |> Map.put("site_id", socket.assigns.selected_site.id)
 
     changeset =
-      Database.new_resource_changeset(socket.assigns.account, attrs)
+      Database.new_resource_changeset(socket.assigns.subject, attrs)
       |> Map.put(:action, :validate)
 
     {:noreply,
@@ -1399,19 +1407,20 @@ defmodule PortalWeb.Sites do
       |> Map.new()
     end
 
-    @spec new_resource_changeset(Portal.Account.t(), map()) :: Ecto.Changeset.t()
-    def new_resource_changeset(account, attrs \\ %{}) do
+    @spec new_resource_changeset(Portal.Authentication.Subject.t(), map()) :: Ecto.Changeset.t()
+    def new_resource_changeset(subject, attrs \\ %{}) do
       %Resource{}
       |> cast(attrs, [:name, :address, :address_description, :type, :ip_stack, :site_id])
       |> validate_required([:name, :address])
-      |> put_change(:account_id, account.id)
+      |> put_change(:account_id, subject.account.id)
       |> Resource.changeset()
+      |> Resource.validate_site_matches_type(subject)
     end
 
     @spec create_resource(map(), Portal.Authentication.Subject.t()) ::
             {:ok, Resource.t()} | {:error, Ecto.Changeset.t()}
     def create_resource(attrs, subject) do
-      new_resource_changeset(subject.account, attrs)
+      new_resource_changeset(subject, attrs)
       |> validate_required([:site_id])
       |> Safe.scoped(subject)
       |> Safe.insert()

--- a/elixir/test/portal_api/controllers/resource_controller_test.exs
+++ b/elixir/test/portal_api/controllers/resource_controller_test.exs
@@ -330,6 +330,67 @@ defmodule PortalAPI.ResourceControllerTest do
                }
              } = json_response(conn, 422)
     end
+
+    test "returns 422 when creating a resource in the Internet Site", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = internet_site_fixture(account: account)
+
+      attrs = %{
+        "address" => "google.com",
+        "name" => "Google",
+        "type" => "dns",
+        "site_id" => site.id
+      }
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/resources", resource: attrs)
+
+      assert %{
+               "type" => "about:blank",
+               "status" => 422,
+               "validation_errors" => %{
+                 "site_id" => ["cannot be the Internet Site"]
+               }
+             } = json_response(conn, 422)
+
+      assert Portal.Repo.aggregate(Resource, :count) == 0
+    end
+
+    test "returns 422 when creating an internet resource in a regular Site", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+
+      attrs = %{
+        "name" => "Internet",
+        "type" => "internet",
+        "site_id" => site.id
+      }
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/resources", resource: attrs)
+
+      assert %{
+               "type" => "about:blank",
+               "status" => 422,
+               "validation_errors" => %{
+                 "site_id" => ["must be the Internet Site for an Internet Resource"]
+               }
+             } = json_response(conn, 422)
+
+      assert Portal.Repo.aggregate(Resource, :count) == 0
+    end
   end
 
   describe "update/2" do
@@ -523,6 +584,59 @@ defmodule PortalAPI.ResourceControllerTest do
                "status" => 403,
                "detail" => "Internet Resource cannot be modified"
              } = json_response(conn, 403)
+    end
+
+    test "returns 422 when moving a resource to the Internet Site", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+      internet_site = internet_site_fixture(account: account)
+      resource = dns_resource_fixture(account: account, site: site)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/resources/#{resource.id}", resource: %{"site_id" => internet_site.id})
+
+      assert %{
+               "type" => "about:blank",
+               "status" => 422,
+               "validation_errors" => %{
+                 "site_id" => ["cannot be the Internet Site"]
+               }
+             } = json_response(conn, 422)
+
+      reloaded = Portal.Repo.get_by!(Resource, id: resource.id, account_id: account.id)
+      assert reloaded.site_id == site.id
+    end
+
+    test "returns 422 when changing a resource to the internet type", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+      resource = dns_resource_fixture(account: account, site: site)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/resources/#{resource.id}", resource: %{"type" => "internet"})
+
+      assert %{
+               "type" => "about:blank",
+               "status" => 422,
+               "validation_errors" => %{
+                 "site_id" => ["must be the Internet Site for an Internet Resource"]
+               }
+             } = json_response(conn, 422)
+
+      reloaded = Portal.Repo.get_by!(Resource, id: resource.id, account_id: account.id)
+      assert reloaded.type == :dns
     end
 
     test "returns 422 when updating resource to static_device_pool type with feature disabled", %{

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -296,6 +296,72 @@ defmodule PortalWeb.ResourcesTest do
       assert html =~ "created successfully"
     end
 
+    test "does not offer the Internet Site", %{conn: conn, account: account, actor: actor} do
+      site = site_fixture(account: account)
+      internet_site = internet_site_fixture(account: account)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/new")
+
+      assert html =~ site.id
+      refute html =~ internet_site.id
+    end
+
+    test "rejects a resource submitted for the Internet Site", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      internet_site = internet_site_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/new")
+
+      html =
+        render_submit(lv, "submit_resource_form", %{
+          "resource" => %{
+            "type" => "dns",
+            "name" => "App Example",
+            "address" => "app.example.com",
+            "site_id" => internet_site.id
+          }
+        })
+
+      assert html =~ "cannot be the Internet Site"
+      refute html =~ "created successfully"
+      assert Repo.aggregate(Resource, :count) == 0
+    end
+
+    test "rejects an internet resource submitted for a regular Site", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/new")
+
+      html =
+        render_submit(lv, "submit_resource_form", %{
+          "resource" => %{
+            "type" => "internet",
+            "name" => "Internet",
+            "site_id" => site.id
+          }
+        })
+
+      assert html =~ "must be the Internet Site for an Internet Resource"
+      refute html =~ "created successfully"
+      assert Repo.aggregate(Resource, :count) == 0
+    end
+
     test "manages DNS traffic restriction controls", %{
       conn: conn,
       account: account,
@@ -927,6 +993,31 @@ defmodule PortalWeb.ResourcesTest do
 
       assert html =~ "updated successfully"
       assert html =~ "Updated Resource Name"
+    end
+
+    test "rejects moving a resource to the Internet Site", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+      internet_site = internet_site_fixture(account: account)
+      resource = resource_fixture(account: account, site: site)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}/edit")
+
+      html =
+        render_submit(lv, "submit_resource_form", %{
+          "resource" => %{"site_id" => internet_site.id}
+        })
+
+      assert html =~ "cannot be the Internet Site"
+      refute html =~ "updated successfully"
+
+      assert Repo.get_by!(Resource, id: resource.id, account_id: account.id).site_id == site.id
     end
 
     test "shows confirm delete then deletes resource", %{

--- a/elixir/test/portal_web/live/sites_test.exs
+++ b/elixir/test/portal_web/live/sites_test.exs
@@ -404,6 +404,34 @@ defmodule PortalWeb.SitesTest do
       refute has_element?(lv, "button", "Delete site")
       refute has_element?(lv, "button", "Add resource")
     end
+
+    test "refuses to add resources to system-managed sites", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = system_site_fixture(%{account: account, name: "Internet"})
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/sites/#{site.id}")
+
+      html = render_click(lv, "add_resource")
+      refute html =~ "Create Resource"
+
+      html =
+        render_submit(lv, "resource_submit", %{
+          "resource" => %{
+            "type" => "dns",
+            "address" => "grafana.internal",
+            "name" => "Grafana"
+          }
+        })
+
+      refute html =~ "created successfully"
+      assert Repo.aggregate(Resource, :count) == 0
+    end
   end
 
   describe "select_site event" do


### PR DESCRIPTION
The Internet Site is a special Site that exists to hold one thing: the Internet Resource. Nothing kept those two together. A regular Resource could be put on the Internet Site, and an Internet Resource could be pointed at a normal Site.

The web UI left the Internet Site out of the Site dropdown, but that was only cosmetic. The REST API accepted any Site ID, and a hand-made form submission got past the UI too.

Creating or updating a Resource now checks that its type and its Site agree. The Internet Resource has to sit on the Internet Site, and every other Resource has to sit on a Site the account manages. Anything else comes back as a validation error on `site_id`.
