### PR TITLE
test(fuzz): fix two reference-model false positives

### DIFF
--- a/rust/tests/fuzz/src/ref_client.rs
+++ b/rust/tests/fuzz/src/ref_client.rs
@@ -404,6 +404,7 @@ impl RefClient {
 
         if self.expected_tcp_connections.values().contains(&rid) {
             self.set_resource_online(rid);
+            self.connected_cidr_resources.insert(rid); // The surviving TCP connection keeps the site in use.
         }
     }
 
@@ -424,6 +425,7 @@ impl RefClient {
 
         if self.expected_tcp_connections.values().contains(&rid) {
             self.set_resource_online(rid);
+            self.connected_dns_resources.insert(rid); // The surviving TCP connection keeps the site in use.
         }
     }
 

--- a/rust/tests/fuzz/src/sim_client.rs
+++ b/rust/tests/fuzz/src/sim_client.rs
@@ -19,8 +19,8 @@ use std::{
     time::{Duration, Instant},
 };
 use tunnel_proto::{
-    ClientState, DNS_SENTINELS_V4, DNS_SENTINELS_V6, DnsMapping, DnsResourceRecord,
-    MaliciousBehaviour, MaliciousBehaviourGuard as Guard, dns,
+    ClientState, DNS_SENTINELS_V4, DNS_SENTINELS_V6, DnsMapping, DnsResourceRecord, IPV4_RESOURCES,
+    IPV6_RESOURCES, MaliciousBehaviour, MaliciousBehaviourGuard as Guard, dns,
 };
 
 /// Simulation state for a particular client.
@@ -475,6 +475,24 @@ impl SimClient {
             }
         {
             tracing::debug!(?packet, "Ignoring TCP teardown from DNS sentinel");
+            return None;
+        }
+
+        // Equally ignore late TCP segments from connlib's proxy IP ranges for
+        // DNS resources. The TCP client only `accepts` packets matching a
+        // currently-open socket, so a retransmission or teardown that arrives
+        // after the socket is gone (for example when the connection predates a
+        // `RestartClient` and the socket timed out while the tunnel was being
+        // re-established) has nothing to be matched against. A real host
+        // answers such a segment with a RST; dropping it is equivalent for the
+        // reference model.
+        if packet.as_tcp().is_some()
+            && match packet.source() {
+                IpAddr::V4(v4) => IPV4_RESOURCES.contains(v4),
+                IpAddr::V6(v6) => IPV6_RESOURCES.contains(v6),
+            }
+        {
+            tracing::debug!(?packet, "Ignoring late TCP segment from resource");
             return None;
         }
 


### PR DESCRIPTION
Growing the tunnel-proto corpus surfaced two reference-model false positives around connection lifecycle. A late TCP segment from a DNS resource's proxy IP that arrives after the simulated socket is gone failed the test as an unhandled packet, even though a real host would answer it with a RST; it is now ignored like the equivalent teardown from a DNS sentinel. And re-adding a resource that still has an expected TCP connection marked it online without recording it as connected, so removing an unrelated resource in the same site garbage-collected the site status and the expectation flipped to unknown while the client correctly kept reporting online.