### PR TITLE
refactor(portal): clean up the flow log detail panel

### DIFF
--- a/elixir/lib/portal/flow_log.ex
+++ b/elixir/lib/portal/flow_log.ex
@@ -13,7 +13,8 @@ defmodule Portal.FlowLog do
             src_ip: String.t() | nil,
             src_port: :inet.port_number() | nil,
             dst_ip: String.t(),
-            dst_port: :inet.port_number()
+            dst_port: :inet.port_number(),
+            path_activated_at: DateTime.t() | nil
           }
 
     embedded_schema do
@@ -21,11 +22,12 @@ defmodule Portal.FlowLog do
       field :src_port, :integer
       field :dst_ip, :string
       field :dst_port, :integer
+      field :path_activated_at, :utc_datetime_usec
     end
 
     def changeset(outer, attrs) do
       outer
-      |> cast(attrs, [:src_ip, :src_port, :dst_ip, :dst_port])
+      |> cast(attrs, [:src_ip, :src_port, :dst_ip, :dst_port, :path_activated_at])
       |> validate_required([:dst_ip, :dst_port])
       |> validate_source_endpoint()
       |> validate_ip(:src_ip)
@@ -342,7 +344,8 @@ defmodule Portal.FlowLog do
         src_ip: outer.src_ip,
         src_port: outer.src_port,
         dst_ip: outer.dst_ip,
-        dst_port: outer.dst_port
+        dst_port: outer.dst_port,
+        path_activated_at: outer.path_activated_at
       }
     end)
   end

--- a/elixir/lib/portal_api/schemas/log_schema.ex
+++ b/elixir/lib/portal_api/schemas/log_schema.ex
@@ -330,7 +330,13 @@ defmodule PortalAPI.Schemas.Log do
                 nullable: true
               },
               dst_ip: %Schema{type: :string},
-              dst_port: %Schema{type: :integer}
+              dst_port: %Schema{type: :integer},
+              path_activated_at: %Schema{
+                type: :string,
+                format: :"date-time",
+                nullable: true,
+                description: "RFC 3339 timestamp of when the path was selected."
+              }
             },
             required: [:dst_ip, :dst_port]
           }

--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -816,8 +816,8 @@ defmodule PortalWeb.CoreComponents do
       role={if @menu?, do: "menu", else: "tooltip"}
       class={~w[
         fixed z-10 invisible inline-block
-        text-xs text-neutral-500 transition-opacity
-        duration-50 bg-white border border-neutral-200
+        text-xs text-body transition-opacity
+        duration-50 bg-elevated border border-border
         rounded-md shadow-xs opacity-0
       ]}
     >
@@ -1636,6 +1636,7 @@ defmodule PortalWeb.CoreComponents do
   attr :id, :string, required: true
   attr :checked, :boolean, default: false
   attr :label, :string, default: nil
+  attr :label_class, :string, default: "text-sm font-medium text-heading"
   attr :disabled, :boolean, default: false
   attr :size, :string, default: "md", values: ~w[sm md]
   attr :label_position, :string, default: "after", values: ~w[before after]
@@ -1652,7 +1653,7 @@ defmodule PortalWeb.CoreComponents do
       not @disabled && "cursor-pointer",
       @class
     ]}>
-      <span :if={@label && @label_position == "before"} class="me-2 text-sm font-medium text-heading">
+      <span :if={@label && @label_position == "before"} class={["me-2", @label_class]}>
         {@label}
       </span>
       <input
@@ -1676,7 +1677,7 @@ defmodule PortalWeb.CoreComponents do
         toggle_size(@size)
       ]}>
       </span>
-      <span :if={@label && @label_position == "after"} class="ms-2 text-sm font-medium text-heading">
+      <span :if={@label && @label_position == "after"} class={["ms-2", @label_class]}>
         {@label}
       </span>
     </label>

--- a/elixir/lib/portal_web/format.ex
+++ b/elixir/lib/portal_web/format.ex
@@ -35,6 +35,18 @@ defmodule PortalWeb.Format do
   end
 
   @doc """
+  Formats a `%DateTime{}` as a full ISO 8601 string in the given IANA timezone,
+  for places where the abbreviated form is not precise enough. Falls back to
+  UTC if the zone cannot be shifted.
+  """
+  def iso_datetime(%DateTime{} = datetime, tz) when is_binary(tz) do
+    case DateTime.shift_zone(datetime, tz, Tz.TimeZoneDatabase) do
+      {:ok, shifted} -> DateTime.to_iso8601(shifted)
+      _ -> DateTime.to_iso8601(datetime)
+    end
+  end
+
+  @doc """
   Returns a relative time string like "2 hours ago" or "in 3 days".
   """
   def relative_datetime(datetime, relative_to \\ nil) do

--- a/elixir/lib/portal_web/live/logs/components.ex
+++ b/elixir/lib/portal_web/live/logs/components.ex
@@ -13,9 +13,10 @@ defmodule PortalWeb.Logs.Components do
   alias PortalWeb.CoreComponents
 
   @doc """
-  Single timestamp table cell. `log_id` keeps the wrapper's id unique so LV's
-  diff can patch it independently. `tz_mode`/`display_tz` flow as explicit
-  props so column re-rendering picks up timezone toggles.
+  Single timestamp cell, abbreviated with the full value in a hover popover.
+  `log_id` keeps the wrapper's id unique so LV's diff can patch it
+  independently. `tz_mode`/`display_tz` flow as explicit props so column
+  re-rendering picks up timezone toggles.
   """
   attr :log_id, :string, required: true
   attr :timestamp, DateTime, required: true
@@ -25,14 +26,22 @@ defmodule PortalWeb.Logs.Components do
 
   def timestamp_cell(assigns) do
     ~H"""
-    <span
-      id={"#{@id_prefix}-#{@log_id}"}
-      data-tz-mode={@tz_mode}
-      title={"#{DateTime.to_iso8601(@timestamp)} (#{@display_tz})"}
-      class="text-xs text-[var(--text-primary)] tabular-nums"
-    >
-      {PortalWeb.Format.short_datetime(@timestamp, @display_tz)}
-    </span>
+    <CoreComponents.popover>
+      <:target>
+        <span
+          id={"#{@id_prefix}-#{@log_id}"}
+          data-tz-mode={@tz_mode}
+          class="text-xs text-[var(--text-primary)] tabular-nums underline underline-offset-2 decoration-1 decoration-dotted"
+        >
+          {PortalWeb.Format.short_datetime(@timestamp, @display_tz)}
+        </span>
+      </:target>
+      <:content>
+        <span class="whitespace-nowrap font-mono">
+          {PortalWeb.Format.iso_datetime(@timestamp, @display_tz)}
+        </span>
+      </:content>
+    </CoreComponents.popover>
     """
   end
 
@@ -196,12 +205,16 @@ defmodule PortalWeb.Logs.Components do
   Section heading in a show panel sidebar.
   """
   attr :label, :string, required: true
+  attr :hint, :string, default: nil
 
   def section_heading(assigns) do
     ~H"""
-    <h3 class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)] mb-3">
-      {@label}
-    </h3>
+    <div class="mb-3 flex items-center justify-between gap-3">
+      <h3 class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
+        {@label}
+      </h3>
+      <span :if={@hint} class="text-[10px] text-[var(--text-tertiary)]">{@hint}</span>
+    </div>
     """
   end
 

--- a/elixir/lib/portal_web/live/logs/flow_logs.ex
+++ b/elixir/lib/portal_web/live/logs/flow_logs.ex
@@ -228,32 +228,11 @@ defmodule PortalWeb.Logs.FlowLogs do
           :if={@selected_report}
           class="flex-1 min-w-0 overflow-y-auto p-5 space-y-5"
         >
-          <.match_notice
-            matching_logs={@selected_report.matching_logs}
-            selected_role={@selected_report.log.role}
-          />
-
           <section>
-            <div class="flex items-center justify-between gap-3 mb-2">
-              <.section_heading label="Initiator and responder logs" />
-              <span class="text-xs text-[var(--text-tertiary)]">
-                Directions are normalized to initiator → responder
-              </span>
-            </div>
-            <div class="grid grid-cols-1 2xl:grid-cols-2 gap-3">
-              <.report_card
-                :for={log <- comparison_logs(@selected_report)}
-                log={log}
-                selected?={log.log_id == @selected_report.log.log_id}
-                path={~p"/#{@account}/logs/flow_logs/#{log.log_id}?#{@query_params}"}
-                tz_mode={@tz_mode}
-                display_tz={@display_tz}
-              />
-            </div>
-          </section>
-
-          <section>
-            <.section_heading label="Connection details" />
+            <.section_heading
+              label="Connection details"
+              hint="Directions are normalized to initiator → responder"
+            />
             <div class="space-y-3">
               <div class="overflow-hidden rounded border border-[var(--border)] bg-[var(--surface)]">
                 <div class="flex items-center justify-between gap-3 border-b border-[var(--border)] bg-[var(--surface-raised)] px-4 py-2">
@@ -303,9 +282,97 @@ defmodule PortalWeb.Logs.FlowLogs do
                 </div>
               </div>
 
+              <div class="overflow-hidden rounded border border-[var(--border)] bg-[var(--surface)]">
+                <div class="flex items-center justify-between gap-3 border-b border-[var(--border)] bg-[var(--surface-raised)] px-4 py-2">
+                  <div class="flex items-center gap-2 text-xs font-medium text-[var(--text-secondary)]">
+                    <.icon name="ri-time-line" class="h-3.5 w-3.5 text-[var(--brand)]" />
+                    Timing and traffic
+                  </div>
+                  <.flow_state log={@selected_report.log} />
+                </div>
+                <div class="space-y-3 px-4 py-3">
+                  <dl class="grid grid-cols-3 gap-x-4 gap-y-2">
+                    <.detail_row label="Started">
+                      <.timestamp_cell
+                        id_prefix="panel-start"
+                        log_id={@selected_report.log.log_id}
+                        timestamp={@selected_report.log.flow_start}
+                        tz_mode={@tz_mode}
+                        display_tz={@display_tz}
+                      />
+                    </.detail_row>
+                    <.detail_row label="Ended">
+                      <.timestamp_cell
+                        :if={@selected_report.log.flow_end}
+                        id_prefix="panel-end"
+                        log_id={@selected_report.log.log_id}
+                        timestamp={@selected_report.log.flow_end}
+                        tz_mode={@tz_mode}
+                        display_tz={@display_tz}
+                      />
+                      <span
+                        :if={is_nil(@selected_report.log.flow_end)}
+                        class="text-xs text-[var(--text-tertiary)]"
+                      >
+                        Open
+                      </span>
+                    </.detail_row>
+                    <.detail_row label="Last packet">
+                      <.timestamp_cell
+                        :if={@selected_report.log.last_packet}
+                        id_prefix="panel-packet"
+                        log_id={@selected_report.log.log_id}
+                        timestamp={@selected_report.log.last_packet}
+                        tz_mode={@tz_mode}
+                        display_tz={@display_tz}
+                      />
+                      <span
+                        :if={is_nil(@selected_report.log.last_packet)}
+                        class="text-xs text-[var(--text-tertiary)]"
+                      >
+                        -
+                      </span>
+                    </.detail_row>
+                  </dl>
+
+                  <div class="grid grid-cols-2 gap-2">
+                    <.metric
+                      label="Initiator → responder"
+                      value={format_bytes(@selected_report.log.tx_bytes)}
+                      secondary={format_packets(@selected_report.log.tx_packets)}
+                    />
+                    <.metric
+                      label="Responder → initiator"
+                      value={format_bytes(@selected_report.log.rx_bytes)}
+                      secondary={format_packets(@selected_report.log.rx_packets)}
+                    />
+                  </div>
+                </div>
+              </div>
+
               <.outer_path_history
                 id={"flow-log-path-history-#{@selected_report.log.log_id}"}
+                log_id={@selected_report.log.log_id}
                 outers={@selected_report.log.outers}
+                tz_mode={@tz_mode}
+                display_tz={@display_tz}
+              />
+            </div>
+          </section>
+
+          <section>
+            <.section_heading label={matching_heading(@selected_report.matching_logs)} />
+            <.match_notice
+              matching_logs={@selected_report.matching_logs}
+              selected_role={@selected_report.log.role}
+            />
+            <div :if={@selected_report.matching_logs != []} class="mt-2 space-y-2">
+              <.matching_log_card
+                :for={log <- @selected_report.matching_logs}
+                log={log}
+                path={~p"/#{@account}/logs/flow_logs/#{log.log_id}?#{@query_params}"}
+                tz_mode={@tz_mode}
+                display_tz={@display_tz}
               />
             </div>
           </section>
@@ -630,46 +697,32 @@ defmodule PortalWeb.Logs.FlowLogs do
   end
 
   attr :log, :any, required: true
-  attr :selected?, :boolean, required: true
   attr :path, :string, required: true
   attr :tz_mode, :string, required: true
   attr :display_tz, :string, required: true
 
-  defp report_card(assigns) do
+  defp matching_log_card(assigns) do
     ~H"""
     <.link
-      id={"flow-log-card-#{@log.log_id}"}
+      id={"flow-log-match-#{@log.log_id}"}
       patch={@path}
       data-role={@log.role}
-      aria-current={if(@selected?, do: "page")}
-      class={[
-        "block rounded border bg-[var(--surface)] overflow-hidden transition-colors",
-        if(@selected?,
-          do: "border-[var(--brand)]/50",
-          else: "border-[var(--border)] hover:border-[var(--brand)]/50"
-        )
-      ]}
+      class="block overflow-hidden rounded border border-[var(--border)] bg-[var(--surface)] transition-colors hover:border-[var(--brand)]/50"
     >
-      <div class="flex items-center justify-between gap-3 px-3 py-2 border-b border-[var(--border)] bg-[var(--surface-raised)]">
-        <div class="flex items-center gap-2 min-w-0">
+      <div class="flex items-center justify-between gap-3 border-b border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2">
+        <div class="flex min-w-0 items-center gap-2">
           <.role_badge role={@log.role} />
-          <span :if={@selected?} class="text-xs text-[var(--text-tertiary)]">
-            Selected log
-          </span>
-          <span
-            :if={not @selected?}
-            class="inline-flex items-center gap-1 text-xs text-[var(--brand)]"
-          >
-            View log <.icon name="ri-arrow-right-line" class="w-3 h-3" />
-          </span>
+          <.flow_state log={@log} />
         </div>
-        <.flow_state log={@log} />
+        <span class="inline-flex shrink-0 items-center gap-1 text-xs text-[var(--brand)]">
+          View log <.icon name="ri-arrow-right-line" class="h-3 w-3" />
+        </span>
       </div>
-      <div class="p-3 space-y-3">
-        <dl class="grid grid-cols-2 gap-x-4 gap-y-2">
+      <div class="px-3 py-2.5">
+        <dl class="grid grid-cols-2 gap-x-4 gap-y-2 xl:grid-cols-4">
           <.detail_row label="Started">
             <.timestamp_cell
-              id_prefix={"report-start-#{@log.role}"}
+              id_prefix="match-start"
               log_id={@log.log_id}
               timestamp={@log.flow_start}
               tz_mode={@tz_mode}
@@ -679,7 +732,7 @@ defmodule PortalWeb.Logs.FlowLogs do
           <.detail_row label="Ended">
             <.timestamp_cell
               :if={@log.flow_end}
-              id_prefix={"report-end-#{@log.role}"}
+              id_prefix="match-end"
               log_id={@log.log_id}
               timestamp={@log.flow_end}
               tz_mode={@tz_mode}
@@ -687,38 +740,25 @@ defmodule PortalWeb.Logs.FlowLogs do
             />
             <span :if={is_nil(@log.flow_end)} class="text-xs text-[var(--text-tertiary)]">Open</span>
           </.detail_row>
-          <.detail_row label="Last packet">
-            <.timestamp_cell
-              :if={@log.last_packet}
-              id_prefix={"report-packet-#{@log.role}"}
-              log_id={@log.log_id}
-              timestamp={@log.last_packet}
-              tz_mode={@tz_mode}
-              display_tz={@display_tz}
-            />
-            <span :if={is_nil(@log.last_packet)} class="text-xs text-[var(--text-tertiary)]">-</span>
+          <.detail_row label="Traffic">
+            <span class="font-mono text-xs tabular-nums text-[var(--text-secondary)]">
+              {format_bytes(total_bytes(@log))}
+            </span>
           </.detail_row>
           <.detail_row label="Log ID">
             <.identifier value={@log.log_id} />
           </.detail_row>
         </dl>
-
-        <div class="grid grid-cols-2 gap-2">
-          <.metric label="Initiator → responder" value={format_bytes(@log.tx_bytes)} secondary={format_packets(@log.tx_packets)} />
-          <.metric label="Responder → initiator" value={format_bytes(@log.rx_bytes)} secondary={format_packets(@log.rx_packets)} />
-        </div>
-
-        <.outer_path_summary
-          id={"flow-log-card-paths-#{@log.log_id}"}
-          outers={@log.outers}
-        />
       </div>
     </.link>
     """
   end
 
   attr :id, :string, required: true
+  attr :log_id, :string, required: true
   attr :outers, :list, required: true
+  attr :tz_mode, :string, required: true
+  attr :display_tz, :string, required: true
 
   defp outer_path_history(assigns) do
     assigns = assign(assigns, :path_count, length(assigns.outers))
@@ -771,8 +811,18 @@ defmodule PortalWeb.Logs.FlowLogs do
           </div>
 
           <div class="min-w-0 flex-1 rounded border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2.5">
-            <div class="mb-2 text-[10px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">
-              {if(index == 1, do: "Initial path", else: "Path change")}
+            <div class="mb-2 flex items-center justify-between gap-2">
+              <div class="text-[10px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">
+                {if(index == 1, do: "Initial path", else: "Path change")}
+              </div>
+              <.timestamp_cell
+                :if={outer.path_activated_at}
+                id_prefix={"path-activated-#{index}"}
+                log_id={@log_id}
+                timestamp={outer.path_activated_at}
+                tz_mode={@tz_mode}
+                display_tz={@display_tz}
+              />
             </div>
             <div class="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2">
               <div class="min-w-0">
@@ -804,65 +854,6 @@ defmodule PortalWeb.Logs.FlowLogs do
               </div>
             </div>
           </div>
-        </li>
-      </ol>
-    </div>
-    """
-  end
-
-  attr :id, :string, required: true
-  attr :outers, :list, required: true
-
-  defp outer_path_summary(assigns) do
-    assigns = assign(assigns, :path_count, length(assigns.outers))
-
-    ~H"""
-    <div id={@id} class="border-t border-[var(--border)] pt-3">
-      <div class="mb-2 flex items-center justify-between gap-2">
-        <div class="flex items-center gap-1.5 text-xs text-[var(--text-tertiary)]">
-          <.icon name="ri-route-line" class="h-3.5 w-3.5" />
-          WireGuard paths
-        </div>
-        <span :if={@path_count > 0} class="text-[10px] text-[var(--text-tertiary)]">
-          {@path_count} observed
-        </span>
-      </div>
-
-      <div :if={@path_count == 0} class="text-xs italic text-[var(--text-tertiary)]">
-        Reported when the flow closes
-      </div>
-
-      <ol :if={@path_count > 0} class="max-h-52 space-y-1.5 overflow-y-auto pr-1">
-        <li
-          :for={{outer, index} <- Enum.with_index(@outers, 1)}
-          data-wireguard-path={index}
-          class="grid grid-cols-[1.25rem_minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 rounded bg-[var(--surface-raised)] px-2 py-1.5"
-        >
-          <span class="inline-flex h-5 w-5 items-center justify-center rounded-full bg-[var(--surface)] font-mono text-[10px] text-[var(--text-tertiary)]">
-            {index}
-          </span>
-          <span
-            data-wireguard-endpoint="initiator"
-            class={[
-              "min-w-0 break-all text-xs",
-              if(outer.src_ip,
-                do: "font-mono text-[var(--text-secondary)]",
-                else: "italic text-[var(--text-tertiary)]"
-              )
-            ]}
-          >
-            {if(outer.src_ip,
-              do: format_endpoint(outer.src_ip, outer.src_port),
-              else: "Not observed"
-            )}
-          </span>
-          <.icon name="ri-arrow-right-line" class="h-3.5 w-3.5 shrink-0 text-[var(--brand)]" />
-          <span
-            data-wireguard-endpoint="responder"
-            class="min-w-0 break-all text-right font-mono text-xs text-[var(--text-secondary)]"
-          >
-            {format_endpoint(outer.dst_ip, outer.dst_port)}
-          </span>
         </li>
       </ol>
     </div>
@@ -901,10 +892,8 @@ defmodule PortalWeb.Logs.FlowLogs do
     """
   end
 
-  defp comparison_logs(report) do
-    [report.log | report.matching_logs]
-    |> Enum.sort_by(&if(&1.role == :initiator, do: 0, else: 1))
-  end
+  defp matching_heading([_, _ | _]), do: "Matching logs"
+  defp matching_heading(_matching_logs), do: "Matching log"
 
   defp role_row_class(%{log: %{role: :initiator}}),
     do:

--- a/elixir/lib/portal_web/live_table.ex
+++ b/elixir/lib/portal_web/live_table.ex
@@ -648,6 +648,7 @@ defmodule PortalWeb.LiveTable do
         checked={@checked}
         size="sm"
         label={@filter.title}
+        label_class="text-xs font-medium text-[var(--text-secondary)] select-none"
         label_position="before"
         class="h-8 px-2.5 rounded border border-input-border bg-input"
       />

--- a/elixir/test/portal/http/sync_test.exs
+++ b/elixir/test/portal/http/sync_test.exs
@@ -100,7 +100,8 @@ defmodule Portal.HTTP.SyncTest do
               src_ip: "198.51.100.9",
               src_port: 42_000,
               dst_ip: "203.0.113.8",
-              dst_port: 443
+              dst_port: 443,
+              path_activated_at: ~U[2026-07-30 10:00:30.000000Z]
             }
           ]
         )
@@ -115,12 +116,19 @@ defmodule Portal.HTTP.SyncTest do
       assert end1["log_id"] == flow1.log_id <> "-e"
 
       assert end1["outers"] == [
-               %{"src_ip" => nil, "src_port" => nil, "dst_ip" => "203.0.113.7", "dst_port" => 51_820},
+               %{
+                 "src_ip" => nil,
+                 "src_port" => nil,
+                 "dst_ip" => "203.0.113.7",
+                 "dst_port" => 51_820,
+                 "path_activated_at" => nil
+               },
                %{
                  "src_ip" => "198.51.100.9",
                  "src_port" => 42_000,
                  "dst_ip" => "203.0.113.8",
-                 "dst_port" => 443
+                 "dst_port" => 443,
+                 "path_activated_at" => "2026-07-30T10:00:30.000000Z"
                }
              ]
 

--- a/elixir/test/portal_api/controllers/flow_log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/flow_log_controller_test.exs
@@ -347,7 +347,8 @@ defmodule PortalAPI.FlowLogControllerTest do
               "src_ip" => "198.51.100.9",
               "src_port" => 42_000,
               "dst_ip" => "203.0.113.8",
-              "dst_port" => 443
+              "dst_port" => 443,
+              "path_activated_at" => "2026-03-20T10:03:15.000000Z"
             }
           ],
           "last_packet" => "2026-03-20T10:04:30.000000Z"
@@ -361,13 +362,23 @@ defmodule PortalAPI.FlowLogControllerTest do
       assert log.rx_packets == 7
       assert log.tx_packets == 9
       assert log.domain == "db.example.com"
-      assert Enum.map(log.outers, &Map.take(&1, [:src_ip, :src_port, :dst_ip, :dst_port])) == [
-               %{src_ip: nil, src_port: nil, dst_ip: "203.0.113.7", dst_port: 51_820},
+      assert Enum.map(
+               log.outers,
+               &Map.take(&1, [:src_ip, :src_port, :dst_ip, :dst_port, :path_activated_at])
+             ) == [
+               %{
+                 src_ip: nil,
+                 src_port: nil,
+                 dst_ip: "203.0.113.7",
+                 dst_port: 51_820,
+                 path_activated_at: nil
+               },
                %{
                  src_ip: "198.51.100.9",
                  src_port: 42_000,
                  dst_ip: "203.0.113.8",
-                 dst_port: 443
+                 dst_port: 443,
+                 path_activated_at: ~U[2026-03-20 10:03:15.000000Z]
                }
              ]
       assert log.last_packet == ~U[2026-03-20 10:04:30.000000Z]

--- a/elixir/test/portal_api/controllers/log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/log_controller_test.exs
@@ -368,7 +368,16 @@ defmodule PortalAPI.LogControllerTest do
           initiator_device_serial: "C02ABC123",
           initiator_device_uuid: "0C4A8D24-FA9F-4E56-9B57-40D0D46A245E",
           initiator_device_identifier_for_vendor: "C242BC21-AB4A-4F6D-B755-F50E2B5B51B7",
-          initiator_device_firebase_installation_id: "firebase-installation-id"
+          initiator_device_firebase_installation_id: "firebase-installation-id",
+          outers: [
+            %{
+              src_ip: "203.0.113.10",
+              src_port: 51_820,
+              dst_ip: "198.51.100.5",
+              dst_port: 51_820,
+              path_activated_at: ~U[2026-06-03 00:00:00.000000Z]
+            }
+          ]
         )
 
       conn =
@@ -428,7 +437,8 @@ defmodule PortalAPI.LogControllerTest do
                  "src_ip" => "203.0.113.10",
                  "src_port" => 51_820,
                  "dst_ip" => "198.51.100.5",
-                 "dst_port" => 51_820
+                 "dst_port" => 51_820,
+                 "path_activated_at" => "2026-06-03T00:00:00.000000Z"
                }
              ]
       assert data["rx_packets"] == 100

--- a/elixir/test/portal_web/live/logs/flow_logs_test.exs
+++ b/elixir/test/portal_web/live/logs/flow_logs_test.exs
@@ -286,6 +286,19 @@ defmodule PortalWeb.Logs.FlowLogsTest do
       assert html =~ complete.log_id
       refute html =~ incomplete.log_id
 
+      html = toggle_show_incomplete(lv, "true")
+
+      assert has_element?(lv, "#flow_logs-show_incomplete-toggle[checked]")
+      assert html =~ complete.log_id
+      assert html =~ incomplete.log_id
+      assert has_element?(lv, "#flow-log-#{incomplete.log_id}", "Incomplete")
+
+      html = toggle_show_incomplete(lv, "false")
+
+      assert has_element?(lv, "#flow_logs-show_incomplete-toggle:not([checked])")
+      assert html =~ complete.log_id
+      refute html =~ incomplete.log_id
+
       {:ok, lv, html} =
         live(
           conn,
@@ -295,7 +308,6 @@ defmodule PortalWeb.Logs.FlowLogsTest do
       assert has_element?(lv, "#flow_logs-show_incomplete-toggle[checked]")
       assert html =~ complete.log_id
       assert html =~ incomplete.log_id
-      assert has_element?(lv, "#flow-log-#{incomplete.log_id}", "Incomplete")
     end
 
     test "shows clock skew in the duration cell", %{
@@ -349,7 +361,8 @@ defmodule PortalWeb.Logs.FlowLogsTest do
               src_ip: "2001:db8::10",
               src_port: 41_003,
               dst_ip: "2001:db8::20",
-              dst_port: 51_820
+              dst_port: 51_820,
+              path_activated_at: ~U[2026-07-30 10:00:30.000000Z]
             }
           ]
         )
@@ -386,7 +399,26 @@ defmodule PortalWeb.Logs.FlowLogsTest do
                "[2001:db8::20]:51820"
              ]
 
-      assert has_element?(lv, "#flow-log-card-paths-#{log.log_id}", "3 observed")
+      assert has_element?(lv, "#path-activated-3-#{log.log_id}", "7/30/26, 10:00 AM")
+      refute has_element?(lv, "#path-activated-1-#{log.log_id}")
+    end
+
+    test "shows the full timestamp in a popover", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      log = flow_log_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/logs/flow_logs/#{log.log_id}")
+
+      panel_html = lv |> element("#flow-log-panel") |> render()
+
+      assert has_element?(lv, "#panel-start-#{log.log_id}")
+      assert panel_html =~ DateTime.to_iso8601(log.flow_start)
     end
 
     test "explains when an open flow has no outer paths yet", %{
@@ -405,12 +437,6 @@ defmodule PortalWeb.Logs.FlowLogsTest do
                lv,
                "#flow-log-path-history-#{log.log_id}",
                "Paths are reported when the flow closes."
-             )
-
-      assert has_element?(
-               lv,
-               "#flow-log-card-paths-#{log.log_id}",
-               "Reported when the flow closes"
              )
     end
 
@@ -473,7 +499,7 @@ defmodule PortalWeb.Logs.FlowLogsTest do
              )
 
       assert html =~ "Flow logs are paired on a best-effort basis."
-      assert html =~ "Initiator and responder logs"
+      assert html =~ "Matching log"
       assert html =~ "Connection details"
       assert panel_html =~ "Flow log JSON"
       assert has_element?(lv, "#flow-log-json .json-key")
@@ -514,7 +540,8 @@ defmodule PortalWeb.Logs.FlowLogsTest do
                  "src_ip" => "203.0.113.44",
                  "src_port" => 62_000,
                  "dst_ip" => "189.172.73.153",
-                 "dst_port" => 51_820
+                 "dst_port" => 51_820,
+                 "path_activated_at" => nil
                }
              ]
       refute Map.has_key?(api_json, "data")
@@ -528,27 +555,29 @@ defmodule PortalWeb.Logs.FlowLogsTest do
       assert panel_html =~ initiator.log_id
       assert panel_html =~ responder.log_id
       assert panel_html =~ "12.5 KB"
-      assert panel_html =~ "12.0 KB"
       assert has_element?(
                lv,
-               "#flow-log-card-#{initiator.log_id} [data-wireguard-endpoint='initiator']",
+               "#flow-log-path-history-#{initiator.log_id} [data-wireguard-endpoint='initiator']",
                "203.0.113.44:62000"
              )
 
       assert has_element?(
                lv,
-               "#flow-log-card-#{initiator.log_id} [data-wireguard-endpoint='responder']",
+               "#flow-log-path-history-#{initiator.log_id} [data-wireguard-endpoint='responder']",
                "189.172.73.153:51820"
              )
 
-      assert has_element?(lv, "#flow-log-card-#{responder.log_id}[href*='#{responder.log_id}']")
+      assert has_element?(lv, "#flow-log-match-#{responder.log_id}[href*='#{responder.log_id}']")
+      refute has_element?(lv, "#flow-log-match-#{initiator.log_id}")
 
       lv
-      |> element("#flow-log-card-#{responder.log_id}")
+      |> element("#flow-log-match-#{responder.log_id}")
       |> render_click()
 
       assert_patch(lv, ~p"/#{account}/logs/flow_logs/#{responder.log_id}")
-      assert has_element?(lv, "#flow-log-card-#{responder.log_id}[aria-current=page]")
+      assert has_element?(lv, "#flow-log-path-history-#{responder.log_id}")
+      assert has_element?(lv, "#flow-log-match-#{initiator.log_id}")
+      refute has_element?(lv, "#flow-log-match-#{responder.log_id}")
     end
 
     test "does not match a non-overlapping reused tuple", %{
@@ -661,11 +690,12 @@ defmodule PortalWeb.Logs.FlowLogsTest do
 
       refute html =~ "No matching responder log"
       assert panel_html =~ other.log_id
+      assert has_element?(lv, "#flow-log-match-#{other.log_id}")
 
       assert has_element?(
                lv,
-               "#flow-log-card-#{other.log_id} [data-wireguard-endpoint='initiator']",
-               "198.51.100.130:41001"
+               "#flow-log-path-history-#{selected.log_id} [data-wireguard-endpoint='initiator']",
+               "192.168.1.86:52625"
              )
     end
 
@@ -762,5 +792,14 @@ defmodule PortalWeb.Logs.FlowLogsTest do
       assert html =~ "No matching responder log"
       refute panel_html =~ other.log_id
     end
+  end
+
+  defp toggle_show_incomplete(lv, value) do
+    lv
+    |> element("#flow_logs-filters")
+    |> render_change(%{
+      "table_id" => "flow_logs",
+      "flow_logs" => %{"show_incomplete" => value}
+    })
   end
 end


### PR DESCRIPTION
The flow log detail panel showed the same log twice: once as a card sitting next to its matching log, and again under Connection details. Connection details now comes first and holds everything about the log you opened, including when it started and ended and how much traffic it carried. The log from the other endpoint follows below as a short summary you can click through to, with the note about best-effort pairing next to it.

Timestamps now show their full value in a hover popover rather than a browser tooltip, and the popover picks up dark mode instead of rendering as a white box. The "Show incomplete" toggle label is the same size and color as the labels next to it.

Each entry in a flow log's `outers` also gains a new `path_activated_at`, which can be null. Endpoints report it as a timestamp string, and it shows up next to the path it belongs to in the path history. Nothing sends it yet.
