### PR TITLE
ci: skip Tauri setup where headless tests do not need it

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -185,6 +185,10 @@ jobs:
         with:
           azure-connection-string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - uses: ./.github/actions/setup-tauri-v2
+        # `linux-group.sh` builds `firezone-client-tunnel`, which is a bin of the
+        # `firezone-gui-client` package and therefore compiles `tauri`. The other
+        # tests build `firezone-headless-client`, which has no such dependency.
+        if: matrix.test == 'linux-group.sh'
         timeout-minutes: 15
       - run: scripts/tests/${{ matrix.test }}
         name: "test script"


### PR DESCRIPTION
Four of the six `headless-client` matrix entries installed the Tauri build dependencies without ever compiling anything that links against them: the `token-path-linux.sh` runs build `firezone-headless-client`, which does not depend on `tauri`, and on Windows the action is inert anyway. On a slow apt mirror that setup is the longest step in the job.