### PR TITLE
feat(portal): retry throttled parts of a Google batch request

### DIFF
--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -632,7 +632,7 @@ defmodule Portal.Google.APIClient do
       end
     else
       status when is_integer(status) and status not in [200, 403, 404] ->
-        log_batch_parse_issue("Skipping batch users response part with unexpected status",
+        log_batch_parse_issue("Failing batch users response part with unexpected status",
           status: status
         )
 
@@ -641,9 +641,8 @@ defmodule Portal.Google.APIClient do
         {:error,
          %Req.Response{status: normalized_status, body: %{"error" => "Batch users part failed"}}}
 
-      # Anything else (parse failure, unexpected status) — skip this part
       malformed ->
-        log_batch_parse_issue("Skipping malformed batch users response part",
+        log_batch_parse_issue("Failing malformed batch users response part",
           detail: inspect(malformed),
           snippet: snippet(part)
         )
@@ -661,7 +660,7 @@ defmodule Portal.Google.APIClient do
       {:throttled,
        %Req.Response{status: 403, body: %{"error" => "Batch users part throttled"}}}
     else
-      log_batch_parse_issue("Skipping batch users response part with unexpected status",
+      log_batch_parse_issue("Failing batch users response part with unexpected status",
         status: 403
       )
 

--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -509,9 +509,8 @@ defmodule Portal.Google.APIClient do
     end
   end
 
-  # The batch endpoint answers 200 even when individual parts are throttled, so
-  # Req's retry never sees those. Any throttled part means the whole chunk is
-  # re-sent, since re-reading a user that already succeeded costs nothing.
+  # The batch endpoint answers 200 even when parts are throttled, so Req's retry
+  # never sees those. Re-sending the whole chunk is cheaper than tracking parts.
   defp get_users_chunk(access_token, chunk, retry_count \\ 0) do
     case do_batch_get_users(access_token, chunk) do
       {:throttled, _response} when retry_count < @max_retries ->
@@ -526,8 +525,7 @@ defmodule Portal.Google.APIClient do
     end
   end
 
-  # Req applies :retry_delay itself for whole-request retries; per-part retries
-  # are ours to schedule, so honour the same setting.
+  # Req schedules its own retries; per-part ones are ours, same setting.
   defp batch_retry_delay(retry_count) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
 
@@ -658,7 +656,6 @@ defmodule Portal.Google.APIClient do
     end
   end
 
-  # Throttling is worth another go; any other 403 would only fail again.
   defp parse_forbidden_batch_part(json_body) do
     if usage_limits_error?(String.trim(json_body)) do
       {:throttled,

--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -22,6 +22,7 @@ defmodule Portal.Google.APIClient do
     :service_account_sign_jwt
   ]
   @token_cache Portal.Google.TokenCache
+  @max_retries 5
 
   @doc """
   Gets a delegated Google Workspace access token using deployment credentials.
@@ -493,7 +494,7 @@ defmodule Portal.Google.APIClient do
       user_ids
       |> Enum.chunk_every(@batch_size)
       |> Enum.reduce_while({:ok, []}, fn chunk, {:ok, acc_chunks} ->
-        case do_batch_get_users(access_token, chunk) do
+        case get_users_chunk(access_token, chunk) do
           {:ok, users} -> {:cont, {:ok, [users | acc_chunks]}}
           {:error, _} = error -> {:halt, error}
         end
@@ -505,6 +506,35 @@ defmodule Portal.Google.APIClient do
 
       {:error, _} = error ->
         error
+    end
+  end
+
+  # The batch endpoint answers 200 even when individual parts are throttled, so
+  # Req's retry never sees those. Any throttled part means the whole chunk is
+  # re-sent, since re-reading a user that already succeeded costs nothing.
+  defp get_users_chunk(access_token, chunk, retry_count \\ 0) do
+    case do_batch_get_users(access_token, chunk) do
+      {:throttled, _response} when retry_count < @max_retries ->
+        Process.sleep(batch_retry_delay(retry_count))
+        get_users_chunk(access_token, chunk, retry_count + 1)
+
+      {:throttled, response} ->
+        {:error, response}
+
+      result ->
+        result
+    end
+  end
+
+  # Req applies :retry_delay itself for whole-request retries; per-part retries
+  # are ours to schedule, so honour the same setting.
+  defp batch_retry_delay(retry_count) do
+    config = Portal.Config.fetch_env!(:portal, __MODULE__)
+
+    case Keyword.get(config[:req_opts] || [], :retry_delay) do
+      nil -> retry_delay(retry_count)
+      milliseconds when is_integer(milliseconds) -> milliseconds
+      fun when is_function(fun, 1) -> fun.(retry_count)
     end
   end
 
@@ -561,13 +591,16 @@ defmodule Portal.Google.APIClient do
         {:ok, users} ->
           {:cont, {:ok, Enum.reverse(users, acc)}}
 
+        {:throttled, _} = throttled ->
+          {:halt, throttled}
+
         {:error, _} = error ->
           {:halt, error}
       end
     end)
     |> case do
       {:ok, users} -> {:ok, Enum.reverse(users)}
-      {:error, _} = error -> error
+      other -> other
     end
   end
 
@@ -588,16 +621,19 @@ defmodule Portal.Google.APIClient do
     #   HTTP/1.1 200 OK\r\n<response headers>\r\n\r\n<JSON body>
     with [_outer_headers, nested] <- String.split(part, "\r\n\r\n", parts: 2),
          [status_and_headers, json_body] <- String.split(nested, "\r\n\r\n", parts: 2),
-         status when status in [200, 404] <- extract_http_status(status_and_headers) do
+         status when status in [200, 403, 404] <- extract_http_status(status_and_headers) do
       case status do
         404 ->
           {:ok, []}
+
+        403 ->
+          parse_forbidden_batch_part(json_body)
 
         200 ->
           decode_json_user(json_body)
       end
     else
-      status when is_integer(status) and status not in [200, 404] ->
+      status when is_integer(status) and status not in [200, 403, 404] ->
         log_batch_parse_issue("Skipping batch users response part with unexpected status",
           status: status
         )
@@ -619,6 +655,20 @@ defmodule Portal.Google.APIClient do
            status: 502,
            body: %{"error" => "Malformed batch users response part"}
          }}
+    end
+  end
+
+  # Throttling is worth another go; any other 403 would only fail again.
+  defp parse_forbidden_batch_part(json_body) do
+    if usage_limits_error?(String.trim(json_body)) do
+      {:throttled,
+       %Req.Response{status: 403, body: %{"error" => "Batch users part throttled"}}}
+    else
+      log_batch_parse_issue("Skipping batch users response part with unexpected status",
+        status: 403
+      )
+
+      {:error, %Req.Response{status: 403, body: %{"error" => "Batch users part failed"}}}
     end
   end
 
@@ -729,7 +779,6 @@ defmodule Portal.Google.APIClient do
   @transient_statuses [408, 429, 500, 502, 503, 504]
   @transient_transport_reasons [:timeout, :econnrefused, :closed]
   @transient_http_reasons [:unprocessed, :pool_not_available]
-  @max_retries 5
 
   # Config may switch retrying off, but must not swap in another strategy.
   defp request_opts(config) do

--- a/elixir/test/portal/google/api_client_test.exs
+++ b/elixir/test/portal/google/api_client_test.exs
@@ -1123,6 +1123,66 @@ defmodule Portal.Google.APIClientTest do
                APIClient.batch_get_users(@test_access_token, ["user1"])
     end
 
+    test "retries the whole chunk when a part is throttled" do
+      Portal.Config.put_env_override(:portal, APIClient,
+        req_opts: [retry_delay: 0, plug: {Req.Test, APIClient}]
+      )
+
+      attempts = :counters.new(1, [:atomics])
+
+      Req.Test.expect(APIClient, 2, fn conn ->
+        :counters.add(attempts, 1, 1)
+        boundary = "throttled_part_boundary"
+
+        second_part =
+          case :counters.get(attempts, 1) do
+            1 -> {"HTTP/1.1 403 Forbidden", JSON.encode!(throttled_error())}
+            2 -> {"HTTP/1.1 200 OK", JSON.encode!(active_google_user(%{"id" => "user2"}))}
+          end
+
+        body =
+          build_batch_body(boundary, [
+            {"HTTP/1.1 200 OK", JSON.encode!(active_google_user(%{"id" => "user1"}))},
+            second_part
+          ])
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:ok, users} = APIClient.batch_get_users(@test_access_token, ["user1", "user2"])
+      assert Enum.map(users, & &1["id"]) == ["user1", "user2"]
+      assert :counters.get(attempts, 1) == 2
+    end
+
+    test "surfaces the error when a throttled part outlasts the retries" do
+      Portal.Config.put_env_override(:portal, APIClient,
+        req_opts: [retry_delay: 0, plug: {Req.Test, APIClient}]
+      )
+
+      attempts = :counters.new(1, [:atomics])
+
+      Req.Test.stub(APIClient, fn conn ->
+        :counters.add(attempts, 1, 1)
+        boundary = "always_throttled_boundary"
+
+        body =
+          build_batch_body(boundary, [
+            {"HTTP/1.1 403 Forbidden", JSON.encode!(throttled_error())}
+          ])
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:error, %Req.Response{status: 403}} =
+               APIClient.batch_get_users(@test_access_token, ["user1"])
+
+      assert :counters.get(attempts, 1) == 6
+    end
+
     test "returns transport error for batch request failure" do
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.transport_error(conn, :timeout)
@@ -1372,6 +1432,22 @@ defmodule Portal.Google.APIClientTest do
   end
 
   # Helper functions
+
+  defp throttled_error do
+    %{
+      "error" => %{
+        "code" => 403,
+        "message" => "Rate Limit Exceeded",
+        "errors" => [
+          %{
+            "domain" => "usageLimits",
+            "message" => "Rate Limit Exceeded",
+            "reason" => "userRateLimitExceeded"
+          }
+        ]
+      }
+    }
+  end
 
   defp build_batch_body(boundary, parts) do
     encoded_parts =

--- a/elixir/test/portal/google/sync_test.exs
+++ b/elixir/test/portal/google/sync_test.exs
@@ -1098,6 +1098,53 @@ defmodule Portal.Google.SyncTest do
       assert length(memberships) == 1
     end
 
+    test "keeps identities when a batch part fails" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      identity =
+        synced_identity_fixture(
+          account: account,
+          directory: Repo.get_by!(Portal.Directory, id: directory.id, account_id: account.id)
+        )
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [%{"id" => "group1", "name" => "Engineering", "email" => "eng@example.com"}]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "members" => [%{"id" => "user1", "type" => "USER", "email" => "user1@example.com"}]
+        })
+      end)
+
+      Req.Test.stub(APIClient, fn conn ->
+        boundary = "server_error_part"
+
+        body =
+          "--#{boundary}\r\nContent-Type: application/http\r\n\r\nHTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json\r\n\r\n" <>
+            JSON.encode!(%{"error" => %{"code" => 500}}) <> "\r\n--#{boundary}--"
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert_raise SyncError, fn -> perform_job(Sync, %{"directory_id" => directory.id}) end
+
+      assert Repo.get_by(Portal.ExternalIdentity, id: identity.id, account_id: account.id)
+    end
+
     test "syncs members from every customer domain and skips external members" do
       # Google returns type="USER" for external members too; the documented
       # EXTERNAL type is marked "not currently used".


### PR DESCRIPTION
Follow-up to #14424, which taught Google requests to back off when throttled. It missed one path.

When we look up many users at once we send a batch request, which packs a hundred lookups into one call. Google answers that call with a 200 even when individual lookups inside it were throttled, and reports the throttling per lookup instead. The retry added in #14424 only inspects the outer response, so it saw a perfectly good 200 and the sync failed anyway.

A throttled lookup now causes the whole batch to be sent again after the same backoff. Re-reading users that already came back fine costs nothing, and it saves having to match each answer back to the user that produced it.

Lookups that fail for any other reason, such as a user we are not allowed to read, still fail straight away rather than being retried. And if throttling lasts longer than the retries allow, the error still surfaces and the sync fails, because carrying on with a short list of users would delete real people.
