### PR TITLE
ci(fuzz): let the nightly job upload its Trivy SARIF

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -40,6 +40,9 @@ jobs:
         fuzz-target: ${{ fromJSON(needs.targets.outputs.targets) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 75
+    permissions:
+      contents: read
+      security-events: write # trivy SARIF upload from setup-mise
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-rust-sccache


### PR DESCRIPTION
`setup-mise` scans the installed tools with Trivy and uploads the result to the Security tab, which needs `security-events: write`. The nightly fuzz workflow only granted `contents: read`, so both discover jobs failed during setup with "Resource not accessible by integration" and never reached the fuzzing step. It has therefore never proposed a corpus update since it was added.

Every other workflow that uses `setup-mise` already grants this.