### PR TITLE
fix(portal): add missing header to the actor edit form

### DIFF
--- a/elixir/lib/portal_web/components/form_components.ex
+++ b/elixir/lib/portal_web/components/form_components.ex
@@ -722,6 +722,51 @@ defmodule PortalWeb.FormComponents do
     """
   end
 
+  @doc """
+  Renders the header row of a slide-over panel: a title on the left and a close
+  button on the right.
+
+  Use `"elevated"` for entity panels (clients, sites, actors) and `"plain"` for
+  settings panels.
+
+  ## Examples
+
+      <.panel_header title="Edit Client" close_event="cancel_client_edit_form" />
+
+      <.panel_header title={"Edit \#{@provider_name}"} variant="plain">
+        <:leading><.provider_icon provider={@type} size="md" /></:leading>
+        <:adornment><.docs_action path={"/authenticate/\#{@type}"} /></:adornment>
+      </.panel_header>
+  """
+  attr :title, :string, required: true
+  attr :variant, :string, default: "elevated", values: ~w[elevated plain]
+  attr :close_event, :string, default: "close_panel"
+  attr :class, :string, default: nil
+  slot :leading, doc: "Rendered before the title, e.g. a provider icon"
+  slot :adornment, doc: "Rendered after the title, e.g. a docs link"
+  slot :actions, doc: "Rendered before the close button"
+
+  def panel_header(assigns) do
+    ~H"""
+    <div class={[
+      "shrink-0 flex items-center justify-between gap-3 border-b border-border",
+      @variant == "elevated" && "px-5 pt-4 pb-3 bg-elevated",
+      @variant == "plain" && "px-5 py-4",
+      @class
+    ]}>
+      <div class="flex items-center gap-2 min-w-0">
+        {render_slot(@leading)}
+        <h2 class="text-sm font-semibold text-heading truncate">{@title}</h2>
+        {render_slot(@adornment)}
+      </div>
+      <div class="flex items-center gap-1.5 shrink-0">
+        {render_slot(@actions)}
+        <.icon_button icon="ri-close-line" title="Close (Esc)" phx-click={@close_event} />
+      </div>
+    </div>
+    """
+  end
+
   defp icon_button_style(nil) do
     ["text-subtle hover:text-heading hover:bg-raised"]
   end

--- a/elixir/lib/portal_web/live/actors/components.ex
+++ b/elixir/lib/portal_web/live/actors/components.ex
@@ -1019,6 +1019,7 @@ defmodule PortalWeb.Actors.Components do
       |> assign(assigns.group_membership_state)
 
     ~H"""
+    <.panel_header title={"Edit #{@actor.name}"} close_event="cancel_actor_edit_form" />
     <.form
       id="actor-edit-form"
       for={@form}

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -269,12 +269,7 @@ defmodule PortalWeb.Clients.Components do
 
   def client_edit_header(assigns) do
     ~H"""
-    <div class="shrink-0 px-5 pt-4 pb-3 border-b border-border bg-elevated">
-      <div class="flex items-center justify-between gap-3">
-        <h2 class="text-sm font-semibold text-heading">Edit Client</h2>
-        <.icon_button icon="ri-close-line" title="Close (Esc)" phx-click="cancel_client_edit_form" />
-      </div>
-    </div>
+    <.panel_header title="Edit Client" close_event="cancel_client_edit_form" />
     """
   end
 

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -251,7 +251,7 @@ defmodule PortalWeb.Clients.Components do
   def client_edit_view(assigns) do
     ~H"""
     <div class="flex flex-1 min-h-0 flex-col overflow-hidden">
-      <.client_edit_header />
+      <.panel_header title="Edit Client" close_event="cancel_client_edit_form" />
       <.form
         :if={@client_edit_form}
         id="client-edit-form"
@@ -264,12 +264,6 @@ defmodule PortalWeb.Clients.Components do
         <.client_edit_actions />
       </.form>
     </div>
-    """
-  end
-
-  def client_edit_header(assigns) do
-    ~H"""
-    <.panel_header title="Edit Client" close_event="cancel_client_edit_form" />
     """
   end
 

--- a/elixir/lib/portal_web/live/settings/api_clients/index.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/index.ex
@@ -298,13 +298,7 @@ defmodule PortalWeb.Settings.ApiClients.Index do
           :if={@live_action == :edit && @selected_actor && @form}
           class="flex flex-col h-full overflow-hidden"
         >
-          <!-- Panel header -->
-          <div class="shrink-0 px-5 pt-4 pb-3 border-b border-border bg-elevated">
-            <div class="flex items-center justify-between gap-3">
-              <h2 class="text-sm font-semibold text-heading">Edit API Token</h2>
-              <.icon_button icon="ri-close-line" title="Close (Esc)" phx-click="close_panel" />
-            </div>
-          </div>
+          <.panel_header title="Edit API Token" />
 
           <.form
             id="api-token-edit-form"

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -799,16 +799,10 @@ defmodule PortalWeb.Settings.Authentication do
           :if={@live_action == :edit and assigns[:form] != nil}
           class="flex flex-col h-full overflow-hidden"
         >
-          <div class="shrink-0 flex items-center justify-between px-5 py-4 border-b border-border">
-            <div class="flex items-center gap-2">
-              <.provider_icon provider={@type} size="md" />
-              <h2 class="text-sm font-semibold text-heading">
-                Edit {@provider_name}
-              </h2>
-              <.docs_action path={"/authenticate/#{@type}"} />
-            </div>
-            <.icon_button icon="ri-close-line" title="Close (Esc)" phx-click="close_panel" />
-          </div>
+          <.panel_header title={"Edit #{@provider_name}"} variant="plain">
+            <:leading><.provider_icon provider={@type} size="md" /></:leading>
+            <:adornment><.docs_action path={"/authenticate/#{@type}"} /></:adornment>
+          </.panel_header>
           <div class="flex-1 overflow-y-auto px-5 py-4">
             <.flash :if={assigns[:is_legacy]} kind={:warning_inline} class="mb-4">
               This provider uses legacy configuration. We recommend setting up a new authentication

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -660,16 +660,10 @@ defmodule PortalWeb.Settings.DirectorySync do
             :if={@live_action == :edit and assigns[:form] != nil}
             class="flex flex-col h-full overflow-hidden"
           >
-            <div class="shrink-0 flex items-center justify-between px-5 py-4 border-b border-border">
-              <div class="flex items-center gap-2">
-                <.provider_icon provider={@type} size="md" />
-                <h2 class="text-sm font-semibold text-heading">
-                  Edit {assigns[:directory_name]}
-                </h2>
-                <.docs_action path={"/directory-sync/#{@type}"} />
-              </div>
-              <.icon_button icon="ri-close-line" title="Close (Esc)" phx-click="close_panel" />
-            </div>
+            <.panel_header title={"Edit #{assigns[:directory_name]}"} variant="plain">
+              <:leading><.provider_icon provider={@type} size="md" /></:leading>
+              <:adornment><.docs_action path={"/directory-sync/#{@type}"} /></:adornment>
+            </.panel_header>
             <div class="flex-1 overflow-y-auto px-5 py-4">
               <.flash :if={assigns[:is_legacy]} kind={:warning_inline} class="mb-4">
                 This directory uses legacy credentials and needs to be updated to use Firezone's shared service account.

--- a/elixir/lib/portal_web/live/settings/dns.ex
+++ b/elixir/lib/portal_web/live/settings/dns.ex
@@ -92,13 +92,9 @@ defmodule PortalWeb.Settings.DNS do
           :if={@live_action == :edit and assigns[:form] != nil}
           class="flex flex-col h-full overflow-hidden"
         >
-          <div class="shrink-0 flex items-center justify-between px-5 py-4 border-b border-border">
-            <div class="flex items-center gap-2">
-              <h2 class="text-sm font-semibold text-heading">Edit DNS Settings</h2>
-              <.docs_action path="/deploy/dns" />
-            </div>
-            <.icon_button icon="ri-close-line" title="Close (Esc)" phx-click="close_panel" />
-          </div>
+          <.panel_header title="Edit DNS Settings" variant="plain">
+            <:adornment><.docs_action path="/deploy/dns" /></:adornment>
+          </.panel_header>
           <div class="flex-1 overflow-y-auto px-5 py-4">
             <.dns_form form={@form} />
           </div>

--- a/elixir/lib/portal_web/live/settings/log_sinks.ex
+++ b/elixir/lib/portal_web/live/settings/log_sinks.ex
@@ -552,16 +552,10 @@ defmodule PortalWeb.Settings.LogSinks do
             :if={@live_action == :edit and assigns[:form] != nil}
             class="flex flex-col h-full overflow-hidden"
           >
-            <div class="shrink-0 flex items-center justify-between px-5 py-4 border-b border-border">
-              <div class="flex items-center gap-2">
-                <.provider_icon provider={@type} size="md" />
-                <h2 class="text-sm font-semibold text-heading">
-                  Edit {assigns[:sink_name]}
-                </h2>
-                <.docs_action path={"/log-sinks/#{@type}"} />
-              </div>
-              <.icon_button icon="ri-close-line" title="Close (Esc)" phx-click="close_panel" />
-            </div>
+            <.panel_header title={"Edit #{assigns[:sink_name]}"} variant="plain">
+              <:leading><.provider_icon provider={@type} size="md" /></:leading>
+              <:adornment><.docs_action path={"/log-sinks/#{@type}"} /></:adornment>
+            </.panel_header>
             <div class="flex-1 overflow-y-auto px-5 py-4">
               <.flash :if={assigns[:sink] && @sink.error_message} kind={:error} class="mb-4">
                 {@sink.error_message}

--- a/elixir/lib/portal_web/live/sites/components.ex
+++ b/elixir/lib/portal_web/live/sites/components.ex
@@ -1767,12 +1767,7 @@ defmodule PortalWeb.Sites.Components do
   def site_edit_view(assigns) do
     ~H"""
     <div class="flex flex-1 min-h-0 flex-col overflow-hidden">
-      <div class="shrink-0 px-5 pt-4 pb-3 border-b border-border bg-elevated">
-        <div class="flex items-center justify-between gap-3">
-          <h2 class="text-sm font-semibold text-heading">Edit Site</h2>
-          <.icon_button icon="ri-close-line" title="Close (Esc)" phx-click="cancel_site_edit_form" />
-        </div>
-      </div>
+      <.panel_header title="Edit Site" close_event="cancel_site_edit_form" />
       <.form
         :if={@form}
         id="site-edit-form"


### PR DESCRIPTION
Open the edit form for a client, a site, an API token, or anything under settings and you get a title bar with a close button. Open it for an actor and you get nothing: the panel goes straight into the form fields, and the only way out is the Cancel button all the way at the bottom.

The actor edit form now has the same header as everything else.

While adding it, the header itself became a shared `<.panel_header>` component rather than a tenth copy of the same markup. It covers both shapes already in use: the raised one on entity panels like clients and sites, and the flat one on settings panels. Slots handle the bits that vary, like the provider icon and the docs link.

The "Add" and "Select type" panels keep their own markup for now. They have a back arrow in the header that does not fit the shared component yet.
