### PR TITLE
fix(connlib): don't split TCP flow on retransmitted SYN

### DIFF
--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -437,6 +437,7 @@ where
                             contexts: smallvec![context],
                             fin_tx: false,
                             fin_rx: false,
+                            non_syn_tx: !tcp_syn,
                             domain,
                             ingest_token,
                         };
@@ -464,6 +465,7 @@ where
                             contexts: smallvec![context],
                             fin_tx: false,
                             fin_rx: false,
+                            non_syn_tx: !tcp_syn,
                             domain,
                             ingest_token,
                         };
@@ -472,12 +474,13 @@ where
 
                         self.active_tcp_flows.insert(key, value);
                     }
-                    // A SYN only starts a new connection if the existing flow has
-                    // seen return traffic; on a half-open flow it is a
-                    // retransmission and just counts as another packet.
-                    hash_map::Entry::Occupied(occupied)
-                        if tcp_syn && occupied.get().stats.rx_packets > 0 =>
-                    {
+                    // A SYN only starts a new connection (i.e. reuses the tuple)
+                    // if the initiator moved past the handshake by sending a
+                    // non-SYN packet. Until then, a SYN is a retransmission and
+                    // just counts as another packet; return traffic proves
+                    // nothing because a SYN-ACK may get lost on its way back to
+                    // the initiator.
+                    hash_map::Entry::Occupied(occupied) if tcp_syn && occupied.get().non_syn_tx => {
                         let (key, value) = occupied.remove_entry();
 
                         tracing::debug!(?key, "Splitting existing TCP flow; new TCP SYN");
@@ -491,6 +494,7 @@ where
                             contexts: smallvec![context],
                             fin_tx: false,
                             fin_rx: false,
+                            non_syn_tx: !tcp_syn,
                             domain,
                             ingest_token,
                         };
@@ -508,6 +512,9 @@ where
                         value.last_packet = now_utc;
                         if tcp_fin {
                             value.fin_tx = true;
+                        }
+                        if !tcp_syn {
+                            value.non_syn_tx = true;
                         }
 
                         if tcp_rst {
@@ -1184,6 +1191,8 @@ struct TcpFlowValue {
 
     fin_tx: bool,
     fin_rx: bool,
+    /// Whether the initiator has sent a packet other than a SYN.
+    non_syn_tx: bool,
 }
 
 #[derive(Debug)]

--- a/rust/libs/connlib/flow-tracker/tests/writer.rs
+++ b/rust/libs/connlib/flow-tracker/tests/writer.rs
@@ -171,7 +171,7 @@ fn syn_retransmit_updates_flow_instead_of_splitting() {
 }
 
 #[test]
-fn syn_after_return_traffic_splits_flow() {
+fn syn_retransmit_after_syn_ack_updates_flow() {
     let authz_id = "44444444-4444-4444-4444-444444444444";
     let spool = SpoolObserver::new(authz_id);
     let mut tracker = enabled_tracker();
@@ -181,7 +181,7 @@ fn syn_after_return_traffic_splits_flow() {
         drive_tx(&mut tracker, &tcp_packet(syn(), &[]), authz_id, t0);
         drive_rx(
             &mut tracker,
-            &tcp_return_packet(&[0; 100]),
+            &tcp_return_packet(syn_ack(), &[]),
             t0 + Duration::from_secs(1),
         );
         drive_tx(
@@ -196,8 +196,45 @@ fn syn_after_return_traffic_splits_flow() {
     let flows = spool.completed_flows();
     assert_eq!(
         packet_counts(&flows),
-        vec![(1, 0), (1, 1)],
-        "a new SYN closes the old flow and starts a fresh one"
+        vec![(2, 1)],
+        "a SYN retransmitted because the SYN-ACK got lost counts into the same flow"
+    );
+}
+
+#[test]
+fn syn_after_established_connection_splits_flow() {
+    let authz_id = "88888888-8888-8888-8888-888888888888";
+    let spool = SpoolObserver::new(authz_id);
+    let mut tracker = enabled_tracker();
+    let t0 = Instant::now();
+
+    spool.observe(|| {
+        drive_tx(&mut tracker, &tcp_packet(syn(), &[]), authz_id, t0);
+        drive_rx(
+            &mut tracker,
+            &tcp_return_packet(syn_ack(), &[]),
+            t0 + Duration::from_secs(1),
+        );
+        drive_tx(
+            &mut tracker,
+            &tcp_packet(ack(), &[]),
+            authz_id,
+            t0 + Duration::from_secs(2),
+        );
+        drive_tx(
+            &mut tracker,
+            &tcp_packet(syn(), &[]),
+            authz_id,
+            t0 + Duration::from_secs(3),
+        );
+        tracker.close_all(t0 + Duration::from_secs(4));
+    });
+
+    let flows = spool.completed_flows();
+    assert_eq!(
+        packet_counts(&flows),
+        vec![(1, 0), (2, 1)],
+        "a SYN after the handshake completed reuses the tuple for a new connection"
     );
 }
 
@@ -320,6 +357,14 @@ fn ack() -> ip_packet::make::TcpFlags {
     }
 }
 
+fn syn_ack() -> ip_packet::make::TcpFlags {
+    ip_packet::make::TcpFlags {
+        syn: true,
+        ack: true,
+        ..Default::default()
+    }
+}
+
 fn tcp_packet(flags: ip_packet::make::TcpFlags, payload: &[u8]) -> IpPacket {
     ip_packet::make::tcp_packet(
         "100.64.0.1".parse::<Ipv4Addr>().unwrap(),
@@ -334,13 +379,13 @@ fn tcp_packet(flags: ip_packet::make::TcpFlags, payload: &[u8]) -> IpPacket {
 
 /// The matching return packet for [`tcp_packet`], in its natural
 /// (responder-to-initiator) orientation.
-fn tcp_return_packet(payload: &[u8]) -> IpPacket {
+fn tcp_return_packet(flags: ip_packet::make::TcpFlags, payload: &[u8]) -> IpPacket {
     ip_packet::make::tcp_packet(
         "10.0.0.5".parse::<Ipv4Addr>().unwrap(),
         "100.64.0.1".parse::<Ipv4Addr>().unwrap(),
         443,
         1234,
-        ip_packet::make::TcpFlags::default(),
+        flags,
         payload,
     )
     .unwrap()


### PR DESCRIPTION
A Client retransmits its SYN when the SYN-ACK does not reach it in time, e.g. because the packet got lost while the Client roams networks. The flow tracker treated any SYN on a flow that has seen return traffic as the start of a new connection, so such a retransmission split the flow on the Gateway: it emitted a bogus zero-byte record plus a second record for the actual connection, while the Client records a single flow log. The portal is then unable to correlate the two sides' flow logs with certainty.

A SYN can only be a retransmission while the initiator is still inside the handshake, and the initiator leaves the handshake exactly when it sends its first non-SYN packet. The tracker now splits on a SYN only after that point; until then, repeated SYNs count into the existing flow. A SYN on an established flow still splits it, since that means the 4-tuple is being reused for a new connection.