### PR TITLE
fix(portal): standardize panel footer buttons

### DIFF
--- a/elixir/lib/portal_web/components/form_components.ex
+++ b/elixir/lib/portal_web/components/form_components.ex
@@ -767,6 +767,58 @@ defmodule PortalWeb.FormComponents do
     """
   end
 
+  @doc """
+  Renders the action row at the bottom of a slide-over panel.
+
+  Use `panel_footer_button/1` for the actions so every panel uses the same
+  button size.
+
+  ## Examples
+
+      <.panel_footer>
+        <.panel_footer_button phx-click="close_panel">Cancel</.panel_footer_button>
+        <.panel_footer_button type="submit" style="primary">Save</.panel_footer_button>
+      </.panel_footer>
+  """
+  attr :class, :any, default: nil
+  slot :inner_block, required: true
+
+  def panel_footer(assigns) do
+    ~H"""
+    <div class={[
+      "shrink-0 flex items-center justify-end gap-2 px-5 py-3",
+      "border-t border-border bg-elevated",
+      @class
+    ]}>
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+
+  @doc """
+  Renders a consistently sized action in a slide-over panel footer.
+
+  This delegates to `button/1`, including its link variants, while fixing the
+  contextual size to `sm`.
+  """
+  attr :type, :string, default: nil
+  attr :style, :string, default: nil
+  attr :icon, :string, default: nil
+  attr :class, :string, default: ""
+
+  attr :rest, :global,
+    include: ~w(disabled form name value navigate href patch title)
+
+  slot :inner_block, required: true
+
+  def panel_footer_button(assigns) do
+    ~H"""
+    <.button type={@type} style={@style} icon={@icon} size="sm" class={@class} {@rest}>
+      {render_slot(@inner_block)}
+    </.button>
+    """
+  end
+
   defp icon_button_style(nil) do
     ["text-subtle hover:text-heading hover:bg-raised"]
   end

--- a/elixir/lib/portal_web/live/actors/components.ex
+++ b/elixir/lib/portal_web/live/actors/components.ex
@@ -1139,17 +1139,16 @@ defmodule PortalWeb.Actors.Components do
           account={@account}
         />
       </div>
-      <div
+      <.panel_footer
         :if={is_nil(@pending_email_change)}
-        class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border bg-elevated"
       >
-        <.button type="button" phx-click="cancel_actor_edit_form" size="xs">
+        <.panel_footer_button type="button" phx-click="cancel_actor_edit_form">
           Cancel
-        </.button>
-        <.button type="submit" style="primary" size="xs">
+        </.panel_footer_button>
+        <.panel_footer_button type="submit" style="primary">
           Save Changes
-        </.button>
-      </div>
+        </.panel_footer_button>
+      </.panel_footer>
       <div
         :if={not is_nil(@pending_email_change)}
         class="shrink-0 px-5 py-3 border-t border-error/20 bg-error-light"
@@ -1166,12 +1165,12 @@ defmodule PortalWeb.Actors.Components do
           </div>
         </div>
         <div class="flex items-center justify-end gap-1.5">
-          <.button type="button" phx-click="cancel_email_change" size="xs">
+          <.panel_footer_button type="button" phx-click="cancel_email_change">
             Cancel
-          </.button>
-          <.button type="button" phx-click="confirm_email_change" style="danger" size="xs">
+          </.panel_footer_button>
+          <.panel_footer_button type="button" phx-click="confirm_email_change" style="danger">
             Yes, change email and clear identities
-          </.button>
+          </.panel_footer_button>
         </div>
       </div>
     </.form>
@@ -1344,14 +1343,14 @@ defmodule PortalWeb.Actors.Components do
             account={@account}
           />
         </div>
-        <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border bg-elevated">
-          <.button type="button" phx-click="close_panel" size="xs">
+        <.panel_footer>
+          <.panel_footer_button type="button" phx-click="close_panel">
             Cancel
-          </.button>
-          <.button type="submit" style="primary" size="xs">
+          </.panel_footer_button>
+          <.panel_footer_button type="submit" style="primary">
             Create User
-          </.button>
-        </div>
+          </.panel_footer_button>
+        </.panel_footer>
       </.form>
 
       <.form
@@ -1391,14 +1390,14 @@ defmodule PortalWeb.Actors.Components do
             account={@account}
           />
         </div>
-        <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border bg-elevated">
-          <.button type="button" phx-click="close_panel" size="xs">
+        <.panel_footer>
+          <.panel_footer_button type="button" phx-click="close_panel">
             Cancel
-          </.button>
-          <.button type="submit" style="primary" size="xs">
+          </.panel_footer_button>
+          <.panel_footer_button type="submit" style="primary">
             Create Service Account
-          </.button>
-        </div>
+          </.panel_footer_button>
+        </.panel_footer>
       </.form>
     </div>
     """

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -293,14 +293,14 @@ defmodule PortalWeb.Clients.Components do
 
   def client_edit_actions(assigns) do
     ~H"""
-    <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border bg-elevated">
-      <.button type="button" phx-click="cancel_client_edit_form" size="xs">
+    <.panel_footer>
+      <.panel_footer_button type="button" phx-click="cancel_client_edit_form">
         Cancel
-      </.button>
-      <.button type="submit" style="primary" size="xs">
+      </.panel_footer_button>
+      <.panel_footer_button type="submit" style="primary">
         Save
-      </.button>
-    </div>
+      </.panel_footer_button>
+    </.panel_footer>
     """
   end
 

--- a/elixir/lib/portal_web/live/groups/components.ex
+++ b/elixir/lib/portal_web/live/groups/components.ex
@@ -205,18 +205,17 @@ defmodule PortalWeb.Groups.Components do
             </div>
           </div>
         </div>
-        <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border bg-elevated">
-          <.link
+        <.panel_footer>
+          <.panel_footer_button
             patch={
               if @panel_view == :edit_form && @group,
                 do: ~p"/#{@account}/groups/#{@group.id}",
                 else: ~p"/#{@account}/groups"
             }
-            class="px-3 py-1.5 text-xs rounded border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
           >
             Cancel
-          </.link>
-          <.button
+          </.panel_footer_button>
+          <.panel_footer_button
             type="submit"
             style="primary"
             disabled={
@@ -224,12 +223,11 @@ defmodule PortalWeb.Groups.Components do
                 do: not @form.source.valid?,
                 else: edit_form_unchanged?(@form, @members_to_add, @members_to_remove)
             }
-            size="sm"
             class="font-medium"
           >
             {if @panel_view == :new_form, do: "Create Group", else: "Save Changes"}
-          </.button>
-        </div>
+          </.panel_footer_button>
+        </.panel_footer>
       </.form>
     </div>
     """
@@ -775,14 +773,18 @@ defmodule PortalWeb.Groups.Components do
       >
         <p :for={{_field, {msg, _}} <- @grant_resource_form.errors}>{msg}</p>
       </div>
-      <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border bg-elevated">
-        <.button type="button" phx-click="close_grant_resource_form" size="xs">
+      <.panel_footer>
+        <.panel_footer_button type="button" phx-click="close_grant_resource_form">
           Cancel
-        </.button>
-        <.button type="submit" style="primary" disabled={@grant_selected_resource_ids == []} size="xs">
+        </.panel_footer_button>
+        <.panel_footer_button
+          type="submit"
+          style="primary"
+          disabled={@grant_selected_resource_ids == []}
+        >
           Grant access
-        </.button>
-      </div>
+        </.panel_footer_button>
+      </.panel_footer>
     </.form>
     """
   end

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -731,14 +731,14 @@ defmodule PortalWeb.Policies.Components do
 
   def policy_form_actions(assigns) do
     ~H"""
-    <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border bg-elevated">
-      <.button type="button" phx-click="cancel_policy_form" size="xs">
+    <.panel_footer>
+      <.panel_footer_button type="button" phx-click="cancel_policy_form">
         Cancel
-      </.button>
-      <.button type="submit" style="primary" size="xs">
+      </.panel_footer_button>
+      <.panel_footer_button type="submit" style="primary">
         {if @mode == :new, do: "Create Policy", else: "Save Changes"}
-      </.button>
-    </div>
+      </.panel_footer_button>
+    </.panel_footer>
     """
   end
 

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1014,14 +1014,14 @@ defmodule PortalWeb.Resources.Components do
           <.resource_site_selector form={@resource_form} sites={@resource_form_sites} />
         </div>
 
-        <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border bg-elevated">
-          <.button type="button" phx-click="cancel_resource_form" size="sm">
+        <.panel_footer>
+          <.panel_footer_button type="button" phx-click="cancel_resource_form">
             Cancel
-          </.button>
-          <.button type="submit" style="primary" size="sm">
+          </.panel_footer_button>
+          <.panel_footer_button type="submit" style="primary">
             {if @panel_view == :new_form, do: "Create Resource", else: "Save Changes"}
-          </.button>
-        </div>
+          </.panel_footer_button>
+        </.panel_footer>
       </.form>
     </div>
     """
@@ -1717,14 +1717,18 @@ defmodule PortalWeb.Resources.Components do
       >
         <p :for={{_field, {msg, _}} <- @grant_form.errors}>{msg}</p>
       </div>
-      <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border bg-elevated">
-        <.button type="button" phx-click="close_grant_form" size="xs">
+      <.panel_footer>
+        <.panel_footer_button type="button" phx-click="close_grant_form">
           Cancel
-        </.button>
-        <.button type="submit" style="primary" disabled={@grant_selected_group_ids == []} size="xs">
+        </.panel_footer_button>
+        <.panel_footer_button
+          type="submit"
+          style="primary"
+          disabled={@grant_selected_group_ids == []}
+        >
           Grant access
-        </.button>
-      </div>
+        </.panel_footer_button>
+      </.panel_footer>
     </.form>
     """
   end

--- a/elixir/lib/portal_web/live/settings/account.ex
+++ b/elixir/lib/portal_web/live/settings/account.ex
@@ -416,14 +416,14 @@ defmodule PortalWeb.Settings.Account do
           />
         </div>
 
-        <div class="flex items-center justify-end gap-2 px-5 py-4 border-t border-border">
-          <.button type="button" phx-click="close_edit_account" size="xs">
+        <.panel_footer>
+          <.panel_footer_button type="button" phx-click="close_edit_account">
             Cancel
-          </.button>
-          <.button type="submit" style="primary" disabled={not @form.source.valid?} size="xs">
+          </.panel_footer_button>
+          <.panel_footer_button type="submit" style="primary" disabled={not @form.source.valid?}>
             Save
-          </.button>
-        </div>
+          </.panel_footer_button>
+        </.panel_footer>
       </.form>
     </div>
     """

--- a/elixir/lib/portal_web/live/settings/api_clients/index.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/index.ex
@@ -265,20 +265,20 @@ defmodule PortalWeb.Settings.ApiClients.Index do
             </div>
 
     <!-- Panel footer -->
-            <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border bg-elevated">
+            <.panel_footer>
               <%= if is_nil(@encoded_token) do %>
-                <.button type="button" phx-click="close_panel" size="sm">
+                <.panel_footer_button type="button" phx-click="close_panel">
                   Cancel
-                </.button>
-                <.button type="submit" style="primary" size="sm">
+                </.panel_footer_button>
+                <.panel_footer_button type="submit" style="primary">
                   Create Token
-                </.button>
+                </.panel_footer_button>
               <% else %>
-                <.button type="button" phx-click="close_reveal" size="sm">
+                <.panel_footer_button type="button" phx-click="close_reveal">
                   Done
-                </.button>
+                </.panel_footer_button>
               <% end %>
-            </div>
+            </.panel_footer>
           </.form>
         </div>
       </div>
@@ -319,14 +319,14 @@ defmodule PortalWeb.Settings.ApiClients.Index do
             </div>
 
     <!-- Panel footer -->
-            <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border bg-elevated">
-              <.button type="button" phx-click="close_panel" size="sm">
+            <.panel_footer>
+              <.panel_footer_button type="button" phx-click="close_panel">
                 Cancel
-              </.button>
-              <.button type="submit" style="primary" size="sm">
+              </.panel_footer_button>
+              <.panel_footer_button type="submit" style="primary">
                 Save
-              </.button>
-            </div>
+              </.panel_footer_button>
+            </.panel_footer>
           </.form>
         </div>
       </div>

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -770,14 +770,19 @@ defmodule PortalWeb.Settings.Authentication do
                 submit_event="submit_provider"
               />
             </div>
-            <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-4 border-t border-border">
-              <.button phx-click="close_panel">
+            <.panel_footer>
+              <.panel_footer_button phx-click="close_panel">
                 Cancel
-              </.button>
-              <.button form="auth-provider-form" type="submit" style="primary" disabled={not @form.source.valid?}>
+              </.panel_footer_button>
+              <.panel_footer_button
+                form="auth-provider-form"
+                type="submit"
+                style="primary"
+                disabled={not @form.source.valid?}
+              >
                 Create
-              </.button>
-            </div>
+              </.panel_footer_button>
+            </.panel_footer>
           </div>
         </div>
       </div>
@@ -817,22 +822,21 @@ defmodule PortalWeb.Settings.Authentication do
               is_legacy={assigns[:is_legacy]}
             />
           </div>
-          <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-4 border-t border-border">
-            <.button phx-click="close_panel" size="sm">
+          <.panel_footer>
+            <.panel_footer_button phx-click="close_panel">
               Cancel
-            </.button>
-            <.button
+            </.panel_footer_button>
+            <.panel_footer_button
               form="auth-provider-form"
               type="submit"
               style="primary"
-              size="sm"
               disabled={
                 not @form.source.valid? or Enum.empty?(@form.source.changes) or not verified?(@form)
               }
             >
               Save
-            </.button>
-          </div>
+            </.panel_footer_button>
+          </.panel_footer>
         </div>
       </div>
     </div>

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -632,14 +632,19 @@ defmodule PortalWeb.Settings.DirectorySync do
                 public_jwk={assigns[:public_jwk]}
               />
             </div>
-            <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-4 border-t border-border">
-              <.button phx-click="close_panel">
+            <.panel_footer>
+              <.panel_footer_button phx-click="close_panel">
                 Cancel
-              </.button>
-              <.button form="directory-form" type="submit" style="primary" disabled={not @form.source.valid?}>
+              </.panel_footer_button>
+              <.panel_footer_button
+                form="directory-form"
+                type="submit"
+                style="primary"
+                disabled={not @form.source.valid?}
+              >
                 Create
-              </.button>
-            </div>
+              </.panel_footer_button>
+            </.panel_footer>
           </div>
         </div>
 
@@ -681,11 +686,11 @@ defmodule PortalWeb.Settings.DirectorySync do
                 public_jwk={assigns[:public_jwk]}
               />
             </div>
-            <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-4 border-t border-border">
-              <.button phx-click="close_panel">
+            <.panel_footer>
+              <.panel_footer_button phx-click="close_panel">
                 Cancel
-              </.button>
-              <.button
+              </.panel_footer_button>
+              <.panel_footer_button
                 form="directory-form"
                 type="submit"
                 style="primary"
@@ -694,8 +699,8 @@ defmodule PortalWeb.Settings.DirectorySync do
                 }
               >
                 Save
-              </.button>
-            </div>
+              </.panel_footer_button>
+            </.panel_footer>
           </div>
         </div>
       <% else %>

--- a/elixir/lib/portal_web/live/settings/dns.ex
+++ b/elixir/lib/portal_web/live/settings/dns.ex
@@ -98,14 +98,14 @@ defmodule PortalWeb.Settings.DNS do
           <div class="flex-1 overflow-y-auto px-5 py-4">
             <.dns_form form={@form} />
           </div>
-          <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-4 border-t border-border">
-            <.button phx-click="close_panel" size="sm">
+          <.panel_footer>
+            <.panel_footer_button phx-click="close_panel">
               Cancel
-            </.button>
-            <.button form="dns-form" type="submit" size="sm" style="primary">
+            </.panel_footer_button>
+            <.panel_footer_button form="dns-form" type="submit" style="primary">
               Save
-            </.button>
-          </div>
+            </.panel_footer_button>
+          </.panel_footer>
         </div>
       </div>
     </div>

--- a/elixir/lib/portal_web/live/settings/log_sinks.ex
+++ b/elixir/lib/portal_web/live/settings/log_sinks.ex
@@ -519,19 +519,19 @@ defmodule PortalWeb.Settings.LogSinks do
             <div class="flex-1 overflow-y-auto px-5 py-4">
               <.sink_form form={@form} type={@type} live_action={@live_action} account={@account} sentinel_setup_tab={@sentinel_setup_tab} s3_setup_tab={@s3_setup_tab} />
             </div>
-            <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-4 border-t border-border">
-              <.button phx-click="close_panel">
+            <.panel_footer>
+              <.panel_footer_button phx-click="close_panel">
                 Cancel
-              </.button>
-              <.button
+              </.panel_footer_button>
+              <.panel_footer_button
                 form="log-sink-form"
                 type="submit"
                 style="primary"
                 disabled={not @form.source.valid?}
               >
                 Create
-              </.button>
-            </div>
+              </.panel_footer_button>
+            </.panel_footer>
           </div>
         </div>
 
@@ -562,19 +562,19 @@ defmodule PortalWeb.Settings.LogSinks do
               </.flash>
               <.sink_form form={@form} type={@type} live_action={@live_action} account={@account} sentinel_setup_tab={@sentinel_setup_tab} s3_setup_tab={@s3_setup_tab} />
             </div>
-            <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-4 border-t border-border">
-              <.button phx-click="close_panel">
+            <.panel_footer>
+              <.panel_footer_button phx-click="close_panel">
                 Cancel
-              </.button>
-              <.button
+              </.panel_footer_button>
+              <.panel_footer_button
                 form="log-sink-form"
                 type="submit"
                 style="primary"
                 disabled={not @form.source.valid?}
               >
                 Save
-              </.button>
-            </div>
+              </.panel_footer_button>
+            </.panel_footer>
           </div>
         </div>
       <% else %>

--- a/elixir/lib/portal_web/live/settings/trust_anchors/index.ex
+++ b/elixir/lib/portal_web/live/settings/trust_anchors/index.ex
@@ -226,14 +226,14 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
               <.trust_anchor_form_fields form={@form} input_mode={@input_mode} uploads={@uploads} />
             </div>
 
-            <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border bg-elevated">
-              <.button type="button" phx-click="close_panel" size="sm">
+            <.panel_footer>
+              <.panel_footer_button type="button" phx-click="close_panel">
                 Cancel
-              </.button>
-              <.button type="submit" style="primary" size="sm">
+              </.panel_footer_button>
+              <.panel_footer_button type="submit" style="primary">
                 Create
-              </.button>
-            </div>
+              </.panel_footer_button>
+            </.panel_footer>
           </.form>
         </div>
       </div>
@@ -271,14 +271,14 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
               <.trust_anchor_form_fields form={@form} input_mode={@input_mode} uploads={@uploads} />
             </div>
 
-            <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border bg-elevated">
-              <.button type="button" phx-click="close_panel" size="sm">
+            <.panel_footer>
+              <.panel_footer_button type="button" phx-click="close_panel">
                 Cancel
-              </.button>
-              <.button type="submit" style="primary" size="sm">
+              </.panel_footer_button>
+              <.panel_footer_button type="submit" style="primary">
                 Save
-              </.button>
-            </div>
+              </.panel_footer_button>
+            </.panel_footer>
           </.form>
         </div>
       </div>

--- a/elixir/lib/portal_web/live/sites/components.ex
+++ b/elixir/lib/portal_web/live/sites/components.ex
@@ -1750,14 +1750,14 @@ defmodule PortalWeb.Sites.Components do
 
   def resource_form_actions(assigns) do
     ~H"""
-    <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border bg-elevated">
-      <.button type="button" phx-click="close_add_resource" size="xs">
+    <.panel_footer>
+      <.panel_footer_button type="button" phx-click="close_add_resource">
         Cancel
-      </.button>
-      <.button type="submit" style="primary" size="xs">
+      </.panel_footer_button>
+      <.panel_footer_button type="submit" style="primary">
         Create Resource
-      </.button>
-    </div>
+      </.panel_footer_button>
+    </.panel_footer>
     """
   end
 
@@ -1804,14 +1804,14 @@ defmodule PortalWeb.Sites.Components do
             </p>
           </div>
         </div>
-        <div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border bg-elevated">
-          <.button type="button" phx-click="cancel_site_edit_form" size="sm">
+        <.panel_footer>
+          <.panel_footer_button type="button" phx-click="cancel_site_edit_form">
             Cancel
-          </.button>
-          <.button type="submit" style="primary" size="sm" class="font-medium">
+          </.panel_footer_button>
+          <.panel_footer_button type="submit" style="primary" class="font-medium">
             Save
-          </.button>
-        </div>
+          </.panel_footer_button>
+        </.panel_footer>
       </.form>
     </div>
     """

--- a/elixir/test/portal_web/components/form_components_test.exs
+++ b/elixir/test/portal_web/components/form_components_test.exs
@@ -1,0 +1,54 @@
+defmodule PortalWeb.FormComponentsTest.Fixture do
+  use Phoenix.Component
+
+  import PortalWeb.FormComponents
+
+  def render(assigns) do
+    ~H"""
+    <.panel_footer class="test-footer">
+      <.panel_footer_button id="cancel" phx-click="close_panel">
+        Cancel
+      </.panel_footer_button>
+      <.panel_footer_button id="save" type="submit" style="primary" disabled>
+        Save
+      </.panel_footer_button>
+      <.panel_footer_button id="back" patch="/groups">
+        Back
+      </.panel_footer_button>
+    </.panel_footer>
+    """
+  end
+end
+
+defmodule PortalWeb.FormComponentsTest do
+  use PortalWeb.ConnCase, async: true
+
+  test "panel footer composes consistently sized base buttons" do
+    html =
+      render_component(&PortalWeb.FormComponentsTest.Fixture.render/1, %{})
+      |> Floki.parse_fragment!()
+
+    assert [footer] = Floki.find(html, ".test-footer")
+    assert "py-3" in classes(footer)
+
+    assert [cancel, save] = Floki.find(footer, "button")
+    assert [back] = Floki.find(footer, "a")
+
+    for action <- [cancel, save, back] do
+      assert "text-xs" in classes(action)
+      assert "px-3" in classes(action)
+      assert "py-1.5" in classes(action)
+    end
+
+    assert Floki.attribute(cancel, "phx-click") == ["close_panel"]
+    assert Floki.attribute(save, "disabled") == ["disabled"]
+    assert Floki.attribute(back, "href") == ["/groups"]
+  end
+
+  defp classes(element) do
+    element
+    |> Floki.attribute("class")
+    |> List.first("")
+    |> String.split()
+  end
+end


### PR DESCRIPTION
In some panels we were using `md` (default) size buttons (in settings forms) and in other places we were using `xs` size.

This adds shared panel footer components that standardize slide-over action button sizing. Existing portal panels now use the shared components instead of defining their footer layout and button sizes individually.

---

Related: #14422