### PR TITLE
refactor(fuzz): make `grow`'s baseline write its own task

### DIFF
--- a/rust/tests/fuzz/README.md
+++ b/rust/tests/fuzz/README.md
@@ -75,12 +75,12 @@ Be wary of shortening it much for `tunnel-proto`: `-fork` re-merges the whole se
 The measurement is taken on the machine that runs it.
 A local run that gets luckier than CI writes a ceiling CI cannot meet, so re-run `coverage-check` before pushing.
 
-The individual steps remain available for doing this by hand:
+After growing and minimizing a corpus yourself, the remaining steps run individually; `update-baseline` records the measurement without the risk of truncating the committed file on a failed one:
 
 ```console
 mise run //rust/tests/fuzz:pack-corpus tunnel-proto
 mise run //rust/tests/fuzz:coverage tunnel-proto
-mise run -q //rust/tests/fuzz:coverage-summary tunnel-proto > expected-coverage/tunnel-proto.json
+mise run //rust/tests/fuzz:update-baseline tunnel-proto
 ```
 
 For a local browsable report:

--- a/rust/tests/fuzz/mise.toml
+++ b/rust/tests/fuzz/mise.toml
@@ -88,7 +88,6 @@ run = '''
 set -euo pipefail
 
 target="$usage_target"
-baseline="expected-coverage/$target.json"
 
 if [ -n "${usage_libfuzzer_args:-}" ]; then
   # `usage` joins variadic arguments as a shell-escaped string.
@@ -111,14 +110,27 @@ else
   set -- "-fork=$fork" -max_total_time=1800
 fi
 
-before="$(cat "$baseline" 2>/dev/null || echo null)"
-
 # Each step consumes what the previous one wrote, so they are invoked in order
 # rather than declared as `depends`, which mise runs in parallel.
 mise run //rust/tests/fuzz:fuzz "$target" "$@"
 mise run //rust/tests/fuzz:cmin "$target"
 mise run //rust/tests/fuzz:pack-corpus "$target"
 mise run //rust/tests/fuzz:coverage "$target"
+mise run //rust/tests/fuzz:update-baseline "$target"
+'''
+
+[tasks.update-baseline]
+description = "Record the last coverage measurement as the target's committed baseline"
+shell = "bash -c"
+usage = 'arg "<target>"'
+raw = true
+run = '''
+set -euo pipefail
+
+target="$usage_target"
+baseline="expected-coverage/$target.json"
+
+before="$(cat "$baseline" 2>/dev/null || echo null)"
 
 # Write the baseline via a temporary so a failed measurement leaves the
 # committed one intact rather than truncating it.


### PR DESCRIPTION
The final step of `grow`, recording the measured summary as the committed baseline, was the only part of the sequence without a task of its own: doing it by hand means a shell redirect, which truncates the committed file before the measurement has succeeded. `update-baseline` wraps that write; the remaining steps already run individually.

Related: #14479