### PR TITLE
feat(clients): authenticate with X.509 on Windows and Linux

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -258,6 +258,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,7 +1323,7 @@ dependencies = [
  "phoenix-channel",
  "rustls",
  "rustls-platform-verifier",
- "secrecy",
+ "secrecy 0.10.3",
  "socket-factory",
  "telemetry",
  "thiserror 2.0.19",
@@ -1593,6 +1632,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cryptoki"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "781357a7779a8e92ea985121bbf379a9adf0777f44ab6392efc6abd5aa9b67db"
+dependencies = [
+ "bitflags 1.3.2",
+ "cryptoki-sys",
+ "libloading 0.8.7",
+ "log",
+ "paste",
+ "secrecy 0.8.0",
+]
+
+[[package]]
+name = "cryptoki-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "753e27d860277930ae9f394c119c8c70303236aab0ffab1d51f3d207dbb2bc4b"
+dependencies = [
+ "libloading 0.8.7",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,6 +1873,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,6 +1955,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "device-trust"
+version = "0.1.0"
+dependencies = [
+ "anyhow-ext",
+ "base64 0.23.1",
+ "cryptoki",
+ "rustls",
+ "rustls-platform-verifier",
+ "serde",
+ "sha2 0.11.0",
+ "tracing",
+ "uuid",
+ "windows",
+ "windows-core",
+ "x509-parser",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,7 +2034,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2388,7 +2482,7 @@ dependencies = [
  "clap",
  "nix 0.31.3",
  "rpassword",
- "secrecy",
+ "secrecy 0.10.3",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2423,7 +2517,7 @@ dependencies = [
  "phoenix-channel",
  "resolv-conf",
  "rustls",
- "secrecy",
+ "secrecy 0.10.3",
  "snownet",
  "socket-factory",
  "telemetry",
@@ -2454,6 +2548,7 @@ dependencies = [
  "dbus-secret-service-keyring-store",
  "derive_more",
  "desktop-notifications",
+ "device-trust",
  "dirs",
  "embed-resource",
  "fd-lock",
@@ -2482,7 +2577,7 @@ dependencies = [
  "rustls",
  "sadness-generator",
  "sd-notify",
- "secrecy",
+ "secrecy 0.10.3",
  "semver",
  "serde",
  "serde_json",
@@ -2530,6 +2625,7 @@ dependencies = [
  "bin-shared",
  "clap",
  "client-shared",
+ "device-trust",
  "flow-log-upload",
  "flow-log-writer",
  "futures",
@@ -2549,7 +2645,7 @@ dependencies = [
  "rpassword",
  "rustls",
  "sd-notify",
- "secrecy",
+ "secrecy 0.10.3",
  "socket-factory",
  "telemetry",
  "tokio",
@@ -2576,7 +2672,7 @@ dependencies = [
  "rand 0.10.2",
  "reqwest",
  "rustls",
- "secrecy",
+ "secrecy 0.10.3",
  "serde",
  "serde_json",
  "socket-factory",
@@ -2615,7 +2711,7 @@ dependencies = [
  "rand 0.10.2",
  "relay-proto",
  "rustls",
- "secrecy",
+ "secrecy 0.10.3",
  "serde",
  "socket-factory",
  "socket2",
@@ -2935,7 +3031,7 @@ dependencies = [
  "libfuzzer-sys",
  "rand 0.10.2",
  "relay-proto",
- "secrecy",
+ "secrecy 0.10.3",
  "serde_json",
  "sha2 0.11.0",
  "smallvec",
@@ -4327,7 +4423,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4716,7 +4812,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4887,7 +4983,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5001,7 +5097,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5242,6 +5338,15 @@ checksum = "182eab3e1cd9cdc0ecf1ce3342d9844f3dc7d098f0694569bfdf327b612d69fd"
 dependencies = [
  "bytes",
  "serde",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -5608,7 +5713,7 @@ dependencies = [
  "os_info",
  "rand 0.10.2",
  "rustls",
- "secrecy",
+ "secrecy 0.10.3",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -5958,7 +6063,7 @@ dependencies = [
  "libc",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6166,7 +6271,7 @@ dependencies = [
  "opentelemetry",
  "proptest",
  "rand 0.10.2",
- "secrecy",
+ "secrecy 0.10.3",
  "sha2 0.11.0",
  "smallvec",
  "stun_codec",
@@ -6336,6 +6441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6358,7 +6472,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6415,7 +6529,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6570,6 +6684,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e4ef7359e694bfaf1dd27a30f9d760b54c00dfae9f19bd0c05a39bc9128fe76"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -7128,7 +7251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7902,7 +8025,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7922,7 +8045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8538,7 +8661,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8656,7 +8779,7 @@ dependencies = [
  "rand 0.10.2",
  "rangemap",
  "ringbuffer",
- "secrecy",
+ "secrecy 0.10.3",
  "serde",
  "serde_json",
  "serde_with",
@@ -9989,7 +10112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10197,6 +10320,23 @@ dependencies = [
  "getrandom 0.4.2",
  "rand_core 0.10.1",
  "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1294,6 +1294,7 @@ dependencies = [
  "tun",
  "tunnel-bypass-resolver",
  "uniffi",
+ "url",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5606,6 +5606,7 @@ dependencies = [
  "logging",
  "os_info",
  "rand 0.10.2",
+ "rustls",
  "secrecy",
  "serde",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1961,6 +1961,7 @@ dependencies = [
  "anyhow-ext",
  "base64 0.23.1",
  "cryptoki",
+ "phoenix-channel",
  "rustls",
  "rustls-platform-verifier",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "libs/connlib/tunnel",
     "libs/connlib/tunnel-proto",
     "libs/desktop-notifications",
+    "libs/device-trust",
     "libs/eventloop-budget",
     "libs/flow-log-spool",
     "libs/flow-log-upload",
@@ -94,10 +95,12 @@ clock = { path = "libs/clock" }
 connlib-model = { path = "libs/connlib/model" }
 crc32fast = "1.5.0"
 crossbeam-queue = "0.3.12"
+cryptoki = "0.10.0"
 dashmap = "6.2.1"
 dbus-secret-service-keyring-store = { version = "1.0.0", features = ["crypto-rust"] }
 derive_more = { version = "2.1.1", default-features = false }
 desktop-notifications = { path = "libs/desktop-notifications" }
+device-trust = { path = "libs/device-trust" }
 difference = "2.0.0"
 dirs = "6.0.0"
 divan = "0.1.21"
@@ -258,6 +261,7 @@ windows-native-keyring-store = "1.1.0"
 windows-security = { path = "libs/windows-security" }
 windows-service = "0.8.1"
 winreg = "0.56.0"
+x509-parser = "0.18.0"
 zbus = "5.15.0"
 zip = { version = "8.6.0", default-features = false }
 

--- a/rust/client-ffi/Cargo.toml
+++ b/rust/client-ffi/Cargo.toml
@@ -26,6 +26,7 @@ otel-attributes = { workspace = true }
 otel-instruments = { workspace = true }
 phoenix-channel = { workspace = true }
 rustls = { workspace = true }
+rustls-platform-verifier = { workspace = true }
 secrecy = { workspace = true }
 socket-factory = { workspace = true }
 telemetry = { workspace = true }
@@ -36,6 +37,7 @@ tracing-subscriber = { workspace = true }
 tun = { workspace = true }
 tunnel-bypass-resolver = { workspace = true }
 uniffi = { workspace = true }
+url = { workspace = true }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 oslog = { version = "0.2.0", default-features = false }
@@ -48,7 +50,6 @@ mimalloc = { workspace = true }
 android_log-sys = "0.3.2"
 jni = { workspace = true }
 mimalloc = { workspace = true, features = ["local_dynamic_tls"] } # The Android `cdylib` is `dlopen`-ed, so it needs the dynamic TLS model.
-rustls-platform-verifier = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/client-ffi/src/client_auth.rs
+++ b/rust/client-ffi/src/client_auth.rs
@@ -1,0 +1,210 @@
+use std::{fmt, sync::Arc};
+
+use anyhow::{Context as _, Result, bail};
+use rustls::{
+    SignatureAlgorithm, SignatureScheme,
+    pki_types::CertificateDer,
+    sign::{CertifiedKey, Signer, SigningKey},
+};
+
+use crate::{ClientTlsIdentity, TlsSignatureScheme};
+
+pub(crate) fn certified_key(identity: Arc<dyn ClientTlsIdentity>) -> Result<Arc<CertifiedKey>> {
+    let certificates = identity
+        .certificate_chain()
+        .context("Failed to read the platform client certificate chain")?;
+    if certificates.is_empty() {
+        bail!("The platform client certificate chain is empty");
+    }
+
+    let signing_key = Arc::new(PlatformSigningKey::new(identity)?);
+    let certificates = certificates.into_iter().map(CertificateDer::from).collect();
+
+    Ok(Arc::new(CertifiedKey::new(certificates, signing_key)))
+}
+
+#[derive(Debug)]
+struct PlatformSigningKey {
+    identity: Arc<dyn ClientTlsIdentity>,
+    schemes: Vec<TlsSignatureScheme>,
+    algorithm: SignatureAlgorithm,
+}
+
+impl PlatformSigningKey {
+    fn new(identity: Arc<dyn ClientTlsIdentity>) -> Result<Self> {
+        let schemes = identity.supported_signature_schemes();
+        let Some(first) = schemes.first() else {
+            bail!("The platform client certificate key supports no TLS signature schemes");
+        };
+        let algorithm = first.algorithm();
+
+        if schemes.iter().any(|scheme| scheme.algorithm() != algorithm) {
+            bail!("The platform client certificate returned mixed key algorithms");
+        }
+
+        Ok(Self {
+            identity,
+            schemes,
+            algorithm,
+        })
+    }
+}
+
+impl SigningKey for PlatformSigningKey {
+    fn choose_scheme(&self, offered: &[SignatureScheme]) -> Option<Box<dyn Signer>> {
+        self.schemes
+            .iter()
+            .copied()
+            .find(|scheme| offered.contains(&scheme.rustls()))
+            .map(|scheme| {
+                Box::new(PlatformSigner {
+                    identity: self.identity.clone(),
+                    scheme,
+                }) as Box<dyn Signer>
+            })
+    }
+
+    fn algorithm(&self) -> SignatureAlgorithm {
+        self.algorithm
+    }
+}
+
+struct PlatformSigner {
+    identity: Arc<dyn ClientTlsIdentity>,
+    scheme: TlsSignatureScheme,
+}
+
+impl fmt::Debug for PlatformSigner {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PlatformSigner")
+            .field("scheme", &self.scheme)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Signer for PlatformSigner {
+    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
+        self.identity
+            .sign(self.scheme, message.to_vec())
+            .map_err(|error| {
+                rustls::Error::General(format!("Platform TLS signing failed: {error}"))
+            })
+    }
+
+    fn scheme(&self) -> SignatureScheme {
+        self.scheme.rustls()
+    }
+}
+
+impl TlsSignatureScheme {
+    fn rustls(self) -> SignatureScheme {
+        match self {
+            Self::RsaPkcs1Sha256 => SignatureScheme::RSA_PKCS1_SHA256,
+            Self::RsaPkcs1Sha384 => SignatureScheme::RSA_PKCS1_SHA384,
+            Self::RsaPkcs1Sha512 => SignatureScheme::RSA_PKCS1_SHA512,
+            Self::RsaPssSha256 => SignatureScheme::RSA_PSS_SHA256,
+            Self::RsaPssSha384 => SignatureScheme::RSA_PSS_SHA384,
+            Self::RsaPssSha512 => SignatureScheme::RSA_PSS_SHA512,
+            Self::EcdsaNistp256Sha256 => SignatureScheme::ECDSA_NISTP256_SHA256,
+            Self::EcdsaNistp384Sha384 => SignatureScheme::ECDSA_NISTP384_SHA384,
+            Self::EcdsaNistp521Sha512 => SignatureScheme::ECDSA_NISTP521_SHA512,
+        }
+    }
+
+    fn algorithm(self) -> SignatureAlgorithm {
+        match self {
+            Self::RsaPkcs1Sha256
+            | Self::RsaPkcs1Sha384
+            | Self::RsaPkcs1Sha512
+            | Self::RsaPssSha256
+            | Self::RsaPssSha384
+            | Self::RsaPssSha512 => SignatureAlgorithm::RSA,
+            Self::EcdsaNistp256Sha256 | Self::EcdsaNistp384Sha384 | Self::EcdsaNistp521Sha512 => {
+                SignatureAlgorithm::ECDSA
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CallbackError;
+
+    #[derive(Debug)]
+    struct MockIdentity {
+        schemes: Vec<TlsSignatureScheme>,
+    }
+
+    impl ClientTlsIdentity for MockIdentity {
+        fn certificate_chain(&self) -> Result<Vec<Vec<u8>>, CallbackError> {
+            Ok(vec![vec![1, 2, 3]])
+        }
+
+        fn supported_signature_schemes(&self) -> Vec<TlsSignatureScheme> {
+            self.schemes.clone()
+        }
+
+        fn sign(
+            &self,
+            scheme: TlsSignatureScheme,
+            mut message: Vec<u8>,
+        ) -> Result<Vec<u8>, CallbackError> {
+            assert_eq!(scheme, TlsSignatureScheme::RsaPssSha256);
+            message.extend_from_slice(&[0x08, 0x04]);
+            Ok(message)
+        }
+    }
+
+    #[test]
+    fn chooses_a_mutually_supported_scheme_and_delegates_signing() {
+        let certified_key = certified_key(Arc::new(MockIdentity {
+            schemes: vec![
+                TlsSignatureScheme::RsaPssSha512,
+                TlsSignatureScheme::RsaPssSha256,
+            ],
+        }))
+        .expect("mock identity should produce a certified key");
+
+        let signer = certified_key
+            .key
+            .choose_scheme(&[
+                SignatureScheme::ECDSA_NISTP256_SHA256,
+                SignatureScheme::RSA_PSS_SHA256,
+            ])
+            .expect("RSA-PSS SHA-256 should be mutually supported");
+
+        assert_eq!(signer.scheme(), SignatureScheme::RSA_PSS_SHA256);
+        assert_eq!(
+            signer.sign(&[4, 5]).expect("mock signing should succeed"),
+            vec![4, 5, 0x08, 0x04]
+        );
+    }
+
+    #[test]
+    fn rejects_an_empty_certificate_chain() {
+        #[derive(Debug)]
+        struct EmptyIdentity;
+
+        impl ClientTlsIdentity for EmptyIdentity {
+            fn certificate_chain(&self) -> Result<Vec<Vec<u8>>, CallbackError> {
+                Ok(Vec::new())
+            }
+
+            fn supported_signature_schemes(&self) -> Vec<TlsSignatureScheme> {
+                vec![TlsSignatureScheme::EcdsaNistp256Sha256]
+            }
+
+            fn sign(
+                &self,
+                _scheme: TlsSignatureScheme,
+                _message: Vec<u8>,
+            ) -> Result<Vec<u8>, CallbackError> {
+                unreachable!()
+            }
+        }
+
+        assert!(certified_key(Arc::new(EmptyIdentity)).is_err());
+    }
+}

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -218,6 +218,10 @@ impl DisconnectError {
         self.0.is_authentication_error()
     }
 
+    pub fn is_certificate_revoked(&self) -> bool {
+        self.0.is_certificate_revoked()
+    }
+
     pub fn is_device_trust_error(&self) -> bool {
         self.0.is_device_trust_error()
     }

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -4,6 +4,7 @@
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+mod client_auth;
 mod fd;
 mod platform;
 
@@ -47,6 +48,32 @@ pub struct ConnlibError(anyhow::Error);
 pub enum CallbackError {
     #[error("{0}")]
     Failed(String),
+}
+
+/// TLS handshake signature schemes supported by a platform-managed client identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum TlsSignatureScheme {
+    RsaPkcs1Sha256,
+    RsaPkcs1Sha384,
+    RsaPkcs1Sha512,
+    RsaPssSha256,
+    RsaPssSha384,
+    RsaPssSha512,
+    EcdsaNistp256Sha256,
+    EcdsaNistp384Sha384,
+    EcdsaNistp521Sha512,
+}
+
+/// A certificate chain and non-exportable platform key used for mutual TLS.
+#[uniffi::export(with_foreign)]
+pub trait ClientTlsIdentity: Send + Sync + fmt::Debug {
+    /// DER-encoded certificate chain, leaf first.
+    fn certificate_chain(&self) -> Result<Vec<Vec<u8>>, CallbackError>;
+
+    fn supported_signature_schemes(&self) -> Vec<TlsSignatureScheme>;
+
+    /// Signs the unhashed TLS handshake message with the requested scheme.
+    fn sign(&self, scheme: TlsSignatureScheme, message: Vec<u8>) -> Result<Vec<u8>, CallbackError>;
 }
 
 #[derive(uniffi::Object, Debug)]
@@ -190,6 +217,10 @@ impl DisconnectError {
     pub fn is_authentication_error(&self) -> bool {
         self.0.is_authentication_error()
     }
+
+    pub fn is_device_trust_error(&self) -> bool {
+        self.0.is_device_trust_error()
+    }
 }
 
 #[uniffi::export(with_foreign)]
@@ -231,6 +262,8 @@ impl Session {
             flow_logs_dir,
             device_info,
             is_internet_resource_active,
+            None,
+            None,
             tcp_socket_factory,
             udp_socket_factory,
         )
@@ -272,6 +305,8 @@ impl Session {
             flow_logs_dir,
             device_info,
             is_internet_resource_active,
+            None,
+            None,
             tcp_socket_factory,
             udp_socket_factory,
         )?;
@@ -318,6 +353,8 @@ impl Session {
             flow_logs_dir,
             device_info,
             is_internet_resource_active,
+            None,
+            None,
             tcp_socket_factory,
             udp_socket_factory,
         )?;
@@ -524,6 +561,8 @@ fn connect(
     flow_logs_dir: Option<String>,
     device_info: DeviceInfo,
     is_internet_resource_active: bool,
+    mdm_device_id: Option<String>,
+    tls_client_config: Option<Arc<rustls::ClientConfig>>,
     tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
 ) -> Result<Session, ConnlibError> {
@@ -556,11 +595,13 @@ fn connect(
     telemetry::start(&api_url, RELEASE, platform::DSN);
     telemetry::set_firezone_id(device_id.clone());
     telemetry::set_account_slug(account_slug.clone());
+    telemetry::set_mdm_device_id(mdm_device_id);
 
     analytics::identify(RELEASE.to_owned(), Some(account_slug));
 
+    let portal_api_url = portal_api_url(&api_url, tls_client_config.is_some())?;
     let url = LoginUrl::client(
-        api_url.as_str(),
+        portal_api_url.as_str(),
         device_id.clone(),
         device_name,
         device_info,
@@ -582,6 +623,10 @@ fn connect(
         },
         tcp_socket_factory.clone(),
     );
+    let portal = match tls_client_config {
+        Some(config) => portal.with_tls_client_config(config),
+        None => portal,
+    };
     // The uploader lives and dies with the session (idle, it would only poll
     // and dial); registered so `drain_flow_logs` nudges it instead of racing it.
     let uploader = flow_logs_dir.clone().map(|dir| {
@@ -611,6 +656,43 @@ fn connect(
         runtime: Some(runtime),
         uploader,
     })
+}
+
+#[doc(hidden)]
+pub fn tls_client_config(
+    identity: Arc<dyn ClientTlsIdentity>,
+) -> Result<Arc<rustls::ClientConfig>> {
+    use rustls::sign::SingleCertAndKey;
+    use rustls_platform_verifier::BuilderVerifierExt as _;
+
+    install_rustls_crypto_provider();
+    let certified_key = client_auth::certified_key(identity)?;
+    let resolver = Arc::new(SingleCertAndKey::from(certified_key));
+    let config = rustls::ClientConfig::builder()
+        .with_platform_verifier()
+        .context("Failed to configure the TLS server certificate verifier")?
+        .with_client_cert_resolver(resolver);
+
+    Ok(Arc::new(config))
+}
+
+fn portal_api_url(api_url: &str, use_client_certificate: bool) -> Result<String> {
+    if !use_client_certificate {
+        return Ok(api_url.to_owned());
+    }
+
+    let mut url = url::Url::parse(api_url).context("Failed to parse the API URL")?;
+    let mtls_host = match url.host_str() {
+        Some("api.firez.one") => Some("mtls.firez.one"),
+        Some("api.firezone.dev") => Some("mtls.firezone.dev"),
+        _ => None,
+    };
+    if let Some(host) = mtls_host {
+        url.set_host(Some(host))
+            .map_err(|_| anyhow!("Failed to set the mTLS API host"))?;
+    }
+
+    Ok(url.into())
 }
 
 fn start_telemetry_inner(tcp: Arc<dyn SocketFactory<TcpSocket>>) {
@@ -905,5 +987,36 @@ impl From<anyhow::Error> for ConnlibError {
 impl From<uniffi::UnexpectedUniFFICallbackError> for CallbackError {
     fn from(value: uniffi::UnexpectedUniFFICallbackError) -> Self {
         Self::Failed(format!("Callback failed: {}", value.reason))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_certificate_uses_mtls_api_host() {
+        assert_eq!(
+            portal_api_url("wss://api.firez.one:444/custom?foo=bar", true)
+                .expect("valid production API URL"),
+            "wss://mtls.firez.one:444/custom?foo=bar"
+        );
+        assert_eq!(
+            portal_api_url("wss://api.firezone.dev/custom?foo=bar", true)
+                .expect("valid staging API URL"),
+            "wss://mtls.firezone.dev/custom?foo=bar"
+        );
+    }
+
+    #[test]
+    fn unattested_and_custom_api_urls_are_unchanged() {
+        assert_eq!(
+            portal_api_url("wss://api.firezone.dev", false).expect("valid API URL"),
+            "wss://api.firezone.dev"
+        );
+        assert_eq!(
+            portal_api_url("wss://portal.example.com/client", true).expect("valid custom API URL"),
+            "wss://portal.example.com/client"
+        );
     }
 }

--- a/rust/gui-client/README.md
+++ b/rust/gui-client/README.md
@@ -167,11 +167,29 @@ Microsoft Platform Crypto Provider/TPM. For zero-touch MDM enrollment, install
 the identity and private-key grant in the local-machine certificate store so
 the `LocalSystem` Tunnel service can use it without prompting.
 When multiple usable certificates match, the newest certificate by `notBefore`
-is selected.
+is selected. If matching certificates exist but none satisfy the certificate
+policy or expose an accessible private key, the connection fails instead of
+silently falling back to a connection without mutual TLS.
 
-On Linux, set `FIREZONE_DEVICE_TRUST_PKCS11_URI` for the Tunnel service to an
-RFC 7512 URI identifying the module, token, and certificate/key object. The
-packaged systemd unit reads `/etc/default/firezone-client-tunnel`, so a typical
+On Ubuntu, install TPM-backed PKCS#11 support with:
+
+```sh
+sudo apt install tpm2-tools libtpm2-pkcs11-1 libtpm2-pkcs11-tools libengine-pkcs11-openssl
+```
+
+Generate a TPM-backed CSR using the device UUID assigned by the enrollment
+administrator:
+
+```sh
+sudo scripts/device-trust/generate-linux-tpm-csr.sh DEVICE_ID device.csr
+```
+
+Send `device.csr` to the certificate authority. The private key remains in the
+TPM.
+
+Then set `FIREZONE_DEVICE_TRUST_PKCS11_URI` for the Tunnel service to an RFC
+7512 URI identifying the module, token, and certificate/key object. The packaged
+systemd unit reads `/etc/default/firezone-client-tunnel`, so a typical
 configuration is:
 
 ```sh
@@ -182,6 +200,21 @@ Only `pin-source=file:` is supported; inline `pin-value` credentials are
 rejected. The URI works with PKCS#11 implementations such as `tpm2-pkcs11`,
 OpenSC, and SoftHSM. The service account must be able to read the module, token,
 and optional PIN file.
+Once a PKCS#11 URI is configured, a missing or unusable matching identity is a
+configuration error and the connection does not fall back to non-mutual TLS.
+
+For certificate-based user authentication, include one unambiguous value for
+each of these URI SAN attributes in the leaf certificate:
+
+```text
+firezone://email/alice%40example.com
+firezone://account-id/5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3
+```
+
+The account ID is the Firezone account UUID. When both attributes are valid,
+the disconnected GUI displays `Connect as alice@example.com` and authenticates
+the mutual-TLS connection without sending a saved bearer token. The X.509
+settings page displays both the derived identity attributes and the raw SANs.
 
 ## Threat model
 

--- a/rust/gui-client/README.md
+++ b/rust/gui-client/README.md
@@ -152,6 +152,37 @@ work if you
 
 `x86_64` architecture is supported for Windows. `aarch64` and `x86_64` are supported for Linux.
 
+## X.509 device identity
+
+The Windows and Linux clients can authenticate the portal connection with an
+MDM-provisioned X.509 identity over mutual TLS. The **X.509 Identity** settings page
+shows certificate validity, client-auth EKU, private-key access, signing
+algorithm, and fingerprint diagnostics. Private-key bytes are never exported.
+
+On Windows, the Tunnel service searches `LocalMachine\My` and
+`CurrentUser\My` for currently valid certificates whose subject CN is
+`dev.firezone.device-trust` and whose EKU permits TLS client authentication.
+Signing uses the certificate's CNG key handle, including keys backed by the
+Microsoft Platform Crypto Provider/TPM. For zero-touch MDM enrollment, install
+the identity and private-key grant in the local-machine certificate store so
+the `LocalSystem` Tunnel service can use it without prompting.
+When multiple usable certificates match, the newest certificate by `notBefore`
+is selected.
+
+On Linux, set `FIREZONE_DEVICE_TRUST_PKCS11_URI` for the Tunnel service to an
+RFC 7512 URI identifying the module, token, and certificate/key object. The
+packaged systemd unit reads `/etc/default/firezone-client-tunnel`, so a typical
+configuration is:
+
+```sh
+FIREZONE_DEVICE_TRUST_PKCS11_URI='pkcs11:token=Firezone;object=device-trust?module-path=/usr/lib/x86_64-linux-gnu/pkcs11/libtpm2_pkcs11.so&pin-source=file:/etc/firezone/pkcs11-pin'
+```
+
+Only `pin-source=file:` is supported; inline `pin-value` credentials are
+rejected. The URI works with PKCS#11 implementations such as `tpm2-pkcs11`,
+OpenSC, and SoftHSM. The service account must be able to read the module, token,
+and optional PIN file.
+
 ## Threat model
 
 See [Security](docs/security.md)

--- a/rust/gui-client/src-frontend/components/App.tsx
+++ b/rust/gui-client/src-frontend/components/App.tsx
@@ -9,6 +9,7 @@ import Overview from "./OverviewPage";
 import ReactRouterSidebarItem from "./ReactRouterSidebarItem";
 import RemixIcon from "./RemixIcon";
 import Titlebar from "./Titlebar";
+import X509SettingsPage from "./X509SettingsPage";
 import {
   AdvancedSettingsViewModel,
   commands,
@@ -74,6 +75,10 @@ export default function App() {
           path="/advanced-settings"
           element={<Titlebar title="Advanced Settings" />}
         />
+        <Route
+          path="/x509"
+          element={<Titlebar title="X.509 Device Identity" />}
+        />
         <Route path="/diagnostics" element={<Titlebar title="Diagnostics" />} />
         <Route path="/about" element={<Titlebar title="About" />} />
         <Route
@@ -126,6 +131,11 @@ export default function App() {
                         href="/advanced-settings"
                       >
                         Advanced
+                      </ReactRouterSidebarItem>
+                    </li>
+                    <li>
+                      <ReactRouterSidebarItem icon="information" href="/x509">
+                        X.509 Identity
                       </ReactRouterSidebarItem>
                     </li>
                   </ul>
@@ -184,6 +194,7 @@ export default function App() {
                 />
               }
             />
+            <Route path="/x509" element={<X509SettingsPage />} />
             <Route
               path="/diagnostics"
               element={

--- a/rust/gui-client/src-frontend/components/OverviewPage.tsx
+++ b/rust/gui-client/src-frontend/components/OverviewPage.tsx
@@ -24,12 +24,21 @@ export default function Overview(props: OverviewPageProps) {
 }
 
 function Session(props: OverviewPageProps) {
-  if (!props.session || props.session === "SignedOut") {
-    return <SignedOut signIn={props.signIn} />;
+  if (!props.session) {
+    return <SignedOut actorEmail={null} signIn={props.signIn} />;
   }
 
   if (props.session === "Loading") {
     return <Loading />;
+  }
+
+  if ("SignedOut" in props.session) {
+    return (
+      <SignedOut
+        actorEmail={props.session.SignedOut.certificate_actor_email}
+        signIn={props.signIn}
+      />
+    );
   }
 
   return (
@@ -37,23 +46,26 @@ function Session(props: OverviewPageProps) {
       accountSlug={props.session.SignedIn.account_slug}
       actorName={props.session.SignedIn.actor_name}
       signOut={props.signOut}
+      x509Authenticated={props.session.SignedIn.x509_authenticated}
     />
   );
 }
 
 interface SignedOutProps {
+  actorEmail: string | null;
   signIn: () => void;
 }
 
-function SignedOut({ signIn }: SignedOutProps) {
+function SignedOut({ actorEmail, signIn }: SignedOutProps) {
   return (
     <div className="flex flex-col items-center gap-4">
       <p className="text-sm text-body">
-        You can sign in by clicking the Firezone icon in the taskbar or by
-        clicking &quot;Sign in&quot; below.
+        {actorEmail
+          ? `Connect as ${actorEmail} to access Resources.`
+          : "You can sign in by clicking the Firezone icon in the taskbar or by clicking “Sign in” below."}
       </p>
       <Button onClick={signIn} variant="primary">
-        Sign in
+        {actorEmail ? `Connect as ${actorEmail}` : "Sign in"}
       </Button>
       <p className="text-xs text-subtle">
         Firezone will continue running after this window is closed.
@@ -68,13 +80,20 @@ interface SignedInProps {
   accountSlug: string;
   actorName: string;
   signOut: () => void;
+  x509Authenticated: boolean;
 }
 
-function SignedIn({ actorName, accountSlug, signOut }: SignedInProps) {
+function SignedIn({
+  actorName,
+  accountSlug,
+  signOut,
+  x509Authenticated,
+}: SignedInProps) {
   return (
     <div className="flex flex-col items-center gap-4">
       <p className="text-sm text-body">
-        You are currently signed into&nbsp;
+        You are currently {x509Authenticated ? "connected to" : "signed into"}
+        &nbsp;
         <span className="font-bold text-heading">{accountSlug}</span>
         &nbsp;as&nbsp;
         <span className="font-bold text-heading">{actorName}</span>
@@ -82,7 +101,7 @@ function SignedIn({ actorName, accountSlug, signOut }: SignedInProps) {
         Click the Firezone icon in the taskbar to see the list of Resources.
       </p>
       <Button onClick={signOut} variant="primary">
-        Sign out
+        {x509Authenticated ? "Disconnect" : "Sign out"}
       </Button>
       <p className="text-xs text-subtle">
         Firezone will continue running in the taskbar after this window is

--- a/rust/gui-client/src-frontend/components/X509SettingsPage.tsx
+++ b/rust/gui-client/src-frontend/components/X509SettingsPage.tsx
@@ -1,0 +1,95 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { commands, X509Status } from "../generated/bindings";
+import Button from "./Button";
+import RemixIcon from "./RemixIcon";
+
+export default function X509SettingsPage() {
+  const [status, setStatus] = useState<X509Status | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await commands.x509Status();
+      if (result.status === "ok") {
+        setStatus(result.data);
+      } else {
+        setStatus(null);
+        setError(result.error);
+      }
+    } catch (error) {
+      setStatus(null);
+      setError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return (
+    <div className="page max-w-3xl space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="page-title">X.509 Device Identity</h2>
+          <p className="page-description mt-1">
+            Firezone uses a managed certificate to prove device enrollment when
+            connecting. Private-key bytes remain in the Windows certificate
+            provider or Linux PKCS#11 token.
+          </p>
+        </div>
+        <Button disabled={loading} onClick={() => void refresh()}>
+          Refresh
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="panel p-4 text-body">Reading X.509 identity…</div>
+      ) : error ? (
+        <div className="rounded border border-warning/30 bg-warning-light p-4 text-warning">
+          <div className="flex items-start gap-2.5">
+            <RemixIcon className="mt-0.5 h-4 w-4" name="alert" />
+            <div>
+              <p className="font-medium">Unable to read the X.509 identity</p>
+              <p className="mt-1 whitespace-pre-wrap break-words font-mono text-xs">
+                {error}
+              </p>
+              <p className="mt-2 text-sm">
+                Contact your administrator for support.
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : status ? (
+        <>
+          <p className="text-body">{status.summary}</p>
+          {status.sections.map((section, sectionIndex) => (
+            <section
+              className="panel p-4"
+              key={`${section.title}-${sectionIndex}`}
+            >
+              <h3 className="font-medium text-heading">{section.title}</h3>
+              <dl className="mt-3 divide-y divide-border">
+                {section.fields.map((field, fieldIndex) => (
+                  <div
+                    className="grid gap-1 py-2.5 first:pt-0 last:pb-0 sm:grid-cols-[12rem_minmax(0,1fr)]"
+                    key={`${field.label}-${fieldIndex}`}
+                  >
+                    <dt className="text-xs text-subtle">{field.label}</dt>
+                    <dd className="whitespace-pre-wrap break-all font-mono text-xs text-body">
+                      {field.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+          ))}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/rust/gui-client/src-frontend/components/X509SettingsPage.tsx
+++ b/rust/gui-client/src-frontend/components/X509SettingsPage.tsx
@@ -35,11 +35,12 @@ export default function X509SettingsPage() {
     <div className="page max-w-3xl space-y-4">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h2 className="page-title">X.509 Device Identity</h2>
+          <h2 className="page-title">X.509 Identity</h2>
           <p className="page-description mt-1">
-            Firezone uses a managed certificate to prove device enrollment when
-            connecting. Private-key bytes remain in the Windows certificate
-            provider or Linux PKCS#11 token.
+            Firezone uses a managed certificate for mutual TLS and, when Actor
+            Email and Account ID attributes are present, user authentication.
+            Private-key bytes remain in the Windows certificate provider or
+            Linux PKCS#11 token.
           </p>
         </div>
         <Button disabled={loading} onClick={() => void refresh()}>

--- a/rust/gui-client/src-frontend/generated/bindings.ts
+++ b/rust/gui-client/src-frontend/generated/bindings.ts
@@ -157,9 +157,15 @@ export type GeneralSettingsViewModel = {
 export type LogsRecounted = FileCount;
 export type SessionChanged = SessionViewModel;
 export type SessionViewModel =
-  | { SignedIn: { account_slug: string; actor_name: string } }
+  | {
+      SignedIn: {
+        account_slug: string;
+        actor_name: string;
+        x509_authenticated: boolean;
+      };
+    }
   | "Loading"
-  | "SignedOut";
+  | { SignedOut: { certificate_actor_email: string | null } };
 export type X509DetailField = { label: string; value: string };
 export type X509DetailSection = {
   title: string;

--- a/rust/gui-client/src-frontend/generated/bindings.ts
+++ b/rust/gui-client/src-frontend/generated/bindings.ts
@@ -15,6 +15,14 @@ export const commands = {
       else return { status: "error", error: e as any };
     }
   },
+  async x509Status(): Promise<Result<X509Status, Error>> {
+    try {
+      return { status: "ok", data: await TAURI_INVOKE("x509_status") };
+    } catch (e) {
+      if (e instanceof Error) throw e;
+      else return { status: "error", error: e as any };
+    }
+  },
   async exportLogs(): Promise<Result<null, Error>> {
     try {
       return { status: "ok", data: await TAURI_INVOKE("export_logs") };
@@ -152,6 +160,15 @@ export type SessionViewModel =
   | { SignedIn: { account_slug: string; actor_name: string } }
   | "Loading"
   | "SignedOut";
+export type X509DetailField = { label: string; value: string };
+export type X509DetailSection = {
+  title: string;
+  fields: X509DetailField[];
+};
+export type X509Status = {
+  summary: string;
+  sections: X509DetailSection[];
+};
 
 /** tauri-specta globals **/
 

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ client-shared = { workspace = true }
 connlib-model = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
 desktop-notifications = { workspace = true }
+device-trust = { workspace = true }
 fd-lock = { workspace = true }
 flow-log-upload = { workspace = true }
 flow-log-writer = { workspace = true }

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -44,6 +44,7 @@ pub struct Controller<I: GuiIntegration> {
     // Sign-in state with the portal / deep links
     auth: auth::Auth,
     clear_logs_callback: Option<oneshot::Sender<Result<(), String>>>,
+    x509_status_callbacks: Vec<oneshot::Sender<Result<device_trust::Status, String>>>,
     ipc_client: ipc::ClientWrite<service::ClientMsg>,
     ipc_rx: ipc::ClientRead<service::ServerMsg>,
     integration: I,
@@ -107,6 +108,8 @@ pub enum ControllerRequest {
     ResetGeneralSettings,
     /// Clear the GUI's logs and await the Tunnel service to clear its logs
     ClearLogs(oneshot::Sender<Result<(), String>>),
+    /// Inspect the native identity provider in the privileged Tunnel service.
+    GetX509Status(oneshot::Sender<Result<device_trust::Status, String>>),
     /// The same as the arguments to `client::logging::export_logs_to`
     ExportLogs {
         path: PathBuf,
@@ -231,6 +234,7 @@ impl<I: GuiIntegration> Controller<I> {
             legacy_advanced_settings_path,
             auth,
             clear_logs_callback: None,
+            x509_status_callbacks: Vec::new(),
             ipc_client,
             ipc_rx,
             integration,
@@ -503,6 +507,12 @@ impl<I: GuiIntegration> Controller<I> {
                 self.send_ipc(&service::ClientMsg::ClearLogs).await?;
                 self.clear_logs_callback = Some(completion_tx);
             }
+            GetX509Status(completion_tx) => {
+                if self.x509_status_callbacks.is_empty() {
+                    self.send_ipc(&service::ClientMsg::GetX509Status).await?;
+                }
+                self.x509_status_callbacks.push(completion_tx);
+            }
             ExportLogs { path, stem } => {
                 // Exporting logs is a best-effort diagnostic action, so a failure must
                 // notify the user rather than bring down the whole controller.
@@ -676,6 +686,7 @@ impl<I: GuiIntegration> Controller<I> {
             service::ServerMsg::OnDisconnect {
                 error_msg,
                 is_authentication_error,
+                is_device_trust_error,
             } => {
                 self.sign_out().await?;
                 if is_authentication_error {
@@ -684,6 +695,13 @@ impl<I: GuiIntegration> Controller<I> {
                         "Firezone disconnected",
                         "To access resources, sign in again.",
                     )?;
+                } else if is_device_trust_error {
+                    tracing::error!(?error_msg, "Device attestation error");
+                    let _ = self.integration.show_notification(
+                        "Device verification failed",
+                        "Contact your administrator for support.",
+                    )?;
+                    dialog::error(&error_msg)?;
                 } else {
                     tracing::error!("Connlib disconnected: {error_msg}");
 
@@ -748,6 +766,18 @@ impl<I: GuiIntegration> Controller<I> {
                 tracing::error!("Tunnel service failed to save advanced settings: {err}");
                 self.integration
                     .show_notification("Failed to save settings", &err)?;
+            }
+            service::ServerMsg::X509Status(result) => {
+                if self.x509_status_callbacks.is_empty() {
+                    return Err(anyhow!(
+                        "Received X.509 status without a pending GUI request"
+                    ));
+                }
+                for completion_tx in std::mem::take(&mut self.x509_status_callbacks) {
+                    // React StrictMode can discard the first receiver while mounting the
+                    // settings page. A later request still receives the shared service result.
+                    let _ = completion_tx.send(result.clone());
+                }
             }
             service::ServerMsg::GatewayVersionMismatch { resource_id } => {
                 let (resource, site) = self.resource_by_id(resource_id)?;
@@ -1115,6 +1145,54 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         assert_eq!(test_controller.integration().shown_overview_page.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn coalesces_x509_status_requests_when_first_receiver_is_dropped() {
+        let _guard = logging::test("debug");
+        let mut test_controller = Controller::start_for_test();
+        let mut mock_tunnel = test_controller.tunnel_service_ipc_accept().await;
+        mock_tunnel.send_hello().await;
+
+        let (first_tx, first_rx) = oneshot::channel();
+        let (second_tx, second_rx) = oneshot::channel();
+        test_controller
+            .ctrl_tx
+            .send(ControllerRequest::GetX509Status(first_tx))
+            .await
+            .unwrap();
+        test_controller
+            .ctrl_tx
+            .send(ControllerRequest::GetX509Status(second_tx))
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(
+                mock_tunnel.rx.next().await.unwrap().unwrap(),
+                service::ClientMsg::GetX509Status
+            ),
+            "expected one X.509 status service message"
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), mock_tunnel.rx.next())
+                .await
+                .is_err(),
+            "the coalesced request should not send a second service message"
+        );
+        drop(first_rx);
+
+        let expected = device_trust::Status {
+            summary: "X.509 identity available.".to_owned(),
+            sections: vec![],
+        };
+        mock_tunnel
+            .tx
+            .send(&service::ServerMsg::X509Status(Ok(expected.clone())))
+            .await
+            .unwrap();
+
+        assert_eq!(second_rx.await.unwrap().unwrap(), expected);
     }
 
     #[tokio::test]

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -43,6 +43,8 @@ pub struct Controller<I: GuiIntegration> {
     legacy_advanced_settings_path: PathBuf,
     // Sign-in state with the portal / deep links
     auth: auth::Auth,
+    certificate_user_identity: Option<device_trust::UserIdentity>,
+    session_uses_x509_authentication: bool,
     clear_logs_callback: Option<oneshot::Sender<Result<(), String>>>,
     x509_status_callbacks: Vec<oneshot::Sender<Result<device_trust::Status, String>>>,
     ipc_client: ipc::ClientWrite<service::ClientMsg>,
@@ -197,9 +199,10 @@ impl<I: GuiIntegration> Controller<I> {
         let (mut ipc_rx, mut ipc_client) =
             ipc::connect(socket, ipc::ConnectOptions::default()).await?;
 
-        let (firezone_id, advanced_settings, mdm_settings) = receive_hello(&mut ipc_rx)
-            .await
-            .map_err(FailedToReceiveHello)?;
+        let (firezone_id, advanced_settings, mdm_settings, certificate_user_identity) =
+            receive_hello(&mut ipc_rx)
+                .await
+                .map_err(FailedToReceiveHello)?;
 
         // The GUI bootstraps logging with a default filter before connecting;
         // now that the authoritative settings have arrived, apply the effective
@@ -233,6 +236,8 @@ impl<I: GuiIntegration> Controller<I> {
             advanced_settings,
             legacy_advanced_settings_path,
             auth,
+            certificate_user_identity,
+            session_uses_x509_authentication: false,
             clear_logs_callback: None,
             x509_status_callbacks: Vec::new(),
             ipc_client,
@@ -336,17 +341,19 @@ impl<I: GuiIntegration> Controller<I> {
         Ok(())
     }
 
-    /// Resume a session at startup: if a token is available and connect-on-start
-    /// is enabled, reconnect.
+    /// Resume a session at startup when either certificate authentication or a
+    /// saved browser token is available and connect-on-start is enabled.
     async fn maybe_start_session(&mut self) -> Result<()> {
-        let Some(token) = self
+        let token = self
             .auth
             .token()
-            .context("Failed to load token from disk during app start")?
-        else {
-            tracing::info!("No token / actor_name on disk, starting in signed-out state");
+            .context("Failed to load token from disk during app start")?;
+        if self.certificate_user_identity.is_none() && token.is_none() {
+            tracing::info!(
+                "No certificate user identity or saved token is available; starting disconnected"
+            );
             return Ok(());
-        };
+        }
 
         // For backwards-compatibility prior to MDM-config, also call `start_session` if not configured.
         if self.connect_on_start().is_none_or(|c| c) {
@@ -387,7 +394,7 @@ impl<I: GuiIntegration> Controller<I> {
         .await
     }
 
-    async fn start_session(&mut self, token: SecretString) -> Result<()> {
+    async fn start_session(&mut self, token: Option<SecretString>) -> Result<()> {
         match self.status {
             Status::Disconnected => {}
             Status::Quitting => Err(anyhow!("Can't connect to Firezone, we're quitting"))?,
@@ -401,6 +408,8 @@ impl<I: GuiIntegration> Controller<I> {
 
         tracing::info!(api_url = %self.api_url(), "Starting connlib...");
 
+        self.session_uses_x509_authentication = self.certificate_user_identity.is_some();
+
         self.send_ipc(&service::ClientMsg::Connect {
             token,
             is_internet_resource_active: self.general_settings.internet_resource_enabled(),
@@ -410,13 +419,14 @@ impl<I: GuiIntegration> Controller<I> {
         // Change the status after we begin connecting
         self.status = Status::WaitingForPortal;
 
-        let session = self.auth.session().context("Missing session")?;
-
-        self.general_settings.account_slug = Some(session.account_slug.clone());
-        self.integration
-            .save_general_settings(&self.general_settings)
-            .await?;
-        self.notify_settings_changed()?;
+        if self.certificate_user_identity.is_none() {
+            let session = self.auth.session().context("Missing session")?;
+            self.general_settings.account_slug = Some(session.account_slug.clone());
+            self.integration
+                .save_general_settings(&self.general_settings)
+                .await?;
+            self.notify_settings_changed()?;
+        }
 
         self.refresh_ui_state();
 
@@ -425,11 +435,17 @@ impl<I: GuiIntegration> Controller<I> {
 
     async fn update_telemetry_context(&mut self) -> Result<()> {
         let environment = self.api_url().to_string();
-        let account_slug = self.auth.session().map(|s| s.account_slug.to_owned());
+        let certificate_user_identity = self.certificate_user_identity.as_ref();
+        let account_slug = certificate_user_identity
+            .is_none()
+            .then(|| self.auth.session().map(|s| s.account_slug.to_owned()))
+            .flatten();
+        let account_id = certificate_user_identity.map(|identity| identity.account_id.clone());
+        let actor_email = certificate_user_identity.map(|identity| identity.email.clone());
 
-        if let Some(account_slug) = account_slug.clone() {
-            telemetry::set_account_slug(account_slug);
-        }
+        telemetry::set_account_slug_or_clear(account_slug.clone());
+        telemetry::set_account_id(account_id.clone());
+        telemetry::set_actor_email(actor_email.clone());
 
         if !self.telemetry_allowed {
             return Ok(());
@@ -441,6 +457,8 @@ impl<I: GuiIntegration> Controller<I> {
             environment: environment.clone(),
             release: crate::RELEASE.to_string(),
             account_slug,
+            account_id,
+            actor_email,
         })
         .await?;
 
@@ -460,7 +478,7 @@ impl<I: GuiIntegration> Controller<I> {
             .context("Couldn't handle auth response")?;
 
         self.update_telemetry_context().await?;
-        self.start_session(token).await?;
+        self.start_session(Some(token)).await?;
 
         Ok(())
     }
@@ -531,6 +549,16 @@ impl<I: GuiIntegration> Controller<I> {
             Fail(Failure::Error) => Err(anyhow!("Test error"))?,
             Fail(Failure::Panic) => panic!("Test panic"),
             SignIn | SystemTrayMenu(system_tray::Event::SignIn) => {
+                if self.certificate_user_identity.is_some() {
+                    let token = self
+                        .auth
+                        .token()
+                        .context("Failed to load the optional saved token")?;
+                    self.update_telemetry_context().await?;
+                    self.start_session(token).await?;
+                    return Ok(());
+                }
+
                 let auth_url = self.auth_url().clone();
                 let account_slug = self.account_slug().map(|a| a.to_owned());
 
@@ -688,8 +716,23 @@ impl<I: GuiIntegration> Controller<I> {
                 is_authentication_error,
                 is_certificate_revoked,
                 is_device_trust_error,
+                used_x509_authentication,
+                certificate_user_identity,
             } => {
-                if is_certificate_revoked {
+                self.certificate_user_identity = certificate_user_identity;
+                telemetry::set_account_id(
+                    self.certificate_user_identity
+                        .as_ref()
+                        .map(|identity| identity.account_id.clone()),
+                );
+                telemetry::set_actor_email(
+                    self.certificate_user_identity
+                        .as_ref()
+                        .map(|identity| identity.email.clone()),
+                );
+                self.session_uses_x509_authentication = false;
+
+                if is_certificate_revoked || used_x509_authentication {
                     self.status = Status::Disconnected;
                     self.refresh_ui_state();
                 } else {
@@ -704,16 +747,23 @@ impl<I: GuiIntegration> Controller<I> {
                     )?;
                 } else if is_certificate_revoked {
                     tracing::error!(?error_msg, "X.509 device identity certificate was revoked");
-                    let _ = self.integration.show_notification(
+                    self.integration.show_notification(
                         "Device certificate revoked",
                         "Contact your administrator for support.",
                     )?;
                     dialog::error(&error_msg)?;
                 } else if is_device_trust_error {
                     tracing::error!(?error_msg, "Device attestation error");
-                    let _ = self.integration.show_notification(
+                    self.integration.show_notification(
                         "Device verification failed",
                         "Contact your administrator for support.",
+                    )?;
+                    dialog::error(&error_msg)?;
+                } else if used_x509_authentication {
+                    tracing::error!(?error_msg, "Managed X.509 connection failed");
+                    self.integration.show_notification(
+                        "Unable to connect",
+                        "Firezone could not authenticate with the managed certificate.",
                     )?;
                     dialog::error(&error_msg)?;
                 } else {
@@ -786,6 +836,20 @@ impl<I: GuiIntegration> Controller<I> {
                     return Err(anyhow!(
                         "Received X.509 status without a pending GUI request"
                     ));
+                }
+                if let Ok(status) = &result {
+                    self.certificate_user_identity = status.user_identity.clone();
+                    telemetry::set_account_id(
+                        self.certificate_user_identity
+                            .as_ref()
+                            .map(|identity| identity.account_id.clone()),
+                    );
+                    telemetry::set_actor_email(
+                        self.certificate_user_identity
+                            .as_ref()
+                            .map(|identity| identity.email.clone()),
+                    );
+                    self.refresh_ui_state();
                 }
                 for completion_tx in std::mem::take(&mut self.x509_status_callbacks) {
                     // React StrictMode can discard the first receiver while mounting the
@@ -910,34 +974,55 @@ impl<I: GuiIntegration> Controller<I> {
     }
 
     fn build_ui_state(&self) -> (system_tray::ConnlibState, SessionViewModel) {
-        // TODO: Refactor `Controller` and the auth module so that "Are we logged in?"
-        // doesn't require such complicated control flow to answer.
-        if let Some(auth_session) = self.auth.session() {
-            match &self.status {
-                Status::Disconnected => {
-                    // If we have an `auth_session` but no connlib session, we are most likely configured to
-                    // _not_ auto-connect on startup. Thus, we treat this the same as being signed out.
+        let x509_authenticated = self.session_uses_x509_authentication;
+        let certificate_identity = self
+            .certificate_user_identity
+            .as_ref()
+            .map(|identity| (identity.account_id.clone(), identity.email.clone()));
+        let token_identity = self
+            .auth
+            .session()
+            .map(|session| (session.account_slug.clone(), session.actor_name.clone()));
+        let display_identity = if x509_authenticated || matches!(self.status, Status::Disconnected)
+        {
+            certificate_identity.or(token_identity)
+        } else {
+            token_identity.or(certificate_identity)
+        };
 
-                    (
-                        system_tray::ConnlibState::SignedOut,
-                        SessionViewModel::SignedOut,
-                    )
-                }
+        if let Some((account_slug, actor_name)) = display_identity {
+            match &self.status {
+                Status::Disconnected => (
+                    system_tray::ConnlibState::SignedOut {
+                        actor_email: self
+                            .certificate_user_identity
+                            .as_ref()
+                            .map(|identity| identity.email.clone()),
+                    },
+                    SessionViewModel::SignedOut {
+                        certificate_actor_email: self
+                            .certificate_user_identity
+                            .as_ref()
+                            .map(|identity| identity.email.clone()),
+                    },
+                ),
                 Status::Quitting => (
                     system_tray::ConnlibState::Quitting,
                     SessionViewModel::Loading,
                 ),
                 Status::TunnelReady { resources } => (
                     system_tray::ConnlibState::SignedIn(system_tray::SignedIn {
-                        actor_name: auth_session.actor_name.clone(),
+                        actor_name: actor_name.clone(),
+                        x509_authenticated,
                         favorite_resources: self.general_settings.favorite_resources.clone(),
                         internet_resource_enabled: self.general_settings.internet_resource_enabled,
                         resources: resources.resources.clone(),
                         connected_devices: resources.connected_devices.clone(),
                     }),
                     SessionViewModel::SignedIn {
-                        account_slug: auth_session.account_slug.clone(),
-                        actor_name: auth_session.actor_name.clone(),
+                        account_slug,
+                        actor_name,
+                        x509_authenticated,
                     },
                 ),
                 Status::WaitingForPortal => (
@@ -957,8 +1042,10 @@ impl<I: GuiIntegration> Controller<I> {
             )
         } else {
             (
-                system_tray::ConnlibState::SignedOut,
-                SessionViewModel::SignedOut,
+                system_tray::ConnlibState::SignedOut { actor_email: None },
+                SessionViewModel::SignedOut {
+                    certificate_actor_email: None,
+                },
             )
         }
     }
@@ -981,7 +1068,8 @@ impl<I: GuiIntegration> Controller<I> {
         }
     }
 
-    /// Deletes the auth token, stops connlib, and refreshes the tray menu
+    /// Stops connlib and refreshes the tray menu. Browser authentication also
+    /// deletes its token; certificate authentication remains available.
     async fn sign_out(&mut self) -> Result<()> {
         match self.status {
             Status::Quitting => return Ok(()),
@@ -990,7 +1078,10 @@ impl<I: GuiIntegration> Controller<I> {
             | Status::WaitingForPortal
             | Status::WaitingForTunnel => {}
         }
-        self.auth.sign_out()?;
+        if !self.session_uses_x509_authentication {
+            self.auth.sign_out()?;
+        }
+        self.session_uses_x509_authentication = false;
         self.status = Status::Disconnected;
         tracing::debug!("disconnecting connlib");
         // This is redundant if the token is expired, in that case
@@ -1065,7 +1156,12 @@ impl<I: GuiIntegration> Controller<I> {
 
 async fn receive_hello(
     ipc_rx: &mut ipc::ClientRead<service::ServerMsg>,
-) -> Result<(String, AdvancedSettings, MdmSettings)> {
+) -> Result<(
+    String,
+    AdvancedSettings,
+    MdmSettings,
+    Option<device_trust::UserIdentity>,
+)> {
     const TIMEOUT: Duration = Duration::from_secs(5);
 
     let server_msg = tokio::time::timeout(TIMEOUT, ipc_rx.next())
@@ -1080,12 +1176,18 @@ async fn receive_hello(
         firezone_id,
         advanced_settings,
         mdm_settings,
+        certificate_user_identity,
     } = server_msg
     else {
         bail!("Expected `Hello` from tunnel service but got `{server_msg}`")
     };
 
-    Ok((firezone_id, advanced_settings, mdm_settings))
+    Ok((
+        firezone_id,
+        advanced_settings,
+        mdm_settings,
+        certificate_user_identity,
+    ))
 }
 
 fn try_delete_legacy_config(path: &Path) -> Result<()> {
@@ -1199,6 +1301,7 @@ mod tests {
         let expected = device_trust::Status {
             summary: "X.509 identity available.".to_owned(),
             sections: vec![],
+            user_identity: None,
         };
         mock_tunnel
             .tx
@@ -1486,6 +1589,29 @@ mod tests {
         mock_tunnel.send_resources(resources).await;
     }
 
+    #[tokio::test]
+    async fn certificate_user_identity_connects_without_browser_token() {
+        let mut test_controller = Controller::start_for_test();
+        let mut mock_tunnel = test_controller.tunnel_service_ipc_accept().await;
+        let identity = device_trust::UserIdentity {
+            email: "alice@example.com".to_owned(),
+            account_id: "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3".to_owned(),
+        };
+
+        mock_tunnel
+            .send_hello_with_user_identity(Some(identity))
+            .await;
+
+        let msg = mock_tunnel.rx.next().await.unwrap().unwrap();
+        let service::ClientMsg::Connect { token, .. } = msg else {
+            panic!("expected certificate-authenticated `Connect`, got {msg:?}");
+        };
+        assert!(token.is_none());
+        assert!(test_controller.integration().opened_urls.is_empty());
+
+        test_controller.join_handle.abort();
+    }
+
     fn canned_advanced_settings() -> AdvancedSettings {
         AdvancedSettings {
             auth_url: Url::parse("https://canned.example.com").unwrap(),
@@ -1695,11 +1821,19 @@ mod tests {
 
     impl MockTunnel {
         async fn send_hello(&mut self) {
+            self.send_hello_with_user_identity(None).await;
+        }
+
+        async fn send_hello_with_user_identity(
+            &mut self,
+            certificate_user_identity: Option<device_trust::UserIdentity>,
+        ) {
             self.tx
                 .send(&service::ServerMsg::Hello {
                     firezone_id: "test-firezone-id".to_owned(),
                     advanced_settings: AdvancedSettings::default(),
                     mdm_settings: MdmSettings::default(),
+                    certificate_user_identity,
                 })
                 .await
                 .unwrap();

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -686,15 +686,29 @@ impl<I: GuiIntegration> Controller<I> {
             service::ServerMsg::OnDisconnect {
                 error_msg,
                 is_authentication_error,
+                is_certificate_revoked,
                 is_device_trust_error,
             } => {
-                self.sign_out().await?;
+                if is_certificate_revoked {
+                    self.status = Status::Disconnected;
+                    self.refresh_ui_state();
+                } else {
+                    self.sign_out().await?;
+                }
+
                 if is_authentication_error {
                     tracing::info!(?error_msg, "Auth error");
                     self.integration.show_notification(
                         "Firezone disconnected",
                         "To access resources, sign in again.",
                     )?;
+                } else if is_certificate_revoked {
+                    tracing::error!(?error_msg, "X.509 device identity certificate was revoked");
+                    let _ = self.integration.show_notification(
+                        "Device certificate revoked",
+                        "Contact your administrator for support.",
+                    )?;
+                    dialog::error(&error_msg)?;
                 } else if is_device_trust_error {
                     tracing::error!(?error_msg, "Device attestation error");
                     let _ = self.integration.show_notification(

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -399,6 +399,7 @@ pub fn run(rt: &Runtime, config: RunConfig, reloader: logging::FilterReloadHandl
         ])
         .commands(tauri_specta::collect_commands![
             crate::view::clear_logs,
+            crate::view::x509_status,
             crate::view::export_logs,
             crate::view::apply_advanced_settings,
             crate::view::reset_advanced_settings,

--- a/rust/gui-client/src-tauri/src/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/gui/system_tray.rs
@@ -98,7 +98,7 @@ pub(crate) fn icon_from_state(state: &AppState) -> Icon {
         | ConnlibState::WaitingForBrowser
         | ConnlibState::WaitingForPortal
         | ConnlibState::WaitingForTunnel => IconBase::Busy,
-        ConnlibState::SignedOut => IconBase::SignedOut,
+        ConnlibState::SignedOut { .. } => IconBase::SignedOut,
         ConnlibState::SignedIn { .. } => IconBase::SignedIn,
     };
     Icon {
@@ -130,7 +130,7 @@ impl AppState {
         let quit_text = match &self.connlib {
             ConnlibState::Loading
             | ConnlibState::Quitting
-            | ConnlibState::SignedOut
+            | ConnlibState::SignedOut { .. }
             | ConnlibState::WaitingForBrowser
             | ConnlibState::WaitingForPortal
             | ConnlibState::WaitingForTunnel => QUIT_TEXT_SIGNED_OUT,
@@ -140,7 +140,12 @@ impl AppState {
             ConnlibState::Loading => Menu::default().disabled("Loading..."),
             ConnlibState::Quitting => Menu::default().disabled("Quitting..."),
             ConnlibState::SignedIn(x) => signed_in(&x),
-            ConnlibState::SignedOut => Menu::default().item(Event::SignIn, "Sign In"),
+            ConnlibState::SignedOut { actor_email } => Menu::default().item(
+                Event::SignIn,
+                actor_email
+                    .map(|email| format!("Connect as {email}"))
+                    .unwrap_or_else(|| "Sign In".to_owned()),
+            ),
             ConnlibState::WaitingForBrowser => signing_in("Waiting for browser..."),
             ConnlibState::WaitingForPortal => signing_in("Connecting to Firezone Portal..."),
             ConnlibState::WaitingForTunnel => signing_in("Raising tunnel..."),
@@ -158,7 +163,7 @@ pub enum ConnlibState {
     Loading,
     Quitting,
     SignedIn(SignedIn),
-    SignedOut,
+    SignedOut { actor_email: Option<String> },
     WaitingForBrowser,
     WaitingForPortal,
     WaitingForTunnel,
@@ -166,6 +171,7 @@ pub enum ConnlibState {
 
 pub struct SignedIn {
     pub actor_name: String,
+    pub x509_authenticated: bool,
     pub favorite_resources: HashSet<ResourceId>,
     pub resources: Vec<ResourceView>,
     pub connected_devices: Vec<ConnectedDeviceView>,
@@ -259,6 +265,7 @@ impl Default for Icon {
 fn signed_in(signed_in: &SignedIn) -> Menu {
     let SignedIn {
         actor_name,
+        x509_authenticated,
         favorite_resources,
         resources, // Make sure these are presented in the order we receive them
         connected_devices,
@@ -270,8 +277,19 @@ fn signed_in(signed_in: &SignedIn) -> Menu {
         .any(|res| favorite_resources.contains(&res.id()));
 
     let mut menu = Menu::default()
-        .disabled(format!("Signed in as {actor_name}"))
-        .item(Event::SignOut, SIGN_OUT)
+        .disabled(if *x509_authenticated {
+            format!("Connected as {actor_name}")
+        } else {
+            format!("Signed in as {actor_name}")
+        })
+        .item(
+            Event::SignOut,
+            if *x509_authenticated {
+                "Disconnect"
+            } else {
+                SIGN_OUT
+            },
+        )
         .separator();
 
     tracing::debug!(
@@ -472,6 +490,7 @@ mod tests {
         AppState {
             connlib: ConnlibState::SignedIn(SignedIn {
                 actor_name: "Jane Doe".into(),
+                x509_authenticated: false,
                 favorite_resources,
                 resources,
                 connected_devices: Vec::new(),
@@ -587,6 +606,40 @@ mod tests {
             "{}",
             serde_json::to_string_pretty(&actual).unwrap()
         );
+    }
+
+    #[test]
+    fn certificate_user_identity_changes_signed_out_action() {
+        let actual = AppState {
+            connlib: ConnlibState::SignedOut {
+                actor_email: Some("alice@example.com".to_owned()),
+            },
+            ..Default::default()
+        }
+        .into_menu();
+
+        let expected = Menu::default()
+            .item(Event::SignIn, "Connect as alice@example.com")
+            .separator()
+            .item(Event::ShowWindow(Window::About), "About Firezone")
+            .item(Event::AdminPortal, "Admin Portal...")
+            .add_submenu(
+                "Help",
+                Menu::default()
+                    .item(
+                        Event::Url(utm_url("https://www.firezone.dev/kb")),
+                        "Documentation...",
+                    )
+                    .item(
+                        Event::Url(utm_url("https://www.firezone.dev/support")),
+                        "Support...",
+                    ),
+            )
+            .item(Event::ShowWindow(Window::Settings), "Settings")
+            .separator()
+            .item(Event::Quit, QUIT_TEXT_SIGNED_OUT);
+
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/rust/gui-client/src-tauri/src/mock_tunnel.rs
+++ b/rust/gui-client/src-tauri/src/mock_tunnel.rs
@@ -89,6 +89,14 @@ async fn serve(server_io: DuplexStream) -> Result<()> {
             ClientMsg::ClearLogs => {
                 ipc_tx.send(&ServerMsg::ClearedLogs(Ok(()))).await?;
             }
+            ClientMsg::GetX509Status => {
+                ipc_tx
+                    .send(&ServerMsg::X509Status(Ok(device_trust::Status {
+                        summary: "No X.509 device identity is configured.".to_owned(),
+                        sections: vec![],
+                    })))
+                    .await?;
+            }
             ClientMsg::ApplyAdvancedSettings(settings) => {
                 ipc_tx
                     .send(&ServerMsg::AdvancedSettingsApplied(Ok(settings)))

--- a/rust/gui-client/src-tauri/src/mock_tunnel.rs
+++ b/rust/gui-client/src-tauri/src/mock_tunnel.rs
@@ -72,6 +72,7 @@ async fn serve(server_io: DuplexStream) -> Result<()> {
             firezone_id: "00000000-0000-0000-0000-000000000000".to_owned(),
             advanced_settings: AdvancedSettings::default(),
             mdm_settings: MdmSettings::default(),
+            certificate_user_identity: None,
         })
         .await?;
 
@@ -94,6 +95,7 @@ async fn serve(server_io: DuplexStream) -> Result<()> {
                     .send(&ServerMsg::X509Status(Ok(device_trust::Status {
                         summary: "No X.509 device identity is configured.".to_owned(),
                         sections: vec![],
+                        user_identity: None,
                     })))
                     .await?;
             }

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -55,7 +55,7 @@ pub enum ClientMsg {
     GetX509Status,
     Connect {
         #[serde(serialize_with = "serialize_token")]
-        token: SecretString,
+        token: Option<SecretString>,
         is_internet_resource_active: bool,
     },
     Disconnect,
@@ -67,16 +67,21 @@ pub enum ClientMsg {
         environment: String,
         release: String,
         account_slug: Option<String>,
+        account_id: Option<String>,
+        actor_email: Option<String>,
     },
     #[cfg(debug_assertions)]
     Panic,
 }
 
-fn serialize_token<S>(token: &SecretString, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_token<S>(token: &Option<SecretString>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
-    serializer.serialize_str(token.expose_secret())
+    match token {
+        Some(token) => serializer.serialize_some(token.expose_secret()),
+        None => serializer.serialize_none(),
+    }
 }
 
 /// Messages that end up in the GUI, either forwarded from connlib or from the Tunnel service.
@@ -86,6 +91,7 @@ pub enum ServerMsg {
         firezone_id: String,
         advanced_settings: AdvancedSettings,
         mdm_settings: MdmSettings,
+        certificate_user_identity: Option<device_trust::UserIdentity>,
     },
     /// The Tunnel service finished clearing its log dir.
     ClearedLogs(Result<(), String>),
@@ -96,6 +102,8 @@ pub enum ServerMsg {
         is_authentication_error: bool,
         is_certificate_revoked: bool,
         is_device_trust_error: bool,
+        used_x509_authentication: bool,
+        certificate_user_identity: Option<device_trust::UserIdentity>,
     },
     AllGatewaysOffline {
         resource_id: ResourceId,
@@ -234,6 +242,7 @@ struct Handler<'a> {
     session: Session,
     telemetry_release: Option<String>,
     mdm_device_id: Option<String>,
+    certificate_user_identity: Option<device_trust::UserIdentity>,
     tun_device: TunDeviceManager,
     dns_notifier: BoxStream<'static, Result<()>>,
     network_notifier: BoxStream<'static, Result<()>>,
@@ -246,17 +255,25 @@ enum Session {
         event_stream: client_shared::EventStream,
         connlib: client_shared::Session,
         started_at: Instant,
+        authentication_mode: AuthenticationMode,
     },
     Connected {
         event_stream: client_shared::EventStream,
         connlib: client_shared::Session,
+        authentication_mode: AuthenticationMode,
     },
     WaitingForNetwork {
-        token: SecretString,
+        token: Option<SecretString>,
         is_internet_resource_active: bool,
     },
     #[default]
     None,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AuthenticationMode {
+    Token,
+    X509,
 }
 
 impl Session {
@@ -266,21 +283,25 @@ impl Session {
                 event_stream,
                 connlib,
                 started_at,
+                authentication_mode,
             } => {
                 tracing::debug!(elapsed = ?started_at.elapsed(), "Tunnel ready");
 
                 *self = Self::Connected {
                     event_stream,
                     connlib,
+                    authentication_mode,
                 };
             }
             Session::Connected {
                 event_stream,
                 connlib,
+                authentication_mode,
             } => {
                 *self = Self::Connected {
                     event_stream,
                     connlib,
+                    authentication_mode,
                 };
             }
             Session::WaitingForNetwork { .. } => {
@@ -321,6 +342,20 @@ impl Session {
 
     fn is_none(&self) -> bool {
         matches!(self, Self::None)
+    }
+
+    fn authentication_mode(&self) -> Option<AuthenticationMode> {
+        match self {
+            Self::Creating {
+                authentication_mode,
+                ..
+            }
+            | Self::Connected {
+                authentication_mode,
+                ..
+            } => Some(*authentication_mode),
+            Self::WaitingForNetwork { .. } | Self::None => None,
+        }
     }
 }
 
@@ -425,11 +460,30 @@ impl<'a> Handler<'a> {
             .inspect_err(|e| tracing::warn!("Failed to load MDM settings, using defaults: {e:#}"))
             .unwrap_or_default();
 
+        let initial_x509_identity = device_trust::identity(&device_trust_config())
+            .inspect_err(|error| {
+                tracing::warn!(
+                    ?error,
+                    "Could not read the X.509 identity while initializing the GUI"
+                )
+            })
+            .ok()
+            .flatten();
+        let mdm_device_id = initial_x509_identity
+            .as_ref()
+            .and_then(device_trust::Identity::mdm_device_id)
+            .map(str::to_owned);
+        let certificate_user_identity = initial_x509_identity
+            .as_ref()
+            .and_then(device_trust::Identity::user_identity)
+            .cloned();
+
         ipc_tx
             .send(&ServerMsg::Hello {
                 firezone_id: device_id.id.clone(),
                 advanced_settings: advanced_settings.clone(),
                 mdm_settings: mdm_settings.clone(),
+                certificate_user_identity: certificate_user_identity.clone(),
             })
             .await
             .context("Failed to greet to new GUI process")?; // Greet the GUI process. If the GUI process doesn't receive this after connecting, it knows that the tunnel service isn't responding.
@@ -444,7 +498,8 @@ impl<'a> Handler<'a> {
             mdm_settings,
             session: Session::None,
             telemetry_release: None,
-            mdm_device_id: None,
+            mdm_device_id,
+            certificate_user_identity,
             tun_device,
             dns_notifier,
             network_notifier,
@@ -599,6 +654,7 @@ impl<'a> Handler<'a> {
     async fn handle_connlib_event(&mut self, msg: client_shared::Event) -> Result<()> {
         match msg {
             client_shared::Event::Disconnected(error) => {
+                let authentication_mode = self.session.authentication_mode();
                 self.session = Session::None;
                 self.reset_telemetry_environment();
                 self.dns_controller.deactivate()?;
@@ -623,6 +679,8 @@ impl<'a> Handler<'a> {
                     is_authentication_error: error.is_authentication_error(),
                     is_certificate_revoked,
                     is_device_trust_error: error.is_device_trust_error(),
+                    used_x509_authentication: authentication_mode == Some(AuthenticationMode::X509),
+                    certificate_user_identity: self.certificate_user_identity.clone(),
                 })
                 .await?
             }
@@ -745,6 +803,8 @@ impl<'a> Handler<'a> {
                 environment,
                 release,
                 account_slug,
+                account_id,
+                actor_email,
             } => {
                 // This is a bit hacky.
                 // It would be cleaner to pass it down from the `Cli` struct.
@@ -760,16 +820,15 @@ impl<'a> Handler<'a> {
                     telemetry::start(&environment, &release, telemetry::GUI_DSN);
                     telemetry::set_firezone_id(self.device_id.id.clone());
                     telemetry::set_mdm_device_id(self.mdm_device_id.clone());
+                    telemetry::set_account_slug_or_clear(account_slug.clone());
+                    telemetry::set_account_id(account_id.clone());
+                    telemetry::set_actor_email(actor_email.clone());
 
                     opentelemetry::global::set_meter_provider(
                         telemetry::SentryMeterProvider::default(),
                     );
 
-                    if let Some(account_slug) = account_slug {
-                        telemetry::set_account_slug(account_slug.clone());
-
-                        analytics::identify(release, Some(account_slug));
-                    }
+                    analytics::identify_with_user(release, account_slug, account_id, actor_email);
                 }
             }
             #[cfg(debug_assertions)]
@@ -790,7 +849,7 @@ impl<'a> Handler<'a> {
 
     fn try_connect(
         &mut self,
-        token: SecretString,
+        token: Option<SecretString>,
         is_internet_resource_active: bool,
     ) -> Result<Session> {
         let started_at = Instant::now();
@@ -800,6 +859,23 @@ impl<'a> Handler<'a> {
 
         let api_url = self.api_url().to_string();
         let identity = self.read_x509_identity()?;
+        let (authentication_mode, token) = select_authentication(
+            identity
+                .as_ref()
+                .and_then(device_trust::Identity::user_identity),
+            token,
+        )?;
+        if let Some(user_identity) = identity
+            .as_ref()
+            .and_then(device_trust::Identity::user_identity)
+        {
+            tracing::info!(
+                account_id = %user_identity.account_id,
+                "Using the managed X.509 identity for user authentication"
+            );
+        } else {
+            tracing::info!("Using the saved web sign-in token for user authentication");
+        }
         let portal_api_url = portal_api_url(
             Url::parse(&api_url).context("Failed to parse URL")?,
             identity.is_some(),
@@ -859,6 +935,7 @@ impl<'a> Handler<'a> {
             event_stream,
             connlib,
             started_at,
+            authentication_mode,
         })
     }
 
@@ -868,7 +945,21 @@ impl<'a> Handler<'a> {
             .as_ref()
             .and_then(device_trust::Identity::mdm_device_id)
             .map(str::to_owned);
+        self.certificate_user_identity = identity
+            .as_ref()
+            .and_then(device_trust::Identity::user_identity)
+            .cloned();
         telemetry::set_mdm_device_id(self.mdm_device_id.clone());
+        telemetry::set_account_id(
+            self.certificate_user_identity
+                .as_ref()
+                .map(|identity| identity.account_id.clone()),
+        );
+        telemetry::set_actor_email(
+            self.certificate_user_identity
+                .as_ref()
+                .map(|identity| identity.email.clone()),
+        );
 
         Ok(identity)
     }
@@ -907,6 +998,19 @@ fn device_trust_config() -> device_trust::Config {
     device_trust::Config {
         pkcs11_uri: std::env::var("FIREZONE_DEVICE_TRUST_PKCS11_URI").ok(),
     }
+}
+
+fn select_authentication(
+    user_identity: Option<&device_trust::UserIdentity>,
+    token: Option<SecretString>,
+) -> Result<(AuthenticationMode, Option<SecretString>)> {
+    if user_identity.is_some() {
+        return Ok((AuthenticationMode::X509, None));
+    }
+    let token = token.context(
+        "No sign-in token is available and the X.509 certificate has no complete user identity",
+    )?;
+    Ok((AuthenticationMode::Token, Some(token)))
 }
 
 fn portal_api_url(mut api_url: Url, use_client_certificate: bool) -> Url {
@@ -1051,6 +1155,31 @@ mod tests {
             "wss://mtls.firez.one:444/custom?foo=bar"
         );
         assert_eq!(portal_api_url(production.clone(), false), production);
+    }
+
+    #[test]
+    fn complete_certificate_user_identity_takes_precedence_over_token() {
+        let identity = device_trust::UserIdentity {
+            email: "alice@example.com".to_owned(),
+            account_id: "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3".to_owned(),
+        };
+
+        let (mode, token) =
+            select_authentication(Some(&identity), Some(SecretString::from("saved-token")))
+                .unwrap();
+
+        assert_eq!(mode, AuthenticationMode::X509);
+        assert!(token.is_none());
+    }
+
+    #[test]
+    fn token_is_required_without_complete_certificate_user_identity() {
+        assert!(select_authentication(None, None).is_err());
+
+        let (mode, token) =
+            select_authentication(None, Some(SecretString::from("saved-token"))).unwrap();
+        assert_eq!(mode, AuthenticationMode::Token);
+        assert!(token.is_some());
     }
 
     #[tokio::test]

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -52,6 +52,7 @@ pub(crate) use platform::ProcessToken;
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub enum ClientMsg {
     ClearLogs,
+    GetX509Status,
     Connect {
         #[serde(serialize_with = "serialize_token")]
         token: SecretString,
@@ -93,6 +94,7 @@ pub enum ServerMsg {
     OnDisconnect {
         error_msg: String,
         is_authentication_error: bool,
+        is_device_trust_error: bool,
     },
     AllGatewaysOffline {
         resource_id: ResourceId,
@@ -104,6 +106,8 @@ pub enum ServerMsg {
     /// Result of an `ApplyAdvancedSettings` from the GUI. `Ok` echoes the
     /// persisted struct so the GUI is certain about what landed.
     AdvancedSettingsApplied(Result<AdvancedSettings, String>),
+    /// Result of inspecting the native X.509 identity provider.
+    X509Status(Result<device_trust::Status, String>),
     /// The Tunnel service is terminating, maybe due to a software update
     ///
     /// This is a hint that the Client should exit with a message like,
@@ -228,6 +232,7 @@ struct Handler<'a> {
     mdm_settings: MdmSettings,
     session: Session,
     telemetry_release: Option<String>,
+    mdm_device_id: Option<String>,
     tun_device: TunDeviceManager,
     dns_notifier: BoxStream<'static, Result<()>>,
     network_notifier: BoxStream<'static, Result<()>>,
@@ -438,6 +443,7 @@ impl<'a> Handler<'a> {
             mdm_settings,
             session: Session::None,
             telemetry_release: None,
+            mdm_device_id: None,
             tun_device,
             dns_notifier,
             network_notifier,
@@ -598,6 +604,7 @@ impl<'a> Handler<'a> {
                 self.send_ipc(ServerMsg::OnDisconnect {
                     error_msg: error.to_string(),
                     is_authentication_error: error.is_authentication_error(),
+                    is_device_trust_error: error.is_device_trust_error(),
                 })
                 .await?
             }
@@ -640,6 +647,15 @@ impl<'a> Handler<'a> {
                 let result = logging::clear_service_logs().await;
                 self.send_ipc(ServerMsg::ClearedLogs(result.map_err(|e| e.to_string())))
                     .await?
+            }
+            ClientMsg::GetX509Status => {
+                let config = device_trust_config();
+                let result = tokio::task::spawn_blocking(move || device_trust::status(&config))
+                    .await
+                    .map_err(anyhow::Error::new)
+                    .and_then(|result| result)
+                    .map_err(|error| format!("{error:#}"));
+                self.send_ipc(ServerMsg::X509Status(result)).await?;
             }
             ClientMsg::Connect {
                 token,
@@ -725,6 +741,7 @@ impl<'a> Handler<'a> {
                     self.telemetry_release = Some(release.clone());
                     telemetry::start(&environment, &release, telemetry::GUI_DSN);
                     telemetry::set_firezone_id(self.device_id.id.clone());
+                    telemetry::set_mdm_device_id(self.mdm_device_id.clone());
 
                     opentelemetry::global::set_meter_provider(
                         telemetry::SentryMeterProvider::default(),
@@ -764,8 +781,18 @@ impl<'a> Handler<'a> {
             device_id::get_or_create_client().context("Failed to get-or-create device ID")?;
 
         let api_url = self.api_url().to_string();
-        let url = LoginUrl::client(
+        let identity = device_trust::identity(&device_trust_config())?;
+        self.mdm_device_id = identity
+            .as_ref()
+            .and_then(device_trust::Identity::mdm_device_id)
+            .map(str::to_owned);
+        telemetry::set_mdm_device_id(self.mdm_device_id.clone());
+        let portal_api_url = portal_api_url(
             Url::parse(&api_url).context("Failed to parse URL")?,
+            identity.is_some(),
+        );
+        let url = LoginUrl::client(
+            portal_api_url,
             device_id.id.clone(),
             None,
             DeviceInfo {
@@ -789,6 +816,10 @@ impl<'a> Handler<'a> {
             },
             Arc::new(tcp_socket_factory),
         );
+        let portal = match identity {
+            Some(identity) => portal.with_tls_client_config(identity.tls_client_config()),
+            None => portal,
+        };
 
         // Read the resolvers before starting connlib, in case connlib's startup interferes.
         let dns = self.dns_controller.system_resolvers();
@@ -846,6 +877,30 @@ impl<'a> Handler<'a> {
 
         Ok(())
     }
+}
+
+fn device_trust_config() -> device_trust::Config {
+    device_trust::Config {
+        pkcs11_uri: std::env::var("FIREZONE_DEVICE_TRUST_PKCS11_URI").ok(),
+    }
+}
+
+fn portal_api_url(mut api_url: Url, use_client_certificate: bool) -> Url {
+    if !use_client_certificate {
+        return api_url;
+    }
+
+    let mtls_host = match api_url.host_str() {
+        Some("api.firez.one") => Some("mtls.firez.one"),
+        Some("api.firezone.dev") => Some("mtls.firezone.dev"),
+        _ => None,
+    };
+    if let Some(host) = mtls_host {
+        api_url
+            .set_host(Some(host))
+            .expect("a known valid hostname should remain valid");
+    }
+    api_url
 }
 
 /// Run the Tunnel service in an interactive terminal rather than as a
@@ -957,6 +1012,22 @@ pub fn run_smoke_test() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn client_certificate_uses_mtls_api_host() {
+        let production = Url::parse("wss://api.firezone.dev/custom?foo=bar").unwrap();
+        let staging = Url::parse("wss://api.firez.one:444/custom?foo=bar").unwrap();
+
+        assert_eq!(
+            portal_api_url(production.clone(), true).as_str(),
+            "wss://mtls.firezone.dev/custom?foo=bar"
+        );
+        assert_eq!(
+            portal_api_url(staging, true).as_str(),
+            "wss://mtls.firez.one:444/custom?foo=bar"
+        );
+        assert_eq!(portal_api_url(production.clone(), false), production);
+    }
 
     #[tokio::test]
     async fn panic_inside_handler_doesnt_interrupt_service() {

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -94,6 +94,7 @@ pub enum ServerMsg {
     OnDisconnect {
         error_msg: String,
         is_authentication_error: bool,
+        is_certificate_revoked: bool,
         is_device_trust_error: bool,
     },
     AllGatewaysOffline {
@@ -601,9 +602,26 @@ impl<'a> Handler<'a> {
                 self.session = Session::None;
                 self.reset_telemetry_environment();
                 self.dns_controller.deactivate()?;
+                let is_certificate_revoked = error.is_certificate_revoked();
+                if is_certificate_revoked {
+                    self.read_x509_identity()
+                        .inspect(|_| {
+                            tracing::info!(
+                                "Re-read X.509 device identity after certificate revocation"
+                            )
+                        })
+                        .inspect_err(|error| {
+                            tracing::warn!(
+                                ?error,
+                                "Could not re-read X.509 device identity after certificate revocation"
+                            )
+                        })
+                        .ok();
+                }
                 self.send_ipc(ServerMsg::OnDisconnect {
                     error_msg: error.to_string(),
                     is_authentication_error: error.is_authentication_error(),
+                    is_certificate_revoked,
                     is_device_trust_error: error.is_device_trust_error(),
                 })
                 .await?
@@ -781,12 +799,7 @@ impl<'a> Handler<'a> {
             device_id::get_or_create_client().context("Failed to get-or-create device ID")?;
 
         let api_url = self.api_url().to_string();
-        let identity = device_trust::identity(&device_trust_config())?;
-        self.mdm_device_id = identity
-            .as_ref()
-            .and_then(device_trust::Identity::mdm_device_id)
-            .map(str::to_owned);
-        telemetry::set_mdm_device_id(self.mdm_device_id.clone());
+        let identity = self.read_x509_identity()?;
         let portal_api_url = portal_api_url(
             Url::parse(&api_url).context("Failed to parse URL")?,
             identity.is_some(),
@@ -847,6 +860,17 @@ impl<'a> Handler<'a> {
             connlib,
             started_at,
         })
+    }
+
+    fn read_x509_identity(&mut self) -> Result<Option<device_trust::Identity>> {
+        let identity = device_trust::identity(&device_trust_config())?;
+        self.mdm_device_id = identity
+            .as_ref()
+            .and_then(device_trust::Identity::mdm_device_id)
+            .map(str::to_owned);
+        telemetry::set_mdm_device_id(self.mdm_device_id.clone());
+
+        Ok(identity)
     }
 
     async fn handle_connect_result(&mut self, result: Result<Session>) -> Result<()> {

--- a/rust/gui-client/src-tauri/src/view.rs
+++ b/rust/gui-client/src-tauri/src/view.rs
@@ -42,6 +42,47 @@ pub struct AdvancedSettingsChanged(pub AdvancedSettingsViewModel);
 #[derive(Clone, serde::Serialize, specta::Type, tauri_specta::Event)]
 pub struct LogsRecounted(pub FileCount);
 
+#[derive(Clone, serde::Serialize, specta::Type)]
+pub struct X509Status {
+    pub summary: String,
+    pub sections: Vec<X509DetailSection>,
+}
+
+#[derive(Clone, serde::Serialize, specta::Type)]
+pub struct X509DetailSection {
+    pub title: String,
+    pub fields: Vec<X509DetailField>,
+}
+
+#[derive(Clone, serde::Serialize, specta::Type)]
+pub struct X509DetailField {
+    pub label: String,
+    pub value: String,
+}
+
+impl From<device_trust::Status> for X509Status {
+    fn from(status: device_trust::Status) -> Self {
+        Self {
+            summary: status.summary,
+            sections: status
+                .sections
+                .into_iter()
+                .map(|section| X509DetailSection {
+                    title: section.title,
+                    fields: section
+                        .fields
+                        .into_iter()
+                        .map(|field| X509DetailField {
+                            label: field.label,
+                            value: field.value,
+                        })
+                        .collect(),
+                })
+                .collect(),
+        }
+    }
+}
+
 #[tauri::command]
 #[specta::specta]
 pub async fn clear_logs(managed: tauri::State<'_, Managed>) -> Result<()> {
@@ -56,6 +97,22 @@ pub async fn clear_logs(managed: tauri::State<'_, Managed>) -> Result<()> {
         .map_err(anyhow::Error::msg)?;
 
     Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn x509_status(managed: tauri::State<'_, Managed>) -> Result<X509Status> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    managed
+        .send_request(ControllerRequest::GetX509Status(tx))
+        .await?;
+
+    let status = rx
+        .await
+        .context("Failed to await X.509 status")?
+        .map_err(anyhow::Error::msg)?;
+
+    Ok(status.into())
 }
 
 #[tauri::command]

--- a/rust/gui-client/src-tauri/src/view.rs
+++ b/rust/gui-client/src-tauri/src/view.rs
@@ -25,9 +25,12 @@ pub enum SessionViewModel {
     SignedIn {
         account_slug: String,
         actor_name: String,
+        x509_authenticated: bool,
     },
     Loading,
-    SignedOut,
+    SignedOut {
+        certificate_actor_email: Option<String>,
+    },
 }
 
 #[derive(Clone, serde::Serialize, specta::Type, tauri_specta::Event)]

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -13,6 +13,7 @@ backoff = { workspace = true }
 bin-shared = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "string"] }
 client-shared = { workspace = true }
+device-trust = { workspace = true }
 flow-log-upload = { workspace = true }
 flow-log-writer = { workspace = true }
 futures = { workspace = true }

--- a/rust/headless-client/README.md
+++ b/rust/headless-client/README.md
@@ -39,6 +39,40 @@ capability to open `/dev/net/tun`. You can add this to the client binary with:
 sudo setcap 'cap_net_admin+eip' /path/to/firezone-headless-client
 ```
 
+## X.509 device identity
+
+The headless client uses the same Windows certificate-store and Linux PKCS#11
+identity providers as the GUI Tunnel service. To inspect enrollment without
+connecting to the portal or reading a Firezone token, run:
+
+```sh
+firezone-headless-client x509
+```
+
+The command prints the matching certificates, validity and client-auth EKU,
+private-key access, signing algorithm, and SHA-256 fingerprint. A missing
+identity is reported as a normal status; malformed configuration or an
+unreadable key store exits non-zero.
+
+Windows needs no Firezone-specific configuration. Provision a currently valid
+certificate with subject CN `dev.firezone.device-trust`, TLS client
+authentication EKU, and a CNG private key into `LocalMachine\My` for the
+service account to use.
+
+On Linux, set `FIREZONE_DEVICE_TRUST_PKCS11_URI` (or pass
+`--device-trust-pkcs11-uri`) to an RFC 7512 URI. For example:
+
+```sh
+export FIREZONE_DEVICE_TRUST_PKCS11_URI='pkcs11:token=Firezone;object=device-trust?module-path=/usr/lib/x86_64-linux-gnu/pkcs11/libtpm2_pkcs11.so&pin-source=file:/etc/firezone/pkcs11-pin'
+firezone-headless-client x509
+```
+
+Only `pin-source=file:` is supported; inline `pin-value` credentials are
+rejected. Private-key bytes remain inside CNG or the PKCS#11 provider.
+The selected identity authenticates the `/client/v2` Phoenix connection with
+mutual TLS. When multiple usable certificates match, the client selects the
+newest certificate by `notBefore`.
+
 ## Building
 
 Assuming you have Rust installed, you can build the headless Client with:

--- a/rust/headless-client/README.md
+++ b/rust/headless-client/README.md
@@ -71,7 +71,15 @@ Only `pin-source=file:` is supported; inline `pin-value` credentials are
 rejected. Private-key bytes remain inside CNG or the PKCS#11 provider.
 The selected identity authenticates the `/client/v2` Phoenix connection with
 mutual TLS. When multiple usable certificates match, the client selects the
-newest certificate by `notBefore`.
+newest certificate by `notBefore`. A configured or matching identity that
+cannot satisfy the certificate policy or access its private key fails the
+connection instead of silently falling back to non-mutual TLS.
+
+If the selected certificate contains one valid, unambiguous
+`firezone://email/...` URI SAN and one `firezone://account-id/...` URI SAN, the
+headless client authenticates as that Firezone user and does not require or send
+a service-account token. The `x509` command displays the derived Actor Email and
+Account ID alongside the raw SAN values.
 
 ## Building
 

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -543,7 +543,28 @@ fn try_main() -> Result<()> {
             };
 
             match event {
-                client_shared::Event::Disconnected(error) => break Err(anyhow!(error).context("Firezone disconnected")),
+                client_shared::Event::Disconnected(error) => {
+                    if error.is_certificate_revoked() {
+                        match device_trust::identity(&x509_config) {
+                            Ok(identity) => {
+                                telemetry::set_mdm_device_id(
+                                    identity
+                                        .as_ref()
+                                        .and_then(device_trust::Identity::mdm_device_id)
+                                        .map(str::to_owned),
+                                );
+                                tracing::info!(
+                                    "Re-read X.509 device identity after certificate revocation"
+                                );
+                            }
+                            Err(error) => tracing::warn!(
+                                ?error,
+                                "Could not re-read X.509 device identity after certificate revocation"
+                            ),
+                        }
+                    }
+                    break Err(anyhow!(error).context("Firezone disconnected"));
+                }
                 client_shared::Event::ResourcesUpdated(_) => {
                     // On every Resources update, flush DNS to mitigate <https://github.com/firezone/firezone/issues/5052>
                     dns_controller.flush()?;

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -153,6 +153,30 @@ struct Cli {
     /// spooling and uploading them is always controlled by the portal.
     #[arg(long, env = "FIREZONE_FLOW_LOGS", default_value_t = false)]
     flow_logs: bool,
+
+    /// RFC 7512 URI for the Linux X.509 device identity.
+    #[arg(long, env = "FIREZONE_DEVICE_TRUST_PKCS11_URI", global = true)]
+    device_trust_pkcs11_uri: Option<Pkcs11Uri>,
+}
+
+#[derive(Clone)]
+struct Pkcs11Uri(String);
+
+impl std::fmt::Debug for Pkcs11Uri {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("[configured]")
+    }
+}
+
+impl std::str::FromStr for Pkcs11Uri {
+    type Err = String;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        if !value.starts_with("pkcs11:") {
+            return Err("PKCS#11 URI must begin with 'pkcs11:'".to_owned());
+        }
+        Ok(Self(value.to_owned()))
+    }
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
@@ -198,6 +222,9 @@ enum Cmd {
         #[arg(long, short)]
         force: bool,
     },
+
+    /// Show the X.509 device identity status and certificate diagnostics
+    X509,
 }
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -240,10 +267,17 @@ fn try_main() -> Result<()> {
 
             return Ok(());
         }
+        Some(Cmd::X509) => {
+            handle_x509_status(device_trust_config(&cli))?;
+
+            return Ok(());
+        }
         Some(Cmd::Standalone) | None => {
             // Continue with normal operation
         }
     }
+
+    let x509_config = device_trust_config(&cli);
 
     // Modifying the environment of a running process is unsafe. If any other
     // thread is reading or writing the environment, something bad can happen.
@@ -343,12 +377,19 @@ fn try_main() -> Result<()> {
         Arc::new(tcp_socket_factory),
         Arc::new(UdpSocketFactory::default()),
     );
+    let x509_identity = device_trust::identity(&x509_config)?;
 
     if cli.is_telemetry_allowed() {
         telemetry::configure(Arc::new(tcp_socket_factory));
 
         telemetry::start(cli.api_url.as_ref(), RELEASE, telemetry::HEADLESS_DSN);
         telemetry::set_firezone_id(firezone_id.clone());
+        telemetry::set_mdm_device_id(
+            x509_identity
+                .as_ref()
+                .and_then(device_trust::Identity::mdm_device_id)
+                .map(str::to_owned),
+        );
 
         analytics::identify(RELEASE.to_owned(), None);
     }
@@ -364,8 +405,9 @@ fn try_main() -> Result<()> {
     // TODO: Should this default to 30 days?
     let max_partition_time = cli.max_partition_time.map(|d| d.into());
 
+    let portal_api_url = portal_api_url(&cli.api_url, x509_identity.is_some());
     let url = LoginUrl::client(
-        cli.api_url.clone(),
+        portal_api_url,
         firezone_id.clone(),
         cli.firezone_name,
         DeviceInfo {
@@ -435,6 +477,10 @@ fn try_main() -> Result<()> {
             },
             Arc::new(tcp_socket_factory),
         );
+        let portal = match x509_identity.as_ref() {
+            Some(identity) => portal.with_tls_client_config(identity.tls_client_config()),
+            None => portal,
+        };
         if let Some(dir) = flow_logs_dir.clone() {
             flow_log_upload::spawn(dir, Arc::new(tcp_socket_factory));
         }
@@ -539,6 +585,43 @@ fn try_main() -> Result<()> {
     rt.shutdown_timeout(Duration::from_secs(1));
 
     Ok(())
+}
+
+fn device_trust_config(cli: &Cli) -> device_trust::Config {
+    device_trust::Config {
+        pkcs11_uri: cli
+            .device_trust_pkcs11_uri
+            .as_ref()
+            .map(|uri| uri.0.clone()),
+    }
+}
+
+#[expect(
+    clippy::print_stdout,
+    reason = "This status command is designed to print to stdout"
+)]
+fn handle_x509_status(config: device_trust::Config) -> Result<()> {
+    let status = device_trust::status(&config)?;
+    print!("{}", status.text_description());
+    Ok(())
+}
+
+fn portal_api_url(api_url: &url::Url, use_client_certificate: bool) -> url::Url {
+    let mut url = api_url.clone();
+    if !use_client_certificate {
+        return url;
+    }
+
+    let mtls_host = match url.host_str() {
+        Some("api.firez.one") => Some("mtls.firez.one"),
+        Some("api.firezone.dev") => Some("mtls.firezone.dev"),
+        _ => None,
+    };
+    if let Some(host) = mtls_host {
+        url.set_host(Some(host))
+            .expect("a known valid hostname should remain valid");
+    }
+    url
 }
 
 /// Constructs the authentication URL for browser-based sign-in.
@@ -708,7 +791,7 @@ fn tonic_otlp_exporter(
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Cmd};
+    use super::{Cli, Cmd, portal_api_url};
     use clap::Parser;
     use std::path::PathBuf;
     use url::Url;
@@ -730,6 +813,22 @@ mod tests {
             Cli::try_parse_from([exe_name, "--check", "--log-dir", "bogus_log_dir"]).unwrap();
         assert!(actual.check);
         assert_eq!(actual.log_dir, Some(PathBuf::from("bogus_log_dir")));
+    }
+
+    #[test]
+    fn client_certificate_uses_mtls_api_host() {
+        let production = Url::parse("wss://api.firezone.dev/custom?foo=bar").unwrap();
+        let staging = Url::parse("wss://api.firez.one:444/custom?foo=bar").unwrap();
+
+        assert_eq!(
+            portal_api_url(&production, true).as_str(),
+            "wss://mtls.firezone.dev/custom?foo=bar"
+        );
+        assert_eq!(
+            portal_api_url(&staging, true).as_str(),
+            "wss://mtls.firez.one:444/custom?foo=bar"
+        );
+        assert_eq!(portal_api_url(&production, false), production);
     }
 
     #[test]
@@ -823,6 +922,37 @@ mod tests {
 
         assert_eq!(actual.token_path, PathBuf::from("/custom/token/path"));
         assert!(matches!(actual._command, Some(Cmd::SignOut { .. })));
+    }
+
+    #[test]
+    fn x509_status_accepts_linux_pkcs11_configuration() {
+        let actual = Cli::try_parse_from([
+            "firezone-headless-client",
+            "x509",
+            "--device-trust-pkcs11-uri",
+            "pkcs11:token=Firezone?module-path=/usr/lib/libpkcs11.so",
+        ])
+        .unwrap();
+
+        assert!(matches!(actual._command, Some(Cmd::X509)));
+        assert_eq!(
+            actual.device_trust_pkcs11_uri.unwrap().0,
+            "pkcs11:token=Firezone?module-path=/usr/lib/libpkcs11.so"
+        );
+    }
+
+    #[test]
+    fn pkcs11_uri_is_redacted_from_debug_output() {
+        let actual = Cli::try_parse_from([
+            "firezone-headless-client",
+            "--device-trust-pkcs11-uri",
+            "pkcs11:token=Firezone?module-path=/usr/lib/libpkcs11.so",
+        ])
+        .unwrap();
+
+        let debug = format!("{actual:?}");
+        assert!(debug.contains("[configured]"));
+        assert!(!debug.contains("libpkcs11"));
     }
 
     /// Verifies that `set_token_permissions` produces a file that passes `check_token_permissions`.

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -378,6 +378,10 @@ fn try_main() -> Result<()> {
         Arc::new(UdpSocketFactory::default()),
     );
     let x509_identity = device_trust::identity(&x509_config)?;
+    let certificate_user_identity = x509_identity
+        .as_ref()
+        .and_then(device_trust::Identity::user_identity)
+        .cloned();
 
     if cli.is_telemetry_allowed() {
         telemetry::configure(Arc::new(tcp_socket_factory));
@@ -390,18 +394,48 @@ fn try_main() -> Result<()> {
                 .and_then(device_trust::Identity::mdm_device_id)
                 .map(str::to_owned),
         );
+        telemetry::set_account_slug_or_clear(None);
+        telemetry::set_account_id(
+            certificate_user_identity
+                .as_ref()
+                .map(|identity| identity.account_id.clone()),
+        );
+        telemetry::set_actor_email(
+            certificate_user_identity
+                .as_ref()
+                .map(|identity| identity.email.clone()),
+        );
 
-        analytics::identify(RELEASE.to_owned(), None);
+        analytics::identify_with_user(
+            RELEASE.to_owned(),
+            None,
+            certificate_user_identity
+                .as_ref()
+                .map(|identity| identity.account_id.clone()),
+            certificate_user_identity
+                .as_ref()
+                .map(|identity| identity.email.clone()),
+        );
     }
 
     tracing::info!(arch = std::env::consts::ARCH, version = VERSION);
 
-    let token = get_token(token_env_var, &cli.token_path)?.with_context(|| {
-        format!(
-            "Can't find the Firezone token in ${TOKEN_ENV_KEY} or in `{}`",
-            cli.token_path.display()
-        )
-    })?;
+    let token = if let Some(user_identity) = &certificate_user_identity {
+        tracing::info!(
+            account_id = %user_identity.account_id,
+            "Using the managed X.509 identity for user authentication"
+        );
+        None
+    } else {
+        let token = get_token(token_env_var, &cli.token_path)?.with_context(|| {
+            format!(
+                "Can't find the Firezone token in ${TOKEN_ENV_KEY} or in `{}`",
+                cli.token_path.display()
+            )
+        })?;
+        tracing::info!("Using the saved service-account token for authentication");
+        Some(token)
+    };
     // TODO: Should this default to 30 days?
     let max_partition_time = cli.max_partition_time.map(|d| d.into());
 
@@ -547,11 +581,20 @@ fn try_main() -> Result<()> {
                     if error.is_certificate_revoked() {
                         match device_trust::identity(&x509_config) {
                             Ok(identity) => {
+                                let user_identity = identity
+                                    .as_ref()
+                                    .and_then(device_trust::Identity::user_identity);
                                 telemetry::set_mdm_device_id(
                                     identity
                                         .as_ref()
                                         .and_then(device_trust::Identity::mdm_device_id)
                                         .map(str::to_owned),
+                                );
+                                telemetry::set_account_id(
+                                    user_identity.map(|identity| identity.account_id.clone()),
+                                );
+                                telemetry::set_actor_email(
+                                    user_identity.map(|identity| identity.email.clone()),
                                 );
                                 tracing::info!(
                                     "Re-read X.509 device identity after certificate revocation"

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -126,6 +126,14 @@ impl DisconnectError {
         e.is_authentication_error()
     }
 
+    pub fn is_certificate_revoked(&self) -> bool {
+        let Some(e) = self.0.any_downcast_ref::<phoenix_channel::Error>() else {
+            return false;
+        };
+
+        e.is_certificate_revoked()
+    }
+
     pub fn is_device_trust_error(&self) -> bool {
         phoenix_channel::http_error_body(&self.0)
             .is_some_and(|body| body.contains("device_untrusted"))

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -125,6 +125,11 @@ impl DisconnectError {
 
         e.is_authentication_error()
     }
+
+    pub fn is_device_trust_error(&self) -> bool {
+        phoenix_channel::http_error_body(&self.0)
+            .is_some_and(|body| body.contains("device_untrusted"))
+    }
 }
 
 impl Eventloop {

--- a/rust/libs/connlib/phoenix-channel/Cargo.toml
+++ b/rust/libs/connlib/phoenix-channel/Cargo.toml
@@ -17,6 +17,7 @@ libc = { workspace = true }
 logging = { workspace = true }
 os_info = { workspace = true }
 rand = { workspace = true }
+rustls = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -25,11 +25,11 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use socket_factory::{SocketFactory, TcpSocket, TcpStream};
 use std::task::{Context, Poll, Waker};
 use tokio_tungstenite::tungstenite::http::header::RETRY_AFTER;
+use tokio_tungstenite::{Connector, client_async_tls_with_config, tungstenite};
 use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream,
     tungstenite::{Message, handshake::client::Request},
 };
-use tokio_tungstenite::{client_async_tls, tungstenite};
 use url::Url;
 
 pub use get_user_agent::get_user_agent;
@@ -57,6 +57,7 @@ pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     url_prototype: LoginUrl<TFinish>,
     last_url: Option<Url>,
     user_agent: String,
+    tls_client_config: Option<Arc<rustls::ClientConfig>>,
     /// The authentication token, sent via X-Authorization header.
     token: SecretString,
     make_initial_backoff: Box<dyn Fn() -> ExponentialBackoff + Send>,
@@ -99,6 +100,7 @@ async fn create_and_connect_websocket(
     token: SecretString,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     connect_timeout: Duration,
+    tls_client_config: Option<Arc<rustls::ClientConfig>>,
 ) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, InternalError> {
     tracing::debug!(%host, ?addresses, %user_agent, "Connecting to portal");
 
@@ -115,9 +117,15 @@ async fn create_and_connect_websocket(
                 )
             })??;
 
-        let (stream, _) = client_async_tls(make_request(url, host, user_agent, &token), socket)
-            .await
-            .map_err(InternalError::WebSocket)?;
+        let connector = tls_client_config.map(Connector::Rustls);
+        let (stream, _) = client_async_tls_with_config(
+            make_request(url, host, user_agent, &token),
+            socket,
+            None,
+            connector,
+        )
+        .await
+        .map_err(InternalError::WebSocket)?;
 
         Ok(stream)
     })
@@ -378,6 +386,7 @@ where
             was_connected: false,
             url_prototype: url,
             user_agent,
+            tls_client_config: None,
             token,
             state: State::Closed,
             socket_factory,
@@ -387,6 +396,16 @@ where
             init_req,
             last_url: None,
         }
+    }
+
+    /// Uses the supplied rustls configuration for TLS connections.
+    ///
+    /// This allows callers to configure client certificate authentication, including
+    /// certificate resolvers backed by platform-managed, non-exportable private keys.
+    /// Without this, the channel uses its existing default TLS configuration.
+    pub fn with_tls_client_config(mut self, config: Arc<rustls::ClientConfig>) -> Self {
+        self.tls_client_config = Some(config);
+        self
     }
 
     /// Join our room.
@@ -475,6 +494,7 @@ where
             let user_agent = self.user_agent.clone();
             let token = self.token.clone();
             let socket_factory = self.socket_factory.clone();
+            let tls_client_config = self.tls_client_config.clone();
 
             async move {
                 if let Err(e) = closing.await {
@@ -490,6 +510,7 @@ where
                     token,
                     socket_factory,
                     CONNECT_TIMEOUT,
+                    tls_client_config,
                 )
                 .await
             }
@@ -1349,6 +1370,7 @@ mod tests {
             SecretString::from("test-token".to_string()),
             Arc::new(socket_factory::tcp),
             Duration::from_secs(2),
+            None,
         )
         .await;
 

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -58,8 +58,8 @@ pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     last_url: Option<Url>,
     user_agent: String,
     tls_client_config: Option<Arc<rustls::ClientConfig>>,
-    /// The authentication token, sent via X-Authorization header.
-    token: SecretString,
+    /// The optional authentication token, sent via X-Authorization when present.
+    token: Option<SecretString>,
     make_initial_backoff: Box<dyn Fn() -> ExponentialBackoff + Send>,
     make_reconnect_backoff: Box<dyn Fn() -> ExponentialBackoff + Send>,
     backoff: Option<ExponentialBackoff>,
@@ -97,7 +97,7 @@ async fn create_and_connect_websocket(
     addresses: Vec<SocketAddr>,
     host: String,
     user_agent: String,
-    token: SecretString,
+    token: Option<SecretString>,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     connect_timeout: Duration,
     tls_client_config: Option<Arc<rustls::ClientConfig>>,
@@ -119,7 +119,7 @@ async fn create_and_connect_websocket(
 
         let connector = tls_client_config.map(Connector::Rustls);
         let (stream, _) = client_async_tls_with_config(
-            make_request(url, host, user_agent, &token),
+            make_request(url, host, user_agent, token.as_ref()),
             socket,
             None,
             connector,
@@ -186,6 +186,10 @@ async fn connect(
 pub enum Error {
     #[error("Authentication token invalid")]
     InvalidToken,
+    #[error("Portal rejected X.509 certificate authentication")]
+    CertificateAuthenticationRejected,
+    #[error("X.509 client certificate signing failed: {0}")]
+    ClientCertificateSigningFailed(String),
     #[error("X.509 device identity certificate was revoked")]
     CertificateRevoked,
     #[error(
@@ -202,6 +206,8 @@ impl Error {
     pub fn is_authentication_error(&self) -> bool {
         match self {
             Error::InvalidToken => true,
+            Error::CertificateAuthenticationRejected => false,
+            Error::ClientCertificateSigningFailed(_) => false,
             Error::CertificateRevoked => false,
             Error::MaxRetriesReached { .. } => false,
             Error::LoginFailed(_) => false,
@@ -211,6 +217,20 @@ impl Error {
 
     pub fn is_certificate_revoked(&self) -> bool {
         matches!(self, Error::CertificateRevoked)
+    }
+}
+
+/// Preserves a platform-backed client-certificate signing failure through rustls and the
+/// WebSocket transport so that it can be treated as terminal rather than a network hiccup.
+#[derive(Debug, thiserror::Error)]
+#[error("Platform TLS signing failed: {0}")]
+pub struct ClientCertificateSigningError(pub String);
+
+fn unauthorized_error(uses_token_authentication: bool) -> Error {
+    if uses_token_authentication {
+        Error::InvalidToken
+    } else {
+        Error::CertificateAuthenticationRejected
     }
 }
 
@@ -229,6 +249,21 @@ enum InternalError {
 }
 
 impl InternalError {
+    fn client_certificate_signing_error(&self) -> Option<String> {
+        let Self::WebSocket(tungstenite::Error::Io(error)) = self else {
+            return None;
+        };
+        let tls_error = error.get_ref()?.downcast_ref::<rustls::Error>()?;
+        let rustls::Error::Other(other) = tls_error else {
+            return None;
+        };
+
+        other
+            .0
+            .downcast_ref::<ClientCertificateSigningError>()
+            .map(|error| error.0.clone())
+    }
+
     /// Parses a Retry-After header value into a Duration.
     ///
     /// The header can be either:
@@ -379,7 +414,7 @@ where
     /// The provided URL must contain a host.
     pub fn disconnected(
         url: LoginUrl<TFinish>,
-        token: SecretString,
+        token: impl Into<Option<SecretString>>,
         user_agent: String,
         login: &'static str,
         init_req: TInitReq,
@@ -394,7 +429,7 @@ where
             url_prototype: url,
             user_agent,
             tls_client_config: None,
-            token,
+            token: token.into(),
             state: State::Closed,
             socket_factory,
             waker: None,
@@ -565,6 +600,8 @@ where
     }
 
     pub fn poll(&mut self, cx: &mut Context) -> Poll<Result<Event<TInboundMsg>, Error>> {
+        let uses_token_authentication = self.token.is_some();
+
         loop {
             // First, check if we are connected.
             let Connected {
@@ -617,9 +654,16 @@ where
                         if r.status() == StatusCode::UNAUTHORIZED =>
                     {
                         self.state = State::Closed;
-                        return Poll::Ready(Err(Error::InvalidToken));
+                        return Poll::Ready(Err(unauthorized_error(uses_token_authentication)));
                     }
                     Poll::Ready(Err(e)) => {
+                        if let Some(message) = e.client_certificate_signing_error() {
+                            self.state = State::Closed;
+                            return Poll::Ready(Err(Error::ClientCertificateSigningFailed(
+                                message,
+                            )));
+                        }
+
                         let backoff = match e.parse_retry_after_header() {
                             Some(duration) => duration,
                             None => {
@@ -865,7 +909,7 @@ where
                             },
                             _,
                         ) => {
-                            return Poll::Ready(Err(Error::InvalidToken));
+                            return Poll::Ready(Err(unauthorized_error(uses_token_authentication)));
                         }
                         (
                             Payload::Disconnect {
@@ -1086,24 +1130,32 @@ impl<T> PhoenixMessage<T> {
 }
 
 // This is basically the same as tungstenite does but we add some new headers (namely user-agent)
-fn make_request(url: Url, host: String, user_agent: String, token: &SecretString) -> Request {
+fn make_request(
+    url: Url,
+    host: String,
+    user_agent: String,
+    token: Option<&SecretString>,
+) -> Request {
     let r: [u8; 16] = rand::random();
     let key = base64::engine::general_purpose::STANDARD.encode(r);
 
     let user_agent = user_agent.replace(|c: char| !c.is_ascii(), "");
-    let token = token
-        .expose_secret()
-        .replace(|c: char| c.is_whitespace(), "");
-
-    Request::builder()
+    let mut builder = Request::builder()
         .method("GET")
         .header("Host", host)
         .header("Connection", "Upgrade")
         .header("Upgrade", "websocket")
         .header("Sec-WebSocket-Version", "13")
         .header("Sec-WebSocket-Key", key)
-        .header("User-Agent", user_agent)
-        .header("X-Authorization", format!("Bearer {token}"))
+        .header("User-Agent", user_agent);
+    if let Some(token) = token {
+        let token = token
+            .expose_secret()
+            .replace(|c: char| c.is_whitespace(), "");
+        builder = builder.header("X-Authorization", format!("Bearer {token}"));
+    }
+
+    builder
         .uri(url.to_string())
         .body(())
         .expect("should always be able to build a request if we only pass strings to it")
@@ -1154,6 +1206,19 @@ mod tests {
         let error = anyhow::Error::msg("some other failure").context("Connection hiccup");
 
         assert_eq!(http_error_body(&error), None);
+    }
+
+    #[test]
+    fn extracts_platform_client_certificate_signing_error() {
+        let tls_error = rustls::Error::Other(rustls::OtherError(Arc::new(
+            ClientCertificateSigningError("provider interaction is unavailable".to_owned()),
+        )));
+        let error = InternalError::WebSocket(tungstenite::Error::Io(io::Error::other(tls_error)));
+
+        assert_eq!(
+            error.client_certificate_signing_error().as_deref(),
+            Some("provider interaction is unavailable")
+        );
     }
 
     #[derive(Deserialize, PartialEq, Debug)]
@@ -1400,7 +1465,7 @@ mod tests {
             vec![addr],
             "127.0.0.1".to_string(),
             "test-agent".to_string(),
-            SecretString::from("test-token".to_string()),
+            Some(SecretString::from("test-token".to_string())),
             Arc::new(socket_factory::tcp),
             Duration::from_secs(2),
             None,
@@ -1419,7 +1484,9 @@ mod tests {
             Url::parse("ws://example.com/websocket").unwrap(),
             "example.com".to_string(),
             "test-agent".to_string(),
-            &SecretString::from("valid-token-part\ninjected".to_string()),
+            Some(&SecretString::from(
+                "valid-token-part\ninjected".to_string(),
+            )),
         );
 
         assert_eq!(
@@ -1434,7 +1501,9 @@ mod tests {
             Url::parse("ws://example.com/websocket").unwrap(),
             "example.com".to_string(),
             "test-agent".to_string(),
-            &SecretString::from("valid-token-part\rinjected".to_string()),
+            Some(&SecretString::from(
+                "valid-token-part\rinjected".to_string(),
+            )),
         );
 
         assert_eq!(
@@ -1449,12 +1518,26 @@ mod tests {
             Url::parse("ws://example.com/websocket").unwrap(),
             "example.com".to_string(),
             "test-agent".to_string(),
-            &SecretString::from("a-perfectly-valid.token_123".to_string()),
+            Some(&SecretString::from(
+                "a-perfectly-valid.token_123".to_string(),
+            )),
         );
 
         assert_eq!(
             request.headers()["X-Authorization"],
             "Bearer a-perfectly-valid.token_123"
         );
+    }
+
+    #[test]
+    fn make_request_omits_authorization_without_token() {
+        let request = make_request(
+            Url::parse("ws://example.com/websocket").unwrap(),
+            "example.com".to_string(),
+            "test-agent".to_string(),
+            None,
+        );
+
+        assert!(!request.headers().contains_key("X-Authorization"));
     }
 }

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -186,6 +186,8 @@ async fn connect(
 pub enum Error {
     #[error("Authentication token invalid")]
     InvalidToken,
+    #[error("X.509 device identity certificate was revoked")]
+    CertificateRevoked,
     #[error(
         "Got disconnected from portal and hit the max-retry limit. Last connection error: {final_error}"
     )]
@@ -200,10 +202,15 @@ impl Error {
     pub fn is_authentication_error(&self) -> bool {
         match self {
             Error::InvalidToken => true,
+            Error::CertificateRevoked => false,
             Error::MaxRetriesReached { .. } => false,
             Error::LoginFailed(_) => false,
             Error::FatalIo(_) => false,
         }
+    }
+
+    pub fn is_certificate_revoked(&self) -> bool {
+        matches!(self, Error::CertificateRevoked)
     }
 }
 
@@ -860,6 +867,14 @@ where
                         ) => {
                             return Poll::Ready(Err(Error::InvalidToken));
                         }
+                        (
+                            Payload::Disconnect {
+                                reason: DisconnectReason::CertificateRevoked,
+                            },
+                            _,
+                        ) => {
+                            return Poll::Ready(Err(Error::CertificateRevoked));
+                        }
                     }
                 }
                 Poll::Ready(Some(Ok(Message::Binary(_)))) => {
@@ -1032,6 +1047,7 @@ impl fmt::Display for ErrorReply {
 #[serde(rename_all = "snake_case")]
 pub enum DisconnectReason {
     TokenExpired,
+    CertificateRevoked,
 }
 
 impl<T> PhoenixMessage<T> {
@@ -1220,6 +1236,23 @@ mod tests {
         let actual_reply = serde_json::from_str::<Payload<()>>(actual_reply).unwrap();
         let expected_reply = Payload::<()>::Disconnect {
             reason: DisconnectReason::TokenExpired,
+        };
+        assert_eq!(actual_reply, expected_reply);
+    }
+
+    #[test]
+    fn certificate_revoked() {
+        let actual_reply = r#"
+        {
+          "event": "disconnect",
+          "ref": null,
+          "topic": "client",
+          "payload": { "reason": "certificate_revoked" }
+        }
+        "#;
+        let actual_reply = serde_json::from_str::<Payload<()>>(actual_reply).unwrap();
+        let expected_reply = Payload::<()>::Disconnect {
+            reason: DisconnectReason::CertificateRevoked,
         };
         assert_eq!(actual_reply, expected_reply);
     }

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -490,7 +490,7 @@ async fn http_400_returns_client_error() {
 }
 
 #[tokio::test]
-async fn http_401_returns_invalid_token() {
+async fn http_401_with_token_returns_invalid_token() {
     let port = http_status_server(http::StatusCode::UNAUTHORIZED).await;
 
     let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
@@ -510,6 +510,33 @@ async fn http_401_returns_invalid_token() {
     assert!(
         matches!(result, Err(phoenix_channel::Error::InvalidToken)),
         "expected Error::InvalidToken for 401, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn http_401_without_token_returns_certificate_authentication_rejected() {
+    let port = http_status_server(http::StatusCode::UNAUTHORIZED).await;
+
+    let mut channel = make_test_channel_without_token("127.0.0.1", port, default_backoff);
+
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        future::poll_fn(|cx| channel.poll(cx)).await
+    })
+    .await
+    .expect("should not timeout");
+
+    assert!(
+        matches!(
+            result,
+            Err(phoenix_channel::Error::CertificateAuthenticationRejected)
+        ),
+        "expected certificate authentication rejection for tokenless 401, got {result:?}"
     );
 }
 
@@ -626,6 +653,28 @@ fn make_test_channel(
     port: u16,
     make_reconnect_backoff: impl Fn() -> backoff::ExponentialBackoff + Send + 'static,
 ) -> TestChannel {
+    make_test_channel_with_optional_token(
+        host,
+        port,
+        Some(SecretString::from("test_token")),
+        make_reconnect_backoff,
+    )
+}
+
+fn make_test_channel_without_token(
+    host: &str,
+    port: u16,
+    make_reconnect_backoff: impl Fn() -> backoff::ExponentialBackoff + Send + 'static,
+) -> TestChannel {
+    make_test_channel_with_optional_token(host, port, None, make_reconnect_backoff)
+}
+
+fn make_test_channel_with_optional_token(
+    host: &str,
+    port: u16,
+    token: Option<SecretString>,
+    make_reconnect_backoff: impl Fn() -> backoff::ExponentialBackoff + Send + 'static,
+) -> TestChannel {
     let url = LoginUrl::client(
         format!("ws://{host}:{port}").as_str(),
         "test-device-id".to_string(),
@@ -636,7 +685,7 @@ fn make_test_channel(
 
     PhoenixChannel::disconnected(
         url,
-        SecretString::from("test_token"),
+        token,
         "test-user-agent".to_string(),
         "test",
         (),

--- a/rust/libs/device-trust/Cargo.toml
+++ b/rust/libs/device-trust/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 base64 = { workspace = true, features = ["std"] }
+phoenix-channel = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 sha2 = { workspace = true }
 tracing = { workspace = true }

--- a/rust/libs/device-trust/Cargo.toml
+++ b/rust/libs/device-trust/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "device-trust"
+version = "0.1.0"
+edition = { workspace = true }
+authors = ["Firezone, Inc."]
+license = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+base64 = { workspace = true, features = ["std"] }
+serde = { workspace = true, features = ["derive"] }
+sha2 = { workspace = true }
+tracing = { workspace = true }
+rustls = { workspace = true }
+rustls-platform-verifier = { workspace = true }
+uuid = { workspace = true }
+x509-parser = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_Security_Cryptography",
+] }
+windows-core = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+cryptoki = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/libs/device-trust/src/lib.rs
+++ b/rust/libs/device-trust/src/lib.rs
@@ -45,6 +45,7 @@ impl std::fmt::Debug for Config {
 pub struct Identity {
     tls_client_config: Arc<rustls::ClientConfig>,
     mdm_device_id: Option<String>,
+    user_identity: Option<UserIdentity>,
 }
 
 impl std::fmt::Debug for Identity {
@@ -52,6 +53,7 @@ impl std::fmt::Debug for Identity {
         formatter
             .debug_struct("Identity")
             .field("mdm_device_id", &self.mdm_device_id)
+            .field("has_user_identity", &self.user_identity.is_some())
             .finish_non_exhaustive()
     }
 }
@@ -64,11 +66,23 @@ impl Identity {
     pub fn mdm_device_id(&self) -> Option<&str> {
         self.mdm_device_id.as_deref()
     }
+
+    pub fn user_identity(&self) -> Option<&UserIdentity> {
+        self.user_identity.as_ref()
+    }
 }
 
 pub(crate) struct PlatformIdentity {
     pub certified_key: Arc<CertifiedKey>,
     pub mdm_device_id: Option<String>,
+    pub user_identity: Option<UserIdentity>,
+}
+
+/// A portal user identity encoded in a managed certificate's URI SANs.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct UserIdentity {
+    pub email: String,
+    pub account_id: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -88,6 +102,7 @@ pub struct DetailSection {
 pub struct Status {
     pub summary: String,
     pub sections: Vec<DetailSection>,
+    pub user_identity: Option<UserIdentity>,
 }
 
 impl Status {
@@ -129,6 +144,7 @@ pub fn identity(config: &Config) -> Result<Option<Identity>> {
     Ok(Some(Identity {
         tls_client_config: Arc::new(config),
         mdm_device_id: identity.mdm_device_id,
+        user_identity: identity.user_identity,
     }))
 }
 
@@ -149,6 +165,7 @@ mod platform {
         Ok(Status {
             summary: "X.509 device identity is not supported on this platform.".to_owned(),
             sections: vec![],
+            user_identity: None,
         })
     }
 
@@ -176,6 +193,7 @@ mod tests {
                     value: "CN=one\nOU=two".to_owned(),
                 }],
             }],
+            user_identity: None,
         };
 
         assert_eq!(

--- a/rust/libs/device-trust/src/lib.rs
+++ b/rust/libs/device-trust/src/lib.rs
@@ -1,0 +1,186 @@
+//! Native X.509 device identities for the Windows and Linux clients.
+//!
+//! Windows identities are discovered in the system certificate stores and used
+//! through CNG. Linux identities are configured with an RFC 7512 PKCS#11 URI.
+//! Neither backend exports private-key material.
+
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use rustls::sign::{CertifiedKey, SingleCertAndKey};
+use rustls_platform_verifier::BuilderVerifierExt as _;
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_SUBJECT_COMMON_NAME: &str = "dev.firezone.device-trust";
+
+#[cfg(any(target_os = "linux", target_os = "windows", test))]
+mod policy;
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "windows")]
+mod windows;
+
+#[derive(Clone, Default)]
+pub struct Config {
+    /// RFC 7512 URI identifying the Linux PKCS#11 module, token and identity.
+    /// Ignored on Windows.
+    pub pkcs11_uri: Option<String>,
+}
+
+impl std::fmt::Debug for Config {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("Config")
+            .field(
+                "pkcs11_uri",
+                &self.pkcs11_uri.as_ref().map(|_| "[configured]"),
+            )
+            .finish()
+    }
+}
+
+/// A selected native identity ready for a mutual-TLS Phoenix connection.
+#[derive(Clone)]
+pub struct Identity {
+    tls_client_config: Arc<rustls::ClientConfig>,
+    mdm_device_id: Option<String>,
+}
+
+impl std::fmt::Debug for Identity {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("Identity")
+            .field("mdm_device_id", &self.mdm_device_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Identity {
+    pub fn tls_client_config(&self) -> Arc<rustls::ClientConfig> {
+        self.tls_client_config.clone()
+    }
+
+    pub fn mdm_device_id(&self) -> Option<&str> {
+        self.mdm_device_id.as_deref()
+    }
+}
+
+pub(crate) struct PlatformIdentity {
+    pub certified_key: Arc<CertifiedKey>,
+    pub mdm_device_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DetailField {
+    pub label: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DetailSection {
+    pub title: String,
+    pub fields: Vec<DetailField>,
+}
+
+/// Read-only diagnostics shared by the desktop GUI and headless command.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct Status {
+    pub summary: String,
+    pub sections: Vec<DetailSection>,
+}
+
+impl Status {
+    pub fn text_description(&self) -> String {
+        use std::fmt::Write as _;
+
+        let mut output = self.summary.clone();
+        output.push('\n');
+
+        for section in &self.sections {
+            output.push('\n');
+            let _ = writeln!(output, "[{}]", section.title);
+            for field in &section.fields {
+                let _ = writeln!(output, "{}:", field.label);
+                for line in field.value.split('\n') {
+                    let _ = writeln!(output, "  {line}");
+                }
+            }
+        }
+
+        output
+    }
+}
+
+pub fn status(config: &Config) -> Result<Status> {
+    platform::status(config, DEFAULT_SUBJECT_COMMON_NAME)
+}
+
+pub fn identity(config: &Config) -> Result<Option<Identity>> {
+    let Some(identity) = platform::identity(config, DEFAULT_SUBJECT_COMMON_NAME)? else {
+        return Ok(None);
+    };
+    let resolver = Arc::new(SingleCertAndKey::from(identity.certified_key));
+    let config = rustls::ClientConfig::builder()
+        .with_platform_verifier()
+        .context("Failed to configure the TLS server certificate verifier")?
+        .with_client_cert_resolver(resolver);
+
+    Ok(Some(Identity {
+        tls_client_config: Arc::new(config),
+        mdm_device_id: identity.mdm_device_id,
+    }))
+}
+
+#[cfg(target_os = "linux")]
+use linux as platform;
+#[cfg(target_os = "windows")]
+use windows as platform;
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+mod platform {
+    use super::*;
+
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "Keep the unsupported-platform API identical to the native providers"
+    )]
+    pub fn status(_config: &Config, _subject_cn: &str) -> Result<Status> {
+        Ok(Status {
+            summary: "X.509 device identity is not supported on this platform.".to_owned(),
+            sections: vec![],
+        })
+    }
+
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "Keep the unsupported-platform API identical to the native providers"
+    )]
+    pub fn identity(_config: &Config, _subject_cn: &str) -> Result<Option<PlatformIdentity>> {
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_text_matches_mobile_diagnostic_format() {
+        let status = Status {
+            summary: "Identity available.".to_owned(),
+            sections: vec![DetailSection {
+                title: "Certificate".to_owned(),
+                fields: vec![DetailField {
+                    label: "Subject".to_owned(),
+                    value: "CN=one\nOU=two".to_owned(),
+                }],
+            }],
+        };
+
+        assert_eq!(
+            status.text_description(),
+            "Identity available.\n\n[Certificate]\nSubject:\n  CN=one\n  OU=two\n"
+        );
+    }
+}

--- a/rust/libs/device-trust/src/linux.rs
+++ b/rust/libs/device-trust/src/linux.rs
@@ -1,0 +1,674 @@
+//! Linux X.509 identities backed by a PKCS#11 token.
+
+use std::{path::PathBuf, sync::Arc, time::SystemTime};
+
+use anyhow::{Context as _, Result, anyhow, bail};
+use cryptoki::{
+    context::{CInitializeArgs, Pkcs11},
+    mechanism::{
+        Mechanism, MechanismType,
+        rsa::{PkcsMgfType, PkcsPssParams},
+    },
+    object::{Attribute, AttributeType, CertificateType, KeyType, ObjectClass, ObjectHandle},
+    session::{Session, UserType},
+    types::AuthPin,
+};
+use rustls::{
+    SignatureAlgorithm, SignatureScheme,
+    pki_types::CertificateDer,
+    sign::{CertifiedKey, Signer, SigningKey},
+};
+use sha2::{Digest as _, Sha256, Sha384, Sha512};
+
+use crate::{
+    Config, DetailSection, PlatformIdentity, Status,
+    policy::{CertificateMetadata, SigningAlgorithm, field, parse_certificate},
+};
+
+pub(crate) fn status(config: &Config, subject_cn: &str) -> Result<Status> {
+    let Some(uri) = config.pkcs11_uri.as_deref() else {
+        return Ok(Status {
+            summary: "No X.509 device identity is configured.".to_owned(),
+            sections: vec![DetailSection {
+                title: "Linux PKCS#11 Configuration".to_owned(),
+                fields: vec![field("PKCS#11 URI", "Not configured")],
+            }],
+        });
+    };
+
+    let parsed = Pkcs11Uri::parse(uri).context("Invalid Linux X.509 PKCS#11 configuration")?;
+    with_session(&parsed, |session| {
+        let identities = identities(session, &parsed, subject_cn)?;
+        let usable = identities.iter().filter(|identity| identity.usable).count();
+        let mut sections = vec![configuration_section(&parsed)];
+        sections.extend(identities.iter().enumerate().map(|(index, identity)| {
+            let mut fields = vec![
+                field(
+                    "Object Label",
+                    identity.label.as_deref().unwrap_or("Unavailable"),
+                ),
+                field(
+                    "Private Key Access",
+                    if identity.key.is_some() {
+                        "Available"
+                    } else {
+                        "Unavailable"
+                    },
+                ),
+                field(
+                    "Usable for Device Attestation",
+                    if identity.usable { "Yes" } else { "No" },
+                ),
+            ];
+            fields.extend(identity.metadata.detail_fields());
+            DetailSection {
+                title: format!("Matching Certificate {}", index + 1),
+                fields,
+            }
+        }));
+
+        let summary = match (usable, identities.len()) {
+            (0, 0) => format!(
+                "No X.509 certificate with subject CN '{subject_cn}' was found in the configured PKCS#11 token."
+            ),
+            (0, count) => format!(
+                "Found {count} matching X.509 certificate(s), but none are usable for device attestation."
+            ),
+            (count, _) => format!(
+                "{count} X.509 device identity certificate(s) are available for device attestation."
+            ),
+        };
+
+        Ok(Status { summary, sections })
+    })
+}
+
+pub(crate) fn identity(config: &Config, subject_cn: &str) -> Result<Option<PlatformIdentity>> {
+    let Some(uri) = config.pkcs11_uri.as_deref() else {
+        tracing::info!("No Linux PKCS#11 identity is configured for mutual TLS");
+        return Ok(None);
+    };
+
+    let parsed = Pkcs11Uri::parse(uri).context("Invalid Linux X.509 PKCS#11 configuration")?;
+    with_session(&parsed, |session| {
+        let identities = identities(session, &parsed, subject_cn)?;
+        // The URI's `object` attribute selects leaf identities. Intermediates often use
+        // different labels, so enumerate every certificate when assembling each chain.
+        let all_certificates = certificate_objects(session, &parsed, false)?;
+        let Some(identity) = identities
+            .into_iter()
+            .filter(|identity| identity.usable)
+            .max_by_key(|identity| identity.metadata.not_before_timestamp)
+        else {
+            return Ok(None);
+        };
+        let algorithm = identity
+            .metadata
+            .signing_algorithm
+            .context("The selected PKCS#11 certificate uses an unsupported key algorithm")?;
+        let signing_key = Arc::new(Pkcs11SigningKey {
+            parsed: parsed.clone(),
+            key_id: identity.id.clone(),
+            key_label: identity.label.clone(),
+            algorithm,
+        });
+        let chain = certificate_chain(&identity.der, &all_certificates)
+            .into_iter()
+            .map(CertificateDer::from)
+            .collect();
+
+        tracing::info!(
+            fingerprint = %identity.metadata.fingerprint,
+            mdm_device_id = identity.metadata.mdm_device_id.as_deref(),
+            "Selected the newest Linux X.509 identity for mutual TLS"
+        );
+
+        Ok(Some(PlatformIdentity {
+            certified_key: Arc::new(CertifiedKey::new(chain, signing_key)),
+            mdm_device_id: identity.metadata.mdm_device_id,
+        }))
+    })
+}
+
+#[derive(Debug)]
+struct Pkcs11SigningKey {
+    parsed: Pkcs11Uri,
+    key_id: Option<Vec<u8>>,
+    key_label: Option<String>,
+    algorithm: SigningAlgorithm,
+}
+
+impl SigningKey for Pkcs11SigningKey {
+    fn choose_scheme(&self, offered: &[SignatureScheme]) -> Option<Box<dyn Signer>> {
+        signature_schemes(self.algorithm)
+            .iter()
+            .copied()
+            .find(|scheme| offered.contains(scheme))
+            .map(|scheme| {
+                Box::new(Pkcs11Signer {
+                    parsed: self.parsed.clone(),
+                    key_id: self.key_id.clone(),
+                    key_label: self.key_label.clone(),
+                    algorithm: self.algorithm,
+                    scheme,
+                }) as Box<dyn Signer>
+            })
+    }
+
+    fn algorithm(&self) -> SignatureAlgorithm {
+        match self.algorithm {
+            SigningAlgorithm::RsaSha256 => SignatureAlgorithm::RSA,
+            SigningAlgorithm::EcdsaSha256
+            | SigningAlgorithm::EcdsaSha384
+            | SigningAlgorithm::EcdsaSha512 => SignatureAlgorithm::ECDSA,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Pkcs11Signer {
+    parsed: Pkcs11Uri,
+    key_id: Option<Vec<u8>>,
+    key_label: Option<String>,
+    algorithm: SigningAlgorithm,
+    scheme: SignatureScheme,
+}
+
+impl Signer for Pkcs11Signer {
+    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
+        with_session(&self.parsed, |session| {
+            let key = find_private_key(
+                session,
+                self.key_id.as_deref(),
+                self.key_label.as_deref(),
+                Some(self.algorithm),
+            )?
+            .context("The selected PKCS#11 private key is no longer available")?;
+            sign(session, key, self.scheme, message)
+        })
+        .map_err(|error| rustls::Error::General(format!("PKCS#11 TLS signing failed: {error:#}")))
+    }
+
+    fn scheme(&self) -> SignatureScheme {
+        self.scheme
+    }
+}
+
+fn signature_schemes(algorithm: SigningAlgorithm) -> &'static [SignatureScheme] {
+    match algorithm {
+        SigningAlgorithm::RsaSha256 => &[
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA256,
+        ],
+        SigningAlgorithm::EcdsaSha256 => &[SignatureScheme::ECDSA_NISTP256_SHA256],
+        SigningAlgorithm::EcdsaSha384 => &[SignatureScheme::ECDSA_NISTP384_SHA384],
+        SigningAlgorithm::EcdsaSha512 => &[SignatureScheme::ECDSA_NISTP521_SHA512],
+    }
+}
+
+fn with_session<T>(parsed: &Pkcs11Uri, operation: impl FnOnce(&Session) -> Result<T>) -> Result<T> {
+    let pkcs11 = Pkcs11::new(&parsed.module_path)
+        .with_context(|| format!("Failed to load {}", parsed.module_path.display()))?;
+    pkcs11
+        .initialize(CInitializeArgs::OsThreads)
+        .context("PKCS#11 initialization failed")?;
+    let slot = find_slot(&pkcs11, parsed.token_label.as_deref())?;
+    let session = pkcs11
+        .open_ro_session(slot)
+        .context("Failed to open the PKCS#11 token")?;
+
+    if let Some(pin) = parsed.read_pin()? {
+        session
+            .login(UserType::User, Some(&AuthPin::new(pin)))
+            .context("Failed to unlock the PKCS#11 token")?;
+    }
+
+    operation(&session)
+}
+
+struct CertificateIdentity {
+    der: Vec<u8>,
+    id: Option<Vec<u8>>,
+    label: Option<String>,
+    metadata: CertificateMetadata,
+    key: Option<ObjectHandle>,
+    usable: bool,
+}
+
+fn identities(
+    session: &Session,
+    parsed: &Pkcs11Uri,
+    subject_cn: &str,
+) -> Result<Vec<CertificateIdentity>> {
+    let now = SystemTime::now();
+    let mut identities = Vec::new();
+
+    for certificate in certificate_objects(session, parsed, true)? {
+        let Some(metadata) = parse_certificate(&certificate.der, now) else {
+            tracing::warn!(
+                object_label = ?certificate.label,
+                "Ignoring an invalid PKCS#11 X.509 certificate"
+            );
+            continue;
+        };
+        if !metadata.matches_subject(subject_cn) {
+            continue;
+        }
+
+        let key = find_private_key(
+            session,
+            certificate.id.as_deref(),
+            certificate.label.as_deref(),
+            metadata.signing_algorithm,
+        )?;
+        let usable = metadata.is_usable(subject_cn) && key.is_some();
+        identities.push(CertificateIdentity {
+            der: certificate.der,
+            id: certificate.id,
+            label: certificate.label,
+            metadata,
+            key,
+            usable,
+        });
+    }
+
+    Ok(identities)
+}
+
+struct CertificateObject {
+    der: Vec<u8>,
+    id: Option<Vec<u8>>,
+    label: Option<String>,
+}
+
+fn certificate_objects(
+    session: &Session,
+    parsed: &Pkcs11Uri,
+    filter_object_label: bool,
+) -> Result<Vec<CertificateObject>> {
+    let handles = session
+        .find_objects(&[
+            Attribute::Class(ObjectClass::CERTIFICATE),
+            Attribute::CertificateType(CertificateType::X_509),
+        ])
+        .context("Failed to enumerate PKCS#11 certificates")?;
+    let mut certificates = Vec::new();
+
+    for handle in handles {
+        let attributes = match session.get_attributes(
+            handle,
+            &[
+                AttributeType::Value,
+                AttributeType::Id,
+                AttributeType::Label,
+            ],
+        ) {
+            Ok(attributes) => attributes,
+            Err(error) => {
+                tracing::warn!(?error, "Failed to read a PKCS#11 certificate object");
+                continue;
+            }
+        };
+        let mut der = None;
+        let mut id = None;
+        let mut label = None;
+        for attribute in attributes {
+            #[allow(clippy::wildcard_enum_match_arm)]
+            match attribute {
+                Attribute::Value(value) => der = Some(value),
+                Attribute::Id(value) => id = Some(value),
+                Attribute::Label(value) => label = String::from_utf8(value).ok(),
+                _ => {}
+            }
+        }
+        if filter_object_label
+            && parsed.object_label.as_deref().is_some()
+            && label.as_deref() != parsed.object_label.as_deref()
+        {
+            continue;
+        }
+        if let Some(der) = der {
+            certificates.push(CertificateObject { der, id, label });
+        }
+    }
+
+    Ok(certificates)
+}
+
+fn find_private_key(
+    session: &Session,
+    id: Option<&[u8]>,
+    label: Option<&str>,
+    algorithm: Option<SigningAlgorithm>,
+) -> Result<Option<ObjectHandle>> {
+    let mut template = vec![Attribute::Class(ObjectClass::PRIVATE_KEY)];
+    match algorithm {
+        Some(SigningAlgorithm::RsaSha256) => template.push(Attribute::KeyType(KeyType::RSA)),
+        Some(
+            SigningAlgorithm::EcdsaSha256
+            | SigningAlgorithm::EcdsaSha384
+            | SigningAlgorithm::EcdsaSha512,
+        ) => {
+            template.push(Attribute::KeyType(KeyType::EC));
+        }
+        None => return Ok(None),
+    }
+    if let Some(id) = id {
+        template.push(Attribute::Id(id.to_vec()));
+    } else if let Some(label) = label {
+        template.push(Attribute::Label(label.as_bytes().to_vec()));
+    } else {
+        return Ok(None);
+    }
+
+    Ok(session
+        .find_objects(&template)
+        .context("Failed to locate the PKCS#11 private key")?
+        .into_iter()
+        .next())
+}
+
+fn sign(
+    session: &Session,
+    key: ObjectHandle,
+    scheme: SignatureScheme,
+    message: &[u8],
+) -> Result<Vec<u8>> {
+    match scheme {
+        SignatureScheme::RSA_PSS_SHA256 => session
+            .sign(
+                &Mechanism::Sha256RsaPkcsPss(PkcsPssParams {
+                    hash_alg: MechanismType::SHA256,
+                    mgf: PkcsMgfType::MGF1_SHA256,
+                    s_len: 32,
+                }),
+                key,
+                message,
+            )
+            .context("PKCS#11 RSA-PSS SHA-256 signing failed"),
+        SignatureScheme::RSA_PSS_SHA384 => session
+            .sign(
+                &Mechanism::Sha384RsaPkcsPss(PkcsPssParams {
+                    hash_alg: MechanismType::SHA384,
+                    mgf: PkcsMgfType::MGF1_SHA384,
+                    s_len: 48,
+                }),
+                key,
+                message,
+            )
+            .context("PKCS#11 RSA-PSS SHA-384 signing failed"),
+        SignatureScheme::RSA_PSS_SHA512 => session
+            .sign(
+                &Mechanism::Sha512RsaPkcsPss(PkcsPssParams {
+                    hash_alg: MechanismType::SHA512,
+                    mgf: PkcsMgfType::MGF1_SHA512,
+                    s_len: 64,
+                }),
+                key,
+                message,
+            )
+            .context("PKCS#11 RSA-PSS SHA-512 signing failed"),
+        SignatureScheme::RSA_PKCS1_SHA256 => session
+            .sign(&Mechanism::Sha256RsaPkcs, key, message)
+            .context("PKCS#11 RSA signing failed"),
+        SignatureScheme::RSA_PKCS1_SHA384 => session
+            .sign(&Mechanism::Sha384RsaPkcs, key, message)
+            .context("PKCS#11 RSA signing failed"),
+        SignatureScheme::RSA_PKCS1_SHA512 => session
+            .sign(&Mechanism::Sha512RsaPkcs, key, message)
+            .context("PKCS#11 RSA signing failed"),
+        SignatureScheme::ECDSA_NISTP256_SHA256 => {
+            let raw = session
+                .sign(&Mechanism::Ecdsa, key, &Sha256::digest(message))
+                .context("PKCS#11 P-256 signing failed")?;
+            der_encode_ecdsa_signature(&raw)
+        }
+        SignatureScheme::ECDSA_NISTP384_SHA384 => {
+            let raw = session
+                .sign(&Mechanism::Ecdsa, key, &Sha384::digest(message))
+                .context("PKCS#11 P-384 signing failed")?;
+            der_encode_ecdsa_signature(&raw)
+        }
+        SignatureScheme::ECDSA_NISTP521_SHA512 => {
+            let raw = session
+                .sign(&Mechanism::Ecdsa, key, &Sha512::digest(message))
+                .context("PKCS#11 P-521 signing failed")?;
+            der_encode_ecdsa_signature(&raw)
+        }
+        _ => bail!("Unsupported TLS signature scheme {scheme:?}"),
+    }
+}
+
+fn certificate_chain(leaf: &[u8], certificates: &[CertificateObject]) -> Vec<Vec<u8>> {
+    let now = SystemTime::now();
+    let mut chain = vec![leaf.to_vec()];
+    let Some(mut current) = parse_certificate(leaf, now) else {
+        return chain;
+    };
+
+    while current.subject != current.issuer {
+        let Some(issuer) = certificates.iter().find(|candidate| {
+            !chain.contains(&candidate.der)
+                && parse_certificate(&candidate.der, now)
+                    .is_some_and(|metadata| metadata.subject == current.issuer)
+        }) else {
+            break;
+        };
+        chain.push(issuer.der.clone());
+        let Some(metadata) = parse_certificate(&issuer.der, now) else {
+            break;
+        };
+        current = metadata;
+    }
+
+    chain
+}
+
+fn find_slot(pkcs11: &Pkcs11, token_label: Option<&str>) -> Result<cryptoki::slot::Slot> {
+    let slots = pkcs11
+        .get_slots_with_token()
+        .context("Failed to enumerate PKCS#11 tokens")?;
+    if let Some(label) = token_label {
+        for slot in slots {
+            if pkcs11.get_token_info(slot)?.label().trim() == label {
+                return Ok(slot);
+            }
+        }
+        bail!("No PKCS#11 token with label '{label}' was found");
+    }
+    slots
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("No PKCS#11 tokens are available"))
+}
+
+fn configuration_section(parsed: &Pkcs11Uri) -> DetailSection {
+    DetailSection {
+        title: "Linux PKCS#11 Configuration".to_owned(),
+        fields: vec![
+            field("Certificate Storage", "PKCS#11 token"),
+            field(
+                "Private Key Storage",
+                "PKCS#11 token (hardware backing is provider-specific)",
+            ),
+            field("Module Path", parsed.module_path.display().to_string()),
+            field(
+                "Token Label",
+                parsed
+                    .token_label
+                    .as_deref()
+                    .unwrap_or("First available token"),
+            ),
+            field(
+                "Object Label",
+                parsed.object_label.as_deref().unwrap_or("Any object"),
+            ),
+            field(
+                "PIN Source",
+                parsed.pin_source.as_deref().unwrap_or("Not configured"),
+            ),
+        ],
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct Pkcs11Uri {
+    module_path: PathBuf,
+    token_label: Option<String>,
+    object_label: Option<String>,
+    pin_source: Option<String>,
+}
+
+impl Pkcs11Uri {
+    fn parse(uri: &str) -> Result<Self> {
+        let body = uri
+            .strip_prefix("pkcs11:")
+            .ok_or_else(|| anyhow!("PKCS#11 URI must begin with 'pkcs11:'"))?;
+        let (path, query) = body
+            .split_once('?')
+            .map_or((body, None), |(path, query)| (path, Some(query)));
+        let mut parsed = Self::default();
+
+        for component in path.split(';').filter(|component| !component.is_empty()) {
+            let (key, value) = component
+                .split_once('=')
+                .ok_or_else(|| anyhow!("Malformed PKCS#11 URI component '{component}'"))?;
+            let value = percent_decode(value)?;
+            match key {
+                "module-path" => parsed.module_path = PathBuf::from(value),
+                "token" => parsed.token_label = Some(value),
+                "object" => parsed.object_label = Some(value),
+                _ => {}
+            }
+        }
+        if let Some(query) = query {
+            for component in query.split('&').filter(|component| !component.is_empty()) {
+                let (key, value) = component
+                    .split_once('=')
+                    .ok_or_else(|| anyhow!("Malformed PKCS#11 URI query '{component}'"))?;
+                let value = percent_decode(value)?;
+                match key {
+                    "module-path" => parsed.module_path = PathBuf::from(value),
+                    "pin-source" => parsed.pin_source = Some(value),
+                    "pin-value" => bail!(
+                        "PKCS#11 pin-value is not supported; use pin-source=file:/path instead"
+                    ),
+                    _ => {}
+                }
+            }
+        }
+        if parsed.module_path.as_os_str().is_empty() {
+            bail!("PKCS#11 URI is missing the required module-path attribute");
+        }
+
+        Ok(parsed)
+    }
+
+    fn read_pin(&self) -> Result<Option<String>> {
+        let Some(source) = self.pin_source.as_deref() else {
+            return Ok(None);
+        };
+        let Some(path) = source.strip_prefix("file:") else {
+            bail!("Unsupported PKCS#11 pin-source scheme; only file: is supported");
+        };
+        let pin = std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read the PKCS#11 PIN from {path}"))?;
+        Ok(Some(pin.trim_end_matches(['\n', '\r']).to_owned()))
+    }
+}
+
+fn percent_decode(input: &str) -> Result<String> {
+    let input = input.as_bytes();
+    let mut output = Vec::with_capacity(input.len());
+    let mut index = 0;
+    while index < input.len() {
+        if input[index] == b'%' {
+            let encoded = input
+                .get(index + 1..index + 3)
+                .context("Truncated percent escape in PKCS#11 URI")?;
+            let encoded = std::str::from_utf8(encoded)?;
+            output.push(u8::from_str_radix(encoded, 16).context("Invalid percent escape")?);
+            index += 3;
+        } else {
+            output.push(input[index]);
+            index += 1;
+        }
+    }
+    String::from_utf8(output).context("PKCS#11 URI component is not UTF-8")
+}
+
+fn der_encode_ecdsa_signature(raw: &[u8]) -> Result<Vec<u8>> {
+    if raw.is_empty() || !raw.len().is_multiple_of(2) {
+        bail!("Invalid raw ECDSA signature length: {}", raw.len());
+    }
+    let half = raw.len() / 2;
+    let r = der_integer(&raw[..half]);
+    let s = der_integer(&raw[half..]);
+    let mut output = vec![0x30];
+    encode_der_length(&mut output, r.len() + s.len());
+    output.extend(r);
+    output.extend(s);
+    Ok(output)
+}
+
+fn der_integer(value: &[u8]) -> Vec<u8> {
+    let first_nonzero = value
+        .iter()
+        .position(|byte| *byte != 0)
+        .unwrap_or(value.len().saturating_sub(1));
+    let value = &value[first_nonzero..];
+    let needs_padding = value.first().is_some_and(|byte| byte & 0x80 != 0);
+    let mut output = vec![0x02];
+    encode_der_length(&mut output, value.len() + usize::from(needs_padding));
+    if needs_padding {
+        output.push(0);
+    }
+    output.extend(value);
+    output
+}
+
+fn encode_der_length(output: &mut Vec<u8>, length: usize) {
+    if length < 0x80 {
+        output.push(length as u8);
+    } else if length < 0x100 {
+        output.extend([0x81, length as u8]);
+    } else {
+        output.extend([0x82, (length >> 8) as u8, length as u8]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_pkcs11_uri() {
+        let uri = "pkcs11:token=Firezone;object=device%20identity?module-path=/usr/lib/libpkcs11.so&pin-source=file:/etc/firezone/pin";
+        let parsed = Pkcs11Uri::parse(uri).expect("URI should be valid");
+        assert_eq!(parsed.module_path, PathBuf::from("/usr/lib/libpkcs11.so"));
+        assert_eq!(parsed.token_label.as_deref(), Some("Firezone"));
+        assert_eq!(parsed.object_label.as_deref(), Some("device identity"));
+        assert_eq!(parsed.pin_source.as_deref(), Some("file:/etc/firezone/pin"));
+    }
+
+    #[test]
+    fn rejects_inline_pin_and_missing_module() {
+        assert!(Pkcs11Uri::parse("pkcs11:token=Firezone?pin-value=1234").is_err());
+        assert!(Pkcs11Uri::parse("pkcs11:token=Firezone").is_err());
+    }
+
+    #[test]
+    fn ecdsa_signature_is_der_encoded() {
+        let mut raw = vec![0; 64];
+        raw[31] = 1;
+        raw[63] = 2;
+        assert_eq!(
+            der_encode_ecdsa_signature(&raw).expect("signature should encode"),
+            vec![0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02]
+        );
+    }
+}

--- a/rust/libs/device-trust/src/linux.rs
+++ b/rust/libs/device-trust/src/linux.rs
@@ -33,6 +33,7 @@ pub(crate) fn status(config: &Config, subject_cn: &str) -> Result<Status> {
                 title: "Linux PKCS#11 Configuration".to_owned(),
                 fields: vec![field("PKCS#11 URI", "Not configured")],
             }],
+            user_identity: None,
         });
     };
 
@@ -40,6 +41,11 @@ pub(crate) fn status(config: &Config, subject_cn: &str) -> Result<Status> {
     with_session(&parsed, |session| {
         let identities = identities(session, &parsed, subject_cn)?;
         let usable = identities.iter().filter(|identity| identity.usable).count();
+        let user_identity = identities
+            .iter()
+            .filter(|identity| identity.usable)
+            .max_by_key(|identity| identity.metadata.not_before_timestamp)
+            .and_then(|identity| identity.metadata.user_identity());
         let mut sections = vec![configuration_section(&parsed)];
         sections.extend(identities.iter().enumerate().map(|(index, identity)| {
             let mut fields = vec![
@@ -56,7 +62,7 @@ pub(crate) fn status(config: &Config, subject_cn: &str) -> Result<Status> {
                     },
                 ),
                 field(
-                    "Usable for Device Attestation",
+                    "Usable for Mutual TLS",
                     if identity.usable { "Yes" } else { "No" },
                 ),
             ];
@@ -72,14 +78,18 @@ pub(crate) fn status(config: &Config, subject_cn: &str) -> Result<Status> {
                 "No X.509 certificate with subject CN '{subject_cn}' was found in the configured PKCS#11 token."
             ),
             (0, count) => format!(
-                "Found {count} matching X.509 certificate(s), but none are usable for device attestation."
+                "Found {count} matching X.509 certificate(s), but none are usable for mutual TLS."
             ),
             (count, _) => format!(
-                "{count} X.509 device identity certificate(s) are available for device attestation."
+                "{count} X.509 device identity certificate(s) are available for mutual TLS."
             ),
         };
 
-        Ok(Status { summary, sections })
+        Ok(Status {
+            summary,
+            sections,
+            user_identity,
+        })
     })
 }
 
@@ -95,12 +105,20 @@ pub(crate) fn identity(config: &Config, subject_cn: &str) -> Result<Option<Platf
         // The URI's `object` attribute selects leaf identities. Intermediates often use
         // different labels, so enumerate every certificate when assembling each chain.
         let all_certificates = certificate_objects(session, &parsed, false)?;
+        if identities.is_empty() {
+            bail!(
+                "The configured PKCS#11 token contains no X.509 certificate with subject CN '{subject_cn}'"
+            );
+        }
+        let matching_count = identities.len();
         let Some(identity) = identities
             .into_iter()
             .filter(|identity| identity.usable)
             .max_by_key(|identity| identity.metadata.not_before_timestamp)
         else {
-            return Ok(None);
+            bail!(
+                "Found {matching_count} matching X.509 certificate(s) in the configured PKCS#11 token, but none have a usable private key and mutual-TLS certificate policy"
+            );
         };
         let algorithm = identity
             .metadata
@@ -125,7 +143,8 @@ pub(crate) fn identity(config: &Config, subject_cn: &str) -> Result<Option<Platf
 
         Ok(Some(PlatformIdentity {
             certified_key: Arc::new(CertifiedKey::new(chain, signing_key)),
-            mdm_device_id: identity.metadata.mdm_device_id,
+            mdm_device_id: identity.metadata.mdm_device_id.clone(),
+            user_identity: identity.metadata.user_identity(),
         }))
     })
 }
@@ -186,7 +205,13 @@ impl Signer for Pkcs11Signer {
             .context("The selected PKCS#11 private key is no longer available")?;
             sign(session, key, self.scheme, message)
         })
-        .map_err(|error| rustls::Error::General(format!("PKCS#11 TLS signing failed: {error:#}")))
+        .map_err(|error| {
+            rustls::Error::Other(rustls::OtherError(Arc::new(
+                phoenix_channel::ClientCertificateSigningError(format!(
+                    "PKCS#11 TLS signing failed: {error:#}"
+                )),
+            )))
+        })
     }
 
     fn scheme(&self) -> SignatureScheme {
@@ -384,7 +409,7 @@ fn sign(
                 &Mechanism::Sha256RsaPkcsPss(PkcsPssParams {
                     hash_alg: MechanismType::SHA256,
                     mgf: PkcsMgfType::MGF1_SHA256,
-                    s_len: 32,
+                    s_len: 32.into(),
                 }),
                 key,
                 message,
@@ -395,7 +420,7 @@ fn sign(
                 &Mechanism::Sha384RsaPkcsPss(PkcsPssParams {
                     hash_alg: MechanismType::SHA384,
                     mgf: PkcsMgfType::MGF1_SHA384,
-                    s_len: 48,
+                    s_len: 48.into(),
                 }),
                 key,
                 message,
@@ -406,7 +431,7 @@ fn sign(
                 &Mechanism::Sha512RsaPkcsPss(PkcsPssParams {
                     hash_alg: MechanismType::SHA512,
                     mgf: PkcsMgfType::MGF1_SHA512,
-                    s_len: 64,
+                    s_len: 64.into(),
                 }),
                 key,
                 message,

--- a/rust/libs/device-trust/src/policy.rs
+++ b/rust/libs/device-trust/src/policy.rs
@@ -1,0 +1,441 @@
+#![cfg_attr(not(any(target_os = "linux", target_os = "windows")), allow(dead_code))]
+
+use std::{
+    net::{Ipv4Addr, Ipv6Addr},
+    time::SystemTime,
+};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use sha2::{Digest as _, Sha256};
+use x509_parser::{
+    extensions::{GeneralName, ParsedExtension},
+    oid_registry::{OID_KEY_TYPE_EC_PUBLIC_KEY, OID_PKCS1_RSAENCRYPTION},
+    prelude::{FromDer as _, X509Certificate},
+};
+
+use crate::DetailField;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SigningAlgorithm {
+    RsaSha256,
+    EcdsaSha256,
+    EcdsaSha384,
+    EcdsaSha512,
+}
+
+impl SigningAlgorithm {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::RsaSha256 => "SHA256withRSA",
+            Self::EcdsaSha256 => "SHA256withECDSA",
+            Self::EcdsaSha384 => "SHA384withECDSA",
+            Self::EcdsaSha512 => "SHA512withECDSA",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CertificateMetadata {
+    pub subject_cn: Option<String>,
+    pub subject: String,
+    pub subject_alternative_names: Vec<String>,
+    pub mdm_device_id: Option<String>,
+    pub issuer: String,
+    pub serial: String,
+    pub has_client_auth_eku: bool,
+    pub digital_signature_allowed: bool,
+    pub is_currently_valid: bool,
+    pub not_before: String,
+    pub not_before_timestamp: i64,
+    pub not_after: String,
+    pub signing_algorithm: Option<SigningAlgorithm>,
+    pub fingerprint: String,
+    pub der_bytes: usize,
+}
+
+impl CertificateMetadata {
+    pub(crate) fn matches_subject(&self, expected_subject_cn: &str) -> bool {
+        self.subject_cn.as_deref() == Some(expected_subject_cn)
+    }
+
+    pub(crate) fn is_usable(&self, expected_subject_cn: &str) -> bool {
+        self.matches_subject(expected_subject_cn)
+            && self.has_client_auth_eku
+            && self.digital_signature_allowed
+            && self.is_currently_valid
+            && self.signing_algorithm.is_some()
+    }
+
+    pub(crate) fn detail_fields(&self) -> Vec<DetailField> {
+        vec![
+            field(
+                "Common Name",
+                self.subject_cn.as_deref().unwrap_or("Unavailable"),
+            ),
+            field("Subject", &self.subject),
+            field(
+                "Subject Alternative Names",
+                if self.subject_alternative_names.is_empty() {
+                    "None".to_owned()
+                } else {
+                    self.subject_alternative_names.join("\n")
+                },
+            ),
+            field("Issuer", &self.issuer),
+            field("Serial Number", &self.serial),
+            field("Not Before", &self.not_before),
+            field("Not After", &self.not_after),
+            field(
+                "Currently Valid",
+                if self.is_currently_valid { "Yes" } else { "No" },
+            ),
+            field(
+                "TLS Client Authentication EKU",
+                if self.has_client_auth_eku {
+                    "Yes"
+                } else {
+                    "No"
+                },
+            ),
+            field(
+                "Digital Signature Key Usage",
+                if self.digital_signature_allowed {
+                    "Allowed"
+                } else {
+                    "Not allowed"
+                },
+            ),
+            field(
+                "Signing Algorithm",
+                self.signing_algorithm
+                    .map(SigningAlgorithm::label)
+                    .unwrap_or("Unsupported"),
+            ),
+            field("SHA-256 Fingerprint", &self.fingerprint),
+            field("DER Byte Count", self.der_bytes.to_string()),
+        ]
+    }
+}
+
+pub(crate) fn parse_certificate(der: &[u8], now: SystemTime) -> Option<CertificateMetadata> {
+    let (_, certificate) = X509Certificate::from_der(der).ok()?;
+
+    let subject_cn = certificate
+        .subject()
+        .iter_common_name()
+        .next()
+        .and_then(|cn| cn.as_str().ok().map(str::to_owned));
+    let has_client_auth_eku = certificate.extensions().iter().any(|extension| {
+        matches!(
+            extension.parsed_extension(),
+            ParsedExtension::ExtendedKeyUsage(eku) if eku.client_auth
+        )
+    });
+    let general_names = certificate
+        .extensions()
+        .iter()
+        .filter_map(|extension| {
+            if let ParsedExtension::SubjectAlternativeName(names) = extension.parsed_extension() {
+                Some(names.general_names.iter())
+            } else {
+                None
+            }
+        })
+        .flatten()
+        .collect::<Vec<_>>();
+    let subject_alternative_names = general_names
+        .iter()
+        .map(|name| format_subject_alternative_name(name))
+        .collect();
+    let mdm_device_id = extract_mdm_device_id(general_names.iter().filter_map(|name| {
+        if let GeneralName::URI(value) = name {
+            Some(*value)
+        } else {
+            None
+        }
+    }));
+    // RFC 5280 permits Key Usage to be omitted. When present, it must allow
+    // digitalSignature, matching the portal's verification policy.
+    let digital_signature_allowed = certificate
+        .extensions()
+        .iter()
+        .find_map(|extension| {
+            if let ParsedExtension::KeyUsage(key_usage) = extension.parsed_extension() {
+                Some(key_usage.digital_signature())
+            } else {
+                None
+            }
+        })
+        .unwrap_or(true);
+
+    let not_before_timestamp = certificate.validity().not_before.timestamp();
+    let not_after_timestamp = certificate.validity().not_after.timestamp();
+    let now_timestamp = now
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| i64::try_from(duration.as_secs()).ok());
+    let is_currently_valid = now_timestamp.is_some_and(|timestamp| {
+        timestamp >= not_before_timestamp && timestamp <= not_after_timestamp
+    });
+
+    let signing_algorithm = {
+        let algorithm = &certificate.subject_pki.algorithm;
+        if algorithm.algorithm == OID_PKCS1_RSAENCRYPTION {
+            Some(SigningAlgorithm::RsaSha256)
+        } else if algorithm.algorithm == OID_KEY_TYPE_EC_PUBLIC_KEY {
+            let curve = algorithm
+                .parameters
+                .as_ref()
+                .and_then(|parameters| parameters.as_oid().ok())
+                .map(|oid| oid.to_id_string());
+            match curve.as_deref() {
+                Some("1.3.132.0.34") => Some(SigningAlgorithm::EcdsaSha384),
+                Some("1.3.132.0.35") => Some(SigningAlgorithm::EcdsaSha512),
+                Some("1.2.840.10045.3.1.7") => Some(SigningAlgorithm::EcdsaSha256),
+                Some(_) | None => None,
+            }
+        } else {
+            None
+        }
+    };
+
+    let fingerprint = Sha256::digest(der)
+        .iter()
+        .map(|byte| format!("{byte:02X}"))
+        .collect::<Vec<_>>()
+        .join(":");
+
+    Some(CertificateMetadata {
+        subject_cn,
+        subject: certificate.subject().to_string(),
+        subject_alternative_names,
+        mdm_device_id,
+        issuer: certificate.issuer().to_string(),
+        serial: certificate.raw_serial_as_string(),
+        has_client_auth_eku,
+        digital_signature_allowed,
+        is_currently_valid,
+        not_before: certificate.validity().not_before.to_string(),
+        not_before_timestamp,
+        not_after: certificate.validity().not_after.to_string(),
+        signing_algorithm,
+        fingerprint,
+        der_bytes: der.len(),
+    })
+}
+
+fn extract_mdm_device_id<'a>(uris: impl IntoIterator<Item = &'a str>) -> Option<String> {
+    let uris = uris
+        .into_iter()
+        .filter(|uri| !uri.starts_with("tag:microsoft.com,2022-09-14:sid:"))
+        .collect::<Vec<_>>();
+    let mut saw_typed_identifier = false;
+    let mut typed_mdm_device_id = None;
+
+    for uri in &uris {
+        let Some((scheme, remainder)) = uri.split_once("://") else {
+            continue;
+        };
+        if !scheme.eq_ignore_ascii_case("firezone") {
+            continue;
+        }
+        let Some((id_type, value)) = remainder.split_once('/') else {
+            continue;
+        };
+        let id_type = id_type.to_ascii_lowercase();
+        if !matches!(
+            id_type.as_str(),
+            "serial"
+                | "apple-serial"
+                | "udid"
+                | "apple-udid"
+                | "smbios-uuid"
+                | "intune-id"
+                | "entra-id"
+                | "ws1-uuid"
+                | "jamf-id"
+                | "kandji-id"
+        ) || !valid_identifier(value)
+        {
+            continue;
+        }
+
+        saw_typed_identifier = true;
+        if matches!(
+            id_type.as_str(),
+            "intune-id" | "entra-id" | "ws1-uuid" | "jamf-id" | "kandji-id"
+        ) && typed_mdm_device_id.is_none()
+        {
+            typed_mdm_device_id = normalize_mdm_device_id(value);
+        }
+    }
+
+    if saw_typed_identifier {
+        return typed_mdm_device_id;
+    }
+
+    uris.into_iter().find_map(|uri| {
+        let value = uri.trim();
+        (value.len() == 36 && uuid::Uuid::parse_str(value).is_ok())
+            .then(|| normalize_mdm_device_id(value))
+            .flatten()
+    })
+}
+
+fn valid_identifier(value: &str) -> bool {
+    let value = value.trim();
+    !value.is_empty()
+        && value.len() <= 255
+        && value.bytes().all(|byte| (0x20..=0x7e).contains(&byte))
+}
+
+fn normalize_mdm_device_id(value: &str) -> Option<String> {
+    let normalized = value.trim().to_ascii_lowercase();
+    if !valid_identifier(&normalized)
+        || matches!(
+            normalized.as_str(),
+            "0" | "00000000-0000-0000-0000-000000000000"
+                | "ffffffff-ffff-ffff-ffff-ffffffffffff"
+                | "03000200-0400-0500-0006-000700080009"
+                | "idnotpresentbutsettable"
+        )
+    {
+        return None;
+    }
+
+    Some(normalized)
+}
+
+fn format_subject_alternative_name(name: &GeneralName<'_>) -> String {
+    match name {
+        GeneralName::OtherName(oid, value) => format!(
+            "Other name ({oid}): DER/Base64 {}",
+            BASE64_STANDARD.encode(value)
+        ),
+        GeneralName::RFC822Name(value) => format!("Email: {value}"),
+        GeneralName::DNSName(value) => format!("DNS: {value}"),
+        GeneralName::X400Address(value) => format!(
+            "X.400 address: DER/Base64 {}",
+            BASE64_STANDARD.encode(value.data)
+        ),
+        GeneralName::DirectoryName(value) => format!("Directory name: {value}"),
+        GeneralName::EDIPartyName(value) => format!(
+            "EDI party name: DER/Base64 {}",
+            BASE64_STANDARD.encode(value.data)
+        ),
+        GeneralName::URI(value) => format!("URI: {value}"),
+        GeneralName::IPAddress(value) => format!("IP address: {}", format_ip_address(value)),
+        GeneralName::RegisteredID(value) => format!("Registered ID: {value}"),
+        GeneralName::Invalid(tag, value) => format!(
+            "Invalid SAN (tag {tag}): DER/Base64 {}",
+            BASE64_STANDARD.encode(value)
+        ),
+    }
+}
+
+fn format_ip_address(value: &[u8]) -> String {
+    match value {
+        [a, b, c, d] => Ipv4Addr::new(*a, *b, *c, *d).to_string(),
+        value if value.len() == 16 => {
+            let octets = <[u8; 16]>::try_from(value).expect("length was checked");
+            Ipv6Addr::from(octets).to_string()
+        }
+        value => format!("DER/Base64 {}", BASE64_STANDARD.encode(value)),
+    }
+}
+
+pub(crate) fn field(label: impl Into<String>, value: impl Into<String>) -> DetailField {
+    DetailField {
+        label: label.into(),
+        value: value.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    const RSA_LEAF: &[u8] =
+        include_bytes!("../../../../elixir/test/support/fixtures/trust_anchors/leaf_cert.der");
+    const P384_LEAF: &[u8] =
+        include_bytes!("../../../../elixir/test/support/fixtures/trust_anchors/p384_leaf.der");
+
+    #[test]
+    fn recognizes_rsa_client_identity() {
+        let metadata = parse_certificate(
+            RSA_LEAF,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1_798_761_600),
+        )
+        .expect("fixture should be a valid RSA certificate");
+        assert_eq!(
+            metadata.subject_cn.as_deref(),
+            Some("dev.firezone.device-trust")
+        );
+        assert!(metadata.has_client_auth_eku);
+        assert!(metadata.digital_signature_allowed);
+        assert!(metadata.is_currently_valid);
+        assert_eq!(
+            metadata.signing_algorithm,
+            Some(SigningAlgorithm::RsaSha256)
+        );
+        assert!(metadata.is_usable("dev.firezone.device-trust"));
+    }
+
+    #[test]
+    fn recognizes_p384_digest() {
+        let metadata = parse_certificate(
+            P384_LEAF,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1_798_761_600),
+        )
+        .expect("fixture should be a valid P-384 certificate");
+        assert_eq!(
+            metadata.signing_algorithm,
+            Some(SigningAlgorithm::EcdsaSha384)
+        );
+        assert_eq!(
+            metadata.subject_alternative_names,
+            [
+                "URI: firezone://serial/C02XK1ZGJGH5",
+                "URI: firezone://udid/7a461ff9-0be2-64a9-a418-539d9a21827b",
+                "DNS: UDID=7A461FF9",
+                "DNS: host.test.invalid",
+            ]
+        );
+    }
+
+    #[test]
+    fn formats_ip_addresses() {
+        assert_eq!(format_ip_address(&[10, 0, 0, 1]), "10.0.0.1");
+        assert_eq!(
+            format_ip_address(&[0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+            "2001:db8::1"
+        );
+    }
+
+    #[test]
+    fn extracts_typed_mdm_device_id_like_the_portal() {
+        assert_eq!(
+            extract_mdm_device_id([
+                "firezone://serial/C02XK1ZGJGH5",
+                "firezone://intune-id/5F2E7B7A-9D54-4BD2-9D4F-8F6C2A01F9D3",
+            ]),
+            Some("5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3".to_owned())
+        );
+    }
+
+    #[test]
+    fn extracts_bare_guid_only_when_no_typed_identifier_exists() {
+        assert_eq!(
+            extract_mdm_device_id(["5F2E7B7A-9D54-4BD2-9D4F-8F6C2A01F9D3"]),
+            Some("5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3".to_owned())
+        );
+        assert_eq!(
+            extract_mdm_device_id([
+                "firezone://serial/C02XK1ZGJGH5",
+                "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3",
+            ]),
+            None
+        );
+    }
+}

--- a/rust/libs/device-trust/src/policy.rs
+++ b/rust/libs/device-trust/src/policy.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(any(target_os = "linux", target_os = "windows")), allow(dead_code))]
 
 use std::{
+    collections::HashSet,
     net::{Ipv4Addr, Ipv6Addr},
     time::SystemTime,
 };
@@ -13,7 +14,7 @@ use x509_parser::{
     prelude::{FromDer as _, X509Certificate},
 };
 
-use crate::DetailField;
+use crate::{DetailField, UserIdentity};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SigningAlgorithm {
@@ -39,7 +40,10 @@ pub(crate) struct CertificateMetadata {
     pub subject_cn: Option<String>,
     pub subject: String,
     pub subject_alternative_names: Vec<String>,
+    pub actor_email: Option<String>,
+    pub account_id: Option<String>,
     pub mdm_device_id: Option<String>,
+    pub device_serial: Option<String>,
     pub issuer: String,
     pub serial: String,
     pub has_client_auth_eku: bool,
@@ -67,12 +71,26 @@ impl CertificateMetadata {
     }
 
     pub(crate) fn detail_fields(&self) -> Vec<DetailField> {
-        vec![
+        let mut fields = vec![
             field(
                 "Common Name",
                 self.subject_cn.as_deref().unwrap_or("Unavailable"),
             ),
             field("Subject", &self.subject),
+        ];
+        if let Some(actor_email) = &self.actor_email {
+            fields.push(field("Actor Email", actor_email));
+        }
+        if let Some(account_id) = &self.account_id {
+            fields.push(field("Account ID", account_id));
+        }
+        if let Some(mdm_device_id) = &self.mdm_device_id {
+            fields.push(field("MDM Device ID", mdm_device_id));
+        }
+        if let Some(device_serial) = &self.device_serial {
+            fields.push(field("Device Serial", device_serial));
+        }
+        fields.extend([
             field(
                 "Subject Alternative Names",
                 if self.subject_alternative_names.is_empty() {
@@ -113,7 +131,15 @@ impl CertificateMetadata {
             ),
             field("SHA-256 Fingerprint", &self.fingerprint),
             field("DER Byte Count", self.der_bytes.to_string()),
-        ]
+        ]);
+        fields
+    }
+
+    pub(crate) fn user_identity(&self) -> Option<UserIdentity> {
+        Some(UserIdentity {
+            email: self.actor_email.clone()?,
+            account_id: self.account_id.clone()?,
+        })
     }
 }
 
@@ -145,15 +171,23 @@ pub(crate) fn parse_certificate(der: &[u8], now: SystemTime) -> Option<Certifica
         .collect::<Vec<_>>();
     let subject_alternative_names = general_names
         .iter()
-        .map(|name| format_subject_alternative_name(name))
+        .flat_map(|name| format_subject_alternative_name(name))
         .collect();
-    let mdm_device_id = extract_mdm_device_id(general_names.iter().filter_map(|name| {
-        if let GeneralName::URI(value) = name {
-            Some(*value)
-        } else {
-            None
-        }
-    }));
+    let uri_subject_alternative_names = general_names
+        .iter()
+        .filter_map(|name| {
+            if let GeneralName::URI(value) = name {
+                Some(*value)
+            } else {
+                None
+            }
+        })
+        .flat_map(split_comma_joined_uris)
+        .collect::<Vec<_>>();
+    let actor_email = extract_actor_email(&uri_subject_alternative_names);
+    let account_id = extract_account_id(&uri_subject_alternative_names);
+    let mdm_device_id = extract_mdm_device_id(uri_subject_alternative_names.iter().copied());
+    let device_serial = extract_device_serial(&uri_subject_alternative_names);
     // RFC 5280 permits Key Usage to be omitted. When present, it must allow
     // digitalSignature, matching the portal's verification policy.
     let digital_signature_allowed = certificate
@@ -209,7 +243,10 @@ pub(crate) fn parse_certificate(der: &[u8], now: SystemTime) -> Option<Certifica
         subject_cn,
         subject: certificate.subject().to_string(),
         subject_alternative_names,
+        actor_email,
+        account_id,
         mdm_device_id,
+        device_serial,
         issuer: certificate.issuer().to_string(),
         serial: certificate.raw_serial_as_string(),
         has_client_auth_eku,
@@ -222,6 +259,99 @@ pub(crate) fn parse_certificate(der: &[u8], now: SystemTime) -> Option<Certifica
         fingerprint,
         der_bytes: der.len(),
     })
+}
+
+fn extract_actor_email(uris: &[&str]) -> Option<String> {
+    let emails = firezone_attribute_values(uris, "email")
+        .into_iter()
+        .filter(|value| valid_email(value))
+        .map(|value| value.to_lowercase())
+        .collect::<HashSet<_>>();
+
+    (emails.len() == 1)
+        .then(|| emails.into_iter().next())
+        .flatten()
+}
+
+fn extract_account_id(uris: &[&str]) -> Option<String> {
+    let account_ids = firezone_attribute_values(uris, "account-id")
+        .into_iter()
+        .filter_map(|value| uuid::Uuid::parse_str(&value).ok())
+        .map(|value| value.hyphenated().to_string().to_lowercase())
+        .collect::<HashSet<_>>();
+
+    (account_ids.len() == 1)
+        .then(|| account_ids.into_iter().next())
+        .flatten()
+}
+
+fn extract_device_serial(uris: &[&str]) -> Option<String> {
+    let serials = firezone_attribute_values(uris, "serial")
+        .into_iter()
+        .chain(firezone_attribute_values(uris, "apple-serial"))
+        .collect::<Vec<_>>();
+    let normalized = serials
+        .iter()
+        .map(|value| value.to_lowercase())
+        .collect::<HashSet<_>>();
+
+    (normalized.len() == 1)
+        .then(|| serials.into_iter().next())
+        .flatten()
+}
+
+fn firezone_attribute_values(uris: &[&str], expected_attribute: &str) -> Vec<String> {
+    uris.iter()
+        .filter_map(|uri| {
+            let (scheme, remainder) = uri.split_once("://")?;
+            if !scheme.eq_ignore_ascii_case("firezone") {
+                return None;
+            }
+            let (attribute, raw_value) = remainder.split_once('/')?;
+            if !attribute.eq_ignore_ascii_case(expected_attribute) {
+                return None;
+            }
+
+            let decoded = percent_decode(raw_value).unwrap_or_else(|| raw_value.to_owned());
+            let value = decoded.trim();
+            valid_identifier(value).then(|| value.to_owned())
+        })
+        .collect()
+}
+
+fn valid_email(value: &str) -> bool {
+    if !valid_identifier(value) || value.chars().any(char::is_whitespace) {
+        return false;
+    }
+    let mut parts = value.split('@');
+    matches!((parts.next(), parts.next(), parts.next()), (Some(local), Some(domain), None) if !local.is_empty() && !domain.is_empty())
+}
+
+fn percent_decode(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'%' {
+            decoded.push(bytes[index]);
+            index += 1;
+            continue;
+        }
+        let high = *bytes.get(index + 1)?;
+        let low = *bytes.get(index + 2)?;
+        decoded.push(hex_value(high)? << 4 | hex_value(low)?);
+        index += 3;
+    }
+    String::from_utf8(decoded).ok()
+}
+
+fn hex_value(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
 }
 
 fn extract_mdm_device_id<'a>(uris: impl IntoIterator<Item = &'a str>) -> Option<String> {
@@ -300,10 +430,10 @@ fn split_comma_joined_uris(value: &str) -> Vec<&str> {
             continue;
         }
 
-        values.push(&value[start..comma]);
+        values.push(value[start..comma].trim());
         start = comma + 1 + (remainder.len() - next.len());
     }
-    values.push(&value[start..]);
+    values.push(value[start..].trim());
 
     values
 }
@@ -326,9 +456,7 @@ fn starts_with_uri_scheme(value: &str) -> bool {
 
 fn valid_identifier(value: &str) -> bool {
     let value = value.trim();
-    !value.is_empty()
-        && value.len() <= 255
-        && value.bytes().all(|byte| (0x20..=0x7e).contains(&byte))
+    !value.is_empty() && value.len() <= 255
 }
 
 fn normalize_mdm_device_id(value: &str) -> Option<String> {
@@ -348,8 +476,8 @@ fn normalize_mdm_device_id(value: &str) -> Option<String> {
     Some(normalized)
 }
 
-fn format_subject_alternative_name(name: &GeneralName<'_>) -> String {
-    match name {
+fn format_subject_alternative_name(name: &GeneralName<'_>) -> Vec<String> {
+    let value = match name {
         GeneralName::OtherName(oid, value) => format!(
             "Other name ({oid}): DER/Base64 {}",
             BASE64_STANDARD.encode(value)
@@ -365,14 +493,20 @@ fn format_subject_alternative_name(name: &GeneralName<'_>) -> String {
             "EDI party name: DER/Base64 {}",
             BASE64_STANDARD.encode(value.data)
         ),
-        GeneralName::URI(value) => format!("URI: {value}"),
+        GeneralName::URI(value) => {
+            return split_comma_joined_uris(value)
+                .into_iter()
+                .map(|value| format!("URI: {value}"))
+                .collect();
+        }
         GeneralName::IPAddress(value) => format!("IP address: {}", format_ip_address(value)),
         GeneralName::RegisteredID(value) => format!("Registered ID: {value}"),
         GeneralName::Invalid(tag, value) => format!(
             "Invalid SAN (tag {tag}): DER/Base64 {}",
             BASE64_STANDARD.encode(value)
         ),
-    }
+    };
+    vec![value]
 }
 
 fn format_ip_address(value: &[u8]) -> String {
@@ -473,6 +607,96 @@ mod tests {
                 "tag:microsoft.com,2022-09-14:sid:S-1-12-1-1, firezone://serial/C02XK1ZGJGH5, firezone://intune-id/5F2E7B7A-9D54-4BD2-9D4F-8F6C2A01F9D3",
             ]),
             Some("5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3".to_owned())
+        );
+    }
+
+    #[test]
+    fn extracts_user_identity_from_intune_comma_joined_uri() {
+        let values = split_comma_joined_uris(
+            "tag:microsoft.com,2022-09-14:sid:S-1-12-1-1, firezone://email/Alice%40Example.COM, firezone://account-id/5F2E7B7A-9D54-4BD2-9D4F-8F6C2A01F9D3, firezone://serial/C02XK1ZGJGH5",
+        );
+
+        assert_eq!(
+            extract_actor_email(&values).as_deref(),
+            Some("alice@example.com")
+        );
+        assert_eq!(
+            extract_account_id(&values).as_deref(),
+            Some("5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3")
+        );
+        assert_eq!(
+            extract_device_serial(&values).as_deref(),
+            Some("C02XK1ZGJGH5")
+        );
+    }
+
+    #[test]
+    fn user_identity_requires_unambiguous_valid_attributes() {
+        let conflicting_emails = [
+            "firezone://email/alice@example.com",
+            "firezone://email/bob@example.com",
+            "firezone://account-id/5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3",
+        ];
+        let malformed_account = [
+            "firezone://email/alice@example.com",
+            "firezone://account-id/not-a-uuid",
+        ];
+        let duplicate_equivalent_values = [
+            "firezone://email/Alice@Example.COM",
+            "firezone://email/alice@example.com",
+            "firezone://account-id/5F2E7B7A-9D54-4BD2-9D4F-8F6C2A01F9D3",
+            "firezone://account-id/5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3",
+        ];
+
+        assert_eq!(extract_actor_email(&conflicting_emails), None);
+        assert_eq!(extract_account_id(&malformed_account), None);
+        assert_eq!(
+            extract_actor_email(&duplicate_equivalent_values).as_deref(),
+            Some("alice@example.com")
+        );
+        assert_eq!(
+            extract_account_id(&duplicate_equivalent_values).as_deref(),
+            Some("5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3")
+        );
+    }
+
+    #[test]
+    fn diagnostics_show_derived_firezone_attributes() {
+        let mut metadata = parse_certificate(
+            RSA_LEAF,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1_798_761_600),
+        )
+        .expect("test certificate should parse");
+        metadata.actor_email = Some("alice@example.com".to_owned());
+        metadata.account_id = Some("5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3".to_owned());
+        metadata.mdm_device_id = Some("intune-device-123".to_owned());
+        metadata.device_serial = Some("C02XK1ZGJGH5".to_owned());
+
+        let fields = metadata.detail_fields();
+        assert!(
+            fields.iter().any(|field| {
+                field.label == "Actor Email" && field.value == "alice@example.com"
+            })
+        );
+        assert!(fields.iter().any(|field| {
+            field.label == "Account ID" && field.value == "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3"
+        }));
+        assert!(
+            fields.iter().any(|field| {
+                field.label == "MDM Device ID" && field.value == "intune-device-123"
+            })
+        );
+        assert!(
+            fields
+                .iter()
+                .any(|field| { field.label == "Device Serial" && field.value == "C02XK1ZGJGH5" })
+        );
+        assert_eq!(
+            metadata.user_identity(),
+            Some(UserIdentity {
+                email: "alice@example.com".to_owned(),
+                account_id: "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3".to_owned(),
+            })
         );
     }
 

--- a/rust/libs/device-trust/src/policy.rs
+++ b/rust/libs/device-trust/src/policy.rs
@@ -227,7 +227,11 @@ pub(crate) fn parse_certificate(der: &[u8], now: SystemTime) -> Option<Certifica
 fn extract_mdm_device_id<'a>(uris: impl IntoIterator<Item = &'a str>) -> Option<String> {
     let uris = uris
         .into_iter()
-        .filter(|uri| !uri.starts_with("tag:microsoft.com,2022-09-14:sid:"))
+        .flat_map(split_comma_joined_uris)
+        .filter(|uri| {
+            !uri.to_ascii_lowercase()
+                .starts_with("tag:microsoft.com,2022-09-14:sid:")
+        })
         .collect::<Vec<_>>();
     let mut saw_typed_identifier = false;
     let mut typed_mdm_device_id = None;
@@ -280,6 +284,44 @@ fn extract_mdm_device_id<'a>(uris: impl IntoIterator<Item = &'a str>) -> Option<
             .then(|| normalize_mdm_device_id(value))
             .flatten()
     })
+}
+
+/// Intune encodes all configured SAN URI rows into one comma-joined value.
+/// Only split where the text following a comma begins with another URI scheme,
+/// preserving the comma in Microsoft's SID URI.
+fn split_comma_joined_uris(value: &str) -> Vec<&str> {
+    let mut values = Vec::new();
+    let mut start = 0;
+
+    for (comma, _) in value.match_indices(',') {
+        let remainder = &value[comma + 1..];
+        let next = remainder.trim_start();
+        if !starts_with_uri_scheme(next) {
+            continue;
+        }
+
+        values.push(&value[start..comma]);
+        start = comma + 1 + (remainder.len() - next.len());
+    }
+    values.push(&value[start..]);
+
+    values
+}
+
+fn starts_with_uri_scheme(value: &str) -> bool {
+    let mut bytes = value.bytes();
+    let Some(first) = bytes.next() else {
+        return false;
+    };
+    if !first.is_ascii_alphabetic() {
+        return false;
+    }
+
+    bytes
+        .take_while(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'.' | b'-' | b':')
+        })
+        .any(|byte| byte == b':')
 }
 
 fn valid_identifier(value: &str) -> bool {
@@ -419,6 +461,16 @@ mod tests {
             extract_mdm_device_id([
                 "firezone://serial/C02XK1ZGJGH5",
                 "firezone://intune-id/5F2E7B7A-9D54-4BD2-9D4F-8F6C2A01F9D3",
+            ]),
+            Some("5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3".to_owned())
+        );
+    }
+
+    #[test]
+    fn extracts_mdm_device_id_from_intune_comma_joined_uri() {
+        assert_eq!(
+            extract_mdm_device_id([
+                "tag:microsoft.com,2022-09-14:sid:S-1-12-1-1, firezone://serial/C02XK1ZGJGH5, firezone://intune-id/5F2E7B7A-9D54-4BD2-9D4F-8F6C2A01F9D3",
             ]),
             Some("5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3".to_owned())
         );

--- a/rust/libs/device-trust/src/windows.rs
+++ b/rust/libs/device-trust/src/windows.rs
@@ -1,0 +1,840 @@
+//! Windows X.509 identities from the machine/user certificate stores and CNG.
+
+use std::{ffi::c_void, fmt, ptr, slice, sync::Arc, time::SystemTime};
+
+use anyhow::{Context as _, Result, bail};
+use rustls::{
+    SignatureAlgorithm, SignatureScheme,
+    pki_types::CertificateDer,
+    sign::{CertifiedKey, Signer, SigningKey},
+};
+use sha2::{Digest as _, Sha256, Sha384, Sha512};
+use windows::{
+    Win32::Security::Cryptography::{
+        BCRYPT_PKCS1_PADDING_INFO, BCRYPT_PSS_PADDING_INFO, BCRYPT_SHA256_ALGORITHM,
+        BCRYPT_SHA384_ALGORITHM, BCRYPT_SHA512_ALGORITHM, CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL,
+        CERT_CHAIN_DISABLE_AIA, CERT_CHAIN_PARA, CERT_CONTEXT, CERT_KEY_PROV_INFO_PROP_ID,
+        CERT_KEY_SPEC, CERT_OPEN_STORE_FLAGS, CERT_QUERY_ENCODING_TYPE,
+        CERT_STORE_OPEN_EXISTING_FLAG, CERT_STORE_PROV_SYSTEM_W, CERT_STORE_READONLY_FLAG,
+        CERT_SYSTEM_STORE_CURRENT_USER, CERT_SYSTEM_STORE_LOCAL_MACHINE,
+        CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG, CRYPT_ACQUIRE_SILENT_FLAG, CRYPT_KEY_PROV_INFO,
+        CertCloseStore, CertDuplicateCertificateContext, CertEnumCertificatesInStore,
+        CertFreeCertificateChain, CertFreeCertificateContext, CertGetCertificateChain,
+        CertGetCertificateContextProperty, CertOpenStore, CryptAcquireCertificatePrivateKey,
+        HCERTSTORE, HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, NCRYPT_FLAGS, NCRYPT_HANDLE,
+        NCRYPT_IMPL_HARDWARE_FLAG, NCRYPT_IMPL_SOFTWARE_FLAG, NCRYPT_IMPL_TYPE_PROPERTY,
+        NCRYPT_KEY_HANDLE, NCRYPT_PAD_PKCS1_FLAG, NCRYPT_PAD_PSS_FLAG, NCRYPT_PROV_HANDLE,
+        NCRYPT_PROVIDER_HANDLE_PROPERTY, NCryptFreeObject, NCryptGetProperty, NCryptSignHash,
+    },
+    core::w,
+};
+
+use crate::{
+    Config, DetailSection, PlatformIdentity, Status,
+    policy::{CertificateMetadata, SigningAlgorithm, field, parse_certificate},
+};
+
+const STORES: &[(u32, &str)] = &[
+    (CERT_SYSTEM_STORE_LOCAL_MACHINE, "LocalMachine\\My"),
+    (CERT_SYSTEM_STORE_CURRENT_USER, "CurrentUser\\My"),
+];
+
+pub(crate) fn status(_config: &Config, subject_cn: &str) -> Result<Status> {
+    let (certificates, errors) = enumerate_matching(subject_cn);
+    if certificates.is_empty() && errors.len() == STORES.len() {
+        bail!(
+            "The Windows certificate stores could not be read: {}",
+            errors.join("; ")
+        );
+    }
+
+    let usable = certificates
+        .iter()
+        .filter(|certificate| certificate.usable)
+        .count();
+    let mut sections = vec![DetailSection {
+        title: "Windows Certificate Store".to_owned(),
+        fields: vec![
+            field("Searched Stores", "LocalMachine\\My\nCurrentUser\\My"),
+            field("Requested Common Name", subject_cn),
+            field(
+                "Store Read Errors",
+                if errors.is_empty() {
+                    "None".to_owned()
+                } else {
+                    errors.join("\n")
+                },
+            ),
+        ],
+    }];
+    sections.extend(certificates.iter().enumerate().map(|(index, certificate)| {
+        let mut fields = vec![
+            field("Store", certificate.store),
+            field(
+                "Private Key Access",
+                if certificate.key_available {
+                    "Available through Windows CNG"
+                } else {
+                    "Unavailable"
+                },
+            ),
+            field(
+                "Usable for Device Attestation",
+                if certificate.usable { "Yes" } else { "No" },
+            ),
+        ];
+        if let Some(error) = &certificate.key_error {
+            fields.push(field("Private Key Error", error));
+        }
+        if let Some(metadata) = &certificate.key_metadata {
+            fields.push(field(
+                "Private Key Provider",
+                metadata.provider.as_deref().unwrap_or("Unavailable"),
+            ));
+            fields.push(field("Private Key Storage", metadata.storage));
+            if let Some(container) = &metadata.container {
+                fields.push(field("Private Key Container", container));
+            }
+            if !metadata.errors.is_empty() {
+                fields.push(field(
+                    "Private Key Metadata Errors",
+                    metadata.errors.join("\n"),
+                ));
+            }
+        }
+        fields.push(field(
+            "Certificate Chain Count",
+            certificate.chain.len().to_string(),
+        ));
+        if let Some(error) = &certificate.chain_error {
+            fields.push(field("Certificate Chain Error", error));
+        }
+        fields.extend(certificate.metadata.detail_fields());
+        DetailSection {
+            title: format!("Matching Certificate {}", index + 1),
+            fields,
+        }
+    }));
+
+    let summary = match (usable, certificates.len()) {
+        (0, 0) => format!(
+            "No X.509 certificate with subject CN '{subject_cn}' was found in the Windows certificate stores."
+        ),
+        (0, count) => format!(
+            "Found {count} matching X.509 certificate(s), but none are usable for device attestation."
+        ),
+        (count, _) => format!(
+            "{count} X.509 device identity certificate(s) are available for device attestation."
+        ),
+    };
+
+    Ok(Status { summary, sections })
+}
+
+pub(crate) fn identity(_config: &Config, subject_cn: &str) -> Result<Option<PlatformIdentity>> {
+    let (certificates, store_errors) = enumerate_matching(subject_cn);
+    if certificates.is_empty() && store_errors.len() == STORES.len() {
+        bail!(
+            "The Windows certificate stores could not be read: {}",
+            store_errors.join("; ")
+        );
+    }
+
+    let Some(certificate) = certificates
+        .into_iter()
+        .filter(|certificate| certificate.metadata.is_usable(subject_cn))
+        .max_by_key(|certificate| certificate.metadata.not_before_timestamp)
+    else {
+        return Ok(None);
+    };
+    let algorithm = certificate
+        .metadata
+        .signing_algorithm
+        .context("The selected Windows certificate uses an unsupported key algorithm")?;
+    let signing_context = unsafe { CertDuplicateCertificateContext(Some(certificate.context)) };
+    if signing_context.is_null() {
+        bail!("Failed to retain the selected Windows certificate context");
+    }
+    let signing_key = Arc::new(WindowsSigningKey {
+        context: Arc::new(CertificateContext(signing_context)),
+        algorithm,
+    });
+    let chain = certificate
+        .chain
+        .iter()
+        .cloned()
+        .map(CertificateDer::from)
+        .collect();
+
+    tracing::info!(
+        store = certificate.store,
+        fingerprint = %certificate.metadata.fingerprint,
+        mdm_device_id = certificate.metadata.mdm_device_id.as_deref(),
+        "Selected the newest Windows X.509 identity for mutual TLS"
+    );
+
+    Ok(Some(PlatformIdentity {
+        certified_key: Arc::new(CertifiedKey::new(chain, signing_key)),
+        mdm_device_id: certificate.metadata.mdm_device_id.clone(),
+    }))
+}
+
+struct CertificateContext(*mut CERT_CONTEXT);
+
+// SAFETY: this owns a duplicated, reference-counted CERT_CONTEXT. Windows permits
+// certificate contexts and their associated CNG key providers to be used from
+// different threads; all signing calls acquire their own key handle.
+unsafe impl Send for CertificateContext {}
+// SAFETY: see the `Send` implementation above. The pointed-to context is immutable.
+unsafe impl Sync for CertificateContext {}
+
+impl fmt::Debug for CertificateContext {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CertificateContext(..)")
+    }
+}
+
+impl Drop for CertificateContext {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CertFreeCertificateContext(Some(self.0));
+        }
+    }
+}
+
+#[derive(Debug)]
+struct WindowsSigningKey {
+    context: Arc<CertificateContext>,
+    algorithm: SigningAlgorithm,
+}
+
+impl SigningKey for WindowsSigningKey {
+    fn choose_scheme(&self, offered: &[SignatureScheme]) -> Option<Box<dyn Signer>> {
+        signature_schemes(self.algorithm)
+            .iter()
+            .copied()
+            .find(|scheme| offered.contains(scheme))
+            .map(|scheme| {
+                Box::new(WindowsSigner {
+                    context: self.context.clone(),
+                    scheme,
+                }) as Box<dyn Signer>
+            })
+    }
+
+    fn algorithm(&self) -> SignatureAlgorithm {
+        match self.algorithm {
+            SigningAlgorithm::RsaSha256 => SignatureAlgorithm::RSA,
+            SigningAlgorithm::EcdsaSha256
+            | SigningAlgorithm::EcdsaSha384
+            | SigningAlgorithm::EcdsaSha512 => SignatureAlgorithm::ECDSA,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct WindowsSigner {
+    context: Arc<CertificateContext>,
+    scheme: SignatureScheme,
+}
+
+impl Signer for WindowsSigner {
+    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
+        unsafe { sign_with_certificate(self.context.0, self.scheme, message) }.map_err(|error| {
+            rustls::Error::General(format!("Windows TLS signing failed: {error:#}"))
+        })
+    }
+
+    fn scheme(&self) -> SignatureScheme {
+        self.scheme
+    }
+}
+
+fn signature_schemes(algorithm: SigningAlgorithm) -> &'static [SignatureScheme] {
+    match algorithm {
+        SigningAlgorithm::RsaSha256 => &[
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA256,
+        ],
+        SigningAlgorithm::EcdsaSha256 => &[SignatureScheme::ECDSA_NISTP256_SHA256],
+        SigningAlgorithm::EcdsaSha384 => &[SignatureScheme::ECDSA_NISTP384_SHA384],
+        SigningAlgorithm::EcdsaSha512 => &[SignatureScheme::ECDSA_NISTP521_SHA512],
+    }
+}
+
+struct Certificate {
+    store: &'static str,
+    context: *mut CERT_CONTEXT,
+    chain: Vec<Vec<u8>>,
+    chain_error: Option<String>,
+    metadata: CertificateMetadata,
+    key_available: bool,
+    key_error: Option<String>,
+    key_metadata: Option<PrivateKeyMetadata>,
+    usable: bool,
+}
+
+struct PrivateKeyMetadata {
+    provider: Option<String>,
+    container: Option<String>,
+    storage: &'static str,
+    errors: Vec<String>,
+}
+
+impl Drop for Certificate {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CertFreeCertificateContext(Some(self.context));
+        }
+    }
+}
+
+fn enumerate_matching(subject_cn: &str) -> (Vec<Certificate>, Vec<String>) {
+    let mut certificates = Vec::new();
+    let mut errors = Vec::new();
+    for &(location, label) in STORES {
+        match unsafe { enumerate_store(location, label, subject_cn) } {
+            Ok(mut found) => certificates.append(&mut found),
+            Err(error) => {
+                tracing::warn!(
+                    store = label,
+                    ?error,
+                    "Failed to read Windows certificate store"
+                );
+                errors.push(format!("{label}: {error:#}"));
+            }
+        }
+    }
+    (certificates, errors)
+}
+
+unsafe fn enumerate_store(
+    location: u32,
+    label: &'static str,
+    subject_cn: &str,
+) -> Result<Vec<Certificate>> {
+    let store = unsafe { open_store(location) }.with_context(|| format!("Opening {label}"))?;
+    let mut certificates = Vec::new();
+    let mut previous: *mut CERT_CONTEXT = ptr::null_mut();
+
+    loop {
+        let context = unsafe {
+            CertEnumCertificatesInStore(
+                store,
+                (!previous.is_null()).then_some(previous as *const CERT_CONTEXT),
+            )
+        };
+        if context.is_null() {
+            break;
+        }
+        previous = context;
+        let der = unsafe {
+            let context = &*context;
+            slice::from_raw_parts(context.pbCertEncoded, context.cbCertEncoded as usize).to_vec()
+        };
+        let Some(metadata) = parse_certificate(&der, SystemTime::now()) else {
+            continue;
+        };
+        if !metadata.matches_subject(subject_cn) {
+            continue;
+        }
+
+        let (key_available, key_error, key_metadata) = match unsafe { acquire_key(context) } {
+            Ok(key) => {
+                let metadata = unsafe { private_key_metadata(context, &key) };
+                (true, None, Some(metadata))
+            }
+            Err(error) => (false, Some(format!("{error:#}")), None),
+        };
+        let usable = metadata.is_usable(subject_cn) && key_available;
+        let (chain, chain_error) = match unsafe { certificate_chain(context) } {
+            Ok(chain) => (chain, None),
+            Err(error) => {
+                tracing::warn!(
+                    store = label,
+                    ?error,
+                    "Failed to build the Windows certificate chain; sending the leaf only"
+                );
+                (vec![der.clone()], Some(format!("{error:#}")))
+            }
+        };
+        let owned_context = unsafe { CertDuplicateCertificateContext(Some(context)) };
+        if owned_context.is_null() {
+            tracing::warn!(
+                store = label,
+                "Failed to retain a Windows certificate context"
+            );
+            continue;
+        }
+        certificates.push(Certificate {
+            store: label,
+            context: owned_context,
+            chain,
+            chain_error,
+            metadata,
+            key_available,
+            key_error,
+            key_metadata,
+            usable,
+        });
+    }
+
+    unsafe {
+        let _ = CertCloseStore(Some(store), 0);
+    }
+    Ok(certificates)
+}
+
+unsafe fn certificate_chain(context: *const CERT_CONTEXT) -> Result<Vec<Vec<u8>>> {
+    let parameters = CERT_CHAIN_PARA {
+        cbSize: std::mem::size_of::<CERT_CHAIN_PARA>() as u32,
+        ..Default::default()
+    };
+    let mut chain_context = ptr::null_mut();
+    unsafe {
+        CertGetCertificateChain(
+            None,
+            context,
+            None,
+            None,
+            &raw const parameters,
+            CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL | CERT_CHAIN_DISABLE_AIA,
+            None,
+            &mut chain_context,
+        )
+    }
+    .context("CertGetCertificateChain failed")?;
+
+    let result = (|| {
+        let chain_context = unsafe { chain_context.as_ref() }
+            .context("CertGetCertificateChain returned a null context")?;
+        anyhow::ensure!(
+            chain_context.cChain > 0,
+            "Windows returned no certificate chains"
+        );
+        let simple_chain = unsafe { chain_context.rgpChain.as_ref() }
+            .context("Windows returned a null certificate-chain list")?;
+        let simple_chain = *simple_chain;
+        let simple_chain = unsafe { simple_chain.as_ref() }
+            .context("Windows returned a null certificate chain")?;
+        let mut certificates = Vec::with_capacity(simple_chain.cElement as usize);
+        let elements = unsafe { simple_chain.rgpElement.as_ref() }
+            .context("Windows returned a null certificate-chain element list")?;
+        for index in 0..simple_chain.cElement as usize {
+            let element = if index == 0 {
+                *elements
+            } else {
+                unsafe { *simple_chain.rgpElement.add(index) }
+            };
+            let element = unsafe { element.as_ref() }
+                .context("Windows returned a null certificate-chain element")?;
+            let certificate = unsafe { element.pCertContext.as_ref() }
+                .context("Windows returned a null certificate context")?;
+            certificates.push(unsafe {
+                slice::from_raw_parts(
+                    certificate.pbCertEncoded,
+                    certificate.cbCertEncoded as usize,
+                )
+                .to_vec()
+            });
+        }
+        Ok(certificates)
+    })();
+
+    unsafe { CertFreeCertificateChain(chain_context) };
+    result
+}
+
+unsafe fn open_store(location: u32) -> Result<HCERTSTORE> {
+    let flags = CERT_OPEN_STORE_FLAGS(
+        location | CERT_STORE_READONLY_FLAG.0 | CERT_STORE_OPEN_EXISTING_FLAG.0,
+    );
+    let store = unsafe {
+        CertOpenStore(
+            CERT_STORE_PROV_SYSTEM_W,
+            CERT_QUERY_ENCODING_TYPE::default(),
+            None,
+            flags,
+            Some(w!("MY").as_ptr().cast::<c_void>()),
+        )
+    }
+    .context("CertOpenStore failed")?;
+    if store.is_invalid() {
+        bail!("CertOpenStore returned an invalid handle");
+    }
+    Ok(store)
+}
+
+struct AcquiredKey {
+    handle: NCRYPT_KEY_HANDLE,
+    must_free: bool,
+}
+
+unsafe fn private_key_metadata(
+    context: *const CERT_CONTEXT,
+    key: &AcquiredKey,
+) -> PrivateKeyMetadata {
+    let mut errors = Vec::new();
+    let (provider, container) = match unsafe { certificate_key_provider_info(context) } {
+        Ok(info) => info,
+        Err(error) => {
+            errors.push(format!("Provider: {error:#}"));
+            (None, None)
+        }
+    };
+    let implementation_type = match key.implementation_type() {
+        Ok(value) => Some(value),
+        Err(error) => {
+            errors.push(format!("Implementation type: {error:#}"));
+            None
+        }
+    };
+    let storage = classify_private_key_storage(provider.as_deref(), implementation_type);
+
+    PrivateKeyMetadata {
+        provider,
+        container,
+        storage,
+        errors,
+    }
+}
+
+unsafe fn certificate_key_provider_info(
+    context: *const CERT_CONTEXT,
+) -> Result<(Option<String>, Option<String>)> {
+    let mut needed = 0;
+    unsafe {
+        CertGetCertificateContextProperty(context, CERT_KEY_PROV_INFO_PROP_ID, None, &mut needed)
+    }
+    .context("Reading the CNG provider metadata size failed")?;
+    anyhow::ensure!(
+        needed as usize >= std::mem::size_of::<CRYPT_KEY_PROV_INFO>(),
+        "Windows returned invalid CNG provider metadata"
+    );
+
+    // The property contains a CRYPT_KEY_PROV_INFO followed by referenced strings,
+    // so allocate in pointer-sized units to preserve the struct's alignment.
+    let words = (needed as usize).div_ceil(std::mem::size_of::<usize>());
+    let mut buffer = vec![0usize; words];
+    unsafe {
+        CertGetCertificateContextProperty(
+            context,
+            CERT_KEY_PROV_INFO_PROP_ID,
+            Some(buffer.as_mut_ptr().cast()),
+            &mut needed,
+        )
+    }
+    .context("Reading the CNG provider metadata failed")?;
+    let info = unsafe { &*buffer.as_ptr().cast::<CRYPT_KEY_PROV_INFO>() };
+    let provider = unsafe { wide_string(info.pwszProvName) };
+    let container = unsafe { wide_string(info.pwszContainerName) };
+    Ok((provider, container))
+}
+
+unsafe fn wide_string(value: windows_core::PWSTR) -> Option<String> {
+    if value.is_null() {
+        None
+    } else {
+        unsafe { value.to_string().ok() }
+    }
+}
+
+fn classify_private_key_storage(
+    provider: Option<&str>,
+    implementation_type: Option<u32>,
+) -> &'static str {
+    if provider
+        .is_some_and(|provider| provider.eq_ignore_ascii_case("Microsoft Platform Crypto Provider"))
+    {
+        return "TPM (hardware-backed keystore)";
+    }
+    if implementation_type.is_some_and(|value| value & NCRYPT_IMPL_HARDWARE_FLAG != 0) {
+        return "Hardware-backed keystore";
+    }
+    if provider.is_some_and(|provider| {
+        provider.eq_ignore_ascii_case("Microsoft Software Key Storage Provider")
+    }) || implementation_type.is_some_and(|value| value & NCRYPT_IMPL_SOFTWARE_FLAG != 0)
+    {
+        return "Software keystore";
+    }
+    "CNG provider (hardware backing unknown)"
+}
+
+impl AcquiredKey {
+    fn implementation_type(&self) -> Result<u32> {
+        let provider: NCRYPT_PROV_HANDLE = unsafe {
+            ncrypt_property(
+                NCRYPT_HANDLE(self.handle.0),
+                NCRYPT_PROVIDER_HANDLE_PROPERTY,
+            )
+        }
+        .context("Reading the CNG provider handle failed")?;
+        unsafe { ncrypt_property(NCRYPT_HANDLE(provider.0), NCRYPT_IMPL_TYPE_PROPERTY) }
+            .context("Reading the CNG implementation type failed")
+    }
+}
+
+unsafe fn ncrypt_property<T: Default>(
+    handle: NCRYPT_HANDLE,
+    property: windows_core::PCWSTR,
+) -> Result<T> {
+    let mut value = T::default();
+    let output = unsafe {
+        slice::from_raw_parts_mut((&raw mut value).cast::<u8>(), std::mem::size_of::<T>())
+    };
+    let mut written = 0;
+    unsafe {
+        NCryptGetProperty(
+            handle,
+            property,
+            Some(output),
+            &mut written,
+            Default::default(),
+        )
+    }
+    .context("NCryptGetProperty failed")?;
+    anyhow::ensure!(
+        written as usize == std::mem::size_of::<T>(),
+        "NCryptGetProperty returned {written} bytes, expected {}",
+        std::mem::size_of::<T>()
+    );
+    Ok(value)
+}
+
+impl Drop for AcquiredKey {
+    fn drop(&mut self) {
+        if self.must_free {
+            unsafe {
+                let _ = NCryptFreeObject(NCRYPT_HANDLE(self.handle.0));
+            }
+        }
+    }
+}
+
+unsafe fn acquire_key(context: *mut CERT_CONTEXT) -> Result<AcquiredKey> {
+    let mut handle = HCRYPTPROV_OR_NCRYPT_KEY_HANDLE::default();
+    let mut key_spec = CERT_KEY_SPEC::default();
+    let mut must_free = windows_core::BOOL(0);
+    unsafe {
+        CryptAcquireCertificatePrivateKey(
+            context,
+            CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG | CRYPT_ACQUIRE_SILENT_FLAG,
+            None,
+            &mut handle,
+            Some(&mut key_spec),
+            Some(&mut must_free),
+        )
+    }
+    .context("Windows could not acquire the certificate's CNG private key")?;
+    Ok(AcquiredKey {
+        handle: NCRYPT_KEY_HANDLE(handle.0),
+        must_free: must_free.as_bool(),
+    })
+}
+
+unsafe fn sign_with_certificate(
+    context: *mut CERT_CONTEXT,
+    scheme: SignatureScheme,
+    message: &[u8],
+) -> Result<Vec<u8>> {
+    let key = unsafe { acquire_key(context) }?;
+    match scheme {
+        SignatureScheme::RSA_PSS_SHA256 => unsafe {
+            sign_rsa_pss(
+                key.handle,
+                BCRYPT_SHA256_ALGORITHM,
+                &Sha256::digest(message),
+            )
+        },
+        SignatureScheme::RSA_PSS_SHA384 => unsafe {
+            sign_rsa_pss(
+                key.handle,
+                BCRYPT_SHA384_ALGORITHM,
+                &Sha384::digest(message),
+            )
+        },
+        SignatureScheme::RSA_PSS_SHA512 => unsafe {
+            sign_rsa_pss(
+                key.handle,
+                BCRYPT_SHA512_ALGORITHM,
+                &Sha512::digest(message),
+            )
+        },
+        SignatureScheme::RSA_PKCS1_SHA256 => unsafe {
+            sign_rsa_pkcs1(
+                key.handle,
+                BCRYPT_SHA256_ALGORITHM,
+                &Sha256::digest(message),
+            )
+        },
+        SignatureScheme::RSA_PKCS1_SHA384 => unsafe {
+            sign_rsa_pkcs1(
+                key.handle,
+                BCRYPT_SHA384_ALGORITHM,
+                &Sha384::digest(message),
+            )
+        },
+        SignatureScheme::RSA_PKCS1_SHA512 => unsafe {
+            sign_rsa_pkcs1(
+                key.handle,
+                BCRYPT_SHA512_ALGORITHM,
+                &Sha512::digest(message),
+            )
+        },
+        SignatureScheme::ECDSA_NISTP256_SHA256 => {
+            let hash = Sha256::digest(message);
+            let raw = unsafe { sign_hash(key.handle, None, &hash, NCRYPT_FLAGS::default()) }?;
+            der_encode_ecdsa_signature(&raw)
+        }
+        SignatureScheme::ECDSA_NISTP384_SHA384 => {
+            let hash = Sha384::digest(message);
+            let raw = unsafe { sign_hash(key.handle, None, &hash, NCRYPT_FLAGS::default()) }?;
+            der_encode_ecdsa_signature(&raw)
+        }
+        SignatureScheme::ECDSA_NISTP521_SHA512 => {
+            let hash = Sha512::digest(message);
+            let raw = unsafe { sign_hash(key.handle, None, &hash, NCRYPT_FLAGS::default()) }?;
+            der_encode_ecdsa_signature(&raw)
+        }
+        _ => bail!("Unsupported TLS signature scheme {scheme:?}"),
+    }
+}
+
+unsafe fn sign_rsa_pss(
+    key: NCRYPT_KEY_HANDLE,
+    hash_algorithm: windows_core::PCWSTR,
+    hash: &[u8],
+) -> Result<Vec<u8>> {
+    let padding = BCRYPT_PSS_PADDING_INFO {
+        pszAlgId: hash_algorithm,
+        cbSalt: hash.len() as u32,
+    };
+    unsafe {
+        sign_hash(
+            key,
+            Some((&raw const padding).cast()),
+            hash,
+            NCRYPT_PAD_PSS_FLAG,
+        )
+    }
+}
+
+unsafe fn sign_rsa_pkcs1(
+    key: NCRYPT_KEY_HANDLE,
+    hash_algorithm: windows_core::PCWSTR,
+    hash: &[u8],
+) -> Result<Vec<u8>> {
+    let padding = BCRYPT_PKCS1_PADDING_INFO {
+        pszAlgId: hash_algorithm,
+    };
+    unsafe {
+        sign_hash(
+            key,
+            Some((&raw const padding).cast()),
+            hash,
+            NCRYPT_PAD_PKCS1_FLAG,
+        )
+    }
+}
+
+unsafe fn sign_hash(
+    key: NCRYPT_KEY_HANDLE,
+    padding: Option<*const c_void>,
+    hash: &[u8],
+    flags: NCRYPT_FLAGS,
+) -> Result<Vec<u8>> {
+    let mut needed = 0;
+    unsafe { NCryptSignHash(key, padding, hash, None, &mut needed, flags) }
+        .context("NCryptSignHash size query failed")?;
+    let mut signature = vec![0; needed as usize];
+    let mut written = 0;
+    unsafe {
+        NCryptSignHash(
+            key,
+            padding,
+            hash,
+            Some(&mut signature),
+            &mut written,
+            flags,
+        )
+    }
+    .context("NCryptSignHash failed")?;
+    signature.truncate(written as usize);
+    Ok(signature)
+}
+
+fn der_encode_ecdsa_signature(raw: &[u8]) -> Result<Vec<u8>> {
+    if raw.is_empty() || !raw.len().is_multiple_of(2) {
+        bail!("Invalid raw ECDSA signature length: {}", raw.len());
+    }
+    let half = raw.len() / 2;
+    let r = der_integer(&raw[..half]);
+    let s = der_integer(&raw[half..]);
+    let mut output = vec![0x30];
+    encode_der_length(&mut output, r.len() + s.len());
+    output.extend(r);
+    output.extend(s);
+    Ok(output)
+}
+
+fn der_integer(value: &[u8]) -> Vec<u8> {
+    let first_nonzero = value
+        .iter()
+        .position(|byte| *byte != 0)
+        .unwrap_or(value.len().saturating_sub(1));
+    let value = &value[first_nonzero..];
+    let needs_padding = value.first().is_some_and(|byte| byte & 0x80 != 0);
+    let mut output = vec![0x02];
+    encode_der_length(&mut output, value.len() + usize::from(needs_padding));
+    if needs_padding {
+        output.push(0);
+    }
+    output.extend(value);
+    output
+}
+
+fn encode_der_length(output: &mut Vec<u8>, length: usize) {
+    if length < 0x80 {
+        output.push(length as u8);
+    } else if length < 0x100 {
+        output.extend([0x81, length as u8]);
+    } else {
+        output.extend([0x82, (length >> 8) as u8, length as u8]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_windows_key_storage() {
+        assert_eq!(
+            classify_private_key_storage(Some("Microsoft Platform Crypto Provider"), None),
+            "TPM (hardware-backed keystore)"
+        );
+        assert_eq!(
+            classify_private_key_storage(Some("Microsoft Software Key Storage Provider"), None),
+            "Software keystore"
+        );
+        assert_eq!(
+            classify_private_key_storage(Some("Third-party KSP"), Some(NCRYPT_IMPL_HARDWARE_FLAG)),
+            "Hardware-backed keystore"
+        );
+    }
+
+    #[test]
+    fn ecdsa_signature_is_der_encoded() {
+        let mut raw = vec![0; 64];
+        raw[31] = 1;
+        raw[63] = 2;
+        assert_eq!(
+            der_encode_ecdsa_signature(&raw).expect("signature should encode"),
+            vec![0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02]
+        );
+    }
+}

--- a/rust/libs/device-trust/src/windows.rs
+++ b/rust/libs/device-trust/src/windows.rs
@@ -52,6 +52,11 @@ pub(crate) fn status(_config: &Config, subject_cn: &str) -> Result<Status> {
         .iter()
         .filter(|certificate| certificate.usable)
         .count();
+    let user_identity = certificates
+        .iter()
+        .filter(|certificate| certificate.usable)
+        .max_by_key(|certificate| certificate.metadata.not_before_timestamp)
+        .and_then(|certificate| certificate.metadata.user_identity());
     let mut sections = vec![DetailSection {
         title: "Windows Certificate Store".to_owned(),
         fields: vec![
@@ -79,7 +84,7 @@ pub(crate) fn status(_config: &Config, subject_cn: &str) -> Result<Status> {
                 },
             ),
             field(
-                "Usable for Device Attestation",
+                "Usable for Mutual TLS",
                 if certificate.usable { "Yes" } else { "No" },
             ),
         ];
@@ -121,14 +126,18 @@ pub(crate) fn status(_config: &Config, subject_cn: &str) -> Result<Status> {
             "No X.509 certificate with subject CN '{subject_cn}' was found in the Windows certificate stores."
         ),
         (0, count) => format!(
-            "Found {count} matching X.509 certificate(s), but none are usable for device attestation."
+            "Found {count} matching X.509 certificate(s), but none are usable for mutual TLS."
         ),
-        (count, _) => format!(
-            "{count} X.509 device identity certificate(s) are available for device attestation."
-        ),
+        (count, _) => {
+            format!("{count} X.509 device identity certificate(s) are available for mutual TLS.")
+        }
     };
 
-    Ok(Status { summary, sections })
+    Ok(Status {
+        summary,
+        sections,
+        user_identity,
+    })
 }
 
 pub(crate) fn identity(_config: &Config, subject_cn: &str) -> Result<Option<PlatformIdentity>> {
@@ -140,12 +149,18 @@ pub(crate) fn identity(_config: &Config, subject_cn: &str) -> Result<Option<Plat
         );
     }
 
+    if certificates.is_empty() {
+        return Ok(None);
+    }
+    let matching_count = certificates.len();
     let Some(certificate) = certificates
         .into_iter()
-        .filter(|certificate| certificate.metadata.is_usable(subject_cn))
+        .filter(|certificate| certificate.usable)
         .max_by_key(|certificate| certificate.metadata.not_before_timestamp)
     else {
-        return Ok(None);
+        bail!(
+            "Found {matching_count} Windows X.509 certificate(s) with subject CN '{subject_cn}', but none have a usable CNG private key and mutual-TLS certificate policy"
+        );
     };
     let algorithm = certificate
         .metadata
@@ -176,6 +191,7 @@ pub(crate) fn identity(_config: &Config, subject_cn: &str) -> Result<Option<Plat
     Ok(Some(PlatformIdentity {
         certified_key: Arc::new(CertifiedKey::new(chain, signing_key)),
         mdm_device_id: certificate.metadata.mdm_device_id.clone(),
+        user_identity: certificate.metadata.user_identity(),
     }))
 }
 
@@ -241,7 +257,11 @@ struct WindowsSigner {
 impl Signer for WindowsSigner {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
         unsafe { sign_with_certificate(self.context.0, self.scheme, message) }.map_err(|error| {
-            rustls::Error::General(format!("Windows TLS signing failed: {error:#}"))
+            rustls::Error::Other(rustls::OtherError(Arc::new(
+                phoenix_channel::ClientCertificateSigningError(format!(
+                    "Windows TLS signing failed: {error:#}"
+                )),
+            )))
         })
     }
 

--- a/rust/libs/telemetry/src/analytics.rs
+++ b/rust/libs/telemetry/src/analytics.rs
@@ -27,6 +27,17 @@ pub fn new_session(maybe_legacy_id: String, api_url: String) {
 
 /// Associate several properties with the current telemetry user.
 pub fn identify(release: String, account_slug: Option<String>) {
+    identify_with_user(release, account_slug, None, None);
+}
+
+/// Associates certificate-derived account and actor attributes with the current
+/// installation without pretending either value is an account slug.
+pub fn identify_with_user(
+    release: String,
+    account_slug: Option<String>,
+    account_id: Option<String>,
+    actor_email: Option<String>,
+) {
     let Some(env) = current_env() else {
         tracing::debug!("Cannot send $identify: Unknown env");
         return;
@@ -46,6 +57,8 @@ pub fn identify(release: String, account_slug: Option<String>) {
                     set: PersonProperties {
                         release,
                         account_slug,
+                        account_id,
+                        actor_email,
                         os: std::env::consts::OS.to_owned(),
                     },
                 },
@@ -155,6 +168,10 @@ struct PersonProperties {
     release: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     account_slug: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    account_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    actor_email: Option<String>,
     #[serde(rename = "$os")]
     os: String,
 }

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -319,6 +319,24 @@ pub fn set_firezone_id(firezone_id: String) {
     feature_flags::reevaluate_current();
 }
 
+/// Attaches the MDM's device identifier to the active Sentry session.
+///
+/// This identifier comes from the client certificate and allows an event to be
+/// correlated with the device attested by the Portal even when multiple
+/// installations share a Firezone ID.
+pub fn set_mdm_device_id(mdm_device_id: Option<String>) {
+    let _ = STATE.try_write(|state| state.set_mdm_device_id(mdm_device_id.clone()));
+
+    update_user(|user| match mdm_device_id {
+        Some(id) => {
+            user.other.insert("mdm_device_id".to_owned(), id.into());
+        }
+        None => {
+            user.other.remove("mdm_device_id");
+        }
+    });
+}
+
 #[doc(hidden)] // Only public for testing.
 pub fn current_env() -> Option<Env> {
     STATE.try_read(|state| state.env()).ok().flatten()
@@ -332,6 +350,11 @@ pub fn current_user() -> Option<String> {
 #[doc(hidden)] // Only public for testing.
 pub fn current_account_slug() -> Option<String> {
     STATE.try_read(|state| state.account_slug()).ok().flatten()
+}
+
+#[doc(hidden)] // Only public for testing.
+pub fn current_mdm_device_id() -> Option<String> {
+    STATE.try_read(|state| state.mdm_device_id()).ok().flatten()
 }
 
 /// The identity feature flags are evaluated for: the current user and environment.

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -296,10 +296,52 @@ pub fn is_active() -> bool {
 }
 
 pub fn set_account_slug(slug: String) {
-    let _ = STATE.try_write(|state| state.set_account_slug(slug.clone()));
+    set_account_slug_or_clear(Some(slug));
+}
+
+pub fn set_account_slug_or_clear(slug: Option<String>) {
+    let _ = STATE.try_write(|state| state.set_account_slug_or_clear(slug.clone()));
+
+    update_user(|user| match slug {
+        Some(slug) => {
+            user.other.insert("account_slug".to_owned(), slug.into());
+        }
+        None => {
+            user.other.remove("account_slug");
+        }
+    });
+}
+
+/// Attaches the account UUID read from a managed certificate.
+pub fn set_account_id(account_id: Option<String>) {
+    let _ = STATE.try_write(|state| state.set_account_id(account_id.clone()));
+
+    update_user(|user| match account_id {
+        Some(account_id) => {
+            user.other
+                .insert("account_id".to_owned(), account_id.into());
+        }
+        None => {
+            user.other.remove("account_id");
+        }
+    });
+}
+
+/// Attaches the actor email read from a managed certificate.
+pub fn set_actor_email(actor_email: Option<String>) {
+    let _ = STATE.try_write(|state| state.set_actor_email(actor_email.clone()));
 
     update_user(|user| {
-        user.other.insert("account_slug".to_owned(), slug.into());
+        user.email.clone_from(&actor_email);
+        match actor_email {
+            Some(actor_email) => {
+                user.other
+                    .insert("actor_email".to_owned(), actor_email.into());
+            }
+            None => {
+                user.other.remove("actor_email");
+            }
+        }
     });
 }
 
@@ -350,6 +392,16 @@ pub fn current_user() -> Option<String> {
 #[doc(hidden)] // Only public for testing.
 pub fn current_account_slug() -> Option<String> {
     STATE.try_read(|state| state.account_slug()).ok().flatten()
+}
+
+#[doc(hidden)] // Only public for testing.
+pub fn current_account_id() -> Option<String> {
+    STATE.try_read(|state| state.account_id()).ok().flatten()
+}
+
+#[doc(hidden)] // Only public for testing.
+pub fn current_actor_email() -> Option<String> {
+    STATE.try_read(|state| state.actor_email()).ok().flatten()
 }
 
 #[doc(hidden)] // Only public for testing.
@@ -455,27 +507,43 @@ fn append_tracing_fields_to_message(mut log: Log) -> Log {
     log
 }
 
-fn insert_user_account_slug_into_log(mut log: Log) -> Log {
-    let Some(account_slug) = current_account_slug() else {
-        return log;
-    };
-
-    log.attributes.insert(
-        "user.account_slug".to_owned(),
-        LogAttribute::from(account_slug),
-    );
+fn insert_user_attributes_into_log(mut log: Log) -> Log {
+    if let Some(account_slug) = current_account_slug() {
+        log.attributes.insert(
+            "user.account_slug".to_owned(),
+            LogAttribute::from(account_slug),
+        );
+    }
+    if let Some(account_id) = current_account_id() {
+        log.attributes
+            .insert("user.account_id".to_owned(), LogAttribute::from(account_id));
+    }
+    if let Some(actor_email) = current_actor_email() {
+        log.attributes.insert(
+            "user.actor_email".to_owned(),
+            LogAttribute::from(actor_email),
+        );
+    }
 
     log
 }
 
-fn insert_user_account_slug_into_metric(mut metric: Metric) -> Metric {
-    let Some(account_slug) = current_account_slug() else {
-        return metric;
-    };
-
-    metric
-        .attributes
-        .insert("user.account_slug".into(), LogAttribute::from(account_slug));
+fn insert_user_attributes_into_metric(mut metric: Metric) -> Metric {
+    if let Some(account_slug) = current_account_slug() {
+        metric
+            .attributes
+            .insert("user.account_slug".into(), LogAttribute::from(account_slug));
+    }
+    if let Some(account_id) = current_account_id() {
+        metric
+            .attributes
+            .insert("user.account_id".into(), LogAttribute::from(account_id));
+    }
+    if let Some(actor_email) = current_actor_email() {
+        metric
+            .attributes
+            .insert("user.actor_email".into(), LogAttribute::from(actor_email));
+    }
 
     metric
 }

--- a/rust/libs/telemetry/src/sentry.rs
+++ b/rust/libs/telemetry/src/sentry.rs
@@ -51,13 +51,13 @@ pub(crate) fn init_sdk_client(
             enable_logs: true,
             enable_metrics: true,
             before_send_log: Some(Arc::new(|log| {
-                let log = crate::insert_user_account_slug_into_log(log);
+                let log = crate::insert_user_attributes_into_log(log);
                 let log = crate::append_tracing_fields_to_message(log);
 
                 Some(log)
             })),
             before_send_metric: Some(Arc::new(|metric| {
-                let metric = crate::insert_user_account_slug_into_metric(metric);
+                let metric = crate::insert_user_attributes_into_metric(metric);
                 let metric = crate::insert_feature_flags_into_metric(metric);
 
                 Some(metric)

--- a/rust/libs/telemetry/src/state.rs
+++ b/rust/libs/telemetry/src/state.rs
@@ -33,6 +33,8 @@ pub(crate) struct State {
     env: Option<Env>,
     firezone_id: Option<String>,
     account_slug: Option<String>,
+    account_id: Option<String>,
+    actor_email: Option<String>,
     mdm_device_id: Option<String>,
     sentry_guard: Option<sentry::ClientInitGuard>,
 }
@@ -43,6 +45,8 @@ impl State {
             env: None,
             firezone_id: None,
             account_slug: None,
+            account_id: None,
+            actor_email: None,
             mdm_device_id: None,
             sentry_guard: None,
         }
@@ -58,6 +62,14 @@ impl State {
 
     pub(crate) fn account_slug(&self) -> Option<String> {
         self.account_slug.clone()
+    }
+
+    pub(crate) fn account_id(&self) -> Option<String> {
+        self.account_id.clone()
+    }
+
+    pub(crate) fn actor_email(&self) -> Option<String> {
+        self.actor_email.clone()
     }
 
     pub(crate) fn mdm_device_id(&self) -> Option<String> {
@@ -82,8 +94,16 @@ impl State {
         self.env = env;
     }
 
-    pub(crate) fn set_account_slug(&mut self, slug: String) {
-        self.account_slug = Some(slug);
+    pub(crate) fn set_account_slug_or_clear(&mut self, slug: Option<String>) {
+        self.account_slug = slug;
+    }
+
+    pub(crate) fn set_account_id(&mut self, account_id: Option<String>) {
+        self.account_id = account_id;
+    }
+
+    pub(crate) fn set_actor_email(&mut self, actor_email: Option<String>) {
+        self.actor_email = actor_email;
     }
 
     pub(crate) fn set_firezone_id(&mut self, firezone_id: Option<String>) {
@@ -107,6 +127,8 @@ impl State {
     pub(crate) fn clear_identity(&mut self) {
         self.firezone_id = None;
         self.account_slug = None;
+        self.account_id = None;
+        self.actor_email = None;
         self.mdm_device_id = None;
     }
 }

--- a/rust/libs/telemetry/src/state.rs
+++ b/rust/libs/telemetry/src/state.rs
@@ -33,6 +33,7 @@ pub(crate) struct State {
     env: Option<Env>,
     firezone_id: Option<String>,
     account_slug: Option<String>,
+    mdm_device_id: Option<String>,
     sentry_guard: Option<sentry::ClientInitGuard>,
 }
 
@@ -42,6 +43,7 @@ impl State {
             env: None,
             firezone_id: None,
             account_slug: None,
+            mdm_device_id: None,
             sentry_guard: None,
         }
     }
@@ -56,6 +58,10 @@ impl State {
 
     pub(crate) fn account_slug(&self) -> Option<String> {
         self.account_slug.clone()
+    }
+
+    pub(crate) fn mdm_device_id(&self) -> Option<String> {
+        self.mdm_device_id.clone()
     }
 
     /// Whether a Sentry session is currently active.
@@ -84,6 +90,10 @@ impl State {
         self.firezone_id = firezone_id;
     }
 
+    pub(crate) fn set_mdm_device_id(&mut self, mdm_device_id: Option<String>) {
+        self.mdm_device_id = mdm_device_id;
+    }
+
     pub(crate) fn set_guard(&mut self, guard: sentry::ClientInitGuard) {
         self.sentry_guard = Some(guard);
     }
@@ -97,6 +107,7 @@ impl State {
     pub(crate) fn clear_identity(&mut self) {
         self.firezone_id = None;
         self.account_slug = None;
+        self.mdm_device_id = None;
     }
 }
 

--- a/rust/libs/telemetry/tests/set_account_before_id.rs
+++ b/rust/libs/telemetry/tests/set_account_before_id.rs
@@ -8,8 +8,16 @@ async fn set_account_slug_before_set_firezone_id_preserves_both() {
     telemetry::start("entrypoint", "1.0.0", TESTING);
 
     telemetry::set_account_slug("acme".to_owned());
+    telemetry::set_mdm_device_id(Some("intune-device-123".to_owned()));
     telemetry::set_firezone_id("device-xyz".to_owned());
 
     assert_eq!(telemetry::current_user().as_deref(), Some("device-xyz"));
     assert_eq!(telemetry::current_account_slug().as_deref(), Some("acme"));
+    assert_eq!(
+        telemetry::current_mdm_device_id().as_deref(),
+        Some("intune-device-123")
+    );
+
+    telemetry::set_mdm_device_id(None);
+    assert_eq!(telemetry::current_mdm_device_id(), None);
 }

--- a/rust/libs/telemetry/tests/set_account_before_id.rs
+++ b/rust/libs/telemetry/tests/set_account_before_id.rs
@@ -9,15 +9,31 @@ async fn set_account_slug_before_set_firezone_id_preserves_both() {
 
     telemetry::set_account_slug("acme".to_owned());
     telemetry::set_mdm_device_id(Some("intune-device-123".to_owned()));
+    telemetry::set_account_id(Some("5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3".to_owned()));
+    telemetry::set_actor_email(Some("alice@example.com".to_owned()));
     telemetry::set_firezone_id("device-xyz".to_owned());
 
     assert_eq!(telemetry::current_user().as_deref(), Some("device-xyz"));
     assert_eq!(telemetry::current_account_slug().as_deref(), Some("acme"));
+    assert_eq!(
+        telemetry::current_account_id().as_deref(),
+        Some("5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3")
+    );
+    assert_eq!(
+        telemetry::current_actor_email().as_deref(),
+        Some("alice@example.com")
+    );
     assert_eq!(
         telemetry::current_mdm_device_id().as_deref(),
         Some("intune-device-123")
     );
 
     telemetry::set_mdm_device_id(None);
+    telemetry::set_account_slug_or_clear(None);
+    telemetry::set_account_id(None);
+    telemetry::set_actor_email(None);
     assert_eq!(telemetry::current_mdm_device_id(), None);
+    assert_eq!(telemetry::current_account_slug(), None);
+    assert_eq!(telemetry::current_account_id(), None);
+    assert_eq!(telemetry::current_actor_email(), None);
 }

--- a/scripts/device-trust/generate-linux-tpm-csr.sh
+++ b/scripts/device-trust/generate-linux-tpm-csr.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly default_store=/etc/tpm2_pkcs11
+readonly default_state_dir=/etc/firezone
+readonly store=${FIREZONE_TPM2_PKCS11_STORE:-$default_store}
+readonly state_dir=${FIREZONE_TPM2_PKCS11_STATE_DIR:-$default_state_dir}
+readonly pin_file="$state_dir/pkcs11-pin"
+readonly so_pin_file="$state_dir/pkcs11-so-pin"
+readonly primary_id_file="$state_dir/tpm2-pkcs11-primary-id"
+readonly token_label=Firezone
+readonly key_label=device-trust
+readonly key_id=666972657a6f6e65
+
+usage() {
+    echo "Usage: sudo $0 DEVICE_ID [CSR_PATH]" >&2
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    usage
+    exit 2
+fi
+
+readonly device_id=$1
+readonly csr_path=${2:-firezone-device.csr}
+
+if [[ ! $device_id =~ ^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$ ]]; then
+    echo "DEVICE_ID must be a UUID assigned by the enrollment administrator." >&2
+    exit 2
+fi
+
+if [[ -e $csr_path ]]; then
+    echo "Refusing to overwrite $csr_path" >&2
+    exit 1
+fi
+
+if [[ $EUID -ne 0 && $store == "$default_store" && $state_dir == "$default_state_dir" ]]; then
+    echo "Run this script with sudo." >&2
+    exit 1
+fi
+
+for required_command in dpkg openssl tpm2_ptool; do
+    if ! command -v "$required_command" >/dev/null; then
+        echo "Missing $required_command. Install the Ubuntu packages listed in the Firezone README." >&2
+        exit 1
+    fi
+done
+
+module_path=$(dpkg -L libtpm2-pkcs11-1 2>/dev/null | awk '/\/libtpm2_pkcs11\.so$/ { print; exit }')
+if [[ -z $module_path || ! -r $module_path ]]; then
+    echo "Could not find libtpm2_pkcs11.so. Install libtpm2-pkcs11-1." >&2
+    exit 1
+fi
+readonly module_path
+
+umask 077
+install -d -m 0700 "$store" "$state_dir"
+
+if [[ ! -f $store/tpm2_pkcs11.sqlite3 ]]; then
+    user_pin=$(openssl rand -hex 16)
+    so_pin=$(openssl rand -hex 16)
+    printf '%s' "$user_pin" >"$pin_file"
+    printf '%s' "$so_pin" >"$so_pin_file"
+    chmod 0600 "$pin_file" "$so_pin_file"
+
+    init_output=$(tpm2_ptool init \
+        --path "$store" \
+        --transient-parent tpm2-tools-ecc-default)
+    primary_id=$(awk '$1 == "id:" { print $2; exit }' <<<"$init_output")
+    if [[ -z $primary_id ]]; then
+        echo "Could not determine the TPM2-PKCS11 primary ID." >&2
+        exit 1
+    fi
+    printf '%s\n' "$primary_id" >"$primary_id_file"
+fi
+
+for state_file in "$pin_file" "$so_pin_file" "$primary_id_file"; do
+    if [[ ! -r $state_file ]]; then
+        echo "Missing TPM2-PKCS11 state file: $state_file" >&2
+        exit 1
+    fi
+done
+
+user_pin=$(<"$pin_file")
+so_pin=$(<"$so_pin_file")
+primary_id=$(<"$primary_id_file")
+
+token_output=$(tpm2_ptool listtokens --path "$store" --pid "$primary_id")
+if ! grep -Fq "label: $token_label" <<<"$token_output"; then
+    tpm2_ptool addtoken \
+        --path "$store" \
+        --pid "$primary_id" \
+        --label "$token_label" \
+        --sopin "$so_pin" \
+        --userpin "$user_pin"
+fi
+
+object_output=$(tpm2_ptool listobjects --path "$store" --label "$token_label")
+if ! grep -Fq "CKA_LABEL: $key_label" <<<"$object_output"; then
+    tpm2_ptool addkey \
+        --path "$store" \
+        --label "$token_label" \
+        --key-label "$key_label" \
+        --id "$key_id" \
+        --algorithm ecc256 \
+        --userpin "$user_pin"
+fi
+
+readonly key_uri="pkcs11:token=$token_label;object=$key_label;type=private?pin-source=file:$pin_file"
+
+PKCS11_MODULE_PATH="$module_path" \
+    TPM2_PKCS11_STORE="$store" \
+    openssl req \
+    -new \
+    -batch \
+    -sha256 \
+    -engine pkcs11 \
+    -keyform engine \
+    -key "$key_uri" \
+    -subj "/CN=dev.firezone.device-trust" \
+    -addext "keyUsage=critical,digitalSignature" \
+    -addext "extendedKeyUsage=clientAuth" \
+    -addext "subjectAltName=URI:$device_id" \
+    -out "$csr_path"
+
+openssl req -in "$csr_path" -noout -verify
+
+if [[ -n ${SUDO_UID:-} && -n ${SUDO_GID:-} ]]; then
+    chown "$SUDO_UID:$SUDO_GID" "$csr_path"
+fi
+
+echo "CSR written to $csr_path"


### PR DESCRIPTION
Depends on #14527. The portal mTLS work in #14507 is merged.

## Summary

- authenticates Windows and Linux GUI and headless clients through the `/client/v2` mTLS endpoint
- follows the Apple/Android architecture for certificate user authentication: one unambiguous `firezone://email/...` URI SAN plus one `firezone://account-id/...` URI SAN makes the certificate identity take precedence over a saved token
- omits `X-Authorization` for certificate-authenticated sessions, distinguishes tokenless certificate rejection from an invalid bearer token, and treats platform signing failures as terminal
- shows `Connect as alice@example.com` while disconnected and `Connected as ...` / `Disconnect` during certificate-authenticated GUI sessions
- exposes Actor Email, Account ID, MDM Device ID, Device Serial, raw SANs, certificate metadata, and private-key provider/location in a dedicated GUI X.509 Identity tab and the headless `x509` command
- coalesces concurrent X.509 diagnostic requests so the X.509 view no longer reports that another request is already in progress
- discovers Windows identities in `LocalMachine\My` and `CurrentUser\My`, signs through CNG, and reports whether the CNG provider is hardware/TPM- or software-backed
- uses RFC 7512 PKCS#11 identities on Linux without exporting private-key material and includes a TPM/PKCS#11 CSR helper
- chooses the newest usable certificate by `notBefore`, fails closed for unusable configured identities, and refreshes identity metadata after certificate revocation

## Validation

- device-trust tests: 10 passed
- Phoenix channel tests: 43 passed
- telemetry tests: 24 passed
- client-shared tests: 4 passed
- GUI library tests: 47 passed; GUI/tunnel binary tests also passed; the pre-existing IPC panic-recovery test was excluded because it hangs on the macOS host
- headless tests: 21 passed
- GUI ESLint, TypeScript checking, and production build passed
- Clippy passed with warnings denied across device-trust, Phoenix channel, telemetry, GUI, headless, and client-shared targets
- `cargo fmt --check` and `git diff --check` passed

The branch is rebased onto `origin/main` at `616d48e47`. Windows and Linux target builds could not run on the macOS host because the Windows SDK and a Linux builder/toolchain are unavailable. Live validation is still required with a Windows CNG/TPM identity and a Linux PKCS#11 token.