### PR TITLE
fix(android): avoid session constructor ABI crash

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
+import uniffi.connlib.AndroidSessionConfig
 import uniffi.connlib.ConnlibException
 import uniffi.connlib.DeviceInfo
 import uniffi.connlib.Event
@@ -330,17 +331,20 @@ class TunnelService : VpnService() {
 
                     Session
                         .newAndroid(
-                            apiUrl = config.apiUrl,
-                            token = token,
-                            accountSlug = config.accountSlug,
-                            deviceId = deviceIdValue,
-                            deviceName = getDeviceName(),
-                            logDir = getLogDir(),
-                            logFilter = config.logFilter,
-                            flowLogsDir = flowLogsDir(this@TunnelService),
-                            isInternetResourceActive = resourceState.isEnabled(),
+                            config =
+                                AndroidSessionConfig(
+                                    apiUrl = config.apiUrl,
+                                    token = token,
+                                    accountSlug = config.accountSlug,
+                                    deviceId = deviceIdValue,
+                                    deviceName = getDeviceName(),
+                                    logDir = getLogDir(),
+                                    logFilter = config.logFilter,
+                                    flowLogsDir = flowLogsDir(this@TunnelService),
+                                    isInternetResourceActive = resourceState.isEnabled(),
+                                    deviceInfo = deviceInfo,
+                                ),
                             protectSocket = protectSocketCallback,
-                            deviceInfo = deviceInfo,
                         ).use { session ->
                             startNetworkMonitoring()
                             startLogCleanup()

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -69,6 +69,24 @@ pub struct DeviceInfo {
     pub identifier_for_vendor: Option<String>,
 }
 
+/// Configuration for constructing an Android session.
+///
+/// Passing one record across the FFI boundary avoids JNA's arm64 calling-convention issues with
+/// constructors that have many by-value `RustBuffer` arguments.
+#[derive(uniffi::Record)]
+pub struct AndroidSessionConfig {
+    pub api_url: String,
+    pub token: String,
+    pub device_id: String,
+    pub account_slug: String,
+    pub device_name: String,
+    pub log_dir: String,
+    pub log_filter: String,
+    pub flow_logs_dir: Option<String>,
+    pub device_info: DeviceInfo,
+    pub is_internet_resource_active: bool,
+}
+
 /// Resource status enum
 #[derive(uniffi::Enum)]
 pub enum ResourceStatus {
@@ -183,23 +201,22 @@ pub trait ProtectSocket: Send + Sync + fmt::Debug {
 #[cfg(target_os = "android")]
 impl Session {
     #[uniffi::constructor]
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "This is the API we want to expose over FFI."
-    )]
     pub fn new_android(
-        api_url: String,
-        token: String,
-        device_id: String,
-        account_slug: String,
-        device_name: String,
-        log_dir: String,
-        log_filter: String,
-        flow_logs_dir: Option<String>,
-        device_info: DeviceInfo,
-        is_internet_resource_active: bool,
+        config: AndroidSessionConfig,
         protect_socket: Arc<dyn ProtectSocket>,
     ) -> Result<Self, ConnlibError> {
+        let AndroidSessionConfig {
+            api_url,
+            token,
+            device_id,
+            account_slug,
+            device_name,
+            log_dir,
+            log_filter,
+            flow_logs_dir,
+            device_info,
+            is_internet_resource_active,
+        } = config;
         let udp_socket_factory = Arc::new(protected_udp_socket_factory(protect_socket.clone()));
         let tcp_socket_factory = Arc::new(protected_tcp_socket_factory(protect_socket));
 


### PR DESCRIPTION
Passing more than 9 arguments over the FFI causes a crash in libc on Android due to JNI / ABI limitations, so we create an `AndroidSessionConfig` configuration object instead and pass that.