### PR TITLE
fix(portal): block private IPs in deprecated IPv6 formats

### DIFF
--- a/elixir/lib/portal/changeset.ex
+++ b/elixir/lib/portal/changeset.ex
@@ -28,8 +28,10 @@ defmodule Portal.Changeset do
   ]
 
   @special_use_ipv6_cidrs [
-    %Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 0}, netmask: 128},
-    %Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: 128},
+    # ::/96 (which subsumes :: and ::1) and ::ffff:0:0:0/96 are deprecated
+    # formats that embed an arbitrary IPv4 address.
+    %Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 0}, netmask: 96},
+    %Postgrex.INET{address: {0, 0, 0, 0, 0xFFFF, 0, 0, 0}, netmask: 96},
     %Postgrex.INET{address: {0x0064, 0xFF9B, 0, 0, 0, 0, 0, 0}, netmask: 96},
     %Postgrex.INET{address: {0x0064, 0xFF9B, 0x0001, 0, 0, 0, 0, 0}, netmask: 48},
     %Postgrex.INET{address: {0x0100, 0, 0, 0, 0, 0, 0, 0}, netmask: 64},
@@ -40,6 +42,7 @@ defmodule Portal.Changeset do
     %Postgrex.INET{address: {0x2002, 0, 0, 0, 0, 0, 0, 0}, netmask: 16},
     %Postgrex.INET{address: {0xFC00, 0, 0, 0, 0, 0, 0, 0}, netmask: 7},
     %Postgrex.INET{address: {0xFE80, 0, 0, 0, 0, 0, 0, 0}, netmask: 10},
+    %Postgrex.INET{address: {0xFEC0, 0, 0, 0, 0, 0, 0, 0}, netmask: 10},
     %Postgrex.INET{address: {0xFF00, 0, 0, 0, 0, 0, 0, 0}, netmask: 8}
   ]
 

--- a/elixir/test/portal/changeset_test.exs
+++ b/elixir/test/portal/changeset_test.exs
@@ -4,6 +4,45 @@ defmodule Portal.ChangesetTest do
   alias Portal.Changeset
 
   describe "private_ip?/1" do
+    test "blocks link-local addresses" do
+      ips = [
+        "169.254.0.0",
+        "169.254.169.254",
+        "169.254.255.255",
+        "fe80::1",
+        "febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
+      ]
+
+      for ip <- ips do
+        assert Changeset.private_ip?(parse_ip!(ip)), "Expected #{ip} to be blocked"
+      end
+    end
+
+    test "blocks link-local addresses wrapped in deprecated IPv6 embeddings" do
+      ips = [
+        "::ffff:169.254.169.254",
+        "::169.254.169.254",
+        "::ffff:0:169.254.169.254",
+        "64:ff9b::169.254.169.254",
+        "2002:a9fe:a9fe::1"
+      ]
+
+      for ip <- ips do
+        assert Changeset.private_ip?(parse_ip!(ip)), "Expected #{ip} to be blocked"
+      end
+    end
+
+    test "blocks site-local addresses" do
+      assert Changeset.private_ip?(parse_ip!("fec0::1"))
+      assert Changeset.private_ip?(parse_ip!("feff::1"))
+    end
+
+    test "allows addresses adjacent to the link-local ranges" do
+      refute Changeset.private_ip?(parse_ip!("169.253.255.255"))
+      refute Changeset.private_ip?(parse_ip!("169.255.0.0"))
+      refute Changeset.private_ip?(parse_ip!("2606:4700:4700::1111"))
+    end
+
     test "blocks IPv4-mapped IPv6 addresses when embedded IPv4 is blocked" do
       for ip <- ["::ffff:127.0.0.1", "::ffff:169.254.169.254", "::ffff:10.0.0.1"] do
         assert Changeset.private_ip?(parse_ip!(ip)), "Expected #{ip} to be blocked"

--- a/elixir/test/portal/req/ssrf_protection_test.exs
+++ b/elixir/test/portal/req/ssrf_protection_test.exs
@@ -41,8 +41,12 @@ defmodule Portal.Req.SSRFProtectionTest do
   test "blocks literal private and reserved IPv4 and IPv6 addresses before the adapter runs" do
     urls = [
       "https://169.254.169.254/latest/meta-data",
+      "http://[fe80::1]/latest/meta-data",
       "http://[::1]/metadata",
-      "http://[::ffff:127.0.0.1]/metadata"
+      "http://[::ffff:127.0.0.1]/metadata",
+      "http://[::ffff:169.254.169.254]/metadata",
+      "http://[::169.254.169.254]/metadata",
+      "http://[::ffff:0:169.254.169.254]/metadata"
     ]
 
     for url <- urls do


### PR DESCRIPTION
The portal blocks user-configured URLs that point at private or reserved IP addresses, so things like OIDC discovery documents and log sink endpoints cannot be used to reach internal services.

IPv6 has three legacy ways to write an IPv4 address inside an IPv6 address. Only one of them was being unwrapped and checked. The other two let a blocked address through: `169.254.169.254` was rejected, but the same address written as `::169.254.169.254` was accepted. That skipped every IPv4 check, not just link-local ones.

Both formats are now rejected outright, since neither is routable. Site-local addresses are rejected too.

Related: #14417
