### PR TITLE
feat(portal): flow logs ui

### DIFF
--- a/elixir/lib/portal/repo/filter.ex
+++ b/elixir/lib/portal/repo/filter.ex
@@ -30,7 +30,10 @@ defmodule Portal.Repo.Filter do
 
   @type numeric_type :: :integer | :number
   @type datetime_type :: :date | :time | :datetime
-  @type binary_type :: :string | {:string, :email | :phone_number | :uuid | :websearch | :select}
+  @type binary_type ::
+          :string
+          | {:string,
+             :email | :phone_number | :uuid | :websearch | :websearch_wide | :protocol_port | :select}
   @type range_type :: {:range, numeric_type() | datetime_type()}
   @type type ::
           :boolean
@@ -242,6 +245,8 @@ defmodule Portal.Repo.Filter do
   defp value_type_valid?({:string, :email}, value), do: is_binary(value)
   defp value_type_valid?({:string, :phone_number}, value), do: is_binary(value)
   defp value_type_valid?({:string, :websearch}, value), do: is_binary(value)
+  defp value_type_valid?({:string, :websearch_wide}, value), do: is_binary(value)
+  defp value_type_valid?({:string, :protocol_port}, value), do: is_binary(value)
   defp value_type_valid?({:string, :select}, value), do: is_binary(value)
   defp value_type_valid?({:string, :uuid}, value), do: is_binary(value)
   defp value_type_valid?(:string, value), do: is_binary(value)

--- a/elixir/lib/portal_api/controllers/log_json.ex
+++ b/elixir/lib/portal_api/controllers/log_json.ex
@@ -16,6 +16,8 @@ defmodule PortalAPI.LogJSON do
     %{data: data(log)}
   end
 
+  def flow_log(%FlowLog{} = log), do: data(log)
+
   defp data(%ChangeLog{} = log) do
     %{
       type: "change",
@@ -47,14 +49,26 @@ defmodule PortalAPI.LogJSON do
       initiator_device_id: log.initiator_device_id,
       responder_device_id: log.responder_device_id,
       role: log.role,
+      policy_authorization_id: log.policy_authorization_id,
+      policy_id: log.policy_id,
       protocol: log.protocol,
       flow_start: log.flow_start,
       flow_end: log.flow_end,
       last_packet: log.last_packet,
+      authorized_at: log.authorized_at,
+      authorization_expires_at: log.authorization_expires_at,
       initiator_auth_provider_id: log.initiator_auth_provider_id,
       initiator_actor_id: log.initiator_actor_id,
       initiator_actor_name: log.initiator_actor_name,
       initiator_actor_email: log.initiator_actor_email,
+      initiator_client_version: log.initiator_client_version,
+      initiator_device_os_name: log.initiator_device_os_name,
+      initiator_device_os_version: log.initiator_device_os_version,
+      initiator_device_serial: log.initiator_device_serial,
+      initiator_device_uuid: log.initiator_device_uuid,
+      initiator_device_identifier_for_vendor: log.initiator_device_identifier_for_vendor,
+      initiator_device_firebase_installation_id:
+        log.initiator_device_firebase_installation_id,
       resource_id: log.resource_id,
       resource_name: log.resource_name,
       resource_address: log.resource_address,

--- a/elixir/lib/portal_api/schemas/log_schema.ex
+++ b/elixir/lib/portal_api/schemas/log_schema.ex
@@ -184,8 +184,16 @@ defmodule PortalAPI.Schemas.Log do
           Which of the two endpoints reported this entry: `initiator` means
           `initiator_device_id` wrote it, `responder` means
           `responder_device_id` did. Gateways always report `responder`;
-          Clients report either role.
+            Clients report either role.
           """
+        },
+        policy_authorization_id: %Schema{
+          type: :string,
+          description: "ID of the Policy Authorization that permitted the flow."
+        },
+        policy_id: %Schema{
+          type: :string,
+          description: "ID of the Policy that permitted the flow."
         },
         protocol: %Schema{
           type: :string,
@@ -204,12 +212,24 @@ defmodule PortalAPI.Schemas.Log do
         flow_end: %Schema{
           type: :string,
           format: :"date-time",
-          description: "RFC 3339 timestamp of when the flow ended."
+          nullable: true,
+          description: "RFC 3339 timestamp of when the flow ended. Null while the flow is open."
         },
         last_packet: %Schema{
           type: :string,
           format: :"date-time",
-          description: "When the last packet of the flow was seen."
+          nullable: true,
+          description: "When the last packet was seen. Null while the flow is open."
+        },
+        authorized_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "When access to the Resource was authorized."
+        },
+        authorization_expires_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "When the Policy Authorization expires."
         },
         initiator_auth_provider_id: %Schema{
           type: :string,
@@ -229,9 +249,48 @@ defmodule PortalAPI.Schemas.Log do
         },
         initiator_actor_name: %Schema{type: :string, nullable: true},
         initiator_actor_email: %Schema{type: :string, nullable: true},
+        initiator_client_version: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Firezone Client version reported by the initiating Client."
+        },
+        initiator_device_os_name: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Operating system reported by the initiating Client."
+        },
+        initiator_device_os_version: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Operating system version reported by the initiating Client."
+        },
+        initiator_device_serial: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Device serial number reported by the initiating Client."
+        },
+        initiator_device_uuid: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Device UUID reported by the initiating Client."
+        },
+        initiator_device_identifier_for_vendor: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Vendor identifier reported by the initiating Client."
+        },
+        initiator_device_firebase_installation_id: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Firebase installation ID reported by the initiating Client."
+        },
         resource_id: %Schema{type: :string, description: "ID of the Resource accessed."},
         resource_name: %Schema{type: :string},
-        resource_address: %Schema{type: :string},
+        resource_address: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Resource address, when the Resource type has one."
+        },
         inner_src_ip: %Schema{
           type: :string,
           description: "Tunnel IP of the initiator, on both entries of the flow."
@@ -263,19 +322,27 @@ defmodule PortalAPI.Schemas.Log do
         outer_dst_port: %Schema{type: :integer},
         rx_packets: %Schema{
           type: :integer,
-          description: "Packets sent responder-to-initiator, as counted by the reporting side."
+          nullable: true,
+          description:
+            "Packets sent responder-to-initiator, as counted by the reporting side. Null while the flow is open."
         },
         tx_packets: %Schema{
           type: :integer,
-          description: "Packets sent initiator-to-responder, as counted by the reporting side."
+          nullable: true,
+          description:
+            "Packets sent initiator-to-responder, as counted by the reporting side. Null while the flow is open."
         },
         rx_bytes: %Schema{
           type: :integer,
-          description: "Bytes sent responder-to-initiator, as counted by the reporting side."
+          nullable: true,
+          description:
+            "Bytes sent responder-to-initiator, as counted by the reporting side. Null while the flow is open."
         },
         tx_bytes: %Schema{
           type: :integer,
-          description: "Bytes sent initiator-to-responder, as counted by the reporting side."
+          nullable: true,
+          description:
+            "Bytes sent initiator-to-responder, as counted by the reporting side. Null while the flow is open."
         }
       },
       required: [
@@ -285,10 +352,14 @@ defmodule PortalAPI.Schemas.Log do
         :initiator_device_id,
         :responder_device_id,
         :role,
+        :policy_authorization_id,
+        :policy_id,
         :protocol,
         :flow_start,
         :flow_end,
         :last_packet,
+        :authorized_at,
+        :authorization_expires_at,
         :resource_id,
         :resource_name,
         :resource_address,
@@ -312,11 +383,18 @@ defmodule PortalAPI.Schemas.Log do
         "initiator_device_id" => "11e7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "responder_device_id" => "9d3a1c40-5f2b-4c8e-9a71-0b6d4e2f8c13",
         "role" => "responder",
+        "policy_authorization_id" => "6fa1d58f-0289-42e6-a3ba-7edfa46ee2d5",
+        "policy_id" => "46f997d1-77c8-4936-8655-8f050dffbfa4",
         "protocol" => "tcp",
         "flow_start" => "2026-05-26T12:30:00.000Z",
         "flow_end" => "2026-05-26T12:34:00.000Z",
         "last_packet" => "2026-05-26T12:33:58.000Z",
+        "authorized_at" => "2026-05-26T12:29:00.000Z",
+        "authorization_expires_at" => "2026-05-26T20:29:00.000Z",
         "initiator_actor_email" => "user@example.com",
+        "initiator_client_version" => "1.5.1",
+        "initiator_device_os_name" => "macOS",
+        "initiator_device_os_version" => "15.5",
         "resource_id" => "44e7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "resource_name" => "GitLab",
         "resource_address" => "gitlab.company.com",

--- a/elixir/lib/portal_web.ex
+++ b/elixir/lib/portal_web.ex
@@ -147,6 +147,7 @@ defmodule PortalWeb do
   def components do
     quote do
       use Gettext, backend: PortalWeb.Gettext
+      import PortalWeb.AuthorizationComponents
       import PortalWeb.CoreComponents
       import PortalWeb.NavigationComponents
       import PortalWeb.FormComponents

--- a/elixir/lib/portal_web/components/authorization_components.ex
+++ b/elixir/lib/portal_web/components/authorization_components.ex
@@ -1,0 +1,23 @@
+defmodule PortalWeb.AuthorizationComponents do
+  @moduledoc "Shared UI for policy authorization views."
+
+  use Phoenix.Component
+  use PortalWeb, :verified_routes
+
+  attr :account, :any, required: true
+
+  def authorization_flow_logs_notice(assigns) do
+    ~H"""
+    <div
+      data-authorization-flow-logs-notice
+      class="shrink-0 border-b border-border bg-raised/40 px-4 py-2 text-xs text-subtle"
+    >
+      See
+      <.link navigate={~p"/#{@account}/logs/flow_logs"} class="text-brand">
+        <span class="hover:underline">flow logs</span>
+      </.link>
+      for detailed access logs.
+    </div>
+    """
+  end
+end

--- a/elixir/lib/portal_web/components/table_components.ex
+++ b/elixir/lib/portal_web/components/table_components.ex
@@ -79,6 +79,7 @@ defmodule PortalWeb.TableComponents do
   attr :patch, :any, default: nil, doc: "the function for generating patch path for each row"
   attr :click, :any, default: nil, doc: "fn(row) -> patch path for row-level phx-click"
   attr :selected, :boolean, default: false, doc: "whether this row is currently selected"
+  attr :class, :any, default: nil, doc: "additional classes for the table row"
 
   attr :columns, :any, required: true, doc: "col slot taken from parent component"
   attr :actions, :list, required: true, doc: "action slot taken from parent component"
@@ -95,7 +96,8 @@ defmodule PortalWeb.TableComponents do
         "border-b border-border group transition-colors",
         @selected && "border-l-4 border-l-brand bg-raised",
         not @selected && (@patch || @click) && "hover:cursor-pointer hover:bg-raised",
-        @selected && (@patch || @click) && "cursor-pointer"
+        @selected && (@patch || @click) && "cursor-pointer",
+        @class
       ]}
       phx-click={@click && "table_row_click"}
       phx-value-path={@click && @click.(@row)}

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -390,9 +390,10 @@ defmodule PortalWeb.Clients.Components do
   def client_policy_authorizations_tab(assigns) do
     ~H"""
     <div class="flex-1 flex flex-col overflow-hidden">
+      <.authorization_flow_logs_notice account={@account} />
       <div
         :if={@policy_authorizations == []}
-        class="flex flex-col items-center justify-center h-full gap-2 text-subtle"
+        class="flex flex-1 flex-col items-center justify-center gap-2 text-subtle"
       >
         <.icon name="ri-shield-check-line" class="w-8 h-8" />
         <p class="text-sm">No recent authorizations</p>

--- a/elixir/lib/portal_web/live/logs/components.ex
+++ b/elixir/lib/portal_web/live/logs/components.ex
@@ -105,6 +105,53 @@ defmodule PortalWeb.Logs.Components do
 
   def format_ip(other), do: to_string(other)
 
+  @doc "Renders an initiating Client and its outer source IP."
+  attr :device_name, :string, required: true
+  attr :outer_src_ip, :any, required: true
+
+  def flow_client_cell(assigns) do
+    ~H"""
+    <div class="min-w-0">
+      <div class="truncate text-xs text-[var(--text-primary)]">{@device_name}</div>
+      <div class="truncate font-mono text-xs text-[var(--text-tertiary)]">
+        {format_ip(@outer_src_ip) || "-"}
+      </div>
+    </div>
+    """
+  end
+
+  @doc "Renders a Resource and its protocol/application destination."
+  attr :name, :string, required: true
+  attr :domain, :string, default: nil
+  attr :protocol, :atom, required: true
+  attr :ip, :any, required: true
+  attr :port, :integer, required: true
+
+  def flow_resource_cell(assigns) do
+    assigns = assign(assigns, :endpoint, format_endpoint(assigns.domain || assigns.ip, assigns.port))
+
+    ~H"""
+    <div class="min-w-0">
+      <div class="truncate text-xs text-[var(--text-primary)]">{@name}</div>
+      <div class="flex min-w-0 items-center gap-1.5 font-mono text-xs text-[var(--text-tertiary)]">
+        <span class="shrink-0 uppercase">{@protocol}</span>
+        <span class="shrink-0">·</span>
+        <span class="truncate">{@endpoint}</span>
+      </div>
+    </div>
+    """
+  end
+
+  def format_endpoint(ip, port) do
+    ip = format_ip(ip) || "-"
+
+    if String.contains?(ip, ":") do
+      "[#{ip}]:#{port}"
+    else
+      "#{ip}:#{port}"
+    end
+  end
+
   @doc """
   Renders a colored rectangular badge for an insert/update/delete operation.
   """

--- a/elixir/lib/portal_web/live/logs/flow_logs.ex
+++ b/elixir/lib/portal_web/live/logs/flow_logs.ex
@@ -1,8 +1,112 @@
 defmodule PortalWeb.Logs.FlowLogs do
   use PortalWeb, :live_view
 
+  import PortalWeb.Logs.Components
+
+  alias __MODULE__.Database
+  alias PortalWeb.Logs.JSONDiff
+
+  @table_id "flow_logs"
+  @filter_key "flow_logs_filter"
+  @json_token_regex ~r/"(?:\\.|[^"\\])*"|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?|\b(?:true|false|null)\b/
+
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, page_title: "Flow Logs")}
+    browser_tz = browser_tz_from_connect(socket)
+
+    socket =
+      socket
+      |> assign(page_title: "Flow Logs")
+      |> assign(selected_report: nil, selected_report_json: nil, browser_tz: browser_tz)
+      |> assign(tz_mode: "utc", display_tz: "Etc/UTC")
+      |> assign_live_table(@table_id,
+        query_module: Database,
+        sortable_fields: [
+          {:flow_logs, :flow_start},
+          {:flow_logs, :total_bytes},
+          {:flow_logs, :log_id}
+        ],
+        callback: &handle_logs_update!/2
+      )
+
+    {:ok, socket}
+  end
+
+  def handle_params(
+        %{"log_id" => log_id} = params,
+        uri,
+        %{assigns: %{live_action: :show}} = socket
+      ) do
+    socket =
+      socket
+      |> assign_tz(params, @filter_key)
+      |> handle_live_tables_params(params, uri)
+
+    case Database.fetch_report(log_id, socket.assigns.subject) do
+      {:ok, report} ->
+        {:noreply,
+         assign(socket,
+           selected_report: report,
+           selected_report_json: flow_log_json(report.log)
+         )}
+
+      {:error, :not_found} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Flow log not found")
+         |> push_navigate(to: ~p"/#{socket.assigns.account}/logs/flow_logs")}
+
+      {:error, :unauthorized} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "You are not authorized to view this flow log")
+         |> push_navigate(to: ~p"/#{socket.assigns.account}/logs/flow_logs")}
+    end
+  end
+
+  def handle_params(params, uri, socket) do
+    socket =
+      socket
+      |> assign(selected_report: nil, selected_report_json: nil)
+      |> assign_tz(params, @filter_key)
+      |> handle_live_tables_params(params, uri)
+
+    {:noreply, socket}
+  end
+
+  def handle_event(event, params, socket)
+      when event in ["paginate", "order_by", "filter", "table_row_click", "change_limit"],
+      do: handle_live_table_event(event, params, socket)
+
+  def handle_event("close_panel", _params, socket) do
+    {:noreply,
+     push_patch(socket,
+       to: ~p"/#{socket.assigns.account}/logs/flow_logs?#{socket.assigns.query_params}"
+     )}
+  end
+
+  def handle_event("handle_keydown", %{"key" => "Escape"}, socket)
+      when not is_nil(socket.assigns.selected_report) do
+    {:noreply,
+     push_patch(socket,
+       to: ~p"/#{socket.assigns.account}/logs/flow_logs?#{socket.assigns.query_params}"
+     )}
+  end
+
+  def handle_event("handle_keydown", _params, socket), do: {:noreply, socket}
+
+  def handle_logs_update!(socket, list_opts) do
+    list_opts =
+      Keyword.update(list_opts, :filter, [show_incomplete: false], &default_show_incomplete/1)
+
+    with {:ok, logs, metadata} <- Database.list_flow_logs(socket.assigns.subject, list_opts) do
+      {:ok, assign(socket, flow_logs: logs, flow_logs_metadata: metadata)}
+    end
+  end
+
+  defp default_show_incomplete(filter) do
+    if Keyword.has_key?(filter, :show_incomplete),
+      do: filter,
+      else: [{:show_incomplete, false} | filter]
   end
 
   def render(assigns) do
@@ -10,45 +114,1076 @@ defmodule PortalWeb.Logs.FlowLogs do
     <div class="relative flex flex-col h-full overflow-hidden">
       <.logs_nav account={@account} current_path={@current_path} />
 
-      <div class="flex-1 min-h-0 overflow-y-auto p-6">
-        <div class="max-w-2xl mx-auto">
-          <div class="rounded-lg border border-[var(--border)] bg-[var(--surface)] overflow-hidden">
-            <div class="px-6 py-8 flex flex-col items-center text-center gap-4">
-              <div class="w-14 h-14 rounded-full border border-[var(--border)] bg-[var(--surface-raised)] flex items-center justify-center">
-                <.icon name="ri-exchange-line" class="w-7 h-7 text-[var(--brand)]" />
+      <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
+        <.live_table
+          id="flow_logs"
+          rows={@flow_logs}
+          row_id={&"flow-log-#{&1.log.log_id}"}
+          row_click={
+            fn row ->
+              ~p"/#{@account}/logs/flow_logs/#{row.log.log_id}?#{@query_params}"
+            end
+          }
+          row_selected={
+            fn row ->
+              not is_nil(@selected_report) and
+                row.log.log_id == @selected_report.log.log_id
+            end
+          }
+          row_class={&role_row_class/1}
+          filters={@filters_by_table_id["flow_logs"]}
+          filter={@filter_form_by_table_id["flow_logs"]}
+          ordered_by={@order_by_table_id["flow_logs"]}
+          metadata={@flow_logs_metadata}
+          class="flex-1 min-h-0"
+          row_item={& &1}
+        >
+          <:col :let={row} field={{:flow_logs, :flow_start}} label="Opened" class="w-44">
+            <span class="sr-only">Logged by {row.log.role}</span>
+            <.timestamp_cell
+              log_id={row.log.log_id}
+              timestamp={row.log.flow_start}
+              tz_mode={@tz_mode}
+              display_tz={@display_tz}
+            />
+          </:col>
+          <:col :let={row} label="Actor" class="w-64">
+            <.actor_cell subject={actor_subject(row.log)} />
+          </:col>
+          <:col :let={row} label="Client" class="w-52">
+            <.flow_client_cell
+              device_name={device_name(row.initiator_device, "Deleted client")}
+              outer_src_ip={row.log.outer_src_ip}
+            />
+          </:col>
+          <:col :let={row} label="Resource" class="w-72">
+            <.flow_resource_cell
+              name={row.log.resource_name}
+              domain={row.log.domain}
+              protocol={row.log.protocol}
+              ip={row.log.inner_dst_ip}
+              port={row.log.inner_dst_port}
+            />
+          </:col>
+          <:col :let={row} label="Duration" class="w-28">
+            <.flow_state log={row.log} />
+          </:col>
+          <:col
+            :let={row}
+            field={{:flow_logs, :total_bytes}}
+            label="Size"
+            class="w-28"
+          >
+            <span
+              class="font-mono text-xs tabular-nums text-[var(--text-secondary)]"
+              title="Total traffic in both directions"
+            >
+              {format_bytes(total_bytes(row.log))}
+            </span>
+          </:col>
+          <:empty>
+            <div class="flex flex-col items-center gap-3 py-16">
+              <div class="w-9 h-9 rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] flex items-center justify-center">
+                <.icon name="ri-exchange-line" class="w-5 h-5 text-[var(--text-tertiary)]" />
               </div>
-              <div>
-                <h3 class="text-base font-semibold text-[var(--text-primary)]">
-                  Flow Logs in the portal are coming soon!
-                </h3>
-                <p class="mt-2 text-sm text-[var(--text-secondary)] max-w-md mx-auto">
-                  In the meantime, flow logs can be emitted to stdout on your gateways by setting
-                  the environment variable below.
+              <div class="text-center">
+                <p class="text-sm font-medium text-[var(--text-primary)]">No flow logs</p>
+                <p class="text-xs text-[var(--text-tertiary)] mt-0.5">
+                  Logs from initiators and responders will appear here as flows are observed.
                 </p>
               </div>
+            </div>
+          </:empty>
+          <:footer>
+            <.log_sinks_notice account={@account} />
+          </:footer>
+        </.live_table>
+      </div>
 
-              <div class="w-full mt-2 rounded border border-[var(--border)] bg-[var(--surface-raised)]">
-                <div class="flex items-center justify-between px-3 py-2 border-b border-[var(--border)]">
-                  <span class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
-                    Gateway environment
-                  </span>
-                  <.icon name="ri-terminal-box-line" class="w-3.5 h-3.5 text-[var(--text-tertiary)]" />
+      <.show_panel id="flow-log-panel" open?={not is_nil(@selected_report)}>
+        <:title>
+          <%= if @selected_report do %>
+            <div id="flow-log-panel-title" class="flex min-w-0 items-center gap-2 text-sm">
+              <span class="truncate text-[var(--text-primary)]">
+                {@selected_report.log.initiator_actor_name || "Unknown actor"}
+                <span
+                  :if={@selected_report.log.initiator_actor_email not in [nil, ""]}
+                  class="text-[var(--text-tertiary)]"
+                >
+                  ({@selected_report.log.initiator_actor_email})
+                </span>
+              </span>
+              <.icon
+                name="ri-arrow-right-line"
+                class="h-4 w-4 shrink-0 text-[var(--text-tertiary)]"
+              />
+              <span class="truncate text-[var(--text-primary)]">
+                {@selected_report.log.resource_name}
+              </span>
+            </div>
+          <% end %>
+        </:title>
+
+        <div
+          :if={@selected_report}
+          class="flex-1 min-w-0 overflow-y-auto p-5 space-y-5"
+        >
+          <.match_notice
+            matching_logs={@selected_report.matching_logs}
+            selected_role={@selected_report.log.role}
+          />
+
+          <section>
+            <div class="flex items-center justify-between gap-3 mb-2">
+              <.section_heading label="Initiator and responder logs" />
+              <span class="text-xs text-[var(--text-tertiary)]">
+                Directions are normalized to initiator → responder
+              </span>
+            </div>
+            <div class="grid grid-cols-1 2xl:grid-cols-2 gap-3">
+              <.report_card
+                :for={log <- comparison_logs(@selected_report)}
+                log={log}
+                selected?={log.log_id == @selected_report.log.log_id}
+                path={~p"/#{@account}/logs/flow_logs/#{log.log_id}?#{@query_params}"}
+                tz_mode={@tz_mode}
+                display_tz={@display_tz}
+              />
+            </div>
+          </section>
+
+          <section>
+            <.section_heading label="Connection details" />
+            <div class="rounded border border-[var(--border)] bg-[var(--surface)] px-4 py-3">
+              <div class="flex items-center gap-3 min-w-0">
+                <div class="min-w-0 flex-1">
+                  <div class="text-xs text-[var(--text-tertiary)]">
+                    Initiator
+                  </div>
+                  <div class="mt-1 truncate font-mono text-xs text-[var(--text-primary)]">
+                    {format_endpoint(
+                      @selected_report.log.inner_src_ip,
+                      @selected_report.log.inner_src_port
+                    )}
+                  </div>
                 </div>
-                <pre class="px-3 py-3 text-left text-xs font-mono text-[var(--text-primary)] overflow-x-auto"><code>FIREZONE_FLOW_LOGS=true</code></pre>
+                <.icon name="ri-arrow-right-line" class="w-4 h-4 shrink-0 text-[var(--brand)]" />
+                <div class="min-w-0 flex-1 text-right">
+                  <div class="truncate text-xs text-[var(--text-tertiary)]">
+                    {destination_label(@selected_report.log)}
+                  </div>
+                  <div class="mt-1 truncate font-mono text-xs text-[var(--text-primary)]">
+                    {format_endpoint(
+                      @selected_report.log.inner_dst_ip,
+                      @selected_report.log.inner_dst_port
+                    )}
+                  </div>
+                </div>
               </div>
-
-              <div class="flex items-start gap-2 text-left rounded border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-xs text-[var(--text-secondary)] w-full">
-                <.icon name="ri-information-line" class="w-4 h-4 shrink-0 mt-0.5 text-[var(--brand)]" />
-                <span>
-                  Flow logs are written to stdout on the gateway process. Capture them with your
-                  log aggregator of choice.
+              <div
+                :if={@selected_report.log.domain}
+                class="mt-3 pt-3 border-t border-[var(--border)] text-xs text-[var(--text-secondary)]"
+              >
+                Resolved domain:
+                <span class="font-mono text-[var(--text-primary)]">
+                  {@selected_report.log.domain}
                 </span>
               </div>
             </div>
+          </section>
+
+          <.json_view id="flow-log-json" value={@selected_report_json} />
+        </div>
+
+        <.show_panel_sidebar :if={@selected_report}>
+          <section>
+            <.section_heading label="Log details" />
+            <dl class="space-y-2.5">
+              <.detail_row label="Logged by">
+                <div class="flex items-center gap-2">
+                  <.role_badge role={@selected_report.log.role} />
+                  <span class="truncate text-xs text-[var(--text-secondary)]">
+                    {reporter_device_name(@selected_report)}
+                  </span>
+                </div>
+              </.detail_row>
+              <.detail_row label="Received">
+                <.timestamp_cell
+                  id_prefix="panel-received"
+                  log_id={@selected_report.log.log_id}
+                  timestamp={@selected_report.log.inserted_at}
+                  tz_mode={@tz_mode}
+                  display_tz={@display_tz}
+                />
+              </.detail_row>
+              <.detail_row label="Log ID">
+                <.identifier value={@selected_report.log.log_id} />
+              </.detail_row>
+            </dl>
+          </section>
+
+          <div class="border-t border-[var(--border)]"></div>
+
+          <section>
+            <.section_heading label="Devices and resource" />
+            <dl class="space-y-2.5">
+              <.detail_row label="Actor">
+                <div class="text-xs text-[var(--text-primary)]">
+                  {@selected_report.log.initiator_actor_name}
+                </div>
+                <div
+                  :if={@selected_report.log.initiator_actor_email}
+                  class="truncate text-xs text-[var(--text-tertiary)]"
+                >
+                  {@selected_report.log.initiator_actor_email}
+                </div>
+              </.detail_row>
+              <.detail_row label="Initiator device">
+                <div class="text-xs text-[var(--text-secondary)]">
+                  {device_name(@selected_report.initiator_device, "Deleted client")}
+                </div>
+                <.identifier value={@selected_report.log.initiator_device_id} />
+              </.detail_row>
+              <.detail_row label="Responder device">
+                <div class="text-xs text-[var(--text-secondary)]">
+                  {device_name(@selected_report.responder_device, "Deleted responder")}
+                </div>
+                <.identifier value={@selected_report.log.responder_device_id} />
+              </.detail_row>
+              <.detail_row label="Resource">
+                <div class="text-xs text-[var(--text-primary)]">
+                  {@selected_report.log.resource_name}
+                </div>
+                <div
+                  :if={@selected_report.log.resource_address}
+                  class="truncate font-mono text-xs text-[var(--text-tertiary)]"
+                >
+                  {@selected_report.log.resource_address}
+                </div>
+                <.identifier value={@selected_report.log.resource_id} />
+              </.detail_row>
+            </dl>
+          </section>
+
+          <div class="border-t border-[var(--border)]"></div>
+
+          <section>
+            <.section_heading label="Authorization" />
+            <dl class="space-y-2.5">
+              <.detail_row label="Authorization ID">
+                <.identifier value={@selected_report.log.policy_authorization_id} />
+              </.detail_row>
+              <.detail_row label="Policy ID">
+                <.identifier value={@selected_report.log.policy_id} />
+              </.detail_row>
+              <.detail_row label="Authorized">
+                <.timestamp_cell
+                  id_prefix="panel-authorized"
+                  log_id={@selected_report.log.log_id}
+                  timestamp={@selected_report.log.authorized_at}
+                  tz_mode={@tz_mode}
+                  display_tz={@display_tz}
+                />
+              </.detail_row>
+              <.detail_row label="Expires">
+                <.timestamp_cell
+                  id_prefix="panel-expires"
+                  log_id={@selected_report.log.log_id}
+                  timestamp={@selected_report.log.authorization_expires_at}
+                  tz_mode={@tz_mode}
+                  display_tz={@display_tz}
+                />
+              </.detail_row>
+            </dl>
+          </section>
+
+          <div
+            :if={has_client_telemetry?(@selected_report.log)}
+            class="border-t border-[var(--border)]"
+          >
+          </div>
+
+          <section :if={has_client_telemetry?(@selected_report.log)}>
+            <.section_heading label="Initiator device details" />
+            <dl class="space-y-2.5">
+              <.detail_row :if={@selected_report.log.initiator_client_version} label="Client">
+                <.detail_value value={@selected_report.log.initiator_client_version} />
+              </.detail_row>
+              <.detail_row :if={@selected_report.log.initiator_device_os_name} label="Operating system">
+                <.detail_value value={os_label(@selected_report.log)} />
+              </.detail_row>
+              <.detail_row :if={@selected_report.log.initiator_device_serial} label="Serial">
+                <.identifier value={@selected_report.log.initiator_device_serial} />
+              </.detail_row>
+              <.detail_row :if={@selected_report.log.initiator_device_uuid} label="Device UUID">
+                <.identifier value={@selected_report.log.initiator_device_uuid} />
+              </.detail_row>
+              <.detail_row
+                :if={@selected_report.log.initiator_device_identifier_for_vendor}
+                label="Vendor identifier"
+              >
+                <.identifier value={@selected_report.log.initiator_device_identifier_for_vendor} />
+              </.detail_row>
+              <.detail_row
+                :if={@selected_report.log.initiator_device_firebase_installation_id}
+                label="Firebase installation"
+              >
+                <.identifier value={
+                  @selected_report.log.initiator_device_firebase_installation_id
+                } />
+              </.detail_row>
+              <.detail_row :if={@selected_report.log.initiator_auth_provider_id} label="Auth provider ID">
+                <.identifier value={@selected_report.log.initiator_auth_provider_id} />
+              </.detail_row>
+            </dl>
+          </section>
+        </.show_panel_sidebar>
+      </.show_panel>
+    </div>
+    """
+  end
+
+  attr :role, :atom, required: true
+
+  defp role_badge(assigns) do
+    ~H"""
+    <.badge type={if(@role == :initiator, do: "primary", else: "accent")} size="xs">
+      {if(@role == :initiator, do: "Initiator", else: "Responder")}
+    </.badge>
+    """
+  end
+
+  attr :log, :any, required: true
+
+  defp flow_state(assigns) do
+    assigns = assign(assigns, :skew?, clock_skew?(assigns.log))
+
+    ~H"""
+    <.badge :if={is_nil(@log.flow_end)} type="info" size="xs">Incomplete</.badge>
+    <.badge
+      :if={@skew?}
+      type="warning"
+      size="xs"
+      title="The reported flow end time is earlier than its start time, usually because the reporting device's clock changed or was out of sync."
+    >
+      Clock skew
+    </.badge>
+    <span
+      :if={not is_nil(@log.flow_end) and not @skew?}
+      class="text-xs tabular-nums text-[var(--text-secondary)]"
+    >
+      {format_duration(@log.flow_start, @log.flow_end)}
+    </span>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :value, :map, required: true
+
+  defp json_view(assigns) do
+    encoded = JSONDiff.pretty(assigns.value)
+
+    assigns = assign(assigns, :tokens, json_tokens(encoded))
+
+    ~H"""
+    <section id={@id} phx-hook="CopyClipboard">
+      <.section_heading label="Flow log JSON" />
+      <div class="relative">
+        <pre class="max-h-96 overflow-auto rounded border border-[var(--border)] bg-[var(--surface-raised)] p-4 pr-24 text-xs leading-5"><code id={"#{@id}-code"} class="block min-w-max" phx-no-format><span :for={token <- @tokens} class={json_token_class(token.kind)}><%= token.text %></span></code></pre>
+        <button
+          type="button"
+          data-copy-to-clipboard-target={"#{@id}-code"}
+          title="Copy JSON to clipboard"
+          class="absolute end-2 top-2 inline-flex h-8 items-center gap-1.5 rounded border border-[var(--control-border)] bg-[var(--surface)] px-2.5 text-xs text-[var(--text-secondary)] shadow-sm hover:text-[var(--text-primary)]"
+        >
+          <span id={"#{@id}-default-message"} class="inline-flex items-center gap-1.5">
+            <.icon name="ri-clipboard-line" data-icon class="h-3.5 w-3.5" /> Copy
+          </span>
+          <span id={"#{@id}-success-message"} class="hidden items-center gap-1.5">
+            <.icon name="ri-check-line" data-icon class="h-3.5 w-3.5 text-emerald-600" /> Copied
+          </span>
+        </button>
+      </div>
+    </section>
+    """
+  end
+
+  defp json_tokens(json) do
+    {groups, cursor} =
+      @json_token_regex
+      |> Regex.scan(json, return: :index, capture: :first)
+      |> Enum.map_reduce(0, fn [{start, length}], cursor ->
+        token_end = start + length
+        leading = binary_part(json, cursor, start - cursor)
+        token = binary_part(json, start, length)
+
+        {[
+           %{kind: :plain, text: leading},
+           %{kind: json_token_kind(token, json, token_end), text: token}
+         ], token_end}
+      end)
+
+    trailing = binary_part(json, cursor, byte_size(json) - cursor)
+
+    groups
+    |> List.flatten()
+    |> Kernel.++([%{kind: :plain, text: trailing}])
+    |> Enum.reject(&(&1.text == ""))
+  end
+
+  defp json_token_kind(<<"\"", _::binary>>, json, token_end) do
+    remainder = binary_part(json, token_end, byte_size(json) - token_end)
+
+    if remainder |> String.trim_leading() |> String.starts_with?(":"),
+      do: :key,
+      else: :string
+  end
+
+  defp json_token_kind(token, _json, _token_end) when token in ["true", "false"],
+    do: :boolean
+
+  defp json_token_kind("null", _json, _token_end), do: :null
+  defp json_token_kind(_token, _json, _token_end), do: :number
+
+  defp json_token_class(:key),
+    do: "json-key text-sky-700 dark:text-sky-300"
+
+  defp json_token_class(:string),
+    do: "json-string text-emerald-700 dark:text-emerald-300"
+
+  defp json_token_class(:number),
+    do: "json-number text-violet-700 dark:text-violet-300"
+
+  defp json_token_class(:boolean),
+    do: "json-boolean text-amber-700 dark:text-amber-300"
+
+  defp json_token_class(:null), do: "json-null text-[var(--text-tertiary)]"
+  defp json_token_class(:plain), do: nil
+
+  attr :matching_logs, :list, required: true
+  attr :selected_role, :atom, required: true
+
+  defp match_notice(assigns) do
+    assigns =
+      assign(assigns,
+        count: length(assigns.matching_logs),
+        other_role: if(assigns.selected_role == :initiator, do: "responder", else: "initiator")
+      )
+
+    ~H"""
+    <div
+      :if={@count == 0}
+      class="flex items-center gap-2 rounded border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-xs text-[var(--text-secondary)]"
+    >
+      <.icon name="ri-information-line" class="h-4 w-4 shrink-0 text-[var(--brand)]" />
+      <span>
+        No matching {@other_role} log was found. It may still be open, delayed, dropped, or beyond
+        the retention period.
+      </span>
+    </div>
+    <div
+      :if={@count == 1}
+      class="flex items-center gap-2 rounded border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-xs text-[var(--text-secondary)]"
+    >
+      <.icon name="ri-link" class="h-4 w-4 shrink-0 text-[var(--brand)]" />
+      <span>
+        Flow logs are paired on a best-effort basis.
+        <.link
+          href="https://www.firezone.dev/kb/audit-logs/flow#two-sided-reporting"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="font-medium text-[var(--brand)] hover:underline"
+        >
+          Read more
+        </.link>
+      </span>
+    </div>
+    <div
+      :if={@count > 1}
+      class="flex items-center gap-2 rounded border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200"
+    >
+      <.icon name="ri-alert-line" class="h-4 w-4 shrink-0" />
+      <span>
+        Multiple {@other_role} logs have the same flow details and overlapping time windows. Up to
+        the three closest matches are shown; none can be selected with certainty.
+      </span>
+    </div>
+    """
+  end
+
+  attr :log, :any, required: true
+  attr :selected?, :boolean, required: true
+  attr :path, :string, required: true
+  attr :tz_mode, :string, required: true
+  attr :display_tz, :string, required: true
+
+  defp report_card(assigns) do
+    ~H"""
+    <.link
+      id={"flow-log-card-#{@log.log_id}"}
+      patch={@path}
+      data-role={@log.role}
+      aria-current={if(@selected?, do: "page")}
+      class={[
+        "block rounded border bg-[var(--surface)] overflow-hidden transition-colors",
+        if(@selected?,
+          do: "border-[var(--brand)]/50",
+          else: "border-[var(--border)] hover:border-[var(--brand)]/50"
+        )
+      ]}
+    >
+      <div class="flex items-center justify-between gap-3 px-3 py-2 border-b border-[var(--border)] bg-[var(--surface-raised)]">
+        <div class="flex items-center gap-2 min-w-0">
+          <.role_badge role={@log.role} />
+          <span :if={@selected?} class="text-xs text-[var(--text-tertiary)]">
+            Selected log
+          </span>
+          <span
+            :if={not @selected?}
+            class="inline-flex items-center gap-1 text-xs text-[var(--brand)]"
+          >
+            View log <.icon name="ri-arrow-right-line" class="w-3 h-3" />
+          </span>
+        </div>
+        <.flow_state log={@log} />
+      </div>
+      <div class="p-3 space-y-3">
+        <dl class="grid grid-cols-2 gap-x-4 gap-y-2">
+          <.detail_row label="Started">
+            <.timestamp_cell
+              id_prefix={"report-start-#{@log.role}"}
+              log_id={@log.log_id}
+              timestamp={@log.flow_start}
+              tz_mode={@tz_mode}
+              display_tz={@display_tz}
+            />
+          </.detail_row>
+          <.detail_row label="Ended">
+            <.timestamp_cell
+              :if={@log.flow_end}
+              id_prefix={"report-end-#{@log.role}"}
+              log_id={@log.log_id}
+              timestamp={@log.flow_end}
+              tz_mode={@tz_mode}
+              display_tz={@display_tz}
+            />
+            <span :if={is_nil(@log.flow_end)} class="text-xs text-[var(--text-tertiary)]">Open</span>
+          </.detail_row>
+          <.detail_row label="Last packet">
+            <.timestamp_cell
+              :if={@log.last_packet}
+              id_prefix={"report-packet-#{@log.role}"}
+              log_id={@log.log_id}
+              timestamp={@log.last_packet}
+              tz_mode={@tz_mode}
+              display_tz={@display_tz}
+            />
+            <span :if={is_nil(@log.last_packet)} class="text-xs text-[var(--text-tertiary)]">-</span>
+          </.detail_row>
+          <.detail_row label="Log ID">
+            <.identifier value={@log.log_id} />
+          </.detail_row>
+        </dl>
+
+        <div class="grid grid-cols-2 gap-2">
+          <.metric label="Initiator → responder" value={format_bytes(@log.tx_bytes)} secondary={format_packets(@log.tx_packets)} />
+          <.metric label="Responder → initiator" value={format_bytes(@log.rx_bytes)} secondary={format_packets(@log.rx_packets)} />
+        </div>
+
+        <div class="pt-3 border-t border-[var(--border)]">
+          <div class="mb-1 text-xs text-[var(--text-tertiary)]">
+            WireGuard endpoints
+          </div>
+          <div class="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 text-xs">
+            <span class="text-[var(--text-tertiary)]">Initiator</span>
+            <span
+              data-wireguard-endpoint="initiator"
+              class="break-all text-right font-mono text-[var(--text-secondary)]"
+            >
+              {format_endpoint(@log.outer_src_ip, @log.outer_src_port)}
+            </span>
+            <span class="text-[var(--text-tertiary)]">Responder</span>
+            <span
+              data-wireguard-endpoint="responder"
+              class="break-all text-right font-mono text-[var(--text-secondary)]"
+            >
+              {format_endpoint(@log.outer_dst_ip, @log.outer_dst_port)}
+            </span>
           </div>
         </div>
       </div>
+    </.link>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :value, :string, required: true
+  attr :secondary, :string, required: true
+
+  defp metric(assigns) do
+    ~H"""
+    <div class="rounded bg-[var(--surface-raised)] px-3 py-2">
+      <div class="text-xs text-[var(--text-tertiary)]">{@label}</div>
+      <div class="mt-1 font-mono text-xs text-[var(--text-primary)]">{@value}</div>
+      <div class="font-mono text-xs text-[var(--text-tertiary)]">{@secondary}</div>
     </div>
     """
+  end
+
+  attr :value, :any, required: true
+
+  defp identifier(assigns) do
+    ~H"""
+    <span class="block font-mono text-xs text-[var(--text-secondary)] break-all">
+      {@value}
+    </span>
+    """
+  end
+
+  attr :value, :any, required: true
+
+  defp detail_value(assigns) do
+    ~H"""
+    <span class="text-xs text-[var(--text-secondary)]">{@value}</span>
+    """
+  end
+
+  defp comparison_logs(report) do
+    [report.log | report.matching_logs]
+    |> Enum.sort_by(&if(&1.role == :initiator, do: 0, else: 1))
+  end
+
+  defp role_row_class(%{log: %{role: :initiator}}),
+    do:
+      "!bg-brand/[0.025] hover:!bg-brand/[0.04] dark:!bg-brand/[0.04] dark:hover:!bg-brand/[0.06]"
+
+  defp role_row_class(%{log: %{role: :responder}}),
+    do:
+      "!bg-accent/[0.025] hover:!bg-accent/[0.04] dark:!bg-accent/[0.04] dark:hover:!bg-accent/[0.06]"
+
+  defp actor_subject(log) do
+    %{
+      "actor_name" => log.initiator_actor_name,
+      "actor_email" => log.initiator_actor_email
+    }
+  end
+
+  defp destination_label(log), do: log.domain || log.resource_name
+
+  defp flow_log_json(log) do
+    log
+    |> PortalAPI.LogJSON.flow_log()
+    |> JSON.encode!()
+    |> JSON.decode!()
+  end
+
+  defp reporter_device_name(%{log: %{role: :initiator}, initiator_device: device}),
+    do: device_name(device, "Deleted client")
+
+  defp reporter_device_name(%{log: %{role: :responder}, responder_device: device}),
+    do: device_name(device, "Deleted responder")
+
+  defp device_name(%{name: name}, _fallback) when name not in [nil, ""], do: name
+  defp device_name(_, fallback), do: fallback
+
+  defp format_duration(started_at, ended_at) do
+    seconds = DateTime.diff(ended_at, started_at, :second)
+
+    cond do
+      seconds < 60 -> "#{seconds}s"
+      seconds < 3_600 -> "#{div(seconds, 60)}m #{rem(seconds, 60)}s"
+      true -> "#{div(seconds, 3_600)}h #{div(rem(seconds, 3_600), 60)}m"
+    end
+  end
+
+  defp clock_skew?(%{flow_end: nil}), do: false
+
+  defp clock_skew?(%{flow_start: started_at, flow_end: ended_at}),
+    do: DateTime.compare(ended_at, started_at) == :lt
+
+  defp format_bytes(nil), do: "-"
+  defp format_bytes(bytes) when bytes < 1_000, do: "#{bytes} B"
+
+  defp format_bytes(bytes) do
+    {value, unit} =
+      cond do
+        bytes < 1_000_000 -> {bytes / 1_000, "KB"}
+        bytes < 1_000_000_000 -> {bytes / 1_000_000, "MB"}
+        bytes < 1_000_000_000_000 -> {bytes / 1_000_000_000, "GB"}
+        true -> {bytes / 1_000_000_000_000, "TB"}
+      end
+
+    formatted =
+      if value >= 100,
+        do: :erlang.float_to_binary(value, decimals: 0),
+        else: :erlang.float_to_binary(value, decimals: 1)
+
+    "#{formatted} #{unit}"
+  end
+
+  defp format_packets(nil), do: "No final packet count"
+  defp format_packets(1), do: "1 packet"
+  defp format_packets(count), do: "#{count} packets"
+
+  defp total_bytes(%{tx_bytes: nil, rx_bytes: nil}), do: nil
+
+  defp total_bytes(log),
+    do: (log.tx_bytes || 0) + (log.rx_bytes || 0)
+
+  defp has_client_telemetry?(log) do
+    Enum.any?(
+      [
+        log.initiator_client_version,
+        log.initiator_device_os_name,
+        log.initiator_device_os_version,
+        log.initiator_device_serial,
+        log.initiator_device_uuid,
+        log.initiator_device_identifier_for_vendor,
+        log.initiator_device_firebase_installation_id,
+        log.initiator_auth_provider_id
+      ],
+      &(&1 not in [nil, ""])
+    )
+  end
+
+  defp os_label(log) do
+    [log.initiator_device_os_name, log.initiator_device_os_version]
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join(" ")
+  end
+
+  defmodule Database do
+    import Ecto.Query
+
+    alias Portal.Device
+    alias Portal.FlowLog
+    alias Portal.Safe
+    alias Portal.Types.LogId
+
+    @candidate_limit 3
+
+    def list_flow_logs(subject, opts \\ []) do
+      {query, opts} =
+        from(fl in FlowLog, as: :flow_logs)
+        |> apply_total_bytes_order(opts)
+
+      result =
+        query
+        |> Safe.scoped(subject)
+        |> Safe.list_offset(__MODULE__, opts)
+
+      case result do
+        {:ok, logs, metadata} -> {:ok, enrich(logs, subject), metadata}
+        other -> other
+      end
+    end
+
+    defp apply_total_bytes_order(queryable, opts) do
+      order_by = Keyword.get(opts, :order_by, [])
+
+      case Enum.find(
+             order_by,
+             &match?(
+               {:flow_logs, direction, :total_bytes} when direction in [:asc, :desc],
+               &1
+             )
+           ) do
+        nil ->
+          {queryable, opts}
+
+        {:flow_logs, direction, :total_bytes} ->
+          remaining_order =
+            Enum.reject(order_by, &match?({:flow_logs, _, :total_bytes}, &1))
+
+          queryable = order_by_total_bytes(queryable, direction)
+          {queryable, Keyword.put(opts, :order_by, remaining_order)}
+      end
+    end
+
+    defp order_by_total_bytes(queryable, :asc) do
+      order_by(
+        queryable,
+        [flow_logs: fl],
+        asc_nulls_last:
+          fragment(
+            "CASE WHEN ? IS NULL AND ? IS NULL THEN NULL ELSE COALESCE(?::numeric, 0) + COALESCE(?::numeric, 0) END",
+            fl.tx_bytes,
+            fl.rx_bytes,
+            fl.tx_bytes,
+            fl.rx_bytes
+          )
+      )
+    end
+
+    defp order_by_total_bytes(queryable, :desc) do
+      order_by(
+        queryable,
+        [flow_logs: fl],
+        desc_nulls_last:
+          fragment(
+            "CASE WHEN ? IS NULL AND ? IS NULL THEN NULL ELSE COALESCE(?::numeric, 0) + COALESCE(?::numeric, 0) END",
+            fl.tx_bytes,
+            fl.rx_bytes,
+            fl.tx_bytes,
+            fl.rx_bytes
+          )
+      )
+    end
+
+    def fetch_report(log_id, subject) do
+      with {:ok, log_id} <- LogId.parse(log_id),
+           %FlowLog{} = log <- fetch_log(log_id, subject),
+           matching_logs when is_list(matching_logs) <- matching_logs(log, subject) do
+        [report] = enrich([log], subject)
+        {:ok, Map.put(report, :matching_logs, matching_logs)}
+      else
+        :error -> {:error, :not_found}
+        nil -> {:error, :not_found}
+        {:error, :unauthorized} -> {:error, :unauthorized}
+      end
+    end
+
+    def cursor_fields,
+      do: [{:flow_logs, :desc, :flow_start}, {:flow_logs, :desc, :log_id}]
+
+    def filters do
+      [
+        %Portal.Repo.Filter{
+          name: :search,
+          title: "actor, resource, IP, or log ID",
+          type: {:string, :websearch_wide},
+          fun: &filter_by_search/2
+        },
+        %Portal.Repo.Filter{
+          name: :role,
+          title: "Logged by",
+          type: :string,
+          values: [{"Initiator", "initiator"}, {"Responder", "responder"}],
+          fun: &filter_by_role/2
+        },
+        %Portal.Repo.Filter{
+          name: :protocol_port,
+          title: "Protocol / port",
+          type: {:string, :protocol_port},
+          fun: &filter_by_protocol_port/2
+        },
+        %Portal.Repo.Filter{
+          name: :show_incomplete,
+          title: "Show incomplete",
+          type: :boolean,
+          fun: &filter_show_incomplete/2
+        },
+        %Portal.Repo.Filter{
+          name: :timestamp,
+          title: "Flow started",
+          type: {:range, :datetime},
+          fun: &filter_by_timestamp/2
+        }
+      ]
+    end
+
+    defp fetch_log(log_id, subject) do
+      from(fl in FlowLog, as: :flow_logs, where: fl.log_id == ^log_id)
+      |> Safe.scoped(subject)
+      |> Safe.one()
+    end
+
+    # Both devices normalize the inner and WireGuard tuples to initiator ->
+    # responder. Exact attribution, protocol, tuple, and domain equality plus
+    # an overlapping time window narrows the matches, but cannot prove identity
+    # because independently created logs have no shared flow ID.
+    defp matching_logs(log, subject) do
+      opposite_role = if log.role == :initiator, do: :responder, else: :initiator
+      {selected_min, selected_max} = normalized_bounds(log)
+
+      query =
+        from(candidate in FlowLog,
+          as: :flow_logs,
+          where: candidate.role == ^opposite_role,
+          where: candidate.policy_authorization_id == ^log.policy_authorization_id,
+          where: candidate.initiator_device_id == ^log.initiator_device_id,
+          where: candidate.responder_device_id == ^log.responder_device_id,
+          where: candidate.resource_id == ^log.resource_id,
+          where: candidate.protocol == ^log.protocol,
+          where: candidate.inner_src_ip == ^log.inner_src_ip,
+          where: candidate.inner_src_port == ^log.inner_src_port,
+          where: candidate.inner_dst_ip == ^log.inner_dst_ip,
+          where: candidate.inner_dst_port == ^log.inner_dst_port,
+          where: candidate.outer_src_ip == ^log.outer_src_ip,
+          where: candidate.outer_src_port == ^log.outer_src_port,
+          where: candidate.outer_dst_ip == ^log.outer_dst_ip,
+          where: candidate.outer_dst_port == ^log.outer_dst_port,
+          where:
+            is_nil(candidate.flow_end) or
+              ^selected_min <= fragment("GREATEST(?, ?)", candidate.flow_start, candidate.flow_end),
+          order_by:
+            fragment(
+              "abs(extract(epoch from (? - ?)))",
+              candidate.flow_start,
+              ^log.flow_start
+            ),
+          limit: @candidate_limit
+        )
+        |> filter_candidate_domain(log.domain)
+        |> filter_candidate_upper_bound(selected_max)
+
+      query
+      |> Safe.scoped(subject)
+      |> Safe.all()
+    end
+
+    defp normalized_bounds(%{flow_start: started_at, flow_end: nil}), do: {started_at, nil}
+
+    defp normalized_bounds(%{flow_start: started_at, flow_end: ended_at}) do
+      if DateTime.compare(started_at, ended_at) == :gt,
+        do: {ended_at, started_at},
+        else: {started_at, ended_at}
+    end
+
+    defp filter_candidate_domain(query, nil),
+      do: where(query, [flow_logs: candidate], is_nil(candidate.domain))
+
+    defp filter_candidate_domain(query, domain),
+      do: where(query, [flow_logs: candidate], candidate.domain == ^domain)
+
+    defp filter_candidate_upper_bound(query, nil), do: query
+
+    defp filter_candidate_upper_bound(query, selected_max) do
+      where(
+        query,
+        [flow_logs: candidate],
+        fragment("LEAST(?, COALESCE(?, ?))", candidate.flow_start, candidate.flow_end, candidate.flow_start) <=
+          ^selected_max
+      )
+    end
+
+    defp enrich([], _subject), do: []
+
+    defp enrich(logs, subject) do
+      device_ids =
+        logs
+        |> Enum.flat_map(&[&1.initiator_device_id, &1.responder_device_id])
+        |> Enum.uniq()
+
+      devices_by_id =
+        from(device in Device, where: device.id in ^device_ids)
+        |> Safe.scoped(subject)
+        |> Safe.all()
+        |> case do
+          devices when is_list(devices) -> Map.new(devices, &{&1.id, &1})
+          _ -> %{}
+        end
+
+      Enum.map(logs, fn log ->
+        %{
+          log: log,
+          initiator_device: Map.get(devices_by_id, log.initiator_device_id),
+          responder_device: Map.get(devices_by_id, log.responder_device_id)
+        }
+      end)
+    end
+
+    defp filter_by_timestamp(queryable, %Portal.Repo.Filter.Range{from: from, to: to}) do
+      {queryable, timestamp_dynamic(from, to)}
+    end
+
+    # Keep the partition key bare in these predicates so PostgreSQL can prune
+    # the daily flow_start partitions selected by the UI's explicit Started
+    # filter.
+    defp timestamp_dynamic(%DateTime{} = from, %DateTime{} = to),
+      do: dynamic([flow_logs: fl], fl.flow_start >= ^from and fl.flow_start <= ^to)
+
+    defp timestamp_dynamic(%DateTime{} = from, nil),
+      do: dynamic([flow_logs: fl], fl.flow_start >= ^from)
+
+    defp timestamp_dynamic(nil, %DateTime{} = to),
+      do: dynamic([flow_logs: fl], fl.flow_start <= ^to)
+
+    defp filter_by_search(queryable, value) do
+      pattern = "%" <> value <> "%"
+
+      {queryable,
+       dynamic(
+         [flow_logs: fl],
+         fragment("? ILIKE ?", fl.initiator_actor_name, ^pattern) or
+           fragment("? ILIKE ?", fl.initiator_actor_email, ^pattern) or
+           fragment("? ILIKE ?", fl.resource_name, ^pattern) or
+           fragment("? ILIKE ?", fl.resource_address, ^pattern) or
+           fragment("? ILIKE ?", fl.domain, ^pattern) or
+           fragment("?::text ILIKE ?", fl.inner_src_ip, ^pattern) or
+           fragment("?::text ILIKE ?", fl.inner_dst_ip, ^pattern) or
+           fragment("?::text ILIKE ?", fl.outer_src_ip, ^pattern) or
+           fragment("?::text ILIKE ?", fl.outer_dst_ip, ^pattern) or
+           fragment("encode(?, 'hex') ILIKE ?", fl.log_id, ^pattern)
+       )}
+    end
+
+    defp filter_by_role(queryable, values) when is_list(values) and values != [] do
+      roles = Enum.map(values, &String.to_existing_atom/1)
+      {queryable, dynamic([flow_logs: fl], fl.role in ^roles)}
+    end
+
+    defp filter_by_role(queryable, value) when value in ["initiator", "responder"],
+      do: filter_by_role(queryable, [value])
+
+    defp filter_by_protocol_port(queryable, value) do
+      dynamic =
+        case parse_protocol_port(value) do
+          {:port, port} ->
+            dynamic([flow_logs: fl], fl.inner_dst_port == ^port)
+
+          {:protocol, protocol} ->
+            dynamic([flow_logs: fl], fl.protocol == ^protocol)
+
+          {:protocol_port, protocol, port} ->
+            dynamic(
+              [flow_logs: fl],
+              fl.protocol == ^protocol and fl.inner_dst_port == ^port
+            )
+
+          :error ->
+            dynamic(false)
+        end
+
+      {queryable, dynamic}
+    end
+
+    defp parse_protocol_port(value) do
+      value = value |> String.trim() |> String.downcase()
+
+      case String.split(value, ~r{[/:]}, parts: 2) do
+        [protocol, port] when protocol in ["tcp", "udp"] ->
+          with {:ok, port} <- parse_port(port) do
+            {:protocol_port, protocol_atom(protocol), port}
+          end
+
+        [protocol] when protocol in ["tcp", "udp"] ->
+          {:protocol, protocol_atom(protocol)}
+
+        [port] ->
+          case parse_port(port) do
+            {:ok, port} -> {:port, port}
+            :error -> :error
+          end
+
+        _other ->
+          :error
+      end
+    end
+
+    defp parse_port(value) do
+      case Integer.parse(value) do
+        {port, ""} when port in 0..65_535 -> {:ok, port}
+        _other -> :error
+      end
+    end
+
+    defp protocol_atom("tcp"), do: :tcp
+    defp protocol_atom("udp"), do: :udp
+
+    defp filter_show_incomplete(queryable, true), do: {queryable, nil}
+
+    defp filter_show_incomplete(queryable, false),
+      do: {queryable, dynamic([flow_logs: fl], not is_nil(fl.flow_end))}
   end
 end

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -1060,9 +1060,10 @@ defmodule PortalWeb.Policies.Components do
   def policy_authorizations_tab(assigns) do
     ~H"""
     <div class="flex-1 flex flex-col overflow-hidden">
+      <.authorization_flow_logs_notice account={@account} />
       <div
         :if={@policy_authorizations == []}
-        class="flex flex-col items-center justify-center h-full gap-2 text-subtle"
+        class="flex flex-1 flex-col items-center justify-center gap-2 text-subtle"
       >
         <.icon name="ri-shield-check-line" class="w-8 h-8" />
         <p class="text-sm">No recent authorizations</p>

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1739,9 +1739,10 @@ defmodule PortalWeb.Resources.Components do
   def resource_policy_authorizations_tab(assigns) do
     ~H"""
     <div class="flex-1 flex flex-col overflow-hidden">
+      <.authorization_flow_logs_notice account={@account} />
       <div
         :if={@policy_authorizations == []}
-        class="flex flex-col items-center justify-center h-full gap-2 text-subtle"
+        class="flex flex-1 flex-col items-center justify-center gap-2 text-subtle"
       >
         <.icon name="ri-shield-check-line" class="w-8 h-8" />
         <p class="text-sm">No recent policy authorizations</p>

--- a/elixir/lib/portal_web/live_table.ex
+++ b/elixir/lib/portal_web/live_table.ex
@@ -29,6 +29,7 @@ defmodule PortalWeb.LiveTable do
   attr :row_patch, :any, default: nil, doc: "the function for generating patch path for each row"
   attr :row_click, :any, default: nil, doc: "fn(row) -> patch path for row click"
   attr :row_selected, :any, default: nil, doc: "fn(row) -> boolean indicating if row is selected"
+  attr :row_class, :any, default: nil, doc: "fn(row) -> additional classes for the table row"
 
   attr :row_item, :any,
     default: &Function.identity/1,
@@ -83,6 +84,7 @@ defmodule PortalWeb.LiveTable do
               patch={@row_patch}
               click={@row_click}
               selected={not is_nil(@row_selected) and @row_selected.(row)}
+              class={@row_class && @row_class.(row)}
               mapper={@row_item}
             />
           </tbody>
@@ -329,9 +331,20 @@ defmodule PortalWeb.LiveTable do
     """
   end
 
-  defp filter(%{filter: %{type: {:string, :websearch}}} = assigns) do
+  defp filter(%{filter: %{type: {:string, search_type}}} = assigns)
+       when search_type in [:websearch, :websearch_wide] do
+    assigns =
+      assign(
+        assigns,
+        :width_class,
+        if(search_type == :websearch_wide, do: "sm:w-80 lg:w-96", else: "sm:w-64")
+      )
+
     ~H"""
-    <div class="relative w-full sm:w-64 shrink-0" phx-feedback-for={@form[@filter.name].name}>
+    <div
+      class={["relative w-full shrink-0", @width_class]}
+      phx-feedback-for={@form[@filter.name].name}
+    >
       <.icon name="ri-search-line" class="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-subtle pointer-events-none" />
       <input
         type="text"
@@ -339,6 +352,73 @@ defmodule PortalWeb.LiveTable do
         id={@form[@filter.name].id}
         value={Phoenix.HTML.Form.normalize_value("text", @form[@filter.name].value)}
         placeholder={"Search by " <> @filter.title}
+        phx-debounce="300"
+        class={[
+          "w-full pl-8 pr-3 py-1.5 text-xs font-medium rounded border h-8",
+          "bg-input border-input-border text-heading",
+          "placeholder:text-muted placeholder:font-normal outline-none transition-colors",
+          "focus:border-border-focus focus:ring-1 focus:ring-border-focus/30",
+          @form[@filter.name].errors != [] && "border-rose-400"
+        ]}
+      />
+      <.error
+        :for={msg <- @form[@filter.name].errors}
+        data-validation-error-for={@form[@filter.name].name}
+      >
+        {msg}
+      </.error>
+    </div>
+    """
+  end
+
+  defp filter(%{filter: %{type: :integer}} = assigns) do
+    ~H"""
+    <div class="relative w-24 shrink-0" phx-feedback-for={@form[@filter.name].name}>
+      <input
+        type="number"
+        name={@form[@filter.name].name}
+        id={@form[@filter.name].id}
+        value={Phoenix.HTML.Form.normalize_value("number", @form[@filter.name].value)}
+        min="0"
+        max="65535"
+        step="1"
+        inputmode="numeric"
+        placeholder="Port"
+        aria-label={@filter.title}
+        phx-debounce="300"
+        class={[
+          "w-full px-3 py-1.5 text-xs font-medium rounded border h-8",
+          "bg-input border-input-border text-heading",
+          "placeholder:text-muted placeholder:font-normal outline-none transition-colors",
+          "focus:border-border-focus focus:ring-1 focus:ring-border-focus/30",
+          @form[@filter.name].errors != [] && "border-rose-400"
+        ]}
+      />
+      <.error
+        :for={msg <- @form[@filter.name].errors}
+        data-validation-error-for={@form[@filter.name].name}
+      >
+        {msg}
+      </.error>
+    </div>
+    """
+  end
+
+  defp filter(%{filter: %{type: {:string, :protocol_port}}} = assigns) do
+    ~H"""
+    <div class="relative w-36 shrink-0" phx-feedback-for={@form[@filter.name].name}>
+      <.icon name="ri-route-line" class="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-subtle pointer-events-none" />
+      <input
+        type="text"
+        name={@form[@filter.name].name}
+        id={@form[@filter.name].id}
+        value={Phoenix.HTML.Form.normalize_value("text", @form[@filter.name].value)}
+        placeholder="Port or tcp/443"
+        aria-label={@filter.title}
+        title="Enter a port, protocol, or protocol/port pair: 443, tcp, or udp/53"
+        autocapitalize="none"
+        autocomplete="off"
+        spellcheck="false"
         phx-debounce="300"
         class={[
           "w-full pl-8 pr-3 py-1.5 text-xs font-medium rounded border h-8",
@@ -1004,6 +1084,16 @@ defmodule PortalWeb.LiveTable do
 
   defp cast_filter(value, :boolean) when value in ["true", true], do: {:ok, true}
   defp cast_filter(value, :boolean) when value in ["false", false], do: {:ok, false}
+  defp cast_filter("", :integer), do: {:ok, nil}
+  defp cast_filter(value, :integer) when is_integer(value), do: {:ok, value}
+
+  defp cast_filter(value, :integer) when is_binary(value) do
+    case Integer.parse(value) do
+      {integer, ""} -> {:ok, integer}
+      _ -> {:error, :invalid_filter}
+    end
+  end
+
   defp cast_filter(value, _type), do: cast_filter(value)
 
   defp cast_filter(%{"from" => from_raw, "to" => to_raw}) do

--- a/elixir/lib/portal_web/router.ex
+++ b/elixir/lib/portal_web/router.ex
@@ -263,6 +263,7 @@ defmodule PortalWeb.Router do
         live "/session_logs", SessionLogs
         live "/session_logs/:log_id", SessionLogs, :show
         live "/flow_logs", FlowLogs
+        live "/flow_logs/:log_id", FlowLogs, :show
         live "/api_request_logs", APIRequestLogs
         live "/api_request_logs/:log_id", APIRequestLogs, :show
       end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -18,6 +18,7 @@ defmodule Portal.Repo.Seeds do
     Entra,
     ExternalIdentity,
     Device,
+    FlowLog,
     PolicyAuthorization,
     Google,
     Group,
@@ -253,6 +254,259 @@ defmodule Portal.Repo.Seeds do
       |> Repo.update!()
 
     {:ok, client}
+  end
+
+  defp create_seed_policy_authorization(
+         subject,
+         initiating_device,
+         receiving_device,
+         resource,
+         policy,
+         membership
+       ) do
+    %PolicyAuthorization{
+      initiating_device_id: initiating_device.id,
+      receiving_device_id: receiving_device.id,
+      resource_id: resource.id,
+      policy_id: policy.id,
+      membership_id: membership && membership.id,
+      account_id: subject.account.id,
+      token_id: subject.credential.id,
+      initiator_remote_ip: {127, 0, 0, 1},
+      initiator_user_agent: @ua_ios,
+      receiver_remote_ip: %Postgrex.INET{address: {189, 172, 73, 153}, netmask: nil},
+      expires_at: subject.expires_at || DateTime.add(DateTime.utc_now(), 1, :hour)
+    }
+    |> Repo.insert!()
+  end
+
+  # Seeds logs from each device rather than pre-aggregated flows. The recent rows
+  # deliberately cover the states the Flow Logs UI needs to communicate:
+  # paired TCP/UDP logs, an open initiator log, a responder-only log,
+  # an invalid-looking interval caused by clock skew, and a one-to-many
+  # overlap that must be labeled ambiguous rather than silently rolled up.
+  defp seed_flow_logs(account, actor, initiator, auth_provider_id, contexts) do
+    now = DateTime.utc_now()
+
+    base = %{
+      account: account,
+      actor: actor,
+      initiator: initiator,
+      auth_provider_id: auth_provider_id,
+      inserted_at: now
+    }
+
+    google = Map.merge(base, contexts.google)
+    httpbin = Map.merge(base, contexts.httpbin)
+    network = Map.merge(base, contexts.network)
+    iperf = Map.merge(base, contexts.iperf)
+
+    open_report =
+      seed_flow_log_row(google, %{
+        role: :initiator,
+        protocol: :tcp,
+        inner_src_port: 54_001,
+        inner_dst_port: 443,
+        flow_start: DateTime.add(now, -2, :minute),
+        flow_end: nil
+      })
+
+    recent_tcp =
+      paired_seed_flow_logs(httpbin, %{
+        protocol: :tcp,
+        inner_src_port: 54_002,
+        inner_dst_port: 443,
+        flow_start: DateTime.add(now, -8, :minute),
+        flow_end: DateTime.add(now, -3, :minute),
+        tx_packets: 6_240,
+        rx_packets: 5_980,
+        tx_bytes: 8_400_000,
+        rx_bytes: 42_700_000
+      })
+
+    recent_udp =
+      paired_seed_flow_logs(google, %{
+        protocol: :udp,
+        inner_src_port: 54_003,
+        inner_dst_port: 53,
+        flow_start: DateTime.add(now, -14, :minute),
+        flow_end: DateTime.add(now, -12, :minute),
+        tx_packets: 24,
+        rx_packets: 22,
+        tx_bytes: 2_480,
+        rx_bytes: 9_720
+      })
+
+    responder_only =
+      seed_flow_log_row(network, %{
+        role: :responder,
+        protocol: :tcp,
+        inner_src_port: 54_004,
+        inner_dst_port: 22,
+        flow_start: DateTime.add(now, -22, :minute),
+        flow_end: DateTime.add(now, -20, :minute)
+      })
+
+    clock_skewed =
+      seed_flow_log_row(iperf, %{
+        role: :initiator,
+        protocol: :tcp,
+        inner_src_port: 54_005,
+        inner_dst_port: 5_201,
+        flow_start: DateTime.add(now, -30, :minute),
+        flow_end: DateTime.add(now, -31, :minute),
+        tx_packets: 8_440,
+        rx_packets: 8_120,
+        tx_bytes: 640_000_000,
+        rx_bytes: 612_000_000
+      })
+
+    # The initiator sees one long flow while the responder sees two sequential
+    # windows for the same tuple. Both overlap the initiator window, so neither
+    # responder can be selected as a guaranteed match from the current fields.
+    ambiguous_attrs = %{
+      protocol: :tcp,
+      inner_src_port: 54_006,
+      inner_dst_port: 80
+    }
+
+    ambiguous = [
+      seed_flow_log_row(
+        httpbin,
+        Map.merge(ambiguous_attrs, %{
+          role: :initiator,
+          flow_start: DateTime.add(now, -55, :minute),
+          flow_end: DateTime.add(now, -30, :minute),
+          tx_packets: 940,
+          rx_packets: 860,
+          tx_bytes: 2_800_000,
+          rx_bytes: 18_600_000
+        })
+      ),
+      seed_flow_log_row(
+        httpbin,
+        Map.merge(ambiguous_attrs, %{
+          role: :responder,
+          flow_start: DateTime.add(now, -54, :minute),
+          flow_end: DateTime.add(now, -43, :minute),
+          tx_packets: 410,
+          rx_packets: 380,
+          tx_bytes: 1_200_000,
+          rx_bytes: 8_100_000
+        })
+      ),
+      seed_flow_log_row(
+        httpbin,
+        Map.merge(ambiguous_attrs, %{
+          role: :responder,
+          flow_start: DateTime.add(now, -42, :minute),
+          flow_end: DateTime.add(now, -29, :minute),
+          tx_packets: 525,
+          rx_packets: 475,
+          tx_bytes: 1_580_000,
+          rx_bytes: 10_420_000
+        })
+      )
+    ]
+
+    historical =
+      1..6
+      |> Enum.flat_map(fn i ->
+        context = Enum.at([google, httpbin, iperf], rem(i - 1, 3))
+        protocol = if rem(i, 3) == 0, do: :udp, else: :tcp
+        started_at = DateTime.add(now, -i * 8, :hour)
+
+        paired_seed_flow_logs(context, %{
+          protocol: protocol,
+          inner_src_port: 55_000 + i,
+          inner_dst_port: if(protocol == :udp, do: 5_201, else: context.default_port),
+          flow_start: started_at,
+          flow_end: DateTime.add(started_at, 90 + i * 20, :second),
+          tx_packets: 80 * i,
+          rx_packets: 65 * i,
+          tx_bytes: 240_000 * i,
+          rx_bytes: 1_100_000 * i
+        })
+      end)
+
+    rows =
+      [open_report]
+      |> Kernel.++(recent_tcp)
+      |> Kernel.++(recent_udp)
+      |> Kernel.++([responder_only, clock_skewed])
+      |> Kernel.++(ambiguous)
+      |> Kernel.++(historical)
+
+    {count, _} = Repo.insert_all(FlowLog, rows)
+    IO.puts("Created #{count} flow logs")
+    IO.puts("")
+  end
+
+  defp paired_seed_flow_logs(context, attrs) do
+    initiator = seed_flow_log_row(context, Map.put(attrs, :role, :initiator))
+
+    responder_attrs =
+      attrs
+      |> Map.put(:role, :responder)
+      |> Map.update!(:flow_start, &DateTime.add(&1, 2, :second))
+      |> Map.update!(:flow_end, &DateTime.add(&1, 3, :second))
+      |> Map.put(:tx_packets, max(Map.get(attrs, :tx_packets, 120) - 2, 0))
+      |> Map.put(:rx_packets, max(Map.get(attrs, :rx_packets, 96) - 2, 0))
+      |> Map.put(:tx_bytes, max(Map.get(attrs, :tx_bytes, 600_000) - 1_200, 0))
+      |> Map.put(:rx_bytes, max(Map.get(attrs, :rx_bytes, 1_800_000) - 2_400, 0))
+
+    [initiator, seed_flow_log_row(context, responder_attrs)]
+  end
+
+  defp seed_flow_log_row(context, attrs) do
+    flow_end = Map.fetch!(attrs, :flow_end)
+    closed? = not is_nil(flow_end)
+
+    %{
+      account_id: context.account.id,
+      log_id: LogId.build_flow_log(),
+      initiator_device_id: context.initiator.id,
+      responder_device_id: context.authorization.receiving_device_id,
+      role: Map.fetch!(attrs, :role),
+      policy_authorization_id: context.authorization.id,
+      policy_id: context.authorization.policy_id,
+      resource_id: context.resource.id,
+      resource_name: context.resource.name,
+      resource_address: context.resource.address,
+      authorized_at: context.authorization.inserted_at,
+      authorization_expires_at: context.authorization.expires_at,
+      initiator_actor_id: context.actor.id,
+      initiator_actor_name: context.actor.name,
+      initiator_actor_email: context.actor.email,
+      initiator_auth_provider_id: context.auth_provider_id,
+      initiator_client_version: context.initiator.last_seen_version,
+      initiator_device_os_name: "iOS",
+      initiator_device_os_version: "18.7.7",
+      initiator_device_serial: context.initiator.device_serial,
+      initiator_device_uuid: context.initiator.device_uuid,
+      initiator_device_identifier_for_vendor: context.initiator.identifier_for_vendor,
+      initiator_device_firebase_installation_id: context.initiator.firebase_installation_id,
+      protocol: Map.fetch!(attrs, :protocol),
+      inner_src_ip: context.initiator.ipv4,
+      inner_src_port: Map.fetch!(attrs, :inner_src_port),
+      inner_dst_ip: context.inner_dst_ip,
+      inner_dst_port: Map.fetch!(attrs, :inner_dst_port),
+      domain: context.domain,
+      # connlib normalizes both logs to initiator -> responder, including the
+      # WireGuard tuple, so paired logs intentionally carry the same values.
+      outer_src_ip: {203, 0, 113, 44},
+      outer_src_port: 62_000,
+      outer_dst_ip: {189, 172, 73, 153},
+      outer_dst_port: 51_820,
+      flow_start: Map.fetch!(attrs, :flow_start),
+      flow_end: flow_end,
+      last_packet: if(closed?, do: Map.get(attrs, :last_packet, DateTime.add(flow_end, -1, :second))),
+      tx_packets: if(closed?, do: Map.get(attrs, :tx_packets, 120)),
+      rx_packets: if(closed?, do: Map.get(attrs, :rx_packets, 96)),
+      tx_bytes: if(closed?, do: Map.get(attrs, :tx_bytes, 600_000)),
+      rx_bytes: if(closed?, do: Map.get(attrs, :rx_bytes, 1_800_000)),
+      inserted_at: context.inserted_at
+    }
   end
 
   # Seeds a mix of change_logs, session_logs, and api_request_logs so the
@@ -1898,7 +2152,7 @@ defmodule Portal.Repo.Seeds do
       {:ok, policy}
     end
 
-    {:ok, policy} =
+    {:ok, google_policy} =
       create_policy.(
         %{
           description: "All Access To Google",
@@ -1968,7 +2222,7 @@ defmodule Portal.Repo.Seeds do
         admin_subject
       )
 
-    {:ok, _} =
+    {:ok, cidr_policy} =
       create_policy.(
         %{
           description: "All Access To Network",
@@ -1988,7 +2242,7 @@ defmodule Portal.Repo.Seeds do
         admin_subject
       )
 
-    {:ok, _} =
+    {:ok, httpbin_policy} =
       create_policy.(
         %{
           description: "All Access To **.httpbin",
@@ -2028,7 +2282,7 @@ defmodule Portal.Repo.Seeds do
         admin_subject
       )
 
-    {:ok, _} =
+    {:ok, iperf_policy} =
       create_policy.(
         %{
           description: "All Access To iperf3.test",
@@ -2075,22 +2329,76 @@ defmodule Portal.Repo.Seeds do
         actor_id: unprivileged_actor.id
       )
 
-    # Create policy_authorization directly without context module
-    _policy_authorization =
-      %PolicyAuthorization{
-        initiating_device_id: user_iphone.id,
-        receiving_device_id: gateway1.id,
-        resource_id: cidr_resource.id,
-        policy_id: policy.id,
-        membership_id: membership.id,
-        account_id: unprivileged_subject.account.id,
-        token_id: unprivileged_subject.credential.id,
-        initiator_remote_ip: {127, 0, 0, 1},
-        initiator_user_agent: @ua_ios,
-        receiver_remote_ip: %Postgrex.INET{address: {189, 172, 73, 153}, netmask: nil},
-        expires_at: unprivileged_subject.expires_at || DateTime.utc_now() |> DateTime.add(3600)
+    cidr_authorization =
+      create_seed_policy_authorization(
+        unprivileged_subject,
+        user_iphone,
+        gateway1,
+        cidr_resource,
+        cidr_policy,
+        membership
+      )
+
+    google_authorization =
+      create_seed_policy_authorization(
+        unprivileged_subject,
+        user_iphone,
+        gateway1,
+        dns_google_resource,
+        google_policy,
+        nil
+      )
+
+    httpbin_authorization =
+      create_seed_policy_authorization(
+        unprivileged_subject,
+        user_iphone,
+        gateway1,
+        dns_httpbin_resource,
+        httpbin_policy,
+        nil
+      )
+
+    iperf_authorization =
+      create_seed_policy_authorization(
+        unprivileged_subject,
+        user_iphone,
+        gateway1,
+        iperf_resource,
+        iperf_policy,
+        nil
+      )
+
+    seed_flow_logs(account, unprivileged_actor, user_iphone, userpass_provider.id, %{
+      google: %{
+        authorization: google_authorization,
+        resource: dns_google_resource,
+        inner_dst_ip: {100, 96, 0, 10},
+        domain: dns_google_resource.address,
+        default_port: 443
+      },
+      httpbin: %{
+        authorization: httpbin_authorization,
+        resource: dns_httpbin_resource,
+        inner_dst_ip: {100, 96, 0, 20},
+        domain: "api.httpbin",
+        default_port: 443
+      },
+      network: %{
+        authorization: cidr_authorization,
+        resource: cidr_resource,
+        inner_dst_ip: {172, 20, 10, 25},
+        domain: nil,
+        default_port: 22
+      },
+      iperf: %{
+        authorization: iperf_authorization,
+        resource: iperf_resource,
+        inner_dst_ip: {100, 96, 0, 30},
+        domain: iperf_resource.address,
+        default_port: 5_201
       }
-      |> Repo.insert!()
+    })
 
     # Populate the audit log tables so /logs pages have realistic data on
     # first boot. Uses a spread of recent timestamps across the seeded

--- a/elixir/test/portal/repo/filter_test.exs
+++ b/elixir/test/portal/repo/filter_test.exs
@@ -110,6 +110,7 @@ defmodule Portal.Repo.FilterTest do
             {{:string, :email}, "foo@example.com"},
             {{:string, :phone_number}, "+15671112233"},
             {{:string, :uuid}, Ecto.UUID.generate()},
+            {{:string, :protocol_port}, "tcp/443"},
             {:list, ["a", "b"], "a"},
             {:list, ["a", "b"], "b"},
             {{:range, :datetime}, %Filter.Range{from: DateTime.utc_now()}},

--- a/elixir/test/portal_api/controllers/log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/log_controller_test.exs
@@ -359,7 +359,17 @@ defmodule PortalAPI.LogControllerTest do
     end
 
     test "renders flow log fields", %{conn: conn, account: account, actor: actor} do
-      flow_log = flow_log_fixture(account: account)
+      flow_log =
+        flow_log_fixture(
+          account: account,
+          initiator_client_version: "1.5.1",
+          initiator_device_os_name: "macOS",
+          initiator_device_os_version: "15.5",
+          initiator_device_serial: "C02ABC123",
+          initiator_device_uuid: "0C4A8D24-FA9F-4E56-9B57-40D0D46A245E",
+          initiator_device_identifier_for_vendor: "C242BC21-AB4A-4F6D-B755-F50E2B5B51B7",
+          initiator_device_firebase_installation_id: "firebase-installation-id"
+        )
 
       conn =
         conn
@@ -367,13 +377,45 @@ defmodule PortalAPI.LogControllerTest do
         |> get(~p"/logs?type=flow")
 
       assert %{"data" => [data]} = json_response(conn, 200)
+
+      expected_keys =
+        Portal.FlowLog.__schema__(:fields)
+        |> Enum.reject(&(&1 in [:account_id, :seq, :start_seq]))
+        |> Enum.map(fn
+          :inserted_at -> "timestamp"
+          :domain -> "inner_domain"
+          field -> Atom.to_string(field)
+        end)
+        |> MapSet.new()
+        |> MapSet.put("type")
+
+      assert MapSet.new(Map.keys(data)) == expected_keys
       assert data["log_id"] == flow_log.log_id
       assert data["initiator_device_id"] == flow_log.initiator_device_id
       assert data["responder_device_id"] == flow_log.responder_device_id
       assert data["role"] == "responder"
+      assert data["policy_authorization_id"] == flow_log.policy_authorization_id
+      assert data["policy_id"] == flow_log.policy_id
       assert data["protocol"] == "tcp"
+      assert data["authorized_at"] == DateTime.to_iso8601(flow_log.authorized_at)
+
+      assert data["authorization_expires_at"] ==
+               DateTime.to_iso8601(flow_log.authorization_expires_at)
+
       assert data["initiator_actor_id"] == flow_log.initiator_actor_id
       assert data["initiator_actor_email"] == "user@example.com"
+      assert data["initiator_client_version"] == "1.5.1"
+      assert data["initiator_device_os_name"] == "macOS"
+      assert data["initiator_device_os_version"] == "15.5"
+      assert data["initiator_device_serial"] == "C02ABC123"
+      assert data["initiator_device_uuid"] == "0C4A8D24-FA9F-4E56-9B57-40D0D46A245E"
+
+      assert data["initiator_device_identifier_for_vendor"] ==
+               "C242BC21-AB4A-4F6D-B755-F50E2B5B51B7"
+
+      assert data["initiator_device_firebase_installation_id"] ==
+               "firebase-installation-id"
+
       assert data["resource_id"] == flow_log.resource_id
       assert data["resource_name"] == "GitLab"
       assert data["resource_address"] == "gitlab.company.com"
@@ -387,6 +429,44 @@ defmodule PortalAPI.LogControllerTest do
       assert data["tx_packets"] == 80
       assert data["rx_bytes"] == 102_400
       assert data["tx_bytes"] == 20_480
+      refute Map.has_key?(data, "account_id")
+      refute Map.has_key?(data, "seq")
+      refute Map.has_key?(data, "start_seq")
+    end
+
+    test "renders and documents incomplete flow fields as null", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      flow_log_fixture(
+        account: account,
+        flow_end: nil,
+        last_packet: nil,
+        rx_packets: nil,
+        tx_packets: nil,
+        rx_bytes: nil,
+        tx_bytes: nil,
+        resource_address: nil
+      )
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> get(~p"/logs?type=flow")
+
+      assert %{"data" => [data]} = json_response(conn, 200)
+
+      for field <- ~w[flow_end last_packet rx_packets tx_packets rx_bytes tx_bytes resource_address] do
+        assert Map.fetch!(data, field) == nil
+      end
+
+      schema = PortalAPI.Schemas.Log.Flow.schema()
+
+      for field <- ~w[flow_end last_packet rx_packets tx_packets rx_bytes tx_bytes resource_address]a do
+        assert schema.properties[field].nullable
+        assert field in schema.required
+      end
     end
 
     test "filters by actor_id", %{conn: conn, account: account, actor: actor} do

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -497,12 +497,18 @@ defmodule PortalWeb.ClientsTest do
     } do
       client = client_fixture(account: account, actor: actor)
 
-      {:ok, _lv, html} =
+      {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/clients/#{client.id}?tab=authorizations")
 
       assert html =~ "No recent authorizations"
+
+      assert has_element?(
+               lv,
+               "[data-authorization-flow-logs-notice] a[href='#{~p"/#{account}/logs/flow_logs"}']",
+               "flow logs"
+             )
     end
 
     test "Authorizations tab renders resource and group name", %{

--- a/elixir/test/portal_web/live/logs/change_logs_test.exs
+++ b/elixir/test/portal_web/live/logs/change_logs_test.exs
@@ -804,15 +804,4 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
     end
   end
 
-  describe "flow_logs" do
-    test "renders the coming soon message", %{conn: conn, account: account, actor: actor} do
-      {:ok, _lv, html} =
-        conn
-        |> authorize_conn(actor)
-        |> live(~p"/#{account}/logs/flow_logs")
-
-      assert html =~ "Flow Logs in the portal are coming soon"
-      assert html =~ "FIREZONE_FLOW_LOGS=true"
-    end
-  end
 end

--- a/elixir/test/portal_web/live/logs/flow_logs_test.exs
+++ b/elixir/test/portal_web/live/logs/flow_logs_test.exs
@@ -1,0 +1,547 @@
+defmodule PortalWeb.Logs.FlowLogsTest do
+  use PortalWeb.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.FlowLogFixtures
+
+  setup do
+    account = account_fixture()
+    actor = admin_actor_fixture(account: account)
+    %{account: account, actor: actor}
+  end
+
+  describe "index" do
+    test "renders the empty flow logs table", %{conn: conn, account: account, actor: actor} do
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/logs/flow_logs")
+
+      assert html =~ "No flow logs"
+      refute html =~ "coming soon"
+    end
+
+    test "lists each reporting side separately", %{conn: conn, account: account, actor: actor} do
+      identity = %{
+        account: account,
+        policy_authorization_id: Ecto.UUID.generate(),
+        initiator_device_id: Ecto.UUID.generate(),
+        responder_device_id: Ecto.UUID.generate(),
+        resource_id: Ecto.UUID.generate(),
+        flow_start: ~U[2026-07-30 10:00:00.000000Z],
+        flow_end: ~U[2026-07-30 10:01:00.000000Z],
+        outer_src_ip: %Postgrex.INET{address: {203, 0, 113, 10}},
+        tx_bytes: 1_600_000,
+        rx_bytes: 10_400_000
+      }
+
+      initiator = flow_log_fixture(Map.put(identity, :role, :initiator))
+
+      responder =
+        flow_log_fixture(
+          identity
+          |> Map.put(:role, :responder)
+          |> Map.put(:flow_start, ~U[2026-07-30 10:00:01.000000Z])
+          |> Map.put(:flow_end, ~U[2026-07-30 10:01:02.000000Z])
+        )
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/logs/flow_logs")
+
+      assert html =~ initiator.log_id
+      assert html =~ responder.log_id
+      assert html =~ "Initiator"
+      assert html =~ "Responder"
+      assert html =~ "Some User"
+      assert html =~ "user@example.com"
+      assert html =~ "203.0.113.10"
+      assert html =~ "GitLab"
+
+      assert has_element?(lv, "#flow_logs-header th", "Opened")
+      assert has_element?(lv, "#flow_logs-header th", "Actor")
+      assert has_element?(lv, "#flow_logs-header th", "Client")
+      assert has_element?(lv, "#flow_logs-header th", "Resource")
+      assert has_element?(lv, "#flow_logs-header th", "Duration")
+      assert has_element?(lv, "#flow_logs-header th", "Size")
+      refute has_element?(lv, "#flow_logs-header th", "Initiator")
+      refute has_element?(lv, "#flow_logs-header th", "Destination")
+      refute has_element?(lv, "#flow_logs-header th", "Last packet")
+      refute has_element?(lv, "#flow_logs-header th", "Logged by")
+      refute has_element?(lv, "#flow_logs-header th", "Protocol")
+      refute has_element?(lv, "#flow_logs-header th", "Clock skew")
+
+      assert has_element?(lv, "#flow-log-#{initiator.log_id}", "12.0 MB")
+
+      assert has_element?(
+               lv,
+               "#flow_logs-header button[phx-value-order_by='flow_logs:asc:total_bytes']"
+             )
+
+      initiator_row = lv |> element("#flow-log-#{initiator.log_id}") |> render()
+      responder_row = lv |> element("#flow-log-#{responder.log_id}") |> render()
+      assert initiator_row =~ "!bg-brand/[0.025]"
+      assert initiator_row =~ "dark:!bg-brand/[0.04]"
+      assert responder_row =~ "!bg-accent/[0.025]"
+      assert responder_row =~ "dark:!bg-accent/[0.04]"
+
+      assert has_element?(lv, "#flow_logs-role-initiator[type='radio'][value='initiator']")
+      assert has_element?(lv, "#flow_logs-role-responder[type='radio'][value='responder']")
+      refute has_element?(lv, "#flow_logs-protocol-tcp")
+      refute has_element?(lv, "#flow_logs-protocol-udp")
+    end
+
+    test "sorts by total size", %{conn: conn, account: account, actor: actor} do
+      smallest =
+        flow_log_fixture(
+          account: account,
+          tx_bytes: 40,
+          rx_bytes: 60,
+          flow_start: ~U[2026-07-30 10:00:00.000000Z]
+        )
+
+      largest =
+        flow_log_fixture(
+          account: account,
+          tx_bytes: 200,
+          rx_bytes: 300,
+          flow_start: ~U[2026-07-30 10:01:00.000000Z]
+        )
+
+      middle =
+        flow_log_fixture(
+          account: account,
+          tx_bytes: 80,
+          rx_bytes: 120,
+          flow_start: ~U[2026-07-30 10:02:00.000000Z]
+        )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(
+          ~p"/#{account}/logs/flow_logs?flow_logs_order_by=flow_logs:desc:total_bytes"
+        )
+
+      row_ids =
+        html
+        |> Floki.parse_fragment!()
+        |> Floki.find("#flow_logs-rows > tr")
+        |> Floki.attribute("id")
+
+      assert row_ids == [
+               "flow-log-#{largest.log_id}",
+               "flow-log-#{middle.log_id}",
+               "flow-log-#{smallest.log_id}"
+             ]
+    end
+
+    test "filters on flow_start and reporting role", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      initiator =
+        flow_log_fixture(
+          account: account,
+          role: :initiator,
+          protocol: :tcp,
+          flow_start: ~U[2026-07-30 10:00:00.000000Z],
+          flow_end: ~U[2026-07-30 10:01:00.000000Z]
+        )
+
+      responder =
+        flow_log_fixture(
+          account: account,
+          role: :responder,
+          flow_start: ~U[2026-07-29 10:00:00.000000Z],
+          flow_end: ~U[2026-07-29 10:01:00.000000Z]
+        )
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(
+          ~p"/#{account}/logs/flow_logs?flow_logs_filter[role]=initiator&flow_logs_filter[timestamp][from]=2026-07-30T00:00:00Z"
+        )
+
+      assert has_element?(lv, "#flow_logs-role-initiator[checked]")
+      assert html =~ initiator.log_id
+      refute html =~ responder.log_id
+    end
+
+    test "filters by protocol and destination port in one input", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      tcp_443 = flow_log_fixture(account: account, protocol: :tcp, inner_dst_port: 443)
+      udp_443 = flow_log_fixture(account: account, protocol: :udp, inner_dst_port: 443)
+      udp_53 = flow_log_fixture(account: account, protocol: :udp, inner_dst_port: 53)
+
+      conn = authorize_conn(conn, actor)
+
+      {:ok, lv, html} =
+        live(
+          conn,
+          ~p"/#{account}/logs/flow_logs?flow_logs_filter[protocol_port]=tcp/443"
+        )
+
+      assert has_element?(
+               lv,
+               "input[type='text'][name='flow_logs[protocol_port]'][placeholder='Port or tcp/443'][value='tcp/443']"
+             )
+
+      assert html =~ tcp_443.log_id
+      refute html =~ udp_443.log_id
+      refute html =~ udp_53.log_id
+
+      {:ok, _lv, port_html} =
+        live(conn, ~p"/#{account}/logs/flow_logs?flow_logs_filter[protocol_port]=53")
+
+      assert port_html =~ udp_53.log_id
+      refute port_html =~ tcp_443.log_id
+      refute port_html =~ udp_443.log_id
+    end
+
+    test "searches inner and WireGuard IPs with the compact port filter", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      matching =
+        flow_log_fixture(
+          account: account,
+          inner_dst_ip: %Postgrex.INET{address: {10, 20, 30, 40}},
+          inner_dst_port: 8_443,
+          outer_src_ip: %Postgrex.INET{address: {203, 0, 113, 77}}
+        )
+
+      wrong_port =
+        flow_log_fixture(
+          account: account,
+          inner_dst_ip: %Postgrex.INET{address: {10, 20, 30, 40}},
+          inner_dst_port: 443,
+          outer_src_ip: %Postgrex.INET{address: {203, 0, 113, 77}}
+        )
+
+      wrong_ip =
+        flow_log_fixture(
+          account: account,
+          inner_dst_ip: %Postgrex.INET{address: {10, 20, 30, 41}},
+          inner_dst_port: 8_443,
+          outer_src_ip: %Postgrex.INET{address: {203, 0, 113, 78}}
+        )
+
+      conn = authorize_conn(conn, actor)
+
+      {:ok, lv, html} =
+        live(
+          conn,
+          ~p"/#{account}/logs/flow_logs?flow_logs_filter[search]=203.0.113.77&flow_logs_filter[protocol_port]=8443"
+        )
+
+      assert has_element?(
+               lv,
+               "input[type='text'][name='flow_logs[protocol_port]'][value='8443']"
+             )
+
+      assert html =~ matching.log_id
+      refute html =~ wrong_port.log_id
+      refute html =~ wrong_ip.log_id
+
+      {:ok, _lv, inner_ip_html} =
+        live(
+          conn,
+          ~p"/#{account}/logs/flow_logs?flow_logs_filter[search]=10.20.30.40&flow_logs_filter[protocol_port]=8443"
+        )
+
+      assert inner_ip_html =~ matching.log_id
+      refute inner_ip_html =~ wrong_port.log_id
+      refute inner_ip_html =~ wrong_ip.log_id
+    end
+
+    test "hides incomplete flows by default and includes them with a toggle", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      complete = flow_log_fixture(account: account)
+      incomplete = flow_log_fixture(account: account, flow_end: nil)
+      conn = authorize_conn(conn, actor)
+
+      {:ok, lv, html} = live(conn, ~p"/#{account}/logs/flow_logs")
+
+      assert has_element?(lv, "#flow_logs-show_incomplete-toggle:not([checked])")
+      assert html =~ complete.log_id
+      refute html =~ incomplete.log_id
+
+      {:ok, lv, html} =
+        live(
+          conn,
+          ~p"/#{account}/logs/flow_logs?flow_logs_filter[show_incomplete]=true"
+        )
+
+      assert has_element?(lv, "#flow_logs-show_incomplete-toggle[checked]")
+      assert html =~ complete.log_id
+      assert html =~ incomplete.log_id
+      assert has_element?(lv, "#flow-log-#{incomplete.log_id}", "Incomplete")
+    end
+
+    test "shows clock skew in the duration cell", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      log =
+        flow_log_fixture(
+          account: account,
+          flow_start: ~U[2026-07-30 10:01:00.000000Z],
+          flow_end: ~U[2026-07-30 10:00:00.000000Z]
+        )
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/logs/flow_logs")
+
+      assert has_element?(
+               lv,
+               "#flow-log-#{log.log_id} [title*='reported flow end time is earlier']",
+               "Clock skew"
+             )
+    end
+  end
+
+  describe "show" do
+    test "shows a plausible overlapping report without claiming a definite pair", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      identity = %{
+        account: account,
+        policy_authorization_id: Ecto.UUID.generate(),
+        initiator_device_id: Ecto.UUID.generate(),
+        responder_device_id: Ecto.UUID.generate(),
+        resource_id: Ecto.UUID.generate(),
+        protocol: :tcp,
+        inner_src_ip: %Postgrex.INET{address: {100, 64, 0, 8}},
+        inner_src_port: 51_234,
+        inner_dst_ip: %Postgrex.INET{address: {10, 0, 0, 9}},
+        inner_dst_port: 443,
+        outer_src_ip: %Postgrex.INET{address: {203, 0, 113, 44}},
+        outer_src_port: 62_000,
+        outer_dst_ip: %Postgrex.INET{address: {189, 172, 73, 153}},
+        outer_dst_port: 51_820,
+        domain: nil
+      }
+
+      initiator =
+        flow_log_fixture(
+          identity
+          |> Map.put(:role, :initiator)
+          |> Map.put(:flow_start, ~U[2026-07-30 10:00:00.000000Z])
+          |> Map.put(:flow_end, ~U[2026-07-30 10:02:00.000000Z])
+          |> Map.put(:tx_bytes, 12_500)
+        )
+
+      responder =
+        flow_log_fixture(
+          identity
+          |> Map.put(:role, :responder)
+          |> Map.put(:flow_start, ~U[2026-07-30 10:00:03.000000Z])
+          |> Map.put(:flow_end, ~U[2026-07-30 10:02:05.000000Z])
+          |> Map.put(:tx_bytes, 12_000)
+        )
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/logs/flow_logs/#{initiator.log_id}")
+
+      panel_html = lv |> element("#flow-log-panel") |> render()
+
+      assert has_element?(
+               lv,
+               "#flow-log-panel-title",
+               "Some User (user@example.com) GitLab"
+             )
+
+      assert html =~ "Flow logs are paired on a best-effort basis."
+      assert html =~ "Initiator and responder logs"
+      assert html =~ "Connection details"
+      assert panel_html =~ "Flow log JSON"
+      assert has_element?(lv, "#flow-log-json .json-key")
+      assert has_element?(lv, "#flow-log-json .json-string")
+      assert has_element?(lv, "#flow-log-json .json-number")
+
+      assert has_element?(
+               lv,
+               "#flow-log-json button[data-copy-to-clipboard-target='flow-log-json-code']",
+               "Copy"
+             )
+
+      api_json =
+        panel_html
+        |> Floki.parse_fragment!()
+        |> Floki.find("#flow-log-json-code")
+        |> Floki.text()
+        |> JSON.decode!()
+
+      expected_api_json =
+        initiator
+        |> PortalAPI.LogJSON.flow_log()
+        |> JSON.encode!()
+        |> JSON.decode!()
+
+      assert api_json == expected_api_json
+      assert api_json["log_id"] == initiator.log_id
+      assert api_json["role"] == "initiator"
+      assert api_json["inner_src_ip"] == "100.64.0.8"
+      assert api_json["inner_dst_ip"] == "10.0.0.9"
+      assert api_json["type"] == "flow"
+      assert api_json["timestamp"] == DateTime.to_iso8601(initiator.inserted_at)
+      assert api_json["policy_authorization_id"] == initiator.policy_authorization_id
+      assert api_json["policy_id"] == initiator.policy_id
+      assert Map.has_key?(api_json, "initiator_client_version")
+      assert Map.has_key?(api_json, "outer_src_ip")
+      assert Map.has_key?(api_json, "outer_dst_ip")
+      refute Map.has_key?(api_json, "data")
+      refute Map.has_key?(api_json, "seq")
+      refute Map.has_key?(api_json, "start_seq")
+      assert has_element?(
+               lv,
+               "a[href='https://www.firezone.dev/kb/audit-logs/flow#two-sided-reporting']",
+               "Read more"
+             )
+      assert panel_html =~ initiator.log_id
+      assert panel_html =~ responder.log_id
+      assert panel_html =~ "12.5 KB"
+      assert panel_html =~ "12.0 KB"
+      assert has_element?(
+               lv,
+               "#flow-log-card-#{initiator.log_id} [data-wireguard-endpoint='initiator']",
+               "203.0.113.44:62000"
+             )
+
+      assert has_element?(
+               lv,
+               "#flow-log-card-#{initiator.log_id} [data-wireguard-endpoint='responder']",
+               "189.172.73.153:51820"
+             )
+
+      assert has_element?(lv, "#flow-log-card-#{responder.log_id}[href*='#{responder.log_id}']")
+
+      lv
+      |> element("#flow-log-card-#{responder.log_id}")
+      |> render_click()
+
+      assert_patch(lv, ~p"/#{account}/logs/flow_logs/#{responder.log_id}")
+      assert has_element?(lv, "#flow-log-card-#{responder.log_id}[aria-current=page]")
+    end
+
+    test "does not match a non-overlapping reused tuple", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      identity = %{
+        account: account,
+        policy_authorization_id: Ecto.UUID.generate(),
+        initiator_device_id: Ecto.UUID.generate(),
+        responder_device_id: Ecto.UUID.generate(),
+        resource_id: Ecto.UUID.generate(),
+        protocol: :udp,
+        inner_src_port: 50_000,
+        inner_dst_port: 53,
+        domain: nil
+      }
+
+      selected =
+        flow_log_fixture(
+          identity
+          |> Map.put(:role, :initiator)
+          |> Map.put(:flow_start, ~U[2026-07-30 10:00:00.000000Z])
+          |> Map.put(:flow_end, ~U[2026-07-30 10:01:00.000000Z])
+        )
+
+      other =
+        flow_log_fixture(
+          identity
+          |> Map.put(:role, :responder)
+          |> Map.put(:flow_start, ~U[2026-07-30 11:00:00.000000Z])
+          |> Map.put(:flow_end, ~U[2026-07-30 11:01:00.000000Z])
+        )
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/logs/flow_logs/#{selected.log_id}")
+
+      panel_html = lv |> element("#flow-log-panel") |> render()
+
+      assert html =~ "No matching responder log"
+
+      assert panel_html
+             |> Floki.parse_fragment!()
+             |> Floki.text()
+             |> String.replace(~r/\s+/, " ") =~ "beyond the retention period"
+
+      refute panel_html =~ other.log_id
+    end
+
+    test "does not match a different WireGuard tuple", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      identity = %{
+        account: account,
+        policy_authorization_id: Ecto.UUID.generate(),
+        initiator_device_id: Ecto.UUID.generate(),
+        responder_device_id: Ecto.UUID.generate(),
+        resource_id: Ecto.UUID.generate(),
+        protocol: :tcp,
+        inner_src_ip: %Postgrex.INET{address: {100, 64, 0, 8}},
+        inner_src_port: 51_234,
+        inner_dst_ip: %Postgrex.INET{address: {10, 0, 0, 9}},
+        inner_dst_port: 443,
+        outer_src_ip: %Postgrex.INET{address: {203, 0, 113, 10}},
+        outer_src_port: 51_820,
+        outer_dst_ip: %Postgrex.INET{address: {198, 51, 100, 5}},
+        outer_dst_port: 51_820,
+        domain: nil
+      }
+
+      selected =
+        flow_log_fixture(
+          identity
+          |> Map.put(:role, :initiator)
+          |> Map.put(:flow_start, ~U[2026-07-30 10:00:00.000000Z])
+          |> Map.put(:flow_end, ~U[2026-07-30 10:01:00.000000Z])
+        )
+
+      other =
+        flow_log_fixture(
+          identity
+          |> Map.put(:role, :responder)
+          |> Map.put(:outer_src_ip, %Postgrex.INET{address: {203, 0, 113, 11}})
+          |> Map.put(:flow_start, ~U[2026-07-30 10:00:02.000000Z])
+          |> Map.put(:flow_end, ~U[2026-07-30 10:01:02.000000Z])
+        )
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/logs/flow_logs/#{selected.log_id}")
+
+      panel_html = lv |> element("#flow-log-panel") |> render()
+
+      assert html =~ "No matching responder log"
+      refute panel_html =~ other.log_id
+    end
+  end
+end

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -1357,12 +1357,18 @@ defmodule PortalWeb.PoliciesTest do
       resource = resource_fixture(account: account)
       policy = policy_fixture(group: group, resource: resource)
 
-      {:ok, _lv, html} =
+      {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/policies/#{policy.id}?tab=authorizations")
 
       assert html =~ "No recent authorizations"
+
+      assert has_element?(
+               lv,
+               "[data-authorization-flow-logs-notice] a[href='#{~p"/#{account}/logs/flow_logs"}']",
+               "flow logs"
+             )
     end
 
     test "Authorizations tab renders actor name", %{

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -1129,12 +1129,18 @@ defmodule PortalWeb.ResourcesTest do
     } do
       resource = resource_fixture(account: account)
 
-      {:ok, _lv, html} =
+      {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/resources/#{resource.id}?tab=authorizations")
 
       assert html =~ "No recent policy authorizations"
+
+      assert has_element?(
+               lv,
+               "[data-authorization-flow-logs-notice] a[href='#{~p"/#{account}/logs/flow_logs"}']",
+               "flow logs"
+             )
     end
 
     test "Authorizations tab renders actor name for membership-based authorization", %{

--- a/elixir/test/portal_web/live_table_test.exs
+++ b/elixir/test/portal_web/live_table_test.exs
@@ -95,6 +95,44 @@ defmodule PortalWeb.LiveTableTest do
       assert Floki.attribute(input, "value") == ["foo"]
     end
 
+    test "renders compact protocol and port filter", %{assigns: assigns} do
+      assigns = %{
+        assigns
+        | filters: [
+            %Portal.Repo.Filter{
+              name: :protocol_port,
+              title: "Protocol / port",
+              type: {:string, :protocol_port}
+            }
+          ],
+          filter: filter_to_form(%{protocol_port: "tcp/443"}, "table-id")
+      }
+
+      input =
+        render_component(&live_table/1, assigns)
+        |> Floki.parse_fragment!()
+        |> Floki.find("form#table-id-filters input[type=text]")
+
+      assert Floki.attribute(input, "id") == ["table-id_protocol_port"]
+      assert Floki.attribute(input, "name") == ["table-id[protocol_port]"]
+      assert Floki.attribute(input, "placeholder") == ["Port or tcp/443"]
+      assert Floki.attribute(input, "value") == ["tcp/443"]
+    end
+
+    test "adds per-row classes", %{assigns: assigns} do
+      html =
+        render_component(
+          &live_table/1,
+          Map.put(assigns, :row_class, fn "foo" -> "bg-brand-muted" end)
+        )
+
+      assert html
+             |> Floki.parse_fragment!()
+             |> Floki.find("#table-id-rows > tr")
+             |> Floki.attribute("class")
+             |> Enum.any?(&String.contains?(&1, "bg-brand-muted"))
+    end
+
     test "renders email filter", %{assigns: assigns} do
       assigns = %{
         assigns


### PR DESCRIPTION
## What this does

Imagine a client opens a network connection to a resource. Both the client that starts the connection and the device that receives it can send Firezone a flow log. This PR turns the old under-construction page into a useful place to inspect those logs.

The new page:

- Shows each client and responder log in a searchable, filterable table.
- Makes it easy to filter by who logged the flow, protocol, state, destination port, time, actor, resource, IP, or log ID.
- Shows useful details such as start time, last packet, source, destination, duration, and total transferred size.
- Lets operators sort by start time or total transferred size.
- Opens a detail panel with the closest matching log from the other side, connection details, device and authorization context, and a copyable JSON view of the stored flow log.
- Adds realistic seed data so the two-sided view can be explored locally.

## How two-sided reporting works

The client and responder currently do not share a unique flow ID. Firezone therefore compares the authorization, devices, resource, protocol, application tuple, WireGuard tuple, domain, and overlapping time window. Think of it as matching two receipts by their details and timestamps: usually clear, but not mathematically guaranteed when the same tuple is reused.

The UI calls this out as best-effort pairing and links to the flow-log documentation for more detail.

Flow logs are stored in daily partitions. The Started filter is applied to the partition key so PostgreSQL can narrow the date range instead of treating the log store as one giant table.