### PR TITLE
ci: extract collect-images into a reusable workflow

### DIFF
--- a/.github/workflows/_collect_images.yml
+++ b/.github/workflows/_collect_images.yml
@@ -1,0 +1,133 @@
+name: Collect Images
+run-name: Triggered from ${{ github.event_name }} by ${{ github.actor }}
+on:
+  workflow_call:
+    inputs:
+      id:
+        description: "Unique identifier for this invocation. Used to namespace the artifact holding the pre-pulled images so that concurrent invocations within the same run don't collide."
+        required: true
+        type: string
+      pull_services:
+        description: "Space-separated compose services to pull. Empty pulls every service in the project."
+        required: false
+        type: string
+        default: ""
+      build_services:
+        description: "Space-separated compose services to build once and ship in the archive."
+        required: false
+        type: string
+        default: "client-1-router gateway-router relay-1-router relay-2-router portal-router client-2-router"
+      portal_image:
+        required: false
+        type: string
+        default: "ghcr.io/firezone/portal"
+      portal_tag:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+      elixir_image:
+        required: false
+        type: string
+        default: "ghcr.io/firezone/elixir"
+      elixir_tag:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+      relay_image:
+        required: false
+        type: string
+        default: "ghcr.io/firezone/debug/relay"
+      relay_tag:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+      gateway_image:
+        required: false
+        type: string
+        default: "ghcr.io/firezone/debug/gateway"
+      gateway_tag:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+      client_image:
+        required: false
+        type: string
+        default: "ghcr.io/firezone/debug/client"
+      client_tag:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+      http_test_server_image:
+        required: false
+        type: string
+        default: "ghcr.io/firezone/debug/http-test-server"
+      http_test_server_tag:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+
+jobs:
+  collect-images:
+    name: collect-images
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    env:
+      PORTAL_IMAGE: ${{ inputs.portal_image }}
+      PORTAL_TAG: ${{ inputs.portal_tag }}
+      RELAY_IMAGE: ${{ inputs.relay_image }}
+      RELAY_TAG: ${{ inputs.relay_tag }}
+      GATEWAY_IMAGE: ${{ inputs.gateway_image }}
+      GATEWAY_TAG: ${{ inputs.gateway_tag }}
+      CLIENT_IMAGE: ${{ inputs.client_image }}
+      CLIENT_TAG: ${{ inputs.client_tag }}
+      ELIXIR_IMAGE: ${{ inputs.elixir_image }}
+      ELIXIR_TAG: ${{ inputs.elixir_tag }}
+      HTTP_TEST_SERVER_IMAGE: ${{ inputs.http_test_server_image }}
+      HTTP_TEST_SERVER_TAG: ${{ inputs.http_test_server_tag }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/ghcr-docker-login
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/setup-scripts
+      - name: Pull all images once
+        # Pulls the registry images of the compose project (resolving `extends`,
+        # anchors and env interpolation). The build-only `*-router` services have
+        # no `image:` and are skipped here; they are built once in the next step.
+        # Callers that only exercise part of the project scope this via
+        # `pull_services`, so they don't pull images that aren't published for them.
+        run: |
+          retry docker compose pull ${{ inputs.pull_services }}
+      - name: Build the router images once
+        # The `*-router` services are built once here and shipped in the images
+        # archive so the downstream test-matrix jobs load them via `docker load`
+        # instead of each running `docker build` + `apk add` against the Alpine
+        # CDN, which was a recurring source of flaky failures.
+        run: retry docker compose build ${{ inputs.build_services }}
+      - name: Save pulled images as a single archive
+        run: |
+          set -xe
+
+          # Save the compose project's images that are present locally: the pulled
+          # registry images plus the `*-router` images built in the previous step.
+          # The `docker image inspect` filter drops any build-only service that
+          # wasn't built.
+          images=$(docker compose config --images | sort -u | while read -r image; do
+            if docker image inspect "$image" > /dev/null 2>&1; then
+              echo "$image"
+            fi
+          done)
+
+          echo "Saving images:"
+          echo "$images"
+
+          # shellcheck disable=SC2086 # $images must be split into separate args
+          docker save $images | zstd --long=30 -T0 -o images.tar.zst
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          overwrite: true
+          name: images-${{ inputs.id }}
+          path: images.tar.zst
+          compression-level: 0
+          retention-days: 1

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -58,67 +58,23 @@ on:
 
 jobs:
   collect-images:
-    name: collect-images
-    runs-on: ubuntu-24.04
+    uses: ./.github/workflows/_collect_images.yml
     permissions:
       contents: read
-    env:
-      PORTAL_IMAGE: ${{ inputs.portal_image }}
-      PORTAL_TAG: ${{ inputs.portal_tag }}
-      RELAY_IMAGE: ${{ inputs.relay_image }}
-      RELAY_TAG: ${{ inputs.relay_tag }}
-      GATEWAY_IMAGE: ${{ inputs.gateway_image }}
-      GATEWAY_TAG: ${{ inputs.gateway_tag }}
-      CLIENT_IMAGE: ${{ inputs.client_image }}
-      CLIENT_TAG: ${{ inputs.client_tag }}
-      ELIXIR_IMAGE: ${{ inputs.elixir_image }}
-      ELIXIR_TAG: ${{ inputs.elixir_tag }}
-      HTTP_TEST_SERVER_IMAGE: ${{ inputs.http_test_server_image }}
-      HTTP_TEST_SERVER_TAG: ${{ inputs.http_test_server_tag }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: ./.github/actions/ghcr-docker-login
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: ./.github/actions/setup-scripts
-      - name: Pull all images once
-        # Pulls every registry image in the compose project (resolving `extends`,
-        # anchors and env interpolation). The build-only `*-router` services have
-        # no `image:` and are skipped here; they are built once in the next step.
-        run: |
-          retry docker compose pull
-      - name: Build the router images once
-        # The `*-router` services are built once here and shipped in the images
-        # archive so the downstream test-matrix jobs load them via `docker load`
-        # instead of each running `docker build` + `apk add` against the Alpine
-        # CDN, which was a recurring source of flaky failures.
-        run: retry docker compose build client-1-router gateway-router relay-1-router relay-2-router portal-router client-2-router
-      - name: Save pulled images as a single archive
-        run: |
-          set -xe
-
-          # Save the compose project's images that are present locally: the pulled
-          # registry images plus the `*-router` images built in the previous step.
-          # The `docker image inspect` filter drops any build-only service that
-          # wasn't built.
-          images=$(docker compose config --images | sort -u | while read -r image; do
-            if docker image inspect "$image" > /dev/null 2>&1; then
-              echo "$image"
-            fi
-          done)
-
-          echo "Saving images:"
-          echo "$images"
-
-          # shellcheck disable=SC2086 # $images must be split into separate args
-          docker save $images | zstd --long=30 -T0 -o images.tar.zst
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          overwrite: true
-          name: images-${{ inputs.id }}
-          path: images.tar.zst
-          compression-level: 0
-          retention-days: 1
+    with:
+      id: ${{ inputs.id }}
+      portal_image: ${{ inputs.portal_image }}
+      portal_tag: ${{ inputs.portal_tag }}
+      relay_image: ${{ inputs.relay_image }}
+      relay_tag: ${{ inputs.relay_tag }}
+      gateway_image: ${{ inputs.gateway_image }}
+      gateway_tag: ${{ inputs.gateway_tag }}
+      client_image: ${{ inputs.client_image }}
+      client_tag: ${{ inputs.client_tag }}
+      elixir_image: ${{ inputs.elixir_image }}
+      elixir_tag: ${{ inputs.elixir_tag }}
+      http_test_server_image: ${{ inputs.http_test_server_image }}
+      http_test_server_tag: ${{ inputs.http_test_server_tag }}
 
   integration-tests:
     name: ${{ matrix.test.name || matrix.test.script }}

--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -7,9 +7,23 @@ env:
   COMPOSE_PARALLEL_LIMIT: 1 # Temporary fix for https://github.com/docker/compose/pull/12752 until compose v2.36.0 lands on GitHub actions runners.
 
 jobs:
+  collect-images:
+    uses: ./.github/workflows/_collect_images.yml
+    permissions:
+      contents: read
+    with:
+      id: perf
+      # `http-test-server` has no perf image, and the perf tests don't use it.
+      pull_services: "elixir postgres portal relay-1 relay-2 gateway client-1 iperf3 secnetperf network-config"
+      build_services: "client-1-router gateway-router relay-1-router relay-2-router portal-router"
+      gateway_image: "ghcr.io/firezone/perf/gateway"
+      client_image: "ghcr.io/firezone/perf/client"
+      relay_image: "ghcr.io/firezone/perf/relay"
+
   perf-tests:
     name: perf-tests
     runs-on: ubuntu-24.04
+    needs: collect-images
     permissions:
       contents: read
       id-token: write # OIDC auth
@@ -40,13 +54,15 @@ jobs:
           - relayed
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: ./.github/actions/ghcr-docker-login
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: ./.github/actions/setup-docker
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: images-perf
+      - name: Load pre-pulled images
+        run: zstd -dc --long=30 images.tar.zst | docker load
       - uses: ./.github/actions/setup-scripts
       - name: Seed database
-        run: docker compose run elixir /bin/sh -c 'mix ecto.migrate && mix ecto.seed'
+        run: docker compose run --pull never elixir /bin/sh -c 'mix ecto.migrate && mix ecto.seed'
       - name: Tune Linux kernel
         run: |
           sudo sysctl -w net.core.wmem_max=2097152            # 2 MB
@@ -60,17 +76,18 @@ jobs:
             echo "UDP_BITRATE=300M" >> "$GITHUB_ENV"
           fi
 
-          docker compose build client-1-router gateway-router relay-1-router relay-2-router portal-router
+          # The `*-router` images are pre-built in the `collect-images` job and
+          # loaded from the images archive above, so they are not built here.
 
           # Start services in the same order each time for the tests
           # Retries are used because network I/O is flaky in GitHub Actions runners
-          retry docker compose up -d iperf3
-          retry docker compose up -d secnetperf
-          retry docker compose up -d portal --no-build
-          retry docker compose up -d relay-1 relay-2 --no-build
-          retry docker compose up -d gateway --no-build
-          retry docker compose up -d client-1 --no-build
-          retry docker compose up -d network-config
+          retry docker compose up -d iperf3 --no-build --pull never
+          retry docker compose up -d secnetperf --no-build --pull never
+          retry docker compose up -d portal --no-build --pull never
+          retry docker compose up -d relay-1 relay-2 --no-build --pull never
+          retry docker compose up -d gateway --no-build --pull never
+          retry docker compose up -d client-1 --no-build --pull never
+          retry docker compose up -d network-config --pull never
       - name: "Performance test: ${{ matrix.flavour }}-${{ matrix.test }}"
         timeout-minutes: 5
         env:

--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -62,7 +62,7 @@ jobs:
         run: zstd -dc --long=30 images.tar.zst | docker load
       - uses: ./.github/actions/setup-scripts
       - name: Seed database
-        run: docker compose run --pull never elixir /bin/sh -c 'mix ecto.migrate && mix ecto.seed'
+        run: docker compose run --no-build --pull never elixir /bin/sh -c 'mix ecto.migrate && mix ecto.seed'
       - name: Tune Linux kernel
         run: |
           sudo sysctl -w net.core.wmem_max=2097152            # 2 MB


### PR DESCRIPTION
The perf tests pulled registry images and rebuilt the router images in every one of their twelve matrix jobs, so each job independently depended on Docker Hub and the Alpine CDN. A single connection reset while pulling `postgres` was enough to fail a job seconds after it started.

The integration tests already avoid this by pulling and building once in a `collect-images` job and shipping the result to the matrix as an archive. Extracting that job into a reusable workflow lets the perf tests reuse it, so the whole matrix loads images from the archive rather than reaching for a registry. Pulls are scoped per caller because the perf image set does not include `http-test-server`.