### PR TITLE
ci: use apt packages restored via cache restore-keys

### DIFF
--- a/.github/actions/setup-tauri-v2/action.yml
+++ b/.github/actions/setup-tauri-v2/action.yml
@@ -20,7 +20,9 @@ runs:
           ${{ runner.os }}-apt-tauri-
 
     - name: Restore cached apt packages
-      if: ${{ runner.os == 'Linux' && steps.apt-cache.outputs.cache-hit == 'true' }}
+      # `cache-hit` is only true on an exact key match, so this also runs for the
+      # `restore-keys` fallback, where the `.deb`s are restored but the key differs.
+      if: ${{ runner.os == 'Linux' }}
       run: |
         sudo cp ~/apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
       shell: bash


### PR DESCRIPTION
The Tauri apt cache copied its `.deb`s into the apt archive only on an exact key match, but that key hashes the action file itself, so any edit to it dropped every job back to a cold download. The `restore-keys` fallback did restore the packages, they were just never used, which left the jobs downloading around 90 packages including a 25 MB WebKit library from a mirror slow enough to blow the 15 minute step timeout.