### PR TITLE
fix(apple): don't renotify unreachable resources

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -54,13 +54,20 @@ public enum IPCClient {
   }
 
   @MainActor
-  static func fetchState(
+  static func pollUpdates(
     session: any TunnelSessionProtocol, currentHash: Data
-  ) async throws -> Data? {
-    let message = ProviderMessage.getState(currentHash)
+  ) async throws -> StatePollResponse {
+    let message = ProviderMessage.pollUpdates(StatePollRequest(stateHash: currentHash))
 
-    // Get data from the provider - if hash matches, provider returns nil
-    return try await sendProviderMessage(session: session, message: message)
+    guard let data = try await sendProviderMessage(session: session, message: message) else {
+      throw Error.noIPCData
+    }
+
+    guard let response = try? decoder.decode(StatePollResponse.self, from: data) else {
+      throw Error.decodeIPCDataFailed
+    }
+
+    return response
   }
 
   @MainActor

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -37,7 +37,7 @@
     #endif
   }
 
-  /// Answers `getState` with the canned snapshot and reports a connected tunnel.
+  /// Answers `pollUpdates` with the canned snapshot and reports a connected tunnel.
   private final class MockTunnelSession: TunnelSessionProtocol {
     var status: NEVPNStatus { .connected }
 
@@ -64,19 +64,27 @@
       // Listed exhaustively (no `default`) so adding a `ProviderMessage` variant
       // fails to compile here and forces a decision about the mock's response.
       switch message {
-      case .getState(let currentHash):
+      case .pollUpdates(let request):
         do {
+          let state = ConnlibState(
+            resources: MockFixtures.resources,
+            connectedDevices: MockFixtures.connectedDevices,
+            isLogStreamingActive: false
+          )
+          let stateHash = try state.contentHash()
+          let stateChanged = stateHash != request.stateHash
+
           responseHandler(
-            try ConnlibState.encodeIfChanged(
-              resources: MockFixtures.resources,
-              connectedDevices: MockFixtures.connectedDevices,
-              unreachableResources: [],
-              isLogStreamingActive: false,
-              comparedTo: currentHash
+            try PropertyListEncoder().encode(
+              StatePollResponse(
+                state: stateChanged ? state : nil,
+                stateHash: stateChanged ? stateHash : nil,
+                notifications: []
+              )
             )
           )
         } catch {
-          Log.warning("MockTunnelSession: failed to encode ConnlibState: \(error)")
+          Log.warning("MockTunnelSession: failed to encode state updates: \(error)")
           responseHandler(nil)
         }
       case .setInternetResourceEnabled, .signOut, .clearLogs, .getLogFolderSize, .exportLogs,

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnlibState.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnlibState.swift
@@ -11,25 +11,21 @@ public struct ConnlibState: Encodable, Decodable {
   // swiftlint:disable:next discouraged_optional_collection
   public let resources: [FirezoneKit.Resource]?
   public let connectedDevices: [FirezoneKit.ConnectedDevice]
-  public let unreachableResources: [UnreachableResource]
   public let isLogStreamingActive: Bool
 
   private enum CodingKeys: String, CodingKey {
     case resources
     case connectedDevices
-    case unreachableResources
     case isLogStreamingActive
   }
 
-  private init(
+  public init(
     resources: [FirezoneKit.Resource]?,  // swiftlint:disable:this discouraged_optional_collection
     connectedDevices: [FirezoneKit.ConnectedDevice],
-    unreachableResources: [UnreachableResource],
     isLogStreamingActive: Bool
   ) {
     self.resources = resources
     self.connectedDevices = connectedDevices
-    self.unreachableResources = unreachableResources
     self.isLogStreamingActive = isLogStreamingActive
   }
 
@@ -39,51 +35,40 @@ public struct ConnlibState: Encodable, Decodable {
     connectedDevices =
       try container.decodeIfPresent([FirezoneKit.ConnectedDevice].self, forKey: .connectedDevices)
       ?? []
-    unreachableResources = try container.decode(
-      [UnreachableResource].self, forKey: .unreachableResources)
     isLogStreamingActive =
       try container.decodeIfPresent(Bool.self, forKey: .isLogStreamingActive) ?? false
   }
 
-  private static let encoder = PropertyListEncoder()
-  private static let decoder = PropertyListDecoder()
-
-  /// Decodes a ConnlibState from data and returns the state and its SHA256 hash.
-  /// - Parameter data: The encoded data to decode
-  /// - Returns: A tuple of the decoded state and its hash
-  /// - Throws: If decoding fails
-  public static func decode(from data: Data) throws -> (ConnlibState, Data) {
-    let hash = Data(SHA256.hash(data: data))
-    let state = try Self.decoder.decode(ConnlibState.self, from: data)
-    return (state, hash)
+  /// A stable content hash used to avoid sending an unchanged snapshot on every poll.
+  public func contentHash() throws -> Data {
+    let encodedData = try PropertyListEncoder().encode(self)
+    return Data(SHA256.hash(data: encodedData))
   }
+}
 
-  /// Creates a ConnlibState from resources and returns encoded data only if different from currentHash
-  /// - Parameters:
-  ///   - resources: Optional array of resources
-  ///   - connectedDevices: Peer devices with a live connection
-  ///   - unreachableResources: Set of unreachable resources
-  ///   - isLogStreamingActive: Whether the NE has log streaming enabled
-  ///   - currentHash: The hash to compare against
-  /// - Returns: The encoded data if the hash differs, nil otherwise
-  /// - Throws: If encoding fails
-  public static func encodeIfChanged(
-    resources: [FirezoneKit.Resource]?,  // swiftlint:disable:this discouraged_optional_collection
-    connectedDevices: [FirezoneKit.ConnectedDevice],
-    unreachableResources: [UnreachableResource],
-    isLogStreamingActive: Bool,
-    comparedTo currentHash: Data
-  ) throws -> Data? {
-    let state = ConnlibState(
-      resources: resources, connectedDevices: connectedDevices,
-      unreachableResources: unreachableResources,
-      isLogStreamingActive: isLogStreamingActive)
-    let encodedData = try Self.encoder.encode(state)
-    let newHash = Data(SHA256.hash(data: encodedData))
+public struct StatePollRequest: Codable, Sendable {
+  public let stateHash: Data
 
-    return newHash == currentHash ? nil : encodedData
+  public init(stateHash: Data) {
+    self.stateHash = stateHash
   }
+}
 
+public struct StatePollResponse: Codable {
+  // `state` and `stateHash` are both nil when the snapshot has not changed.
+  public let state: ConnlibState?
+  public let stateHash: Data?
+  public let notifications: [UnreachableResource]
+
+  public init(
+    state: ConnlibState?,
+    stateHash: Data?,
+    notifications: [UnreachableResource]
+  ) {
+    self.state = state
+    self.stateHash = stateHash
+    self.notifications = notifications
+  }
 }
 
 public enum UnreachableReason: Hashable, Encodable, Decodable {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ProviderMessage.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ProviderMessage.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public enum ProviderMessage: Codable {
-  case getState(Data)
+  case pollUpdates(StatePollRequest)
   case setInternetResourceEnabled(Bool)
   case signOut
   case clearLogs
@@ -23,7 +23,7 @@ public enum ProviderMessage: Codable {
   }
 
   enum MessageType: String, Codable {
-    case getState
+    case pollUpdates
     case setInternetResourceEnabled
     case signOut
     case clearLogs
@@ -37,9 +37,9 @@ public enum ProviderMessage: Codable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let type = try container.decode(MessageType.self, forKey: .type)
     switch type {
-    case .getState:
-      let value = try container.decode(Data.self, forKey: .value)
-      self = .getState(value)
+    case .pollUpdates:
+      let value = try container.decode(StatePollRequest.self, forKey: .value)
+      self = .pollUpdates(value)
     case .setInternetResourceEnabled:
       let value = try container.decode(Bool.self, forKey: .value)
       self = .setInternetResourceEnabled(value)
@@ -61,8 +61,8 @@ public enum ProviderMessage: Codable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     switch self {
-    case .getState(let value):
-      try container.encode(MessageType.getState, forKey: .type)
+    case .pollUpdates(let value):
+      try container.encode(MessageType.pollUpdates, forKey: .type)
       try container.encode(value, forKey: .value)
     case .setInternetResourceEnabled(let value):
       try container.encode(MessageType.setInternetResourceEnabled, forKey: .type)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -82,9 +82,6 @@ public final class Store: ObservableObject {
   // Track which session expired alerts have been shown to prevent duplicates
   private var shownAlertIds: Set<String>
 
-  // Track which unreachable resource notifications we have already shown
-  private var unreachableResources: Set<UnreachableResource> = []
-
   /// UserDefaults instance for persisting GUI state.
   let userDefaults: UserDefaults
 
@@ -550,9 +547,6 @@ public final class Store: ObservableObject {
     shownAlertIds.removeAll()
     userDefaults.removeObject(forKey: "shownAlertIds")
 
-    // Clear notified unreachable resources for fresh session
-    unreachableResources.removeAll()
-
     // Bring the tunnel up and send it a token to start
     guard let session = try manager().session() else {
       throw VPNConfigurationManagerError.managerNotInitialized
@@ -657,7 +651,6 @@ public final class Store: ObservableObject {
     stateUpdateTask = nil
     resourceList = ResourceList.loading
     connlibStateHash = Data()
-    unreachableResources.removeAll()
     connectedDevices.removeAll()
     Log.setStreamingActive(false)
   }
@@ -735,15 +728,10 @@ public final class Store: ObservableObject {
 
     connectedDevices = state.connectedDevices
 
-    let newlyUnreachableResources = Set(state.unreachableResources).subtracting(
-      self.unreachableResources)
-
     await showNotificationsForUnreachableResources(
-      unreachableResources: newlyUnreachableResources,
+      unreachableResources: Set(state.unreachableResources),
       resources: state.resources ?? []
     )
-
-    self.unreachableResources = Set(state.unreachableResources)
   }
 
   private func showNotificationsForUnreachableResources(

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -28,8 +28,8 @@ public final class Store: ObservableObject {
   // Encapsulate Tunnel status here to make it easier for other components to observe
   @Published public private(set) var vpnStatus: NEVPNStatus?
 
-  // Hash for resource list optimisation
-  private var connlibStateHash = Data()
+  // Hash of the last tunnel state snapshot received from the network extension.
+  private var tunnelStateHash = Data()
 
   // User notifications
   @Published private(set) var decision: UNAuthorizationStatus?
@@ -613,7 +613,7 @@ public final class Store: ObservableObject {
 
       while !Task.isCancelled {
         do {
-          try await self.pollStateOnce()
+          try await self.pollUpdatesOnce()
           didReload = false
         } catch is CancellationError {
           break
@@ -650,7 +650,7 @@ public final class Store: ObservableObject {
     stateUpdateTask?.cancel()
     stateUpdateTask = nil
     resourceList = ResourceList.loading
-    connlibStateHash = Data()
+    tunnelStateHash = Data()
     connectedDevices.removeAll()
     Log.setStreamingActive(false)
   }
@@ -687,50 +687,35 @@ public final class Store: ObservableObject {
     }
   #endif
 
-  private func pollStateOnce() async throws {
+  private func pollUpdatesOnce() async throws {
     guard let session = try self.manager().session() else { return }
-    try await self.fetchState(session: session)
-  }
-
-  /// Fetches state from the tunnel provider, using hash-based optimisation.
-  ///
-  /// If the hash matches what the provider has, state is unchanged.
-  /// Otherwise, fetches and caches the new state.
-  ///
-  /// - Parameter session: The tunnel provider session to communicate with
-  /// - Throws: IPCClient.Error if IPC communication fails
-  private func fetchState(session: any TunnelSessionProtocol) async throws {
-    // Capture current hash before IPC call
-    let currentHash = self.connlibStateHash
-
-    // If no data returned, state hasn't changed - no update needed
-    guard let data = try await IPCClient.fetchState(session: session, currentHash: currentHash)
-    else {
-      return
-    }
+    let response = try await IPCClient.pollUpdates(
+      session: session,
+      currentHash: tunnelStateHash
+    )
 
     try Task.checkCancellation()
 
     guard vpnStatus == .connected else { return }
 
-    // Decode state and compute hash
-    let (state, hash) = try ConnlibState.decode(from: data)
+    if let state = response.state {
+      guard let stateHash = response.stateHash else {
+        throw IPCClient.Error.decodeIPCDataFailed
+      }
 
-    // Update both hash and resource list
-    self.connlibStateHash = hash
+      tunnelStateHash = stateHash
+      Log.setStreamingActive(state.isLogStreamingActive)
 
-    // Propagate log streaming state from the NE to the main app process
-    Log.setStreamingActive(state.isLogStreamingActive)
+      if let resources = state.resources {
+        resourceList = ResourceList.loaded(resources)
+      }
 
-    if let resources = state.resources {
-      resourceList = ResourceList.loaded(resources)
+      connectedDevices = state.connectedDevices
     }
 
-    connectedDevices = state.connectedDevices
-
     await showNotificationsForUnreachableResources(
-      unreachableResources: Set(state.unreachableResources),
-      resources: state.resources ?? []
+      unreachableResources: Set(response.notifications),
+      resources: resourceList.asArray()
     )
   }
 

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConfigurationTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConfigurationTests.swift
@@ -667,6 +667,7 @@ struct ProviderMessageCodableTests {
   func valuelessCasesRoundTrip() throws {
     let cases: [ProviderMessage] = [
       .signOut, .clearLogs, .getLogFolderSize, .exportLogs, .getEncodedFirezoneId,
+      .drainFlowLogs,
     ]
 
     for message in cases {
@@ -677,15 +678,15 @@ struct ProviderMessageCodableTests {
     }
   }
 
-  @Test("getState round-trips through JSON")
-  func getStateRoundTrip() throws {
+  @Test("pollUpdates round-trips through JSON")
+  func pollUpdatesRoundTrip() throws {
     let hash = Data([0x01, 0x02, 0x03])
-    let decoded = try roundTrip(.getState(hash))
+    let decoded = try roundTrip(.pollUpdates(StatePollRequest(stateHash: hash)))
 
-    if case .getState(let decodedHash) = decoded {
-      #expect(decodedHash == hash)
+    if case .pollUpdates(let request) = decoded {
+      #expect(request.stateHash == hash)
     } else {
-      Issue.record("Expected .getState, got \(decoded)")
+      Issue.record("Expected .pollUpdates, got \(decoded)")
     }
   }
 

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
@@ -11,266 +11,161 @@ import Testing
 
 @Suite("ConnlibState Tests")
 struct ConnlibStateTests {
-
-  // MARK: - decode() Tests
-
-  @Test("decode() returns state and hash")
-  func decodeReturnsStateAndHash() throws {
-    let resource = makeTestResource(id: "1", name: "Resource A")
-    let unreachable = UnreachableResource(resourceId: "2", reason: .offline)
-
-    // Use encodeIfChanged with empty hash to get initial data
-    let data = try ConnlibState.encodeIfChanged(
-      resources: [resource],
-      connectedDevices: [],
-      unreachableResources: [unreachable],
-      isLogStreamingActive: false,
-      comparedTo: Data()
+  @Test("State round-trips through a property list")
+  func stateRoundTrip() throws {
+    let state = ConnlibState(
+      resources: [makeTestResource(id: "resource-1", name: "Resource A")],
+      connectedDevices: [makeTestConnectedDevice(id: "device-1")],
+      isLogStreamingActive: true
     )
 
-    let unwrappedData = try #require(data)
-    let (state, hash) = try ConnlibState.decode(from: unwrappedData)
+    let decoded = try roundTrip(state)
 
-    #expect(hash.count == 32)  // SHA256 hash size
-    #expect(state.resources?.count == 1)
-    #expect(state.resources?[0].id == "1")
-    #expect(state.unreachableResources.count == 1)
+    #expect(decoded.resources?.first?.id == "resource-1")
+    #expect(decoded.connectedDevices.first?.id == "device-1")
+    #expect(decoded.isLogStreamingActive)
   }
 
-  @Test("decode() produces same hash for identical content")
-  func decodeSameHashForIdenticalContent() throws {
-    let resource = makeTestResource(id: "1", name: "Resource A")
-
-    let data1 = try ConnlibState.encodeIfChanged(
-      resources: [resource],
-      connectedDevices: [],
-      unreachableResources: [],
-      isLogStreamingActive: false,
-      comparedTo: Data()
-    )
-
-    let data2 = try ConnlibState.encodeIfChanged(
-      resources: [resource],
-      connectedDevices: [],
-      unreachableResources: [],
-      isLogStreamingActive: false,
-      comparedTo: Data()
-    )
-
-    let unwrappedData1 = try #require(data1)
-    let unwrappedData2 = try #require(data2)
-    let (_, hash1) = try ConnlibState.decode(from: unwrappedData1)
-    let (_, hash2) = try ConnlibState.decode(from: unwrappedData2)
-
-    #expect(hash1 == hash2)
-  }
-
-  @Test("decode() produces different hash for different content")
-  func decodeDifferentHashForDifferentContent() throws {
-    let resource1 = makeTestResource(id: "1", name: "Resource A")
-    let resource2 = makeTestResource(id: "2", name: "Resource B")
-
-    let data1 = try ConnlibState.encodeIfChanged(
-      resources: [resource1],
-      connectedDevices: [],
-      unreachableResources: [],
-      isLogStreamingActive: false,
-      comparedTo: Data()
-    )
-
-    let data2 = try ConnlibState.encodeIfChanged(
-      resources: [resource2],
-      connectedDevices: [],
-      unreachableResources: [],
-      isLogStreamingActive: false,
-      comparedTo: Data()
-    )
-
-    let unwrappedData1 = try #require(data1)
-    let unwrappedData2 = try #require(data2)
-    let (_, hash1) = try ConnlibState.decode(from: unwrappedData1)
-    let (_, hash2) = try ConnlibState.decode(from: unwrappedData2)
-
-    #expect(hash1 != hash2)
-  }
-
-  // MARK: - encodeIfChanged() Tests
-
-  @Test("encodeIfChanged() returns nil when hash matches")
-  func encodeIfChangedReturnsNilWhenHashMatches() throws {
-    let resource = makeTestResource(id: "1", name: "Resource A")
-    let unreachable = UnreachableResource(resourceId: "2", reason: .offline)
-
-    // First encode to get the hash
-    let data = try ConnlibState.encodeIfChanged(
-      resources: [resource],
-      connectedDevices: [],
-      unreachableResources: [unreachable],
-      isLogStreamingActive: false,
-      comparedTo: Data()
-    )
-
-    let unwrappedData = try #require(data)
-    let (_, hash) = try ConnlibState.decode(from: unwrappedData)
-
-    // Now try to encode again with the same hash
-    let result = try ConnlibState.encodeIfChanged(
-      resources: [resource],
-      connectedDevices: [],
-      unreachableResources: [unreachable],
-      isLogStreamingActive: false,
-      comparedTo: hash
-    )
-
-    #expect(result == nil)
-  }
-
-  @Test("encodeIfChanged() returns data when hash differs")
-  func encodeIfChangedReturnsDataWhenHashDiffers() throws {
-    let resource1 = makeTestResource(id: "1", name: "Resource A")
-    let resource2 = makeTestResource(id: "2", name: "Resource B")
-
-    // Get hash for first state
-    let data1 = try ConnlibState.encodeIfChanged(
-      resources: [resource1],
-      connectedDevices: [],
-      unreachableResources: [],
-      isLogStreamingActive: false,
-      comparedTo: Data()
-    )
-
-    let unwrappedData1 = try #require(data1)
-    let (_, hash1) = try ConnlibState.decode(from: unwrappedData1)
-
-    // Try to encode different state with first hash
-    let result = try ConnlibState.encodeIfChanged(
-      resources: [resource2],
-      connectedDevices: [],
-      unreachableResources: [],
-      isLogStreamingActive: false,
-      comparedTo: hash1
-    )
-
-    #expect(result != nil)
-
-    let unwrappedResult = try #require(result)
-    let (state, _) = try ConnlibState.decode(from: unwrappedResult)
-    #expect(state.resources?.count == 1)
-    #expect(state.resources?[0].id == "2")
-  }
-
-  @Test("encodeIfChanged() handles nil resources")
-  func encodeIfChangedHandlesNilResources() throws {
-    let result = try ConnlibState.encodeIfChanged(
+  @Test("State round-trips nil resources")
+  func nilResourcesRoundTrip() throws {
+    let state = ConnlibState(
       resources: nil,
       connectedDevices: [],
-      unreachableResources: [],
-      isLogStreamingActive: false,
-      comparedTo: Data()
+      isLogStreamingActive: false
     )
 
-    #expect(result != nil)
+    let decoded = try roundTrip(state)
 
-    let unwrappedResult = try #require(result)
-    let (state, _) = try ConnlibState.decode(from: unwrappedResult)
-    #expect(state.resources == nil)
-    #expect(state.unreachableResources.isEmpty)
+    #expect(decoded.resources == nil)
   }
 
-  // MARK: - isLogStreamingActive Tests
-
-  @Test("decode() round-trips isLogStreamingActive = true")
-  func decodeRoundTripsLogStreamingActive() throws {
-    let data = try ConnlibState.encodeIfChanged(
-      resources: nil,
-      connectedDevices: [],
-      unreachableResources: [],
-      isLogStreamingActive: true,
-      comparedTo: Data()
-    )
-
-    let unwrapped = try #require(data)
-    let (state, _) = try ConnlibState.decode(from: unwrapped)
-
-    #expect(state.isLogStreamingActive == true)
-  }
-
-  @Test("encodeIfChanged() detects isLogStreamingActive change")
-  func encodeIfChangedDetectsLogStreamingChange() throws {
-    let data = try ConnlibState.encodeIfChanged(
-      resources: nil,
-      connectedDevices: [],
-      unreachableResources: [],
-      isLogStreamingActive: false,
-      comparedTo: Data()
-    )
-
-    let unwrapped = try #require(data)
-    let (_, hash) = try ConnlibState.decode(from: unwrapped)
-
-    // Same resources, different streaming flag — should return data
-    let result = try ConnlibState.encodeIfChanged(
-      resources: nil,
-      connectedDevices: [],
-      unreachableResources: [],
-      isLogStreamingActive: true,
-      comparedTo: hash
-    )
-
-    #expect(result != nil)
-  }
-
-  // MARK: - connectedDevices Tests
-
-  @Test("decode() round-trips non-empty connectedDevices")
-  func decodeRoundTripsConnectedDevices() throws {
-    let device = makeTestConnectedDevice(id: "device-1")
-
-    let data = try ConnlibState.encodeIfChanged(
-      resources: nil,
-      connectedDevices: [device],
-      unreachableResources: [],
-      isLogStreamingActive: false,
-      comparedTo: Data()
-    )
-
-    let unwrapped = try #require(data)
-    let (state, _) = try ConnlibState.decode(from: unwrapped)
-
-    #expect(state.connectedDevices.count == 1)
-    #expect(state.connectedDevices[0].id == "device-1")
-    #expect(state.connectedDevices[0].name == "Device device-1")
-    #expect(state.connectedDevices[0].tunIPv4 == "100.64.0.1")
-    #expect(state.connectedDevices[0].tunIPv6 == "fd00:2021:1111::1")
-    #expect(state.connectedDevices[0].pools == ["pool-a"])
-  }
-
-  @Test("encodeIfChanged() detects connectedDevices change")
-  func encodeIfChangedDetectsConnectedDevicesChange() throws {
-    let data = try ConnlibState.encodeIfChanged(
-      resources: nil,
-      connectedDevices: [],
-      unreachableResources: [],
-      isLogStreamingActive: false,
-      comparedTo: Data()
-    )
-
-    let unwrapped = try #require(data)
-    let (_, hash) = try ConnlibState.decode(from: unwrapped)
-
-    // Only the device list differs from the encoded state — should return data.
-    let result = try ConnlibState.encodeIfChanged(
+  @Test("Connected-device fields round-trip")
+  func connectedDeviceFieldsRoundTrip() throws {
+    let state = ConnlibState(
       resources: nil,
       connectedDevices: [makeTestConnectedDevice(id: "device-1")],
-      unreachableResources: [],
-      isLogStreamingActive: false,
-      comparedTo: hash
+      isLogStreamingActive: false
     )
 
-    #expect(result != nil)
+    let device = try #require(roundTrip(state).connectedDevices.first)
+
+    #expect(device.id == "device-1")
+    #expect(device.name == "Device device-1")
+    #expect(device.tunIPv4 == "100.64.0.1")
+    #expect(device.tunIPv6 == "fd00:2021:1111::1")
+    #expect(device.pools == ["pool-a"])
   }
 
-  // MARK: - Helper Functions
+  @Test("Identical state has an identical content hash")
+  func identicalStateHash() throws {
+    let first = ConnlibState(
+      resources: [makeTestResource(id: "resource-1", name: "Resource A")],
+      connectedDevices: [],
+      isLogStreamingActive: false
+    )
+    let second = ConnlibState(
+      resources: [makeTestResource(id: "resource-1", name: "Resource A")],
+      connectedDevices: [],
+      isLogStreamingActive: false
+    )
+
+    #expect(try first.contentHash() == second.contentHash())
+    #expect(try first.contentHash().count == 32)
+  }
+
+  @Test("Resource changes alter the content hash")
+  func resourceChangeAltersHash() throws {
+    let first = ConnlibState(
+      resources: [makeTestResource(id: "resource-1", name: "Resource A")],
+      connectedDevices: [],
+      isLogStreamingActive: false
+    )
+    let second = ConnlibState(
+      resources: [makeTestResource(id: "resource-2", name: "Resource B")],
+      connectedDevices: [],
+      isLogStreamingActive: false
+    )
+
+    #expect(try first.contentHash() != second.contentHash())
+  }
+
+  @Test("Connected-device changes alter the content hash")
+  func connectedDeviceChangeAltersHash() throws {
+    let first = ConnlibState(
+      resources: nil,
+      connectedDevices: [],
+      isLogStreamingActive: false
+    )
+    let second = ConnlibState(
+      resources: nil,
+      connectedDevices: [makeTestConnectedDevice(id: "device-1")],
+      isLogStreamingActive: false
+    )
+
+    #expect(try first.contentHash() != second.contentHash())
+  }
+
+  @Test("Log-streaming changes alter the content hash")
+  func logStreamingChangeAltersHash() throws {
+    let first = ConnlibState(
+      resources: nil,
+      connectedDevices: [],
+      isLogStreamingActive: false
+    )
+    let second = ConnlibState(
+      resources: nil,
+      connectedDevices: [],
+      isLogStreamingActive: true
+    )
+
+    #expect(try first.contentHash() != second.contentHash())
+  }
+
+  @Test("Poll response round-trips state and notifications independently")
+  func pollResponseRoundTrip() throws {
+    let state = ConnlibState(
+      resources: [makeTestResource(id: "resource-1", name: "Resource A")],
+      connectedDevices: [],
+      isLogStreamingActive: false
+    )
+    let hash = try state.contentHash()
+    let response = StatePollResponse(
+      state: state,
+      stateHash: hash,
+      notifications: [UnreachableResource(resourceId: "resource-1", reason: .offline)]
+    )
+
+    let decoded = try roundTrip(response)
+
+    #expect(decoded.state?.resources?.first?.id == "resource-1")
+    #expect(decoded.stateHash == hash)
+    #expect(
+      decoded.notifications == [
+        UnreachableResource(resourceId: "resource-1", reason: .offline)
+      ])
+  }
+
+  @Test("Poll response can contain notifications without a state change")
+  func pollResponseWithoutState() throws {
+    let response = StatePollResponse(
+      state: nil,
+      stateHash: nil,
+      notifications: [
+        UnreachableResource(resourceId: "resource-1", reason: .versionMismatch)
+      ]
+    )
+
+    let decoded = try roundTrip(response)
+
+    #expect(decoded.state == nil)
+    #expect(decoded.stateHash == nil)
+    #expect(decoded.notifications.count == 1)
+  }
+
+  private func roundTrip<T: Codable>(_ value: T) throws -> T {
+    let data = try PropertyListEncoder().encode(value)
+    return try PropertyListDecoder().decode(T.self, from: data)
+  }
 
   private func makeTestResource(id: String, name: String) -> FirezoneKit.Resource {
     let site = Site(id: "site-1", name: "Test Site")

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/IPCClientTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/IPCClientTests.swift
@@ -17,9 +17,11 @@ private final class RecordingTunnelSession: TunnelSessionProtocol, @unchecked Se
   private(set) var startTunnelCallCount = 0
   private(set) var stopTunnelCallCount = 0
   private(set) var sentMessages: [ProviderMessage] = []
+  private let responseData: Data?
 
-  init(status: NEVPNStatus) {
+  init(status: NEVPNStatus, responseData: Data? = nil) {
     self.status = status
+    self.responseData = responseData
   }
 
   // swiftlint:disable:next discouraged_optional_collection
@@ -33,7 +35,7 @@ private final class RecordingTunnelSession: TunnelSessionProtocol, @unchecked Se
 
   func sendProviderMessage(_ messageData: Data, responseHandler: ((Data?) -> Void)?) throws {
     sentMessages.append(try PropertyListDecoder().decode(ProviderMessage.self, from: messageData))
-    responseHandler?(nil)
+    responseHandler?(responseData)
   }
 
   func fetchLastDisconnectError(completionHandler: @escaping @Sendable (Error?) -> Void) {
@@ -41,9 +43,43 @@ private final class RecordingTunnelSession: TunnelSessionProtocol, @unchecked Se
   }
 }
 
-@Suite("IPCClient flow-log drain")
+@Suite("IPCClient")
 @MainActor
 struct IPCClientTests {
+  @Test("Polling decodes state and notifications from one response")
+  func pollUpdates() async throws {
+    let state = ConnlibState(
+      resources: nil,
+      connectedDevices: [],
+      isLogStreamingActive: false
+    )
+    let stateHash = try state.contentHash()
+    let response = StatePollResponse(
+      state: state,
+      stateHash: stateHash,
+      notifications: [UnreachableResource(resourceId: "resource-1", reason: .offline)]
+    )
+    let session = RecordingTunnelSession(
+      status: .connected,
+      responseData: try PropertyListEncoder().encode(response)
+    )
+    let previousHash = Data([0x01, 0x02])
+
+    let decoded = try await IPCClient.pollUpdates(
+      session: session,
+      currentHash: previousHash
+    )
+
+    #expect(decoded.stateHash == stateHash)
+    #expect(decoded.notifications == response.notifications)
+    #expect(session.sentMessages.count == 1)
+    guard case .pollUpdates(let request) = session.sentMessages[0] else {
+      Issue.record("Expected a pollUpdates message")
+      return
+    }
+    #expect(request.stateHash == previousHash)
+  }
+
   @Test("A running tunnel is left alone")
   func drainDoesNotCycleRunningTunnel() async throws {
     for status in [NEVPNStatus.connected, .connecting, .reasserting] {

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -120,8 +120,8 @@ actor Adapter {
   private var resources: [Resource]?  // swiftlint:disable:this discouraged_optional_collection
   private var connectedDevices: [ConnectedDevice] = []
 
-  /// Resources we couldn't connect to
-  private var unreachableResources: [UnreachableResource]
+  /// Resource notifications waiting for the UI process to poll them.
+  private var pendingUnreachableResources: [UnreachableResource]
 
   /// Starting parameters
   private let apiURL: String
@@ -145,7 +145,7 @@ actor Adapter {
     self.accountSlug = accountSlug
     self.internetResourceEnabled = internetResourceEnabled
     self.providerCommandSender = providerCommandSender
-    self.unreachableResources = []
+    self.pendingUnreachableResources = []
     // Start log cleanup immediately - doesn't depend on tunnel being connected
     providerCommandSender.send(.startLogCleanupTask)
   }
@@ -309,13 +309,19 @@ actor Adapter {
     hash: Data
   ) -> Data? {
     do {
-      return try ConnlibState.encodeIfChanged(
+      let state = try ConnlibState.encodeIfChanged(
         resources: self.resources?.map { self.convertResource($0) },
         connectedDevices: self.connectedDevices.map { FirezoneKit.ConnectedDevice($0) },
-        unreachableResources: self.unreachableResources,
+        unreachableResources: self.pendingUnreachableResources,
         isLogStreamingActive: Log.isStreamingActive,
         comparedTo: hash
       )
+
+      // Connlib already deduplicates these notifications. The array is only a mailbox between
+      // processes, so drain it after the UI has polled rather than retaining it as session state.
+      pendingUnreachableResources.removeAll()
+
+      return state
     } catch {
       Log.log("Failed to encode state as PropertyList: \(error)")
       return nil
@@ -461,11 +467,11 @@ actor Adapter {
       providerCommandSender.send(.cancelWithError(sendableError))
 
     case .allGatewaysOffline(let resourceId):
-      self.unreachableResources.append(
+      self.pendingUnreachableResources.append(
         UnreachableResource(resourceId: resourceId, reason: UnreachableReason.offline))
 
     case .gatewayVersionMismatch(let resourceId):
-      self.unreachableResources.append(
+      self.pendingUnreachableResources.append(
         UnreachableResource(resourceId: resourceId, reason: UnreachableReason.versionMismatch))
     }
   }

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -31,6 +31,10 @@ enum AdapterError: Error {
 
 // Loosely inspired from WireGuardAdapter from WireGuardKit
 actor Adapter {
+  private struct PendingUnreachableResource {
+    let resource: UnreachableResource
+    let receivedAt: ContinuousClock.Instant
+  }
 
   /// Command sender for sending commands to the session
   private var commandSender: Sender<SessionCommand>?
@@ -45,6 +49,7 @@ actor Adapter {
   /// Shorter than `RE_EVAL_DURATION` (5 min) on the Rust side so the NE
   /// picks up a flag change soon after PostHog re-evaluation.
   private static let featureFlagPollInterval: Duration = .seconds(5)
+  private static let resourceNotificationTTL: Duration = .seconds(15)
 
   // Our local copy of the accountSlug
   private let accountSlug: String
@@ -121,7 +126,8 @@ actor Adapter {
   private var connectedDevices: [ConnectedDevice] = []
 
   /// Resource notifications waiting for the UI process to poll them.
-  private var pendingUnreachableResources: [UnreachableResource]
+  private var pendingUnreachableResources: [PendingUnreachableResource]
+  private let notificationClock = ContinuousClock()
 
   /// Starting parameters
   private let apiURL: String
@@ -301,29 +307,40 @@ actor Adapter {
     // stopTunnel's completionHandler lets the OS reap this process. Capped so a
     // wedged loop can't hang stopTunnel; connlib's own flush wait is 10s.
     await eventLoopTask?.wait(timeout: .seconds(15))
+
+    pendingUnreachableResources.removeAll()
   }
 
-  /// Get the current state in the completionHandler, only returning
-  /// them if the content has changed.
-  func getStateIfVersionDifferentFrom(
-    hash: Data
-  ) -> Data? {
+  /// Returns state changes and consumes fresh notifications in one UI polling operation.
+  func pollUpdates(_ request: StatePollRequest) -> Data? {
     do {
-      let state = try ConnlibState.encodeIfChanged(
+      let state = ConnlibState(
         resources: self.resources?.map { self.convertResource($0) },
         connectedDevices: self.connectedDevices.map { FirezoneKit.ConnectedDevice($0) },
-        unreachableResources: self.pendingUnreachableResources,
-        isLogStreamingActive: Log.isStreamingActive,
-        comparedTo: hash
+        isLogStreamingActive: Log.isStreamingActive
       )
+      let stateHash = try state.contentHash()
+      let stateChanged = stateHash != request.stateHash
 
-      // Connlib already deduplicates these notifications. The array is only a mailbox between
-      // processes, so drain it after the UI has polled rather than retaining it as session state.
+      let now = notificationClock.now
+      let notifications = pendingUnreachableResources.compactMap { pending in
+        let age = pending.receivedAt.duration(to: now)
+        return age < Self.resourceNotificationTTL ? pending.resource : nil
+      }
+
+      let response = StatePollResponse(
+        state: stateChanged ? state : nil,
+        stateHash: stateChanged ? stateHash : nil,
+        notifications: notifications
+      )
+      let encodedResponse = try PropertyListEncoder().encode(response)
+
+      // Only consume the mailbox after the complete response has been encoded successfully.
       pendingUnreachableResources.removeAll()
 
-      return state
+      return encodedResponse
     } catch {
-      Log.log("Failed to encode state as PropertyList: \(error)")
+      Log.log("Failed to encode state updates as PropertyList: \(error)")
       return nil
     }
   }
@@ -338,6 +355,18 @@ actor Adapter {
 
   func setInternetResourceEnabled(_ enabled: Bool) async {
     internetResourceEnabled = enabled
+
+    if !enabled {
+      let internetResourceIds = Set(
+        (resources ?? []).compactMap { resource -> String? in
+          guard case .internet(let internetResource) = resource else { return nil }
+          return internetResource.id
+        })
+      pendingUnreachableResources.removeAll { pending in
+        internetResourceIds.contains(pending.resource.resourceId)
+      }
+    }
+
     sendCommand(.setInternetResourceState(enabled))
   }
 
@@ -468,11 +497,19 @@ actor Adapter {
 
     case .allGatewaysOffline(let resourceId):
       self.pendingUnreachableResources.append(
-        UnreachableResource(resourceId: resourceId, reason: UnreachableReason.offline))
+        PendingUnreachableResource(
+          resource: UnreachableResource(
+            resourceId: resourceId, reason: UnreachableReason.offline),
+          receivedAt: notificationClock.now
+        ))
 
     case .gatewayVersionMismatch(let resourceId):
       self.pendingUnreachableResources.append(
-        UnreachableResource(resourceId: resourceId, reason: UnreachableReason.versionMismatch))
+        PendingUnreachableResource(
+          resource: UnreachableResource(
+            resourceId: resourceId, reason: UnreachableReason.versionMismatch),
+          receivedAt: notificationClock.now
+        ))
     }
   }
 

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -226,18 +226,16 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       case .signOut:
         do { try Token.delete() } catch { Log.error(error) }
         completionHandler?(nil)
-      case .getState(let hash):
+      case .pollUpdates(let request):
         guard let adapter else {
           Log.warning("Adapter is nil")
           completionHandler?(nil)
           return
         }
 
-        // Use hash comparison to only return resources if they've changed
         Task { @Sendable in
-          // Use hash comparison to only return state if it changed
-          let connlibState = await adapter.getStateIfVersionDifferentFrom(hash: hash)
-          completionHandler?(connlibState)
+          let updates = await adapter.pollUpdates(request)
+          completionHandler?(updates)
         }
       case .getEncodedFirezoneId:
         guard let rawId = defaults.string(forKey: "firezoneId") else {


### PR DESCRIPTION
When receiving a gateways offline notification from connlib, the network extension would cache them and show on the next UI poll if the VPN status had changed. This caused old notifications from long ago to keep re-appearing on each roam or transient network event.

To fix this we simply flush the cache after the UI polls it.

Fixes #14477 