### PR TITLE
feat(portal): let Enterprise accounts add seats in the portal

### DIFF
--- a/elixir/lib/portal/account.ex
+++ b/elixir/lib/portal/account.ex
@@ -190,6 +190,7 @@ defmodule Portal.Account.Metadata.Stripe do
     field :billing_email, :string
     field :trial_ends_at, :utc_datetime_usec
     field :support_type, :string
+    field :portal_configuration_id, :string
   end
 
   def changeset(stripe \\ %__MODULE__{}, attrs) do
@@ -200,7 +201,8 @@ defmodule Portal.Account.Metadata.Stripe do
       :product_name,
       :billing_email,
       :trial_ends_at,
-      :support_type
+      :support_type,
+      :portal_configuration_id
     ])
   end
 end

--- a/elixir/lib/portal/billing.ex
+++ b/elixir/lib/portal/billing.ex
@@ -100,9 +100,14 @@ defmodule Portal.Billing do
   Returns the plan type for the account based on the Stripe product name.
   Returns :enterprise, :team, :starter, or :unknown.
   """
-  @spec plan_type(Portal.Account.t()) :: :enterprise | :team | :starter | :unknown
-  def plan_type(%Portal.Account{metadata: %{stripe: %{product_name: product_name}}})
-      when is_binary(product_name) do
+  @spec plan_type(Portal.Account.t() | String.t() | nil) ::
+          :enterprise | :team | :starter | :unknown
+  def plan_type(%Portal.Account{metadata: %{stripe: %{product_name: product_name}}}),
+    do: plan_type(product_name)
+
+  def plan_type(%Portal.Account{}), do: :unknown
+
+  def plan_type(product_name) when is_binary(product_name) do
     cond do
       String.starts_with?(product_name, "Enterprise") -> :enterprise
       product_name == "Team" -> :team
@@ -111,7 +116,7 @@ defmodule Portal.Billing do
     end
   end
 
-  def plan_type(%Portal.Account{}), do: :unknown
+  def plan_type(nil), do: :unknown
 
   @spec paid_plan?(Portal.Account.t()) :: boolean()
   def paid_plan?(%Portal.Account{} = account), do: plan_type(account) in [:team, :enterprise]
@@ -578,23 +583,235 @@ defmodule Portal.Billing do
         return_url,
         %Authentication.Subject{} = subject
       ) do
-    secret_key = fetch_config!(:secret_key)
-
     # Only account admins can manage billing
     case subject.actor.type do
       :account_admin_user when subject.account.id == account.id ->
-        with {:ok, %{"url" => url}} <-
-               APIClient.create_billing_portal_session(
-                 secret_key,
-                 account.metadata.stripe.customer_id,
-                 return_url
-               ) do
-          {:ok, url}
-        end
+        create_billing_portal_session(account, return_url)
 
       _ ->
         {:error, :unauthorized}
     end
+  end
+
+  @doc """
+  Finds the subscription item that carries the plan the account is on.
+  """
+  @spec fetch_plan_item([map()]) ::
+          {:ok, map()}
+          | {:error, :no_plan_product | :no_plan_quantity | :multiple_plan_products}
+  def fetch_plan_item(items) do
+    {plan_items, other_items} =
+      Enum.split_with(items, &(get_in(&1, ["price", "product"]) in plan_product_ids()))
+
+    log_non_plan_items(other_items)
+
+    case plan_items do
+      [%{"quantity" => quantity} = item] when is_integer(quantity) ->
+        {:ok, item}
+
+      [item] ->
+        Logger.error("Plan product has no seat quantity", item_id: item["id"])
+        {:error, :no_plan_quantity}
+
+      [] ->
+        {:error, :no_plan_product}
+
+      multiple ->
+        ids = Enum.map(multiple, &get_in(&1, ["price", "product"]))
+        Logger.error("Multiple plan products found in subscription", product_ids: inspect(ids))
+        {:error, :multiple_plan_products}
+    end
+  end
+
+  @doc """
+  Moves the seat floor of the account's billing portal configuration to the
+  quantity Stripe is now billing, so that seats added through the portal cannot
+  be given back through the portal.
+
+  Called after a subscription change. Best effort: the configuration is rebuilt
+  from the subscription anyway the next time the portal is opened.
+  """
+  @spec sync_billing_portal_configuration(Portal.Account.t(), map()) :: :ok
+  def sync_billing_portal_configuration(%Portal.Account{} = account, subscription_data) do
+    configuration_id = account.metadata.stripe.portal_configuration_id
+
+    if plan_type(account) == :enterprise and is_binary(configuration_id) do
+      items = get_in(subscription_data, ["items", "data"]) || []
+
+      with {:ok, item} <- fetch_plan_item(items),
+           {:ok, _configuration_id} <- update_portal_configuration(account, configuration_id, item) do
+        :ok
+      else
+        {:error, reason} ->
+          Logger.warning("Cannot sync Stripe billing portal configuration",
+            account_id: account.id,
+            reason: inspect(reason)
+          )
+
+          :ok
+      end
+    else
+      :ok
+    end
+  end
+
+  @doc """
+  Serializes work for a Stripe customer across the cluster.
+  """
+  def with_customer_lock(customer_id, fun) do
+    Database.with_customer_lock(customer_id, fun)
+  end
+
+  defp create_billing_portal_session(%Portal.Account{} = account, return_url) do
+    secret_key = fetch_config!(:secret_key)
+
+    with {:ok, configuration_id} <- billing_portal_configuration_id(account),
+         {:ok, %{"url" => url}} <-
+           APIClient.create_billing_portal_session(
+             secret_key,
+             account.metadata.stripe.customer_id,
+             return_url,
+             configuration_id
+           ) do
+      {:ok, url}
+    end
+  end
+
+  # Starter and Team accounts use the default configuration managed from the
+  # Stripe dashboard. Enterprise accounts get one of their own, rebuilt on every
+  # visit, that only lets them buy more seats.
+  defp billing_portal_configuration_id(%Portal.Account{} = account) do
+    if plan_type(account) == :enterprise do
+      put_enterprise_portal_configuration(account)
+    else
+      {:ok, nil}
+    end
+  end
+
+  defp put_enterprise_portal_configuration(%Portal.Account{} = account) do
+    with_customer_lock(account.metadata.stripe.customer_id, fn ->
+      account = Database.fetch_account_by_id!(account.id)
+
+      with {:ok, item} <- fetch_subscription_plan_item(account) do
+        put_portal_configuration(account, item)
+      end
+    end)
+  end
+
+  defp put_portal_configuration(%Portal.Account{} = account, item) do
+    case account.metadata.stripe.portal_configuration_id do
+      nil ->
+        create_portal_configuration(account, item)
+
+      configuration_id ->
+        update_portal_configuration(account, configuration_id, item)
+    end
+  end
+
+  defp fetch_subscription_plan_item(%Portal.Account{} = account) do
+    secret_key = fetch_config!(:secret_key)
+
+    case account.metadata.stripe.subscription_id do
+      nil ->
+        Logger.error("Account has no Stripe subscription", account_id: account.id)
+        {:error, :no_subscription}
+
+      subscription_id ->
+        with {:ok, %{"items" => %{"data" => items}}} <-
+               APIClient.fetch_subscription(secret_key, subscription_id) do
+          fetch_plan_item(items)
+        end
+    end
+  end
+
+  defp create_portal_configuration(%Portal.Account{} = account, item) do
+    secret_key = fetch_config!(:secret_key)
+    params = portal_configuration_params(account, item)
+
+    with {:ok, %{"id" => configuration_id}} <-
+           APIClient.create_billing_portal_configuration(secret_key, params),
+         {:ok, _account} <-
+           account
+           |> update_account_metadata_changeset(%{portal_configuration_id: configuration_id})
+           |> Database.update() do
+      {:ok, configuration_id}
+    else
+      {:error, reason} ->
+        :ok =
+          Logger.error("Cannot create Stripe billing portal configuration",
+            account_id: account.id,
+            reason: inspect(reason)
+          )
+
+        {:error, :retry_later}
+    end
+  end
+
+  defp update_portal_configuration(%Portal.Account{} = account, configuration_id, item) do
+    secret_key = fetch_config!(:secret_key)
+    params = portal_configuration_params(account, item)
+
+    case APIClient.update_billing_portal_configuration(secret_key, configuration_id, params) do
+      {:ok, %{"id" => configuration_id}} ->
+        {:ok, configuration_id}
+
+      # The stored configuration is gone, e.g. because the Stripe account changed.
+      {:error, {404, _body}} ->
+        create_portal_configuration(account, item)
+
+      {:error, reason} ->
+        :ok =
+          Logger.error("Cannot update Stripe billing portal configuration",
+            account_id: account.id,
+            configuration_id: configuration_id,
+            reason: inspect(reason)
+          )
+
+        {:error, :retry_later}
+    end
+  end
+
+  # The floor tracks the billed quantity in both directions: only the customer's
+  # self-serve path is restricted, so seats we take away for them stay removed.
+  defp portal_configuration_params(%Portal.Account{} = account, item) do
+    %{
+      "metadata[account_id]" => account.id,
+      "features[customer_update][enabled]" => "true",
+      "features[customer_update][allowed_updates][0]" => "address",
+      "features[customer_update][allowed_updates][1]" => "email",
+      "features[customer_update][allowed_updates][2]" => "name",
+      "features[customer_update][allowed_updates][3]" => "phone",
+      "features[customer_update][allowed_updates][4]" => "tax_id",
+      "features[invoice_history][enabled]" => "true",
+      "features[payment_method_update][enabled]" => "true",
+      "features[subscription_cancel][enabled]" => "false",
+      "features[subscription_update][enabled]" => "true",
+      "features[subscription_update][default_allowed_updates][0]" => "quantity",
+      "features[subscription_update][proration_behavior]" => "create_prorations",
+      "features[subscription_update][products][0][product]" =>
+        get_in(item, ["price", "product"]),
+      "features[subscription_update][products][0][prices][0]" => get_in(item, ["price", "id"]),
+      "features[subscription_update][products][0][adjustable_quantity][enabled]" => "true",
+      "features[subscription_update][products][0][adjustable_quantity][minimum]" => item["quantity"]
+    }
+  end
+
+  defp log_non_plan_items(items) do
+    adhoc_id = adhoc_device_product_id()
+
+    Enum.each(items, fn %{"price" => %{"product" => product_id}} = item ->
+      if product_id == adhoc_id do
+        Logger.info("Ignoring adhoc device product in subscription",
+          product_id: product_id,
+          item_id: item["id"]
+        )
+      else
+        Logger.warning("Ignoring unrecognized product in subscription",
+          product_id: product_id,
+          item_id: item["id"]
+        )
+      end
+    end)
   end
 
   def handle_events(events) when is_list(events) do
@@ -636,6 +853,21 @@ defmodule Portal.Billing do
     alias Portal.Account
     alias Portal.Actor
     alias Portal.Device
+
+    def with_customer_lock(customer_id, fun) do
+      hashed_id = :erlang.phash2(customer_id)
+
+      Safe.transact(fn ->
+        {:ok, _} = Safe.unscoped() |> Safe.query("SELECT pg_advisory_xact_lock($1)", [hashed_id])
+        fun.()
+      end)
+    end
+
+    def fetch_account_by_id!(id) do
+      from(a in Account, where: a.id == ^id)
+      |> Safe.unscoped()
+      |> Safe.one!()
+    end
 
     def update(changeset) do
       changeset

--- a/elixir/lib/portal/billing.ex
+++ b/elixir/lib/portal/billing.ex
@@ -5,6 +5,8 @@ defmodule Portal.Billing do
   alias __MODULE__.Database
   require Logger
 
+  @invoice_terms_days 30
+
   # Configuration helpers
 
   def enabled? do
@@ -692,7 +694,9 @@ defmodule Portal.Billing do
     with_customer_lock(account.metadata.stripe.customer_id, fn ->
       account = Database.fetch_account_by_id!(account.id)
 
-      with {:ok, item} <- fetch_subscription_plan_item(account) do
+      with {:ok, subscription} <- fetch_subscription(account),
+           {:ok, item} <- fetch_plan_item(get_in(subscription, ["items", "data"]) || []) do
+        :ok = warn_unless_net30(account, subscription)
         put_portal_configuration(account, item)
       end
     end)
@@ -708,7 +712,7 @@ defmodule Portal.Billing do
     end
   end
 
-  defp fetch_subscription_plan_item(%Portal.Account{} = account) do
+  defp fetch_subscription(%Portal.Account{} = account) do
     secret_key = fetch_config!(:secret_key)
 
     case account.metadata.stripe.subscription_id do
@@ -717,11 +721,26 @@ defmodule Portal.Billing do
         {:error, :no_subscription}
 
       subscription_id ->
-        with {:ok, %{"items" => %{"data" => items}}} <-
-               APIClient.fetch_subscription(secret_key, subscription_id) do
-          fetch_plan_item(items)
-        end
+        APIClient.fetch_subscription(secret_key, subscription_id)
     end
+  end
+
+  # Stripe copies the payment terms from the subscription onto the invoice it
+  # raises for the extra seats, and there is no way to set them per invoice.
+  defp warn_unless_net30(%Portal.Account{} = account, subscription) do
+    collection_method = subscription["collection_method"]
+    days_until_due = subscription["days_until_due"]
+
+    if collection_method != "send_invoice" or days_until_due != @invoice_terms_days do
+      Logger.warning("Enterprise subscription does not invoice seats on the expected terms",
+        account_id: account.id,
+        collection_method: collection_method,
+        days_until_due: days_until_due,
+        expected_days_until_due: @invoice_terms_days
+      )
+    end
+
+    :ok
   end
 
   defp create_portal_configuration(%Portal.Account{} = account, item) do
@@ -787,7 +806,7 @@ defmodule Portal.Billing do
       "features[subscription_cancel][enabled]" => "false",
       "features[subscription_update][enabled]" => "true",
       "features[subscription_update][default_allowed_updates][0]" => "quantity",
-      "features[subscription_update][proration_behavior]" => "create_prorations",
+      "features[subscription_update][proration_behavior]" => "always_invoice",
       "features[subscription_update][products][0][product]" =>
         get_in(item, ["price", "product"]),
       "features[subscription_update][products][0][prices][0]" => get_in(item, ["price", "id"]),

--- a/elixir/lib/portal/billing/event_handler.ex
+++ b/elixir/lib/portal/billing/event_handler.ex
@@ -18,7 +18,7 @@ defmodule Portal.Billing.EventHandler do
   defp process_event_with_lock(event) do
     customer_id = extract_customer_id(event)
 
-    Database.with_customer_lock(customer_id, fn ->
+    Billing.with_customer_lock(customer_id, fn ->
       process_event(event, customer_id)
     end)
   end
@@ -233,7 +233,7 @@ defmodule Portal.Billing.EventHandler do
     with {:ok, attrs} <- build_subscription_update_attrs(subscription_data),
          {:ok, account} <- update_account_and_return(customer_id, attrs),
          {:ok, _account} <- Billing.evaluate_account_limits(account) do
-      :ok
+      Billing.sync_billing_portal_configuration(account, subscription_data)
     else
       {:error, reason} ->
         Logger.error("Failed to build subscription update attrs",
@@ -293,43 +293,10 @@ defmodule Portal.Billing.EventHandler do
   end
 
   defp find_plan_product(items) do
-    plan_ids = Billing.plan_product_ids()
-
-    {plan_items, other_items} =
-      Enum.split_with(items, &(get_in(&1, ["price", "product"]) in plan_ids))
-
-    log_non_plan_items(other_items)
-
-    case plan_items do
-      [%{"price" => %{"product" => product_id}, "quantity" => quantity}] ->
-        with {:ok, info} <- Billing.fetch_product(product_id), do: {:ok, info, quantity}
-
-      [] ->
-        {:error, :no_plan_product}
-
-      multiple ->
-        ids = Enum.map(multiple, &get_in(&1, ["price", "product"]))
-        Logger.error("Multiple plan products found in subscription", product_ids: inspect(ids))
-        {:error, :multiple_plan_products}
+    with {:ok, item} <- Billing.fetch_plan_item(items),
+         {:ok, info} <- Billing.fetch_product(get_in(item, ["price", "product"])) do
+      {:ok, info, item["quantity"]}
     end
-  end
-
-  defp log_non_plan_items(items) do
-    adhoc_id = Billing.adhoc_device_product_id()
-
-    Enum.each(items, fn %{"price" => %{"product" => product_id}} = item ->
-      if product_id == adhoc_id do
-        Logger.info("Ignoring adhoc device product in subscription",
-          product_id: product_id,
-          item_id: item["id"]
-        )
-      else
-        Logger.warning("Ignoring unrecognized product in subscription",
-          product_id: product_id,
-          item_id: item["id"]
-        )
-      end
-    end)
   end
 
   defp update_account(customer_id, attrs) do
@@ -592,7 +559,10 @@ defmodule Portal.Billing.EventHandler do
     {limits, params} = Map.split(params, limit_fields)
     {features, _} = Map.split(params, feature_fields)
 
-    limits = Map.merge(limits, %{"users_count" => users_count})
+    limits =
+      limits
+      |> Map.put("users_count", users_count)
+      |> put_seat_limit(Billing.plan_type(stripe_metadata["product_name"]), seats)
 
     %{
       features: features,
@@ -600,6 +570,13 @@ defmodule Portal.Billing.EventHandler do
       metadata: %{stripe: Map.merge(metadata, stripe_metadata)}
     }
   end
+
+  # Enterprise seats are sold as monthly active users and can be bought from the
+  # billing portal, so the subscription quantity wins over the product metadata.
+  defp put_seat_limit(limits, :enterprise, seats),
+    do: Map.put(limits, "monthly_active_users_count", seats)
+
+  defp put_seat_limit(limits, _plan_type, _seats), do: limits
 
   defp parse_metadata_params(metadata, limit_fields, metadata_fields) do
     metadata
@@ -654,15 +631,6 @@ defmodule Portal.Billing.EventHandler do
       EmailOTP,
       Safe
     }
-
-    def with_customer_lock(customer_id, fun) do
-      hashed_id = :erlang.phash2(customer_id)
-
-      Safe.transact(fn ->
-        {:ok, _} = Safe.unscoped() |> Safe.query("SELECT pg_advisory_xact_lock($1)", [hashed_id])
-        fun.()
-      end)
-    end
 
     def slug_exists?(slug) do
       from(a in Portal.Account, where: a.slug == ^slug)

--- a/elixir/lib/portal/billing/stripe/api_client.ex
+++ b/elixir/lib/portal/billing/stripe/api_client.ex
@@ -1,4 +1,9 @@
 defmodule Portal.Billing.Stripe.APIClient do
+  @api_version "2023-10-16"
+
+  # `adjustable_quantity` on customer portal configurations was only added in this version.
+  @portal_configuration_api_version "2025-07-30.basil"
+
   def create_customer(api_token, name, email, metadata) do
     metadata_params =
       for {key, value} <- metadata, into: %{} do
@@ -61,9 +66,41 @@ defmodule Portal.Billing.Stripe.APIClient do
     request(api_token, :get, "subscriptions?customer=#{customer_id}&status=active", "")
   end
 
-  def create_billing_portal_session(api_token, customer_id, return_url) do
-    body = URI.encode_query(%{"customer" => customer_id, "return_url" => return_url}, :www_form)
+  def fetch_subscription(api_token, subscription_id) do
+    request(api_token, :get, "subscriptions/#{subscription_id}", "")
+  end
+
+  def create_billing_portal_session(api_token, customer_id, return_url, configuration_id \\ nil) do
+    body =
+      %{"customer" => customer_id, "return_url" => return_url}
+      |> put_if_not_nil("configuration", configuration_id)
+      |> URI.encode_query(:www_form)
+
     request(api_token, :post, "billing_portal/sessions", body)
+  end
+
+  def create_billing_portal_configuration(api_token, params) do
+    body = URI.encode_query(params, :www_form)
+
+    request(
+      api_token,
+      :post,
+      "billing_portal/configurations",
+      body,
+      @portal_configuration_api_version
+    )
+  end
+
+  def update_billing_portal_configuration(api_token, configuration_id, params) do
+    body = URI.encode_query(params, :www_form)
+
+    request(
+      api_token,
+      :post,
+      "billing_portal/configurations/#{configuration_id}",
+      body,
+      @portal_configuration_api_version
+    )
   end
 
   def create_subscription(api_token, customer_id, price_id) do
@@ -83,14 +120,14 @@ defmodule Portal.Billing.Stripe.APIClient do
     request(api_token, :delete, "subscriptions/#{subscription_id}", "")
   end
 
-  def request(api_token, method, path, body) do
+  def request(api_token, method, path, body, api_version \\ @api_version) do
     endpoint = fetch_config!(:endpoint)
     url = "#{endpoint}/v1/#{path}"
 
     headers = [
       {"authorization", "Bearer #{api_token}"},
       {"content-type", "application/x-www-form-urlencoded"},
-      {"stripe-version", "2023-10-16"}
+      {"stripe-version", api_version}
     ]
 
     req_opts =

--- a/elixir/test/portal/billing/event_handler_test.exs
+++ b/elixir/test/portal/billing/event_handler_test.exs
@@ -342,6 +342,99 @@ defmodule Portal.Billing.EventHandlerTest do
       assert {:error, :no_plan_product} = EventHandler.handle_event(event)
     end
 
+    test "sets the monthly active users limit from Enterprise seats", %{
+      account: account,
+      customer: customer
+    } do
+      {product, _price, subscription} =
+        Stripe.build_all(:enterprise, account.metadata.stripe.customer_id, 42)
+
+      event = Stripe.build_event("customer.subscription.updated", subscription)
+
+      Stripe.stub(
+        Stripe.fetch_customer_endpoint(customer) ++
+          Stripe.fetch_product_endpoint(product)
+      )
+
+      assert {:ok, _event} = EventHandler.handle_event(event)
+
+      updated = Portal.Repo.get!(Portal.Account, account.id)
+      assert updated.limits.monthly_active_users_count == 42
+    end
+
+    test "leaves the monthly active users limit alone for Team seats", %{
+      account: account,
+      customer: customer
+    } do
+      {product, _price, subscription} =
+        Stripe.build_all(:team, account.metadata.stripe.customer_id, 42)
+
+      event = Stripe.build_event("customer.subscription.updated", subscription)
+
+      Stripe.stub(
+        Stripe.fetch_customer_endpoint(customer) ++
+          Stripe.fetch_product_endpoint(product)
+      )
+
+      assert {:ok, _event} = EventHandler.handle_event(event)
+
+      updated = Portal.Repo.get!(Portal.Account, account.id)
+      assert updated.limits.monthly_active_users_count == nil
+      assert updated.limits.users_count == 42
+    end
+
+    test "raises the seat floor on the Enterprise billing portal configuration", %{
+      account: account,
+      customer: customer
+    } do
+      update_account(account, %{
+        metadata: %{stripe: %{portal_configuration_id: "bpc_existing"}}
+      })
+
+      {product, _price, subscription} =
+        Stripe.build_all(:enterprise, account.metadata.stripe.customer_id, 55)
+
+      event = Stripe.build_event("customer.subscription.updated", subscription)
+
+      Stripe.stub(
+        Stripe.fetch_customer_endpoint(customer) ++
+          Stripe.fetch_product_endpoint(product) ++
+          Stripe.mock_update_portal_configuration_endpoint("bpc_existing")
+      )
+
+      assert {:ok, _event} = EventHandler.handle_event(event)
+
+      assert_received {:stripe_request, "POST", "/v1/billing_portal/configurations/bpc_existing",
+                       params}
+
+      assert params["features[subscription_update][products][0][adjustable_quantity][minimum]"] ==
+               "55"
+    end
+
+    test "does not touch a billing portal configuration for Team seats", %{
+      account: account,
+      customer: customer
+    } do
+      update_account(account, %{
+        metadata: %{stripe: %{portal_configuration_id: "bpc_existing"}}
+      })
+
+      {product, _price, subscription} =
+        Stripe.build_all(:team, account.metadata.stripe.customer_id, 55)
+
+      event = Stripe.build_event("customer.subscription.updated", subscription)
+
+      Stripe.stub(
+        Stripe.fetch_customer_endpoint(customer) ++
+          Stripe.fetch_product_endpoint(product)
+      )
+
+      assert {:ok, _event} = EventHandler.handle_event(event)
+
+      refute_received {:stripe_request, "POST", "/v1/billing_portal/configurations/bpc_existing",
+                       _params}
+    end
+
     test "clears account limit flags when subscription update increases limits", %{
       account: account,
       customer: customer

--- a/elixir/test/portal/billing_test.exs
+++ b/elixir/test/portal/billing_test.exs
@@ -785,6 +785,115 @@ defmodule Portal.BillingTest do
 
       assert url =~ "billing.stripe.com"
     end
+
+    test "uses the default configuration for non-Enterprise accounts", %{account: account} do
+      account =
+        update_account(account, %{
+          metadata: %{stripe: %{customer_id: "cus_test123", product_name: "Team"}}
+        })
+
+      subject = admin_subject(account)
+
+      Stripe.stub(Stripe.mock_create_billing_session_endpoint(account))
+
+      assert {:ok, _url} =
+               Portal.Billing.billing_portal_url(account, "https://example.com", subject)
+
+      assert_received {:stripe_request, "POST", "/v1/billing_portal/sessions", params}
+      refute Map.has_key?(params, "configuration")
+
+      refute_received {:stripe_request, "POST", "/v1/billing_portal/configurations", _params}
+    end
+
+    test "creates an increase-only configuration for Enterprise accounts", %{account: account} do
+      account = enterprise_account(account)
+      subject = admin_subject(account)
+
+      Stripe.stub(
+        Stripe.mock_fetch_subscription_endpoint(enterprise_subscription(account, 25)) ++
+          Stripe.mock_create_portal_configuration_endpoint("bpc_test123") ++
+          Stripe.mock_create_billing_session_endpoint(account)
+      )
+
+      assert {:ok, _url} =
+               Portal.Billing.billing_portal_url(account, "https://example.com", subject)
+
+      assert_received {:stripe_request, "POST", "/v1/billing_portal/configurations", params}
+
+      assert params["features[subscription_update][products][0][adjustable_quantity][minimum]"] ==
+               "25"
+
+      assert params["features[subscription_update][products][0][adjustable_quantity][enabled]"] ==
+               "true"
+
+      assert params["features[subscription_update][products][0][product]"] ==
+               "prod_test_enterprise"
+
+      assert params["features[subscription_update][default_allowed_updates][0]"] == "quantity"
+      refute params["features[subscription_update][default_allowed_updates][1]"]
+      assert params["features[subscription_cancel][enabled]"] == "false"
+
+      assert_received {:stripe_request, "POST", "/v1/billing_portal/sessions", session_params}
+      assert session_params["configuration"] == "bpc_test123"
+
+      updated = Portal.Repo.get!(Portal.Account, account.id)
+      assert updated.metadata.stripe.portal_configuration_id == "bpc_test123"
+    end
+
+    test "reuses the stored configuration for Enterprise accounts", %{account: account} do
+      account = enterprise_account(account, %{portal_configuration_id: "bpc_existing"})
+      subject = admin_subject(account)
+
+      Stripe.stub(
+        Stripe.mock_fetch_subscription_endpoint(enterprise_subscription(account, 30)) ++
+          Stripe.mock_update_portal_configuration_endpoint("bpc_existing") ++
+          Stripe.mock_create_billing_session_endpoint(account)
+      )
+
+      assert {:ok, _url} =
+               Portal.Billing.billing_portal_url(account, "https://example.com", subject)
+
+      assert_received {:stripe_request, "POST", "/v1/billing_portal/configurations/bpc_existing",
+                       params}
+
+      assert params["features[subscription_update][products][0][adjustable_quantity][minimum]"] ==
+               "30"
+
+      refute_received {:stripe_request, "POST", "/v1/billing_portal/configurations", _params}
+
+      assert_received {:stripe_request, "POST", "/v1/billing_portal/sessions", session_params}
+      assert session_params["configuration"] == "bpc_existing"
+    end
+
+    test "recreates the configuration when Stripe no longer has it", %{account: account} do
+      account = enterprise_account(account, %{portal_configuration_id: "bpc_gone"})
+      subject = admin_subject(account)
+
+      Stripe.stub(
+        Stripe.mock_fetch_subscription_endpoint(enterprise_subscription(account, 5)) ++
+          Stripe.mock_update_portal_configuration_endpoint("bpc_gone", 404) ++
+          Stripe.mock_create_portal_configuration_endpoint("bpc_new") ++
+          Stripe.mock_create_billing_session_endpoint(account)
+      )
+
+      assert {:ok, _url} =
+               Portal.Billing.billing_portal_url(account, "https://example.com", subject)
+
+      updated = Portal.Repo.get!(Portal.Account, account.id)
+      assert updated.metadata.stripe.portal_configuration_id == "bpc_new"
+    end
+
+    test "fails when the Enterprise subscription cannot be read", %{account: account} do
+      account = enterprise_account(account)
+      subject = admin_subject(account)
+
+      Stripe.stub([{"GET", "/v1/subscriptions/sub_test123", 500, %{"error" => "Server error"}}])
+
+      assert {:error, _reason} =
+               Portal.Billing.billing_portal_url(account, "https://example.com", subject)
+
+      refute_received {:stripe_request, "POST", "/v1/billing_portal/sessions", _params}
+    end
   end
 
   describe "Database.count_users_for_account/1" do
@@ -1088,5 +1197,31 @@ defmodule Portal.BillingTest do
                assert {:error, :retry_later} = handle_events([event])
              end) =~ "Cannot fetch Stripe product"
     end
+  end
+
+  defp admin_subject(account) do
+    actor = actor_fixture(type: :account_admin_user, account: account)
+    Portal.SubjectFixtures.subject_fixture(account: account, actor: actor)
+  end
+
+  defp enterprise_account(account, stripe_metadata \\ %{}) do
+    stripe =
+      Map.merge(
+        %{
+          customer_id: "cus_test123",
+          subscription_id: "sub_test123",
+          product_name: "Enterprise"
+        },
+        stripe_metadata
+      )
+
+    update_account(account, %{metadata: %{stripe: stripe}})
+  end
+
+  defp enterprise_subscription(account, seats) do
+    {_product, _price, subscription} =
+      Stripe.build_all(:enterprise, account.metadata.stripe.customer_id, seats)
+
+    Map.put(subscription, "id", account.metadata.stripe.subscription_id)
   end
 end

--- a/elixir/test/portal/billing_test.exs
+++ b/elixir/test/portal/billing_test.exs
@@ -883,6 +883,45 @@ defmodule Portal.BillingTest do
       assert updated.metadata.stripe.portal_configuration_id == "bpc_new"
     end
 
+    test "invoices Enterprise seat upgrades immediately", %{account: account} do
+      account = enterprise_account(account)
+      subject = admin_subject(account)
+
+      Stripe.stub(
+        Stripe.mock_fetch_subscription_endpoint(enterprise_subscription(account, 25)) ++
+          Stripe.mock_create_portal_configuration_endpoint("bpc_test123") ++
+          Stripe.mock_create_billing_session_endpoint(account)
+      )
+
+      assert {:ok, _url} =
+               Portal.Billing.billing_portal_url(account, "https://example.com", subject)
+
+      assert_received {:stripe_request, "POST", "/v1/billing_portal/configurations", params}
+      assert params["features[subscription_update][proration_behavior]"] == "always_invoice"
+    end
+
+    test "warns when the Enterprise subscription is not on NET 30 terms", %{account: account} do
+      account = enterprise_account(account)
+      subject = admin_subject(account)
+
+      subscription =
+        enterprise_subscription(account, 25, %{
+          "collection_method" => "charge_automatically",
+          "days_until_due" => nil
+        })
+
+      Stripe.stub(
+        Stripe.mock_fetch_subscription_endpoint(subscription) ++
+          Stripe.mock_create_portal_configuration_endpoint("bpc_test123") ++
+          Stripe.mock_create_billing_session_endpoint(account)
+      )
+
+      assert capture_log(fn ->
+               assert {:ok, _url} =
+                        Portal.Billing.billing_portal_url(account, "https://example.com", subject)
+             end) =~ "does not invoice seats on the expected terms"
+    end
+
     test "fails when the Enterprise subscription cannot be read", %{account: account} do
       account = enterprise_account(account)
       subject = admin_subject(account)
@@ -1218,10 +1257,16 @@ defmodule Portal.BillingTest do
     update_account(account, %{metadata: %{stripe: stripe}})
   end
 
-  defp enterprise_subscription(account, seats) do
+  defp enterprise_subscription(account, seats, overrides \\ %{}) do
     {_product, _price, subscription} =
       Stripe.build_all(:enterprise, account.metadata.stripe.customer_id, seats)
 
-    Map.put(subscription, "id", account.metadata.stripe.subscription_id)
+    subscription
+    |> Map.merge(%{
+      "id" => account.metadata.stripe.subscription_id,
+      "collection_method" => "send_invoice",
+      "days_until_due" => 30
+    })
+    |> Map.merge(overrides)
   end
 end

--- a/elixir/test/support/mocks/stripe.ex
+++ b/elixir/test/support/mocks/stripe.ex
@@ -12,6 +12,10 @@ defmodule Portal.Mocks.Stripe do
 
   Expectations are a list of tuples: `{method, path, status, response}`
 
+  Every request is also sent to the calling process as
+  `{:stripe_request, method, path, decoded_body}` so that tests can assert on
+  what was sent.
+
   ## Example
 
       Stripe.stub([
@@ -20,10 +24,16 @@ defmodule Portal.Mocks.Stripe do
       ])
   """
   def stub(expectations) when is_list(expectations) do
+    test_pid = self()
+
     Req.Test.stub(APIClient, fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+
       method = conn.method
       base_path = "/" <> Enum.join(conn.path_info, "/")
       path = if conn.query_string != "", do: base_path <> "?" <> conn.query_string, else: base_path
+
+      send(test_pid, {:stripe_request, method, base_path, URI.decode_query(body)})
 
       case find_expectation(expectations, method, path) do
         {:ok, {status, response}} ->
@@ -157,6 +167,38 @@ defmodule Portal.Mocks.Stripe do
       )
 
     [{"POST", "/v1/billing_portal/sessions", 200, response}]
+  end
+
+  def mock_fetch_subscription_endpoint(subscription) do
+    [{"GET", "/v1/subscriptions/#{subscription["id"]}", 200, subscription}]
+  end
+
+  def mock_create_portal_configuration_endpoint(configuration_id \\ "bpc_test123") do
+    [
+      {"POST", "/v1/billing_portal/configurations", 200,
+       portal_configuration_object(configuration_id)}
+    ]
+  end
+
+  def mock_update_portal_configuration_endpoint(configuration_id, status \\ 200) do
+    response =
+      if status == 200 do
+        portal_configuration_object(configuration_id)
+      else
+        %{"error" => %{"message" => "No such configuration: #{configuration_id}"}}
+      end
+
+    [{"POST", "/v1/billing_portal/configurations/#{configuration_id}", status, response}]
+  end
+
+  def portal_configuration_object(id) do
+    %{
+      "id" => id,
+      "object" => "billing_portal.configuration",
+      "active" => true,
+      "is_default" => false,
+      "livemode" => false
+    }
   end
 
   def mock_fetch_customer_subscriptions_endpoint(customer_id, subscriptions \\ []) do

--- a/elixir/test/support/mocks/stripe.ex
+++ b/elixir/test/support/mocks/stripe.ex
@@ -512,6 +512,8 @@ defmodule Portal.Mocks.Stripe do
       "id" => "sub_" <> random_id(),
       "object" => "subscription",
       "status" => "active",
+      "collection_method" => "charge_automatically",
+      "days_until_due" => nil,
       "customer" => "cus_" <> random_id(),
       "items" => %{
         "object" => "list",


### PR DESCRIPTION
Enterprise customers can now change their own seat count from the Stripe billing portal, but only upwards.

Everyone used to get the same portal options, managed from the Stripe dashboard. Enterprise accounts now get a portal of their own that only lets them buy more seats: the lowest number they can pick is what they are billed for today, and cancelling or switching plans is turned off. Team and Starter accounts are untouched.

Buying seats raises an invoice for them straight away. Stripe puts the subscription's own payment terms on that invoice, so an Enterprise subscription set up to be invoiced with 30 days to pay produces a NET 30 invoice. We log a warning if a subscription is not set up that way, since the terms cannot be set per invoice.

An Enterprise account's monthly active user limit now comes from its seat count instead of the number written on the subscription metadata. The limit is only written when Stripe tells us the subscription changed, so Stripe stays the single source of truth and there is nothing to race with.

Fixes #10303
