### PR TITLE
fix(portal): pair flow logs on fields both sides agree on

### DIFF
--- a/elixir/lib/portal_api/schemas/log_schema.ex
+++ b/elixir/lib/portal_api/schemas/log_schema.ex
@@ -309,13 +309,17 @@ defmodule PortalAPI.Schemas.Log do
         outer_src_ip: %Schema{
           type: :string,
           description: """
-          WireGuard endpoint IP of the initiator, on both entries of the flow.
+          WireGuard endpoint IP of the initiator, as observed by the reporting
+          side. The two entries of a flow disagree whenever NAT or a relay sits
+          between the peers.
           """
         },
         outer_dst_ip: %Schema{
           type: :string,
           description: """
-          WireGuard endpoint IP of the responder, on both entries of the flow.
+          WireGuard endpoint IP of the responder, as observed by the reporting
+          side. The two entries of a flow disagree whenever NAT or a relay sits
+          between the peers.
           """
         },
         outer_src_port: %Schema{type: :integer},

--- a/elixir/lib/portal_web/live/logs/flow_logs.ex
+++ b/elixir/lib/portal_web/live/logs/flow_logs.ex
@@ -692,7 +692,7 @@ defmodule PortalWeb.Logs.FlowLogs do
 
         <div class="pt-3 border-t border-[var(--border)]">
           <div class="mb-1 text-xs text-[var(--text-tertiary)]">
-            WireGuard endpoints
+            WireGuard endpoints, as seen by this side
           </div>
           <div class="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 text-xs">
             <span class="text-[var(--text-tertiary)]">Initiator</span>
@@ -988,10 +988,16 @@ defmodule PortalWeb.Logs.FlowLogs do
       |> Safe.one()
     end
 
-    # Both devices normalize the inner and WireGuard tuples to initiator ->
-    # responder. Exact attribution, protocol, tuple, and domain equality plus
-    # an overlapping time window narrows the matches, but cannot prove identity
+    # Both devices normalize the inner tuple to initiator -> responder. Exact
+    # attribution, protocol, inner tuple, and domain equality plus an
+    # overlapping time window narrows the matches, but cannot prove identity
     # because independently created logs have no shared flow ID.
+    #
+    # Only fields both sides can agree on are matched, and the WireGuard tuple
+    # is not one of them: each side records the path from its own vantage point
+    # (its own bound socket address and the peer address it observes), so NAT on
+    # either end, or a relay in between, leaves the two sides disagreeing on
+    # every outer address in the common case.
     defp matching_logs(log, subject) do
       opposite_role = if log.role == :initiator, do: :responder, else: :initiator
       {selected_min, selected_max} = normalized_bounds(log)
@@ -1007,12 +1013,7 @@ defmodule PortalWeb.Logs.FlowLogs do
           where: candidate.protocol == ^log.protocol,
           where: candidate.inner_src_ip == ^log.inner_src_ip,
           where: candidate.inner_src_port == ^log.inner_src_port,
-          where: candidate.inner_dst_ip == ^log.inner_dst_ip,
           where: candidate.inner_dst_port == ^log.inner_dst_port,
-          where: candidate.outer_src_ip == ^log.outer_src_ip,
-          where: candidate.outer_src_port == ^log.outer_src_port,
-          where: candidate.outer_dst_ip == ^log.outer_dst_ip,
-          where: candidate.outer_dst_port == ^log.outer_dst_port,
           where:
             is_nil(candidate.flow_end) or
               ^selected_min <= fragment("GREATEST(?, ?)", candidate.flow_start, candidate.flow_end),
@@ -1024,6 +1025,7 @@ defmodule PortalWeb.Logs.FlowLogs do
             ),
           limit: @candidate_limit
         )
+        |> filter_candidate_inner_dst_ip(log)
         |> filter_candidate_domain(log.domain)
         |> filter_candidate_upper_bound(selected_max)
 
@@ -1039,6 +1041,15 @@ defmodule PortalWeb.Logs.FlowLogs do
         do: {ended_at, started_at},
         else: {started_at, ended_at}
     end
+
+    # A flow to a DNS Resource is addressed to the proxy IP the Client assigned
+    # to the domain, and the Gateway swaps that for the IP it resolved before
+    # forwarding, so the two sides never agree on the destination. Their shared
+    # domain identifies the destination instead.
+    defp filter_candidate_inner_dst_ip(query, %{domain: nil} = log),
+      do: where(query, [flow_logs: candidate], candidate.inner_dst_ip == ^log.inner_dst_ip)
+
+    defp filter_candidate_inner_dst_ip(query, _log), do: query
 
     defp filter_candidate_domain(query, nil),
       do: where(query, [flow_logs: candidate], is_nil(candidate.domain))

--- a/elixir/test/portal_web/live/logs/flow_logs_test.exs
+++ b/elixir/test/portal_web/live/logs/flow_logs_test.exs
@@ -493,7 +493,7 @@ defmodule PortalWeb.Logs.FlowLogsTest do
       refute panel_html =~ other.log_id
     end
 
-    test "does not match a different WireGuard tuple", %{
+    test "matches when NAT rewrote the WireGuard tuple", %{
       conn: conn,
       account: account,
       actor: actor
@@ -509,10 +509,6 @@ defmodule PortalWeb.Logs.FlowLogsTest do
         inner_src_port: 51_234,
         inner_dst_ip: %Postgrex.INET{address: {10, 0, 0, 9}},
         inner_dst_port: 443,
-        outer_src_ip: %Postgrex.INET{address: {203, 0, 113, 10}},
-        outer_src_port: 51_820,
-        outer_dst_ip: %Postgrex.INET{address: {198, 51, 100, 5}},
-        outer_dst_port: 51_820,
         domain: nil
       }
 
@@ -520,6 +516,10 @@ defmodule PortalWeb.Logs.FlowLogsTest do
         flow_log_fixture(
           identity
           |> Map.put(:role, :initiator)
+          |> Map.put(:outer_src_ip, %Postgrex.INET{address: {192, 168, 1, 86}})
+          |> Map.put(:outer_src_port, 52_625)
+          |> Map.put(:outer_dst_ip, %Postgrex.INET{address: {203, 0, 113, 5}})
+          |> Map.put(:outer_dst_port, 52_625)
           |> Map.put(:flow_start, ~U[2026-07-30 10:00:00.000000Z])
           |> Map.put(:flow_end, ~U[2026-07-30 10:01:00.000000Z])
         )
@@ -528,7 +528,110 @@ defmodule PortalWeb.Logs.FlowLogsTest do
         flow_log_fixture(
           identity
           |> Map.put(:role, :responder)
-          |> Map.put(:outer_src_ip, %Postgrex.INET{address: {203, 0, 113, 11}})
+          |> Map.put(:outer_src_ip, %Postgrex.INET{address: {198, 51, 100, 130}})
+          |> Map.put(:outer_src_port, 41_001)
+          |> Map.put(:outer_dst_ip, %Postgrex.INET{address: {10, 122, 5, 4}})
+          |> Map.put(:outer_dst_port, 52_625)
+          |> Map.put(:flow_start, ~U[2026-07-30 10:00:02.000000Z])
+          |> Map.put(:flow_end, ~U[2026-07-30 10:01:02.000000Z])
+        )
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/logs/flow_logs/#{selected.log_id}")
+
+      panel_html = lv |> element("#flow-log-panel") |> render()
+
+      refute html =~ "No matching responder log"
+      assert panel_html =~ other.log_id
+
+      assert has_element?(
+               lv,
+               "#flow-log-card-#{other.log_id} [data-wireguard-endpoint='initiator']",
+               "198.51.100.130:41001"
+             )
+    end
+
+    test "matches a DNS Resource flow on its domain, not the proxy IP", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      identity = %{
+        account: account,
+        policy_authorization_id: Ecto.UUID.generate(),
+        initiator_device_id: Ecto.UUID.generate(),
+        responder_device_id: Ecto.UUID.generate(),
+        resource_id: Ecto.UUID.generate(),
+        protocol: :tcp,
+        inner_src_ip: %Postgrex.INET{address: {100, 64, 0, 8}},
+        inner_src_port: 51_234,
+        inner_dst_port: 443,
+        domain: "gitlab.company.com"
+      }
+
+      selected =
+        flow_log_fixture(
+          identity
+          |> Map.put(:role, :initiator)
+          |> Map.put(:inner_dst_ip, %Postgrex.INET{address: {100, 96, 0, 3}})
+          |> Map.put(:flow_start, ~U[2026-07-30 10:00:00.000000Z])
+          |> Map.put(:flow_end, ~U[2026-07-30 10:01:00.000000Z])
+        )
+
+      other =
+        flow_log_fixture(
+          identity
+          |> Map.put(:role, :responder)
+          |> Map.put(:inner_dst_ip, %Postgrex.INET{address: {10, 0, 0, 9}})
+          |> Map.put(:flow_start, ~U[2026-07-30 10:00:02.000000Z])
+          |> Map.put(:flow_end, ~U[2026-07-30 10:01:02.000000Z])
+        )
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/logs/flow_logs/#{selected.log_id}")
+
+      panel_html = lv |> element("#flow-log-panel") |> render()
+
+      refute html =~ "No matching responder log"
+      assert panel_html =~ other.log_id
+    end
+
+    test "does not match a different destination without a domain", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      identity = %{
+        account: account,
+        policy_authorization_id: Ecto.UUID.generate(),
+        initiator_device_id: Ecto.UUID.generate(),
+        responder_device_id: Ecto.UUID.generate(),
+        resource_id: Ecto.UUID.generate(),
+        protocol: :tcp,
+        inner_src_ip: %Postgrex.INET{address: {100, 64, 0, 8}},
+        inner_src_port: 51_234,
+        inner_dst_port: 443,
+        domain: nil
+      }
+
+      selected =
+        flow_log_fixture(
+          identity
+          |> Map.put(:role, :initiator)
+          |> Map.put(:inner_dst_ip, %Postgrex.INET{address: {10, 0, 0, 9}})
+          |> Map.put(:flow_start, ~U[2026-07-30 10:00:00.000000Z])
+          |> Map.put(:flow_end, ~U[2026-07-30 10:01:00.000000Z])
+        )
+
+      other =
+        flow_log_fixture(
+          identity
+          |> Map.put(:role, :responder)
+          |> Map.put(:inner_dst_ip, %Postgrex.INET{address: {10, 0, 0, 10}})
           |> Map.put(:flow_start, ~U[2026-07-30 10:00:02.000000Z])
           |> Map.put(:flow_end, ~U[2026-07-30 10:01:02.000000Z])
         )


### PR DESCRIPTION
Every flow is logged twice, once by each side. The log details panel finds the other side by looking for a log with the same details, and it compared the WireGuard endpoints as part of that.

Each side only knows its own view of the path. The client sees its local address and the gateway's public one, the gateway sees the client's NAT'd address and its own local one. So the two logs almost never matched on those, and the panel kept saying no matching log was found.

Pairing now only uses details both sides can agree on. The WireGuard endpoints are still shown, just not compared.

Flows to DNS resources were broken for a second reason. The client sends to the proxy IP it picked for the domain, and the gateway swaps in the IP it actually resolved. Those flows now pair on the domain, which both sides do agree on.

Related: #14443
