### PR TITLE
ci: skip toolchain setup when the binary cache hits

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Arguments to pass to `mise install`"
     required: false
     default: ""
+  install:
+    description: "Whether to run `mise install`. Set to false to get `mise` itself without any tools, e.g. to only run a task that shells out to coreutils."
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -30,6 +34,7 @@ runs:
       continue-on-error: true
       with:
         version: ${{ inputs.version }}
+        install: ${{ inputs.install }}
         install_args: ${{ inputs.install_args }}
         reshim: true
         cache_key_prefix: "mise-v2"
@@ -40,6 +45,7 @@ runs:
       continue-on-error: true
       with:
         version: ${{ inputs.version }}
+        install: ${{ inputs.install }}
         install_args: ${{ inputs.install_args }}
         reshim: true
         cache_key_prefix: "mise-v2"
@@ -48,6 +54,7 @@ runs:
       if: ${{ steps.mise-2.outcome == 'failure' }}
       with:
         version: ${{ inputs.version }}
+        install: ${{ inputs.install }}
         install_args: ${{ inputs.install_args }}
         reshim: true
         cache_key_prefix: "mise-v2"
@@ -59,7 +66,7 @@ runs:
     # then point the default cache location at the result so subsequent
     # workflow invocations of the tool don't re-extract.
     - name: Pre-warm self-extracting tool caches
-      if: ${{ runner.os != 'Windows' }}
+      if: ${{ runner.os != 'Windows' && inputs.install == 'true' }}
       shell: bash
       run: |
         firebase_bin=$(mise which firebase 2>/dev/null || true)
@@ -79,6 +86,7 @@ runs:
     #    Those are not scanned with this approach.
 
     - name: Scan mise installs with Trivy
+      if: ${{ inputs.install == 'true' }}
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         scan-type: fs
@@ -90,7 +98,7 @@ runs:
         output: trivy-mise.sarif
 
     - name: Upload results to GitHub Security tab
-      if: always()
+      if: ${{ always() && inputs.install == 'true' }}
       uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         sarif_file: trivy-mise.sarif

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -287,6 +287,9 @@ jobs:
       - uses: ./.github/actions/setup-mise
         if: ${{ steps.binary-cache.outputs.cache-hit != 'true' || env.BUILDS_DEB == 'true' || matrix.name.package == 'firezone-relay' }}
         with:
+          # Stamping the SHA into the relay shells out to coreutils only, so a
+          # restored relay needs `mise` as a task runner but none of its tools.
+          install: ${{ steps.binary-cache.outputs.cache-hit != 'true' || env.BUILDS_DEB == 'true' }}
           install_args: --cd rust
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -239,8 +239,10 @@ jobs:
       BINARY_DEST_PATH: ${{ matrix.name.artifact }}_${{ matrix.name.version }}_${{ matrix.arch.shortname }}
       SENTRY_ENVIRONMENT: "production"
       RESOLVED_SHA: ${{ inputs.sha || github.sha }}
-      # `firezone-cli` and the `.deb` are only produced for release Gateways.
-      BUILDS_DEB: ${{ inputs.profile == 'release' && inputs.stage == 'release' && matrix.name.artifact == 'firezone-gateway' }}
+      # `firezone-cli` and the `.deb` are only produced for release Gateways, and
+      # only a dispatched build publishes them. On a push, the `.deb` would just
+      # expire unread as an artifact.
+      BUILDS_DEB: ${{ github.event_name == 'workflow_dispatch' && inputs.profile == 'release' && inputs.stage == 'release' && matrix.name.artifact == 'firezone-gateway' }}
     outputs:
       client_image: ${{ steps.image-name.outputs.client_image }}
       relay_image: ${{ steps.image-name.outputs.relay_image }}
@@ -386,6 +388,7 @@ jobs:
             --auth-mode login \
             --account-name firezoneartifacts
       - name: Upload `.deb` artifact
+        if: ${{ env.BUILDS_DEB == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.BINARY_DEST_PATH }}.deb

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -130,17 +130,21 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.RESOLVED_SHA }}
-      - uses: ./.github/actions/setup-rust-stable
-        with:
-          targets: ${{ matrix.target }}
-      - uses: ./.github/actions/setup-rust-sccache
-        with:
-          azure-connection-string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - uses: ./.github/actions/setup-rust-binary-cache
         id: binary-cache
         with:
           path: rust/target/${{ matrix.target }}/${{ inputs.profile }}/${{ matrix.package }}.exe
           key: ${{ matrix.package }}-${{ matrix.target }}-${{ inputs.profile }}
+      # A restored binary skips the build below, so the toolchain that only
+      # exists to compile it is skipped too.
+      - uses: ./.github/actions/setup-rust-stable
+        if: steps.binary-cache.outputs.cache-hit != 'true'
+        with:
+          targets: ${{ matrix.target }}
+      - uses: ./.github/actions/setup-rust-sccache
+        if: steps.binary-cache.outputs.cache-hit != 'true'
+        with:
+          azure-connection-string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - name: Build binaries
         if: steps.binary-cache.outputs.cache-hit != 'true'
         shell: bash
@@ -235,6 +239,8 @@ jobs:
       BINARY_DEST_PATH: ${{ matrix.name.artifact }}_${{ matrix.name.version }}_${{ matrix.arch.shortname }}
       SENTRY_ENVIRONMENT: "production"
       RESOLVED_SHA: ${{ inputs.sha || github.sha }}
+      # `firezone-cli` and the `.deb` are only produced for release Gateways.
+      BUILDS_DEB: ${{ inputs.profile == 'release' && inputs.stage == 'release' && matrix.name.artifact == 'firezone-gateway' }}
     outputs:
       client_image: ${{ steps.image-name.outputs.client_image }}
       relay_image: ${{ steps.image-name.outputs.relay_image }}
@@ -248,15 +254,6 @@ jobs:
         id: login
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: ./.github/actions/setup-musl
-        with:
-          target: ${{ matrix.arch.target }}
-      - uses: ./.github/actions/setup-rust-stable
-        with:
-          targets: ${{ matrix.arch.target }}
-      - uses: ./.github/actions/setup-rust-sccache
-        with:
-          azure-connection-string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - uses: ./.github/actions/setup-rust-binary-cache
         id: binary-cache
         with:
@@ -266,11 +263,27 @@ jobs:
       # separately below and needs its own entry.
       - uses: ./.github/actions/setup-rust-binary-cache
         id: cli-binary-cache
-        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-gateway' }}
+        if: ${{ env.BUILDS_DEB == 'true' }}
         with:
           path: rust/target/${{ matrix.arch.target }}/release/firezone-cli
           key: firezone-cli-${{ matrix.arch.target }}-release
+      # Restored binaries skip every `cargo build` below, so the toolchains only
+      # needed to compile them are skipped too. `cargo deb` still needs cargo and
+      # `cargo-deb`, and the relay still needs mise to stamp in the commit SHA.
+      - uses: ./.github/actions/setup-musl
+        if: ${{ steps.binary-cache.outputs.cache-hit != 'true' || (env.BUILDS_DEB == 'true' && steps.cli-binary-cache.outputs.cache-hit != 'true') }}
+        with:
+          target: ${{ matrix.arch.target }}
+      - uses: ./.github/actions/setup-rust-stable
+        if: ${{ steps.binary-cache.outputs.cache-hit != 'true' || env.BUILDS_DEB == 'true' }}
+        with:
+          targets: ${{ matrix.arch.target }}
+      - uses: ./.github/actions/setup-rust-sccache
+        if: ${{ steps.binary-cache.outputs.cache-hit != 'true' || env.BUILDS_DEB == 'true' }}
+        with:
+          azure-connection-string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - uses: ./.github/actions/setup-mise
+        if: ${{ steps.binary-cache.outputs.cache-hit != 'true' || env.BUILDS_DEB == 'true' || matrix.name.package == 'firezone-relay' }}
         with:
           install_args: --cd rust
         env:
@@ -345,10 +358,10 @@ jobs:
             --account-name firezoneartifacts
 
       - name: Build firezone-cli
-        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-gateway' && steps.cli-binary-cache.outputs.cache-hit != 'true' }}
+        if: ${{ env.BUILDS_DEB == 'true' && steps.cli-binary-cache.outputs.cache-hit != 'true' }}
         run: cargo build --bin firezone-cli --release --target ${{ matrix.arch.target }}
       - name: Create Firezone Gateway .deb package
-        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-gateway' }}
+        if: ${{ env.BUILDS_DEB == 'true' }}
         run: |
           cargo deb --package firezone-gateway --target ${{ matrix.arch.target }} --no-build --no-strip
           cp target/debian/*.deb "$BINARY_DEST_PATH".deb

--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -46,19 +46,23 @@ jobs:
         with:
           ref: ${{ inputs.sha }}
 
-      - uses: ./.github/actions/setup-rust-stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - uses: ./.github/actions/setup-rust-sccache
-        with:
-          azure-connection-string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
-
       - uses: ./.github/actions/setup-rust-binary-cache
         id: binary-cache
         with:
           path: rust/target/${{ matrix.target }}/release/${{ matrix.binary }}
           key: firezone-loadtest-${{ matrix.target }}-release
+
+      # A restored binary skips the build below, so the toolchain that only
+      # exists to compile it is skipped too.
+      - uses: ./.github/actions/setup-rust-stable
+        if: steps.binary-cache.outputs.cache-hit != 'true'
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: ./.github/actions/setup-rust-sccache
+        if: steps.binary-cache.outputs.cache-hit != 'true'
+        with:
+          azure-connection-string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
 
       - name: Install dependencies (Linux)
         if: matrix.os == 'linux' && steps.binary-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Every data plane and loadtest build job installed `mise`, `rustup`, `sccache` and the musl toolchain before consulting the binary cache, so a cache hit still paid around 80 seconds of setup for a build that never ran. Those setups now happen only on a cache miss, except for `cargo` plus `cargo-deb`, which the Gateway `.deb` needs regardless. Stamping the commit SHA into a restored relay needs `mise` as a task runner but none of its tools, so that path installs `mise` on its own: `mise install` is the expensive part, since its cache regularly misses and `cargo:cargo-deb` is then compiled from source.

The `.deb` itself is now only built for dispatched builds, which are the only ones that publish it to the release and the apt import. On a push it expired unread as a one day artifact, and not building it lets the release Gateway jobs skip their toolchain setup as well.

As a side effect, fewer jobs run the Trivy scan bundled into `setup-mise`. The same tool set is still installed and scanned by the Rust workflow on every CI and CD run.