### PR TITLE
feat(portal): back off and retry throttled Google requests

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -254,9 +254,7 @@ config :portal, Portal.Google.APIClient,
   req_opts: [
     # 1 minute
     receive_timeout: 60_000
-    # Retries are set by Portal.Google.APIClient itself, which covers everything
-    # `:transient` did plus Google's throttling. Setting `:retry` here replaces
-    # that entirely, so don't.
+    # Don't set :retry here; Portal.Google.APIClient owns the strategy.
   ]
 
 config :portal, Portal.TokenCache, enabled: true

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -253,10 +253,10 @@ config :portal, Portal.Google.APIClient,
   token_endpoint: "https://oauth2.googleapis.com/token",
   req_opts: [
     # 1 minute
-    receive_timeout: 60_000,
-    # Fixes `pool_not_available` errors on a cold Finch pool right after a deploy,
-    # since some requests are POSTs and the default `:safe_transient` retry strategy only retries HEADS and GETs.
-    retry: :transient
+    receive_timeout: 60_000
+    # Retries are set by Portal.Google.APIClient itself, which covers everything
+    # `:transient` did plus Google's throttling. Setting `:retry` here replaces
+    # that entirely, so don't.
   ]
 
 config :portal, Portal.TokenCache, enabled: true

--- a/elixir/lib/portal/config.ex
+++ b/elixir/lib/portal/config.ex
@@ -111,16 +111,10 @@ defmodule Portal.Config do
     end
 
     @doc """
-    Overrides application env for the current process, merging nested keyword
-    lists rather than replacing them.
+    Like `put_env_override/3` but merges nested keyword lists instead of
+    replacing them, so overriding one entry of `:req_opts` keeps the rest.
 
-    `put_env_override/3` merges only the top level, so overriding one entry of a
-    nested list such as `:req_opts` drops everything else configured under it.
-    That silently hides whatever `config.exs` set, leaving tests agreeing with a
-    configuration no environment actually runs. Prefer this when overriding part
-    of a nested list.
-
-    Builds on any override already in place, so repeated calls accumulate.
+    Builds on any override already in place.
     """
     def merge_env_override(app \\ :portal, key, value) do
       Process.put(pdict_key_function(app, key), deep_merge(fetch_env!(app, key), value))
@@ -130,13 +124,9 @@ defmodule Portal.Config do
     @doc """
     Removes a key from the application env for the current process.
 
-    Given a path it reaches into nested keyword lists, so a test can run against
-    the configured value minus a single entry:
-
         delete_env_override(:portal, Portal.Google.APIClient, [:req_opts, :retry])
 
-    Without a path the whole override is dropped and the configured value
-    applies again.
+    Without a path the whole override is dropped.
     """
     def delete_env_override(app \\ :portal, key, path \\ [])
 

--- a/elixir/lib/portal/config.ex
+++ b/elixir/lib/portal/config.ex
@@ -110,6 +110,69 @@ defmodule Portal.Config do
       :ok
     end
 
+    @doc """
+    Overrides application env for the current process, merging nested keyword
+    lists rather than replacing them.
+
+    `put_env_override/3` merges only the top level, so overriding one entry of a
+    nested list such as `:req_opts` drops everything else configured under it.
+    That silently hides whatever `config.exs` set, leaving tests agreeing with a
+    configuration no environment actually runs. Prefer this when overriding part
+    of a nested list.
+
+    Builds on any override already in place, so repeated calls accumulate.
+    """
+    def merge_env_override(app \\ :portal, key, value) do
+      Process.put(pdict_key_function(app, key), deep_merge(fetch_env!(app, key), value))
+      :ok
+    end
+
+    @doc """
+    Removes a key from the application env for the current process.
+
+    Given a path it reaches into nested keyword lists, so a test can run against
+    the configured value minus a single entry:
+
+        delete_env_override(:portal, Portal.Google.APIClient, [:req_opts, :retry])
+
+    Without a path the whole override is dropped and the configured value
+    applies again.
+    """
+    def delete_env_override(app \\ :portal, key, path \\ [])
+
+    def delete_env_override(app, key, []) do
+      Process.delete(pdict_key_function(app, key))
+      :ok
+    end
+
+    def delete_env_override(app, key, path) when is_list(path) do
+      Process.put(pdict_key_function(app, key), delete_in(fetch_env!(app, key), path))
+      :ok
+    end
+
+    defp deep_merge(base, override) when is_list(base) and is_list(override) do
+      if Keyword.keyword?(base) and Keyword.keyword?(override) do
+        Keyword.merge(base, override, fn _key, base_value, override_value ->
+          deep_merge(base_value, override_value)
+        end)
+      else
+        override
+      end
+    end
+
+    defp deep_merge(_base, override), do: override
+
+    defp delete_in(keyword, [key]) when is_list(keyword), do: Keyword.delete(keyword, key)
+
+    defp delete_in(keyword, [key | rest]) when is_list(keyword) do
+      case Keyword.fetch(keyword, key) do
+        {:ok, nested} -> Keyword.put(keyword, key, delete_in(nested, rest))
+        :error -> keyword
+      end
+    end
+
+    defp delete_in(value, _path), do: value
+
     def put_system_env_override(key, value) when is_atom(key) do
       Process.put({Portal.Config.Resolver, key}, {:env, value})
       :ok

--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -149,7 +149,7 @@ defmodule Portal.Google.APIClient do
            [
              headers: [{"Content-Type", "application/x-www-form-urlencoded"}],
              body: payload
-           ] ++ (config[:req_opts] || [])
+           ] ++ request_opts(config)
          ) do
       {:ok,
        %Req.Response{
@@ -240,7 +240,7 @@ defmodule Portal.Google.APIClient do
            [
              headers: [{"Authorization", "Bearer #{access_token}"}],
              json: %{"payload" => JSON.encode!(claims)}
-           ] ++ (config[:req_opts] || [])
+           ] ++ request_opts(config)
          ) do
       {:ok, %Req.Response{status: 200, body: %{"signedJwt" => signed_jwt}}} ->
         {:ok, signed_jwt}
@@ -278,7 +278,7 @@ defmodule Portal.Google.APIClient do
       [
         headers: [{"Content-Type", "application/x-www-form-urlencoded"}],
         body: payload
-      ] ++ (config[:req_opts] || [])
+      ] ++ request_opts(config)
     )
   end
 
@@ -725,17 +725,26 @@ defmodule Portal.Google.APIClient do
   @usage_limits_domain "usageLimits"
   @transient_statuses [408, 429, 500, 502, 503, 504]
   @transient_transport_reasons [:timeout, :econnrefused, :closed]
+  @transient_http_reasons [:unprocessed, :pool_not_available]
   @max_retries 5
 
+  # Config may switch retrying off, which is how tests keep themselves fast, but
+  # it must not be able to swap in a different strategy: a plain merge once let
+  # `retry: :transient` from config.exs replace the predicate below, which threw
+  # away the throttling handling without failing anything.
   defp request_opts(config) do
-    Keyword.merge(
-      [
-        retry: &retry_google_error/2,
-        retry_delay: &retry_delay/1,
-        max_retries: @max_retries
-      ],
-      config[:req_opts] || []
-    )
+    req_opts = config[:req_opts] || []
+
+    retry =
+      case Keyword.fetch(req_opts, :retry) do
+        {:ok, false} -> false
+        _otherwise -> &retry_google_error/2
+      end
+
+    req_opts
+    |> Keyword.put(:retry, retry)
+    |> Keyword.put_new(:retry_delay, &retry_delay/1)
+    |> Keyword.put_new(:max_retries, @max_retries)
   end
 
   defp retry_google_error(_request, %Req.Response{status: 403, body: body}) do
@@ -748,6 +757,12 @@ defmodule Portal.Google.APIClient do
 
   defp retry_google_error(_request, %Req.TransportError{reason: reason}) do
     reason in @transient_transport_reasons
+  end
+
+  # Cold Finch pools right after a deploy reject requests this way, and unlike
+  # Req's :safe_transient we need it on the POSTs too.
+  defp retry_google_error(_request, %Req.HTTPError{reason: reason}) do
+    reason in @transient_http_reasons
   end
 
   defp retry_google_error(_request, _response_or_exception), do: false

--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -383,11 +383,10 @@ defmodule Portal.Google.APIClient do
 
   defp test_endpoint(path, access_token, params) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
-    req_opts = config[:req_opts] || []
     query = URI.encode_query(params)
     url = "#{config[:endpoint]}#{path}?#{query}"
 
-    case Req.get(url, [headers: [Authorization: "Bearer #{access_token}"]] ++ req_opts) do
+    case Req.get(url, [headers: [Authorization: "Bearer #{access_token}"]] ++ request_opts(config)) do
       {:ok, %Req.Response{status: 200}} -> :ok
       other -> other
     end
@@ -507,7 +506,7 @@ defmodule Portal.Google.APIClient do
 
   defp do_batch_get_users(access_token, user_ids) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
-    req_opts = config[:req_opts] || []
+    req_opts = request_opts(config)
     batch_endpoint = config[:batch_endpoint] || @default_batch_endpoint
     boundary = "batch_#{System.unique_integer([:positive])}"
 
@@ -714,10 +713,63 @@ defmodule Portal.Google.APIClient do
 
   defp get(path, access_token) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
-    req_opts = config[:req_opts] || []
 
     (config[:endpoint] <> path)
-    |> Req.get([headers: [Authorization: "Bearer #{access_token}"]] ++ req_opts)
+    |> Req.get([headers: [Authorization: "Bearer #{access_token}"]] ++ request_opts(config))
+  end
+
+  # Google reports throttling as 403 with an error whose domain is "usageLimits",
+  # which Req's default :safe_transient retry does not cover. Supplying our own
+  # predicate replaces that default, so the transient cases are repeated here.
+  # https://developers.google.com/workspace/admin/directory/v1/limits
+  @usage_limits_domain "usageLimits"
+  @transient_statuses [408, 429, 500, 502, 503, 504]
+  @transient_transport_reasons [:timeout, :econnrefused, :closed]
+  @max_retries 5
+
+  defp request_opts(config) do
+    Keyword.merge(
+      [
+        retry: &retry_google_error/2,
+        retry_delay: &retry_delay/1,
+        max_retries: @max_retries
+      ],
+      config[:req_opts] || []
+    )
+  end
+
+  defp retry_google_error(_request, %Req.Response{status: 403, body: body}) do
+    usage_limits_error?(body)
+  end
+
+  defp retry_google_error(_request, %Req.Response{status: status}) do
+    status in @transient_statuses
+  end
+
+  defp retry_google_error(_request, %Req.TransportError{reason: reason}) do
+    reason in @transient_transport_reasons
+  end
+
+  defp retry_google_error(_request, _response_or_exception), do: false
+
+  # The retry step runs before the body is decoded, so this sees raw JSON.
+  defp usage_limits_error?(body) when is_binary(body) do
+    case JSON.decode(body) do
+      {:ok, decoded} -> usage_limits_error?(decoded)
+      {:error, _reason} -> false
+    end
+  end
+
+  defp usage_limits_error?(%{"error" => %{"errors" => errors}}) when is_list(errors) do
+    Enum.any?(errors, &(Map.get(&1, "domain") == @usage_limits_domain))
+  end
+
+  defp usage_limits_error?(_body), do: false
+
+  # Google documents truncated exponential backoff as (2 ^ n) seconds plus a
+  # random number of milliseconds up to 1000, with n starting at 0.
+  defp retry_delay(retry_count) do
+    Integer.pow(2, retry_count) * 1000 + :rand.uniform(1000)
   end
 
   defp stream_pages(path, query, access_token, result_key) do
@@ -736,10 +788,9 @@ defmodule Portal.Google.APIClient do
 
   defp fetch_page(current_path, current_query, access_token, result_key) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
-    req_opts = config[:req_opts] || []
     url = "#{config[:endpoint]}#{current_path}?#{current_query}"
 
-    case Req.get(url, [headers: [Authorization: "Bearer #{access_token}"]] ++ req_opts) do
+    case Req.get(url, [headers: [Authorization: "Bearer #{access_token}"]] ++ request_opts(config)) do
       {:ok, %Req.Response{status: 200, body: body}} ->
         parse_page_response(body, current_path, current_query, result_key)
 

--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -718,9 +718,8 @@ defmodule Portal.Google.APIClient do
     |> Req.get([headers: [Authorization: "Bearer #{access_token}"]] ++ request_opts(config))
   end
 
-  # Google reports throttling as 403 with an error whose domain is "usageLimits",
-  # which Req's default :safe_transient retry does not cover. Supplying our own
-  # predicate replaces that default, so the transient cases are repeated here.
+  # Throttling is a 403 with domain "usageLimits", not a 429, so Req's built-in
+  # strategies miss it. A custom predicate replaces them, hence the repetition.
   # https://developers.google.com/workspace/admin/directory/v1/limits
   @usage_limits_domain "usageLimits"
   @transient_statuses [408, 429, 500, 502, 503, 504]
@@ -728,10 +727,7 @@ defmodule Portal.Google.APIClient do
   @transient_http_reasons [:unprocessed, :pool_not_available]
   @max_retries 5
 
-  # Config may switch retrying off, which is how tests keep themselves fast, but
-  # it must not be able to swap in a different strategy: a plain merge once let
-  # `retry: :transient` from config.exs replace the predicate below, which threw
-  # away the throttling handling without failing anything.
+  # Config may switch retrying off, but must not swap in another strategy.
   defp request_opts(config) do
     req_opts = config[:req_opts] || []
 
@@ -759,8 +755,7 @@ defmodule Portal.Google.APIClient do
     reason in @transient_transport_reasons
   end
 
-  # Cold Finch pools right after a deploy reject requests this way, and unlike
-  # Req's :safe_transient we need it on the POSTs too.
+  # Cold Finch pools reject this way right after a deploy, POSTs included.
   defp retry_google_error(_request, %Req.HTTPError{reason: reason}) do
     reason in @transient_http_reasons
   end
@@ -781,8 +776,7 @@ defmodule Portal.Google.APIClient do
 
   defp usage_limits_error?(_body), do: false
 
-  # Google documents truncated exponential backoff as (2 ^ n) seconds plus a
-  # random number of milliseconds up to 1000, with n starting at 0.
+  # Truncated exponential backoff, as Google documents it.
   defp retry_delay(retry_count) do
     Integer.pow(2, retry_count) * 1000 + :rand.uniform(1000)
   end

--- a/elixir/test/portal/config_test.exs
+++ b/elixir/test/portal/config_test.exs
@@ -327,4 +327,59 @@ defmodule Portal.ConfigTest do
                Portal.ConfigTest.Test
     end
   end
+
+  describe "merge_env_override/3 and delete_env_override/3" do
+    @client Portal.Google.APIClient
+
+    test "merging keeps configured entries of a nested list" do
+      configured = Portal.Config.fetch_env!(:portal, @client)[:req_opts]
+      assert Keyword.has_key?(configured, :receive_timeout)
+
+      Portal.Config.merge_env_override(:portal, @client, req_opts: [retry_delay: 0])
+
+      req_opts = Portal.Config.fetch_env!(:portal, @client)[:req_opts]
+      assert req_opts[:retry_delay] == 0
+      assert req_opts[:receive_timeout] == configured[:receive_timeout]
+      assert req_opts[:plug] == configured[:plug]
+    end
+
+    test "merging leaves unrelated top-level keys alone" do
+      endpoint = Portal.Config.fetch_env!(:portal, @client)[:endpoint]
+      Portal.Config.merge_env_override(:portal, @client, req_opts: [retry_delay: 0])
+      assert Portal.Config.fetch_env!(:portal, @client)[:endpoint] == endpoint
+    end
+
+    test "merging accumulates across calls" do
+      Portal.Config.merge_env_override(:portal, @client, req_opts: [retry_delay: 0])
+      Portal.Config.merge_env_override(:portal, @client, req_opts: [max_retries: 1])
+
+      req_opts = Portal.Config.fetch_env!(:portal, @client)[:req_opts]
+      assert req_opts[:retry_delay] == 0
+      assert req_opts[:max_retries] == 1
+    end
+
+    test "deleting removes a nested key and keeps the rest" do
+      assert Portal.Config.fetch_env!(:portal, @client)[:req_opts]
+             |> Keyword.has_key?(:retry)
+
+      Portal.Config.delete_env_override(:portal, @client, [:req_opts, :retry])
+
+      req_opts = Portal.Config.fetch_env!(:portal, @client)[:req_opts]
+      refute Keyword.has_key?(req_opts, :retry)
+      assert Keyword.has_key?(req_opts, :receive_timeout)
+    end
+
+    test "deleting a missing key is a no-op" do
+      before = Portal.Config.fetch_env!(:portal, @client)[:req_opts]
+      Portal.Config.delete_env_override(:portal, @client, [:req_opts, :nope])
+      assert Portal.Config.fetch_env!(:portal, @client)[:req_opts] == before
+    end
+
+    test "deleting without a path restores the configured value" do
+      configured = Portal.Config.fetch_env!(:portal, @client)
+      Portal.Config.merge_env_override(:portal, @client, req_opts: [retry_delay: 0])
+      Portal.Config.delete_env_override(:portal, @client)
+      assert Portal.Config.fetch_env!(:portal, @client) == configured
+    end
+  end
 end

--- a/elixir/test/portal/google/api_client_test.exs
+++ b/elixir/test/portal/google/api_client_test.exs
@@ -818,8 +818,6 @@ defmodule Portal.Google.APIClientTest do
   end
 
   describe "retrying throttled requests" do
-    # Google reports throttling as 403 with domain "usageLimits" rather than 429.
-    # https://developers.google.com/workspace/admin/directory/v1/limits
     @usage_limits_body %{
       "error" => %{
         "code" => 403,
@@ -845,10 +843,7 @@ defmodule Portal.Google.APIClientTest do
     }
 
     setup do
-      # test.exs switches retrying off for the rest of the suite. Drop that one
-      # key so the client's own strategy applies and everything else stays as
-      # configured, rather than replacing req_opts and testing a shape no
-      # environment runs.
+      # test.exs switches retrying off suite-wide; drop just that key.
       Portal.Config.delete_env_override(:portal, APIClient, [:req_opts, :retry])
       Portal.Config.merge_env_override(:portal, APIClient, req_opts: [retry_delay: 0])
 
@@ -856,8 +851,6 @@ defmodule Portal.Google.APIClientTest do
     end
 
     test "keeps the throttling predicate when config sets another retry strategy" do
-      # config.exs used to set `retry: :transient`, which replaced the predicate
-      # and silently dropped throttling handling everywhere but in tests.
       Portal.Config.merge_env_override(:portal, APIClient,
         req_opts: [retry: :transient, retry_delay: 0]
       )

--- a/elixir/test/portal/google/api_client_test.exs
+++ b/elixir/test/portal/google/api_client_test.exs
@@ -817,6 +817,91 @@ defmodule Portal.Google.APIClientTest do
     end
   end
 
+  describe "retrying throttled requests" do
+    # Google reports throttling as 403 with domain "usageLimits" rather than 429.
+    # https://developers.google.com/workspace/admin/directory/v1/limits
+    @usage_limits_body %{
+      "error" => %{
+        "code" => 403,
+        "message" => "Rate Limit Exceeded",
+        "errors" => [
+          %{
+            "domain" => "usageLimits",
+            "message" => "Rate Limit Exceeded",
+            "reason" => "userRateLimitExceeded"
+          }
+        ]
+      }
+    }
+
+    @permission_denied_body %{
+      "error" => %{
+        "code" => 403,
+        "message" => "Not Authorized to access this resource/api",
+        "errors" => [
+          %{"domain" => "global", "message" => "Forbidden", "reason" => "forbidden"}
+        ]
+      }
+    }
+
+    setup do
+      Portal.Config.put_env_override(:portal, APIClient,
+        req_opts: [retry_delay: 0, plug: {Req.Test, APIClient}]
+      )
+
+      :ok
+    end
+
+    test "retries a 403 caused by throttling and succeeds" do
+      attempts = :counters.new(1, [:atomics])
+
+      Req.Test.expect(APIClient, 2, fn conn ->
+        :counters.add(attempts, 1, 1)
+
+        case :counters.get(attempts, 1) do
+          1 ->
+            conn |> Plug.Conn.put_status(403) |> Req.Test.json(@usage_limits_body)
+
+          2 ->
+            Req.Test.json(conn, %{"organizationUnits" => [%{"orgUnitId" => "ou1"}]})
+        end
+      end)
+
+      assert [[%{"orgUnitId" => "ou1"}]] =
+               APIClient.stream_organization_units(@test_access_token) |> Enum.to_list()
+
+      assert :counters.get(attempts, 1) == 2
+    end
+
+    test "does not retry a 403 caused by a permission failure" do
+      attempts = :counters.new(1, [:atomics])
+
+      Req.Test.stub(APIClient, fn conn ->
+        :counters.add(attempts, 1, 1)
+        conn |> Plug.Conn.put_status(403) |> Req.Test.json(@permission_denied_body)
+      end)
+
+      assert [{:error, %Req.Response{status: 403}}] =
+               APIClient.stream_organization_units(@test_access_token) |> Enum.to_list()
+
+      assert :counters.get(attempts, 1) == 1
+    end
+
+    test "surfaces the error when throttling outlasts the retries" do
+      attempts = :counters.new(1, [:atomics])
+
+      Req.Test.stub(APIClient, fn conn ->
+        :counters.add(attempts, 1, 1)
+        conn |> Plug.Conn.put_status(403) |> Req.Test.json(@usage_limits_body)
+      end)
+
+      assert [{:error, %Req.Response{status: 403}}] =
+               APIClient.stream_organization_units(@test_access_token) |> Enum.to_list()
+
+      assert :counters.get(attempts, 1) == 6
+    end
+  end
+
   describe "stream_organization_units/1" do
     test "streams a single page of organization units" do
       test_pid = self()

--- a/elixir/test/portal/google/api_client_test.exs
+++ b/elixir/test/portal/google/api_client_test.exs
@@ -845,11 +845,54 @@ defmodule Portal.Google.APIClientTest do
     }
 
     setup do
-      Portal.Config.put_env_override(:portal, APIClient,
-        req_opts: [retry_delay: 0, plug: {Req.Test, APIClient}]
-      )
+      # test.exs switches retrying off for the rest of the suite. Drop that one
+      # key so the client's own strategy applies and everything else stays as
+      # configured, rather than replacing req_opts and testing a shape no
+      # environment runs.
+      Portal.Config.delete_env_override(:portal, APIClient, [:req_opts, :retry])
+      Portal.Config.merge_env_override(:portal, APIClient, req_opts: [retry_delay: 0])
 
       :ok
+    end
+
+    test "keeps the throttling predicate when config sets another retry strategy" do
+      # config.exs used to set `retry: :transient`, which replaced the predicate
+      # and silently dropped throttling handling everywhere but in tests.
+      Portal.Config.merge_env_override(:portal, APIClient,
+        req_opts: [retry: :transient, retry_delay: 0]
+      )
+
+      attempts = :counters.new(1, [:atomics])
+
+      Req.Test.expect(APIClient, 2, fn conn ->
+        :counters.add(attempts, 1, 1)
+
+        case :counters.get(attempts, 1) do
+          1 -> conn |> Plug.Conn.put_status(403) |> Req.Test.json(@usage_limits_body)
+          2 -> Req.Test.json(conn, %{"organizationUnits" => [%{"orgUnitId" => "ou1"}]})
+        end
+      end)
+
+      assert [[%{"orgUnitId" => "ou1"}]] =
+               APIClient.stream_organization_units(@test_access_token) |> Enum.to_list()
+
+      assert :counters.get(attempts, 1) == 2
+    end
+
+    test "lets config switch retrying off" do
+      Portal.Config.merge_env_override(:portal, APIClient, req_opts: [retry: false])
+
+      attempts = :counters.new(1, [:atomics])
+
+      Req.Test.stub(APIClient, fn conn ->
+        :counters.add(attempts, 1, 1)
+        conn |> Plug.Conn.put_status(403) |> Req.Test.json(@usage_limits_body)
+      end)
+
+      assert [{:error, %Req.Response{status: 403}}] =
+               APIClient.stream_organization_units(@test_access_token) |> Enum.to_list()
+
+      assert :counters.get(attempts, 1) == 1
     end
 
     test "retries a 403 caused by throttling and succeeds" do


### PR DESCRIPTION
When Google throttles us, the whole directory sync gives up and waits for the next scheduled run.

The reason it was never retried is that the Directory API does not report throttling the way most APIs do. Instead of a 429, it answers 403 with an error whose `domain` is `usageLimits`:

```json
{
  "error": {
    "code": 403,
    "message": "Rate Limit Exceeded",
    "errors": [
      { "domain": "usageLimits", "message": "Rate Limit Exceeded", "reason": "userRateLimitExceeded" }
    ]
  }
}
```

Req retries 429 and 5xx out of the box, so this slipped straight through. Directory requests now retry it too, waiting the truncated exponential backoff Google asks for: roughly 1, 2, 4, 8 and 16 seconds, each with up to a second of jitter.

Only throttling is retried. A 403 that means the caller lacks permission still fails on the first response, because retrying it would just delay the same answer.

If throttling outlasts all the retries, the error still surfaces and the sync fails. That matters more than it sounds: sync deletes anything it did not see this run, so quietly carrying on with a short list of users would delete real people.

Token requests are left alone. They go to a different service that reports errors in its own format.

Sources: [Directory API: Limits and Quotas](https://developers.google.com/workspace/admin/directory/v1/limits), [Resolve errors](https://developers.google.com/workspace/gmail/api/guides/handle-errors)
