### PR TITLE
fix(portal): enforce billing limits when enabling actors

### DIFF
--- a/elixir/lib/portal/billing.ex
+++ b/elixir/lib/portal/billing.ex
@@ -197,6 +197,50 @@ defmodule Portal.Billing do
          api_clients_count < account.limits.api_clients_count)
   end
 
+  @type actor_enable_limit_error ::
+          :users_limit_reached
+          | :admin_users_limit_reached
+          | :service_accounts_limit_reached
+          | :api_clients_limit_reached
+
+  @doc """
+  Checks whether an actor can be enabled without exceeding its account's billing limits.
+  """
+  @spec check_actor_enable_limits(Portal.Account.t(), Portal.Actor.t()) ::
+          :ok | {:error, actor_enable_limit_error()}
+  def check_actor_enable_limits(%Portal.Account{} = account, %Portal.Actor{
+        type: :account_admin_user
+      }) do
+    cond do
+      not can_create_users?(account) ->
+        {:error, :users_limit_reached}
+
+      not can_create_admin_users?(account) ->
+        {:error, :admin_users_limit_reached}
+
+      true ->
+        :ok
+    end
+  end
+
+  def check_actor_enable_limits(%Portal.Account{} = account, %Portal.Actor{
+        type: :account_user
+      }) do
+    if can_create_users?(account), do: :ok, else: {:error, :users_limit_reached}
+  end
+
+  def check_actor_enable_limits(%Portal.Account{} = account, %Portal.Actor{
+        type: :service_account
+      }) do
+    if can_create_service_accounts?(account),
+      do: :ok,
+      else: {:error, :service_accounts_limit_reached}
+  end
+
+  def check_actor_enable_limits(%Portal.Account{} = account, %Portal.Actor{type: :api_client}) do
+    if can_create_api_clients?(account), do: :ok, else: {:error, :api_clients_limit_reached}
+  end
+
   def api_tokens_limit_exceeded?(%Portal.Account{} = account, api_tokens_count) do
     not is_nil(account.limits.api_tokens_per_client_count) and
       api_tokens_count > account.limits.api_tokens_per_client_count

--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -524,7 +524,8 @@ defmodule PortalWeb.Actors do
   end
 
   def handle_event("enable", %{"id" => id}, socket) do
-    with {:ok, actor} <- Database.get_actor(id, socket.assigns.subject) do
+    with {:ok, actor} <- Database.get_actor(id, socket.assigns.subject),
+         :ok <- Portal.Billing.check_actor_enable_limits(socket.assigns.account, actor) do
       case actor
            |> change()
            |> put_change(:disabled_at, nil)
@@ -546,6 +547,12 @@ defmodule PortalWeb.Actors do
 
       {:error, :unauthorized} ->
         {:noreply, put_flash(socket, :error, "You are not authorized to enable this actor")}
+
+      {:error, :users_limit_reached} ->
+        {:noreply, put_flash(socket, :error, "User limit reached for your account")}
+
+      {:error, :admin_users_limit_reached} ->
+        {:noreply, put_flash(socket, :error, "Admin user limit reached for your account")}
     end
   end
 

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -451,7 +451,8 @@ defmodule PortalWeb.ServiceAccounts do
   end
 
   def handle_event("enable", %{"id" => id}, socket) do
-    with {:ok, actor} <- Database.get_actor(id, socket.assigns.subject) do
+    with {:ok, actor} <- Database.get_actor(id, socket.assigns.subject),
+         :ok <- Portal.Billing.check_actor_enable_limits(socket.assigns.account, actor) do
       case actor
            |> change()
            |> put_change(:disabled_at, nil)
@@ -474,6 +475,9 @@ defmodule PortalWeb.ServiceAccounts do
       {:error, :unauthorized} ->
         {:noreply,
          put_flash(socket, :error, "You are not authorized to enable this service account")}
+
+      {:error, :service_accounts_limit_reached} ->
+        {:noreply, put_flash(socket, :error, "Service account limit reached for your account")}
     end
   end
 

--- a/elixir/lib/portal_web/live/settings/api_clients/index.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/index.ex
@@ -647,7 +647,8 @@ defmodule PortalWeb.Settings.ApiClients.Index do
       |> change()
       |> put_change(:disabled_at, nil)
 
-    with {:ok, updated} <-
+    with :ok <- Portal.Billing.check_actor_enable_limits(socket.assigns.account, actor),
+         {:ok, updated} <-
            Portal.Safe.scoped(changeset, socket.assigns.subject) |> Portal.Safe.update() do
       socket =
         socket
@@ -659,6 +660,17 @@ defmodule PortalWeb.Settings.ApiClients.Index do
         |> maybe_update_selected(updated)
 
       {:noreply, socket}
+    else
+      {:error, :api_clients_limit_reached} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "You have reached the maximum number of API tokens allowed for your account."
+         )}
+
+      {:error, _reason} ->
+        {:noreply, put_flash(socket, :error, "Failed to enable API token")}
     end
   end
 

--- a/elixir/test/portal/billing_test.exs
+++ b/elixir/test/portal/billing_test.exs
@@ -346,6 +346,53 @@ defmodule Portal.BillingTest do
     end
   end
 
+  describe "check_actor_enable_limits/2" do
+    test "rejects a user when the user limit is reached", %{account: account} do
+      account = update_account(account, %{limits: %{users_count: 0}})
+      actor = disabled_actor_fixture(account: account, type: :account_user)
+
+      assert check_actor_enable_limits(account, actor) == {:error, :users_limit_reached}
+    end
+
+    test "rejects an admin when the user limit is reached", %{account: account} do
+      account = update_account(account, %{limits: %{users_count: 0}})
+      actor = disabled_actor_fixture(account: account, type: :account_admin_user)
+
+      assert check_actor_enable_limits(account, actor) == {:error, :users_limit_reached}
+    end
+
+    test "rejects an admin when the admin limit is reached", %{account: account} do
+      account = update_account(account, %{limits: %{account_admin_users_count: 0}})
+      actor = disabled_actor_fixture(account: account, type: :account_admin_user)
+
+      assert check_actor_enable_limits(account, actor) == {:error, :admin_users_limit_reached}
+    end
+
+    test "rejects a service account when the service account limit is reached", %{
+      account: account
+    } do
+      account = update_account(account, %{limits: %{service_accounts_count: 0}})
+      actor = disabled_actor_fixture(account: account, type: :service_account)
+
+      assert check_actor_enable_limits(account, actor) ==
+               {:error, :service_accounts_limit_reached}
+    end
+
+    test "rejects an API client when the API client limit is reached", %{account: account} do
+      account = update_account(account, %{limits: %{api_clients_count: 0}})
+      actor = disabled_actor_fixture(account: account, type: :api_client)
+
+      assert check_actor_enable_limits(account, actor) == {:error, :api_clients_limit_reached}
+    end
+
+    test "allows all actor types when limits are not reached", %{account: account} do
+      for type <- [:account_user, :account_admin_user, :service_account, :api_client] do
+        actor = disabled_actor_fixture(account: account, type: type)
+        assert check_actor_enable_limits(account, actor) == :ok
+      end
+    end
+  end
+
   describe "api_tokens_limit_exceeded?/2" do
     test "returns false when api_tokens_per_client_count limit is not exceeded", %{
       account: account

--- a/elixir/test/portal_web/live/actors_test.exs
+++ b/elixir/test/portal_web/live/actors_test.exs
@@ -540,6 +540,44 @@ defmodule PortalWeb.ActorsTest do
       assert html =~ "Disable"
     end
 
+    test "does not re-enable actor when users limit is reached", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      account = update_account(account, %{limits: %{users_count: 1}})
+      other_actor = disabled_actor_fixture(account: account, type: :account_user)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/#{other_actor}")
+
+      html = render_click(lv, "enable", %{"id" => other_actor.id})
+
+      assert html =~ "User limit reached for your account"
+      assert Portal.Repo.get_by!(Portal.Actor, id: other_actor.id).disabled_at
+    end
+
+    test "does not re-enable admin when admins limit is reached", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      account = update_account(account, %{limits: %{account_admin_users_count: 1}})
+      other_actor = disabled_actor_fixture(account: account, type: :account_admin_user)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/#{other_actor}")
+
+      html = render_click(lv, "enable", %{"id" => other_actor.id})
+
+      assert html =~ "Admin user limit reached for your account"
+      assert Portal.Repo.get_by!(Portal.Actor, id: other_actor.id).disabled_at
+    end
+
     test "cancel delete actor returns to detail view", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_web/live/service_accounts_test.exs
+++ b/elixir/test/portal_web/live/service_accounts_test.exs
@@ -636,6 +636,25 @@ defmodule PortalWeb.ServiceAccountsTest do
       refute Portal.Repo.get_by!(Portal.Actor, id: service_account.id, account_id: account.id).disabled_at
     end
 
+    test "does not enable when the service account limit is reached", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      account = update_account(account, %{limits: %{service_accounts_count: 0}})
+      service_account = disabled_actor_fixture(account: account, type: :service_account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/service_accounts/#{service_account}")
+
+      html = render_click(lv, "enable", %{"id" => service_account.id})
+
+      assert html =~ "Service account limit reached for your account"
+      assert Repo.get_by!(Actor, id: service_account.id, account_id: account.id).disabled_at
+    end
+
     test "confirm and cancel delete service account", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_web/live/settings/api_clients/index_test.exs
+++ b/elixir/test/portal_web/live/settings/api_clients/index_test.exs
@@ -333,6 +333,27 @@ defmodule PortalWeb.Settings.ApiClients.IndexTest do
       assert is_nil(Repo.get_by!(Actor, account_id: account.id, id: api_client.id).disabled_at)
     end
 
+    test "does not re-enable an API client when the billing limit is reached", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      account = update_account(account, %{limits: %{api_clients_count: 0}})
+      api_client = disabled_actor_fixture(account: account, type: :api_client)
+      api_token_fixture(account: account, actor: api_client)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/api_clients")
+
+      request_confirm(lv, "toggle", api_client.id)
+      html = render_click(lv, "enable", %{"id" => api_client.id})
+
+      assert html =~ "maximum number of API tokens allowed for your account"
+      assert Repo.get_by!(Actor, account_id: account.id, id: api_client.id).disabled_at
+    end
+
     test "deletes an api client after confirmation", %{conn: conn, account: account, actor: actor} do
       api_client = api_client_fixture(account: account, name: "Delete Client")
       api_token_fixture(account: account, actor: api_client)


### PR DESCRIPTION
## Summary

- add a shared billing-limit check for re-enabling users, admins, service accounts, and API clients
- keep actors disabled and show the existing limit-specific error when the account is at capacity
- add billing and LiveView regression coverage for every actor type

The REST Actors API does not currently expose enable/disable operations, and its update schema does not accept disabled_at, so this PR does not change the REST API contract.

## Testing

- mix test (4,403 passed)
- mix format --check-formatted
- mix credo --strict
- mix dialyzer --format dialyxir