### PR TITLE
feat(android): use managed X.509 identities for mTLS

### DIFF
--- a/kotlin/android/README.md
+++ b/kotlin/android/README.md
@@ -70,6 +70,27 @@ returns the current chain. If renewal creates multiple aliases, the DPC must
 return the newest suitable alias from `onChoosePrivateKeyAlias`; the system
 picker performs that choice for user-managed selection.
 
+### Certificate user authentication
+
+Firezone can connect without a saved web sign-in token when the leaf certificate
+contains exactly one valid value for both of these URI SAN attributes:
+
+- `firezone://email/<percent-encoded actor email>`
+- `firezone://account-id/<Firezone account UUID>`
+
+For example:
+
+```text
+firezone://email/alice%40example.com
+firezone://account-id/5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3
+```
+
+The values may be separate URI SAN entries or part of Intune's comma-joined URI
+SAN. Advanced Settings shows parsed identity attributes and all raw SAN values.
+If either required attribute is missing, malformed, or ambiguous, the
+certificate is still used for mutual TLS device identity and Firezone falls back
+to the saved token or interactive web sign-in for user authentication.
+
 ### Wireless ADB
 
 Useful when your USB connection is flaky. Both flows give you a regular `adb`

--- a/kotlin/android/README.md
+++ b/kotlin/android/README.md
@@ -29,6 +29,47 @@ Both tasks build only the cargo target matching the device's ABI (detected via
 `adb` for `install-phone`, host arch for `install-emulator`), which is roughly
 4x faster than the default all-ABI build.
 
+## X.509 device identity
+
+Firezone uses Android's system `KeyChain` for X.509 device identity. The private
+key remains in the KeyChain; Firezone receives a key handle and asks it to sign
+the mutual-TLS handshake. The **X.509 Device Identity** section in Advanced
+Settings shows the configured alias, key access, and certificate-chain
+diagnostics.
+
+Android ownership and distribution do not create four different certificate
+APIs. The important distinction is whether a device policy controller (DPC)
+has granted Firezone access to a key:
+
+| Deployment | Certificate provisioning and Firezone access | User interaction |
+| --- | --- | --- |
+| Personally owned, personal profile | Not supported. A work-profile DPC cannot provision private keys across the profile boundary. | Advanced Settings explains that X.509 device identity requires a managed work profile or corporate-owned device. |
+| Personally owned, work profile | The DPC installs the identity in the work profile. It may pre-grant access on Android 11+, or handle the KeyChain chooser on older versions. | No prompt when pre-granted; otherwise Advanced Settings launches the system picker. |
+| Corporate owned | The device/profile owner installs the identity, grants the Firezone package access, and supplies its alias as managed configuration. | None on Android 11+ when fully configured. On older releases, **Authorize Certificate** invokes the chooser so the DPC can return the alias silently. |
+| AOSP | `KeyChain` is an Android framework API and does not depend on Google Play services. Managed work-profile and corporate-owned provisioning are supported when the build includes a working KeyChain service and selection UI. | Determined by whether a DPC pre-granted the key, just as on other Android builds. Unmanaged personal profiles are not supported. |
+
+For managed deployment, set the `x509CertificateAlias` application restriction
+to the exact alias used when installing the key pair. The selected leaf
+certificate must have subject common name `dev.firezone.device-trust`. On
+Android 11 (API 30) or newer, the DPC should also call
+[`DevicePolicyManager.grantKeyPairToApp`](https://developer.android.com/reference/android/app/admin/DevicePolicyManager#grantKeyPairToApp(android.content.ComponentName,%20java.lang.String,%20java.lang.String))
+for `dev.firezone.android`. On earlier supported versions, the DPC can implement
+[`onChoosePrivateKeyAlias`](https://developer.android.com/reference/android/app/admin/DeviceAdminReceiver#onChoosePrivateKeyAlias(android.content.Context,%20android.content.Intent,%20int,%20android.net.Uri,%20java.lang.String))
+and return the managed alias when Firezone requests access.
+
+An installation in a supported profile can remember an alias returned by
+[`KeyChain.choosePrivateKeyAlias`](https://developer.android.com/reference/android/security/KeyChain#choosePrivateKeyAlias(android.app.Activity,%20android.security.KeyChainAliasCallback,%20java.lang.String[],%20java.security.Principal[],%20android.net.Uri,%20java.lang.String)).
+If the key is removed or its grant is revoked, Advanced Settings reports it as
+unavailable and the user can select it again.
+
+The public KeyChain API intentionally resolves client identities by alias and
+does not let applications enumerate every installed private-key alias. A DPC
+therefore controls zero-touch selection and certificate renewal. When a SCEP
+identity is renewed under the same alias, `KeyChain.getCertificateChain`
+returns the current chain. If renewal creates multiple aliases, the DPC must
+return the newest suitable alias from `onChoosePrivateKeyAlias`; the system
+picker performs that choice for user-managed selection.
+
 ### Wireless ADB
 
 Useful when your USB connection is flaky. Both flows give you a regular `adb`

--- a/kotlin/android/app/src/debug/java/dev/firezone/android/features/session/ui/compose/SampleSessionActivity.kt
+++ b/kotlin/android/app/src/debug/java/dev/firezone/android/features/session/ui/compose/SampleSessionActivity.kt
@@ -26,6 +26,7 @@ class SampleSessionActivity : AppCompatActivity() {
 
                 SessionScreen(
                     actorName = "Jane Doe",
+                    isCertificateAuthenticated = false,
                     resources = sampleResources,
                     connectedDevices = sampleConnectedDevices,
                     favorites = favorites,

--- a/kotlin/android/app/src/debug/java/dev/firezone/android/features/session/ui/compose/SessionSamples.kt
+++ b/kotlin/android/app/src/debug/java/dev/firezone/android/features/session/ui/compose/SessionSamples.kt
@@ -21,6 +21,7 @@ private fun SessionScreenPreview() {
     FirezoneTheme {
         SessionScreen(
             actorName = "Jane Doe",
+            isCertificateAuthenticated = false,
             resources = sampleResources,
             connectedDevices = sampleConnectedDevices,
             favorites = Favorites(HashSet()),

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/Log.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/Log.kt
@@ -33,27 +33,33 @@ object Log {
 
     fun setUser(
         firezoneId: String,
-        accountSlug: String,
+        accountSlug: String?,
+        accountId: String?,
+        actorEmail: String?,
         mdmDeviceId: String?,
     ) {
         synchronized(attributesLock) {
-            attributes = attributes +
-                mapOf(
-                    "user.id" to firezoneId,
-                    "user.account_slug" to accountSlug,
-                )
-            attributes =
-                if (mdmDeviceId == null) {
-                    attributes - "user.mdm_device_id"
-                } else {
-                    attributes + ("user.mdm_device_id" to mdmDeviceId)
-                }
+            attributes = attributes + ("user.id" to firezoneId)
+            listOf(
+                "user.account_slug" to accountSlug,
+                "user.account_id" to accountId,
+                "user.actor_email" to actorEmail,
+                "user.mdm_device_id" to mdmDeviceId,
+            ).forEach { (key, value) ->
+                attributes = if (value == null) attributes - key else attributes + (key to value)
+            }
         }
     }
 
     fun clearUser() {
         synchronized(attributesLock) {
-            attributes = attributes - "user.id" - "user.account_slug" - "user.mdm_device_id"
+            attributes =
+                attributes -
+                "user.id" -
+                "user.account_slug" -
+                "user.account_id" -
+                "user.actor_email" -
+                "user.mdm_device_id"
         }
     }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/Log.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/Log.kt
@@ -34,6 +34,7 @@ object Log {
     fun setUser(
         firezoneId: String,
         accountSlug: String,
+        mdmDeviceId: String?,
     ) {
         synchronized(attributesLock) {
             attributes = attributes +
@@ -41,12 +42,18 @@ object Log {
                     "user.id" to firezoneId,
                     "user.account_slug" to accountSlug,
                 )
+            attributes =
+                if (mdmDeviceId == null) {
+                    attributes - "user.mdm_device_id"
+                } else {
+                    attributes + ("user.mdm_device_id" to mdmDeviceId)
+                }
         }
     }
 
     fun clearUser() {
         synchronized(attributesLock) {
-            attributes = attributes - "user.id" - "user.account_slug"
+            attributes = attributes - "user.id" - "user.account_slug" - "user.mdm_device_id"
         }
     }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/Telemetry.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/Telemetry.kt
@@ -11,6 +11,8 @@ import io.sentry.protocol.User
 object Telemetry {
     private var firezoneId: String? = null
     private var accountSlug: String? = null
+    private var accountId: String? = null
+    private var actorEmail: String? = null
     private var mdmDeviceId: String? = null
 
     fun start(context: Context) {
@@ -24,13 +26,26 @@ object Telemetry {
         }
     }
 
-    fun setFirezoneId(id: String?) {
-        firezoneId = id
+    fun setUser(
+        firezoneId: String,
+        accountSlug: String,
+    ) {
+        this.firezoneId = firezoneId
+        this.accountSlug = accountSlug
+        accountId = null
+        actorEmail = null
         updateUser()
     }
 
-    fun setAccountSlug(slug: String?) {
-        accountSlug = slug
+    fun setUser(
+        firezoneId: String,
+        accountId: String,
+        actorEmail: String,
+    ) {
+        this.firezoneId = firezoneId
+        accountSlug = null
+        this.accountId = accountId
+        this.actorEmail = actorEmail
         updateUser()
     }
 
@@ -42,16 +57,21 @@ object Telemetry {
     private fun updateUser() {
         val id = firezoneId
         val slug = accountSlug
+        val accountId = accountId
+        val actorEmail = actorEmail
         val mdmId = mdmDeviceId
 
-        if (id != null && slug != null) {
-            Log.setUser(id, slug, mdmId)
+        if (id != null && (slug != null || (accountId != null && actorEmail != null))) {
+            Log.setUser(id, slug, accountId, actorEmail, mdmId)
             val user =
                 User().apply {
                     this.id = id
+                    this.email = actorEmail
                     this.data =
                         buildMap {
-                            put("account_slug", slug)
+                            slug?.let { put("account_slug", it) }
+                            accountId?.let { put("account_id", it) }
+                            actorEmail?.let { put("actor_email", it) }
                             mdmId?.let { put("mdm_device_id", it) }
                         }
                 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/Telemetry.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/Telemetry.kt
@@ -11,6 +11,7 @@ import io.sentry.protocol.User
 object Telemetry {
     private var firezoneId: String? = null
     private var accountSlug: String? = null
+    private var mdmDeviceId: String? = null
 
     fun start(context: Context) {
         SentryAndroid.init(context) { options ->
@@ -33,16 +34,26 @@ object Telemetry {
         updateUser()
     }
 
+    fun setMdmDeviceId(id: String?) {
+        mdmDeviceId = id
+        updateUser()
+    }
+
     private fun updateUser() {
         val id = firezoneId
         val slug = accountSlug
+        val mdmId = mdmDeviceId
 
         if (id != null && slug != null) {
-            Log.setUser(id, slug)
+            Log.setUser(id, slug, mdmId)
             val user =
                 User().apply {
                     this.id = id
-                    this.data = mapOf("account_slug" to slug)
+                    this.data =
+                        buildMap {
+                            put("account_slug", slug)
+                            mdmId?.let { put("mdm_device_id", it) }
+                        }
                 }
             Sentry.setUser(user)
         } else {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -21,6 +21,7 @@ import javax.inject.Inject
 
 const val ON_SYMBOL: String = "<->"
 const val OFF_SYMBOL: String = " — "
+const val X509_CERTIFICATE_ALIAS_RESTRICTION: String = "x509CertificateAlias"
 
 enum class ResourceState {
     @SerializedName("enabled")
@@ -174,9 +175,37 @@ class Repository
                 if (bundle.containsKey(CONNECT_ON_START_KEY)) {
                     editor.putBoolean(MANAGED_CONNECT_ON_START_KEY, bundle.getBoolean(CONNECT_ON_START_KEY, false))
                 }
+                val managedX509Alias =
+                    bundle
+                        .getString(X509_CERTIFICATE_ALIAS_RESTRICTION)
+                        ?.takeUnless { it.isBlank() || it == "null" }
+                if (managedX509Alias != null) {
+                    editor.putString(MANAGED_X509_CERTIFICATE_ALIAS_KEY, managedX509Alias)
+                } else {
+                    editor.remove(MANAGED_X509_CERTIFICATE_ALIAS_KEY)
+                }
 
                 emit(editor.apply())
             }.flowOn(coroutineDispatcher)
+
+        fun getX509CertificateAliasSync(): String? =
+            sharedPreferences.getString(MANAGED_X509_CERTIFICATE_ALIAS_KEY, null)
+                ?: sharedPreferences.getString(X509_CERTIFICATE_ALIAS_KEY, null)
+
+        fun getSelectedX509CertificateAliasSync(): String? = sharedPreferences.getString(X509_CERTIFICATE_ALIAS_KEY, null)
+
+        fun isX509CertificateAliasManaged(): Boolean = sharedPreferences.contains(MANAGED_X509_CERTIFICATE_ALIAS_KEY)
+
+        fun saveSelectedX509CertificateAliasSync(alias: String?) {
+            sharedPreferences.edit().apply {
+                if (alias == null) {
+                    remove(X509_CERTIFICATE_ALIAS_KEY)
+                } else {
+                    putString(X509_CERTIFICATE_ALIAS_KEY, alias)
+                }
+                apply()
+            }
+        }
 
         fun getDeviceIdSync(): String? = sharedPreferences.getString(DEVICE_ID_KEY, null)
 
@@ -366,6 +395,8 @@ class Repository
             private const val MANAGED_ACCOUNT_SLUG_KEY = "managedAccountSlug"
             private const val MANAGED_START_ON_LOGIN_KEY = "managedStartOnLogin"
             private const val MANAGED_CONNECT_ON_START_KEY = "managedConnectOnStart"
+            private const val MANAGED_X509_CERTIFICATE_ALIAS_KEY = "managedX509CertificateAlias"
+            private const val X509_CERTIFICATE_ALIAS_KEY = "x509CertificateAlias"
             private const val TOKEN_KEY = "token"
             private const val NONCE_KEY = "nonce"
             private const val STATE_KEY = "state"

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/x509/X509Identity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/x509/X509Identity.kt
@@ -22,6 +22,7 @@ import java.security.spec.MGF1ParameterSpec
 import java.security.spec.PSSParameterSpec
 import java.time.format.DateTimeFormatter
 import java.util.Base64
+import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -40,9 +41,15 @@ data class X509IdentityDetails(
     val sections: List<X509DetailSection>,
 )
 
+data class X509UserIdentity(
+    val email: String,
+    val accountId: String,
+)
+
 data class LoadedX509Identity(
     val clientTlsIdentity: ClientTlsIdentity,
     val mdmDeviceId: String?,
+    val userIdentity: X509UserIdentity?,
 )
 
 internal object NoClientTlsIdentity : ClientTlsIdentity {
@@ -84,13 +91,16 @@ class X509Identity
             validateLeafCommonName(leaf)
             val privateKey = loadPrivateKey(alias)
             val schemes = supportedSignatureSchemes(leaf.publicKey)
-            val mdmDeviceId = mdmDeviceId(leaf)
+            val uriSubjectAlternativeNames = uriSubjectAlternativeNames(leaf)
+            val mdmDeviceId = mdmDeviceId(uriSubjectAlternativeNames)
+            val userIdentity = userIdentity(uriSubjectAlternativeNames)
 
             Log.i(
                 TAG,
                 "Loaded mutual-TLS client identity " +
                     "(alias=$alias, certificates=${chain.size}, notBefore=${leaf.notBefore.toInstant()}, " +
-                    "leafFingerprint=${sha256Hex(leaf.encoded)}, mdmDeviceId=${mdmDeviceId ?: "Unavailable"})",
+                    "leafFingerprint=${sha256Hex(leaf.encoded)}, mdmDeviceId=${mdmDeviceId ?: "Unavailable"}, " +
+                    "certificateUserAuth=${if (userIdentity == null) "unavailable" else "available"})",
             )
 
             return LoadedX509Identity(
@@ -102,8 +112,11 @@ class X509Identity
                         schemes = schemes,
                     ),
                 mdmDeviceId = mdmDeviceId,
+                userIdentity = userIdentity,
             )
         }
+
+        fun userIdentity(alias: String?): X509UserIdentity? = clientTlsIdentity(alias)?.userIdentity
 
         fun details(
             alias: String?,
@@ -135,16 +148,23 @@ class X509Identity
             val sections =
                 mutableListOf(
                     X509DetailSection("Configuration", configurationFields),
-                    X509DetailSection(
-                        "Private Key",
-                        listOf(
-                            X509DetailField("Algorithm", privateKey.algorithm),
-                            X509DetailField("Provider class", privateKey.javaClass.name),
-                            X509DetailField("Encoded format", privateKey.format ?: "Non-exportable"),
-                            X509DetailField(
-                                "Private key export",
-                                "Not attempted; mutual-TLS signing occurs through the KeyChain key handle.",
-                            ),
+                )
+
+            val identityAttributeFields = identityAttributeFields(chain.first())
+            if (identityAttributeFields.isNotEmpty()) {
+                sections += X509DetailSection("Identity Attributes", identityAttributeFields)
+            }
+
+            sections +=
+                X509DetailSection(
+                    "Private Key",
+                    listOf(
+                        X509DetailField("Algorithm", privateKey.algorithm),
+                        X509DetailField("Provider class", privateKey.javaClass.name),
+                        X509DetailField("Encoded format", privateKey.format ?: "Non-exportable"),
+                        X509DetailField(
+                            "Private key export",
+                            "Not attempted; mutual-TLS signing occurs through the KeyChain key handle.",
                         ),
                     ),
                 )
@@ -505,13 +525,16 @@ class X509Identity
                         value.toString()
                     }
 
+                if (type == 6 && value is String) {
+                    return splitCommaJoinedUris(listOf(value)).joinToString("\n") { uri -> "$label: $uri" }
+                }
+
                 return "$label: $renderedValue"
             }
 
             internal fun mdmDeviceId(uris: List<String>): String? {
                 val filteredUris =
-                    uris
-                        .flatMap { it.split(COMMA_JOINED_URI_BOUNDARY) }
+                    splitCommaJoinedUris(uris)
                         .filterNot { it.startsWith(MICROSOFT_SID_URI_PREFIX, ignoreCase = true) }
                 var sawTypedIdentifier = false
                 var typedMdmDeviceId: String? = null
@@ -540,7 +563,51 @@ class X509Identity
                 }
             }
 
-            private fun mdmDeviceId(certificate: X509Certificate): String? =
+            internal fun userIdentity(uris: List<String>): X509UserIdentity? {
+                val email = actorEmail(uris) ?: return null
+                val accountId = accountId(uris) ?: return null
+                return X509UserIdentity(email = email, accountId = accountId)
+            }
+
+            internal fun actorEmail(uris: List<String>): String? {
+                val emails =
+                    firezoneAttributeValues("email", uris)
+                        .filter(::validEmail)
+                        .mapTo(mutableSetOf()) { it.lowercase() }
+                return emails.singleOrNull()
+            }
+
+            internal fun accountId(uris: List<String>): String? {
+                val accountIds =
+                    firezoneAttributeValues("account-id", uris)
+                        .mapNotNull { value ->
+                            runCatching { UUID.fromString(value).toString() }
+                                .getOrNull()
+                                ?.takeIf { canonical -> canonical.equals(value, ignoreCase = true) }
+                        }.mapTo(mutableSetOf()) { it.lowercase() }
+                return accountIds.singleOrNull()
+            }
+
+            internal fun deviceSerial(uris: List<String>): String? {
+                val serials =
+                    firezoneAttributeValues("serial", uris) +
+                        firezoneAttributeValues("apple-serial", uris)
+                val valuesByNormalizedValue = serials.groupBy { it.lowercase() }
+                return valuesByNormalizedValue.values.singleOrNull()?.firstOrNull()
+            }
+
+            internal fun identityAttributeFields(uris: List<String>): List<X509DetailField> =
+                listOfNotNull(
+                    actorEmail(uris)?.let { X509DetailField("Actor Email", it) },
+                    accountId(uris)?.let { X509DetailField("Account ID", it) },
+                    mdmDeviceId(uris)?.let { X509DetailField("MDM Device ID", it) },
+                    deviceSerial(uris)?.let { X509DetailField("Device Serial", it) },
+                )
+
+            private fun identityAttributeFields(certificate: X509Certificate): List<X509DetailField> =
+                identityAttributeFields(uriSubjectAlternativeNames(certificate))
+
+            private fun uriSubjectAlternativeNames(certificate: X509Certificate): List<String> =
                 runCatching {
                     certificate.subjectAlternativeNames
                         ?.mapNotNull { name ->
@@ -548,14 +615,47 @@ class X509Identity
                             val value = name.getOrNull(1) as? String
                             value?.takeIf { type == 6 }
                         }.orEmpty()
-                }.map(::mdmDeviceId)
-                    .getOrNull()
+                }.map(::splitCommaJoinedUris)
+                    .getOrDefault(emptyList())
+
+            private fun firezoneAttributeValues(
+                expectedAttribute: String,
+                uris: List<String>,
+            ): List<String> =
+                splitCommaJoinedUris(uris).mapNotNull { uri ->
+                    val match = FIREZONE_URI.matchEntire(uri) ?: return@mapNotNull null
+                    val attribute = match.groupValues[1].lowercase()
+                    if (attribute != expectedAttribute) return@mapNotNull null
+
+                    val rawValue = match.groupValues[2]
+                    val decodedValue = decodeUriPathValue(rawValue).trim()
+                    decodedValue.takeIf(::validIdentifier)
+                }
+
+            private fun splitCommaJoinedUris(uris: List<String>): List<String> =
+                uris
+                    .flatMap { it.split(COMMA_JOINED_URI_BOUNDARY) }
+                    .map(String::trim)
+                    .filter(String::isNotEmpty)
+
+            private fun decodeUriPathValue(rawValue: String): String =
+                runCatching {
+                    java.net.URI
+                        .create("firezone://attribute/$rawValue")
+                        .path
+                        .removePrefix("/")
+                }.getOrDefault(rawValue)
+
+            private fun validEmail(value: String): Boolean {
+                if (!validIdentifier(value) || value.any(Char::isWhitespace)) return false
+                val parts = value.split('@')
+                return parts.size == 2 && parts.all(String::isNotEmpty)
+            }
 
             private fun validIdentifier(value: String): Boolean {
                 val trimmed = value.trim()
                 return trimmed.isNotEmpty() &&
-                    trimmed.toByteArray(Charsets.UTF_8).size <= 255 &&
-                    trimmed.all { it.code in 0x20..0x7E }
+                    trimmed.toByteArray(Charsets.UTF_8).size <= 255
             }
 
             private fun normalizeMdmDeviceId(value: String): String? {
@@ -589,6 +689,8 @@ class X509Identity
                     "ws1-uuid",
                     "jamf-id",
                     "kandji-id",
+                    "email",
+                    "account-id",
                 )
             private val MDM_IDENTIFIER_TYPES =
                 setOf("intune-id", "entra-id", "ws1-uuid", "jamf-id", "kandji-id")

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/x509/X509Identity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/x509/X509Identity.kt
@@ -394,9 +394,10 @@ class X509Identity
                 message: ByteArray,
             ): ByteArray =
                 try {
-                    signature(scheme).run {
+                    val (signature, parameters) = signature(scheme)
+                    signature.run {
                         initSign(privateKey)
-                        pssParameters(scheme)?.let(::setParameter)
+                        parameters?.let(::setParameter)
                         update(message)
                         sign()
                     }
@@ -409,17 +410,28 @@ class X509Identity
                     )
                 }
 
-            private fun signature(scheme: TlsSignatureScheme): Signature {
+            private fun signature(scheme: TlsSignatureScheme): ConfiguredSignature {
                 val algorithm = signatureAlgorithm(scheme)
-                return runCatching { Signature.getInstance(algorithm) }
-                    .getOrElse {
-                        if (pssParameters(scheme) != null) {
-                            Signature.getInstance("RSASSA-PSS")
-                        } else {
-                            throw it
-                        }
+                return runCatching {
+                    // Android's digest-specific RSA/PSS implementations already fix the
+                    // digest, MGF digest, and salt length. Their KeyChain-backed SignatureSpi
+                    // deliberately rejects setParameter, so parameters must only be supplied
+                    // when using the generic RSASSA-PSS fallback.
+                    ConfiguredSignature(Signature.getInstance(algorithm), null)
+                }.getOrElse {
+                    val parameters = pssParameters(scheme)
+                    if (parameters != null) {
+                        ConfiguredSignature(Signature.getInstance("RSASSA-PSS"), parameters)
+                    } else {
+                        throw it
                     }
+                }
             }
+
+            private data class ConfiguredSignature(
+                val signature: Signature,
+                val parameters: PSSParameterSpec?,
+            )
 
             private fun pssParameters(scheme: TlsSignatureScheme): PSSParameterSpec? =
                 when (scheme) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/x509/X509Identity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/x509/X509Identity.kt
@@ -498,7 +498,9 @@ class X509Identity
 
             internal fun mdmDeviceId(uris: List<String>): String? {
                 val filteredUris =
-                    uris.filterNot { it.startsWith(MICROSOFT_SID_URI_PREFIX, ignoreCase = true) }
+                    uris
+                        .flatMap { it.split(COMMA_JOINED_URI_BOUNDARY) }
+                        .filterNot { it.startsWith(MICROSOFT_SID_URI_PREFIX, ignoreCase = true) }
                 var sawTypedIdentifier = false
                 var typedMdmDeviceId: String? = null
 
@@ -561,6 +563,7 @@ class X509Identity
 
             private val RFC2253_COMMON_NAME = Regex("(?:^|,)CN=((?:\\\\.|[^,])*)", RegexOption.IGNORE_CASE)
             private val FIREZONE_URI = Regex("firezone://([^/]+)/(.+)", RegexOption.IGNORE_CASE)
+            private val COMMA_JOINED_URI_BOUNDARY = Regex(",\\s*(?=[a-zA-Z][a-zA-Z0-9+.\\-]*:)")
             private const val MICROSOFT_SID_URI_PREFIX = "tag:microsoft.com,2022-09-14:sid:"
             private val KNOWN_IDENTIFIER_TYPES =
                 setOf(

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/x509/X509Identity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/x509/X509Identity.kt
@@ -1,0 +1,589 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.core.x509
+
+import android.app.admin.DevicePolicyManager
+import android.content.Context
+import android.os.Build
+import android.os.UserManager
+import android.security.KeyChain
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.firezone.android.core.Log
+import uniffi.connlib.CallbackException
+import uniffi.connlib.ClientTlsIdentity
+import uniffi.connlib.TlsSignatureScheme
+import java.security.MessageDigest
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.Signature
+import java.security.cert.X509Certificate
+import java.security.interfaces.ECPublicKey
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.MGF1ParameterSpec
+import java.security.spec.PSSParameterSpec
+import java.time.format.DateTimeFormatter
+import java.util.Base64
+import javax.inject.Inject
+import javax.inject.Singleton
+
+data class X509DetailField(
+    val label: String,
+    val value: String,
+)
+
+data class X509DetailSection(
+    val title: String,
+    val fields: List<X509DetailField>,
+)
+
+data class X509IdentityDetails(
+    val summary: String,
+    val sections: List<X509DetailSection>,
+)
+
+data class LoadedX509Identity(
+    val clientTlsIdentity: ClientTlsIdentity,
+    val mdmDeviceId: String?,
+)
+
+internal object NoClientTlsIdentity : ClientTlsIdentity {
+    override fun certificateChain(): List<ByteArray> = emptyList()
+
+    override fun supportedSignatureSchemes(): List<TlsSignatureScheme> = emptyList()
+
+    override fun sign(
+        scheme: TlsSignatureScheme,
+        message: ByteArray,
+    ): ByteArray = throw CallbackException.Failed("No X.509 client identity is configured.")
+}
+
+class X509IdentityException(
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)
+
+/**
+ * Uses an identity from Android's system KeyChain without exporting its private-key bytes.
+ *
+ * KeyChain calls can block on a system service, so callers must invoke [clientTlsIdentity] and
+ * [details] from a worker thread.
+ */
+@Singleton
+class X509Identity
+    @Inject
+    constructor(
+        @param:ApplicationContext private val context: Context,
+    ) {
+        fun clientTlsIdentity(alias: String?): LoadedX509Identity? {
+            if (alias == null) {
+                Log.i(TAG, "No Android KeyChain alias is configured for mutual TLS")
+                return null
+            }
+
+            val chain = loadCertificateChain(alias)
+            val leaf = chain.first()
+            validateLeafCommonName(leaf)
+            val privateKey = loadPrivateKey(alias)
+            val schemes = supportedSignatureSchemes(leaf.publicKey)
+            val mdmDeviceId = mdmDeviceId(leaf)
+
+            Log.i(
+                TAG,
+                "Loaded mutual-TLS client identity " +
+                    "(alias=$alias, certificates=${chain.size}, notBefore=${leaf.notBefore.toInstant()}, " +
+                    "leafFingerprint=${sha256Hex(leaf.encoded)}, mdmDeviceId=${mdmDeviceId ?: "Unavailable"})",
+            )
+
+            return LoadedX509Identity(
+                clientTlsIdentity =
+                    AndroidClientTlsIdentity(
+                        alias = alias,
+                        privateKey = privateKey,
+                        certificateChain = chain,
+                        schemes = schemes,
+                    ),
+                mdmDeviceId = mdmDeviceId,
+            )
+        }
+
+        fun details(
+            alias: String?,
+            isManaged: Boolean,
+        ): X509IdentityDetails {
+            val configurationFields =
+                mutableListOf(
+                    X509DetailField("Android profile", profileDescription()),
+                    X509DetailField(
+                        "Alias source",
+                        if (isManaged) "Managed configuration" else "User selection",
+                    ),
+                    X509DetailField("KeyChain alias", alias ?: "Not configured"),
+                )
+
+            if (alias == null) {
+                return X509IdentityDetails(
+                    summary = "No X.509 device identity is configured.",
+                    sections = listOf(X509DetailSection("Configuration", configurationFields)),
+                )
+            }
+
+            val chain = loadCertificateChain(alias)
+            validateLeafCommonName(chain.first())
+            val privateKey = loadPrivateKey(alias)
+            configurationFields += X509DetailField("Key access", "Available")
+            configurationFields += X509DetailField("Certificate count", chain.size.toString())
+
+            val sections =
+                mutableListOf(
+                    X509DetailSection("Configuration", configurationFields),
+                    X509DetailSection(
+                        "Private Key",
+                        listOf(
+                            X509DetailField("Algorithm", privateKey.algorithm),
+                            X509DetailField("Provider class", privateKey.javaClass.name),
+                            X509DetailField("Encoded format", privateKey.format ?: "Non-exportable"),
+                            X509DetailField(
+                                "Private key export",
+                                "Not attempted; mutual-TLS signing occurs through the KeyChain key handle.",
+                            ),
+                        ),
+                    ),
+                )
+
+            sections +=
+                chain.mapIndexed { index, certificate ->
+                    certificateSection(
+                        certificate = certificate,
+                        title = if (index == 0) "Leaf Certificate" else "Certificate ${index + 1}",
+                    )
+                }
+
+            return X509IdentityDetails(
+                summary = "The configured X.509 identity is available for mutual TLS.",
+                sections = sections,
+            )
+        }
+
+        fun isSupportedProfile(): Boolean {
+            val profileState = profileState()
+            return isSupportedProfile(
+                isManagedProfile = profileState.isManagedProfile,
+                hasDeviceOwner = profileState.hasDeviceOwner,
+            )
+        }
+
+        private fun loadCertificateChain(alias: String): List<X509Certificate> {
+            val chain =
+                try {
+                    KeyChain.getCertificateChain(context, alias)
+                } catch (exception: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    throw X509IdentityException("Reading the X.509 certificate was interrupted.", exception)
+                } catch (exception: Exception) {
+                    throw X509IdentityException(
+                        "The X.509 certificate chain for alias '$alias' could not be read.",
+                        exception,
+                    )
+                }
+
+            if (chain.isNullOrEmpty()) {
+                throw X509IdentityException(
+                    "The X.509 certificate for alias '$alias' is missing or Firezone has not been granted access to it.",
+                )
+            }
+
+            return chain.toList()
+        }
+
+        private fun loadPrivateKey(alias: String): PrivateKey {
+            val privateKey =
+                try {
+                    KeyChain.getPrivateKey(context, alias)
+                } catch (exception: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    throw X509IdentityException("Reading the X.509 private key was interrupted.", exception)
+                } catch (exception: Exception) {
+                    throw X509IdentityException(
+                        "The X.509 private key for alias '$alias' could not be opened.",
+                        exception,
+                    )
+                }
+
+            return privateKey
+                ?: throw X509IdentityException(
+                    "The X.509 private key for alias '$alias' is missing or Firezone has not been granted access to it.",
+                )
+        }
+
+        private fun validateLeafCommonName(certificate: X509Certificate) {
+            val commonName = commonName(certificate)
+            if (commonName != EXPECTED_SUBJECT_COMMON_NAME) {
+                throw X509IdentityException(
+                    "The selected certificate has subject CN '${commonName ?: "None"}'; " +
+                        "Firezone requires '$EXPECTED_SUBJECT_COMMON_NAME'.",
+                )
+            }
+        }
+
+        private fun profileState(): ProfileState {
+            val userManager = context.getSystemService(UserManager::class.java)
+            val devicePolicyManager = context.getSystemService(DevicePolicyManager::class.java)
+            val activeAdmins = runCatching { devicePolicyManager?.activeAdmins.orEmpty() }.getOrDefault(emptyList())
+            val hasDeviceOwner =
+                activeAdmins.any { admin ->
+                    runCatching { devicePolicyManager?.isDeviceOwnerApp(admin.packageName) == true }
+                        .getOrDefault(false)
+                }
+            val hasProfileOwner =
+                activeAdmins.any { admin ->
+                    runCatching { devicePolicyManager?.isProfileOwnerApp(admin.packageName) == true }
+                        .getOrDefault(false)
+                }
+            val isManagedProfile =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    userManager?.isManagedProfile == true
+                } else {
+                    hasProfileOwner && !hasDeviceOwner
+                }
+            val isOrganizationOwned =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    runCatching { devicePolicyManager?.isOrganizationOwnedDeviceWithManagedProfile == true }
+                        .getOrDefault(false)
+                } else {
+                    false
+                }
+
+            return ProfileState(
+                isManagedProfile = isManagedProfile,
+                hasDeviceOwner = hasDeviceOwner,
+                isOrganizationOwned = isOrganizationOwned,
+            )
+        }
+
+        private fun profileDescription(): String =
+            profileState().run {
+                when {
+                    isManagedProfile && isOrganizationOwned -> "Organization-owned work profile"
+                    isManagedProfile -> "Personally owned work profile"
+                    hasDeviceOwner -> "Corporate-owned fully managed device"
+                    isOrganizationOwned -> "Organization-owned personal profile"
+                    else -> "Personal profile"
+                }
+            }
+
+        private data class ProfileState(
+            val isManagedProfile: Boolean,
+            val hasDeviceOwner: Boolean,
+            val isOrganizationOwned: Boolean,
+        )
+
+        private class AndroidClientTlsIdentity(
+            private val alias: String,
+            private val privateKey: PrivateKey,
+            private val certificateChain: List<X509Certificate>,
+            private val schemes: List<TlsSignatureScheme>,
+        ) : ClientTlsIdentity {
+            override fun certificateChain(): List<ByteArray> = certificateChain.map { it.encoded }
+
+            override fun supportedSignatureSchemes(): List<TlsSignatureScheme> = schemes
+
+            override fun sign(
+                scheme: TlsSignatureScheme,
+                message: ByteArray,
+            ): ByteArray =
+                try {
+                    sign(privateKey, scheme, message)
+                } catch (exception: Exception) {
+                    Log.e(TAG, "Android KeyChain failed to sign the TLS handshake", exception)
+                    throw CallbackException.Failed(
+                        exception.message ?: "The Android KeyChain failed to sign the TLS handshake.",
+                    )
+                }
+
+            override fun toString(): String = "AndroidClientTlsIdentity(alias=$alias)"
+        }
+
+        private fun certificateSection(
+            certificate: X509Certificate,
+            title: String,
+        ): X509DetailSection =
+            X509DetailSection(
+                title,
+                listOf(
+                    X509DetailField("Subject", certificate.subjectX500Principal.name),
+                    X509DetailField("Issuer", certificate.issuerX500Principal.name),
+                    X509DetailField("Subject alternative names", subjectAlternativeNames(certificate)),
+                    X509DetailField("Serial number", certificate.serialNumber.toString(16).uppercase()),
+                    X509DetailField("Not valid before", DateTimeFormatter.ISO_INSTANT.format(certificate.notBefore.toInstant())),
+                    X509DetailField("Not valid after", DateTimeFormatter.ISO_INSTANT.format(certificate.notAfter.toInstant())),
+                    X509DetailField("Public-key algorithm", certificate.publicKey.algorithm),
+                    X509DetailField("Certificate signature algorithm", certificate.sigAlgName),
+                    X509DetailField("SHA-256 fingerprint", sha256Hex(certificate.encoded)),
+                    X509DetailField("DER byte count", certificate.encoded.size.toString()),
+                    X509DetailField("PEM", pem(certificate.encoded)),
+                ),
+            )
+
+        companion object {
+            private const val TAG = "X509Identity"
+            private const val EXPECTED_SUBJECT_COMMON_NAME = "dev.firezone.device-trust"
+
+            internal fun isSupportedProfile(
+                isManagedProfile: Boolean,
+                hasDeviceOwner: Boolean,
+            ): Boolean = isManagedProfile || hasDeviceOwner
+
+            internal fun supportedSignatureSchemes(publicKey: PublicKey): List<TlsSignatureScheme> =
+                when (publicKey) {
+                    is RSAPublicKey -> {
+                        listOf(
+                            TlsSignatureScheme.RSA_PSS_SHA512,
+                            TlsSignatureScheme.RSA_PSS_SHA384,
+                            TlsSignatureScheme.RSA_PSS_SHA256,
+                            TlsSignatureScheme.RSA_PKCS1_SHA512,
+                            TlsSignatureScheme.RSA_PKCS1_SHA384,
+                            TlsSignatureScheme.RSA_PKCS1_SHA256,
+                        )
+                    }
+
+                    is ECPublicKey -> {
+                        when (publicKey.params.curve.field.fieldSize) {
+                            256 -> {
+                                listOf(TlsSignatureScheme.ECDSA_NISTP256_SHA256)
+                            }
+
+                            384 -> {
+                                listOf(TlsSignatureScheme.ECDSA_NISTP384_SHA384)
+                            }
+
+                            521 -> {
+                                listOf(TlsSignatureScheme.ECDSA_NISTP521_SHA512)
+                            }
+
+                            else -> {
+                                throw X509IdentityException(
+                                    "The X.509 identity uses an unsupported EC curve " +
+                                        "(${publicKey.params.curve.field.fieldSize} bits).",
+                                )
+                            }
+                        }
+                    }
+
+                    else -> {
+                        throw X509IdentityException(
+                            "The X.509 identity uses an unsupported private key (${publicKey.algorithm}).",
+                        )
+                    }
+                }
+
+            internal fun signatureAlgorithm(scheme: TlsSignatureScheme): String =
+                when (scheme) {
+                    TlsSignatureScheme.RSA_PKCS1_SHA256 -> "SHA256withRSA"
+                    TlsSignatureScheme.RSA_PKCS1_SHA384 -> "SHA384withRSA"
+                    TlsSignatureScheme.RSA_PKCS1_SHA512 -> "SHA512withRSA"
+                    TlsSignatureScheme.RSA_PSS_SHA256 -> "SHA256withRSA/PSS"
+                    TlsSignatureScheme.RSA_PSS_SHA384 -> "SHA384withRSA/PSS"
+                    TlsSignatureScheme.RSA_PSS_SHA512 -> "SHA512withRSA/PSS"
+                    TlsSignatureScheme.ECDSA_NISTP256_SHA256 -> "SHA256withECDSA"
+                    TlsSignatureScheme.ECDSA_NISTP384_SHA384 -> "SHA384withECDSA"
+                    TlsSignatureScheme.ECDSA_NISTP521_SHA512 -> "SHA512withECDSA"
+                }
+
+            internal fun sign(
+                privateKey: PrivateKey,
+                scheme: TlsSignatureScheme,
+                message: ByteArray,
+            ): ByteArray =
+                try {
+                    signature(scheme).run {
+                        initSign(privateKey)
+                        pssParameters(scheme)?.let(::setParameter)
+                        update(message)
+                        sign()
+                    }
+                } catch (exception: X509IdentityException) {
+                    throw exception
+                } catch (exception: Exception) {
+                    throw X509IdentityException(
+                        "The X.509 identity could not sign the TLS handshake.",
+                        exception,
+                    )
+                }
+
+            private fun signature(scheme: TlsSignatureScheme): Signature {
+                val algorithm = signatureAlgorithm(scheme)
+                return runCatching { Signature.getInstance(algorithm) }
+                    .getOrElse {
+                        if (pssParameters(scheme) != null) {
+                            Signature.getInstance("RSASSA-PSS")
+                        } else {
+                            throw it
+                        }
+                    }
+            }
+
+            private fun pssParameters(scheme: TlsSignatureScheme): PSSParameterSpec? =
+                when (scheme) {
+                    TlsSignatureScheme.RSA_PSS_SHA256 -> {
+                        PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1)
+                    }
+
+                    TlsSignatureScheme.RSA_PSS_SHA384 -> {
+                        PSSParameterSpec("SHA-384", "MGF1", MGF1ParameterSpec.SHA384, 48, 1)
+                    }
+
+                    TlsSignatureScheme.RSA_PSS_SHA512 -> {
+                        PSSParameterSpec("SHA-512", "MGF1", MGF1ParameterSpec.SHA512, 64, 1)
+                    }
+
+                    else -> {
+                        null
+                    }
+                }
+
+            private fun sha256Hex(data: ByteArray): String =
+                MessageDigest
+                    .getInstance("SHA-256")
+                    .digest(data)
+                    .joinToString(":") { byte -> "%02X".format(byte) }
+
+            private fun commonName(certificate: X509Certificate): String? =
+                RFC2253_COMMON_NAME
+                    .find(certificate.subjectX500Principal.name)
+                    ?.groupValues
+                    ?.get(1)
+                    ?.replace("\\,", ",")
+                    ?.replace("\\+", "+")
+                    ?.replace("\\=", "=")
+
+            private fun subjectAlternativeNames(certificate: X509Certificate): String =
+                try {
+                    certificate.subjectAlternativeNames
+                        ?.mapNotNull { subjectAlternativeName ->
+                            val type = subjectAlternativeName.getOrNull(0) as? Int ?: return@mapNotNull null
+                            val value = subjectAlternativeName.getOrNull(1) ?: return@mapNotNull null
+                            formatSubjectAlternativeName(type, value)
+                        }?.takeIf { it.isNotEmpty() }
+                        ?.joinToString("\n")
+                        ?: "None"
+                } catch (exception: Exception) {
+                    "Could not parse (${exception.message ?: exception.javaClass.simpleName})"
+                }
+
+            internal fun formatSubjectAlternativeName(
+                type: Int,
+                value: Any,
+            ): String {
+                val label =
+                    when (type) {
+                        0 -> "Other name"
+                        1 -> "Email"
+                        2 -> "DNS"
+                        3 -> "X.400 address"
+                        4 -> "Directory name"
+                        5 -> "EDI party name"
+                        6 -> "URI"
+                        7 -> "IP address"
+                        8 -> "Registered ID"
+                        else -> "Type $type"
+                    }
+                val renderedValue =
+                    if (value is ByteArray) {
+                        "DER/Base64 ${Base64.getEncoder().encodeToString(value)}"
+                    } else {
+                        value.toString()
+                    }
+
+                return "$label: $renderedValue"
+            }
+
+            internal fun mdmDeviceId(uris: List<String>): String? {
+                val filteredUris =
+                    uris.filterNot { it.startsWith(MICROSOFT_SID_URI_PREFIX, ignoreCase = true) }
+                var sawTypedIdentifier = false
+                var typedMdmDeviceId: String? = null
+
+                filteredUris.forEach { uri ->
+                    val match = FIREZONE_URI.matchEntire(uri) ?: return@forEach
+                    val idType = match.groupValues[1].lowercase()
+                    val value = match.groupValues[2]
+                    if (idType !in KNOWN_IDENTIFIER_TYPES || !validIdentifier(value)) return@forEach
+
+                    sawTypedIdentifier = true
+                    if (idType in MDM_IDENTIFIER_TYPES && typedMdmDeviceId == null) {
+                        typedMdmDeviceId = normalizeMdmDeviceId(value)
+                    }
+                }
+
+                if (sawTypedIdentifier) return typedMdmDeviceId
+
+                return filteredUris.firstNotNullOfOrNull { uri ->
+                    val value = uri.trim()
+                    if (value.length == 36 && runCatching { java.util.UUID.fromString(value) }.isSuccess) {
+                        normalizeMdmDeviceId(value)
+                    } else {
+                        null
+                    }
+                }
+            }
+
+            private fun mdmDeviceId(certificate: X509Certificate): String? =
+                runCatching {
+                    certificate.subjectAlternativeNames
+                        ?.mapNotNull { name ->
+                            val type = name.getOrNull(0) as? Int
+                            val value = name.getOrNull(1) as? String
+                            value?.takeIf { type == 6 }
+                        }.orEmpty()
+                }.map(::mdmDeviceId)
+                    .getOrNull()
+
+            private fun validIdentifier(value: String): Boolean {
+                val trimmed = value.trim()
+                return trimmed.isNotEmpty() &&
+                    trimmed.toByteArray(Charsets.UTF_8).size <= 255 &&
+                    trimmed.all { it.code in 0x20..0x7E }
+            }
+
+            private fun normalizeMdmDeviceId(value: String): String? {
+                val normalized = value.trim().lowercase()
+                return normalized.takeIf { validIdentifier(it) && it !in INVALID_IDENTIFIER_SENTINELS }
+            }
+
+            private fun pem(data: ByteArray): String {
+                val body =
+                    Base64
+                        .getEncoder()
+                        .encodeToString(data)
+                        .chunked(64)
+                        .joinToString("\n")
+                return "-----BEGIN CERTIFICATE-----\n$body\n-----END CERTIFICATE-----"
+            }
+
+            private val RFC2253_COMMON_NAME = Regex("(?:^|,)CN=((?:\\\\.|[^,])*)", RegexOption.IGNORE_CASE)
+            private val FIREZONE_URI = Regex("firezone://([^/]+)/(.+)", RegexOption.IGNORE_CASE)
+            private const val MICROSOFT_SID_URI_PREFIX = "tag:microsoft.com,2022-09-14:sid:"
+            private val KNOWN_IDENTIFIER_TYPES =
+                setOf(
+                    "serial",
+                    "apple-serial",
+                    "udid",
+                    "apple-udid",
+                    "smbios-uuid",
+                    "intune-id",
+                    "entra-id",
+                    "ws1-uuid",
+                    "jamf-id",
+                    "kandji-id",
+                )
+            private val MDM_IDENTIFIER_TYPES =
+                setOf("intune-id", "entra-id", "ws1-uuid", "jamf-id", "kandji-id")
+            private val INVALID_IDENTIFIER_SENTINELS =
+                setOf(
+                    "0",
+                    "00000000-0000-0000-0000-000000000000",
+                    "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                    "03000200-0400-0500-0006-000700080009",
+                    "idnotpresentbutsettable",
+                )
+        }
+    }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
@@ -69,6 +69,8 @@ class SessionActivity : AppCompatActivity() {
                 val connectedDevicesState by viewModel.connectedDevicesStateFlow.collectAsStateWithLifecycle()
                 val favorites by viewModel.favorites.collectAsStateWithLifecycle()
                 val serviceStatus by viewModel.serviceStatusStateFlow.collectAsStateWithLifecycle()
+                val certificateUserIdentity by
+                    viewModel.certificateUserIdentity.collectAsStateWithLifecycle()
 
                 // Finish if the tunnel service dies.
                 LaunchedEffect(serviceStatus) {
@@ -96,10 +98,11 @@ class SessionActivity : AppCompatActivity() {
                             }.toImmutableList()
                     }
 
-                val actorName = remember { viewModel.getActorName() }
+                val actorName = certificateUserIdentity?.email ?: remember { viewModel.getActorName() }
 
                 SessionScreen(
                     actorName = actorName,
+                    isCertificateAuthenticated = certificateUserIdentity != null,
                     resources = resources,
                     connectedDevices = connectedDevicesState.toImmutableList(),
                     favorites = favorites,
@@ -116,13 +119,17 @@ class SessionActivity : AppCompatActivity() {
                         startActivity(settings)
                     },
                     onSignOut = {
-                        viewModel.clearToken()
-                        viewModel.clearActorName()
+                        if (certificateUserIdentity == null) {
+                            viewModel.clearToken()
+                            viewModel.clearActorName()
+                        }
                         tunnelService?.disconnect()
                     },
                 )
             }
         }
+
+        viewModel.refreshCertificateUserIdentity()
     }
 
     override fun onDestroy() {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
@@ -1,27 +1,38 @@
 // Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.session.ui
 
+import android.os.Bundle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.firezone.android.core.Log
 import dev.firezone.android.core.data.Favorites
 import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.data.X509_CERTIFICATE_ALIAS_RESTRICTION
+import dev.firezone.android.core.x509.X509Identity
+import dev.firezone.android.core.x509.X509UserIdentity
 import dev.firezone.android.tunnel.TunnelService.Companion.State
 import dev.firezone.android.tunnel.model.ConnectedDevice
 import dev.firezone.android.tunnel.model.Resource
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
 internal class SessionViewModel
     @Inject
-    constructor() : ViewModel() {
-        // Must be `internal` because Dagger does not support injection into `private` fields
-        @Inject
-        internal lateinit var repo: Repository
+    constructor(
+        private val repo: Repository,
+        private val applicationRestrictions: Bundle,
+        private val x509Identity: X509Identity,
+    ) : ViewModel() {
         private val _serviceStatusStateFlow = MutableStateFlow<State?>(null)
         private val _resourcesStateFlow = MutableStateFlow<List<Resource>>(emptyList())
         private val _connectedDevicesStateFlow = MutableStateFlow<List<ConnectedDevice>>(emptyList())
+        private val _certificateUserIdentity = MutableStateFlow<X509UserIdentity?>(null)
 
         val serviceStatusStateFlow: StateFlow<State?>
             get() = _serviceStatusStateFlow
@@ -29,6 +40,8 @@ internal class SessionViewModel
             get() = _resourcesStateFlow
         val connectedDevicesStateFlow: StateFlow<List<ConnectedDevice>>
             get() = _connectedDevicesStateFlow
+        val certificateUserIdentity: StateFlow<X509UserIdentity?>
+            get() = _certificateUserIdentity
 
         // Internal getters for TunnelService to update state
         internal fun getServiceStatusMutableStateFlow(): MutableStateFlow<State?> = _serviceStatusStateFlow
@@ -45,6 +58,24 @@ internal class SessionViewModel
 
         fun getActorName() = repo.getActorNameSync()
 
+        fun refreshCertificateUserIdentity() {
+            viewModelScope.launch {
+                _certificateUserIdentity.value =
+                    withContext(Dispatchers.IO) {
+                        runCatching {
+                            if (!x509Identity.isSupportedProfile()) return@runCatching null
+                            x509Identity.userIdentity(configuredX509Alias())
+                        }.onFailure { exception ->
+                            Log.w(
+                                TAG,
+                                "Could not refresh the connected X.509 user identity",
+                                exception,
+                            )
+                        }.getOrNull()
+                    }
+            }
+        }
+
         fun addFavoriteResource(id: String) {
             repo.addFavoriteResource(id)
         }
@@ -54,4 +85,18 @@ internal class SessionViewModel
         }
 
         fun clearToken() = repo.clearToken()
+
+        private fun configuredX509Alias(): String? =
+            applicationRestrictions
+                .getString(X509_CERTIFICATE_ALIAS_RESTRICTION)
+                ?.takeUnless { it.isBlank() || it == "null" }
+                ?: if (applicationRestrictions.containsKey(X509_CERTIFICATE_ALIAS_RESTRICTION)) {
+                    null
+                } else {
+                    repo.getX509CertificateAliasSync()
+                }
+
+        companion object {
+            private const val TAG = "SessionViewModel"
+        }
     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/compose/SessionScreen.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/compose/SessionScreen.kt
@@ -50,6 +50,7 @@ private const val TAB_ALL = 1
 @Composable
 fun SessionScreen(
     actorName: String?,
+    isCertificateAuthenticated: Boolean,
     resources: ImmutableList<ResourceUiModel>,
     connectedDevices: ImmutableList<ConnectedDevice>,
     favorites: Favorites,
@@ -109,7 +110,17 @@ fun SessionScreen(
                     modifier = Modifier.padding(start = 8.dp),
                 )
                 Spacer(Modifier.weight(1f))
-                actorName?.let { Text(text = it, style = MaterialTheme.typography.bodySmall) }
+                actorName?.let {
+                    Text(
+                        text =
+                            if (isCertificateAuthenticated) {
+                                stringResource(R.string.connected_as, it)
+                            } else {
+                                it
+                            },
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
             }
 
             // The tab bar is the top-level switcher, pinned below the app bar so it stays visible and
@@ -164,7 +175,11 @@ fun SessionScreen(
                     Text(stringResource(R.string.settings))
                 }
                 Button(onClick = onSignOut, modifier = Modifier.weight(1f)) {
-                    Text(stringResource(R.string.sign_out))
+                    Text(
+                        stringResource(
+                            if (isCertificateAuthenticated) R.string.disconnect else R.string.sign_out,
+                        ),
+                    )
                 }
             }
         }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/AdvancedSettingsFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/AdvancedSettingsFragment.kt
@@ -2,6 +2,7 @@
 package dev.firezone.android.features.settings.ui
 
 import android.os.Bundle
+import android.security.KeyChain
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.Toast
@@ -9,20 +10,27 @@ import androidx.appcompat.widget.TooltipCompat
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import dagger.hilt.android.AndroidEntryPoint
 import dev.firezone.android.R
 import dev.firezone.android.core.data.model.ManagedConfigStatus
 import dev.firezone.android.databinding.FragmentSettingsAdvancedBinding
+import dev.firezone.android.databinding.ViewSettingsX509Binding
 import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class AdvancedSettingsFragment : Fragment(R.layout.fragment_settings_advanced) {
     private var _binding: FragmentSettingsAdvancedBinding? = null
+    private var x509SectionBinding: ViewSettingsX509Binding? = null
 
     val binding get() = _binding!!
+    private val x509Binding get() = x509SectionBinding!!
 
     private val viewModel: SettingsViewModel by activityViewModels()
+    private val x509ViewModel: X509SettingsViewModel by viewModels()
 
     override fun onViewCreated(
         view: View,
@@ -30,6 +38,7 @@ class AdvancedSettingsFragment : Fragment(R.layout.fragment_settings_advanced) {
     ) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentSettingsAdvancedBinding.bind(view)
+        x509SectionBinding = ViewSettingsX509Binding.bind(view.findViewById(R.id.x509Section))
 
         setupViews()
         setupActionObservers()
@@ -65,6 +74,12 @@ class AdvancedSettingsFragment : Fragment(R.layout.fragment_settings_advanced) {
                 viewModel.resetSettingsToDefaults()
             }
         }
+
+        x509Binding.apply {
+            btSelectX509Certificate.setOnClickListener { chooseCertificate() }
+            btForgetX509Certificate.setOnClickListener { x509ViewModel.forgetSelection() }
+            btRefreshX509.setOnClickListener { x509ViewModel.loadDetails() }
+        }
     }
 
     private fun setupActionObservers() {
@@ -98,7 +113,107 @@ class AdvancedSettingsFragment : Fragment(R.layout.fragment_settings_advanced) {
                         }
                     }
                 }
+
+                launch {
+                    x509ViewModel.uiState.collect(::renderX509)
+                }
             }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        x509ViewModel.loadDetails()
+    }
+
+    private fun chooseCertificate() {
+        val activity = requireActivity()
+        val currentAlias = x509ViewModel.uiState.value.alias
+        KeyChain.choosePrivateKeyAlias(
+            activity,
+            { alias ->
+                activity.runOnUiThread {
+                    if (_binding == null) return@runOnUiThread
+
+                    if (alias == null) {
+                        Toast
+                            .makeText(
+                                activity,
+                                R.string.x509_no_certificate_selected,
+                                Toast.LENGTH_LONG,
+                            ).show()
+                    } else {
+                        x509ViewModel.onAliasSelected(alias)
+                    }
+                }
+            },
+            arrayOf("RSA", "EC"),
+            null,
+            x509ViewModel.keyChainRequestUri(),
+            currentAlias,
+        )
+    }
+
+    private fun renderX509(state: X509SettingsViewModel.UiState) {
+        x509Binding.apply {
+            val supportedContentVisibility =
+                if (state.isProfileSupported == true) View.VISIBLE else View.GONE
+            tvX509IdentityDescription.visibility = supportedContentVisibility
+            tvX509Guidance.visibility = supportedContentVisibility
+            x509Actions.visibility = supportedContentVisibility
+            btRefreshX509.visibility = supportedContentVisibility
+            tvX509Unsupported.visibility =
+                if (state.isProfileSupported == false) View.VISIBLE else View.GONE
+
+            progressX509.visibility = if (state.isLoading) View.VISIBLE else View.GONE
+            if (state.isProfileSupported != true) {
+                progressX509.visibility = View.GONE
+                tvX509Summary.visibility = View.GONE
+                tvX509Error.visibility = View.GONE
+                tvX509Details.visibility = View.GONE
+                return@apply
+            }
+
+            tvX509Summary.text = state.summary
+            tvX509Summary.visibility =
+                if (!state.isLoading && state.error == null) View.VISIBLE else View.GONE
+            tvX509Details.text = state.details
+            tvX509Details.visibility =
+                if (!state.isLoading && state.error == null && state.details.isNotEmpty()) {
+                    View.VISIBLE
+                } else {
+                    View.GONE
+                }
+
+            tvX509Error.text =
+                state.error
+                    ?.let { error ->
+                        getString(R.string.x509_error_title) + "\n\n" + error + "\n\n" +
+                            getString(R.string.x509_contact_admin)
+                    }.orEmpty()
+            tvX509Error.visibility =
+                if (!state.isLoading && state.error != null) View.VISIBLE else View.GONE
+
+            tvX509Guidance.setText(
+                if (state.isManaged) {
+                    R.string.x509_managed_description
+                } else {
+                    R.string.x509_user_description
+                },
+            )
+            val canAuthorizeManagedAlias = state.isManaged && state.alias != null && state.error != null
+            btSelectX509Certificate.visibility =
+                if (!state.isManaged || canAuthorizeManagedAlias) View.VISIBLE else View.GONE
+            btSelectX509Certificate.setText(
+                if (state.isManaged) {
+                    R.string.x509_authorize_certificate
+                } else {
+                    R.string.x509_select_certificate
+                },
+            )
+            btForgetX509Certificate.visibility =
+                if (!state.isManaged && state.alias != null) View.VISIBLE else View.GONE
+            btRefreshX509.isEnabled = !state.isLoading
         }
     }
 
@@ -154,6 +269,7 @@ class AdvancedSettingsFragment : Fragment(R.layout.fragment_settings_advanced) {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        x509SectionBinding = null
         _binding = null
     }
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
@@ -159,7 +159,7 @@ internal class SettingsActivity : AppCompatActivity() {
     private inner class SettingsPagerAdapter(
         activity: FragmentActivity,
     ) : FragmentStateAdapter(activity) {
-        override fun getItemCount(): Int = 3 // Three tabs
+        override fun getItemCount(): Int = 3
 
         override fun createFragment(position: Int): Fragment =
             when (position) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/X509SettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/X509SettingsViewModel.kt
@@ -1,0 +1,134 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.features.settings.ui
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.firezone.android.core.Log
+import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.x509.X509Identity
+import dev.firezone.android.core.x509.X509IdentityDetails
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@HiltViewModel
+internal class X509SettingsViewModel
+    @Inject
+    constructor(
+        private val repository: Repository,
+        private val x509Identity: X509Identity,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow(UiState())
+        val uiState: StateFlow<UiState> = _uiState
+        private var loadJob: Job? = null
+
+        fun loadDetails() {
+            val alias = repository.getX509CertificateAliasSync()
+            val isManaged = repository.isX509CertificateAliasManaged()
+            _uiState.value =
+                _uiState.value.copy(
+                    alias = alias,
+                    isManaged = isManaged,
+                    isLoading = true,
+                    summary = "",
+                    details = "",
+                    error = null,
+                    isProfileSupported = null,
+                )
+
+            loadJob?.cancel()
+            loadJob =
+                viewModelScope.launch {
+                    try {
+                        val isProfileSupported =
+                            withContext(Dispatchers.IO) {
+                                x509Identity.isSupportedProfile()
+                            }
+                        if (!isProfileSupported) {
+                            _uiState.value =
+                                _uiState.value.copy(
+                                    isLoading = false,
+                                    isProfileSupported = false,
+                                )
+                            return@launch
+                        }
+
+                        _uiState.value = _uiState.value.copy(isProfileSupported = true)
+
+                        val result =
+                            withContext(Dispatchers.IO) {
+                                x509Identity.details(alias = alias, isManaged = isManaged)
+                            }
+                        _uiState.value =
+                            _uiState.value.copy(
+                                isLoading = false,
+                                isProfileSupported = true,
+                                summary = result.summary,
+                                details = result.textDescription(),
+                            )
+                    } catch (exception: CancellationException) {
+                        throw exception
+                    } catch (exception: Exception) {
+                        Log.e(TAG, "Failed to load X.509 settings diagnostics", exception)
+                        _uiState.value =
+                            _uiState.value.copy(
+                                isLoading = false,
+                                error = exception.message ?: "The Android KeyChain could not be read.",
+                            )
+                    }
+                }
+        }
+
+        fun onAliasSelected(alias: String?) {
+            if (alias == null) return
+
+            if (repository.isX509CertificateAliasManaged()) {
+                Log.w(TAG, "Ignoring a user-selected alias because the X.509 alias is managed")
+            } else {
+                repository.saveSelectedX509CertificateAliasSync(alias)
+            }
+            loadDetails()
+        }
+
+        fun forgetSelection() {
+            if (repository.isX509CertificateAliasManaged()) return
+
+            repository.saveSelectedX509CertificateAliasSync(null)
+            loadDetails()
+        }
+
+        fun keyChainRequestUri(): Uri? = runCatching { Uri.parse(repository.getConfigSync().apiUrl) }.getOrNull()
+
+        internal data class UiState(
+            val alias: String? = null,
+            val isManaged: Boolean = false,
+            val isLoading: Boolean = true,
+            val summary: String = "",
+            val details: String = "",
+            val error: String? = null,
+            val isProfileSupported: Boolean? = null,
+        )
+
+        companion object {
+            private const val TAG = "X509SettingsViewModel"
+        }
+    }
+
+private fun X509IdentityDetails.textDescription(): String =
+    buildString {
+        sections.forEachIndexed { sectionIndex, section ->
+            if (sectionIndex > 0) appendLine()
+            appendLine("[${section.title}]")
+            section.fields.forEach { field ->
+                appendLine("${field.label}:")
+                field.value.lineSequence().forEach { line -> appendLine("  $line") }
+            }
+        }
+    }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/signin/ui/SignInFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/signin/ui/SignInFragment.kt
@@ -5,15 +5,23 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import dev.firezone.android.R
 import dev.firezone.android.databinding.FragmentSignInBinding
 import dev.firezone.android.features.auth.ui.AuthActivity
+import dev.firezone.android.features.session.ui.SessionActivity
+import dev.firezone.android.tunnel.TunnelService
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 internal class SignInFragment : Fragment(R.layout.fragment_sign_in) {
     private lateinit var binding: FragmentSignInBinding
+    private val viewModel: SignInViewModel by viewModels()
 
     override fun onViewCreated(
         view: View,
@@ -22,18 +30,43 @@ internal class SignInFragment : Fragment(R.layout.fragment_sign_in) {
         super.onViewCreated(view, savedInstanceState)
         binding = FragmentSignInBinding.bind(view)
 
+        setupIdentityObserver()
         setupButtonListener()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.refreshCertificateUserIdentity()
+    }
+
+    private fun setupIdentityObserver() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.certificateUserIdentity.collect { identity ->
+                    binding.btSignIn.text =
+                        identity?.let { getString(R.string.connect_as, it.email) }
+                            ?: getString(R.string.sign_in)
+                    binding.tvSessionStatus.text =
+                        identity?.let { getString(R.string.disconnected_connect_as, it.email) }
+                            ?: getString(R.string.signed_out)
+                }
+            }
+        }
     }
 
     private fun setupButtonListener() {
         with(binding) {
             btSignIn.setOnClickListener {
-                startActivity(
-                    Intent(
-                        requireContext(),
-                        AuthActivity::class.java,
-                    ),
-                )
+                if (viewModel.certificateUserIdentity.value != null) {
+                    TunnelService.start(requireContext())
+                    startActivity(
+                        Intent(requireContext(), SessionActivity::class.java).apply {
+                            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                        },
+                    )
+                } else {
+                    startActivity(Intent(requireContext(), AuthActivity::class.java))
+                }
                 requireActivity().finish()
             }
             btSettings.setOnClickListener {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/signin/ui/SignInViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/signin/ui/SignInViewModel.kt
@@ -1,0 +1,62 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.features.signin.ui
+
+import android.os.Bundle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.firezone.android.core.Log
+import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.data.X509_CERTIFICATE_ALIAS_RESTRICTION
+import dev.firezone.android.core.x509.X509Identity
+import dev.firezone.android.core.x509.X509UserIdentity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@HiltViewModel
+internal class SignInViewModel
+    @Inject
+    constructor(
+        private val repository: Repository,
+        private val applicationRestrictions: Bundle,
+        private val x509Identity: X509Identity,
+    ) : ViewModel() {
+        private val _certificateUserIdentity = MutableStateFlow<X509UserIdentity?>(null)
+        val certificateUserIdentity: StateFlow<X509UserIdentity?> = _certificateUserIdentity
+
+        fun refreshCertificateUserIdentity() {
+            viewModelScope.launch {
+                _certificateUserIdentity.value =
+                    withContext(Dispatchers.IO) {
+                        runCatching {
+                            if (!x509Identity.isSupportedProfile()) return@runCatching null
+                            x509Identity.userIdentity(configuredX509Alias())
+                        }.onFailure { exception ->
+                            Log.w(
+                                TAG,
+                                "Could not read the X.509 user identity; using web sign-in",
+                                exception,
+                            )
+                        }.getOrNull()
+                    }
+            }
+        }
+
+        private fun configuredX509Alias(): String? =
+            applicationRestrictions
+                .getString(X509_CERTIFICATE_ALIAS_RESTRICTION)
+                ?.takeUnless { it.isBlank() || it == "null" }
+                ?: if (applicationRestrictions.containsKey(X509_CERTIFICATE_ALIAS_RESTRICTION)) {
+                    null
+                } else {
+                    repository.getX509CertificateAliasSync()
+                }
+
+        companion object {
+            private const val TAG = "SignInViewModel"
+        }
+    }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
@@ -13,12 +13,17 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.firezone.android.core.ApplicationMode
+import dev.firezone.android.core.Log
 import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.data.X509_CERTIFICATE_ALIAS_RESTRICTION
+import dev.firezone.android.core.x509.X509Identity
 import dev.firezone.android.tunnel.TunnelService
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 private const val REQUEST_DELAY = 1000L
@@ -30,6 +35,7 @@ internal class SplashViewModel
         private val repo: Repository,
         private val applicationRestrictions: Bundle,
         private val applicationMode: ApplicationMode,
+        private val x509Identity: X509Identity,
     ) : ViewModel() {
         private val actionMutableStateFlow = MutableStateFlow<ViewAction?>(null)
         val actionStateFlow: StateFlow<ViewAction?> = actionMutableStateFlow
@@ -55,9 +61,15 @@ internal class SplashViewModel
                 }
 
                 val token = applicationRestrictions.getString("token") ?: repo.getTokenSync()
+                val hasCertificateUserIdentity =
+                    if (token.isNullOrBlank()) {
+                        hasCertificateUserIdentity()
+                    } else {
+                        false
+                    }
 
-                // If we don't have a token, we can't connect.
-                if (token.isNullOrBlank()) {
+                // A complete certificate identity can authenticate without a web sign-in token.
+                if (token.isNullOrBlank() && !hasCertificateUserIdentity) {
                     actionMutableStateFlow.value = ViewAction.NavigateToSignIn
                     return@launch
                 }
@@ -87,6 +99,30 @@ internal class SplashViewModel
         internal fun clearAction() {
             actionMutableStateFlow.value = null
         }
+
+        private suspend fun hasCertificateUserIdentity(): Boolean =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    if (!x509Identity.isSupportedProfile()) return@runCatching false
+                    x509Identity.userIdentity(configuredX509Alias()) != null
+                }.onFailure { exception ->
+                    Log.w(
+                        TAG,
+                        "Could not read the X.509 user identity while choosing the startup flow",
+                        exception,
+                    )
+                }.getOrDefault(false)
+            }
+
+        private fun configuredX509Alias(): String? =
+            applicationRestrictions
+                .getString(X509_CERTIFICATE_ALIAS_RESTRICTION)
+                ?.takeUnless { it.isBlank() || it == "null" }
+                ?: if (applicationRestrictions.containsKey(X509_CERTIFICATE_ALIAS_RESTRICTION)) {
+                    null
+                } else {
+                    repo.getX509CertificateAliasSync()
+                }
 
         private fun hasVpnPermissions(context: Context): Boolean = android.net.VpnService.prepare(context) == null
 
@@ -128,5 +164,9 @@ internal class SplashViewModel
             object NavigateToSignIn : ViewAction()
 
             object NavigateToSession : ViewAction()
+        }
+
+        companion object {
+            private const val TAG = "SplashViewModel"
         }
     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -24,7 +24,11 @@ import dev.firezone.android.core.Log
 import dev.firezone.android.core.Telemetry
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.data.ResourceState
+import dev.firezone.android.core.data.X509_CERTIFICATE_ALIAS_RESTRICTION
 import dev.firezone.android.core.data.isEnabled
+import dev.firezone.android.core.x509.NoClientTlsIdentity
+import dev.firezone.android.core.x509.X509Identity
+import dev.firezone.android.core.x509.X509IdentityException
 import dev.firezone.android.tunnel.model.Cidr
 import dev.firezone.android.tunnel.model.ConnectedDevice
 import dev.firezone.android.tunnel.model.Resource
@@ -45,6 +49,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.withContext
 import uniffi.connlib.AndroidSessionConfig
 import uniffi.connlib.ConnlibException
 import uniffi.connlib.DeviceInfo
@@ -75,6 +80,9 @@ class TunnelService : VpnService() {
 
     @Inject
     internal lateinit var moshi: Moshi
+
+    @Inject
+    internal lateinit var x509Identity: X509Identity
 
     private var tunnelIpv4Address: String? = null
     private var tunnelIpv6Address: String? = null
@@ -329,6 +337,26 @@ class TunnelService : VpnService() {
                     Telemetry.setFirezoneId(deviceIdValue)
                     Telemetry.setAccountSlug(config.accountSlug)
 
+                    val x509Alias =
+                        appRestrictions
+                            .getString(X509_CERTIFICATE_ALIAS_RESTRICTION)
+                            ?.takeUnless { it.isBlank() || it == "null" }
+                            ?: if (appRestrictions.containsKey(X509_CERTIFICATE_ALIAS_RESTRICTION)) {
+                                null
+                            } else {
+                                repo.getSelectedX509CertificateAliasSync()
+                            }
+                    val x509ClientIdentity =
+                        if (x509Identity.isSupportedProfile()) {
+                            withContext(Dispatchers.IO) {
+                                x509Identity.clientTlsIdentity(x509Alias)
+                            }
+                        } else {
+                            null
+                        }
+                    val mdmDeviceId = x509ClientIdentity?.mdmDeviceId
+                    Telemetry.setMdmDeviceId(mdmDeviceId)
+
                     Session
                         .newAndroid(
                             config =
@@ -343,8 +371,12 @@ class TunnelService : VpnService() {
                                     flowLogsDir = flowLogsDir(this@TunnelService),
                                     isInternetResourceActive = resourceState.isEnabled(),
                                     deviceInfo = deviceInfo,
+                                    useClientCertificate = x509ClientIdentity != null,
+                                    mdmDeviceId = mdmDeviceId,
                                 ),
                             protectSocket = protectSocketCallback,
+                            clientTlsIdentity =
+                                x509ClientIdentity?.clientTlsIdentity ?: NoClientTlsIdentity,
                         ).use { session ->
                             startNetworkMonitoring()
                             startLogCleanup()
@@ -362,6 +394,13 @@ class TunnelService : VpnService() {
                 } catch (e: ConnlibException) {
                     Log.e(TAG, "Failed to start session", e)
                     e.close()
+                } catch (e: X509IdentityException) {
+                    Log.e(TAG, "Failed to load X.509 device identity", e)
+                    showErrorNotification(
+                        "Device verification failed",
+                        (e.message ?: "The Android KeyChain could not load the device identity.") +
+                            " Contact your administrator for support.",
+                    )
                 } finally {
                     commandChannel = null
                     tunnelState = State.DOWN
@@ -787,7 +826,13 @@ class TunnelService : VpnService() {
         }
 
         private val MANAGED_CONFIGURATIONS =
-            arrayOf("token", "allowedApplications", "disallowedApplications", "deviceName")
+            arrayOf(
+                "token",
+                "allowedApplications",
+                "disallowedApplications",
+                "deviceName",
+                X509_CERTIFICATE_ALIAS_RESTRICTION,
+            )
 
         @Volatile
         private var activeService: TunnelService? = null

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -301,11 +301,13 @@ class TunnelService : VpnService() {
     }
 
     private fun connect() {
-        val token = appRestrictions.getString("token") ?: repo.getTokenSync()
+        val token =
+            (appRestrictions.getString("token") ?: repo.getTokenSync())
+                ?.takeUnless(String::isBlank)
         val config = repo.getConfigSync()
         resourceState = repo.getInternetResourceStateSync()
 
-        if (!token.isNullOrBlank()) {
+        if (token != null || configuredX509Alias() != null) {
             tunnelState = State.CONNECTING
             // Dismiss any previous disconnected notifications
             TunnelNotification.dismissDisconnectedNotification(this)
@@ -334,11 +336,40 @@ class TunnelService : VpnService() {
                     // Set telemetry environment and user context
                     val deviceIdValue = deviceId()
                     Telemetry.setEnvironmentOrClose(config.apiUrl)
-                    Telemetry.setFirezoneId(deviceIdValue)
-                    Telemetry.setAccountSlug(config.accountSlug)
 
                     val x509ClientIdentity = loadX509ClientIdentity()
                     val mdmDeviceId = x509ClientIdentity?.mdmDeviceId
+                    val certificateUserIdentity = x509ClientIdentity?.userIdentity
+                    val authToken: String?
+                    val accountSlug: String?
+                    val accountId: String?
+                    val actorEmail: String?
+                    if (certificateUserIdentity != null) {
+                        authToken = null
+                        accountSlug = null
+                        accountId = certificateUserIdentity.accountId
+                        actorEmail = certificateUserIdentity.email
+                        Telemetry.setUser(
+                            firezoneId = deviceIdValue,
+                            accountId = certificateUserIdentity.accountId,
+                            actorEmail = certificateUserIdentity.email,
+                        )
+                        Log.i(
+                            TAG,
+                            "Using the managed X.509 identity for user authentication " +
+                                "(accountId=${certificateUserIdentity.accountId}); omitting bearer authorization",
+                        )
+                    } else {
+                        authToken =
+                            token ?: throw X509IdentityException(
+                                "No sign-in token is available and the X.509 certificate has no complete user identity.",
+                            )
+                        accountSlug = config.accountSlug
+                        accountId = null
+                        actorEmail = null
+                        Telemetry.setUser(deviceIdValue, config.accountSlug)
+                        Log.i(TAG, "Using the saved web sign-in token for user authentication")
+                    }
                     Telemetry.setMdmDeviceId(mdmDeviceId)
 
                     Session
@@ -346,8 +377,10 @@ class TunnelService : VpnService() {
                             config =
                                 AndroidSessionConfig(
                                     apiUrl = config.apiUrl,
-                                    token = token,
-                                    accountSlug = config.accountSlug,
+                                    token = authToken,
+                                    accountSlug = accountSlug,
+                                    accountId = accountId,
+                                    actorEmail = actorEmail,
                                     deviceId = deviceIdValue,
                                     deviceName = getDeviceName(),
                                     logDir = getLogDir(),
@@ -623,6 +656,13 @@ class TunnelService : VpnService() {
         try {
             val refreshedIdentity = loadX509ClientIdentity()
             Telemetry.setMdmDeviceId(refreshedIdentity?.mdmDeviceId)
+            refreshedIdentity?.userIdentity?.let { userIdentity ->
+                Telemetry.setUser(
+                    firezoneId = deviceId(),
+                    accountId = userIdentity.accountId,
+                    actorEmail = userIdentity.email,
+                )
+            }
             Log.i(TAG, "Re-read X.509 device identity after certificate revocation")
         } catch (exception: X509IdentityException) {
             Log.w(TAG, "Could not re-read X.509 device identity after certificate revocation", exception)
@@ -718,7 +758,7 @@ class TunnelService : VpnService() {
                                             refreshX509IdentityAfterRevocation()
                                         }
 
-                                        else -> {
+                                        event.error.isAuthenticationError() -> {
                                             repo.clearToken()
                                             repo.clearActorName()
                                         }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -337,23 +337,7 @@ class TunnelService : VpnService() {
                     Telemetry.setFirezoneId(deviceIdValue)
                     Telemetry.setAccountSlug(config.accountSlug)
 
-                    val x509Alias =
-                        appRestrictions
-                            .getString(X509_CERTIFICATE_ALIAS_RESTRICTION)
-                            ?.takeUnless { it.isBlank() || it == "null" }
-                            ?: if (appRestrictions.containsKey(X509_CERTIFICATE_ALIAS_RESTRICTION)) {
-                                null
-                            } else {
-                                repo.getSelectedX509CertificateAliasSync()
-                            }
-                    val x509ClientIdentity =
-                        if (x509Identity.isSupportedProfile()) {
-                            withContext(Dispatchers.IO) {
-                                x509Identity.clientTlsIdentity(x509Alias)
-                            }
-                        } else {
-                            null
-                        }
+                    val x509ClientIdentity = loadX509ClientIdentity()
                     val mdmDeviceId = x509ClientIdentity?.mdmDeviceId
                     Telemetry.setMdmDeviceId(mdmDeviceId)
 
@@ -616,6 +600,35 @@ class TunnelService : VpnService() {
         TunnelNotification.showErrorNotification(this, title, message)
     }
 
+    private fun configuredX509Alias(): String? =
+        appRestrictions
+            .getString(X509_CERTIFICATE_ALIAS_RESTRICTION)
+            ?.takeUnless { it.isBlank() || it == "null" }
+            ?: if (appRestrictions.containsKey(X509_CERTIFICATE_ALIAS_RESTRICTION)) {
+                null
+            } else {
+                repo.getSelectedX509CertificateAliasSync()
+            }
+
+    private suspend fun loadX509ClientIdentity() =
+        if (x509Identity.isSupportedProfile()) {
+            withContext(Dispatchers.IO) {
+                x509Identity.clientTlsIdentity(configuredX509Alias())
+            }
+        } else {
+            null
+        }
+
+    private suspend fun refreshX509IdentityAfterRevocation() {
+        try {
+            val refreshedIdentity = loadX509ClientIdentity()
+            Telemetry.setMdmDeviceId(refreshedIdentity?.mdmDeviceId)
+            Log.i(TAG, "Re-read X.509 device identity after certificate revocation")
+        } catch (exception: X509IdentityException) {
+            Log.w(TAG, "Could not re-read X.509 device identity after certificate revocation", exception)
+        }
+    }
+
     private suspend fun eventLoop(
         session: SessionInterface,
         commandChannel: Channel<TunnelCommand>,
@@ -700,9 +713,16 @@ class TunnelService : VpnService() {
                                 }
 
                                 is Event.Disconnected -> {
-                                    // Clear any user tokens and actorNames
-                                    repo.clearToken()
-                                    repo.clearActorName()
+                                    when {
+                                        event.error.isCertificateRevoked() -> {
+                                            refreshX509IdentityAfterRevocation()
+                                        }
+
+                                        else -> {
+                                            repo.clearToken()
+                                            repo.clearActorName()
+                                        }
+                                    }
 
                                     stopReason = StopReason.Disconnected
                                 }

--- a/kotlin/android/app/src/main/res/layout/fragment_settings_advanced.xml
+++ b/kotlin/android/app/src/main/res/layout/fragment_settings_advanced.xml
@@ -10,7 +10,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content">
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/ilAuthUrlInput"
@@ -120,15 +120,27 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/ilLogFilterInput" />
 
+        <include
+            android:id="@+id/x509Section"
+            layout="@layout/view_settings_x509"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_8x"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btResetDefaults" />
+
         <TextView
             android:id="@+id/tvGitSha"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_8x"
             android:layout_marginBottom="56dp"
             android:text="@string/git_sha"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/x509Section" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.core.widget.NestedScrollView>

--- a/kotlin/android/app/src/main/res/layout/view_settings_x509.xml
+++ b/kotlin/android/app/src/main/res/layout/view_settings_x509.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/x509Section"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/tvX509IdentityTitle"
+        style="@style/AppTheme.Base.H6"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/x509_identity_title" />
+
+    <TextView
+        android:id="@+id/tvX509IdentityDescription"
+        style="@style/AppTheme.Base.Body2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_small"
+        android:text="@string/x509_identity_description" />
+
+    <TextView
+        android:id="@+id/tvX509Unsupported"
+        style="@style/AppTheme.Base.Body2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_small"
+        android:text="@string/x509_unsupported_personal_profile"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/tvX509Guidance"
+        style="@style/AppTheme.Base.Body2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_medium" />
+
+    <LinearLayout
+        android:id="@+id/x509Actions"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_medium"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btSelectX509Certificate"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/x509_select_certificate" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btForgetX509Certificate"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/spacing_small"
+            android:text="@string/x509_forget_certificate"
+            android:visibility="gone" />
+    </LinearLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btRefreshX509"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:text="@string/x509_refresh" />
+
+    <ProgressBar
+        android:id="@+id/progressX509"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/spacing_medium"
+        android:contentDescription="@string/x509_loading" />
+
+    <TextView
+        android:id="@+id/tvX509Summary"
+        style="@style/AppTheme.Base.Body2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_medium"
+        android:textIsSelectable="true"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/tvX509Error"
+        style="@style/AppTheme.Base.Body2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_medium"
+        android:background="@color/neutral_100"
+        android:padding="@dimen/spacing_medium"
+        android:textIsSelectable="true"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/tvX509Details"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_medium"
+        android:fontFamily="monospace"
+        android:textIsSelectable="true"
+        android:textSize="@dimen/text_caption"
+        android:visibility="gone" />
+</LinearLayout>

--- a/kotlin/android/app/src/main/res/values/strings.xml
+++ b/kotlin/android/app/src/main/res/values/strings.xml
@@ -53,13 +53,17 @@
 
 	<!-- Sign In -->
 	<string name="sign_in">Sign In</string>
+	<string name="connect_as">Connect as %1$s</string>
 	<string name="settings">Settings</string>
 	<string name="signed_out">Signed Out</string>
+	<string name="disconnected_connect_as">Disconnected. Connect as %1$s to access Resources.</string>
+	<string name="connected_as">Connected as %1$s</string>
 
 	<!-- Sign Out -->
 	<string name="resources">Resources</string>
 	<string name="connected_devices">Connected Devices</string>
 	<string name="sign_out">Sign Out</string>
+	<string name="disconnect">Disconnect</string>
 
 	<!-- Auth -->
 	<string name="launching_auth_flow">Launching Browser to sign in…</string>

--- a/kotlin/android/app/src/main/res/values/strings.xml
+++ b/kotlin/android/app/src/main/res/values/strings.xml
@@ -24,6 +24,32 @@
 	<string name="share_diagnostic_logs">Export Logs</string>
 	<string name="log_directory_size">Log directory size: %1$s</string>
 	<string name="clear_log_directory">Clear Log Directory</string>
+	<!-- X.509 Device Identity -->
+	<string name="x509_identity_title">X.509 Device Identity</string>
+	<string name="x509_identity_description">
+		Firezone uses this system KeyChain identity to prove device enrollment when connecting.
+		Private-key bytes never leave the Android KeyChain.
+	</string>
+	<string name="x509_unsupported_personal_profile">
+		X.509 device identity is supported only in managed work profiles and on corporate-owned
+		Android devices.
+	</string>
+	<string name="x509_select_certificate">Select Certificate</string>
+	<string name="x509_authorize_certificate">Authorize Certificate</string>
+	<string name="x509_forget_certificate">Forget Selection</string>
+	<string name="x509_refresh">Refresh</string>
+	<string name="x509_loading">Reading KeyChain identity…</string>
+	<string name="x509_no_certificate_selected">No RSA or EC certificate was selected.</string>
+	<string name="x509_managed_description">
+		Your organization configured this certificate alias. The administrator must also grant
+		Firezone access to the corresponding KeyChain key.
+	</string>
+	<string name="x509_user_description">
+		Choose a certificate once. Android will ask you to confirm access, and Firezone will remember
+		the selected alias for future connections.
+	</string>
+	<string name="x509_error_title">Unable to read the X.509 identity</string>
+	<string name="x509_contact_admin">Contact your administrator for support.</string>
 
 	<!-- Sign In -->
 	<string name="sign_in">Sign In</string>
@@ -111,6 +137,11 @@
 	<string name="config_connect_on_start_title">Connect on Start</string>
 	<string name="config_connect_on_start_description">
 		Whether Firezone should automatically try to connect when the app is launched.
+	</string>
+	<string name="config_x509_certificate_alias_title">X.509 Certificate Alias</string>
+	<string name="config_x509_certificate_alias_description">
+		The Android KeyChain alias of the client certificate used for mutual TLS. The device
+		policy controller must install the key pair and grant dev.firezone.android access to it.
 	</string>
 
 	<string name="managed_setting_info_description">

--- a/kotlin/android/app/src/main/res/values/styles.xml
+++ b/kotlin/android/app/src/main/res/values/styles.xml
@@ -44,6 +44,12 @@
         <item name="android:textColorPrimary">@color/neutral_900</item>
     </style>
 
+    <style name="AppTheme.Base.H6">
+        <item name="fontFamily">@font/source_sans_pro_bold</item>
+        <item name="android:textSize">@dimen/text_h6</item>
+        <item name="android:textColorPrimary">@color/neutral_900</item>
+    </style>
+
     <style name="AppTheme.Base.Body1">
         <item name="fontFamily">@font/source_sans_pro</item>
         <item name="android:textSize">@dimen/text_body1</item>

--- a/kotlin/android/app/src/main/res/xml/app_restrictions.xml
+++ b/kotlin/android/app/src/main/res/xml/app_restrictions.xml
@@ -60,4 +60,10 @@
         android:key="connectOnStart"
         android:restrictionType="bool"
         android:title="@string/config_connect_on_start_title" />
+
+    <restriction
+        android:description="@string/config_x509_certificate_alias_description"
+        android:key="x509CertificateAlias"
+        android:restrictionType="string"
+        android:title="@string/config_x509_certificate_alias_title" />
 </restrictions>

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/x509/X509IdentityTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/x509/X509IdentityTest.kt
@@ -137,6 +137,74 @@ class X509IdentityTest {
     }
 
     @Test
+    fun `extracts certificate user identity from Intune comma-joined URI SAN`() {
+        val uris =
+            listOf(
+                "tag:microsoft.com,2022-09-14:sid:S-1-12-1-1, " +
+                    "firezone://email/Alice%40Example.COM, " +
+                    "firezone://account-id/5F2E7B7A-9D54-4BD2-9D4F-8F6C2A01F9D3, " +
+                    "firezone://intune-id/ADBCB238-5C99-47D6-957D-F14A1B3C7E41, " +
+                    "firezone://serial/C02XK1ZGJGH5",
+            )
+
+        assertEquals(
+            X509UserIdentity(
+                email = "alice@example.com",
+                accountId = "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3",
+            ),
+            X509Identity.userIdentity(uris),
+        )
+        assertEquals("alice@example.com", X509Identity.actorEmail(uris))
+        assertEquals(
+            "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3",
+            X509Identity.accountId(uris),
+        )
+        assertEquals("adbcb238-5c99-47d6-957d-f14a1b3c7e41", X509Identity.mdmDeviceId(uris))
+        assertEquals("C02XK1ZGJGH5", X509Identity.deviceSerial(uris))
+        assertEquals(
+            listOf("Actor Email", "Account ID", "MDM Device ID", "Device Serial"),
+            X509Identity.identityAttributeFields(uris).map { it.label },
+        )
+    }
+
+    @Test
+    fun `certificate user identity requires complete unambiguous attributes`() {
+        assertEquals(
+            null,
+            X509Identity.userIdentity(listOf("firezone://email/alice@example.com")),
+        )
+        assertEquals(
+            null,
+            X509Identity.userIdentity(
+                listOf(
+                    "firezone://email/alice@example.com, " +
+                        "firezone://email/bob@example.com, " +
+                        "firezone://account-id/5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3",
+                ),
+            ),
+        )
+        assertEquals(
+            null,
+            X509Identity.userIdentity(
+                listOf("firezone://email/alice@example.com,firezone://account-id/not-a-uuid"),
+            ),
+        )
+    }
+
+    @Test
+    fun `formats Intune comma-joined URI SAN values on separate lines`() {
+        assertEquals(
+            "URI: firezone://email/alice@example.com\n" +
+                "URI: firezone://account-id/5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3",
+            X509Identity.formatSubjectAlternativeName(
+                6,
+                "firezone://email/alice@example.com," +
+                    "firezone://account-id/5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3",
+            ),
+        )
+    }
+
+    @Test
     fun `uses bare UUID fallback only when typed identifiers are absent`() {
         val bareId = "4125c235-441b-48b7-b96d-1c17494931a2"
 

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/x509/X509IdentityTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/x509/X509IdentityTest.kt
@@ -1,0 +1,150 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.core.x509
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import uniffi.connlib.TlsSignatureScheme
+import java.security.KeyPairGenerator
+import java.security.Signature
+import java.security.spec.ECGenParameterSpec
+import java.security.spec.MGF1ParameterSpec
+import java.security.spec.PSSParameterSpec
+
+class X509IdentityTest {
+    @Test
+    fun `supports managed profiles and device-owner devices only`() {
+        assertTrue(X509Identity.isSupportedProfile(isManagedProfile = true, hasDeviceOwner = false))
+        assertTrue(X509Identity.isSupportedProfile(isManagedProfile = false, hasDeviceOwner = true))
+        assertTrue(X509Identity.isSupportedProfile(isManagedProfile = true, hasDeviceOwner = true))
+        assertFalse(X509Identity.isSupportedProfile(isManagedProfile = false, hasDeviceOwner = false))
+    }
+
+    @Test
+    fun `signs TLS handshake with RSA-PSS SHA-256`() {
+        val keyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+        val message = ByteArray(96) { it.toByte() }
+        val scheme = TlsSignatureScheme.RSA_PSS_SHA256
+
+        val signature = X509Identity.sign(keyPair.private, scheme, message)
+
+        assertTrue(X509Identity.supportedSignatureSchemes(keyPair.public).contains(scheme))
+        assertTrue(verify(scheme, keyPair.public, message, signature))
+    }
+
+    @Test
+    fun `signs P-256 challenge with SHA-256`() {
+        val keyPair = ecKeyPair("secp256r1")
+        val message = ByteArray(96) { (it + 1).toByte() }
+        val scheme = TlsSignatureScheme.ECDSA_NISTP256_SHA256
+
+        val signature = X509Identity.sign(keyPair.private, scheme, message)
+
+        assertEquals(listOf(scheme), X509Identity.supportedSignatureSchemes(keyPair.public))
+        assertTrue(verify(scheme, keyPair.public, message, signature))
+    }
+
+    @Test
+    fun `signs P-384 challenge with SHA-384`() {
+        val keyPair = ecKeyPair("secp384r1")
+        val message = ByteArray(96) { (it + 2).toByte() }
+        val scheme = TlsSignatureScheme.ECDSA_NISTP384_SHA384
+
+        val signature = X509Identity.sign(keyPair.private, scheme, message)
+
+        assertEquals(listOf(scheme), X509Identity.supportedSignatureSchemes(keyPair.public))
+        assertTrue(verify(scheme, keyPair.public, message, signature))
+    }
+
+    @Test
+    fun `rejects unsupported key algorithms`() {
+        val keyPair = KeyPairGenerator.getInstance("DSA").apply { initialize(2048) }.generateKeyPair()
+
+        assertThrows(X509IdentityException::class.java) {
+            X509Identity.supportedSignatureSchemes(keyPair.public)
+        }
+    }
+
+    @Test
+    fun `formats readable subject alternative names`() {
+        assertEquals(
+            "URI: firezone://intune-id/4125c235-441b-48b7-b96d-1c17494931a2",
+            X509Identity.formatSubjectAlternativeName(
+                6,
+                "firezone://intune-id/4125c235-441b-48b7-b96d-1c17494931a2",
+            ),
+        )
+        assertEquals(
+            "DNS: device.example.com",
+            X509Identity.formatSubjectAlternativeName(2, "device.example.com"),
+        )
+        assertEquals(
+            "Other name: DER/Base64 AQID",
+            X509Identity.formatSubjectAlternativeName(0, byteArrayOf(1, 2, 3)),
+        )
+    }
+
+    @Test
+    fun `extracts and normalizes MDM device ID from typed URI SAN`() {
+        assertEquals(
+            "4125c235-441b-48b7-b96d-1c17494931a2",
+            X509Identity.mdmDeviceId(
+                listOf(
+                    "firezone://serial/ABC123",
+                    "firezone://intune-id/4125C235-441B-48B7-B96D-1C17494931A2",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `uses bare UUID fallback only when typed identifiers are absent`() {
+        val bareId = "4125c235-441b-48b7-b96d-1c17494931a2"
+
+        assertEquals(bareId, X509Identity.mdmDeviceId(listOf(bareId)))
+        assertEquals(
+            null,
+            X509Identity.mdmDeviceId(listOf("firezone://serial/ABC123", bareId)),
+        )
+    }
+
+    @Test
+    fun `rejects sentinel MDM identifiers`() {
+        assertEquals(
+            null,
+            X509Identity.mdmDeviceId(
+                listOf("firezone://intune-id/00000000-0000-0000-0000-000000000000"),
+            ),
+        )
+    }
+
+    private fun ecKeyPair(curve: String) =
+        KeyPairGenerator
+            .getInstance("EC")
+            .apply { initialize(ECGenParameterSpec(curve)) }
+            .generateKeyPair()
+
+    private fun verify(
+        scheme: TlsSignatureScheme,
+        publicKey: java.security.PublicKey,
+        message: ByteArray,
+        signature: ByteArray,
+    ): Boolean =
+        Signature
+            .getInstance(
+                if (scheme == TlsSignatureScheme.RSA_PSS_SHA256) {
+                    "RSASSA-PSS"
+                } else {
+                    X509Identity.signatureAlgorithm(scheme)
+                },
+            ).run {
+                initVerify(publicKey)
+                if (scheme == TlsSignatureScheme.RSA_PSS_SHA256) {
+                    setParameter(PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1))
+                }
+                update(message)
+                verify(signature)
+            }
+}

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/x509/X509IdentityTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/x509/X509IdentityTest.kt
@@ -8,7 +8,12 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import uniffi.connlib.TlsSignatureScheme
 import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.Provider
+import java.security.PublicKey
+import java.security.Security
 import java.security.Signature
+import java.security.SignatureSpi
 import java.security.spec.ECGenParameterSpec
 import java.security.spec.MGF1ParameterSpec
 import java.security.spec.PSSParameterSpec
@@ -32,6 +37,24 @@ class X509IdentityTest {
 
         assertTrue(X509Identity.supportedSignatureSchemes(keyPair.public).contains(scheme))
         assertTrue(verify(scheme, keyPair.public, message, signature))
+    }
+
+    @Test
+    fun `does not set parameters on digest-specific Android RSA-PSS implementation`() {
+        val provider = FixedRsaPssProvider()
+        Security.insertProviderAt(provider, 1)
+
+        try {
+            val keyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+            val message = ByteArray(96) { it.toByte() }
+            val scheme = TlsSignatureScheme.RSA_PSS_SHA256
+
+            val signature = X509Identity.sign(keyPair.private, scheme, message)
+
+            assertTrue(verify(scheme, keyPair.public, message, signature))
+        } finally {
+            Security.removeProvider(provider.name)
+        }
     }
 
     @Test
@@ -161,4 +184,52 @@ class X509IdentityTest {
                 update(message)
                 verify(signature)
             }
+}
+
+private class FixedRsaPssProvider : Provider(NAME, 1.0, "Android-style fixed RSA-PSS test provider") {
+    init {
+        put("Signature.SHA256withRSA/PSS", FixedRsaPssSignatureSpi::class.java.name)
+    }
+
+    companion object {
+        private const val NAME = "FixedRsaPss"
+    }
+}
+
+@Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+class FixedRsaPssSignatureSpi : SignatureSpi() {
+    private val delegate = Signature.getInstance("RSASSA-PSS")
+
+    override fun engineInitVerify(publicKey: PublicKey) {
+        configure()
+        delegate.initVerify(publicKey)
+    }
+
+    override fun engineInitSign(privateKey: PrivateKey) {
+        configure()
+        delegate.initSign(privateKey)
+    }
+
+    override fun engineUpdate(input: Byte) = delegate.update(input)
+
+    override fun engineUpdate(
+        input: ByteArray,
+        offset: Int,
+        len: Int,
+    ) = delegate.update(input, offset, len)
+
+    override fun engineSign(): ByteArray = delegate.sign()
+
+    override fun engineVerify(signature: ByteArray): Boolean = delegate.verify(signature)
+
+    override fun engineSetParameter(
+        param: String,
+        value: Any,
+    ) = throw UnsupportedOperationException()
+
+    override fun engineGetParameter(param: String): Any = throw UnsupportedOperationException()
+
+    private fun configure() {
+        delegate.setParameter(PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1))
+    }
 }

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/x509/X509IdentityTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/x509/X509IdentityTest.kt
@@ -100,6 +100,20 @@ class X509IdentityTest {
     }
 
     @Test
+    fun `extracts MDM device ID from Intune comma-joined URI SAN`() {
+        assertEquals(
+            "4125c235-441b-48b7-b96d-1c17494931a2",
+            X509Identity.mdmDeviceId(
+                listOf(
+                    "tag:microsoft.com,2022-09-14:sid:S-1-12-1-1, " +
+                        "firezone://serial/ABC123, " +
+                        "firezone://intune-id/4125C235-441B-48B7-B96D-1C17494931A2",
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun `uses bare UUID fallback only when typed identifiers are absent`() {
         val bareId = "4125c235-441b-48b7-b96d-1c17494931a2"
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1295,6 +1295,7 @@ dependencies = [
  "tunnel-bypass-resolver",
  "uniffi",
  "url",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/rust/client-ffi/Cargo.toml
+++ b/rust/client-ffi/Cargo.toml
@@ -50,6 +50,7 @@ mimalloc = { workspace = true }
 android_log-sys = "0.3.2"
 jni = { workspace = true }
 mimalloc = { workspace = true, features = ["local_dynamic_tls"] } # The Android `cdylib` is `dlopen`-ed, so it needs the dynamic TLS model.
+webpki-roots = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/client-ffi/src/client_auth.rs
+++ b/rust/client-ffi/src/client_auth.rs
@@ -88,7 +88,9 @@ impl Signer for PlatformSigner {
         self.identity
             .sign(self.scheme, message.to_vec())
             .map_err(|error| {
-                rustls::Error::General(format!("Platform TLS signing failed: {error}"))
+                rustls::Error::Other(rustls::OtherError(Arc::new(
+                    phoenix_channel::ClientCertificateSigningError(error.to_string()),
+                )))
             })
     }
 
@@ -206,5 +208,54 @@ mod tests {
         }
 
         assert!(certified_key(Arc::new(EmptyIdentity)).is_err());
+    }
+
+    #[test]
+    fn preserves_platform_signing_failures_as_typed_tls_errors() {
+        #[derive(Debug)]
+        struct FailingIdentity;
+
+        impl ClientTlsIdentity for FailingIdentity {
+            fn certificate_chain(&self) -> Result<Vec<Vec<u8>>, CallbackError> {
+                Ok(vec![vec![1, 2, 3]])
+            }
+
+            fn supported_signature_schemes(&self) -> Vec<TlsSignatureScheme> {
+                vec![TlsSignatureScheme::RsaPssSha256]
+            }
+
+            fn sign(
+                &self,
+                _scheme: TlsSignatureScheme,
+                _message: Vec<u8>,
+            ) -> Result<Vec<u8>, CallbackError> {
+                Err(CallbackError::Failed(
+                    "keychain interaction is unavailable".to_owned(),
+                ))
+            }
+        }
+
+        let certified_key = certified_key(Arc::new(FailingIdentity))
+            .expect("mock identity should produce a certified key");
+        let signer = certified_key
+            .key
+            .choose_scheme(&[SignatureScheme::RSA_PSS_SHA256])
+            .expect("RSA-PSS SHA-256 should be supported");
+        let error = signer
+            .sign(&[4, 5])
+            .expect_err("platform signing should fail");
+        let rustls::Error::Other(other) = error else {
+            panic!("expected a typed rustls error");
+        };
+        let signing_error = other
+            .0
+            .downcast_ref::<phoenix_channel::ClientCertificateSigningError>()
+            .expect("signing error type should survive rustls");
+
+        assert!(
+            signing_error
+                .0
+                .contains("keychain interaction is unavailable")
+        );
     }
 }

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -112,6 +112,8 @@ pub struct AndroidSessionConfig {
     pub flow_logs_dir: Option<String>,
     pub device_info: DeviceInfo,
     pub is_internet_resource_active: bool,
+    pub use_client_certificate: bool,
+    pub mdm_device_id: Option<String>,
 }
 
 /// Resource status enum
@@ -239,6 +241,7 @@ impl Session {
     pub fn new_android(
         config: AndroidSessionConfig,
         protect_socket: Arc<dyn ProtectSocket>,
+        client_tls_identity: Arc<dyn ClientTlsIdentity>,
     ) -> Result<Self, ConnlibError> {
         let AndroidSessionConfig {
             api_url,
@@ -251,9 +254,14 @@ impl Session {
             flow_logs_dir,
             device_info,
             is_internet_resource_active,
+            use_client_certificate,
+            mdm_device_id,
         } = config;
         let udp_socket_factory = Arc::new(protected_udp_socket_factory(protect_socket.clone()));
         let tcp_socket_factory = Arc::new(protected_tcp_socket_factory(protect_socket));
+        let tls_client_config = use_client_certificate
+            .then(|| tls_client_config(client_tls_identity))
+            .transpose()?;
 
         connect(
             api_url,
@@ -266,8 +274,8 @@ impl Session {
             flow_logs_dir,
             device_info,
             is_internet_resource_active,
-            None,
-            None,
+            mdm_device_id,
+            tls_client_config,
             tcp_socket_factory,
             udp_socket_factory,
         )

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -103,9 +103,11 @@ pub struct DeviceInfo {
 #[derive(uniffi::Record)]
 pub struct AndroidSessionConfig {
     pub api_url: String,
-    pub token: String,
+    pub token: Option<String>,
     pub device_id: String,
-    pub account_slug: String,
+    pub account_slug: Option<String>,
+    pub account_id: Option<String>,
+    pub actor_email: Option<String>,
     pub device_name: String,
     pub log_dir: String,
     pub log_filter: String,
@@ -248,6 +250,8 @@ impl Session {
             token,
             device_id,
             account_slug,
+            account_id,
+            actor_email,
             device_name,
             log_dir,
             log_filter,
@@ -268,6 +272,8 @@ impl Session {
             token,
             device_id,
             account_slug,
+            account_id,
+            actor_email,
             Some(device_name),
             log_dir,
             log_filter,
@@ -308,9 +314,11 @@ impl Session {
 
         let session = connect(
             api_url,
-            token,
+            Some(token),
             device_id,
-            account_slug,
+            Some(account_slug),
+            None,
+            None,
             device_name,
             log_dir,
             log_filter,
@@ -356,9 +364,11 @@ impl Session {
 
         let session = connect(
             api_url,
-            token,
+            Some(token),
             device_id,
-            account_slug,
+            Some(account_slug),
+            None,
+            None,
             device_name,
             log_dir,
             log_filter,
@@ -564,9 +574,11 @@ impl Drop for Session {
 
 fn connect(
     api_url: String,
-    token: String,
+    token: Option<String>,
     device_id: String,
-    account_slug: String,
+    account_slug: Option<String>,
+    account_id: Option<String>,
+    actor_email: Option<String>,
     device_name: Option<String>,
     log_dir: String,
     log_filter: String,
@@ -585,7 +597,7 @@ fn connect(
         identifier_for_vendor: device_info.identifier_for_vendor,
         firebase_installation_id: device_info.firebase_installation_id,
     };
-    let secret = SecretString::from(token);
+    let secret = token.map(SecretString::from);
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(1)
@@ -606,10 +618,12 @@ fn connect(
 
     telemetry::start(&api_url, RELEASE, platform::DSN);
     telemetry::set_firezone_id(device_id.clone());
-    telemetry::set_account_slug(account_slug.clone());
+    telemetry::set_account_slug_or_clear(account_slug.clone());
+    telemetry::set_account_id(account_id.clone());
+    telemetry::set_actor_email(actor_email.clone());
     telemetry::set_mdm_device_id(mdm_device_id);
 
-    analytics::identify(RELEASE.to_owned(), Some(account_slug));
+    analytics::identify_with_user(RELEASE.to_owned(), account_slug, account_id, actor_email);
 
     let portal_api_url = portal_api_url(&api_url, tls_client_config.is_some())?;
     let url = LoginUrl::client(
@@ -675,15 +689,27 @@ pub fn tls_client_config(
     identity: Arc<dyn ClientTlsIdentity>,
 ) -> Result<Arc<rustls::ClientConfig>> {
     use rustls::sign::SingleCertAndKey;
+    #[cfg(not(target_os = "android"))]
     use rustls_platform_verifier::BuilderVerifierExt as _;
 
     install_rustls_crypto_provider();
     let certified_key = client_auth::certified_key(identity)?;
     let resolver = Arc::new(SingleCertAndKey::from(certified_key));
-    let config = rustls::ClientConfig::builder()
+    let builder = rustls::ClientConfig::builder();
+    #[cfg(target_os = "android")]
+    let builder = {
+        // Match the Android channel's existing server-verification behavior. The Android
+        // platform verifier currently misclassifies valid CRL-only Let's Encrypt certificates
+        // as revoked when they omit an OCSP responder.
+        let mut roots = rustls::RootCertStore::empty();
+        roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        builder.with_root_certificates(roots)
+    };
+    #[cfg(not(target_os = "android"))]
+    let builder = builder
         .with_platform_verifier()
-        .context("Failed to configure the TLS server certificate verifier")?
-        .with_client_cert_resolver(resolver);
+        .context("Failed to configure the TLS server certificate verifier")?;
+    let config = builder.with_client_cert_resolver(resolver);
 
     Ok(Arc::new(config))
 }

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -58,8 +58,8 @@ pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     last_url: Option<Url>,
     user_agent: String,
     tls_client_config: Option<Arc<rustls::ClientConfig>>,
-    /// The authentication token, sent via X-Authorization header.
-    token: SecretString,
+    /// The optional authentication token, sent via X-Authorization when present.
+    token: Option<SecretString>,
     make_initial_backoff: Box<dyn Fn() -> ExponentialBackoff + Send>,
     make_reconnect_backoff: Box<dyn Fn() -> ExponentialBackoff + Send>,
     backoff: Option<ExponentialBackoff>,
@@ -97,7 +97,7 @@ async fn create_and_connect_websocket(
     addresses: Vec<SocketAddr>,
     host: String,
     user_agent: String,
-    token: SecretString,
+    token: Option<SecretString>,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     connect_timeout: Duration,
     tls_client_config: Option<Arc<rustls::ClientConfig>>,
@@ -119,7 +119,7 @@ async fn create_and_connect_websocket(
 
         let connector = tls_client_config.map(Connector::Rustls);
         let (stream, _) = client_async_tls_with_config(
-            make_request(url, host, user_agent, &token),
+            make_request(url, host, user_agent, token.as_ref()),
             socket,
             None,
             connector,
@@ -186,6 +186,10 @@ async fn connect(
 pub enum Error {
     #[error("Authentication token invalid")]
     InvalidToken,
+    #[error("Portal rejected X.509 certificate authentication")]
+    CertificateAuthenticationRejected,
+    #[error("X.509 client certificate signing failed: {0}")]
+    ClientCertificateSigningFailed(String),
     #[error("X.509 device identity certificate was revoked")]
     CertificateRevoked,
     #[error(
@@ -202,6 +206,8 @@ impl Error {
     pub fn is_authentication_error(&self) -> bool {
         match self {
             Error::InvalidToken => true,
+            Error::CertificateAuthenticationRejected => false,
+            Error::ClientCertificateSigningFailed(_) => false,
             Error::CertificateRevoked => false,
             Error::MaxRetriesReached { .. } => false,
             Error::LoginFailed(_) => false,
@@ -211,6 +217,20 @@ impl Error {
 
     pub fn is_certificate_revoked(&self) -> bool {
         matches!(self, Error::CertificateRevoked)
+    }
+}
+
+/// Preserves a platform-backed client-certificate signing failure through rustls and the
+/// WebSocket transport so that it can be treated as terminal rather than a network hiccup.
+#[derive(Debug, thiserror::Error)]
+#[error("Platform TLS signing failed: {0}")]
+pub struct ClientCertificateSigningError(pub String);
+
+fn unauthorized_error(uses_token_authentication: bool) -> Error {
+    if uses_token_authentication {
+        Error::InvalidToken
+    } else {
+        Error::CertificateAuthenticationRejected
     }
 }
 
@@ -229,6 +249,21 @@ enum InternalError {
 }
 
 impl InternalError {
+    fn client_certificate_signing_error(&self) -> Option<String> {
+        let Self::WebSocket(tungstenite::Error::Io(error)) = self else {
+            return None;
+        };
+        let tls_error = error.get_ref()?.downcast_ref::<rustls::Error>()?;
+        let rustls::Error::Other(other) = tls_error else {
+            return None;
+        };
+
+        other
+            .0
+            .downcast_ref::<ClientCertificateSigningError>()
+            .map(|error| error.0.clone())
+    }
+
     /// Parses a Retry-After header value into a Duration.
     ///
     /// The header can be either:
@@ -379,7 +414,7 @@ where
     /// The provided URL must contain a host.
     pub fn disconnected(
         url: LoginUrl<TFinish>,
-        token: SecretString,
+        token: impl Into<Option<SecretString>>,
         user_agent: String,
         login: &'static str,
         init_req: TInitReq,
@@ -394,7 +429,7 @@ where
             url_prototype: url,
             user_agent,
             tls_client_config: None,
-            token,
+            token: token.into(),
             state: State::Closed,
             socket_factory,
             waker: None,
@@ -565,6 +600,8 @@ where
     }
 
     pub fn poll(&mut self, cx: &mut Context) -> Poll<Result<Event<TInboundMsg>, Error>> {
+        let uses_token_authentication = self.token.is_some();
+
         loop {
             // First, check if we are connected.
             let Connected {
@@ -617,9 +654,16 @@ where
                         if r.status() == StatusCode::UNAUTHORIZED =>
                     {
                         self.state = State::Closed;
-                        return Poll::Ready(Err(Error::InvalidToken));
+                        return Poll::Ready(Err(unauthorized_error(uses_token_authentication)));
                     }
                     Poll::Ready(Err(e)) => {
+                        if let Some(message) = e.client_certificate_signing_error() {
+                            self.state = State::Closed;
+                            return Poll::Ready(Err(Error::ClientCertificateSigningFailed(
+                                message,
+                            )));
+                        }
+
                         let backoff = match e.parse_retry_after_header() {
                             Some(duration) => duration,
                             None => {
@@ -865,7 +909,7 @@ where
                             },
                             _,
                         ) => {
-                            return Poll::Ready(Err(Error::InvalidToken));
+                            return Poll::Ready(Err(unauthorized_error(uses_token_authentication)));
                         }
                         (
                             Payload::Disconnect {
@@ -1086,24 +1130,32 @@ impl<T> PhoenixMessage<T> {
 }
 
 // This is basically the same as tungstenite does but we add some new headers (namely user-agent)
-fn make_request(url: Url, host: String, user_agent: String, token: &SecretString) -> Request {
+fn make_request(
+    url: Url,
+    host: String,
+    user_agent: String,
+    token: Option<&SecretString>,
+) -> Request {
     let r: [u8; 16] = rand::random();
     let key = base64::engine::general_purpose::STANDARD.encode(r);
 
     let user_agent = user_agent.replace(|c: char| !c.is_ascii(), "");
-    let token = token
-        .expose_secret()
-        .replace(|c: char| c.is_whitespace(), "");
-
-    Request::builder()
+    let mut builder = Request::builder()
         .method("GET")
         .header("Host", host)
         .header("Connection", "Upgrade")
         .header("Upgrade", "websocket")
         .header("Sec-WebSocket-Version", "13")
         .header("Sec-WebSocket-Key", key)
-        .header("User-Agent", user_agent)
-        .header("X-Authorization", format!("Bearer {token}"))
+        .header("User-Agent", user_agent);
+    if let Some(token) = token {
+        let token = token
+            .expose_secret()
+            .replace(|c: char| c.is_whitespace(), "");
+        builder = builder.header("X-Authorization", format!("Bearer {token}"));
+    }
+
+    builder
         .uri(url.to_string())
         .body(())
         .expect("should always be able to build a request if we only pass strings to it")
@@ -1154,6 +1206,19 @@ mod tests {
         let error = anyhow::Error::msg("some other failure").context("Connection hiccup");
 
         assert_eq!(http_error_body(&error), None);
+    }
+
+    #[test]
+    fn extracts_platform_client_certificate_signing_error() {
+        let tls_error = rustls::Error::Other(rustls::OtherError(Arc::new(
+            ClientCertificateSigningError("keychain interaction is unavailable".to_owned()),
+        )));
+        let error = InternalError::WebSocket(tungstenite::Error::Io(io::Error::other(tls_error)));
+
+        assert_eq!(
+            error.client_certificate_signing_error().as_deref(),
+            Some("keychain interaction is unavailable")
+        );
     }
 
     #[derive(Deserialize, PartialEq, Debug)]
@@ -1400,7 +1465,7 @@ mod tests {
             vec![addr],
             "127.0.0.1".to_string(),
             "test-agent".to_string(),
-            SecretString::from("test-token".to_string()),
+            Some(SecretString::from("test-token".to_string())),
             Arc::new(socket_factory::tcp),
             Duration::from_secs(2),
             None,
@@ -1419,7 +1484,9 @@ mod tests {
             Url::parse("ws://example.com/websocket").unwrap(),
             "example.com".to_string(),
             "test-agent".to_string(),
-            &SecretString::from("valid-token-part\ninjected".to_string()),
+            Some(&SecretString::from(
+                "valid-token-part\ninjected".to_string(),
+            )),
         );
 
         assert_eq!(
@@ -1434,7 +1501,9 @@ mod tests {
             Url::parse("ws://example.com/websocket").unwrap(),
             "example.com".to_string(),
             "test-agent".to_string(),
-            &SecretString::from("valid-token-part\rinjected".to_string()),
+            Some(&SecretString::from(
+                "valid-token-part\rinjected".to_string(),
+            )),
         );
 
         assert_eq!(
@@ -1449,12 +1518,26 @@ mod tests {
             Url::parse("ws://example.com/websocket").unwrap(),
             "example.com".to_string(),
             "test-agent".to_string(),
-            &SecretString::from("a-perfectly-valid.token_123".to_string()),
+            Some(&SecretString::from(
+                "a-perfectly-valid.token_123".to_string(),
+            )),
         );
 
         assert_eq!(
             request.headers()["X-Authorization"],
             "Bearer a-perfectly-valid.token_123"
         );
+    }
+
+    #[test]
+    fn make_request_omits_authorization_without_token() {
+        let request = make_request(
+            Url::parse("ws://example.com/websocket").unwrap(),
+            "example.com".to_string(),
+            "test-agent".to_string(),
+            None,
+        );
+
+        assert!(!request.headers().contains_key("X-Authorization"));
     }
 }

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -490,7 +490,7 @@ async fn http_400_returns_client_error() {
 }
 
 #[tokio::test]
-async fn http_401_returns_invalid_token() {
+async fn http_401_with_token_returns_invalid_token() {
     let port = http_status_server(http::StatusCode::UNAUTHORIZED).await;
 
     let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
@@ -510,6 +510,33 @@ async fn http_401_returns_invalid_token() {
     assert!(
         matches!(result, Err(phoenix_channel::Error::InvalidToken)),
         "expected Error::InvalidToken for 401, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn http_401_without_token_returns_certificate_authentication_rejected() {
+    let port = http_status_server(http::StatusCode::UNAUTHORIZED).await;
+
+    let mut channel = make_test_channel_without_token("127.0.0.1", port, default_backoff);
+
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        future::poll_fn(|cx| channel.poll(cx)).await
+    })
+    .await
+    .expect("should not timeout");
+
+    assert!(
+        matches!(
+            result,
+            Err(phoenix_channel::Error::CertificateAuthenticationRejected)
+        ),
+        "expected certificate authentication rejection for tokenless 401, got {result:?}"
     );
 }
 
@@ -626,6 +653,37 @@ fn make_test_channel(
     port: u16,
     make_reconnect_backoff: impl Fn() -> backoff::ExponentialBackoff + Send + 'static,
 ) -> TestChannel {
+    make_test_channel_with_token(
+        host,
+        port,
+        SecretString::from("test_token"),
+        make_reconnect_backoff,
+    )
+}
+
+fn make_test_channel_without_token(
+    host: &str,
+    port: u16,
+    make_reconnect_backoff: impl Fn() -> backoff::ExponentialBackoff + Send + 'static,
+) -> TestChannel {
+    make_test_channel_with_optional_token(host, port, None, make_reconnect_backoff)
+}
+
+fn make_test_channel_with_token(
+    host: &str,
+    port: u16,
+    token: SecretString,
+    make_reconnect_backoff: impl Fn() -> backoff::ExponentialBackoff + Send + 'static,
+) -> TestChannel {
+    make_test_channel_with_optional_token(host, port, Some(token), make_reconnect_backoff)
+}
+
+fn make_test_channel_with_optional_token(
+    host: &str,
+    port: u16,
+    token: Option<SecretString>,
+    make_reconnect_backoff: impl Fn() -> backoff::ExponentialBackoff + Send + 'static,
+) -> TestChannel {
     let url = LoginUrl::client(
         format!("ws://{host}:{port}").as_str(),
         "test-device-id".to_string(),
@@ -636,7 +694,7 @@ fn make_test_channel(
 
     PhoenixChannel::disconnected(
         url,
-        SecretString::from("test_token"),
+        token,
         "test-user-agent".to_string(),
         "test",
         (),

--- a/rust/libs/telemetry/src/analytics.rs
+++ b/rust/libs/telemetry/src/analytics.rs
@@ -27,6 +27,17 @@ pub fn new_session(maybe_legacy_id: String, api_url: String) {
 
 /// Associate several properties with the current telemetry user.
 pub fn identify(release: String, account_slug: Option<String>) {
+    identify_with_user(release, account_slug, None, None);
+}
+
+/// Associates certificate-derived account and actor attributes with the current
+/// installation without pretending either value is an account slug.
+pub fn identify_with_user(
+    release: String,
+    account_slug: Option<String>,
+    account_id: Option<String>,
+    actor_email: Option<String>,
+) {
     let Some(env) = current_env() else {
         tracing::debug!("Cannot send $identify: Unknown env");
         return;
@@ -46,6 +57,8 @@ pub fn identify(release: String, account_slug: Option<String>) {
                     set: PersonProperties {
                         release,
                         account_slug,
+                        account_id,
+                        actor_email,
                         os: std::env::consts::OS.to_owned(),
                     },
                 },
@@ -155,6 +168,10 @@ struct PersonProperties {
     release: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     account_slug: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    account_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    actor_email: Option<String>,
     #[serde(rename = "$os")]
     os: String,
 }

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -296,10 +296,52 @@ pub fn is_active() -> bool {
 }
 
 pub fn set_account_slug(slug: String) {
-    let _ = STATE.try_write(|state| state.set_account_slug(slug.clone()));
+    set_account_slug_or_clear(Some(slug));
+}
+
+pub fn set_account_slug_or_clear(slug: Option<String>) {
+    let _ = STATE.try_write(|state| state.set_account_slug_or_clear(slug.clone()));
+
+    update_user(|user| match slug {
+        Some(slug) => {
+            user.other.insert("account_slug".to_owned(), slug.into());
+        }
+        None => {
+            user.other.remove("account_slug");
+        }
+    });
+}
+
+/// Attaches the account UUID read from a managed certificate.
+pub fn set_account_id(account_id: Option<String>) {
+    let _ = STATE.try_write(|state| state.set_account_id(account_id.clone()));
+
+    update_user(|user| match account_id {
+        Some(account_id) => {
+            user.other
+                .insert("account_id".to_owned(), account_id.into());
+        }
+        None => {
+            user.other.remove("account_id");
+        }
+    });
+}
+
+/// Attaches the actor email read from a managed certificate.
+pub fn set_actor_email(actor_email: Option<String>) {
+    let _ = STATE.try_write(|state| state.set_actor_email(actor_email.clone()));
 
     update_user(|user| {
-        user.other.insert("account_slug".to_owned(), slug.into());
+        user.email.clone_from(&actor_email);
+        match actor_email {
+            Some(actor_email) => {
+                user.other
+                    .insert("actor_email".to_owned(), actor_email.into());
+            }
+            None => {
+                user.other.remove("actor_email");
+            }
+        }
     });
 }
 
@@ -350,6 +392,16 @@ pub fn current_user() -> Option<String> {
 #[doc(hidden)] // Only public for testing.
 pub fn current_account_slug() -> Option<String> {
     STATE.try_read(|state| state.account_slug()).ok().flatten()
+}
+
+#[doc(hidden)] // Only public for testing.
+pub fn current_account_id() -> Option<String> {
+    STATE.try_read(|state| state.account_id()).ok().flatten()
+}
+
+#[doc(hidden)] // Only public for testing.
+pub fn current_actor_email() -> Option<String> {
+    STATE.try_read(|state| state.actor_email()).ok().flatten()
 }
 
 #[doc(hidden)] // Only public for testing.
@@ -455,27 +507,43 @@ fn append_tracing_fields_to_message(mut log: Log) -> Log {
     log
 }
 
-fn insert_user_account_slug_into_log(mut log: Log) -> Log {
-    let Some(account_slug) = current_account_slug() else {
-        return log;
-    };
-
-    log.attributes.insert(
-        "user.account_slug".to_owned(),
-        LogAttribute::from(account_slug),
-    );
+fn insert_user_attributes_into_log(mut log: Log) -> Log {
+    if let Some(account_slug) = current_account_slug() {
+        log.attributes.insert(
+            "user.account_slug".to_owned(),
+            LogAttribute::from(account_slug),
+        );
+    }
+    if let Some(account_id) = current_account_id() {
+        log.attributes
+            .insert("user.account_id".to_owned(), LogAttribute::from(account_id));
+    }
+    if let Some(actor_email) = current_actor_email() {
+        log.attributes.insert(
+            "user.actor_email".to_owned(),
+            LogAttribute::from(actor_email),
+        );
+    }
 
     log
 }
 
-fn insert_user_account_slug_into_metric(mut metric: Metric) -> Metric {
-    let Some(account_slug) = current_account_slug() else {
-        return metric;
-    };
-
-    metric
-        .attributes
-        .insert("user.account_slug".into(), LogAttribute::from(account_slug));
+fn insert_user_attributes_into_metric(mut metric: Metric) -> Metric {
+    if let Some(account_slug) = current_account_slug() {
+        metric
+            .attributes
+            .insert("user.account_slug".into(), LogAttribute::from(account_slug));
+    }
+    if let Some(account_id) = current_account_id() {
+        metric
+            .attributes
+            .insert("user.account_id".into(), LogAttribute::from(account_id));
+    }
+    if let Some(actor_email) = current_actor_email() {
+        metric
+            .attributes
+            .insert("user.actor_email".into(), LogAttribute::from(actor_email));
+    }
 
     metric
 }

--- a/rust/libs/telemetry/src/sentry.rs
+++ b/rust/libs/telemetry/src/sentry.rs
@@ -51,13 +51,13 @@ pub(crate) fn init_sdk_client(
             enable_logs: true,
             enable_metrics: true,
             before_send_log: Some(Arc::new(|log| {
-                let log = crate::insert_user_account_slug_into_log(log);
+                let log = crate::insert_user_attributes_into_log(log);
                 let log = crate::append_tracing_fields_to_message(log);
 
                 Some(log)
             })),
             before_send_metric: Some(Arc::new(|metric| {
-                let metric = crate::insert_user_account_slug_into_metric(metric);
+                let metric = crate::insert_user_attributes_into_metric(metric);
                 let metric = crate::insert_feature_flags_into_metric(metric);
 
                 Some(metric)

--- a/rust/libs/telemetry/src/state.rs
+++ b/rust/libs/telemetry/src/state.rs
@@ -33,6 +33,8 @@ pub(crate) struct State {
     env: Option<Env>,
     firezone_id: Option<String>,
     account_slug: Option<String>,
+    account_id: Option<String>,
+    actor_email: Option<String>,
     mdm_device_id: Option<String>,
     sentry_guard: Option<sentry::ClientInitGuard>,
 }
@@ -43,6 +45,8 @@ impl State {
             env: None,
             firezone_id: None,
             account_slug: None,
+            account_id: None,
+            actor_email: None,
             mdm_device_id: None,
             sentry_guard: None,
         }
@@ -58,6 +62,14 @@ impl State {
 
     pub(crate) fn account_slug(&self) -> Option<String> {
         self.account_slug.clone()
+    }
+
+    pub(crate) fn account_id(&self) -> Option<String> {
+        self.account_id.clone()
+    }
+
+    pub(crate) fn actor_email(&self) -> Option<String> {
+        self.actor_email.clone()
     }
 
     pub(crate) fn mdm_device_id(&self) -> Option<String> {
@@ -82,8 +94,16 @@ impl State {
         self.env = env;
     }
 
-    pub(crate) fn set_account_slug(&mut self, slug: String) {
-        self.account_slug = Some(slug);
+    pub(crate) fn set_account_slug_or_clear(&mut self, slug: Option<String>) {
+        self.account_slug = slug;
+    }
+
+    pub(crate) fn set_account_id(&mut self, account_id: Option<String>) {
+        self.account_id = account_id;
+    }
+
+    pub(crate) fn set_actor_email(&mut self, actor_email: Option<String>) {
+        self.actor_email = actor_email;
     }
 
     pub(crate) fn set_firezone_id(&mut self, firezone_id: Option<String>) {
@@ -107,6 +127,8 @@ impl State {
     pub(crate) fn clear_identity(&mut self) {
         self.firezone_id = None;
         self.account_slug = None;
+        self.account_id = None;
+        self.actor_email = None;
         self.mdm_device_id = None;
     }
 }

--- a/rust/libs/telemetry/tests/set_account_before_id.rs
+++ b/rust/libs/telemetry/tests/set_account_before_id.rs
@@ -9,15 +9,31 @@ async fn set_account_slug_before_set_firezone_id_preserves_both() {
 
     telemetry::set_account_slug("acme".to_owned());
     telemetry::set_mdm_device_id(Some("intune-device-123".to_owned()));
+    telemetry::set_account_id(Some("5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3".to_owned()));
+    telemetry::set_actor_email(Some("alice@example.com".to_owned()));
     telemetry::set_firezone_id("device-xyz".to_owned());
 
     assert_eq!(telemetry::current_user().as_deref(), Some("device-xyz"));
     assert_eq!(telemetry::current_account_slug().as_deref(), Some("acme"));
+    assert_eq!(
+        telemetry::current_account_id().as_deref(),
+        Some("5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3")
+    );
+    assert_eq!(
+        telemetry::current_actor_email().as_deref(),
+        Some("alice@example.com")
+    );
     assert_eq!(
         telemetry::current_mdm_device_id().as_deref(),
         Some("intune-device-123")
     );
 
     telemetry::set_mdm_device_id(None);
+    telemetry::set_account_slug_or_clear(None);
+    telemetry::set_account_id(None);
+    telemetry::set_actor_email(None);
     assert_eq!(telemetry::current_mdm_device_id(), None);
+    assert_eq!(telemetry::current_account_slug(), None);
+    assert_eq!(telemetry::current_account_id(), None);
+    assert_eq!(telemetry::current_actor_email(), None);
 }


### PR DESCRIPTION
Depends on #14527, which is stacked on the portal mTLS work in #14507.

## Summary

- uses an Android KeyChain identity for the /client/v2 Phoenix mTLS connection
- delegates rustls handshake signing to Android JCA without exporting the private key, with RSA-PSS, RSA PKCS#1, P-256, P-384, and P-521 support
- validates CN=dev.firezone.device-trust and shows certificate-chain and SAN diagnostics in Advanced Settings
- extracts mdm_device_id from the exact leaf certificate used for mTLS and adds it to Android and Rust Sentry user context alongside firezone_id
- supports work profiles and corporate-owned devices, while clearly marking personal-profile X.509 identity as unsupported
- accepts an MDM-provided alias for zero-touch selection

## Android KeyChain constraint

The public KeyChain API cannot enumerate private-key aliases. An EMM or DPC must grant the current identity under the configured alias, or resolve the alias through the system chooser. Renewal under the same alias returns the current chain.

## Validation

- ./gradlew testDebugUnitTest -Pandroid.injected.build.abi=arm64-v8a
- client-ffi, telemetry, and Phoenix Rust tests and Clippy: passed

End-to-end validation with a managed physical Android device remains required.