### PR TITLE
refactor(portal): unify boolean toggles on one component

### DIFF
--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -1637,6 +1637,8 @@ defmodule PortalWeb.CoreComponents do
   attr :checked, :boolean, default: false
   attr :label, :string, default: nil
   attr :disabled, :boolean, default: false
+  attr :size, :string, default: "md", values: ~w[sm md]
+  attr :label_position, :string, default: "after", values: ~w[before after]
   attr :name, :string, default: nil
   attr :value, :string, default: nil
   attr :class, :string, default: nil
@@ -1644,7 +1646,15 @@ defmodule PortalWeb.CoreComponents do
 
   def toggle(assigns) do
     ~H"""
-    <label class={["inline-flex items-center cursor-pointer", @class]}>
+    <label class={[
+      "inline-flex items-center shrink-0",
+      @disabled && "opacity-50 cursor-not-allowed",
+      not @disabled && "cursor-pointer",
+      @class
+    ]}>
+      <span :if={@label && @label_position == "before"} class="me-2 text-sm font-medium text-heading">
+        {@label}
+      </span>
       <input
         type="checkbox"
         id={@id}
@@ -1655,23 +1665,26 @@ defmodule PortalWeb.CoreComponents do
         class="sr-only peer"
         {@rest}
       />
-      <div class={[
-        "relative w-11 h-6 bg-gray-200 rounded-full peer",
-        "peer-focus:outline-hidden peer-focus:ring-4 peer-focus:ring-accent-300",
+      <span class={[
+        "relative rounded-full border transition-colors shrink-0",
+        "bg-input border-input-border",
+        "peer-checked:bg-brand peer-checked:border-brand",
+        "peer-focus-visible:ring-2 peer-focus-visible:ring-border-focus",
+        "after:content-[''] after:absolute after:top-[1px] after:start-[1px]",
+        "after:bg-white after:rounded-full after:shadow-sm after:transition-transform",
         "peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full",
-        "peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px]",
-        "after:start-[2px] after:bg-white after:border-neutral-300 after:border",
-        "after:rounded-full after:h-5 after:w-5 after:transition-all",
-        "peer-checked:bg-accent-600",
-        @disabled && "opacity-50 cursor-not-allowed"
+        toggle_size(@size)
       ]}>
-      </div>
-      <span :if={@label} class="ms-3 text-sm font-medium text-gray-900">
+      </span>
+      <span :if={@label && @label_position == "after"} class="ms-2 text-sm font-medium text-heading">
         {@label}
       </span>
     </label>
     """
   end
+
+  defp toggle_size("sm"), do: "w-7 h-4 after:h-3 after:w-3"
+  defp toggle_size(_md), do: "w-9 h-5 after:h-4 after:w-4"
 
   @doc """
   Renders a status badge pill.

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -2049,14 +2049,13 @@ defmodule PortalWeb.Policies.Components do
           Allow access when the Client is manually verified by the administrator.
         </p>
         <div class="space-y-2" phx-update="ignore" id="conditions-client-verified-values">
-          <.input
-            type="checkbox"
+          <.toggle
             label="Require client verification"
             name="policy[conditions][client_verified][values][]"
             id="policy_conditions_client_verified_value"
+            value="true"
             disabled={@disabled}
             checked={List.first(List.wrap(condition_form[:values].value)) == "true"}
-            unchecked_value={nil}
           />
         </div>
       </div>

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -159,10 +159,11 @@ defmodule PortalWeb.Resources.Components do
         <div class="flex items-top mb-4">
           <.input type="hidden" name={"#{@form.name}[tcp][protocol]"} value="tcp" />
           <div class="mt-2.5 w-24" phx-update="ignore" id="tcp-filter-checkbox">
-            <.input
+            <.toggle
+              id="tcp-filter-toggle"
               title="Restrict traffic to TCP traffic"
-              type="checkbox"
               name={"#{@form.name}[tcp][enabled]"}
+              value="true"
               checked={Map.has_key?(@forms_by_protocol, :tcp)}
               disabled={!@traffic_filters_enabled?}
               label="TCP"
@@ -190,9 +191,10 @@ defmodule PortalWeb.Resources.Components do
         <div class="flex items-top mb-4">
           <.input type="hidden" name={"#{@form.name}[udp][protocol]"} value="udp" />
           <div class="mt-2.5 w-24" phx-update="ignore" id="udp-filter-checkbox">
-            <.input
-              type="checkbox"
+            <.toggle
+              id="udp-filter-toggle"
               name={"#{@form.name}[udp][enabled]"}
+              value="true"
               checked={Map.has_key?(@forms_by_protocol, :udp)}
               disabled={!@traffic_filters_enabled?}
               label="UDP"
@@ -221,10 +223,11 @@ defmodule PortalWeb.Resources.Components do
           <.input type="hidden" name={"#{@form.name}[icmp][protocol]"} value="icmp" />
 
           <div class="mt-2.5 w-24" phx-update="ignore" id="icmp-filter-checkbox">
-            <.input
+            <.toggle
+              id="icmp-filter-toggle"
               title="Allow ICMP echo requests/replies"
-              type="checkbox"
               name={"#{@form.name}[icmp][enabled]"}
+              value="true"
               checked={Map.has_key?(@forms_by_protocol, :icmp)}
               disabled={!@traffic_filters_enabled?}
               label="ICMP echo"

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -1281,24 +1281,23 @@ defmodule PortalWeb.Settings.DirectorySync do
           </div>
         </fieldset>
 
-        <div :if={@type == "google"} class="mt-4">
-          <label class="flex items-center gap-3 cursor-pointer">
-            <input type="hidden" name={@form[:orgunit_sync_enabled].name} value="false" />
-            <input
-              type="checkbox"
-              name={@form[:orgunit_sync_enabled].name}
-              value="true"
-              checked={get_field(@form.source, :orgunit_sync_enabled)}
-              class="w-4 h-4 text-brand border-border rounded"
-            />
+        <div :if={@type == "google"} class="mt-4 flex items-start justify-between gap-4">
+          <div>
             <span class="text-sm font-medium text-heading">
               Sync Organization Units
             </span>
-          </label>
-          <p class="mt-1 ml-7 text-xs text-subtle">
-            Sync Google Workspace organizational units as groups. <strong>Note:</strong>
-            When enabled, all org units and active users will be synced.
-          </p>
+            <p class="mt-1 text-xs text-subtle">
+              Sync Google Workspace organizational units as groups. <strong>Note:</strong>
+              When enabled, all org units and active users will be synced.
+            </p>
+          </div>
+          <input type="hidden" name={@form[:orgunit_sync_enabled].name} value="false" />
+          <.toggle
+            id={@form[:orgunit_sync_enabled].id}
+            name={@form[:orgunit_sync_enabled].name}
+            value="true"
+            checked={get_field(@form.source, :orgunit_sync_enabled)}
+          />
         </div>
 
         <div :if={@type == "okta"}>

--- a/elixir/lib/portal_web/live/settings/log_sinks.ex
+++ b/elixir/lib/portal_web/live/settings/log_sinks.ex
@@ -1566,29 +1566,28 @@ defmodule PortalWeb.Settings.LogSinks do
           </div>
         </fieldset>
 
-        <div :if={@live_action == :new}>
-          <label class="flex items-center gap-3 cursor-pointer">
-            <input type="hidden" name={@form[:retroactive].name} value="false" />
-            <input
-              type="checkbox"
-              name={@form[:retroactive].name}
-              value="true"
-              checked={get_field(@form.source, :retroactive)}
-              class="w-4 h-4 text-brand border-border rounded"
-            />
+        <div :if={@live_action == :new} class="flex items-start justify-between gap-4">
+          <div>
             <span class="text-sm font-medium text-heading">
               Deliver existing logs
             </span>
-          </label>
-          <p class="mt-1 ml-7 text-xs text-subtle">
-            Backfill logs recorded before this sink was created, oldest first, while new
-            logs are delivered as they arrive. When disabled, only logs recorded from now
-            on are delivered.
-          </p>
-          <p :if={@type == "newrelic"} class="mt-1 ml-7 text-xs text-subtle">
-            New Relic drops payloads with timestamps older than 48 hours, so backfilled
-            events older than that will not appear in New Relic.
-          </p>
+            <p class="mt-1 text-xs text-subtle">
+              Backfill logs recorded before this sink was created, oldest first, while new
+              logs are delivered as they arrive. When disabled, only logs recorded from now
+              on are delivered.
+            </p>
+            <p :if={@type == "newrelic"} class="mt-1 text-xs text-subtle">
+              New Relic drops payloads with timestamps older than 48 hours, so backfilled
+              events older than that will not appear in New Relic.
+            </p>
+          </div>
+          <input type="hidden" name={@form[:retroactive].name} value="false" />
+          <.toggle
+            id={@form[:retroactive].id}
+            name={@form[:retroactive].name}
+            value="true"
+            checked={get_field(@form.source, :retroactive)}
+          />
         </div>
       </div>
     </.form>

--- a/elixir/lib/portal_web/live/settings/notifications.ex
+++ b/elixir/lib/portal_web/live/settings/notifications.ex
@@ -61,29 +61,8 @@ defmodule PortalWeb.Settings.Notifications do
         <p class="text-sm font-medium text-heading">{@label}</p>
         <p :if={@description} class="text-xs text-subtle mt-0.5">{@description}</p>
       </div>
-      <label class="inline-flex items-center shrink-0 cursor-pointer">
-        <input type="hidden" name={@field.name} value="false" />
-        <input
-          type="checkbox"
-          id={@field.id}
-          name={@field.name}
-          value="true"
-          checked={@checked}
-          class="sr-only"
-        />
-        <div class={[
-          "w-9 h-5 rounded-full border transition-colors flex items-center px-0.5",
-          @checked && "bg-brand border-brand",
-          not @checked && "bg-input border-input-border"
-        ]}>
-          <span class={[
-            "w-4 h-4 bg-white rounded-full shadow-sm transition-transform",
-            @checked && "translate-x-4",
-            not @checked && "translate-x-0"
-          ]}>
-          </span>
-        </div>
-      </label>
+      <input type="hidden" name={@field.name} value="false" />
+      <.toggle id={@field.id} name={@field.name} value="true" checked={@checked} />
     </div>
     """
   end

--- a/elixir/lib/portal_web/live_table.ex
+++ b/elixir/lib/portal_web/live_table.ex
@@ -559,35 +559,19 @@ defmodule PortalWeb.LiveTable do
     assigns = assign(assigns, checked: checked)
 
     ~H"""
-    <label
-      for={"#{@live_table_id}-#{@filter.name}-toggle"}
-      class="inline-flex items-center gap-2 h-8 px-2.5 rounded border border-[var(--control-border)] bg-[var(--control-bg)] cursor-pointer shrink-0"
-    >
-      <span class="text-xs font-medium text-[var(--text-secondary)] select-none">
-        {@filter.title}
-      </span>
+    <div class="inline-flex shrink-0">
       <input type="hidden" name={@form[@filter.name].name} value="false" />
-      <input
-        type="checkbox"
+      <.toggle
         id={"#{@live_table_id}-#{@filter.name}-toggle"}
         name={@form[@filter.name].name}
         value="true"
         checked={@checked}
-        class="sr-only peer"
+        size="sm"
+        label={@filter.title}
+        label_position="before"
+        class="h-8 px-2.5 rounded border border-input-border bg-input"
       />
-      <span class={[
-        "relative inline-flex w-7 h-4 rounded-full border transition-colors items-center px-0.5 shrink-0",
-        @checked && "bg-[var(--brand)] border-[var(--brand)]",
-        not @checked && "bg-[var(--surface)] border-[var(--control-border)]"
-      ]}>
-        <span class={[
-          "w-3 h-3 bg-white rounded-full shadow-sm transition-transform",
-          @checked && "translate-x-3",
-          not @checked && "translate-x-0"
-        ]}>
-        </span>
-      </span>
-    </label>
+    </div>
     """
   end
 

--- a/elixir/portal_dev/live/dev/components_live.ex
+++ b/elixir/portal_dev/live/dev/components_live.ex
@@ -185,14 +185,63 @@ defmodule PortalWeb.Dev.ComponentsLive do
       id: "toggle",
       label: "Toggle",
       variants: [
-        %{name: "Off", props: %{"checked" => false, "disabled" => false, "label" => "Enable feature"}},
-        %{name: "On", props: %{"checked" => true, "disabled" => false, "label" => "Enable feature"}},
-        %{name: "Disabled", props: %{"checked" => false, "disabled" => true, "label" => "Locked"}}
+        %{
+          name: "Off",
+          props: %{
+            "checked" => false,
+            "disabled" => false,
+            "label" => "Enable feature",
+            "size" => "md",
+            "label_position" => "after"
+          }
+        },
+        %{
+          name: "On",
+          props: %{
+            "checked" => true,
+            "disabled" => false,
+            "label" => "Enable feature",
+            "size" => "md",
+            "label_position" => "after"
+          }
+        },
+        %{
+          name: "Disabled",
+          props: %{
+            "checked" => false,
+            "disabled" => true,
+            "label" => "Locked",
+            "size" => "md",
+            "label_position" => "after"
+          }
+        },
+        %{
+          name: "Small",
+          props: %{
+            "checked" => true,
+            "disabled" => false,
+            "label" => "Only failures",
+            "size" => "sm",
+            "label_position" => "after"
+          }
+        },
+        %{
+          name: "Label before",
+          props: %{
+            "checked" => true,
+            "disabled" => false,
+            "label" => "Only failures",
+            "size" => "sm",
+            "label_position" => "before"
+          }
+        }
       ],
       controls: [
         %{name: "label", type: "text"},
         %{name: "checked", type: "boolean"},
-        %{name: "disabled", type: "boolean"}
+        %{name: "disabled", type: "boolean"},
+        %{name: "size", type: "select", options: ~w[sm md]},
+        %{name: "label_position", type: "select", options: ~w[before after]}
       ]
     },
     %{
@@ -683,6 +732,8 @@ defmodule PortalWeb.Dev.ComponentsLive do
       checked={@props["checked"]}
       disabled={@props["disabled"]}
       label={@props["label"]}
+      size={@props["size"]}
+      label_position={@props["label_position"]}
     />
     """
   end


### PR DESCRIPTION
On/off switches were built three different ways: the shared `<.toggle>` component, a hand-rolled one in notification settings, and another in the live table filter bar. Three different sizes, and three different ways of picking colors.

The shared one was the worst of the three. It hardcoded gray values while the other two used the theme tokens, so it was the only switch on the site that ignored dark mode. That is likely why nobody reached for it and hand-rolled instead.

`<.toggle>` now uses the same theme tokens the other two already used, and takes `size` and `label_position` options so it can cover both shapes that existed. Both hand-rolled copies are deleted.

A few plain on/off checkboxes are now switches as well, since they were booleans wearing the wrong control: "Deliver existing logs" on log sinks, "Require client verification" on policies, the TCP/UDP/ICMP filters on resources, and "Sync Organization Units" on directory sync.

Checkboxes that let you pick several things at once are untouched, as are the radio-style card pickers that use similar CSS. Those are not booleans.