### PR TITLE
test(fuzz): cover structurally invalid DNS queries

### DIFF
--- a/rust/libs/connlib/dns-types/lib.rs
+++ b/rust/libs/connlib/dns-types/lib.rs
@@ -554,62 +554,6 @@ mod tests {
     }
 
     #[test]
-    fn rejects_query_with_qr_bit_set() {
-        let domain = DomainName::vec_from_str("example.com").unwrap();
-        let query = Query::new(domain, RecordType::A);
-        let response = Response::no_error(&query).into_bytes(u16::MAX);
-
-        assert!(matches!(Query::parse(&response), Err(Error::NotAQuery)));
-    }
-
-    #[test]
-    fn rejects_query_without_question() {
-        let message = MessageBuilder::new_vec().question().into_message();
-
-        assert!(matches!(
-            Query::parse(message.as_slice()),
-            Err(Error::Parse(_))
-        ));
-    }
-
-    #[test]
-    fn rejects_query_with_two_questions() {
-        let domain = DomainName::vec_from_str("example.com").unwrap();
-
-        let mut builder = MessageBuilder::new_vec().question();
-        builder.push((domain.clone(), RecordType::A)).unwrap();
-        builder.push((domain, RecordType::AAAA)).unwrap();
-        let message = builder.into_message();
-
-        assert!(matches!(
-            Query::parse(message.as_slice()),
-            Err(Error::Parse(_))
-        ));
-    }
-
-    #[test]
-    fn rejects_query_shorter_than_header() {
-        assert!(matches!(Query::parse(&[0u8; 11]), Err(Error::TooShort)));
-    }
-
-    #[test]
-    fn ignores_answers_in_query() {
-        let domain = DomainName::vec_from_str("example.com").unwrap();
-
-        let mut builder = MessageBuilder::new_vec().question();
-        builder.push((domain.clone(), RecordType::A)).unwrap();
-        let mut builder = builder.answer();
-        builder
-            .push((domain.clone(), 300, records::a(Ipv4Addr::LOCALHOST)))
-            .unwrap();
-        let message = builder.into_message();
-
-        let query = Query::parse(message.as_slice()).unwrap();
-
-        assert_eq!(query.domain(), domain);
-    }
-
-    #[test]
     fn parse_host_from_known_url() {
         assert_eq!(DoHUrl::google().host(), "dns.google");
         assert_eq!(DoHUrl::cloudflare().host(), "cloudflare-dns.com");

--- a/rust/libs/connlib/dns-types/lib.rs
+++ b/rust/libs/connlib/dns-types/lib.rs
@@ -70,10 +70,7 @@ impl Query {
         // See: https://stackoverflow.com/a/55093896
         let _ = message.sole_question()?; // Verify that there is exactly one question.
 
-        // Verify that we can parse the answers + all records
-        for record in message.answer()? {
-            record?.into_any_record::<AllRecordData<_, _>>()?;
-        }
+        // Any other sections of a query are irrelevant to us: we never read them.
 
         Ok(Self {
             inner: message.octets_into(),
@@ -554,6 +551,62 @@ mod tests {
         assert!(parsed_response.truncated());
         assert_eq!(parsed_response.records().count(), 0);
         assert_eq!(parsed_response.domain(), domain);
+    }
+
+    #[test]
+    fn rejects_query_with_qr_bit_set() {
+        let domain = DomainName::vec_from_str("example.com").unwrap();
+        let query = Query::new(domain, RecordType::A);
+        let response = Response::no_error(&query).into_bytes(u16::MAX);
+
+        assert!(matches!(Query::parse(&response), Err(Error::NotAQuery)));
+    }
+
+    #[test]
+    fn rejects_query_without_question() {
+        let message = MessageBuilder::new_vec().question().into_message();
+
+        assert!(matches!(
+            Query::parse(message.as_slice()),
+            Err(Error::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_query_with_two_questions() {
+        let domain = DomainName::vec_from_str("example.com").unwrap();
+
+        let mut builder = MessageBuilder::new_vec().question();
+        builder.push((domain.clone(), RecordType::A)).unwrap();
+        builder.push((domain, RecordType::AAAA)).unwrap();
+        let message = builder.into_message();
+
+        assert!(matches!(
+            Query::parse(message.as_slice()),
+            Err(Error::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_query_shorter_than_header() {
+        assert!(matches!(Query::parse(&[0u8; 11]), Err(Error::TooShort)));
+    }
+
+    #[test]
+    fn ignores_answers_in_query() {
+        let domain = DomainName::vec_from_str("example.com").unwrap();
+
+        let mut builder = MessageBuilder::new_vec().question();
+        builder.push((domain.clone(), RecordType::A)).unwrap();
+        let mut builder = builder.answer();
+        builder
+            .push((domain.clone(), 300, records::a(Ipv4Addr::LOCALHOST)))
+            .unwrap();
+        let message = builder.into_message();
+
+        let query = Query::parse(message.as_slice()).unwrap();
+
+        assert_eq!(query.domain(), domain);
     }
 
     #[test]

--- a/rust/tests/fuzz/src/arb/context.rs
+++ b/rust/tests/fuzz/src/arb/context.rs
@@ -307,6 +307,12 @@ impl<'a> Generator<'a> {
             .collect::<String>()
     }
 
+    pub(super) fn bytes(&mut self, lo: usize, hi: usize) -> Vec<u8> {
+        let n = self.count(lo, hi);
+
+        (0..n).map(|_| self.u8()).collect()
+    }
+
     fn u8_in(&mut self, range: RangeInclusive<u8>) -> u8 {
         let fallback = *range.start();
 

--- a/rust/tests/fuzz/src/arb/context.rs
+++ b/rust/tests/fuzz/src/arb/context.rs
@@ -306,6 +306,12 @@ impl<'a> Generator<'a> {
             .collect::<String>()
     }
 
+    pub(super) fn bytes(&mut self, lo: usize, hi: usize) -> Vec<u8> {
+        let n = self.count(lo, hi);
+
+        (0..n).map(|_| self.u8()).collect()
+    }
+
     fn u8_in(&mut self, range: RangeInclusive<u8>) -> u8 {
         let fallback = *range.start();
 

--- a/rust/tests/fuzz/src/arb/dns_queries.rs
+++ b/rust/tests/fuzz/src/arb/dns_queries.rs
@@ -10,7 +10,7 @@ use tunnel_proto::dns;
 use super::context::Generator;
 use super::packets::{host_in_v4, host_in_v6};
 use crate::reference::ReferenceState;
-use crate::transition::{DnsQuery, DnsTransport, IpFamily, Transition};
+use crate::transition::{DnsQuery, DnsTransport, IpFamily, MalformedDnsQuery, Transition};
 
 #[derive(Clone)]
 pub(super) struct DnsQueryTarget {
@@ -175,6 +175,23 @@ pub(super) fn generate(
             dns_server: target.dns_server,
             transport: arb_dns_transport(g),
         },
+    }
+}
+
+pub(super) fn generate_malformed(g: &mut Generator, target: DnsQueryTarget) -> Transition {
+    let kinds = [
+        MalformedDnsQuery::QrBitSet,
+        MalformedDnsQuery::NoQuestion,
+        MalformedDnsQuery::TwoQuestions,
+        MalformedDnsQuery::TruncatedHeader,
+    ];
+
+    Transition::SendMalformedDnsQuery {
+        client_id: target.client_id,
+        kind: kinds[g.choose_index(kinds.len())],
+        query_id: arb_dns_query_id(g),
+        dns_server: target.dns_server,
+        local_port: g.u16(),
     }
 }
 

--- a/rust/tests/fuzz/src/arb/dns_queries.rs
+++ b/rust/tests/fuzz/src/arb/dns_queries.rs
@@ -10,7 +10,7 @@ use tunnel_proto::dns;
 use super::context::Generator;
 use super::packets::{host_in_v4, host_in_v6};
 use crate::reference::ReferenceState;
-use crate::transition::{DnsQuery, DnsTransport, IpFamily, MalformedDnsQuery, Transition};
+use crate::transition::{DnsQuery, DnsTransport, IpFamily, Transition};
 
 #[derive(Clone)]
 pub(super) struct DnsQueryTarget {
@@ -178,18 +178,22 @@ pub(super) fn generate(
     }
 }
 
+/// Sends arbitrary bytes to a stub resolver instead of a well-formed query.
+///
+/// Which byte patterns reach which of the structural checks in `dns_types::Query::parse`
+/// is left to the fuzzer; enumerating them here would only cover the ways we thought of.
 pub(super) fn generate_malformed(g: &mut Generator, target: DnsQueryTarget) -> Transition {
-    let kinds = [
-        MalformedDnsQuery::QrBitSet,
-        MalformedDnsQuery::NoQuestion,
-        MalformedDnsQuery::TwoQuestions,
-        MalformedDnsQuery::TruncatedHeader,
-    ];
+    let payload = g.bytes(0, 64);
+
+    // Bytes that happen to parse are a valid query like any other, which the client
+    // answers. Modelling that is `SendDnsQuery`'s job, so leave those to it.
+    if dns_types::Query::parse(&payload).is_ok() {
+        return Transition::Idle;
+    }
 
     Transition::SendMalformedDnsQuery {
         client_id: target.client_id,
-        kind: kinds[g.choose_index(kinds.len())],
-        query_id: arb_dns_query_id(g),
+        payload,
         dns_server: target.dns_server,
         local_port: g.u16(),
     }

--- a/rust/tests/fuzz/src/arb/dns_queries.rs
+++ b/rust/tests/fuzz/src/arb/dns_queries.rs
@@ -10,7 +10,7 @@ use tunnel_proto::dns;
 use super::context::Generator;
 use super::packets::{host_in_v4, host_in_v6};
 use crate::reference::ReferenceState;
-use crate::transition::{DnsQuery, DnsTransport, MalformedDnsQuery, Transition};
+use crate::transition::{DnsQuery, DnsTransport, Transition};
 
 #[derive(Clone)]
 pub(super) struct DnsQueryTarget {
@@ -144,18 +144,22 @@ pub(super) fn generate(g: &mut Generator, target: DnsQueryTarget) -> Transition 
     }
 }
 
+/// Sends arbitrary bytes to a stub resolver instead of a well-formed query.
+///
+/// Which byte patterns reach which of the structural checks in `dns_types::Query::parse`
+/// is left to the fuzzer; enumerating them here would only cover the ways we thought of.
 pub(super) fn generate_malformed(g: &mut Generator, target: DnsQueryTarget) -> Transition {
-    let kinds = [
-        MalformedDnsQuery::QrBitSet,
-        MalformedDnsQuery::NoQuestion,
-        MalformedDnsQuery::TwoQuestions,
-        MalformedDnsQuery::TruncatedHeader,
-    ];
+    let payload = g.bytes(0, 64);
+
+    // Bytes that happen to parse are a valid query like any other, which the client
+    // answers. Modelling that is `SendDnsQuery`'s job, so leave those to it.
+    if dns_types::Query::parse(&payload).is_ok() {
+        return Transition::Idle;
+    }
 
     Transition::SendMalformedDnsQuery {
         client_id: target.client_id,
-        kind: kinds[g.choose_index(kinds.len())],
-        query_id: arb_dns_query_id(g),
+        payload,
         dns_server: target.dns_server,
         local_port: g.u16(),
     }

--- a/rust/tests/fuzz/src/arb/dns_queries.rs
+++ b/rust/tests/fuzz/src/arb/dns_queries.rs
@@ -10,7 +10,7 @@ use tunnel_proto::dns;
 use super::context::Generator;
 use super::packets::{host_in_v4, host_in_v6};
 use crate::reference::ReferenceState;
-use crate::transition::{DnsQuery, DnsTransport, Transition};
+use crate::transition::{DnsQuery, DnsTransport, MalformedDnsQuery, Transition};
 
 #[derive(Clone)]
 pub(super) struct DnsQueryTarget {
@@ -141,6 +141,23 @@ pub(super) fn generate(g: &mut Generator, target: DnsQueryTarget) -> Transition 
             dns_server: target.dns_server,
             transport: arb_dns_transport(g),
         },
+    }
+}
+
+pub(super) fn generate_malformed(g: &mut Generator, target: DnsQueryTarget) -> Transition {
+    let kinds = [
+        MalformedDnsQuery::QrBitSet,
+        MalformedDnsQuery::NoQuestion,
+        MalformedDnsQuery::TwoQuestions,
+        MalformedDnsQuery::TruncatedHeader,
+    ];
+
+    Transition::SendMalformedDnsQuery {
+        client_id: target.client_id,
+        kind: kinds[g.choose_index(kinds.len())],
+        query_id: arb_dns_query_id(g),
+        dns_server: target.dns_server,
+        local_port: g.u16(),
     }
 }
 

--- a/rust/tests/fuzz/src/arb/transitions.rs
+++ b/rust/tests/fuzz/src/arb/transitions.rs
@@ -49,6 +49,7 @@ enum TransitionKind {
     UpdateDnsRecords,
     SendPacket,
     SendDnsQuery,
+    SendMalformedDnsQuery,
     // Static device pool membership update.
     UpdateStaticDevicePool,
 }
@@ -100,11 +101,12 @@ pub(super) fn generate(
         (!dns_record_domains.is_empty()).then_some((K::UpdateDnsRecords, 5)),
         (!packet_targets.is_empty()).then_some((K::SendPacket, 50)),
         (!dns_query_targets.is_empty()).then_some((K::SendDnsQuery, 10)),
+        (!dns_query_targets.is_empty()).then_some((K::SendMalformedDnsQuery, 2)),
         (!static_device_pools.is_empty()).then_some((K::UpdateStaticDevicePool, 2)),
     ]
     .into_iter()
     .flatten()
-    .collect::<SmallVec<[_; 23]>>();
+    .collect::<SmallVec<[_; 24]>>();
 
     // Weighted pick over the legal list.
     let kind = weighted_choose(g, &legal)?;
@@ -252,6 +254,10 @@ pub(super) fn generate(
         K::SendDnsQuery => {
             let target = dns_query_targets[g.choose_index(dns_query_targets.len())].clone();
             dns_queries::generate(g, target, state)
+        }
+        K::SendMalformedDnsQuery => {
+            let target = dns_query_targets[g.choose_index(dns_query_targets.len())].clone();
+            dns_queries::generate_malformed(g, target)
         }
         K::UpdateStaticDevicePool => {
             let pool = static_device_pools[g.choose_index(static_device_pools.len())].clone();

--- a/rust/tests/fuzz/src/arb/transitions.rs
+++ b/rust/tests/fuzz/src/arb/transitions.rs
@@ -48,6 +48,7 @@ enum TransitionKind {
     UpdateDnsRecords,
     SendPacket,
     SendDnsQuery,
+    SendMalformedDnsQuery,
     // Static device pool membership update.
     UpdateStaticDevicePool,
 }
@@ -99,11 +100,12 @@ pub(super) fn generate(
         (!dns_record_domains.is_empty()).then_some((K::UpdateDnsRecords, 5)),
         (!packet_targets.is_empty()).then_some((K::SendPacket, 50)),
         (!dns_query_targets.is_empty()).then_some((K::SendDnsQuery, 10)),
+        (!dns_query_targets.is_empty()).then_some((K::SendMalformedDnsQuery, 2)),
         (!static_device_pools.is_empty()).then_some((K::UpdateStaticDevicePool, 2)),
     ]
     .into_iter()
     .flatten()
-    .collect::<SmallVec<[_; 23]>>();
+    .collect::<SmallVec<[_; 24]>>();
 
     // Weighted pick over the legal list.
     let kind = weighted_choose(g, &legal)?;
@@ -236,6 +238,10 @@ pub(super) fn generate(
         K::SendDnsQuery => {
             let target = dns_query_targets[g.choose_index(dns_query_targets.len())].clone();
             dns_queries::generate(g, target)
+        }
+        K::SendMalformedDnsQuery => {
+            let target = dns_query_targets[g.choose_index(dns_query_targets.len())].clone();
+            dns_queries::generate_malformed(g, target)
         }
         K::UpdateStaticDevicePool => {
             let pool = static_device_pools[g.choose_index(static_device_pools.len())].clone();

--- a/rust/tests/fuzz/src/reference.rs
+++ b/rust/tests/fuzz/src/reference.rs
@@ -257,6 +257,11 @@ impl ReferenceState {
                     c.on_dns_resource_ptr_query(dns_server, *query_id, *transport);
                 });
             }
+            Transition::SendMalformedDnsQuery { .. } => {
+                // The client must drop structurally invalid queries, so there is
+                // nothing to record: without an expected UDP DNS handshake, any
+                // response is flagged as an unexpected reply.
+            }
             Transition::SendIcmpPacket {
                 client_id,
                 src,

--- a/rust/tests/fuzz/src/reference.rs
+++ b/rust/tests/fuzz/src/reference.rs
@@ -237,6 +237,11 @@ impl ReferenceState {
                     c.on_dns_query(query, upstream_do53, icmp_error_hosts);
                 });
             }
+            Transition::SendMalformedDnsQuery { .. } => {
+                // The client must drop structurally invalid queries, so there is
+                // nothing to record: without an expected UDP DNS handshake, any
+                // response is flagged as an unexpected reply.
+            }
             Transition::SendIcmpPacket {
                 client_id,
                 dst,

--- a/rust/tests/fuzz/src/sim_client.rs
+++ b/rust/tests/fuzz/src/sim_client.rs
@@ -9,7 +9,7 @@ use super::{
     reference::PrivateKey,
     sim_net::{ExecMutScope, Host},
     sim_relay::{SimRelay, map_explode},
-    transition::{DPort, DnsTransport, Identifier, IpFamily, MalformedDnsQuery, SPort, Seq},
+    transition::{DPort, DnsTransport, Identifier, IpFamily, SPort, Seq},
 };
 use chrono::{DateTime, Utc};
 use connlib_model::{ClientId, RelayId, ResourceList};
@@ -241,8 +241,7 @@ impl SimClient {
 
     pub(crate) fn send_malformed_dns_query(
         &mut self,
-        kind: MalformedDnsQuery,
-        query_id: u16,
+        payload: &[u8],
         upstream: dns::Upstream,
         local_port: u16,
         now: Instant,
@@ -252,15 +251,14 @@ impl SimClient {
             return None;
         };
 
-        tracing::debug!(%sentinel, ?kind, "Sending malformed DNS query");
+        tracing::debug!(%sentinel, len = %payload.len(), "Sending malformed DNS query");
 
         let src = self
             .sut
             .tunnel_ip_for(sentinel)
             .expect("tunnel should be initialised");
 
-        let payload = malformed_dns_query(kind, query_id);
-        let packet = ip_packet::make::udp_packet(src, sentinel, local_port, 53, &payload).unwrap();
+        let packet = ip_packet::make::udp_packet(src, sentinel, local_port, 53, payload).unwrap();
 
         // Deliberately not tracked in `sent_udp_dns_queries`: the client must drop
         // the query, and any response shows up as an unexpected UDP DNS reply.
@@ -686,36 +684,4 @@ impl ExecMutScope for SimClient {
     fn enter(&self) -> Self::Guard {
         self.malicious_behaviour.guard()
     }
-}
-
-/// Serializes a structurally invalid DNS query of the given kind.
-///
-/// Starts from a valid single-question query and patches the wire format;
-/// the header is id (2 bytes), flags (2 bytes) and four section counts
-/// (2 bytes each), followed by the question section.
-fn malformed_dns_query(kind: MalformedDnsQuery, query_id: u16) -> Vec<u8> {
-    let domain = DomainName::vec_from_str("malformed.example.com").unwrap();
-    let mut bytes = Query::new(domain, RecordType::A)
-        .with_id(query_id)
-        .into_bytes();
-
-    match kind {
-        MalformedDnsQuery::QrBitSet => {
-            bytes[2] |= 0b1000_0000; // The QR bit is the top bit of the flags.
-        }
-        MalformedDnsQuery::NoQuestion => {
-            bytes.truncate(12); // Just the header ...
-            bytes[5] = 0; // ... with QDCOUNT set to match.
-        }
-        MalformedDnsQuery::TwoQuestions => {
-            let question = bytes[12..].to_vec();
-            bytes.extend_from_slice(&question); // Repeat the question ...
-            bytes[5] = 2; // ... with QDCOUNT set to match.
-        }
-        MalformedDnsQuery::TruncatedHeader => {
-            bytes.truncate(11); // One byte short of a full header.
-        }
-    }
-
-    bytes
 }

--- a/rust/tests/fuzz/src/sim_client.rs
+++ b/rust/tests/fuzz/src/sim_client.rs
@@ -9,7 +9,7 @@ use super::{
     reference::PrivateKey,
     sim_net::{ExecMutScope, Host},
     sim_relay::{SimRelay, map_explode},
-    transition::{DPort, DnsTransport, Identifier, IpFamily, SPort, Seq},
+    transition::{DPort, DnsTransport, Identifier, IpFamily, MalformedDnsQuery, SPort, Seq},
 };
 use chrono::{DateTime, Utc};
 use connlib_model::{ClientId, RelayId, ResourceList};
@@ -237,6 +237,34 @@ impl SimClient {
                 None
             }
         }
+    }
+
+    pub(crate) fn send_malformed_dns_query(
+        &mut self,
+        kind: MalformedDnsQuery,
+        query_id: u16,
+        upstream: dns::Upstream,
+        local_port: u16,
+        now: Instant,
+    ) -> Option<Transmit> {
+        let Some(sentinel) = self.dns_by_sentinel.sentinel_by_upstream(&upstream) else {
+            tracing::error!(%upstream, "Unknown DNS server");
+            return None;
+        };
+
+        tracing::debug!(%sentinel, ?kind, "Sending malformed DNS query");
+
+        let src = self
+            .sut
+            .tunnel_ip_for(sentinel)
+            .expect("tunnel should be initialised");
+
+        let payload = malformed_dns_query(kind, query_id);
+        let packet = ip_packet::make::udp_packet(src, sentinel, local_port, 53, &payload).unwrap();
+
+        // Deliberately not tracked in `sent_udp_dns_queries`: the client must drop
+        // the query, and any response shows up as an unexpected UDP DNS reply.
+        self.encapsulate(packet, now)
     }
 
     pub fn connect_tcp(&mut self, src: IpAddr, dst: IpAddr, sport: SPort, dport: DPort) {
@@ -658,4 +686,36 @@ impl ExecMutScope for SimClient {
     fn enter(&self) -> Self::Guard {
         self.malicious_behaviour.guard()
     }
+}
+
+/// Serializes a structurally invalid DNS query of the given kind.
+///
+/// Starts from a valid single-question query and patches the wire format;
+/// the header is id (2 bytes), flags (2 bytes) and four section counts
+/// (2 bytes each), followed by the question section.
+fn malformed_dns_query(kind: MalformedDnsQuery, query_id: u16) -> Vec<u8> {
+    let domain = DomainName::vec_from_str("malformed.example.com").unwrap();
+    let mut bytes = Query::new(domain, RecordType::A)
+        .with_id(query_id)
+        .into_bytes();
+
+    match kind {
+        MalformedDnsQuery::QrBitSet => {
+            bytes[2] |= 0b1000_0000; // The QR bit is the top bit of the flags.
+        }
+        MalformedDnsQuery::NoQuestion => {
+            bytes.truncate(12); // Just the header ...
+            bytes[5] = 0; // ... with QDCOUNT set to match.
+        }
+        MalformedDnsQuery::TwoQuestions => {
+            let question = bytes[12..].to_vec();
+            bytes.extend_from_slice(&question); // Repeat the question ...
+            bytes[5] = 2; // ... with QDCOUNT set to match.
+        }
+        MalformedDnsQuery::TruncatedHeader => {
+            bytes.truncate(11); // One byte short of a full header.
+        }
+    }
+
+    bytes
 }

--- a/rust/tests/fuzz/src/sim_client.rs
+++ b/rust/tests/fuzz/src/sim_client.rs
@@ -5,7 +5,7 @@ use super::{
     reference::PrivateKey,
     sim_net::{ExecMutScope, Host},
     sim_relay::{SimRelay, map_explode},
-    transition::{DPort, DnsTransport, Identifier, MalformedDnsQuery, SPort, Seq},
+    transition::{DPort, DnsTransport, Identifier, SPort, Seq},
 };
 use chrono::{DateTime, Utc};
 use connlib_model::{ClientId, RelayId, ResourceId, ResourceStatus};
@@ -210,8 +210,7 @@ impl SimClient {
 
     pub(crate) fn send_malformed_dns_query(
         &mut self,
-        kind: MalformedDnsQuery,
-        query_id: u16,
+        payload: &[u8],
         upstream: dns::Upstream,
         local_port: u16,
         now: Instant,
@@ -221,15 +220,14 @@ impl SimClient {
             return None;
         };
 
-        tracing::debug!(%sentinel, ?kind, "Sending malformed DNS query");
+        tracing::debug!(%sentinel, len = %payload.len(), "Sending malformed DNS query");
 
         let src = self
             .sut
             .tunnel_ip_for(sentinel)
             .expect("tunnel should be initialised");
 
-        let payload = malformed_dns_query(kind, query_id);
-        let packet = ip_packet::make::udp_packet(src, sentinel, local_port, 53, &payload).unwrap();
+        let packet = ip_packet::make::udp_packet(src, sentinel, local_port, 53, payload).unwrap();
 
         // Deliberately not tracked in `sent_udp_dns_queries`: the client must drop
         // the query, and any response shows up as an unexpected UDP DNS reply.
@@ -599,36 +597,4 @@ impl ExecMutScope for SimClient {
     fn enter(&self) -> Self::Guard {
         self.malicious_behaviour.guard()
     }
-}
-
-/// Serializes a structurally invalid DNS query of the given kind.
-///
-/// Starts from a valid single-question query and patches the wire format;
-/// the header is id (2 bytes), flags (2 bytes) and four section counts
-/// (2 bytes each), followed by the question section.
-fn malformed_dns_query(kind: MalformedDnsQuery, query_id: u16) -> Vec<u8> {
-    let domain = DomainName::vec_from_str("malformed.example.com").unwrap();
-    let mut bytes = Query::new(domain, RecordType::A)
-        .with_id(query_id)
-        .into_bytes();
-
-    match kind {
-        MalformedDnsQuery::QrBitSet => {
-            bytes[2] |= 0b1000_0000; // The QR bit is the top bit of the flags.
-        }
-        MalformedDnsQuery::NoQuestion => {
-            bytes.truncate(12); // Just the header ...
-            bytes[5] = 0; // ... with QDCOUNT set to match.
-        }
-        MalformedDnsQuery::TwoQuestions => {
-            let question = bytes[12..].to_vec();
-            bytes.extend_from_slice(&question); // Repeat the question ...
-            bytes[5] = 2; // ... with QDCOUNT set to match.
-        }
-        MalformedDnsQuery::TruncatedHeader => {
-            bytes.truncate(11); // One byte short of a full header.
-        }
-    }
-
-    bytes
 }

--- a/rust/tests/fuzz/src/sim_client.rs
+++ b/rust/tests/fuzz/src/sim_client.rs
@@ -5,7 +5,7 @@ use super::{
     reference::PrivateKey,
     sim_net::{ExecMutScope, Host},
     sim_relay::{SimRelay, map_explode},
-    transition::{DPort, DnsTransport, Identifier, SPort, Seq},
+    transition::{DPort, DnsTransport, Identifier, MalformedDnsQuery, SPort, Seq},
 };
 use chrono::{DateTime, Utc};
 use connlib_model::{ClientId, RelayId, ResourceId, ResourceStatus};
@@ -206,6 +206,34 @@ impl SimClient {
                 None
             }
         }
+    }
+
+    pub(crate) fn send_malformed_dns_query(
+        &mut self,
+        kind: MalformedDnsQuery,
+        query_id: u16,
+        upstream: dns::Upstream,
+        local_port: u16,
+        now: Instant,
+    ) -> Option<Transmit> {
+        let Some(sentinel) = self.dns_by_sentinel.sentinel_by_upstream(&upstream) else {
+            tracing::error!(%upstream, "Unknown DNS server");
+            return None;
+        };
+
+        tracing::debug!(%sentinel, ?kind, "Sending malformed DNS query");
+
+        let src = self
+            .sut
+            .tunnel_ip_for(sentinel)
+            .expect("tunnel should be initialised");
+
+        let payload = malformed_dns_query(kind, query_id);
+        let packet = ip_packet::make::udp_packet(src, sentinel, local_port, 53, &payload).unwrap();
+
+        // Deliberately not tracked in `sent_udp_dns_queries`: the client must drop
+        // the query, and any response shows up as an unexpected UDP DNS reply.
+        self.encapsulate(packet, now)
     }
 
     pub fn connect_tcp(&mut self, src: IpAddr, dst: IpAddr, sport: SPort, dport: DPort) {
@@ -571,4 +599,36 @@ impl ExecMutScope for SimClient {
     fn enter(&self) -> Self::Guard {
         self.malicious_behaviour.guard()
     }
+}
+
+/// Serializes a structurally invalid DNS query of the given kind.
+///
+/// Starts from a valid single-question query and patches the wire format;
+/// the header is id (2 bytes), flags (2 bytes) and four section counts
+/// (2 bytes each), followed by the question section.
+fn malformed_dns_query(kind: MalformedDnsQuery, query_id: u16) -> Vec<u8> {
+    let domain = DomainName::vec_from_str("malformed.example.com").unwrap();
+    let mut bytes = Query::new(domain, RecordType::A)
+        .with_id(query_id)
+        .into_bytes();
+
+    match kind {
+        MalformedDnsQuery::QrBitSet => {
+            bytes[2] |= 0b1000_0000; // The QR bit is the top bit of the flags.
+        }
+        MalformedDnsQuery::NoQuestion => {
+            bytes.truncate(12); // Just the header ...
+            bytes[5] = 0; // ... with QDCOUNT set to match.
+        }
+        MalformedDnsQuery::TwoQuestions => {
+            let question = bytes[12..].to_vec();
+            bytes.extend_from_slice(&question); // Repeat the question ...
+            bytes[5] = 2; // ... with QDCOUNT set to match.
+        }
+        MalformedDnsQuery::TruncatedHeader => {
+            bytes.truncate(11); // One byte short of a full header.
+        }
+    }
+
+    bytes
 }

--- a/rust/tests/fuzz/src/sut.rs
+++ b/rust/tests/fuzz/src/sut.rs
@@ -418,14 +418,13 @@ impl TunnelTest {
             }
             Transition::SendMalformedDnsQuery {
                 client_id,
-                kind,
-                query_id,
+                payload,
                 dns_server,
                 local_port,
             } => {
                 let client = state.clients.get_mut(&client_id).unwrap();
                 let transmit = client.exec_mut(|sim| {
-                    sim.send_malformed_dns_query(kind, query_id, dns_server, local_port, now)
+                    sim.send_malformed_dns_query(&payload, dns_server, local_port, now)
                 });
 
                 buffered_transmits.push_from(transmit, client, now);

--- a/rust/tests/fuzz/src/sut.rs
+++ b/rust/tests/fuzz/src/sut.rs
@@ -416,6 +416,20 @@ impl TunnelTest {
 
                 buffered_transmits.push_from(transmit, client, now);
             }
+            Transition::SendMalformedDnsQuery {
+                client_id,
+                kind,
+                query_id,
+                dns_server,
+                local_port,
+            } => {
+                let client = state.clients.get_mut(&client_id).unwrap();
+                let transmit = client.exec_mut(|sim| {
+                    sim.send_malformed_dns_query(kind, query_id, dns_server, local_port, now)
+                });
+
+                buffered_transmits.push_from(transmit, client, now);
+            }
             Transition::UpdateSystemDnsServers { servers } => {
                 for client in state.clients.values_mut() {
                     client.exec_mut(|c| c.sut.update_system_resolvers(servers.clone()));

--- a/rust/tests/fuzz/src/sut.rs
+++ b/rust/tests/fuzz/src/sut.rs
@@ -392,6 +392,20 @@ impl TunnelTest {
 
                 buffered_transmits.push_from(transmit, client, now);
             }
+            Transition::SendMalformedDnsQuery {
+                client_id,
+                kind,
+                query_id,
+                dns_server,
+                local_port,
+            } => {
+                let client = state.clients.get_mut(&client_id).unwrap();
+                let transmit = client.exec_mut(|sim| {
+                    sim.send_malformed_dns_query(kind, query_id, dns_server, local_port, now)
+                });
+
+                buffered_transmits.push_from(transmit, client, now);
+            }
             Transition::UpdateSystemDnsServers { servers } => {
                 for client in state.clients.values_mut() {
                     client.exec_mut(|c| c.sut.update_system_resolvers(servers.clone()));

--- a/rust/tests/fuzz/src/sut.rs
+++ b/rust/tests/fuzz/src/sut.rs
@@ -394,14 +394,13 @@ impl TunnelTest {
             }
             Transition::SendMalformedDnsQuery {
                 client_id,
-                kind,
-                query_id,
+                payload,
                 dns_server,
                 local_port,
             } => {
                 let client = state.clients.get_mut(&client_id).unwrap();
                 let transmit = client.exec_mut(|sim| {
-                    sim.send_malformed_dns_query(kind, query_id, dns_server, local_port, now)
+                    sim.send_malformed_dns_query(&payload, dns_server, local_port, now)
                 });
 
                 buffered_transmits.push_from(transmit, client, now);

--- a/rust/tests/fuzz/src/transition.rs
+++ b/rust/tests/fuzz/src/transition.rs
@@ -83,6 +83,13 @@ pub enum Transition {
         dns_server: dns::Upstream,
         transport: DnsTransport,
     },
+    SendMalformedDnsQuery {
+        client_id: ClientId,
+        kind: MalformedDnsQuery,
+        query_id: u16,
+        dns_server: dns::Upstream,
+        local_port: u16,
+    },
     UpdateSystemDnsServers {
         servers: Vec<IpAddr>,
     },
@@ -132,6 +139,7 @@ impl Transition {
             Transition::ConnectTcp { .. } => false,
             Transition::SendDnsQuery { .. } => false,
             Transition::SendDnsResourcePtrQuery { .. } => false,
+            Transition::SendMalformedDnsQuery { .. } => false,
             Transition::UpdateSystemDnsServers { .. } => false,
             Transition::UpdateUpstreamDo53Servers(_) => false,
             Transition::UpdateUpstreamDoHServers(_) => false,
@@ -168,6 +176,21 @@ pub(crate) enum IpFamily {
 pub(crate) enum DnsTransport {
     Udp { local_port: u16 },
     Tcp,
+}
+
+/// The ways in which a DNS query can be structurally invalid.
+///
+/// The client must drop all of these without emitting a response.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum MalformedDnsQuery {
+    /// The QR bit claims the message is a response.
+    QrBitSet,
+    /// The message does not contain a question.
+    NoQuestion,
+    /// The message contains two questions.
+    TwoQuestions,
+    /// The message is shorter than a DNS header.
+    TruncatedHeader,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/rust/tests/fuzz/src/transition.rs
+++ b/rust/tests/fuzz/src/transition.rs
@@ -85,8 +85,7 @@ pub enum Transition {
     },
     SendMalformedDnsQuery {
         client_id: ClientId,
-        kind: MalformedDnsQuery,
-        query_id: u16,
+        payload: Vec<u8>,
         dns_server: dns::Upstream,
         local_port: u16,
     },
@@ -176,21 +175,6 @@ pub(crate) enum IpFamily {
 pub(crate) enum DnsTransport {
     Udp { local_port: u16 },
     Tcp,
-}
-
-/// The ways in which a DNS query can be structurally invalid.
-///
-/// The client must drop all of these without emitting a response.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum MalformedDnsQuery {
-    /// The QR bit claims the message is a response.
-    QrBitSet,
-    /// The message does not contain a question.
-    NoQuestion,
-    /// The message contains two questions.
-    TwoQuestions,
-    /// The message is shorter than a DNS header.
-    TruncatedHeader,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/rust/tests/fuzz/src/transition.rs
+++ b/rust/tests/fuzz/src/transition.rs
@@ -76,6 +76,13 @@ pub enum Transition {
         client_id: ClientId,
         query: DnsQuery,
     },
+    SendMalformedDnsQuery {
+        client_id: ClientId,
+        kind: MalformedDnsQuery,
+        query_id: u16,
+        dns_server: dns::Upstream,
+        local_port: u16,
+    },
     UpdateSystemDnsServers {
         servers: Vec<IpAddr>,
     },
@@ -124,6 +131,7 @@ impl Transition {
             Transition::SendUdpPacket { .. } => false,
             Transition::ConnectTcp { .. } => false,
             Transition::SendDnsQuery { .. } => false,
+            Transition::SendMalformedDnsQuery { .. } => false,
             Transition::UpdateSystemDnsServers { .. } => false,
             Transition::UpdateUpstreamDo53Servers(_) => false,
             Transition::UpdateUpstreamDoHServers(_) => false,
@@ -154,6 +162,21 @@ pub(crate) struct DnsQuery {
 pub(crate) enum DnsTransport {
     Udp { local_port: u16 },
     Tcp,
+}
+
+/// The ways in which a DNS query can be structurally invalid.
+///
+/// The client must drop all of these without emitting a response.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum MalformedDnsQuery {
+    /// The QR bit claims the message is a response.
+    QrBitSet,
+    /// The message does not contain a question.
+    NoQuestion,
+    /// The message contains two questions.
+    TwoQuestions,
+    /// The message is shorter than a DNS header.
+    TruncatedHeader,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/rust/tests/fuzz/src/transition.rs
+++ b/rust/tests/fuzz/src/transition.rs
@@ -78,8 +78,7 @@ pub enum Transition {
     },
     SendMalformedDnsQuery {
         client_id: ClientId,
-        kind: MalformedDnsQuery,
-        query_id: u16,
+        payload: Vec<u8>,
         dns_server: dns::Upstream,
         local_port: u16,
     },
@@ -162,21 +161,6 @@ pub(crate) struct DnsQuery {
 pub(crate) enum DnsTransport {
     Udp { local_port: u16 },
     Tcp,
-}
-
-/// The ways in which a DNS query can be structurally invalid.
-///
-/// The client must drop all of these without emitting a response.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum MalformedDnsQuery {
-    /// The QR bit claims the message is a response.
-    QrBitSet,
-    /// The message does not contain a question.
-    NoQuestion,
-    /// The message contains two questions.
-    TwoQuestions,
-    /// The message is shorter than a DNS header.
-    TruncatedHeader,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
The tunnel-proto fuzzer only ever sends well-formed DNS queries, so the client's rejection paths for structurally invalid ones were never exercised. A new `SendMalformedDnsQuery` transition sends a query to a sentinel resolver that is broken in one of four ways: the QR bit claims a response, no question, two questions, or fewer bytes than a DNS header. The reference model records no expectation for these, so the client answering or forwarding such a query fails the test as an unexpected DNS reply.

Nothing ever reads answer records from a `Query`, so `Query::parse` also no longer parses the answer section; it was dead validation on the per-packet hot path. The structural checks (QR bit, exactly one question) remain.