### PR TITLE
fix(portal): stop logging expected actor changes as errors

### DIFF
--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -776,18 +776,11 @@ defmodule PortalWeb.Actors do
      end)}
   end
 
-  # User-actor updates are broadcast on the shared :actors topic but the table
-  # is not auto-refreshed here, so ignore them without warning.
-  def handle_info(%Change{struct: %Actor{type: type}}, socket)
-      when type in [:account_user, :account_admin_user] do
-    {:noreply, socket}
-  end
-
-  def handle_info(%Change{struct: %Actor{}} = message, socket),
-    do: PortalWeb.Live.Helpers.handle_info_fallback(message, socket)
-
-  def handle_info(%Change{old_struct: %Actor{}} = message, socket),
-    do: PortalWeb.Live.Helpers.handle_info_fallback(message, socket)
+  # The :actors topic carries every actor type, so this page also sees service
+  # accounts and API clients, which have pages of their own. Those and user
+  # updates that leave the count alone change nothing here.
+  def handle_info(%Change{struct: %Actor{}}, socket), do: {:noreply, socket}
+  def handle_info(%Change{old_struct: %Actor{}}, socket), do: {:noreply, socket}
 
   def handle_info(%Phoenix.Socket.Broadcast{event: "presence_diff", topic: topic}, socket) do
     actor = socket.assigns.selected_actor

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -594,11 +594,10 @@ defmodule PortalWeb.ServiceAccounts do
     {:noreply, mark_stale_if_unreflected(socket, change)}
   end
 
-  def handle_info(%Change{struct: %Actor{}} = message, socket),
-    do: PortalWeb.Live.Helpers.handle_info_fallback(message, socket)
-
-  def handle_info(%Change{old_struct: %Actor{}} = message, socket),
-    do: PortalWeb.Live.Helpers.handle_info_fallback(message, socket)
+  # The :actors topic carries every actor type, so this page also sees users and
+  # API clients, which have pages of their own and change nothing here.
+  def handle_info(%Change{struct: %Actor{}}, socket), do: {:noreply, socket}
+  def handle_info(%Change{old_struct: %Actor{}}, socket), do: {:noreply, socket}
 
   def handle_info(%Phoenix.Socket.Broadcast{event: "presence_diff", topic: topic}, socket) do
     actor = socket.assigns.selected_actor

--- a/elixir/test/portal_web/live/actors_test.exs
+++ b/elixir/test/portal_web/live/actors_test.exs
@@ -1523,7 +1523,7 @@ defmodule PortalWeb.ActorsTest do
       assert html =~ "Total"
     end
 
-    test "logs and ignores service account changes", %{
+    test "quietly ignores other actor types on the shared topic", %{
       conn: conn,
       account: account,
       actor: actor
@@ -1538,11 +1538,12 @@ defmodule PortalWeb.ActorsTest do
       log =
         capture_log(fn ->
           send(lv.pid, %Change{op: :insert, struct: %Actor{type: :service_account}})
+          send(lv.pid, %Change{op: :update, struct: %Actor{type: :api_client}})
+          send(lv.pid, %Change{op: :delete, old_struct: %Actor{type: :service_account}})
           render(lv)
         end)
 
-      assert log =~ "[error]"
-      assert log =~ "Unhandled handle_info message in LiveView"
+      refute log =~ "Unhandled handle_info message in LiveView"
 
       html = render(lv)
       assert html =~ "1"

--- a/elixir/test/portal_web/live/service_accounts_test.exs
+++ b/elixir/test/portal_web/live/service_accounts_test.exs
@@ -1062,7 +1062,7 @@ defmodule PortalWeb.ServiceAccountsTest do
       assert html =~ "Total"
     end
 
-    test "logs and ignores regular actor changes", %{
+    test "quietly ignores other actor types on the shared topic", %{
       conn: conn,
       account: account,
       actor: actor
@@ -1077,11 +1077,12 @@ defmodule PortalWeb.ServiceAccountsTest do
       log =
         capture_log(fn ->
           send(lv.pid, %Change{op: :insert, struct: %Actor{type: :account_user}})
+          send(lv.pid, %Change{op: :update, struct: %Actor{type: :api_client}})
+          send(lv.pid, %Change{op: :delete, old_struct: %Actor{type: :account_admin_user}})
           render(lv)
         end)
 
-      assert log =~ "[error]"
-      assert log =~ "Unhandled handle_info message in LiveView"
+      refute log =~ "Unhandled handle_info message in LiveView"
 
       html = render(lv)
       assert html =~ "0"


### PR DESCRIPTION
Sentry has been collecting "Unhandled handle_info message in LiveView" errors from the Actors page in production.

Nothing is actually broken. The Actors page and the Service Accounts page both listen to the same account-wide actors topic, and that topic carries every kind of actor: users, admins, service accounts and API clients. Each page only knew what to do with the kind it shows, and passed everything else to the handler for messages we did not expect, which logs an error and reports it to Sentry.

So someone creating an API client was enough to raise a production error for anyone who happened to have the Actors page open at the time. Deleting a service account did the same, and the reverse happened on the Service Accounts page.

Those messages are a normal consequence of sharing a topic, so both pages now ignore the kinds of actor they do not display. Messages that really are unexpected still get logged.

Two tests asserted that the error was logged, so they pinned the behaviour rather than caught it. They now check that nothing is logged, and cover every actor type each page can receive rather than just one.

Related: https://firezone-inc.sentry.io/issues/7561621987/events/3e38956dce364120aa322b984181a2ac/
