### PR TITLE
fix(ci): avoid false positives in warning checks

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -298,7 +298,7 @@ jobs:
           # Disabling checksum offloading causes one or two "I/O error (os error 5)" warnings
           docker compose logs client-1 client-2 | \
             grep --invert "I/O error (os error 5)" | \
-            grep "WARN" && exit 1 || exit 0
+            grep " WARN " && exit 1 || exit 0
       - name: Show Client logs
         if: "!cancelled()"
         run: docker compose logs client-1 client-2
@@ -318,7 +318,7 @@ jobs:
           docker compose logs gateway | \
             grep --invert "I/O error (os error 5)" | \
             ${{ matrix.test.gateway_disable_ipv6 == 1 && 'grep --invert "Failed to add route: Received a netlink error message Permission denied (os error 13) route=fd00:2021:1111::/107" |' || '' }} \
-            grep "WARN" && exit 1 || exit 0
+            grep " WARN " && exit 1 || exit 0
       - name: Show Gateway logs
         if: "!cancelled()"
         run: docker compose logs gateway

--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -108,18 +108,18 @@ jobs:
         if: "!cancelled()"
         run: |
           docker compose logs client-1 |
-            grep "WARN" && exit 1 || exit 0
+            grep " WARN " && exit 1 || exit 0
 
           docker compose logs gateway |
-            grep "WARN" && exit 1 || exit 0
+            grep " WARN " && exit 1 || exit 0
 
           # BTF doesn't load for veth interfaces
           docker compose logs relay-1 | \
             grep --invert "Object BTF couldn't be loaded in the kernel: the BPF_BTF_LOAD syscall failed." | \
-            grep "WARN" && exit 1 || exit 0
+            grep " WARN " && exit 1 || exit 0
           docker compose logs relay-2 | \
             grep --invert "Object BTF couldn't be loaded in the kernel: the BPF_BTF_LOAD syscall failed." | \
-            grep "WARN" && exit 1 || exit 0
+            grep " WARN " && exit 1 || exit 0
 
       - name: Ensure no UDP socket errors
         if: "!cancelled() && startsWith(matrix.test, 'tcp')"


### PR DESCRIPTION
Restrict warning-log checks to the space-delimited ` WARN ` level token. This prevents base64 values containing `WARN` from failing integration and performance jobs while preserving detection of actual warning records.

Tested with `actionlint`, `git diff --check`, and representative warning/base64 log lines.

Related: https://github.com/firezone/firezone/actions/runs/30708808772/job/91392953092?pr=14443