### PR TITLE
feat(connlib): don't split flows when the outer tuple changes

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -149,11 +149,15 @@ jobs:
             rust_log: debug,path_agent=trace
             iceless: true
           - script: download-roaming-network
-            min_gateway_version: 1.4.18
+            # The flow-log assertions require a gateway that accumulates outer
+            # tuples instead of splitting the flow on a roam.
+            min_gateway_version: 1.6.0
             rust_log: debug,flow_logs=trace # Too noisy can cause flaky tests due to the amount of data
           - name: download-roaming-network-iceless
             script: download-roaming-network
-            min_gateway_version: 1.4.18
+            # The flow-log assertions require a gateway that accumulates outer
+            # tuples instead of splitting the flow on a roam.
+            min_gateway_version: 1.6.0
             iceless: true
             rust_log: debug,path_agent=trace,flow_logs=trace # Too noisy can cause flaky tests due to the amount of data
     steps:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2650,6 +2650,7 @@ dependencies = [
  "ip-packet",
  "serde",
  "serde_json",
+ "smallvec",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/rust/libs/connlib/flow-tracker/Cargo.toml
+++ b/rust/libs/connlib/flow-tracker/Cargo.toml
@@ -12,6 +12,7 @@ dns-types = { workspace = true }
 ip-packet = { workspace = true }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true }
+smallvec = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -1270,29 +1270,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn push_context_records_only_changes() {
-        let mut contexts = vec![context(1)];
-
-        push_context(&"key", &mut contexts, context(1));
-        push_context(&"key", &mut contexts, context(2));
-        push_context(&"key", &mut contexts, context(2));
-        push_context(&"key", &mut contexts, context(1));
-
-        assert_eq!(contexts, vec![context(1), context(2), context(1)]);
-    }
-
-    #[test]
-    fn push_context_caps_the_list() {
-        let mut contexts = vec![context(0)];
-
-        for port in 1..=2 * MAX_CONTEXTS_PER_FLOW as u16 {
-            push_context(&"key", &mut contexts, context(port));
-        }
-
-        assert_eq!(contexts.len(), MAX_CONTEXTS_PER_FLOW);
-    }
-
-    #[test]
     fn flow_context_diff_rendering() {
         let old = FlowContext {
             src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
@@ -1313,14 +1290,5 @@ mod tests {
             "FlowContextDiff { old_src_ip: 10.0.0.1, new_src_ip: 1.1.1.1, old_src_port: 8080, new_src_port: 50000 }",
             format!("{diff:?}")
         );
-    }
-
-    fn context(src_port: u16) -> FlowContext {
-        FlowContext {
-            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            dst_ip: IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
-            src_port,
-            dst_port: 443,
-        }
     }
 }

--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -45,11 +45,12 @@ pub use token::{IngestToken, IngestTokenClaims, IngestTokenRole, TEST_INGEST_TOK
 /// A flow is closed if no packet is seen for this long.
 const FLOW_TIMEOUT: TimeDelta = TimeDelta::minutes(2);
 
-/// A flow records at most this many outer (transport) 4-tuples.
+/// A flow records at most this many outer (transport) tuples.
 ///
 /// The outer tuple changes only on rare path events such as roaming or a relay
 /// switchover; the cap bounds the tracker's memory and the emitted record's
-/// size should a flow's path flap indefinitely.
+/// size. A change past the cap splits the flow instead of going unrecorded, so
+/// a peer cannot flap its path to keep later tuples out of the log.
 const MAX_CONTEXTS_PER_FLOW: usize = 16;
 
 thread_local! {
@@ -471,6 +472,33 @@ where
 
                         self.active_tcp_flows.insert(key, value);
                     }
+                    // A changed outer tuple splits the flow once the context
+                    // list is full, so a peer that keeps flapping its path
+                    // cannot make later tuples go unrecorded.
+                    hash_map::Entry::Occupied(occupied)
+                        if context_overflows(&occupied.get().contexts, context) =>
+                    {
+                        let (key, value) = occupied.remove_entry();
+
+                        tracing::debug!(?key, "Splitting existing TCP flow; context cap reached");
+
+                        emit(&Record::tcp_close(key, value, now_utc));
+
+                        let value = TcpFlowValue {
+                            start: now_utc,
+                            last_packet: now_utc,
+                            stats: FlowStats::default().with_tx(payload_len as u64),
+                            contexts: smallvec![context],
+                            fin_tx: false,
+                            fin_rx: false,
+                            domain,
+                            ingest_token,
+                        };
+
+                        emit(&Record::tcp_open(&key, &value));
+
+                        self.active_tcp_flows.insert(key, value);
+                    }
                     hash_map::Entry::Occupied(mut occupied) => {
                         let key = *occupied.key();
                         let value = occupied.get_mut();
@@ -517,6 +545,31 @@ where
                         emit(&Record::udp_open(&key, &value));
 
                         vacant.insert(value);
+                    }
+                    // A changed outer tuple splits the flow once the context
+                    // list is full, so a peer that keeps flapping its path
+                    // cannot make later tuples go unrecorded.
+                    hash_map::Entry::Occupied(occupied)
+                        if context_overflows(&occupied.get().contexts, context) =>
+                    {
+                        let (key, value) = occupied.remove_entry();
+
+                        tracing::debug!(?key, "Splitting existing UDP flow; context cap reached");
+
+                        emit(&Record::udp_close(key, value, now_utc));
+
+                        let value = UdpFlowValue {
+                            start: now_utc,
+                            last_packet: now_utc,
+                            stats: FlowStats::default().with_tx(payload_len as u64),
+                            contexts: smallvec![context],
+                            domain,
+                            ingest_token,
+                        };
+
+                        emit(&Record::udp_open(&key, &value));
+
+                        self.active_udp_flows.insert(key, value);
                     }
                     hash_map::Entry::Occupied(mut occupied) => {
                         let key = *occupied.key();
@@ -1206,8 +1259,8 @@ type Contexts = SmallVec<[FlowContext; 4]>;
 
 /// Appends `context` to a flow's outer tuples if it differs from the current one.
 ///
-/// The list is capped at [`MAX_CONTEXTS_PER_FLOW`]; changes past the cap are
-/// dropped.
+/// Callers split the flow before the list would grow past
+/// [`MAX_CONTEXTS_PER_FLOW`], see [`context_overflows`].
 fn push_context(key: &impl Debug, contexts: &mut Contexts, context: FlowContext) {
     let Some(current) = contexts.last().copied() else {
         contexts.push(context);
@@ -1218,17 +1271,19 @@ fn push_context(key: &impl Debug, contexts: &mut Contexts, context: FlowContext)
         return;
     }
 
-    if contexts.len() >= MAX_CONTEXTS_PER_FLOW {
-        tracing::debug!(?key, "Flow reached its context cap; dropping the change");
-
-        return;
-    }
-
     let context_diff = FlowContextDiff::new(current, context);
 
     tracing::debug!(?key, ?context_diff, "Context of flow changed");
 
     contexts.push(context);
+
+    debug_assert!(contexts.len() <= MAX_CONTEXTS_PER_FLOW);
+}
+
+/// Whether recording `context` would grow the flow's outer tuples past
+/// [`MAX_CONTEXTS_PER_FLOW`].
+fn context_overflows(contexts: &Contexts, context: FlowContext) -> bool {
+    contexts.last() != Some(&context) && contexts.len() >= MAX_CONTEXTS_PER_FLOW
 }
 
 #[derive(PartialEq, Eq)]

--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -36,6 +36,7 @@ use chrono::{DateTime, TimeDelta, Utc};
 use connlib_model::{ClientId, ClientOrGatewayId, ResourceId};
 use dns_types::DomainName;
 use ip_packet::{IcmpError, IpPacket, Protocol, UnsupportedProtocol};
+use smallvec::{SmallVec, smallvec};
 
 mod token;
 
@@ -47,9 +48,9 @@ const FLOW_TIMEOUT: TimeDelta = TimeDelta::minutes(2);
 /// A flow records at most this many outer (transport) 4-tuples.
 ///
 /// The outer tuple changes only on rare path events such as roaming or a relay
-/// switchover, so the cap is generous; it bounds the tracker's memory and the
-/// emitted record's size should a flow's path flap indefinitely.
-const MAX_CONTEXTS_PER_FLOW: usize = 64;
+/// switchover; the cap bounds the tracker's memory and the emitted record's
+/// size should a flow's path flap indefinitely.
+const MAX_CONTEXTS_PER_FLOW: usize = 16;
 
 thread_local! {
     /// The [`FlowData`] for the packet currently being processed on this thread.
@@ -432,7 +433,7 @@ where
                             start: now_utc,
                             last_packet: now_utc,
                             stats: FlowStats::default().with_tx(payload_len as u64),
-                            contexts: vec![context],
+                            contexts: smallvec![context],
                             fin_tx: false,
                             fin_rx: false,
                             domain,
@@ -459,7 +460,7 @@ where
                             start: now_utc,
                             last_packet: now_utc,
                             stats: FlowStats::default().with_tx(payload_len as u64),
-                            contexts: vec![context],
+                            contexts: smallvec![context],
                             fin_tx: false,
                             fin_rx: false,
                             domain,
@@ -508,7 +509,7 @@ where
                             start: now_utc,
                             last_packet: now_utc,
                             stats: FlowStats::default().with_tx(payload_len as u64),
-                            contexts: vec![context],
+                            contexts: smallvec![context],
                             domain,
                             ingest_token,
                         };
@@ -904,7 +905,7 @@ impl Record {
             key.dst_port,
             value.ingest_token.clone(),
             value.domain.clone(),
-            value.contexts.clone(),
+            value.contexts.to_vec(),
             value.start,
             None,
         )
@@ -921,7 +922,7 @@ impl Record {
             key.dst_port,
             value.ingest_token,
             value.domain,
-            value.contexts,
+            value.contexts.into_vec(),
             value.start,
             Some(close),
         )
@@ -936,7 +937,7 @@ impl Record {
             key.dst_port,
             value.ingest_token.clone(),
             value.domain.clone(),
-            value.contexts.clone(),
+            value.contexts.to_vec(),
             value.start,
             None,
         )
@@ -953,7 +954,7 @@ impl Record {
             key.dst_port,
             value.ingest_token,
             value.domain,
-            value.contexts,
+            value.contexts.into_vec(),
             value.start,
             Some(close),
         )
@@ -1110,7 +1111,7 @@ struct TcpFlowValue {
     last_packet: DateTime<Utc>,
     stats: FlowStats,
     /// The outer (transport) 4-tuples the flow has used, in order of first use.
-    contexts: Vec<FlowContext>,
+    contexts: Contexts,
 
     domain: Option<DomainName>,
 
@@ -1127,7 +1128,7 @@ struct UdpFlowValue {
     last_packet: DateTime<Utc>,
     stats: FlowStats,
     /// The outer (transport) 4-tuples the flow has used, in order of first use.
-    contexts: Vec<FlowContext>,
+    contexts: Contexts,
 
     domain: Option<DomainName>,
 
@@ -1164,10 +1165,8 @@ impl FlowStats {
 /// The outer (transport) 4-tuple a flow is tunneled over.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, serde::Serialize)]
 pub struct FlowContext {
-    pub src_ip: IpAddr,
-    pub dst_ip: IpAddr,
-    pub src_port: u16,
-    pub dst_port: u16,
+    pub src: SocketAddr,
+    pub dst: SocketAddr,
 }
 
 impl FlowContext {
@@ -1175,19 +1174,20 @@ impl FlowContext {
     /// initiator side is the source, the responder side the destination.
     pub fn new(initiator: SocketAddr, responder: SocketAddr) -> Self {
         Self {
-            src_ip: initiator.ip(),
-            dst_ip: responder.ip(),
-            src_port: initiator.port(),
-            dst_port: responder.port(),
+            src: initiator,
+            dst: responder,
         }
     }
 }
+
+/// The outer tuples one flow has used, inline up to the common few path changes.
+type Contexts = SmallVec<[FlowContext; 4]>;
 
 /// Appends `context` to a flow's outer tuples if it differs from the current one.
 ///
 /// The list is capped at [`MAX_CONTEXTS_PER_FLOW`]; changes past the cap are
 /// dropped.
-fn push_context(key: &impl Debug, contexts: &mut Vec<FlowContext>, context: FlowContext) {
+fn push_context(key: &impl Debug, contexts: &mut Contexts, context: FlowContext) {
     let Some(current) = contexts.last().copied() else {
         contexts.push(context);
         return;
@@ -1212,24 +1212,18 @@ fn push_context(key: &impl Debug, contexts: &mut Vec<FlowContext>, context: Flow
 
 #[derive(PartialEq, Eq)]
 struct FlowContextDiff {
-    src_ip: Option<(IpAddr, IpAddr)>,
-    dst_ip: Option<(IpAddr, IpAddr)>,
-    src_port: Option<(u16, u16)>,
-    dst_port: Option<(u16, u16)>,
+    src: Option<(SocketAddr, SocketAddr)>,
+    dst: Option<(SocketAddr, SocketAddr)>,
 }
 
 impl FlowContextDiff {
     fn new(old: FlowContext, new: FlowContext) -> Self {
-        let src_ip_diff = (old.src_ip != new.src_ip).then_some((old.src_ip, new.src_ip));
-        let dst_ip_diff = (old.dst_ip != new.dst_ip).then_some((old.dst_ip, new.dst_ip));
-        let src_port_diff = (old.src_port != new.src_port).then_some((old.src_port, new.src_port));
-        let dst_port_diff = (old.dst_port != new.dst_port).then_some((old.dst_port, new.dst_port));
+        let src_diff = (old.src != new.src).then_some((old.src, new.src));
+        let dst_diff = (old.dst != new.dst).then_some((old.dst, new.dst));
 
         Self {
-            src_ip: src_ip_diff,
-            dst_ip: dst_ip_diff,
-            src_port: src_port_diff,
-            dst_port: dst_port_diff,
+            src: src_diff,
+            dst: dst_diff,
         }
     }
 }
@@ -1238,25 +1232,11 @@ impl std::fmt::Debug for FlowContextDiff {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FlowContextDiff");
 
-        if let Some((old, new)) = self.src_ip {
-            debug_struct
-                .field("old_src_ip", &old)
-                .field("new_src_ip", &new);
+        if let Some((old, new)) = self.src {
+            debug_struct.field("old_src", &old).field("new_src", &new);
         }
-        if let Some((old, new)) = self.dst_ip {
-            debug_struct
-                .field("old_dst_ip", &old)
-                .field("new_dst_ip", &new);
-        }
-        if let Some((old, new)) = self.src_port {
-            debug_struct
-                .field("old_src_port", &old)
-                .field("new_src_port", &new);
-        }
-        if let Some((old, new)) = self.dst_port {
-            debug_struct
-                .field("old_dst_port", &old)
-                .field("new_dst_port", &new);
+        if let Some((old, new)) = self.dst {
+            debug_struct.field("old_dst", &old).field("new_dst", &new);
         }
 
         debug_struct.finish()
@@ -1265,29 +1245,23 @@ impl std::fmt::Debug for FlowContextDiff {
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
-
     use super::*;
 
     #[test]
     fn flow_context_diff_rendering() {
         let old = FlowContext {
-            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            dst_ip: IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
-            src_port: 8080,
-            dst_port: 443,
+            src: "10.0.0.1:8080".parse().unwrap(),
+            dst: "192.168.0.1:443".parse().unwrap(),
         };
         let new = FlowContext {
-            src_ip: IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
-            dst_ip: IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
-            src_port: 50000,
-            dst_port: 443,
+            src: "1.1.1.1:50000".parse().unwrap(),
+            dst: "192.168.0.1:443".parse().unwrap(),
         };
 
         let diff = FlowContextDiff::new(old, new);
 
         assert_eq!(
-            "FlowContextDiff { old_src_ip: 10.0.0.1, new_src_ip: 1.1.1.1, old_src_port: 8080, new_src_port: 50000 }",
+            "FlowContextDiff { old_src: 10.0.0.1:8080, new_src: 1.1.1.1:50000 }",
             format!("{diff:?}")
         );
     }

--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -44,6 +44,13 @@ pub use token::{IngestToken, IngestTokenClaims, IngestTokenRole, TEST_INGEST_TOK
 /// A flow is closed if no packet is seen for this long.
 const FLOW_TIMEOUT: TimeDelta = TimeDelta::minutes(2);
 
+/// A flow records at most this many outer (transport) 4-tuples.
+///
+/// The outer tuple changes only on rare path events such as roaming or a relay
+/// switchover, so the cap is generous; it bounds the tracker's memory and the
+/// emitted record's size should a flow's path flap indefinitely.
+const MAX_CONTEXTS_PER_FLOW: usize = 64;
+
 thread_local! {
     /// The [`FlowData`] for the packet currently being processed on this thread.
     static CURRENT_FLOW: RefCell<Option<FlowData>> = const { RefCell::new(None) };
@@ -93,7 +100,7 @@ pub struct Tracker<S> {
 /// Recording this creates, updates or splits a flow.
 struct TxPacket<S> {
     scope: S,
-    /// The outer (transport) 4-tuple this flow is tunneled over.
+    /// The outer (transport) 4-tuple this packet was tunneled over.
     context: FlowContext,
     src_ip: IpAddr,
     dst_ip: IpAddr,
@@ -425,7 +432,7 @@ where
                             start: now_utc,
                             last_packet: now_utc,
                             stats: FlowStats::default().with_tx(payload_len as u64),
-                            context,
+                            contexts: vec![context],
                             fin_tx: false,
                             fin_rx: false,
                             domain,
@@ -435,33 +442,6 @@ where
                         emit(&Record::tcp_open(&key, &value));
 
                         vacant.insert(value);
-                    }
-                    hash_map::Entry::Occupied(occupied) if occupied.get().context != context => {
-                        let (key, value) = occupied.remove_entry();
-                        let context_diff = FlowContextDiff::new(value.context, context);
-
-                        tracing::debug!(
-                            ?key,
-                            ?context_diff,
-                            "Splitting existing TCP flow; context changed"
-                        );
-
-                        emit(&Record::tcp_close(key, value, now_utc));
-
-                        let value = TcpFlowValue {
-                            start: now_utc,
-                            last_packet: now_utc,
-                            stats: FlowStats::default().with_tx(payload_len as u64),
-                            context,
-                            fin_tx: false,
-                            fin_rx: false,
-                            domain,
-                            ingest_token,
-                        };
-
-                        emit(&Record::tcp_open(&key, &value));
-
-                        self.active_tcp_flows.insert(key, value);
                     }
                     // A SYN only starts a new connection if the existing flow has
                     // seen return traffic; on a half-open flow it is a
@@ -479,7 +459,7 @@ where
                             start: now_utc,
                             last_packet: now_utc,
                             stats: FlowStats::default().with_tx(payload_len as u64),
-                            context,
+                            contexts: vec![context],
                             fin_tx: false,
                             fin_rx: false,
                             domain,
@@ -491,8 +471,10 @@ where
                         self.active_tcp_flows.insert(key, value);
                     }
                     hash_map::Entry::Occupied(mut occupied) => {
+                        let key = *occupied.key();
                         let value = occupied.get_mut();
 
+                        push_context(&key, &mut value.contexts, context);
                         value.stats.inc_tx(payload_len as u64);
                         value.last_packet = now_utc;
                         if tcp_fin {
@@ -526,7 +508,7 @@ where
                             start: now_utc,
                             last_packet: now_utc,
                             stats: FlowStats::default().with_tx(payload_len as u64),
-                            context,
+                            contexts: vec![context],
                             domain,
                             ingest_token,
                         };
@@ -535,34 +517,11 @@ where
 
                         vacant.insert(value);
                     }
-                    hash_map::Entry::Occupied(occupied) if occupied.get().context != context => {
-                        let (key, value) = occupied.remove_entry();
-                        let context_diff = FlowContextDiff::new(value.context, context);
-
-                        tracing::debug!(
-                            ?key,
-                            ?context_diff,
-                            "Splitting existing UDP flow; context changed"
-                        );
-
-                        emit(&Record::udp_close(key, value, now_utc));
-
-                        let value = UdpFlowValue {
-                            start: now_utc,
-                            last_packet: now_utc,
-                            stats: FlowStats::default().with_tx(payload_len as u64),
-                            context,
-                            domain,
-                            ingest_token,
-                        };
-
-                        emit(&Record::udp_open(&key, &value));
-
-                        self.active_udp_flows.insert(key, value);
-                    }
                     hash_map::Entry::Occupied(mut occupied) => {
+                        let key = *occupied.key();
                         let value = occupied.get_mut();
 
+                        push_context(&key, &mut value.contexts, context);
                         value.stats.inc_tx(payload_len as u64);
                         value.last_packet = now_utc;
                     }
@@ -928,10 +887,8 @@ pub struct Record {
     pub inner_dst_port: u16,
     pub domain: Option<DomainName>,
 
-    pub outer_src_ip: IpAddr,
-    pub outer_src_port: u16,
-    pub outer_dst_ip: IpAddr,
-    pub outer_dst_port: u16,
+    /// The outer (transport) 4-tuples the flow has used, in order of first use.
+    pub outer_tuples: Vec<FlowContext>,
 
     pub flow_start: DateTime<Utc>,
     pub close: Option<FlowClose>,
@@ -947,7 +904,7 @@ impl Record {
             key.dst_port,
             value.ingest_token.clone(),
             value.domain.clone(),
-            value.context,
+            value.contexts.clone(),
             value.start,
             None,
         )
@@ -964,7 +921,7 @@ impl Record {
             key.dst_port,
             value.ingest_token,
             value.domain,
-            value.context,
+            value.contexts,
             value.start,
             Some(close),
         )
@@ -979,7 +936,7 @@ impl Record {
             key.dst_port,
             value.ingest_token.clone(),
             value.domain.clone(),
-            value.context,
+            value.contexts.clone(),
             value.start,
             None,
         )
@@ -996,7 +953,7 @@ impl Record {
             key.dst_port,
             value.ingest_token,
             value.domain,
-            value.context,
+            value.contexts,
             value.start,
             Some(close),
         )
@@ -1011,7 +968,7 @@ impl Record {
         inner_dst_port: u16,
         ingest_token: IngestToken,
         domain: Option<DomainName>,
-        context: FlowContext,
+        outer_tuples: Vec<FlowContext>,
         flow_start: DateTime<Utc>,
         close: Option<FlowClose>,
     ) -> Self {
@@ -1023,10 +980,7 @@ impl Record {
             inner_dst_ip,
             inner_dst_port,
             domain,
-            outer_src_ip: context.src_ip,
-            outer_src_port: context.src_port,
-            outer_dst_ip: context.dst_ip,
-            outer_dst_port: context.dst_port,
+            outer_tuples,
             flow_start,
             close,
         }
@@ -1094,10 +1048,7 @@ pub fn emit(record: &Record) {
                 inner_dst_port = record.inner_dst_port,
                 domain = record.domain.as_ref().map(tracing::field::display),
 
-                outer_src_ip = %record.outer_src_ip,
-                outer_src_port = record.outer_src_port,
-                outer_dst_ip = %record.outer_dst_ip,
-                outer_dst_port = record.outer_dst_port,
+                outer_tuples = %OuterTuples(&record.outer_tuples),
 
                 flow_start = ?record.flow_start,
                 flow_end = close.map(|c| tracing::field::debug(c.flow_end)),
@@ -1116,6 +1067,22 @@ pub fn emit(record: &Record) {
         (FlowProtocol::Tcp, true) => emit!("TCP flow completed"),
         (FlowProtocol::Udp, false) => emit!("UDP flow started"),
         (FlowProtocol::Udp, true) => emit!("UDP flow completed"),
+    }
+}
+
+/// Renders a record's outer tuples as one compact JSON array.
+///
+/// A tracing-event field holds a single scalar value, so the list rides as one
+/// JSON-encoded field that `flow-log-writer` decodes into the report payload.
+struct OuterTuples<'a>(&'a [FlowContext]);
+
+impl std::fmt::Display for OuterTuples<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let json = serde_json::to_string(self.0).map_err(|_| std::fmt::Error)?;
+
+        f.write_str(&json)?;
+
+        Ok(())
     }
 }
 
@@ -1142,7 +1109,8 @@ struct TcpFlowValue {
     start: DateTime<Utc>,
     last_packet: DateTime<Utc>,
     stats: FlowStats,
-    context: FlowContext,
+    /// The outer (transport) 4-tuples the flow has used, in order of first use.
+    contexts: Vec<FlowContext>,
 
     domain: Option<DomainName>,
 
@@ -1158,7 +1126,8 @@ struct UdpFlowValue {
     start: DateTime<Utc>,
     last_packet: DateTime<Utc>,
     stats: FlowStats,
-    context: FlowContext,
+    /// The outer (transport) 4-tuples the flow has used, in order of first use.
+    contexts: Vec<FlowContext>,
 
     domain: Option<DomainName>,
 
@@ -1193,7 +1162,7 @@ impl FlowStats {
 }
 
 /// The outer (transport) 4-tuple a flow is tunneled over.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, serde::Serialize)]
 pub struct FlowContext {
     pub src_ip: IpAddr,
     pub dst_ip: IpAddr,
@@ -1212,6 +1181,33 @@ impl FlowContext {
             dst_port: responder.port(),
         }
     }
+}
+
+/// Appends `context` to a flow's outer tuples if it differs from the current one.
+///
+/// The list is capped at [`MAX_CONTEXTS_PER_FLOW`]; changes past the cap are
+/// dropped.
+fn push_context(key: &impl Debug, contexts: &mut Vec<FlowContext>, context: FlowContext) {
+    let Some(current) = contexts.last().copied() else {
+        contexts.push(context);
+        return;
+    };
+
+    if current == context {
+        return;
+    }
+
+    if contexts.len() >= MAX_CONTEXTS_PER_FLOW {
+        tracing::debug!(?key, "Flow reached its context cap; dropping the change");
+
+        return;
+    }
+
+    let context_diff = FlowContextDiff::new(current, context);
+
+    tracing::debug!(?key, ?context_diff, "Context of flow changed");
+
+    contexts.push(context);
 }
 
 #[derive(PartialEq, Eq)]
@@ -1274,6 +1270,29 @@ mod tests {
     use super::*;
 
     #[test]
+    fn push_context_records_only_changes() {
+        let mut contexts = vec![context(1)];
+
+        push_context(&"key", &mut contexts, context(1));
+        push_context(&"key", &mut contexts, context(2));
+        push_context(&"key", &mut contexts, context(2));
+        push_context(&"key", &mut contexts, context(1));
+
+        assert_eq!(contexts, vec![context(1), context(2), context(1)]);
+    }
+
+    #[test]
+    fn push_context_caps_the_list() {
+        let mut contexts = vec![context(0)];
+
+        for port in 1..=2 * MAX_CONTEXTS_PER_FLOW as u16 {
+            push_context(&"key", &mut contexts, context(port));
+        }
+
+        assert_eq!(contexts.len(), MAX_CONTEXTS_PER_FLOW);
+    }
+
+    #[test]
     fn flow_context_diff_rendering() {
         let old = FlowContext {
             src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
@@ -1294,5 +1313,14 @@ mod tests {
             "FlowContextDiff { old_src_ip: 10.0.0.1, new_src_ip: 1.1.1.1, old_src_port: 8080, new_src_port: 50000 }",
             format!("{diff:?}")
         );
+    }
+
+    fn context(src_port: u16) -> FlowContext {
+        FlowContext {
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
+            src_port,
+            dst_port: 443,
+        }
     }
 }

--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -879,7 +879,8 @@ pub struct Record {
     pub inner_dst_port: u16,
     pub domain: Option<DomainName>,
 
-    /// The outer (transport) 4-tuples the flow has used, in order of first use.
+    /// The outer (transport) tuples the flow has used, appended on every change,
+    /// so a tuple the flow returned to appears again.
     pub outers: Vec<FlowContext>,
 
     pub flow_start: DateTime<Utc>,
@@ -1119,7 +1120,8 @@ struct TcpFlowValue {
     start: DateTime<Utc>,
     last_packet: DateTime<Utc>,
     stats: FlowStats,
-    /// The outer (transport) 4-tuples the flow has used, in order of first use.
+    /// The outer (transport) tuples the flow has used, appended on every change,
+    /// so a tuple the flow returned to appears again.
     contexts: Contexts,
 
     domain: Option<DomainName>,
@@ -1136,7 +1138,8 @@ struct UdpFlowValue {
     start: DateTime<Utc>,
     last_packet: DateTime<Utc>,
     stats: FlowStats,
-    /// The outer (transport) 4-tuples the flow has used, in order of first use.
+    /// The outer (transport) tuples the flow has used, appended on every change,
+    /// so a tuple the flow returned to appears again.
     contexts: Contexts,
 
     domain: Option<DomainName>,

--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -280,7 +280,7 @@ where
                 self.record_tx(
                     TxPacket {
                         scope,
-                        context: FlowContext::new(Some(remote), local),
+                        context: FlowContext::new(remote, local),
                         src_ip,
                         dst_ip,
                         src_proto,
@@ -1175,7 +1175,7 @@ struct TcpFlowValue {
     stats: FlowStats,
     /// The outer (transport) tuples the flow has used, appended on every change,
     /// so a tuple the flow returned to appears again.
-    contexts: Contexts,
+    contexts: SmallVec<[FlowContext; 4]>,
 
     domain: Option<DomainName>,
 
@@ -1193,7 +1193,7 @@ struct UdpFlowValue {
     stats: FlowStats,
     /// The outer (transport) tuples the flow has used, appended on every change,
     /// so a tuple the flow returned to appears again.
-    contexts: Contexts,
+    contexts: SmallVec<[FlowContext; 4]>,
 
     domain: Option<DomainName>,
 
@@ -1244,7 +1244,9 @@ pub struct FlowContext {
 impl FlowContext {
     /// Builds a context from the outer addresses as seen by the initiator: the
     /// initiator side is the source, the responder side the destination.
-    pub fn new(initiator: Option<SocketAddr>, responder: SocketAddr) -> Self {
+    pub fn new(initiator: impl Into<Option<SocketAddr>>, responder: SocketAddr) -> Self {
+        let initiator = initiator.into();
+
         Self {
             src_ip: initiator.map(|initiator| initiator.ip()),
             src_port: initiator.map(|initiator| initiator.port()),
@@ -1254,14 +1256,11 @@ impl FlowContext {
     }
 }
 
-/// The outer tuples one flow has used, inline up to the common few path changes.
-type Contexts = SmallVec<[FlowContext; 4]>;
-
 /// Appends `context` to a flow's outer tuples if it differs from the current one.
 ///
 /// Callers split the flow before the list would grow past
 /// [`MAX_CONTEXTS_PER_FLOW`], see [`context_overflows`].
-fn push_context(key: &impl Debug, contexts: &mut Contexts, context: FlowContext) {
+fn push_context(key: &impl Debug, contexts: &mut SmallVec<[FlowContext; 4]>, context: FlowContext) {
     let Some(current) = contexts.last().copied() else {
         contexts.push(context);
         return;
@@ -1282,7 +1281,7 @@ fn push_context(key: &impl Debug, contexts: &mut Contexts, context: FlowContext)
 
 /// Whether recording `context` would grow the flow's outer tuples past
 /// [`MAX_CONTEXTS_PER_FLOW`].
-fn context_overflows(contexts: &Contexts, context: FlowContext) -> bool {
+fn context_overflows(contexts: &SmallVec<[FlowContext; 4]>, context: FlowContext) -> bool {
     contexts.last() != Some(&context) && contexts.len() >= MAX_CONTEXTS_PER_FLOW
 }
 
@@ -1346,11 +1345,11 @@ mod tests {
     #[test]
     fn flow_context_diff_rendering() {
         let old = FlowContext::new(
-            Some("10.0.0.1:8080".parse().unwrap()),
+            "10.0.0.1:8080".parse::<SocketAddr>().unwrap(),
             "192.168.0.1:443".parse().unwrap(),
         );
         let new = FlowContext::new(
-            Some("1.1.1.1:50000".parse().unwrap()),
+            "1.1.1.1:50000".parse::<SocketAddr>().unwrap(),
             "192.168.0.1:443".parse().unwrap(),
         );
 

--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -1070,10 +1070,28 @@ struct Outers<'a>(&'a [FlowContext]);
 
 impl std::fmt::Display for Outers<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let json = serde_json::to_string(self.0).map_err(|_| std::fmt::Error)?;
+        serde_json::to_writer(FmtWriter(f), self.0).map_err(|_| std::fmt::Error)?;
 
-        f.write_str(&json)?;
+        Ok(())
+    }
+}
 
+/// Adapts a [`std::fmt::Formatter`] to [`std::io::Write`] so serialising can
+/// stream into it without an intermediate `String`.
+///
+/// `serde_json` guarantees it feeds only valid UTF-8 sequences to the writer.
+struct FmtWriter<'a, 'b>(&'a mut std::fmt::Formatter<'b>);
+
+impl std::io::Write for FmtWriter<'_, '_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let utf8 = std::str::from_utf8(buf).map_err(std::io::Error::other)?;
+
+        self.0.write_str(utf8).map_err(std::io::Error::other)?;
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
         Ok(())
     }
 }

--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -28,7 +28,7 @@ use std::{
     collections::{HashMap, hash_map},
     fmt::Debug,
     hash::Hash,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    net::{IpAddr, SocketAddr},
     time::{Duration, Instant},
 };
 
@@ -279,7 +279,7 @@ where
                 self.record_tx(
                     TxPacket {
                         scope,
-                        context: FlowContext::new(remote, local),
+                        context: FlowContext::new(Some(remote), local),
                         src_ip,
                         dst_ip,
                         src_proto,
@@ -785,10 +785,10 @@ pub fn record_translated_packet(packet: &IpPacket) {
 }
 
 /// Records that the current packet was encapsulated and sent from `src` to `dst`.
+///
+/// `src` is unknown for relayed sends and omitted from the flow's outer tuple.
 pub fn record_transmit(src: Option<SocketAddr>, dst: SocketAddr) {
     update_current_flow(|data| {
-        let src = src.unwrap_or_else(|| unspecified_socket_like(dst));
-
         data.outer_tx = Some(FlowContext::new(src, dst));
     });
 }
@@ -802,15 +802,6 @@ pub fn record_icmp_error(packet: &IpPacket) {
     update_current_flow(|data| {
         data.icmp_error = Some(icmp_error);
     });
-}
-
-/// The local address is unknown when the socket layer has not bound one yet
-/// (e.g. a relayed transmit).
-fn unspecified_socket_like(addr: SocketAddr) -> SocketAddr {
-    match addr {
-        SocketAddr::V4(_) => SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0),
-        SocketAddr::V6(_) => SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 0),
-    }
 }
 
 /// The flow-relevant fields of one inner (application) IP packet, in the packet's
@@ -889,7 +880,7 @@ pub struct Record {
     pub domain: Option<DomainName>,
 
     /// The outer (transport) 4-tuples the flow has used, in order of first use.
-    pub outer_tuples: Vec<FlowContext>,
+    pub outers: Vec<FlowContext>,
 
     pub flow_start: DateTime<Utc>,
     pub close: Option<FlowClose>,
@@ -969,7 +960,7 @@ impl Record {
         inner_dst_port: u16,
         ingest_token: IngestToken,
         domain: Option<DomainName>,
-        outer_tuples: Vec<FlowContext>,
+        outers: Vec<FlowContext>,
         flow_start: DateTime<Utc>,
         close: Option<FlowClose>,
     ) -> Self {
@@ -981,7 +972,7 @@ impl Record {
             inner_dst_ip,
             inner_dst_port,
             domain,
-            outer_tuples,
+            outers,
             flow_start,
             close,
         }
@@ -1049,7 +1040,7 @@ pub fn emit(record: &Record) {
                 inner_dst_port = record.inner_dst_port,
                 domain = record.domain.as_ref().map(tracing::field::display),
 
-                outer_tuples = %OuterTuples(&record.outer_tuples),
+                outers = %Outers(&record.outers),
 
                 flow_start = ?record.flow_start,
                 flow_end = close.map(|c| tracing::field::debug(c.flow_end)),
@@ -1075,9 +1066,9 @@ pub fn emit(record: &Record) {
 ///
 /// A tracing-event field holds a single scalar value, so the list rides as one
 /// JSON-encoded field that `flow-log-writer` decodes into the report payload.
-struct OuterTuples<'a>(&'a [FlowContext]);
+struct Outers<'a>(&'a [FlowContext]);
 
-impl std::fmt::Display for OuterTuples<'_> {
+impl std::fmt::Display for Outers<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let json = serde_json::to_string(self.0).map_err(|_| std::fmt::Error)?;
 
@@ -1163,19 +1154,28 @@ impl FlowStats {
 }
 
 /// The outer (transport) 4-tuple a flow is tunneled over.
+///
+/// The source is unknown for relayed sends; it is `None` there and omitted
+/// from the serialised tuple.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, serde::Serialize)]
 pub struct FlowContext {
-    pub src: SocketAddr,
-    pub dst: SocketAddr,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub src_ip: Option<IpAddr>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub src_port: Option<u16>,
+    pub dst_ip: IpAddr,
+    pub dst_port: u16,
 }
 
 impl FlowContext {
     /// Builds a context from the outer addresses as seen by the initiator: the
     /// initiator side is the source, the responder side the destination.
-    pub fn new(initiator: SocketAddr, responder: SocketAddr) -> Self {
+    pub fn new(initiator: Option<SocketAddr>, responder: SocketAddr) -> Self {
         Self {
-            src: initiator,
-            dst: responder,
+            src_ip: initiator.map(|initiator| initiator.ip()),
+            src_port: initiator.map(|initiator| initiator.port()),
+            dst_ip: responder.ip(),
+            dst_port: responder.port(),
         }
     }
 }
@@ -1212,18 +1212,24 @@ fn push_context(key: &impl Debug, contexts: &mut Contexts, context: FlowContext)
 
 #[derive(PartialEq, Eq)]
 struct FlowContextDiff {
-    src: Option<(SocketAddr, SocketAddr)>,
-    dst: Option<(SocketAddr, SocketAddr)>,
+    src_ip: Option<(Option<IpAddr>, Option<IpAddr>)>,
+    src_port: Option<(Option<u16>, Option<u16>)>,
+    dst_ip: Option<(IpAddr, IpAddr)>,
+    dst_port: Option<(u16, u16)>,
 }
 
 impl FlowContextDiff {
     fn new(old: FlowContext, new: FlowContext) -> Self {
-        let src_diff = (old.src != new.src).then_some((old.src, new.src));
-        let dst_diff = (old.dst != new.dst).then_some((old.dst, new.dst));
+        let src_ip_diff = (old.src_ip != new.src_ip).then_some((old.src_ip, new.src_ip));
+        let src_port_diff = (old.src_port != new.src_port).then_some((old.src_port, new.src_port));
+        let dst_ip_diff = (old.dst_ip != new.dst_ip).then_some((old.dst_ip, new.dst_ip));
+        let dst_port_diff = (old.dst_port != new.dst_port).then_some((old.dst_port, new.dst_port));
 
         Self {
-            src: src_diff,
-            dst: dst_diff,
+            src_ip: src_ip_diff,
+            src_port: src_port_diff,
+            dst_ip: dst_ip_diff,
+            dst_port: dst_port_diff,
         }
     }
 }
@@ -1232,11 +1238,25 @@ impl std::fmt::Debug for FlowContextDiff {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FlowContextDiff");
 
-        if let Some((old, new)) = self.src {
-            debug_struct.field("old_src", &old).field("new_src", &new);
+        if let Some((old, new)) = self.src_ip {
+            debug_struct
+                .field("old_src_ip", &old)
+                .field("new_src_ip", &new);
         }
-        if let Some((old, new)) = self.dst {
-            debug_struct.field("old_dst", &old).field("new_dst", &new);
+        if let Some((old, new)) = self.src_port {
+            debug_struct
+                .field("old_src_port", &old)
+                .field("new_src_port", &new);
+        }
+        if let Some((old, new)) = self.dst_ip {
+            debug_struct
+                .field("old_dst_ip", &old)
+                .field("new_dst_ip", &new);
+        }
+        if let Some((old, new)) = self.dst_port {
+            debug_struct
+                .field("old_dst_port", &old)
+                .field("new_dst_port", &new);
         }
 
         debug_struct.finish()
@@ -1249,19 +1269,19 @@ mod tests {
 
     #[test]
     fn flow_context_diff_rendering() {
-        let old = FlowContext {
-            src: "10.0.0.1:8080".parse().unwrap(),
-            dst: "192.168.0.1:443".parse().unwrap(),
-        };
-        let new = FlowContext {
-            src: "1.1.1.1:50000".parse().unwrap(),
-            dst: "192.168.0.1:443".parse().unwrap(),
-        };
+        let old = FlowContext::new(
+            Some("10.0.0.1:8080".parse().unwrap()),
+            "192.168.0.1:443".parse().unwrap(),
+        );
+        let new = FlowContext::new(
+            Some("1.1.1.1:50000".parse().unwrap()),
+            "192.168.0.1:443".parse().unwrap(),
+        );
 
         let diff = FlowContextDiff::new(old, new);
 
         assert_eq!(
-            "FlowContextDiff { old_src: 10.0.0.1:8080, new_src: 1.1.1.1:50000 }",
+            "FlowContextDiff { old_src_ip: Some(10.0.0.1), new_src_ip: Some(1.1.1.1), old_src_port: Some(8080), new_src_port: Some(50000) }",
             format!("{diff:?}")
         );
     }

--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -445,15 +445,15 @@ where
 
                         vacant.insert(value);
                     }
-                    // A SYN only starts a new connection if the existing flow has
-                    // seen return traffic; on a half-open flow it is a
-                    // retransmission and just counts as another packet.
+                    // A changed outer tuple splits the flow once the context
+                    // list is full, so a peer that keeps flapping its path
+                    // cannot make later tuples go unrecorded.
                     hash_map::Entry::Occupied(occupied)
-                        if tcp_syn && occupied.get().stats.rx_packets > 0 =>
+                        if context_overflows(&occupied.get().contexts, context) =>
                     {
                         let (key, value) = occupied.remove_entry();
 
-                        tracing::debug!(?key, "Splitting existing TCP flow; new TCP SYN");
+                        tracing::debug!(?key, "Splitting existing TCP flow; context cap reached");
 
                         emit(&Record::tcp_close(key, value, now_utc));
 
@@ -472,15 +472,15 @@ where
 
                         self.active_tcp_flows.insert(key, value);
                     }
-                    // A changed outer tuple splits the flow once the context
-                    // list is full, so a peer that keeps flapping its path
-                    // cannot make later tuples go unrecorded.
+                    // A SYN only starts a new connection if the existing flow has
+                    // seen return traffic; on a half-open flow it is a
+                    // retransmission and just counts as another packet.
                     hash_map::Entry::Occupied(occupied)
-                        if context_overflows(&occupied.get().contexts, context) =>
+                        if tcp_syn && occupied.get().stats.rx_packets > 0 =>
                     {
                         let (key, value) = occupied.remove_entry();
 
-                        tracing::debug!(?key, "Splitting existing TCP flow; context cap reached");
+                        tracing::debug!(?key, "Splitting existing TCP flow; new TCP SYN");
 
                         emit(&Record::tcp_close(key, value, now_utc));
 

--- a/rust/libs/connlib/flow-tracker/tests/writer.rs
+++ b/rust/libs/connlib/flow-tracker/tests/writer.rs
@@ -30,7 +30,7 @@ fn emitted_records_spool_via_flow_log_writer_layer() {
         domain: Some("download.httpbin".parse().unwrap()),
         outers: vec![
             FlowContext::new(
-                Some("198.51.100.1:51820".parse().unwrap()),
+                "198.51.100.1:51820".parse::<SocketAddr>().unwrap(),
                 "203.0.113.7:51820".parse().unwrap(),
             ),
             FlowContext::new(None, "203.0.113.7:51820".parse().unwrap()),

--- a/rust/libs/connlib/flow-tracker/tests/writer.rs
+++ b/rust/libs/connlib/flow-tracker/tests/writer.rs
@@ -30,16 +30,12 @@ fn emitted_records_spool_via_flow_log_writer_layer() {
         domain: Some("download.httpbin".parse().unwrap()),
         outer_tuples: vec![
             FlowContext {
-                src_ip: "198.51.100.1".parse().unwrap(),
-                dst_ip: "203.0.113.7".parse().unwrap(),
-                src_port: 51820,
-                dst_port: 51820,
+                src: "198.51.100.1:51820".parse().unwrap(),
+                dst: "203.0.113.7:51820".parse().unwrap(),
             },
             FlowContext {
-                src_ip: "198.51.100.2".parse().unwrap(),
-                dst_ip: "203.0.113.7".parse().unwrap(),
-                src_port: 45000,
-                dst_port: 51820,
+                src: "198.51.100.2:45000".parse().unwrap(),
+                dst: "203.0.113.7:51820".parse().unwrap(),
             },
         ],
         flow_start: chrono::Utc.timestamp_opt(1_700_000_000, 500).unwrap(),
@@ -67,8 +63,8 @@ fn emitted_records_spool_via_flow_log_writer_layer() {
     assert_eq!(
         payload["outer_tuples"],
         serde_json::json!([
-            {"src_ip": "198.51.100.1", "dst_ip": "203.0.113.7", "src_port": 51820, "dst_port": 51820},
-            {"src_ip": "198.51.100.2", "dst_ip": "203.0.113.7", "src_port": 45000, "dst_port": 51820},
+            {"src": "198.51.100.1:51820", "dst": "203.0.113.7:51820"},
+            {"src": "198.51.100.2:45000", "dst": "203.0.113.7:51820"},
         ])
     );
     assert_eq!(payload["flow_start"], format!("{:?}", record.flow_start));
@@ -138,7 +134,7 @@ fn tracked_packets_spool_open_and_completed_reports() {
     assert_eq!(
         open["outer_tuples"],
         serde_json::json!([
-            {"src_ip": "198.51.100.1", "dst_ip": "203.0.113.1", "src_port": 45000, "dst_port": 51820}
+            {"src": "198.51.100.1:45000", "dst": "203.0.113.1:51820"}
         ])
     );
     assert!(open.get("flow_end").is_none());

--- a/rust/libs/connlib/flow-tracker/tests/writer.rs
+++ b/rust/libs/connlib/flow-tracker/tests/writer.rs
@@ -209,40 +209,6 @@ fn syn_after_return_traffic_splits_flow() {
 }
 
 #[test]
-fn context_change_accumulates_outer_tuples_instead_of_splitting() {
-    let authz_id = "77777777-7777-7777-7777-777777777777";
-    let spool = SpoolObserver::new(authz_id);
-    let mut tracker = enabled_tracker();
-    let t0 = Instant::now();
-
-    spool.observe(|| {
-        drive_tx(&mut tracker, &tcp_packet(syn(), &[]), authz_id, t0);
-        drive_tx_from(
-            &mut tracker,
-            "198.51.100.2:45000",
-            &tcp_packet(ack(), &[0; 100]),
-            authz_id,
-            t0 + Duration::from_secs(1),
-        );
-        tracker.close_all(t0 + Duration::from_secs(2));
-    });
-
-    let flows = spool.completed_flows();
-    assert_eq!(
-        packet_counts(&flows),
-        vec![(2, 0)],
-        "a changed outer tuple counts into the same flow"
-    );
-    assert_eq!(
-        flows[0]["outer_tuples"],
-        serde_json::json!([
-            {"src_ip": "203.0.113.7", "dst_ip": "198.51.100.1", "src_port": 51820, "dst_port": 51820},
-            {"src_ip": "198.51.100.2", "dst_ip": "198.51.100.1", "src_port": 45000, "dst_port": 51820},
-        ])
-    );
-}
-
-#[test]
 fn bare_ack_does_not_create_flow() {
     let authz_id = "55555555-5555-5555-5555-555555555555";
     let spool = SpoolObserver::new(authz_id);
@@ -287,20 +253,9 @@ fn drive_tx(
     authz_id: &str,
     now: Instant,
 ) {
-    drive_tx_from(tracker, "203.0.113.7:51820", packet, authz_id, now);
-}
-
-/// [`drive_tx`] with the Client sending from `remote`, e.g. after a roam.
-fn drive_tx_from(
-    tracker: &mut Tracker<ClientOrGatewayId>,
-    remote: &str,
-    packet: &IpPacket,
-    authz_id: &str,
-    now: Instant,
-) {
     let _flow = tracker.begin_network_packet(
         "198.51.100.1:51820".parse().unwrap(),
-        remote.parse().unwrap(),
+        "203.0.113.7:51820".parse().unwrap(),
         now,
     );
     flow_tracker::record_decrypted_packet(packet);

--- a/rust/libs/connlib/flow-tracker/tests/writer.rs
+++ b/rust/libs/connlib/flow-tracker/tests/writer.rs
@@ -28,15 +28,12 @@ fn emitted_records_spool_via_flow_log_writer_layer() {
         inner_dst_ip: "10.0.0.5".parse().unwrap(),
         inner_dst_port: 443,
         domain: Some("download.httpbin".parse().unwrap()),
-        outer_tuples: vec![
-            FlowContext {
-                src: "198.51.100.1:51820".parse().unwrap(),
-                dst: "203.0.113.7:51820".parse().unwrap(),
-            },
-            FlowContext {
-                src: "198.51.100.2:45000".parse().unwrap(),
-                dst: "203.0.113.7:51820".parse().unwrap(),
-            },
+        outers: vec![
+            FlowContext::new(
+                Some("198.51.100.1:51820".parse().unwrap()),
+                "203.0.113.7:51820".parse().unwrap(),
+            ),
+            FlowContext::new(None, "203.0.113.7:51820".parse().unwrap()),
         ],
         flow_start: chrono::Utc.timestamp_opt(1_700_000_000, 500).unwrap(),
         close: Some(FlowClose {
@@ -61,10 +58,10 @@ fn emitted_records_spool_via_flow_log_writer_layer() {
     assert_eq!(payload["inner_dst_port"], record.inner_dst_port);
     assert_eq!(payload["domain"], "download.httpbin");
     assert_eq!(
-        payload["outer_tuples"],
+        payload["outers"],
         serde_json::json!([
-            {"src": "198.51.100.1:51820", "dst": "203.0.113.7:51820"},
-            {"src": "198.51.100.2:45000", "dst": "203.0.113.7:51820"},
+            {"src_ip": "198.51.100.1", "src_port": 51820, "dst_ip": "203.0.113.7", "dst_port": 51820},
+            {"dst_ip": "203.0.113.7", "dst_port": 51820},
         ])
     );
     assert_eq!(payload["flow_start"], format!("{:?}", record.flow_start));
@@ -132,9 +129,9 @@ fn tracked_packets_spool_open_and_completed_reports() {
     assert_eq!(open["inner_dst_ip"], "10.0.0.5");
     assert_eq!(open["inner_dst_port"], 5201);
     assert_eq!(
-        open["outer_tuples"],
+        open["outers"],
         serde_json::json!([
-            {"src": "198.51.100.1:45000", "dst": "203.0.113.1:51820"}
+            {"src_ip": "198.51.100.1", "src_port": 45000, "dst_ip": "203.0.113.1", "dst_port": 51820}
         ])
     );
     assert!(open.get("flow_end").is_none());

--- a/rust/libs/connlib/flow-tracker/tests/writer.rs
+++ b/rust/libs/connlib/flow-tracker/tests/writer.rs
@@ -11,7 +11,7 @@ use std::{
 use base64::Engine as _;
 use chrono::TimeZone as _;
 use connlib_model::{ClientId, ClientOrGatewayId, ResourceId};
-use flow_tracker::{FlowClose, FlowProtocol, IngestToken, Record, Role, Tracker};
+use flow_tracker::{FlowClose, FlowContext, FlowProtocol, IngestToken, Record, Role, Tracker};
 use ip_packet::IpPacket;
 use tracing_subscriber::layer::SubscriberExt as _;
 
@@ -28,10 +28,20 @@ fn emitted_records_spool_via_flow_log_writer_layer() {
         inner_dst_ip: "10.0.0.5".parse().unwrap(),
         inner_dst_port: 443,
         domain: Some("download.httpbin".parse().unwrap()),
-        outer_src_ip: "198.51.100.1".parse().unwrap(),
-        outer_src_port: 51820,
-        outer_dst_ip: "203.0.113.7".parse().unwrap(),
-        outer_dst_port: 51820,
+        outer_tuples: vec![
+            FlowContext {
+                src_ip: "198.51.100.1".parse().unwrap(),
+                dst_ip: "203.0.113.7".parse().unwrap(),
+                src_port: 51820,
+                dst_port: 51820,
+            },
+            FlowContext {
+                src_ip: "198.51.100.2".parse().unwrap(),
+                dst_ip: "203.0.113.7".parse().unwrap(),
+                src_port: 45000,
+                dst_port: 51820,
+            },
+        ],
         flow_start: chrono::Utc.timestamp_opt(1_700_000_000, 500).unwrap(),
         close: Some(FlowClose {
             flow_end: chrono::Utc.timestamp_opt(1_700_000_060, 0).unwrap(),
@@ -54,10 +64,13 @@ fn emitted_records_spool_via_flow_log_writer_layer() {
     assert_eq!(payload["inner_dst_ip"], record.inner_dst_ip.to_string());
     assert_eq!(payload["inner_dst_port"], record.inner_dst_port);
     assert_eq!(payload["domain"], "download.httpbin");
-    assert_eq!(payload["outer_src_ip"], record.outer_src_ip.to_string());
-    assert_eq!(payload["outer_src_port"], record.outer_src_port);
-    assert_eq!(payload["outer_dst_ip"], record.outer_dst_ip.to_string());
-    assert_eq!(payload["outer_dst_port"], record.outer_dst_port);
+    assert_eq!(
+        payload["outer_tuples"],
+        serde_json::json!([
+            {"src_ip": "198.51.100.1", "dst_ip": "203.0.113.7", "src_port": 51820, "dst_port": 51820},
+            {"src_ip": "198.51.100.2", "dst_ip": "203.0.113.7", "src_port": 45000, "dst_port": 51820},
+        ])
+    );
     assert_eq!(payload["flow_start"], format!("{:?}", record.flow_start));
     // Attribution rides the token, not the spooled record.
     assert!(payload.get("initiator_actor_id").is_none());
@@ -122,10 +135,12 @@ fn tracked_packets_spool_open_and_completed_reports() {
     assert_eq!(open["inner_src_port"], 1234);
     assert_eq!(open["inner_dst_ip"], "10.0.0.5");
     assert_eq!(open["inner_dst_port"], 5201);
-    assert_eq!(open["outer_src_ip"], "198.51.100.1");
-    assert_eq!(open["outer_src_port"], 45000);
-    assert_eq!(open["outer_dst_ip"], "203.0.113.1");
-    assert_eq!(open["outer_dst_port"], 51820);
+    assert_eq!(
+        open["outer_tuples"],
+        serde_json::json!([
+            {"src_ip": "198.51.100.1", "dst_ip": "203.0.113.1", "src_port": 45000, "dst_port": 51820}
+        ])
+    );
     assert!(open.get("flow_end").is_none());
 
     let completed = spool.report(".end.json");
@@ -194,6 +209,40 @@ fn syn_after_return_traffic_splits_flow() {
 }
 
 #[test]
+fn context_change_accumulates_outer_tuples_instead_of_splitting() {
+    let authz_id = "77777777-7777-7777-7777-777777777777";
+    let spool = SpoolObserver::new(authz_id);
+    let mut tracker = enabled_tracker();
+    let t0 = Instant::now();
+
+    spool.observe(|| {
+        drive_tx(&mut tracker, &tcp_packet(syn(), &[]), authz_id, t0);
+        drive_tx_from(
+            &mut tracker,
+            "198.51.100.2:45000",
+            &tcp_packet(ack(), &[0; 100]),
+            authz_id,
+            t0 + Duration::from_secs(1),
+        );
+        tracker.close_all(t0 + Duration::from_secs(2));
+    });
+
+    let flows = spool.completed_flows();
+    assert_eq!(
+        packet_counts(&flows),
+        vec![(2, 0)],
+        "a changed outer tuple counts into the same flow"
+    );
+    assert_eq!(
+        flows[0]["outer_tuples"],
+        serde_json::json!([
+            {"src_ip": "203.0.113.7", "dst_ip": "198.51.100.1", "src_port": 51820, "dst_port": 51820},
+            {"src_ip": "198.51.100.2", "dst_ip": "198.51.100.1", "src_port": 45000, "dst_port": 51820},
+        ])
+    );
+}
+
+#[test]
 fn bare_ack_does_not_create_flow() {
     let authz_id = "55555555-5555-5555-5555-555555555555";
     let spool = SpoolObserver::new(authz_id);
@@ -238,9 +287,20 @@ fn drive_tx(
     authz_id: &str,
     now: Instant,
 ) {
+    drive_tx_from(tracker, "203.0.113.7:51820", packet, authz_id, now);
+}
+
+/// [`drive_tx`] with the Client sending from `remote`, e.g. after a roam.
+fn drive_tx_from(
+    tracker: &mut Tracker<ClientOrGatewayId>,
+    remote: &str,
+    packet: &IpPacket,
+    authz_id: &str,
+    now: Instant,
+) {
     let _flow = tracker.begin_network_packet(
         "198.51.100.1:51820".parse().unwrap(),
-        "203.0.113.7:51820".parse().unwrap(),
+        remote.parse().unwrap(),
         now,
     );
     flow_tracker::record_decrypted_packet(packet);

--- a/rust/libs/connlib/flow-tracker/tests/writer.rs
+++ b/rust/libs/connlib/flow-tracker/tests/writer.rs
@@ -202,6 +202,34 @@ fn syn_after_return_traffic_splits_flow() {
 }
 
 #[test]
+fn context_change_past_the_cap_splits_flow() {
+    let authz_id = "77777777-7777-7777-7777-777777777777";
+    let spool = SpoolObserver::new(authz_id);
+    let mut tracker = enabled_tracker();
+    let t0 = Instant::now();
+
+    spool.observe(|| {
+        // The 17th distinct tuple does not fit the cap of 16 and splits the flow.
+        for i in 0..17u16 {
+            drive_tx_from(
+                &mut tracker,
+                &format!("203.0.113.7:{}", 51820 + i),
+                &tcp_packet(ack(), &[0; 10]),
+                authz_id,
+                t0 + Duration::from_secs(u64::from(i)),
+            );
+        }
+        tracker.close_all(t0 + Duration::from_secs(30));
+    });
+
+    assert_eq!(
+        packet_counts(&spool.completed_flows()),
+        vec![(1, 0), (16, 0)],
+        "the flow splits only once the context list is full"
+    );
+}
+
+#[test]
 fn bare_ack_does_not_create_flow() {
     let authz_id = "55555555-5555-5555-5555-555555555555";
     let spool = SpoolObserver::new(authz_id);
@@ -246,9 +274,20 @@ fn drive_tx(
     authz_id: &str,
     now: Instant,
 ) {
+    drive_tx_from(tracker, "203.0.113.7:51820", packet, authz_id, now);
+}
+
+/// [`drive_tx`] with the Client sending from `remote`, e.g. after a roam.
+fn drive_tx_from(
+    tracker: &mut Tracker<ClientOrGatewayId>,
+    remote: &str,
+    packet: &IpPacket,
+    authz_id: &str,
+    now: Instant,
+) {
     let _flow = tracker.begin_network_packet(
         "198.51.100.1:51820".parse().unwrap(),
-        "203.0.113.7:51820".parse().unwrap(),
+        remote.parse().unwrap(),
         now,
     );
     flow_tracker::record_decrypted_packet(packet);

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -535,13 +535,6 @@ mod tests {
         assert!(start.get("role").is_none());
         assert!(start.get("message").is_none());
         assert!(start.get("actor_id").is_none()); // attribution rides the token only
-        // The JSON-encoded outer tuples are decoded into the payload's array.
-        assert_eq!(
-            start["outer_tuples"],
-            serde_json::json!([
-                {"src_ip": "198.51.100.1", "dst_ip": "203.0.113.7", "src_port": 51820, "dst_port": 51820}
-            ])
-        );
         assert_eq!(end["rx_bytes"], 1024); // the `.end` is a self-describing report
         assert_eq!(end["inner_dst_port"], "443");
     }
@@ -577,35 +570,6 @@ mod tests {
         drop(guard);
 
         assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
-    }
-
-    #[test]
-    fn drops_event_with_undecodable_outer_tuples() {
-        let dir = tempfile::tempdir().unwrap();
-        write_token(dir.path(), &token_for(AUTHZ_ID)).unwrap();
-
-        let (layer, guard) = layer(dir.path().to_owned());
-        let subscriber = tracing_subscriber::registry().with(layer);
-        tracing::subscriber::with_default(subscriber, || {
-            tracing::trace!(
-                target: "flow_logs",
-                protocol = "tcp",
-                role = "responder",
-                policy_authorization_id = AUTHZ_ID,
-                outer_tuples = %"not json",
-                flow_start = ?Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
-                "TCP flow started"
-            );
-        });
-        drop(guard);
-
-        let authz_dir = dir.path().join("responder").join(AUTHZ_ID);
-        let reports = std::fs::read_dir(&authz_dir)
-            .unwrap()
-            .map(|entry| entry.unwrap().file_name())
-            .filter(|name| name != "token")
-            .count();
-        assert_eq!(reports, 0);
     }
 
     #[test]

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -627,7 +627,7 @@ mod tests {
             inner_src_port = %1234,
             inner_dst_ip = %"10.0.0.5",
             inner_dst_port = %443,
-            outer_tuples = %r#"[{"src_ip":"198.51.100.1","dst_ip":"203.0.113.7","src_port":51820,"dst_port":51820}]"#,
+            outer_tuples = %r#"[{"src":"198.51.100.1:51820","dst":"203.0.113.7:51820"}]"#,
             actor_id = "a-1",
             flow_start = ?flow_start,
             flow_end = flow_end.map(tracing::field::debug),

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -24,9 +24,10 @@
 //! directive would copy it into log files); the eventloops receive it in the
 //! portal's authorization messages and persist it via [`write_token`] instead.
 //! A report's payload is the event's record fields as emitted (see
-//! [`RECORD_FIELDS`]); attribution deliberately rides only the token, and the
-//! portal validates the payload on ingest, so the writer only interprets what
-//! routing and naming need.
+//! [`RECORD_FIELDS`]), with the JSON-encoded `outer_tuples` field decoded into
+//! its array; attribution deliberately rides only the token, and the portal
+//! validates the payload on ingest, so beyond that the writer only interprets
+//! what routing and naming need.
 //!
 //! `<flow_start>` is the flow's start time as zero-padded unix seconds, so a
 //! lexical sort of the report names is oldest-first and the uploader needs no
@@ -266,10 +267,7 @@ const RECORD_FIELDS: &[&str] = &[
     "inner_dst_ip",
     "inner_dst_port",
     "domain",
-    "outer_src_ip",
-    "outer_src_port",
-    "outer_dst_ip",
-    "outer_dst_port",
+    "outer_tuples",
     "flow_start",
     "flow_end",
     "last_packet",
@@ -334,8 +332,19 @@ impl FieldVisitor {
         self.fields
             .retain(|name, _| RECORD_FIELDS.contains(&name.as_str()));
 
-        // The only field the writer interprets: the file name needs it so a
-        // lexical sort of the reports is oldest-first.
+        // The record's outer tuples ride the event as one JSON-encoded field (a
+        // tracing field holds a single scalar); decode it so the report payload
+        // carries the array itself.
+        if let Some(outer_tuples) = self.fields.get_mut("outer_tuples") {
+            let decoded = outer_tuples
+                .as_str()
+                .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())?;
+
+            *outer_tuples = decoded;
+        }
+
+        // The only other field the writer interprets: the file name needs it so
+        // a lexical sort of the reports is oldest-first.
         let flow_start = DateTime::parse_from_rfc3339(self.fields.get("flow_start")?.as_str()?)
             .ok()?
             .timestamp();
@@ -526,6 +535,13 @@ mod tests {
         assert!(start.get("role").is_none());
         assert!(start.get("message").is_none());
         assert!(start.get("actor_id").is_none()); // attribution rides the token only
+        // The JSON-encoded outer tuples are decoded into the payload's array.
+        assert_eq!(
+            start["outer_tuples"],
+            serde_json::json!([
+                {"src_ip": "198.51.100.1", "dst_ip": "203.0.113.7", "src_port": 51820, "dst_port": 51820}
+            ])
+        );
         assert_eq!(end["rx_bytes"], 1024); // the `.end` is a self-describing report
         assert_eq!(end["inner_dst_port"], "443");
     }
@@ -561,6 +577,35 @@ mod tests {
         drop(guard);
 
         assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn drops_event_with_undecodable_outer_tuples() {
+        let dir = tempfile::tempdir().unwrap();
+        write_token(dir.path(), &token_for(AUTHZ_ID)).unwrap();
+
+        let (layer, guard) = layer(dir.path().to_owned());
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::trace!(
+                target: "flow_logs",
+                protocol = "tcp",
+                role = "responder",
+                policy_authorization_id = AUTHZ_ID,
+                outer_tuples = %"not json",
+                flow_start = ?Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+                "TCP flow started"
+            );
+        });
+        drop(guard);
+
+        let authz_dir = dir.path().join("responder").join(AUTHZ_ID);
+        let reports = std::fs::read_dir(&authz_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .filter(|name| name != "token")
+            .count();
+        assert_eq!(reports, 0);
     }
 
     #[test]
@@ -618,10 +663,7 @@ mod tests {
             inner_src_port = %1234,
             inner_dst_ip = %"10.0.0.5",
             inner_dst_port = %443,
-            outer_src_ip = %"198.51.100.1",
-            outer_src_port = %51820,
-            outer_dst_ip = %"203.0.113.7",
-            outer_dst_port = %51820,
+            outer_tuples = %r#"[{"src_ip":"198.51.100.1","dst_ip":"203.0.113.7","src_port":51820,"dst_port":51820}]"#,
             actor_id = "a-1",
             flow_start = ?flow_start,
             flow_end = flow_end.map(tracing::field::debug),

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -24,8 +24,8 @@
 //! directive would copy it into log files); the eventloops receive it in the
 //! portal's authorization messages and persist it via [`write_token`] instead.
 //! A report's payload is the event's record fields as emitted (see
-//! [`RECORD_FIELDS`]), with the JSON-encoded `outer_tuples` field decoded into
-//! its array; attribution deliberately rides only the token, and the portal
+//! [`RECORD_FIELDS`]), with the JSON-encoded `outers` field decoded into its
+//! array; attribution deliberately rides only the token, and the portal
 //! validates the payload on ingest, so beyond that the writer only interprets
 //! what routing and naming need.
 //!
@@ -267,7 +267,7 @@ const RECORD_FIELDS: &[&str] = &[
     "inner_dst_ip",
     "inner_dst_port",
     "domain",
-    "outer_tuples",
+    "outers",
     "flow_start",
     "flow_end",
     "last_packet",
@@ -335,12 +335,12 @@ impl FieldVisitor {
         // The record's outer tuples ride the event as one JSON-encoded field (a
         // tracing field holds a single scalar); decode it so the report payload
         // carries the array itself.
-        if let Some(outer_tuples) = self.fields.get_mut("outer_tuples") {
-            let decoded = outer_tuples
+        if let Some(outers) = self.fields.get_mut("outers") {
+            let decoded = outers
                 .as_str()
                 .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())?;
 
-            *outer_tuples = decoded;
+            *outers = decoded;
         }
 
         // The only other field the writer interprets: the file name needs it so
@@ -627,7 +627,7 @@ mod tests {
             inner_src_port = %1234,
             inner_dst_ip = %"10.0.0.5",
             inner_dst_port = %443,
-            outer_tuples = %r#"[{"src":"198.51.100.1:51820","dst":"203.0.113.7:51820"}]"#,
+            outers = %r#"[{"src_ip":"198.51.100.1","src_port":51820,"dst_ip":"203.0.113.7","dst_port":51820}]"#,
             actor_id = "a-1",
             flow_start = ?flow_start,
             flow_end = flow_end.map(tracing::field::debug),

--- a/scripts/tests/download-roaming-network.sh
+++ b/scripts/tests/download-roaming-network.sh
@@ -64,10 +64,10 @@ assert_eq "$(get_flow_field "$flow" "inner_dst_ip")" "172.21.0.101"
 
 outer_tuples="$(get_flow_field "$flow" "outer_tuples")"
 
-num_tuples="$(echo "$outer_tuples" | grep -o '"src_ip":' | wc -l || true)"
+num_tuples="$(echo "$outer_tuples" | grep -o '"src":' | wc -l || true)"
 assert_gteq "$num_tuples" 2
 
 # At least one tuple must come from the reconnected path, i.e. not from the
 # client's standard p2p port.
-non_standard_ports="$(echo "$outer_tuples" | grep -oP '"src_port":\K[0-9]+' | grep -cv '^52625$' || true)"
+non_standard_ports="$(echo "$outer_tuples" | grep -oP '"src":"[^"]*:\K[0-9]+' | grep -cv '^52625$' || true)"
 assert_gteq "$non_standard_ports" 1

--- a/scripts/tests/download-roaming-network.sh
+++ b/scripts/tests/download-roaming-network.sh
@@ -62,12 +62,12 @@ flow="${flows[0]}"
 
 assert_eq "$(get_flow_field "$flow" "inner_dst_ip")" "172.21.0.101"
 
-outer_tuples="$(get_flow_field "$flow" "outer_tuples")"
+outers="$(get_flow_field "$flow" "outers")"
 
-num_tuples="$(echo "$outer_tuples" | grep -o '"src":' | wc -l || true)"
+num_tuples="$(echo "$outers" | grep -o '"dst_ip":' | wc -l || true)"
 assert_gteq "$num_tuples" 2
 
 # At least one tuple must come from the reconnected path, i.e. not from the
 # client's standard p2p port.
-non_standard_ports="$(echo "$outer_tuples" | grep -oP '"src":"[^"]*:\K[0-9]+' | grep -cv '^52625$' || true)"
+non_standard_ports="$(echo "$outers" | grep -oP '"src_port":\K[0-9]+' | grep -cv '^52625$' || true)"
 assert_gteq "$non_standard_ports" 1

--- a/scripts/tests/download-roaming-network.sh
+++ b/scripts/tests/download-roaming-network.sh
@@ -54,17 +54,20 @@ fi
 sleep 3
 readarray -t flows < <(get_flow_logs "tcp")
 
-assert_gteq "${#flows[@]}" 2
+# A roam must not split the flow: the whole download is one flow that
+# accumulates the reconnected path as another outer tuple.
+assert_eq "${#flows[@]}" 1
 
-declare -i non_standard_ports=0
+flow="${flows[0]}"
 
-for flow in "${flows[@]}"; do
-    # All flows should have same inner_dst_ip
-    assert_eq "$(get_flow_field "$flow" "inner_dst_ip")" "172.21.0.101"
+assert_eq "$(get_flow_field "$flow" "inner_dst_ip")" "172.21.0.101"
 
-    if [ "$(get_flow_field "$flow" "outer_src_port")" != "52625" ]; then
-        non_standard_ports+=1
-    fi
-done
+outer_tuples="$(get_flow_field "$flow" "outer_tuples")"
 
+num_tuples="$(echo "$outer_tuples" | grep -o '"src_ip":' | wc -l || true)"
+assert_gteq "$num_tuples" 2
+
+# At least one tuple must come from the reconnected path, i.e. not from the
+# client's standard p2p port.
+non_standard_ports="$(echo "$outer_tuples" | grep -oP '"src_port":\K[0-9]+' | grep -cv '^52625$' || true)"
 assert_gteq "$non_standard_ports" 1


### PR DESCRIPTION
A flow whose outer (transport) 4-tuple changes, e.g. because the peer roamed to a different network, used to be closed and re-opened, so one logical flow surfaced as several records with disjoint counters.

The tracker now keeps the flow alive and records every outer tuple the flow uses, and the record carries the whole list as a single `outers` field. A relayed send has no known source address, so a tuple's source pair is omitted there rather than reported as the unspecified address. The list is capped at 16 tuples; a change past the cap splits the flow, so a peer that keeps flapping its path cannot make later tuples go unrecorded.