### PR TITLE
chore: experimental_monorepo_root -> monorepo_root

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
-experimental_monorepo_root = true
+monorepo_root = true
 
 [settings]
 # Refuse to install tool versions released less than 7 days ago. Mitigates the


### PR DESCRIPTION
Fixes incessant warnings outputted by mise on each shell line.

<img width="1840" height="1191" alt="Screenshot 2026-07-30 at 9 56 43 PM" src="https://github.com/user-attachments/assets/83085a1f-5168-4bb4-95cd-902828086476" />
