### PR TITLE
chore(fuzz): drop a codegen-units override that never applied

### DIFF
--- a/rust/tests/fuzz/mise.toml
+++ b/rust/tests/fuzz/mise.toml
@@ -21,9 +21,6 @@
 RUSTUP_TOOLCHAIN = "nightly-2026-06-10"
 # LTO conflicts with the libFuzzer instrumentation.
 CARGO_PROFILE_RELEASE_LTO = "false"
-# The workspace profile trades compile time for smaller binaries
-# (codegen-units = 1); for fuzz builds, compile time matters more.
-CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "16"
 
 [tasks.install-toolchain]
 description = "Install the pinned nightly with the components fuzzing needs"


### PR DESCRIPTION
`cargo fuzz` passes `-Ccodegen-units=1` of its own through `RUSTFLAGS`, which cargo appends after the flags it derives from the profile. rustc takes the last value for a repeated codegen option, so the profile override was read and then discarded on every fuzz build.