### PR TITLE
fix(portal): give action buttons a border like other buttons

### DIFF
--- a/elixir/lib/portal_web/components/form_components.ex
+++ b/elixir/lib/portal_web/components/form_components.ex
@@ -1019,10 +1019,22 @@ defmodule PortalWeb.FormComponents do
       ]
   end
 
-  def action_button_style(nil), do: action_button_base() ++ ["text-body", "hover:text-heading", "hover:bg-raised"]
-  def action_button_style("info"), do: action_button_base() ++ ["text-info", "hover:bg-raised"]
-  def action_button_style("success"), do: action_button_base() ++ ["text-success", "hover:bg-raised"]
-  def action_button_style("warning"), do: action_button_base() ++ ["text-warning", "hover:bg-raised"]
+  def action_button_style(nil) do
+    action_button_base() ++
+      ["text-body", "border border-border-strong", "hover:text-heading", "hover:bg-raised"]
+  end
+
+  def action_button_style("info") do
+    action_button_base() ++ ["text-info", "border border-info", "hover:bg-raised"]
+  end
+
+  def action_button_style("success") do
+    action_button_base() ++ ["text-success", "border border-success", "hover:bg-raised"]
+  end
+
+  def action_button_style("warning") do
+    action_button_base() ++ ["text-warning", "border border-warning", "hover:bg-raised"]
+  end
 
   def action_button_style(style) when style in ["error", "danger"] do
     action_button_base() ++ ["text-error", "border", "border-error/20", "hover:bg-error-light"]


### PR DESCRIPTION
The Disable and Enable buttons in the actor side panel had no border, so they looked flat next to the bordered buttons everywhere else, including the Cancel and Disable buttons that appear right below them in the confirmation box.

Every style of the regular button component draws a border. The action button component, used for the side panel action rows, only drew one for the danger style. The other four drew none.

They now all draw a border, each in the same color the matching regular button style uses. This affects the other side panel actions too, such as Send Welcome Email and the token actions, which had the same problem.

Hover colors are left as they were. The regular buttons tint their hover to match the button color, while these stay neutral gray. That is a separate call about how loud a stack of full-width action rows should be, so it seemed better not to fold it in here.
