### PR TITLE
ci: drop unsupported --no-build from perf seed step

### DIFF
--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -62,7 +62,7 @@ jobs:
         run: zstd -dc --long=30 images.tar.zst | docker load
       - uses: ./.github/actions/setup-scripts
       - name: Seed database
-        run: docker compose run --no-build --pull never elixir /bin/sh -c 'mix ecto.migrate && mix ecto.seed'
+        run: docker compose run --pull never elixir /bin/sh -c 'mix ecto.migrate && mix ecto.seed'
       - name: Tune Linux kernel
         run: |
           sudo sysctl -w net.core.wmem_max=2097152            # 2 MB


### PR DESCRIPTION
`docker compose run` has no `--no-build` flag, so the seed step of the perf tests exited immediately with `unknown flag` on the first run after the images archive landed. Only `docker compose up` accepts it, which is why the service startup steps were unaffected.

Related: #14484