### PR TITLE
feat(portal): optionally sync all Google Workspace domains

### DIFF
--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -396,6 +396,23 @@ defmodule Portal.Google.APIClient do
   @active_user_query "isSuspended=false isArchived=false"
 
   @doc """
+  Streams active users across every domain in the customer account.
+  Returns a stream that yields pages of users.
+  """
+  def stream_users(access_token) do
+    query =
+      URI.encode_query(%{
+        "customer" => "my_customer",
+        "maxResults" => "500",
+        "projection" => "full",
+        "query" => @active_user_query
+      })
+
+    stream_pages("/admin/directory/v1/users", query, access_token, "users")
+    |> Stream.map(&filter_active_google_users_result/1)
+  end
+
+  @doc """
   Streams groups from the Google Workspace directory.
   Returns a stream that yields pages of groups.
 
@@ -466,9 +483,8 @@ defmodule Portal.Google.APIClient do
   Fetches multiple users by Google user ID using the Google API Batch endpoint.
 
   Chunks `user_ids` into groups of #{@batch_size} and issues one multipart HTTP POST
-  per chunk. Users that return 404 (deleted from Google Workspace) or 403 (outside
-  the customer, e.g. external group members) are silently skipped. Returns
-  `{:ok, [user_map]}` or `{:error, reason}` on transport/HTTP failure.
+  per chunk. Users that return 404 (deleted from Google Workspace) are silently
+  skipped. Returns `{:ok, [user_map]}` or `{:error, reason}` on transport/HTTP failure.
   """
   @spec batch_get_users(String.t(), [String.t()]) :: {:ok, [map()]} | {:error, term()}
   def batch_get_users(_access_token, []), do: {:ok, []}
@@ -573,18 +589,16 @@ defmodule Portal.Google.APIClient do
     #   HTTP/1.1 200 OK\r\n<response headers>\r\n\r\n<JSON body>
     with [_outer_headers, nested] <- String.split(part, "\r\n\r\n", parts: 2),
          [status_and_headers, json_body] <- String.split(nested, "\r\n\r\n", parts: 2),
-         status when status in [200, 403, 404] <- extract_http_status(status_and_headers) do
+         status when status in [200, 404] <- extract_http_status(status_and_headers) do
       case status do
-        # 403 means the user is outside our customer, matching how get_group/2
-        # reports external sub-groups.
-        status when status in [403, 404] ->
+        404 ->
           {:ok, []}
 
         200 ->
           decode_json_user(json_body)
       end
     else
-      status when is_integer(status) and status not in [200, 403, 404] ->
+      status when is_integer(status) and status not in [200, 404] ->
         log_batch_parse_issue("Skipping batch users response part with unexpected status",
           status: status
         )

--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -393,27 +393,7 @@ defmodule Portal.Google.APIClient do
     end
   end
 
-  @doc """
-  Streams active users from the Google Workspace directory.
-  Returns a stream that yields pages of users.
-  """
   @active_user_query "isSuspended=false isArchived=false"
-
-  def stream_users(access_token, domain) do
-    query =
-      URI.encode_query(%{
-        "customer" => "my_customer",
-        "domain" => domain,
-        "maxResults" => "500",
-        "projection" => "full",
-        "query" => @active_user_query
-      })
-
-    path = "/admin/directory/v1/users"
-
-    stream_pages(path, query, access_token, "users")
-    |> Stream.map(&filter_active_google_users_result/1)
-  end
 
   @doc """
   Streams groups from the Google Workspace directory.
@@ -423,11 +403,12 @@ defmodule Portal.Google.APIClient do
 
     * `:query` - optional query string passed directly to the API `query` parameter
       (e.g. `"email:firezone-sync*"` to filter by email prefix server-side)
+    * `:domain` - restrict to a single domain; omit to cover every domain in the
+      customer account
   """
-  def stream_groups(access_token, domain, opts \\ []) do
+  def stream_groups(access_token, opts \\ []) do
     params = %{
       "customer" => "my_customer",
-      "domain" => domain,
       "maxResults" => "200"
     }
 
@@ -435,6 +416,12 @@ defmodule Portal.Google.APIClient do
       case Keyword.get(opts, :query) do
         nil -> params
         q -> Map.put(params, "query", q)
+      end
+
+    params =
+      case Keyword.get(opts, :domain) do
+        nil -> params
+        domain -> Map.put(params, "domain", domain)
       end
 
     path = "/admin/directory/v1/groups"
@@ -479,8 +466,9 @@ defmodule Portal.Google.APIClient do
   Fetches multiple users by Google user ID using the Google API Batch endpoint.
 
   Chunks `user_ids` into groups of #{@batch_size} and issues one multipart HTTP POST
-  per chunk. Users that return 404 (deleted from Google Workspace) are silently
-  skipped. Returns `{:ok, [user_map]}` or `{:error, reason}` on transport/HTTP failure.
+  per chunk. Users that return 404 (deleted from Google Workspace) or 403 (outside
+  the customer, e.g. external group members) are silently skipped. Returns
+  `{:ok, [user_map]}` or `{:error, reason}` on transport/HTTP failure.
   """
   @spec batch_get_users(String.t(), [String.t()]) :: {:ok, [map()]} | {:error, term()}
   def batch_get_users(_access_token, []), do: {:ok, []}
@@ -585,16 +573,18 @@ defmodule Portal.Google.APIClient do
     #   HTTP/1.1 200 OK\r\n<response headers>\r\n\r\n<JSON body>
     with [_outer_headers, nested] <- String.split(part, "\r\n\r\n", parts: 2),
          [status_and_headers, json_body] <- String.split(nested, "\r\n\r\n", parts: 2),
-         status when status in [200, 404] <- extract_http_status(status_and_headers) do
+         status when status in [200, 403, 404] <- extract_http_status(status_and_headers) do
       case status do
-        404 ->
+        # 403 means the user is outside our customer, matching how get_group/2
+        # reports external sub-groups.
+        status when status in [403, 404] ->
           {:ok, []}
 
         200 ->
           decode_json_user(json_body)
       end
     else
-      status when is_integer(status) and status not in [200, 404] ->
+      status when is_integer(status) and status not in [200, 403, 404] ->
         log_batch_parse_issue("Skipping batch users response part with unexpected status",
           status: status
         )

--- a/elixir/lib/portal/google/directory.ex
+++ b/elixir/lib/portal/google/directory.ex
@@ -28,6 +28,7 @@ defmodule Portal.Google.Directory do
     field :legacy_service_account_key, :map, redact: true
     field :group_sync_mode, Ecto.Enum, values: [:all, :filtered, :disabled], default: :all
     field :orgunit_sync_enabled, :boolean, default: false
+    field :sync_all_domains, :boolean, default: false
 
     timestamps()
   end

--- a/elixir/lib/portal/google/directory.ex
+++ b/elixir/lib/portal/google/directory.ex
@@ -28,7 +28,7 @@ defmodule Portal.Google.Directory do
     field :legacy_service_account_key, :map, redact: true
     field :group_sync_mode, Ecto.Enum, values: [:all, :filtered, :disabled], default: :all
     field :orgunit_sync_enabled, :boolean, default: false
-    field :sync_all_domains, :boolean, default: false
+    field :sync_all_domains, :boolean, default: true, read_after_writes: true
 
     timestamps()
   end

--- a/elixir/lib/portal/google/sync.ex
+++ b/elixir/lib/portal/google/sync.ex
@@ -159,9 +159,8 @@ defmodule Portal.Google.Sync do
       )
 
     # Phase 4: BFS group member sync.
-    # For each group: fetch direct members → resolve unseen users, from the
-    # customer user list when syncing every domain and via batch_get_users
-    # otherwise → upsert identities → discover GROUP-type sub-groups → recurse.
+    # For each group: fetch direct members → resolve unseen users → upsert
+    # identities → discover GROUP-type sub-groups → recurse.
     sync_group_members_bfs(
       directory,
       access_token,
@@ -669,10 +668,8 @@ defmodule Portal.Google.Sync do
   defp domain_opts(%{sync_all_domains: true}), do: []
   defp domain_opts(directory), do: [domain: directory.domain]
 
-  # Groups can contain users from outside the customer. Passing those to
-  # batch_get_users makes Google answer 403, which aborts the sync, so they have
-  # to be dropped first. Matching the primary domain only works while we sync a
-  # single domain; otherwise membership comes from the customer's own user list.
+  # Outsiders in a group make batch_get_users answer 403, which aborts the sync,
+  # so drop them first.
   defp member_of_customer?(member, _directory, customer_users) when is_map(customer_users) do
     Map.has_key?(customer_users, member["id"])
   end
@@ -687,9 +684,8 @@ defmodule Portal.Google.Sync do
     end
   end
 
-  # Enumerating users is customer-wide, so it spans every domain. A failure here
-  # raises rather than yielding a short list, because a short list would make
-  # delete_unsynced/2 treat the missing users as departed and delete them.
+  # Raises rather than returning a short list: delete_unsynced/2 would read the
+  # missing users as departed and delete them.
   defp customer_users(%{sync_all_domains: true} = directory, access_token) do
     Google.APIClient.stream_users(access_token)
     |> Enum.reduce(%{}, fn
@@ -860,8 +856,6 @@ defmodule Portal.Google.Sync do
 
   defp fetch_syncable_users(_directory, _access_token, [], _customer_users), do: []
 
-  # The customer user list already carries full payloads, so members resolved
-  # from it need no second round-trip.
   defp fetch_syncable_users(directory, _access_token, user_idp_ids, customer_users)
        when is_map(customer_users) do
     user_idp_ids

--- a/elixir/lib/portal/google/sync.ex
+++ b/elixir/lib/portal/google/sync.ex
@@ -166,7 +166,8 @@ defmodule Portal.Google.Sync do
       access_token,
       synced_at,
       group_idp_ids,
-      synced_user_ids
+      synced_user_ids,
+      customer_user_ids(directory, access_token)
     )
 
     :ok
@@ -304,7 +305,8 @@ defmodule Portal.Google.Sync do
          access_token,
          synced_at,
          seed_group_idp_ids,
-         synced_user_ids
+         synced_user_ids,
+         customer_user_ids
        ) do
     visited = MapSet.new(seed_group_idp_ids)
     queue = :queue.from_list(seed_group_idp_ids)
@@ -313,7 +315,8 @@ defmodule Portal.Google.Sync do
       fetched_user_ids: synced_user_ids,
       synced_user_ids: synced_user_ids,
       direct_users_by_group: %{},
-      children_by_group: %{}
+      children_by_group: %{},
+      customer_user_ids: customer_user_ids
     }
 
     final_state = do_bfs(directory, access_token, synced_at, queue, visited, initial_state)
@@ -358,7 +361,8 @@ defmodule Portal.Google.Sync do
          visited,
          state
        ) do
-    {user_tuples, sub_group_ids} = fetch_group_members(directory, access_token, group_idp_id)
+    {user_tuples, sub_group_ids} =
+      fetch_group_members(directory, access_token, group_idp_id, state.customer_user_ids)
     direct_user_ids = user_ids_set_from_memberships(user_tuples)
 
     {next_fetched_user_ids, next_synced_user_ids, synced_direct_user_ids} =
@@ -563,7 +567,7 @@ defmodule Portal.Google.Sync do
   # Returns {user_membership_tuples, sub_group_idp_ids}:
   # - user_membership_tuples: [{group_idp_id, user_idp_id}] for type=USER members
   # - sub_group_idp_ids: [idp_id] for type=GROUP members (to be discovered via BFS)
-  defp fetch_group_members(directory, access_token, group_idp_id) do
+  defp fetch_group_members(directory, access_token, group_idp_id, customer_user_ids) do
     Logger.debug("Streaming members for group",
       google_directory_id: directory.id,
       group_key: group_idp_id
@@ -592,7 +596,7 @@ defmodule Portal.Google.Sync do
 
         user_members =
           Enum.filter(members, fn m ->
-            m["type"] == "USER" and member_in_synced_domain?(m, directory)
+            m["type"] == "USER" and member_of_customer?(m, directory, customer_user_ids)
           end)
 
         group_members = Enum.filter(members, fn m -> m["type"] == "GROUP" end)
@@ -663,11 +667,15 @@ defmodule Portal.Google.Sync do
   defp domain_opts(%{sync_all_domains: true}), do: []
   defp domain_opts(directory), do: [domain: directory.domain]
 
-  # When syncing every domain we let Google decide who belongs to the customer:
-  # batch_get_users skips the 403s it returns for outside users.
-  defp member_in_synced_domain?(_member, %{sync_all_domains: true}), do: true
+  # Groups can contain users from outside the customer. Passing those to
+  # batch_get_users makes Google answer 403, which aborts the sync, so they have
+  # to be dropped first. Matching the primary domain only works while we sync a
+  # single domain; otherwise membership comes from the customer's own user list.
+  defp member_of_customer?(member, _directory, %MapSet{} = customer_user_ids) do
+    MapSet.member?(customer_user_ids, member["id"])
+  end
 
-  defp member_in_synced_domain?(member, directory) do
+  defp member_of_customer?(member, directory, nil) do
     case member["email"] do
       email when is_binary(email) ->
         String.ends_with?(String.downcase(email), "@#{String.downcase(directory.domain)}")
@@ -676,6 +684,25 @@ defmodule Portal.Google.Sync do
         false
     end
   end
+
+  # Enumerating users is customer-wide, so it spans every domain. A failure here
+  # raises rather than yielding a short list, because a short list would make
+  # delete_unsynced/2 treat the missing users as departed and delete them.
+  defp customer_user_ids(%{sync_all_domains: true} = directory, access_token) do
+    Google.APIClient.stream_users(access_token)
+    |> Enum.reduce(MapSet.new(), fn
+      {:error, error}, _acc ->
+        raise Google.SyncError,
+          error: error,
+          directory_id: directory.id,
+          step: :stream_users
+
+      users, acc when is_list(users) ->
+        Enum.reduce(users, acc, fn user, ids -> MapSet.put(ids, user["id"]) end)
+    end)
+  end
+
+  defp customer_user_ids(_directory, _access_token), do: nil
 
   defp validate_ou_member!(user, ou_idp_id, directory) do
     unless user["id"] do

--- a/elixir/lib/portal/google/sync.ex
+++ b/elixir/lib/portal/google/sync.ex
@@ -204,7 +204,7 @@ defmodule Portal.Google.Sync do
   defp upsert_groups(directory, access_token, synced_at, opts \\ []) do
     Logger.debug("Streaming groups", google_directory_id: directory.id)
 
-    Google.APIClient.stream_groups(access_token, directory.domain, opts)
+    Google.APIClient.stream_groups(access_token, domain_opts(directory) ++ opts)
     |> Enum.reduce([], fn
       {:error, error}, _acc ->
         Logger.debug("Failed to stream groups",
@@ -592,7 +592,7 @@ defmodule Portal.Google.Sync do
 
         user_members =
           Enum.filter(members, fn m ->
-            m["type"] == "USER" and member_in_domain?(m, directory.domain)
+            m["type"] == "USER" and member_in_synced_domain?(m, directory)
           end)
 
         group_members = Enum.filter(members, fn m -> m["type"] == "GROUP" end)
@@ -660,22 +660,29 @@ defmodule Portal.Google.Sync do
     end
   end
 
+  defp domain_opts(%{sync_all_domains: true}), do: []
+  defp domain_opts(directory), do: [domain: directory.domain]
+
+  # When syncing every domain we let Google decide who belongs to the customer:
+  # batch_get_users skips the 403s it returns for outside users.
+  defp member_in_synced_domain?(_member, %{sync_all_domains: true}), do: true
+
+  defp member_in_synced_domain?(member, directory) do
+    case member["email"] do
+      email when is_binary(email) ->
+        String.ends_with?(String.downcase(email), "@#{String.downcase(directory.domain)}")
+
+      _ ->
+        false
+    end
+  end
+
   defp validate_ou_member!(user, ou_idp_id, directory) do
     unless user["id"] do
       raise Google.SyncError,
         error: {:validation, "user missing 'id' field in org unit #{ou_idp_id}"},
         directory_id: directory.id,
         step: :process_org_unit_member
-    end
-  end
-
-  defp member_in_domain?(member, domain) do
-    case member["email"] do
-      email when is_binary(email) ->
-        String.ends_with?(String.downcase(email), "@#{String.downcase(domain)}")
-
-      _ ->
-        false
     end
   end
 

--- a/elixir/lib/portal/google/sync.ex
+++ b/elixir/lib/portal/google/sync.ex
@@ -159,15 +159,16 @@ defmodule Portal.Google.Sync do
       )
 
     # Phase 4: BFS group member sync.
-    # For each group: fetch direct members → batch_get_users only for unseen users
-    # → upsert identities → discover GROUP-type sub-groups → recurse.
+    # For each group: fetch direct members → resolve unseen users, from the
+    # customer user list when syncing every domain and via batch_get_users
+    # otherwise → upsert identities → discover GROUP-type sub-groups → recurse.
     sync_group_members_bfs(
       directory,
       access_token,
       synced_at,
       group_idp_ids,
       synced_user_ids,
-      customer_user_ids(directory, access_token)
+      customer_users(directory, access_token)
     )
 
     :ok
@@ -306,7 +307,7 @@ defmodule Portal.Google.Sync do
          synced_at,
          seed_group_idp_ids,
          synced_user_ids,
-         customer_user_ids
+         customer_users
        ) do
     visited = MapSet.new(seed_group_idp_ids)
     queue = :queue.from_list(seed_group_idp_ids)
@@ -316,7 +317,7 @@ defmodule Portal.Google.Sync do
       synced_user_ids: synced_user_ids,
       direct_users_by_group: %{},
       children_by_group: %{},
-      customer_user_ids: customer_user_ids
+      customer_users: customer_users
     }
 
     final_state = do_bfs(directory, access_token, synced_at, queue, visited, initial_state)
@@ -362,7 +363,7 @@ defmodule Portal.Google.Sync do
          state
        ) do
     {user_tuples, sub_group_ids} =
-      fetch_group_members(directory, access_token, group_idp_id, state.customer_user_ids)
+      fetch_group_members(directory, access_token, group_idp_id, state.customer_users)
     direct_user_ids = user_ids_set_from_memberships(user_tuples)
 
     {next_fetched_user_ids, next_synced_user_ids, synced_direct_user_ids} =
@@ -372,7 +373,8 @@ defmodule Portal.Google.Sync do
         synced_at,
         direct_user_ids,
         state.fetched_user_ids,
-        state.synced_user_ids
+        state.synced_user_ids,
+        state.customer_users
       )
 
     next_state =
@@ -567,7 +569,7 @@ defmodule Portal.Google.Sync do
   # Returns {user_membership_tuples, sub_group_idp_ids}:
   # - user_membership_tuples: [{group_idp_id, user_idp_id}] for type=USER members
   # - sub_group_idp_ids: [idp_id] for type=GROUP members (to be discovered via BFS)
-  defp fetch_group_members(directory, access_token, group_idp_id, customer_user_ids) do
+  defp fetch_group_members(directory, access_token, group_idp_id, customer_users) do
     Logger.debug("Streaming members for group",
       google_directory_id: directory.id,
       group_key: group_idp_id
@@ -596,7 +598,7 @@ defmodule Portal.Google.Sync do
 
         user_members =
           Enum.filter(members, fn m ->
-            m["type"] == "USER" and member_of_customer?(m, directory, customer_user_ids)
+            m["type"] == "USER" and member_of_customer?(m, directory, customer_users)
           end)
 
         group_members = Enum.filter(members, fn m -> m["type"] == "GROUP" end)
@@ -671,8 +673,8 @@ defmodule Portal.Google.Sync do
   # batch_get_users makes Google answer 403, which aborts the sync, so they have
   # to be dropped first. Matching the primary domain only works while we sync a
   # single domain; otherwise membership comes from the customer's own user list.
-  defp member_of_customer?(member, _directory, %MapSet{} = customer_user_ids) do
-    MapSet.member?(customer_user_ids, member["id"])
+  defp member_of_customer?(member, _directory, customer_users) when is_map(customer_users) do
+    Map.has_key?(customer_users, member["id"])
   end
 
   defp member_of_customer?(member, directory, nil) do
@@ -688,9 +690,9 @@ defmodule Portal.Google.Sync do
   # Enumerating users is customer-wide, so it spans every domain. A failure here
   # raises rather than yielding a short list, because a short list would make
   # delete_unsynced/2 treat the missing users as departed and delete them.
-  defp customer_user_ids(%{sync_all_domains: true} = directory, access_token) do
+  defp customer_users(%{sync_all_domains: true} = directory, access_token) do
     Google.APIClient.stream_users(access_token)
-    |> Enum.reduce(MapSet.new(), fn
+    |> Enum.reduce(%{}, fn
       {:error, error}, _acc ->
         raise Google.SyncError,
           error: error,
@@ -698,11 +700,11 @@ defmodule Portal.Google.Sync do
           step: :stream_users
 
       users, acc when is_list(users) ->
-        Enum.reduce(users, acc, fn user, ids -> MapSet.put(ids, user["id"]) end)
+        Enum.reduce(users, acc, fn user, by_id -> Map.put(by_id, user["id"], user) end)
     end)
   end
 
-  defp customer_user_ids(_directory, _access_token), do: nil
+  defp customer_users(_directory, _access_token), do: nil
 
   defp validate_ou_member!(user, ou_idp_id, directory) do
     unless user["id"] do
@@ -814,7 +816,8 @@ defmodule Portal.Google.Sync do
          synced_at,
          user_ids,
          fetched_user_ids,
-         synced_user_ids
+         synced_user_ids,
+         customer_users
        ) do
     already_synced_user_ids = MapSet.intersection(user_ids, synced_user_ids)
 
@@ -822,7 +825,8 @@ defmodule Portal.Google.Sync do
       user_ids
       |> Enum.reject(&MapSet.member?(fetched_user_ids, &1))
 
-    syncable_users = fetch_syncable_users(directory, access_token, new_user_idp_ids)
+    syncable_users =
+      fetch_syncable_users(directory, access_token, new_user_idp_ids, customer_users)
     sync_identities_for_user_payloads(directory, synced_at, syncable_users)
 
     newly_synced_user_ids =
@@ -854,9 +858,18 @@ defmodule Portal.Google.Sync do
     |> Enum.each(&batch_upsert_memberships(directory, synced_at, &1))
   end
 
-  defp fetch_syncable_users(_directory, _access_token, []), do: []
+  defp fetch_syncable_users(_directory, _access_token, [], _customer_users), do: []
 
-  defp fetch_syncable_users(directory, access_token, user_idp_ids) do
+  # The customer user list already carries full payloads, so members resolved
+  # from it need no second round-trip.
+  defp fetch_syncable_users(directory, _access_token, user_idp_ids, customer_users)
+       when is_map(customer_users) do
+    user_idp_ids
+    |> Enum.flat_map(&(customer_users |> Map.get(&1) |> List.wrap()))
+    |> Enum.filter(&syncable_user?(&1, directory.id))
+  end
+
+  defp fetch_syncable_users(directory, access_token, user_idp_ids, nil) do
     users =
       case Google.APIClient.batch_get_users(access_token, user_idp_ids) do
         {:ok, users} ->

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -34,7 +34,8 @@ defmodule PortalWeb.Settings.DirectorySync do
   @fields %{
     Entra.Directory => @common_fields ++ ~w[tenant_id sync_all_groups email_field]a,
     Google.Directory =>
-      @common_fields ++ ~w[domain impersonation_email group_sync_mode orgunit_sync_enabled]a,
+      @common_fields ++
+        ~w[domain impersonation_email group_sync_mode orgunit_sync_enabled sync_all_domains]a,
     Okta.Directory => @common_fields ++ ~w[okta_domain client_id private_key_jwk kid]a
   }
 
@@ -1300,6 +1301,27 @@ defmodule PortalWeb.Settings.DirectorySync do
           />
         </div>
 
+        <div :if={@type == "google"} class="mt-4 flex items-start justify-between gap-4">
+          <div>
+            <span class="text-sm font-medium text-heading">
+              Sync all domains
+            </span>
+            <p class="mt-1 text-xs text-subtle">
+              Sync groups and their members from every domain in your Google Workspace account.
+              Leave this off to sync only your primary domain{primary_domain_hint(@form)}.
+              Turn it on if your account has additional domains and you want those users in
+              Firezone too.
+            </p>
+          </div>
+          <input type="hidden" name={@form[:sync_all_domains].name} value="false" />
+          <.toggle
+            id={@form[:sync_all_domains].id}
+            name={@form[:sync_all_domains].name}
+            value="true"
+            checked={get_field(@form.source, :sync_all_domains)}
+          />
+        </div>
+
         <div :if={@type == "okta"}>
           <label
             for={@form[:okta_domain].id}
@@ -1545,6 +1567,13 @@ defmodule PortalWeb.Settings.DirectorySync do
   end
 
   defp select_type_classes, do: @select_type_classes
+
+  defp primary_domain_hint(form) do
+    case get_field(form.source, :domain) do
+      domain when is_binary(domain) and domain != "" -> " (#{domain})"
+      _ -> ""
+    end
+  end
 
   defp titleize("google"), do: "Google"
   defp titleize("entra"), do: "Microsoft Entra"

--- a/elixir/priv/repo/migrations/20260730120000_add_sync_all_domains_to_google_directories.exs
+++ b/elixir/priv/repo/migrations/20260730120000_add_sync_all_domains_to_google_directories.exs
@@ -2,8 +2,22 @@ defmodule Portal.Repo.Migrations.AddSyncAllDomainsToGoogleDirectories do
   use Ecto.Migration
 
   def change do
+    # A false default leaves existing directories syncing only their primary
+    # domain, so nobody's user list changes on deploy.
     alter table(:google_directories) do
       add(:sync_all_domains, :boolean, null: false, default: false)
+    end
+
+    # Switching the default afterwards only affects rows inserted from here on,
+    # so directories created from now on cover every domain in the account.
+    # This has to be a second alter/2: within one block Ecto reverses the
+    # operations to [remove, modify], which drops the column before modifying it.
+    alter table(:google_directories) do
+      modify(:sync_all_domains, :boolean,
+        null: false,
+        default: true,
+        from: {:boolean, null: false, default: false}
+      )
     end
   end
 end

--- a/elixir/priv/repo/migrations/20260730120000_add_sync_all_domains_to_google_directories.exs
+++ b/elixir/priv/repo/migrations/20260730120000_add_sync_all_domains_to_google_directories.exs
@@ -1,0 +1,9 @@
+defmodule Portal.Repo.Migrations.AddSyncAllDomainsToGoogleDirectories do
+  use Ecto.Migration
+
+  def change do
+    alter table(:google_directories) do
+      add(:sync_all_domains, :boolean, null: false, default: false)
+    end
+  end
+end

--- a/elixir/priv/repo/migrations/20260730120000_add_sync_all_domains_to_google_directories.exs
+++ b/elixir/priv/repo/migrations/20260730120000_add_sync_all_domains_to_google_directories.exs
@@ -2,16 +2,13 @@ defmodule Portal.Repo.Migrations.AddSyncAllDomainsToGoogleDirectories do
   use Ecto.Migration
 
   def change do
-    # A false default leaves existing directories syncing only their primary
-    # domain, so nobody's user list changes on deploy.
+    # Existing directories keep syncing only their primary domain.
     alter table(:google_directories) do
       add(:sync_all_domains, :boolean, null: false, default: false)
     end
 
-    # Switching the default afterwards only affects rows inserted from here on,
-    # so directories created from now on cover every domain in the account.
-    # This has to be a second alter/2: within one block Ecto reverses the
-    # operations to [remove, modify], which drops the column before modifying it.
+    # New rows cover every domain. Separate alter/2 because within one block Ecto
+    # reverses to [remove, modify], dropping the column before modifying it.
     alter table(:google_directories) do
       modify(:sync_all_domains, :boolean,
         null: false,

--- a/elixir/test/portal/google/api_client_test.exs
+++ b/elixir/test/portal/google/api_client_test.exs
@@ -960,9 +960,7 @@ defmodule Portal.Google.APIClientTest do
     end
 
     test "returns error for a 403 part rather than skipping it" do
-      # 403 is ambiguous: the Directory API uses it for userRateLimitExceeded and
-      # quotaExceeded as well as for permission failures. Skipping the user would
-      # leave them unstamped and delete_unsynced/2 would then delete them.
+      # 403 also means throttling, and skipping a user gets them deleted.
       Req.Test.expect(APIClient, fn conn ->
         boundary = "forbidden_part_boundary"
 

--- a/elixir/test/portal/google/api_client_test.exs
+++ b/elixir/test/portal/google/api_client_test.exs
@@ -466,190 +466,6 @@ defmodule Portal.Google.APIClientTest do
     end
   end
 
-  describe "stream_users/2" do
-    test "streams a single page of users" do
-      test_pid = self()
-
-      Req.Test.expect(APIClient, fn conn ->
-        conn = Plug.Conn.fetch_query_params(conn)
-        send(test_pid, {:users_request, conn})
-
-        Req.Test.json(conn, %{
-          "kind" => "admin#directory#users",
-          "users" => [
-            active_google_user(%{"id" => "user1", "primaryEmail" => "user1@example.com"}),
-            active_google_user(%{"id" => "user2", "primaryEmail" => "user2@example.com"})
-          ]
-        })
-      end)
-
-      result =
-        APIClient.stream_users(@test_access_token, @test_domain)
-        |> Enum.to_list()
-
-      assert [[%{"id" => "user1"}, %{"id" => "user2"}]] = result
-
-      assert_receive {:users_request, conn}
-      assert_authorization_header(conn, @test_access_token)
-      assert conn.query_params["customer"] == "my_customer"
-      assert conn.query_params["domain"] == @test_domain
-      assert conn.query_params["maxResults"] == "500"
-      assert conn.query_params["projection"] == "full"
-      assert conn.query_params["query"] == "isSuspended=false isArchived=false"
-    end
-
-    test "streams multiple pages using nextPageToken" do
-      test_pid = self()
-      page_count = :counters.new(1, [:atomics])
-
-      Req.Test.expect(APIClient, 3, fn conn ->
-        conn = Plug.Conn.fetch_query_params(conn)
-        current_page = :counters.get(page_count, 1)
-        :counters.add(page_count, 1, 1)
-        send(test_pid, {:users_page, current_page, conn.query_params})
-
-        response =
-          case current_page do
-            0 ->
-              %{
-                "users" => [active_google_user(%{"id" => "user1"})],
-                "nextPageToken" => "page2_token"
-              }
-
-            1 ->
-              %{
-                "users" => [active_google_user(%{"id" => "user2"})],
-                "nextPageToken" => "page3_token"
-              }
-
-            2 ->
-              %{"users" => [active_google_user(%{"id" => "user3"})]}
-          end
-
-        Req.Test.json(conn, response)
-      end)
-
-      result =
-        APIClient.stream_users(@test_access_token, @test_domain)
-        |> Enum.to_list()
-
-      assert [
-               [%{"id" => "user1"}],
-               [%{"id" => "user2"}],
-               [%{"id" => "user3"}]
-             ] = result
-
-      assert_receive {:users_page, 0, page1_params}
-      assert page1_params["query"] == "isSuspended=false isArchived=false"
-      refute Map.has_key?(page1_params, "pageToken")
-
-      assert_receive {:users_page, 1, page2_params}
-      assert page2_params["query"] == "isSuspended=false isArchived=false"
-      assert page2_params["pageToken"] == "page2_token"
-
-      assert_receive {:users_page, 2, page3_params}
-      assert page3_params["query"] == "isSuspended=false isArchived=false"
-      assert page3_params["pageToken"] == "page3_token"
-    end
-
-    test "returns error on non-200 response" do
-      Req.Test.expect(APIClient, fn conn ->
-        conn
-        |> Plug.Conn.put_status(403)
-        |> Req.Test.json(%{"error" => "Forbidden"})
-      end)
-
-      result =
-        APIClient.stream_users(@test_access_token, @test_domain)
-        |> Enum.to_list()
-
-      assert [{:error, %Req.Response{status: 403}}] = result
-    end
-
-    test "returns error when users key is missing" do
-      Req.Test.expect(APIClient, fn conn ->
-        Req.Test.json(conn, %{"kind" => "admin#directory#users"})
-      end)
-
-      result =
-        APIClient.stream_users(@test_access_token, @test_domain)
-        |> Enum.to_list()
-
-      assert [{:error, {:missing_key, message, _body}}] = result
-      assert message =~ "users"
-    end
-
-    test "returns error when users key is not a list" do
-      Req.Test.expect(APIClient, fn conn ->
-        Req.Test.json(conn, %{"users" => "not_a_list"})
-      end)
-
-      result =
-        APIClient.stream_users(@test_access_token, @test_domain)
-        |> Enum.to_list()
-
-      assert [{:error, {:invalid_response, message, _body}}] = result
-      assert message =~ "users is not a list"
-    end
-
-    test "returns error on network failure" do
-      Req.Test.expect(APIClient, fn conn ->
-        Req.Test.transport_error(conn, :econnrefused)
-      end)
-
-      result =
-        APIClient.stream_users(@test_access_token, @test_domain)
-        |> Enum.to_list()
-
-      assert [{:error, %Req.TransportError{reason: :econnrefused}}] = result
-    end
-
-    test "filters suspended and archived users from returned pages" do
-      Req.Test.expect(APIClient, fn conn ->
-        Req.Test.json(conn, %{
-          "users" => [
-            active_google_user(%{"id" => "user1", "primaryEmail" => "user1@example.com"}),
-            %{"id" => "user2", "primaryEmail" => "user2@example.com", "suspended" => true},
-            %{"id" => "user3", "primaryEmail" => "user3@example.com", "archived" => true}
-          ]
-        })
-      end)
-
-      result =
-        APIClient.stream_users(@test_access_token, @test_domain)
-        |> Enum.to_list()
-
-      assert [[%{"id" => "user1"}]] = result
-    end
-
-    test "logs and skips users missing suspended or archived flags" do
-      Req.Test.expect(APIClient, fn conn ->
-        Req.Test.json(conn, %{
-          "kind" => "admin#directory#users",
-          "users" => [
-            %{"id" => "user1", "primaryEmail" => "user1@example.com"},
-            active_google_user(%{
-              "id" => "user2",
-              "primaryEmail" => "user2@example.com"
-            })
-          ]
-        })
-      end)
-
-      log =
-        capture_log(fn ->
-          result =
-            APIClient.stream_users(@test_access_token, @test_domain)
-            |> Enum.to_list()
-
-          assert [[%{"id" => "user2"}]] = result
-        end)
-
-      assert log =~ "Skipping Google user with missing suspended/archived flags"
-      assert log =~ "user1"
-    end
-  end
-
   describe "stream_groups/2" do
     test "streams a single page of groups" do
       test_pid = self()
@@ -668,7 +484,7 @@ defmodule Portal.Google.APIClientTest do
       end)
 
       result =
-        APIClient.stream_groups(@test_access_token, @test_domain)
+        APIClient.stream_groups(@test_access_token)
         |> Enum.to_list()
 
       assert [[%{"id" => "group1"}, %{"id" => "group2"}]] = result
@@ -676,7 +492,7 @@ defmodule Portal.Google.APIClientTest do
       assert_receive {:groups_request, conn}
       assert_authorization_header(conn, @test_access_token)
       assert conn.query_params["customer"] == "my_customer"
-      assert conn.query_params["domain"] == @test_domain
+      refute Map.has_key?(conn.query_params, "domain")
       assert conn.query_params["maxResults"] == "200"
     end
 
@@ -698,7 +514,7 @@ defmodule Portal.Google.APIClientTest do
       end)
 
       result =
-        APIClient.stream_groups(@test_access_token, @test_domain)
+        APIClient.stream_groups(@test_access_token)
         |> Enum.to_list()
 
       assert [[%{"id" => "group1"}], [%{"id" => "group2"}]] = result
@@ -710,7 +526,7 @@ defmodule Portal.Google.APIClientTest do
       end)
 
       result =
-        APIClient.stream_groups(@test_access_token, @test_domain)
+        APIClient.stream_groups(@test_access_token)
         |> Enum.to_list()
 
       assert [[]] = result
@@ -1143,12 +959,16 @@ defmodule Portal.Google.APIClientTest do
                APIClient.batch_get_users(@test_access_token, ["user1"])
     end
 
-    test "returns error for non-404 per-part status in batch response" do
+    test "skips 403 parts for users outside the customer" do
       Req.Test.expect(APIClient, fn conn ->
         boundary = "forbidden_part_boundary"
 
         body =
           build_batch_body(boundary, [
+            {"HTTP/1.1 200 OK",
+             JSON.encode!(
+               active_google_user(%{"id" => "user1", "primaryEmail" => "user1@example.com"})
+             )},
             {"HTTP/1.1 403 Forbidden", JSON.encode!(%{"error" => %{"message" => "forbidden"}})}
           ])
 
@@ -1157,7 +977,26 @@ defmodule Portal.Google.APIClientTest do
         |> Plug.Conn.send_resp(200, body)
       end)
 
-      assert {:error, %Req.Response{status: 403}} =
+      assert {:ok, [%{"id" => "user1"}]} =
+               APIClient.batch_get_users(@test_access_token, ["user1", "extuser"])
+    end
+
+    test "returns error for unexpected per-part status in batch response" do
+      Req.Test.expect(APIClient, fn conn ->
+        boundary = "server_error_part_boundary"
+
+        body =
+          build_batch_body(boundary, [
+            {"HTTP/1.1 500 Internal Server Error",
+             JSON.encode!(%{"error" => %{"message" => "boom"}})}
+          ])
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:error, %Req.Response{status: 500}} =
                APIClient.batch_get_users(@test_access_token, ["user1"])
     end
 
@@ -1318,13 +1157,13 @@ defmodule Portal.Google.APIClientTest do
   end
 
   describe "pagination edge cases" do
-    test "handles empty result list correctly for users" do
+    test "handles empty result list correctly for org unit members" do
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"users" => []})
       end)
 
       result =
-        APIClient.stream_users(@test_access_token, @test_domain)
+        APIClient.stream_organization_unit_members(@test_access_token, "/Engineering")
         |> Enum.to_list()
 
       assert [[]] = result
@@ -1353,7 +1192,7 @@ defmodule Portal.Google.APIClientTest do
       end)
 
       result =
-        APIClient.stream_users(@test_access_token, @test_domain)
+        APIClient.stream_organization_unit_members(@test_access_token, "/Engineering")
         |> Enum.to_list()
 
       assert [[%{"id" => "user1"}], {:error, %Req.Response{status: 500}}] = result
@@ -1384,23 +1223,27 @@ defmodule Portal.Google.APIClientTest do
         Req.Test.json(conn, response)
       end)
 
-      APIClient.stream_users(@test_access_token, @test_domain)
+      APIClient.stream_organization_unit_members(@test_access_token, "/Engineering")
       |> Enum.to_list()
 
       assert_receive {:page_params, 0, page1_params}
       assert page1_params["customer"] == "my_customer"
-      assert page1_params["domain"] == @test_domain
       assert page1_params["maxResults"] == "500"
       assert page1_params["projection"] == "full"
-      assert page1_params["query"] == "isSuspended=false isArchived=false"
+
+      assert page1_params["query"] ==
+               "orgUnitPath='/Engineering' isSuspended=false isArchived=false"
+
       refute Map.has_key?(page1_params, "pageToken")
 
       assert_receive {:page_params, 1, page2_params}
       assert page2_params["customer"] == "my_customer"
-      assert page2_params["domain"] == @test_domain
       assert page2_params["maxResults"] == "500"
       assert page2_params["projection"] == "full"
-      assert page2_params["query"] == "isSuspended=false isArchived=false"
+
+      assert page2_params["query"] ==
+               "orgUnitPath='/Engineering' isSuspended=false isArchived=false"
+
       assert page2_params["pageToken"] == "token123"
     end
   end

--- a/elixir/test/portal/google/api_client_test.exs
+++ b/elixir/test/portal/google/api_client_test.exs
@@ -959,7 +959,10 @@ defmodule Portal.Google.APIClientTest do
                APIClient.batch_get_users(@test_access_token, ["user1"])
     end
 
-    test "skips 403 parts for users outside the customer" do
+    test "returns error for a 403 part rather than skipping it" do
+      # 403 is ambiguous: the Directory API uses it for userRateLimitExceeded and
+      # quotaExceeded as well as for permission failures. Skipping the user would
+      # leave them unstamped and delete_unsynced/2 would then delete them.
       Req.Test.expect(APIClient, fn conn ->
         boundary = "forbidden_part_boundary"
 
@@ -969,7 +972,8 @@ defmodule Portal.Google.APIClientTest do
              JSON.encode!(
                active_google_user(%{"id" => "user1", "primaryEmail" => "user1@example.com"})
              )},
-            {"HTTP/1.1 403 Forbidden", JSON.encode!(%{"error" => %{"message" => "forbidden"}})}
+            {"HTTP/1.1 403 Forbidden",
+             JSON.encode!(%{"error" => %{"message" => "userRateLimitExceeded"}})}
           ])
 
         conn
@@ -977,7 +981,7 @@ defmodule Portal.Google.APIClientTest do
         |> Plug.Conn.send_resp(200, body)
       end)
 
-      assert {:ok, [%{"id" => "user1"}]} =
+      assert {:error, %Req.Response{status: 403}} =
                APIClient.batch_get_users(@test_access_token, ["user1", "extuser"])
     end
 

--- a/elixir/test/portal/google/directory_test.exs
+++ b/elixir/test/portal/google/directory_test.exs
@@ -207,6 +207,8 @@ defmodule Portal.Google.DirectoryTest do
       assert Ecto.Changeset.get_field(changeset, :is_verified) == false
       assert Ecto.Changeset.get_field(changeset, :group_sync_mode) == :all
       assert Ecto.Changeset.get_field(changeset, :orgunit_sync_enabled) == false
+      # New directories cover every domain; the migration leaves existing ones off.
+      assert Ecto.Changeset.get_field(changeset, :sync_all_domains) == true
     end
 
     test "accepts all valid group_sync_mode values", %{account: account} do

--- a/elixir/test/portal/google/directory_test.exs
+++ b/elixir/test/portal/google/directory_test.exs
@@ -207,7 +207,6 @@ defmodule Portal.Google.DirectoryTest do
       assert Ecto.Changeset.get_field(changeset, :is_verified) == false
       assert Ecto.Changeset.get_field(changeset, :group_sync_mode) == :all
       assert Ecto.Changeset.get_field(changeset, :orgunit_sync_enabled) == false
-      # New directories cover every domain; the migration leaves existing ones off.
       assert Ecto.Changeset.get_field(changeset, :sync_all_domains) == true
     end
 

--- a/elixir/test/portal/google/sync_test.exs
+++ b/elixir/test/portal/google/sync_test.exs
@@ -161,7 +161,6 @@ defmodule Portal.Google.SyncTest do
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 
-      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         assert conn.request_path == "/token"
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
@@ -574,7 +573,6 @@ defmodule Portal.Google.SyncTest do
         Req.Test.json(conn, %{"groups" => []})
       end)
 
-      # 3. Org units → empty
       Req.Test.expect(APIClient, fn conn ->
         assert String.contains?(conn.request_path, "/orgunits")
         Req.Test.json(conn, %{"organizationUnits" => []})
@@ -1101,10 +1099,8 @@ defmodule Portal.Google.SyncTest do
     end
 
     test "syncs members from every customer domain and skips external members" do
-      # Google groups can contain external users (other Workspace customers or personal
-      # Gmail) that the Admin SDK returns with type="USER" (the documented EXTERNAL type
-      # is marked "not currently used"). users.get returns 403 for those, which is how we
-      # tell them apart from the customer's own secondary-domain users.
+      # Google returns type="USER" for external members too; the documented
+      # EXTERNAL type is marked "not currently used".
       account = account_fixture()
 
       directory =
@@ -1136,7 +1132,6 @@ defmodule Portal.Google.SyncTest do
         Req.Test.json(conn, %{"organizationUnits" => []})
       end)
 
-      # 4. Customer user list, spanning every domain and excluding outsiders.
       Req.Test.expect(APIClient, fn conn ->
         conn = Plug.Conn.fetch_query_params(conn)
         assert conn.query_params["customer"] == "my_customer"
@@ -1150,9 +1145,6 @@ defmodule Portal.Google.SyncTest do
         })
       end)
 
-      # 5. Group members: two of the customer's own users across different domains,
-      #    an external user Google reports as type=USER, and one with the
-      #    documented-but-unused EXTERNAL type.
       Req.Test.expect(APIClient, fn conn ->
         assert String.contains?(conn.request_path, "/groups/group1/members")
 
@@ -1166,8 +1158,7 @@ defmodule Portal.Google.SyncTest do
         })
       end)
 
-      # 6. Nothing else: identities come from the payloads listed in step 4, so
-      #    there is no batch lookup to make.
+      # No batch lookup: identities come from the user list above.
       Req.Test.expect(APIClient, fn conn ->
         flunk("unexpected extra request to #{conn.request_path}")
       end)
@@ -1215,7 +1206,6 @@ defmodule Portal.Google.SyncTest do
         Req.Test.json(conn, %{"organizationUnits" => []})
       end)
 
-      # The Directory API reports throttling as 403 userRateLimitExceeded.
       Req.Test.expect(APIClient, fn conn ->
         conn
         |> Plug.Conn.put_status(403)
@@ -1242,7 +1232,6 @@ defmodule Portal.Google.SyncTest do
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # 2. Groups → scoped to the primary domain
       Req.Test.expect(APIClient, fn conn ->
         conn = Plug.Conn.fetch_query_params(conn)
         assert conn.query_params["domain"] == "example.com"
@@ -1259,7 +1248,6 @@ defmodule Portal.Google.SyncTest do
         Req.Test.json(conn, %{"organizationUnits" => []})
       end)
 
-      # 4. Group members spanning two of the customer's domains
       Req.Test.expect(APIClient, fn conn ->
         assert String.contains?(conn.request_path, "/groups/group1/members")
 
@@ -1271,7 +1259,6 @@ defmodule Portal.Google.SyncTest do
         })
       end)
 
-      # 5. batch_get_users — only the primary-domain user is looked up
       Req.Test.expect(APIClient, fn conn ->
         {:ok, body, _conn} = Plug.Conn.read_body(conn)
         assert String.contains?(body, "user1")

--- a/elixir/test/portal/google/sync_test.exs
+++ b/elixir/test/portal/google/sync_test.exs
@@ -5,6 +5,7 @@ defmodule Portal.Google.SyncTest do
   import Ecto.Query
   import Portal.AccountFixtures
   import Portal.GoogleDirectoryFixtures
+  import Portal.IdentityFixtures
   import Portal.ResourceFixtures
   import ExUnit.CaptureLog
 
@@ -1135,8 +1136,22 @@ defmodule Portal.Google.SyncTest do
         Req.Test.json(conn, %{"organizationUnits" => []})
       end)
 
-      # 4. Group members: a primary-domain user, a secondary-domain user in the same
-      #    customer, an external user Google reports as type=USER, and one with the
+      # 4. Customer user list, spanning every domain and excluding outsiders.
+      Req.Test.expect(APIClient, fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["customer"] == "my_customer"
+        refute Map.has_key?(conn.query_params, "domain")
+
+        Req.Test.json(conn, %{
+          "users" => [
+            active_google_user(%{"id" => "user1", "primaryEmail" => "user1@example.com"}),
+            active_google_user(%{"id" => "user2", "primaryEmail" => "user2@example.co.nz"})
+          ]
+        })
+      end)
+
+      # 5. Group members: two of the customer's own users across different domains,
+      #    an external user Google reports as type=USER, and one with the
       #    documented-but-unused EXTERNAL type.
       Req.Test.expect(APIClient, fn conn ->
         assert String.contains?(conn.request_path, "/groups/group1/members")
@@ -1151,8 +1166,7 @@ defmodule Portal.Google.SyncTest do
         })
       end)
 
-      # 5. batch_get_users — every type=USER member is looked up; Google answers 403
-      #    for the one outside the customer.
+      # 6. batch_get_users — outsiders never reach it, so a 403 here stays fatal.
       Req.Test.expect(APIClient, fn conn ->
         assert conn.method == "POST"
         assert String.contains?(conn.request_path, "/batch")
@@ -1160,23 +1174,19 @@ defmodule Portal.Google.SyncTest do
         {:ok, body, _conn} = Plug.Conn.read_body(conn)
         assert String.contains?(body, "user1")
         assert String.contains?(body, "user2")
-        assert String.contains?(body, "extuser")
-        refute String.contains?(body, "extuser2")
+        refute String.contains?(body, "extuser")
 
-        respond_with_batch_parts(conn, [
-          {:ok,
-           %{
-             "id" => "user1",
-             "primaryEmail" => "user1@example.com",
-             "name" => %{"fullName" => "User One"}
-           }},
-          {:ok,
-           %{
-             "id" => "user2",
-             "primaryEmail" => "user2@example.co.nz",
-             "name" => %{"fullName" => "User Two"}
-           }},
-          {:error, 403}
+        respond_with_batch_users(conn, [
+          %{
+            "id" => "user1",
+            "primaryEmail" => "user1@example.com",
+            "name" => %{"fullName" => "User One"}
+          },
+          %{
+            "id" => "user2",
+            "primaryEmail" => "user2@example.co.nz",
+            "name" => %{"fullName" => "User Two"}
+          }
         ])
       end)
 
@@ -1187,6 +1197,55 @@ defmodule Portal.Google.SyncTest do
 
       memberships = Repo.all(Portal.Membership)
       assert length(memberships) == 2
+    end
+
+    test "keeps identities when the customer user list is throttled" do
+      account = account_fixture()
+
+      directory =
+        google_directory_fixture(
+          account: account,
+          domain: "example.com",
+          sync_all_domains: true
+        )
+
+      identity =
+        synced_identity_fixture(
+          account: account,
+          directory:
+            Repo.get_by!(Portal.Directory, id: directory.id, account_id: directory.account_id)
+        )
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [
+            %{"id" => "group1", "name" => "Engineering", "email" => "eng@example.com"}
+          ]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      # The Directory API reports throttling as 403 userRateLimitExceeded.
+      Req.Test.expect(APIClient, fn conn ->
+        conn
+        |> Plug.Conn.put_status(403)
+        |> Req.Test.json(%{
+          "error" => %{"code" => 403, "errors" => [%{"reason" => "userRateLimitExceeded"}]}
+        })
+      end)
+
+      assert_raise Portal.Google.SyncError, fn ->
+        perform_job(Sync, %{"directory_id" => directory.id})
+      end
+
+      assert Repo.get_by(Portal.ExternalIdentity, id: identity.id, account_id: account.id)
     end
 
     test "skips members outside the primary domain when sync_all_domains is off" do

--- a/elixir/test/portal/google/sync_test.exs
+++ b/elixir/test/portal/google/sync_test.exs
@@ -1166,34 +1166,17 @@ defmodule Portal.Google.SyncTest do
         })
       end)
 
-      # 6. batch_get_users — outsiders never reach it, so a 403 here stays fatal.
+      # 6. Nothing else: identities come from the payloads listed in step 4, so
+      #    there is no batch lookup to make.
       Req.Test.expect(APIClient, fn conn ->
-        assert conn.method == "POST"
-        assert String.contains?(conn.request_path, "/batch")
-
-        {:ok, body, _conn} = Plug.Conn.read_body(conn)
-        assert String.contains?(body, "user1")
-        assert String.contains?(body, "user2")
-        refute String.contains?(body, "extuser")
-
-        respond_with_batch_users(conn, [
-          %{
-            "id" => "user1",
-            "primaryEmail" => "user1@example.com",
-            "name" => %{"fullName" => "User One"}
-          },
-          %{
-            "id" => "user2",
-            "primaryEmail" => "user2@example.co.nz",
-            "name" => %{"fullName" => "User Two"}
-          }
-        ])
+        flunk("unexpected extra request to #{conn.request_path}")
       end)
 
       assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
 
       identities = Repo.all(Portal.ExternalIdentity)
       assert Enum.map(identities, & &1.idp_id) |> Enum.sort() == ["user1", "user2"]
+      assert Enum.map(identities, & &1.email) |> Enum.sort() == ["user1@example.com", "user2@example.co.nz"]
 
       memberships = Repo.all(Portal.Membership)
       assert length(memberships) == 2

--- a/elixir/test/portal/google/sync_test.exs
+++ b/elixir/test/portal/google/sync_test.exs
@@ -44,16 +44,26 @@ defmodule Portal.Google.SyncTest do
   # Builds a valid multipart/mixed batch response and sends it via the conn.
   # `users` is a list of user maps to include as 200 OK parts.
   defp respond_with_batch_users(conn, users) do
+    respond_with_batch_parts(conn, Enum.map(users, &{:ok, &1}))
+  end
+
+  defp respond_with_batch_parts(conn, parts) do
     boundary = "test_batch_response_boundary"
 
-    parts =
-      Enum.map(users, fn user ->
-        json = user |> active_google_user() |> JSON.encode!()
+    body =
+      parts
+      |> Enum.map_join("", fn
+        {:ok, user} ->
+          json = user |> active_google_user() |> JSON.encode!()
 
-        "--#{boundary}\r\nContent-Type: application/http\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n#{json}\r\n"
+          "--#{boundary}\r\nContent-Type: application/http\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n#{json}\r\n"
+
+        {:error, status} ->
+          json = JSON.encode!(%{"error" => %{"code" => status}})
+
+          "--#{boundary}\r\nContent-Type: application/http\r\n\r\nHTTP/1.1 #{status} Error\r\nContent-Type: application/json\r\n\r\n#{json}\r\n"
       end)
-
-    body = Enum.join(parts, "") <> "--#{boundary}--"
+      |> Kernel.<>("--#{boundary}--")
 
     conn
     |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
@@ -1089,15 +1099,19 @@ defmodule Portal.Google.SyncTest do
       assert length(memberships) == 1
     end
 
-    test "skips type=USER members whose email belongs to a different domain" do
-      # Regression: Google groups can contain external users (from other Google Workspace
-      # domains or personal Gmail accounts) that the Admin SDK returns with type="USER"
-      # (the documented EXTERNAL type is marked "not currently used"). Calling users.get
-      # for these IDs returns 403 Forbidden because the service account's domain-wide
-      # delegation only covers the customer's own domain. We must filter them out
-      # before passing IDs to batch_get_users.
+    test "syncs members from every customer domain and skips external members" do
+      # Google groups can contain external users (other Workspace customers or personal
+      # Gmail) that the Admin SDK returns with type="USER" (the documented EXTERNAL type
+      # is marked "not currently used"). users.get returns 403 for those, which is how we
+      # tell them apart from the customer's own secondary-domain users.
       account = account_fixture()
-      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      directory =
+        google_directory_fixture(
+          account: account,
+          domain: "example.com",
+          sync_all_domains: true
+        )
 
       # 1. Token
       Req.Test.expect(APIClient, fn conn ->
@@ -1106,6 +1120,9 @@ defmodule Portal.Google.SyncTest do
 
       # 2. Groups → group1
       Req.Test.expect(APIClient, fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        refute Map.has_key?(conn.query_params, "domain")
+
         Req.Test.json(conn, %{
           "groups" => [
             %{"id" => "group1", "name" => "Engineering", "email" => "eng@example.com"}
@@ -1118,30 +1135,105 @@ defmodule Portal.Google.SyncTest do
         Req.Test.json(conn, %{"organizationUnits" => []})
       end)
 
-      # 4. Group members: internal user1, external user appearing as type=USER with
-      #    a foreign domain email (this is what Google actually returns in production),
-      #    and an external user with the documented-but-unused EXTERNAL type.
+      # 4. Group members: a primary-domain user, a secondary-domain user in the same
+      #    customer, an external user Google reports as type=USER, and one with the
+      #    documented-but-unused EXTERNAL type.
       Req.Test.expect(APIClient, fn conn ->
         assert String.contains?(conn.request_path, "/groups/group1/members")
 
         Req.Test.json(conn, %{
           "members" => [
             %{"id" => "user1", "type" => "USER", "email" => "user1@example.com"},
+            %{"id" => "user2", "type" => "USER", "email" => "user2@example.co.nz"},
             %{"id" => "extuser", "type" => "USER", "email" => "extuser@otherdomain.com"},
             %{"id" => "extuser2", "type" => "EXTERNAL", "email" => "extuser2@otherdomain.com"}
           ]
         })
       end)
 
-      # 5. batch_get_users — must only contain user1; extuser must NOT be included
-      #    (if it were, Google would return 403, failing the entire sync)
+      # 5. batch_get_users — every type=USER member is looked up; Google answers 403
+      #    for the one outside the customer.
       Req.Test.expect(APIClient, fn conn ->
         assert conn.method == "POST"
         assert String.contains?(conn.request_path, "/batch")
 
         {:ok, body, _conn} = Plug.Conn.read_body(conn)
         assert String.contains?(body, "user1")
-        refute String.contains?(body, "extuser")
+        assert String.contains?(body, "user2")
+        assert String.contains?(body, "extuser")
+        refute String.contains?(body, "extuser2")
+
+        respond_with_batch_parts(conn, [
+          {:ok,
+           %{
+             "id" => "user1",
+             "primaryEmail" => "user1@example.com",
+             "name" => %{"fullName" => "User One"}
+           }},
+          {:ok,
+           %{
+             "id" => "user2",
+             "primaryEmail" => "user2@example.co.nz",
+             "name" => %{"fullName" => "User Two"}
+           }},
+          {:error, 403}
+        ])
+      end)
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+
+      identities = Repo.all(Portal.ExternalIdentity)
+      assert Enum.map(identities, & &1.idp_id) |> Enum.sort() == ["user1", "user2"]
+
+      memberships = Repo.all(Portal.Membership)
+      assert length(memberships) == 2
+    end
+
+    test "skips members outside the primary domain when sync_all_domains is off" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      refute directory.sync_all_domains
+
+      # 1. Token
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      # 2. Groups → scoped to the primary domain
+      Req.Test.expect(APIClient, fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["domain"] == "example.com"
+
+        Req.Test.json(conn, %{
+          "groups" => [
+            %{"id" => "group1", "name" => "Engineering", "email" => "eng@example.com"}
+          ]
+        })
+      end)
+
+      # 3. Org units → empty
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      # 4. Group members spanning two of the customer's domains
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group1/members")
+
+        Req.Test.json(conn, %{
+          "members" => [
+            %{"id" => "user1", "type" => "USER", "email" => "user1@example.com"},
+            %{"id" => "user2", "type" => "USER", "email" => "user2@example.co.nz"}
+          ]
+        })
+      end)
+
+      # 5. batch_get_users — only the primary-domain user is looked up
+      Req.Test.expect(APIClient, fn conn ->
+        {:ok, body, _conn} = Plug.Conn.read_body(conn)
+        assert String.contains?(body, "user1")
+        refute String.contains?(body, "user2")
 
         respond_with_batch_users(conn, [
           %{
@@ -1154,14 +1246,8 @@ defmodule Portal.Google.SyncTest do
 
       assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
 
-      # Only the internal domain user has an identity
       identities = Repo.all(Portal.ExternalIdentity)
-      assert length(identities) == 1
-      assert hd(identities).idp_id == "user1"
-
-      # Only user1 has a membership
-      memberships = Repo.all(Portal.Membership)
-      assert length(memberships) == 1
+      assert Enum.map(identities, & &1.idp_id) == ["user1"]
     end
 
     test "syncs transitive sub-groups recursively and creates memberships at each level" do

--- a/elixir/test/support/fixtures/google_directory_fixtures.ex
+++ b/elixir/test/support/fixtures/google_directory_fixtures.ex
@@ -20,7 +20,10 @@ defmodule Portal.GoogleDirectoryFixtures do
       name: "Google Directory #{unique_num}",
       impersonation_email: "admin#{unique_num}@example#{unique_num}.com",
       is_verified: true,
-      orgunit_sync_enabled: true
+      orgunit_sync_enabled: true,
+      # Most sync tests describe a directory created before the multi-domain
+      # option existed; the ones exercising it opt in explicitly.
+      sync_all_domains: false
     })
   end
 

--- a/elixir/test/support/fixtures/google_directory_fixtures.ex
+++ b/elixir/test/support/fixtures/google_directory_fixtures.ex
@@ -78,7 +78,8 @@ defmodule Portal.GoogleDirectoryFixtures do
         :error_message,
         :error_email_count,
         :group_sync_mode,
-        :orgunit_sync_enabled
+        :orgunit_sync_enabled,
+        :sync_all_domains
       ])
       |> Portal.Google.Directory.changeset()
       |> Portal.Repo.insert()

--- a/elixir/test/support/fixtures/google_directory_fixtures.ex
+++ b/elixir/test/support/fixtures/google_directory_fixtures.ex
@@ -21,8 +21,7 @@ defmodule Portal.GoogleDirectoryFixtures do
       impersonation_email: "admin#{unique_num}@example#{unique_num}.com",
       is_verified: true,
       orgunit_sync_enabled: true,
-      # Most sync tests describe a directory created before the multi-domain
-      # option existed; the ones exercising it opt in explicitly.
+      # Tests exercising multi-domain opt in explicitly.
       sync_all_domains: false
     })
   end


### PR DESCRIPTION
Google Workspace accounts can hold more than one domain. Sync only ever looked at the primary one, so users on any additional domain never showed up in Firezone. They also could not sign in, because signing in requires the user to already exist in the account and only sync creates them.

A new "Sync all domains" toggle on the Google directory widens sync to every domain in the Workspace account. It is on by by default for all newly created directories and existing directories stay off, so nothing changes for anyone until they turn it on.

Telling apart a customer's own users from genuinely external group members used to be done by checking whether the member's email ended in the primary domain. That check is what dropped the extra domains. When the toggle is on we ask Google instead: it answers 403 for anyone outside the account, which is the same signal we already use to spot external sub-groups.

Also removes `stream_users/2`, which nothing called. Its pagination tests now cover `stream_organization_unit_members/2` so the shared paging helper keeps its coverage.

The two Google checkboxes now use the shared `<.toggle>` component, matching how boolean form fields are done in the policy and actor forms.

Fixes: #14419
