### PR TITLE
feat(connlib): record when each outer flow path was selected

### DIFF
--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -170,7 +170,11 @@ where
     /// Dropping the returned guard inserts the gathered flow data.
     pub fn begin_tun_packet(&mut self, packet: &IpPacket, now: Instant) -> CurrentFlowGuard<'_, S> {
         if self.enabled {
-            set_current_flow(FlowData::new(Entry::Tun, Some(InnerFlow::from(packet))));
+            set_current_flow(FlowData::new(
+                Entry::Tun,
+                Some(InnerFlow::from(packet)),
+                self.now_utc(now),
+            ));
         }
 
         CurrentFlowGuard { tracker: self, now }
@@ -186,7 +190,11 @@ where
         now: Instant,
     ) -> CurrentFlowGuard<'_, S> {
         if self.enabled {
-            set_current_flow(FlowData::new(Entry::Network { local, remote }, None));
+            set_current_flow(FlowData::new(
+                Entry::Network { local, remote },
+                None,
+                self.now_utc(now),
+            ));
         }
 
         CurrentFlowGuard { tracker: self, now }
@@ -195,6 +203,7 @@ where
     fn insert_flow(&mut self, data: FlowData, now: Instant) {
         let FlowData {
             entry,
+            now_utc,
             inner:
                 Some(InnerFlow {
                     src_ip,
@@ -232,7 +241,7 @@ where
             // network (packets buffered during connection setup are recorded by
             // the responder once they arrive).
             (Entry::Tun, Role::Initiator) => {
-                let Some((src, dst)) = outer_tx else {
+                let Some(context) = outer_tx else {
                     tracing::trace!("Not recording flow for packet that was never sent");
 
                     return;
@@ -250,7 +259,7 @@ where
                 self.record_tx(
                     TxPacket {
                         scope,
-                        context: FlowContext::new(src, dst, self.now_utc(now)),
+                        context,
                         src_ip,
                         dst_ip,
                         src_proto,
@@ -280,7 +289,7 @@ where
                 self.record_tx(
                     TxPacket {
                         scope,
-                        context: FlowContext::new(remote, local, self.now_utc(now)),
+                        context: FlowContext::new(remote, local, now_utc),
                         src_ip,
                         dst_ip,
                         src_proto,
@@ -725,11 +734,13 @@ enum Entry {
 /// role; [`Tracker::insert_flow`] interprets them (see the module docs).
 struct FlowData {
     entry: Entry,
+    /// The tracker's UTC clock reading for this packet.
+    now_utc: DateTime<Utc>,
     /// The inner (application) packet's flow fields.
     inner: Option<InnerFlow>,
-    /// The outer (transport) endpoints a TUN-entry packet was encapsulated to,
-    /// as a (src, dst) pair. Absence means the packet was never sent.
-    outer_tx: Option<(Option<SocketAddr>, SocketAddr)>,
+    /// The outer (transport) 4-tuple a TUN-entry packet was encapsulated to,
+    /// in transmit direction. Absence means the packet was never sent.
+    outer_tx: Option<FlowContext>,
     /// The peer the packet is tunneled through and our role in the flow.
     peer: Option<(ClientOrGatewayId, Role)>,
     resource: Option<ResourceId>,
@@ -746,6 +757,7 @@ impl Debug for FlowData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FlowData")
             .field("entry", &self.entry)
+            .field("now_utc", &self.now_utc)
             .field("inner", &self.inner)
             .field("outer_tx", &self.outer_tx)
             .field("peer", &self.peer)
@@ -761,9 +773,10 @@ impl Debug for FlowData {
 }
 
 impl FlowData {
-    fn new(entry: Entry, inner: Option<InnerFlow>) -> Self {
+    fn new(entry: Entry, inner: Option<InnerFlow>, now_utc: DateTime<Utc>) -> Self {
         Self {
             entry,
+            now_utc,
             inner,
             outer_tx: None,
             peer: None,
@@ -849,7 +862,7 @@ pub fn record_translated_packet(packet: &IpPacket) {
 /// `src` is unknown for relayed sends and omitted from the flow's outer tuple.
 pub fn record_transmit(src: Option<SocketAddr>, dst: SocketAddr) {
     update_current_flow(|data| {
-        data.outer_tx = Some((src, dst));
+        data.outer_tx = Some(FlowContext::new(src, dst, data.now_utc));
     });
 }
 

--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -728,8 +728,7 @@ struct FlowData {
     /// The inner (application) packet's flow fields.
     inner: Option<InnerFlow>,
     /// The outer (transport) endpoints a TUN-entry packet was encapsulated to,
-    /// as an (initiator, responder) pair. Absence means the packet was never
-    /// sent.
+    /// as a (src, dst) pair. Absence means the packet was never sent.
     outer_tx: Option<(Option<SocketAddr>, SocketAddr)>,
     /// The peer the packet is tunneled through and our role in the flow.
     peer: Option<(ClientOrGatewayId, Role)>,
@@ -940,9 +939,8 @@ pub struct Record {
     pub inner_dst_port: u16,
     pub domain: Option<DomainName>,
 
-    /// The outer (transport) tuples the flow has used, appended on every change
-    /// with the time each was selected, so a tuple the flow returned to
-    /// appears again.
+    /// The outer (transport) tuples the flow has used, appended on every change,
+    /// so a tuple the flow returned to appears again.
     pub outers: Vec<FlowContext>,
 
     pub flow_start: DateTime<Utc>,
@@ -1182,9 +1180,8 @@ struct TcpFlowValue {
     start: DateTime<Utc>,
     last_packet: DateTime<Utc>,
     stats: FlowStats,
-    /// The outer (transport) tuples the flow has used, appended on every change
-    /// with the time each was selected, so a tuple the flow returned to
-    /// appears again.
+    /// The outer (transport) tuples the flow has used, appended on every change,
+    /// so a tuple the flow returned to appears again.
     contexts: SmallVec<[FlowContext; 4]>,
 
     domain: Option<DomainName>,
@@ -1203,9 +1200,8 @@ struct UdpFlowValue {
     start: DateTime<Utc>,
     last_packet: DateTime<Utc>,
     stats: FlowStats,
-    /// The outer (transport) tuples the flow has used, appended on every change
-    /// with the time each was selected, so a tuple the flow returned to
-    /// appears again.
+    /// The outer (transport) tuples the flow has used, appended on every change,
+    /// so a tuple the flow returned to appears again.
     contexts: SmallVec<[FlowContext; 4]>,
 
     domain: Option<DomainName>,
@@ -1240,14 +1236,13 @@ impl FlowStats {
     }
 }
 
-/// The outer (transport) 4-tuple a flow is tunneled over and the time the flow
-/// selected it.
+/// The outer (transport) 4-tuple a flow is tunneled over.
 ///
 /// The source is unknown for relayed sends; it is `None` there and omitted
 /// from the serialised tuple. `path_selected_at` is the time of the packet
 /// that revealed the tuple: the flow's first packet for the initial entry of
 /// [`Record::outers`], the first packet after a change for every later one.
-#[derive(Debug, PartialEq, Eq, Clone, Copy, serde::Serialize)]
+#[derive(Debug, Clone, Copy, serde::Serialize)]
 pub struct FlowContext {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub src_ip: Option<IpAddr>,
@@ -1276,10 +1271,12 @@ impl FlowContext {
             path_selected_at,
         }
     }
+}
 
-    /// Whether `other` names the same outer tuple, regardless of when each was
-    /// selected.
-    fn same_tuple(&self, other: &Self) -> bool {
+/// Contexts compare by their tuple alone; `path_selected_at` only records when
+/// the flow started using it.
+impl PartialEq for FlowContext {
+    fn eq(&self, other: &Self) -> bool {
         let Self {
             src_ip,
             src_port,
@@ -1293,6 +1290,8 @@ impl FlowContext {
     }
 }
 
+impl Eq for FlowContext {}
+
 /// Appends `context` to a flow's outer tuples if it differs from the current one.
 ///
 /// Callers split the flow before the list would grow past
@@ -1303,7 +1302,7 @@ fn push_context(key: &impl Debug, contexts: &mut SmallVec<[FlowContext; 4]>, con
         return;
     };
 
-    if current.same_tuple(&context) {
+    if current == context {
         return;
     }
 
@@ -1319,11 +1318,7 @@ fn push_context(key: &impl Debug, contexts: &mut SmallVec<[FlowContext; 4]>, con
 /// Whether recording `context` would grow the flow's outer tuples past
 /// [`MAX_CONTEXTS_PER_FLOW`].
 fn context_overflows(contexts: &SmallVec<[FlowContext; 4]>, context: FlowContext) -> bool {
-    let same_as_current = contexts
-        .last()
-        .is_some_and(|current| current.same_tuple(&context));
-
-    !same_as_current && contexts.len() >= MAX_CONTEXTS_PER_FLOW
+    contexts.last() != Some(&context) && contexts.len() >= MAX_CONTEXTS_PER_FLOW
 }
 
 #[derive(PartialEq, Eq)]

--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -232,7 +232,7 @@ where
             // network (packets buffered during connection setup are recorded by
             // the responder once they arrive).
             (Entry::Tun, Role::Initiator) => {
-                let Some(context) = outer_tx else {
+                let Some((src, dst)) = outer_tx else {
                     tracing::trace!("Not recording flow for packet that was never sent");
 
                     return;
@@ -250,7 +250,7 @@ where
                 self.record_tx(
                     TxPacket {
                         scope,
-                        context,
+                        context: FlowContext::new(src, dst, self.now_utc(now)),
                         src_ip,
                         dst_ip,
                         src_proto,
@@ -280,7 +280,7 @@ where
                 self.record_tx(
                     TxPacket {
                         scope,
-                        context: FlowContext::new(remote, local),
+                        context: FlowContext::new(remote, local, self.now_utc(now)),
                         src_ip,
                         dst_ip,
                         src_proto,
@@ -727,9 +727,10 @@ struct FlowData {
     entry: Entry,
     /// The inner (application) packet's flow fields.
     inner: Option<InnerFlow>,
-    /// The outer (transport) 4-tuple a TUN-entry packet was encapsulated to,
-    /// oriented initiator-to-responder. Absence means the packet was never sent.
-    outer_tx: Option<FlowContext>,
+    /// The outer (transport) endpoints a TUN-entry packet was encapsulated to,
+    /// as an (initiator, responder) pair. Absence means the packet was never
+    /// sent.
+    outer_tx: Option<(Option<SocketAddr>, SocketAddr)>,
     /// The peer the packet is tunneled through and our role in the flow.
     peer: Option<(ClientOrGatewayId, Role)>,
     resource: Option<ResourceId>,
@@ -849,7 +850,7 @@ pub fn record_translated_packet(packet: &IpPacket) {
 /// `src` is unknown for relayed sends and omitted from the flow's outer tuple.
 pub fn record_transmit(src: Option<SocketAddr>, dst: SocketAddr) {
     update_current_flow(|data| {
-        data.outer_tx = Some(FlowContext::new(src, dst));
+        data.outer_tx = Some((src, dst));
     });
 }
 
@@ -939,8 +940,9 @@ pub struct Record {
     pub inner_dst_port: u16,
     pub domain: Option<DomainName>,
 
-    /// The outer (transport) tuples the flow has used, appended on every change,
-    /// so a tuple the flow returned to appears again.
+    /// The outer (transport) tuples the flow has used, appended on every change
+    /// with the time each was selected, so a tuple the flow returned to
+    /// appears again.
     pub outers: Vec<FlowContext>,
 
     pub flow_start: DateTime<Utc>,
@@ -1180,8 +1182,9 @@ struct TcpFlowValue {
     start: DateTime<Utc>,
     last_packet: DateTime<Utc>,
     stats: FlowStats,
-    /// The outer (transport) tuples the flow has used, appended on every change,
-    /// so a tuple the flow returned to appears again.
+    /// The outer (transport) tuples the flow has used, appended on every change
+    /// with the time each was selected, so a tuple the flow returned to
+    /// appears again.
     contexts: SmallVec<[FlowContext; 4]>,
 
     domain: Option<DomainName>,
@@ -1200,8 +1203,9 @@ struct UdpFlowValue {
     start: DateTime<Utc>,
     last_packet: DateTime<Utc>,
     stats: FlowStats,
-    /// The outer (transport) tuples the flow has used, appended on every change,
-    /// so a tuple the flow returned to appears again.
+    /// The outer (transport) tuples the flow has used, appended on every change
+    /// with the time each was selected, so a tuple the flow returned to
+    /// appears again.
     contexts: SmallVec<[FlowContext; 4]>,
 
     domain: Option<DomainName>,
@@ -1236,10 +1240,13 @@ impl FlowStats {
     }
 }
 
-/// The outer (transport) 4-tuple a flow is tunneled over.
+/// The outer (transport) 4-tuple a flow is tunneled over and the time the flow
+/// selected it.
 ///
 /// The source is unknown for relayed sends; it is `None` there and omitted
-/// from the serialised tuple.
+/// from the serialised tuple. `path_selected_at` is the time of the packet
+/// that revealed the tuple: the flow's first packet for the initial entry of
+/// [`Record::outers`], the first packet after a change for every later one.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, serde::Serialize)]
 pub struct FlowContext {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1248,12 +1255,17 @@ pub struct FlowContext {
     pub src_port: Option<u16>,
     pub dst_ip: IpAddr,
     pub dst_port: u16,
+    pub path_selected_at: DateTime<Utc>,
 }
 
 impl FlowContext {
     /// Builds a context from the outer addresses as seen by the initiator: the
     /// initiator side is the source, the responder side the destination.
-    pub fn new(initiator: impl Into<Option<SocketAddr>>, responder: SocketAddr) -> Self {
+    pub fn new(
+        initiator: impl Into<Option<SocketAddr>>,
+        responder: SocketAddr,
+        path_selected_at: DateTime<Utc>,
+    ) -> Self {
         let initiator = initiator.into();
 
         Self {
@@ -1261,7 +1273,23 @@ impl FlowContext {
             src_port: initiator.map(|initiator| initiator.port()),
             dst_ip: responder.ip(),
             dst_port: responder.port(),
+            path_selected_at,
         }
+    }
+
+    /// Whether `other` names the same outer tuple, regardless of when each was
+    /// selected.
+    fn same_tuple(&self, other: &Self) -> bool {
+        let Self {
+            src_ip,
+            src_port,
+            dst_ip,
+            dst_port,
+            path_selected_at: _,
+        } = self;
+
+        (*src_ip, *src_port, *dst_ip, *dst_port)
+            == (other.src_ip, other.src_port, other.dst_ip, other.dst_port)
     }
 }
 
@@ -1275,7 +1303,7 @@ fn push_context(key: &impl Debug, contexts: &mut SmallVec<[FlowContext; 4]>, con
         return;
     };
 
-    if current == context {
+    if current.same_tuple(&context) {
         return;
     }
 
@@ -1291,7 +1319,11 @@ fn push_context(key: &impl Debug, contexts: &mut SmallVec<[FlowContext; 4]>, con
 /// Whether recording `context` would grow the flow's outer tuples past
 /// [`MAX_CONTEXTS_PER_FLOW`].
 fn context_overflows(contexts: &SmallVec<[FlowContext; 4]>, context: FlowContext) -> bool {
-    contexts.last() != Some(&context) && contexts.len() >= MAX_CONTEXTS_PER_FLOW
+    let same_as_current = contexts
+        .last()
+        .is_some_and(|current| current.same_tuple(&context));
+
+    !same_as_current && contexts.len() >= MAX_CONTEXTS_PER_FLOW
 }
 
 #[derive(PartialEq, Eq)]
@@ -1356,10 +1388,12 @@ mod tests {
         let old = FlowContext::new(
             "10.0.0.1:8080".parse::<SocketAddr>().unwrap(),
             "192.168.0.1:443".parse().unwrap(),
+            DateTime::UNIX_EPOCH,
         );
         let new = FlowContext::new(
             "1.1.1.1:50000".parse::<SocketAddr>().unwrap(),
             "192.168.0.1:443".parse().unwrap(),
+            DateTime::UNIX_EPOCH,
         );
 
         let diff = FlowContextDiff::new(old, new);

--- a/rust/libs/connlib/flow-tracker/tests/writer.rs
+++ b/rust/libs/connlib/flow-tracker/tests/writer.rs
@@ -32,8 +32,13 @@ fn emitted_records_spool_via_flow_log_writer_layer() {
             FlowContext::new(
                 "198.51.100.1:51820".parse::<SocketAddr>().unwrap(),
                 "203.0.113.7:51820".parse().unwrap(),
+                chrono::Utc.timestamp_opt(1_700_000_000, 500).unwrap(),
             ),
-            FlowContext::new(None, "203.0.113.7:51820".parse().unwrap()),
+            FlowContext::new(
+                None,
+                "203.0.113.7:51820".parse().unwrap(),
+                chrono::Utc.timestamp_opt(1_700_000_030, 0).unwrap(),
+            ),
         ],
         flow_start: chrono::Utc.timestamp_opt(1_700_000_000, 500).unwrap(),
         close: Some(FlowClose {
@@ -60,8 +65,8 @@ fn emitted_records_spool_via_flow_log_writer_layer() {
     assert_eq!(
         payload["outers"],
         serde_json::json!([
-            {"src_ip": "198.51.100.1", "src_port": 51820, "dst_ip": "203.0.113.7", "dst_port": 51820},
-            {"dst_ip": "203.0.113.7", "dst_port": 51820},
+            {"src_ip": "198.51.100.1", "src_port": 51820, "dst_ip": "203.0.113.7", "dst_port": 51820, "path_selected_at": "2023-11-14T22:13:20.000000500Z"},
+            {"dst_ip": "203.0.113.7", "dst_port": 51820, "path_selected_at": "2023-11-14T22:13:50Z"},
         ])
     );
     assert_eq!(payload["flow_start"], format!("{:?}", record.flow_start));
@@ -85,8 +90,8 @@ fn tracked_packets_spool_open_and_completed_reports() {
     let token = test_token(authz_id, "responder");
 
     let spool = SpoolObserver::new(authz_id);
-    let mut tracker = enabled_tracker::<(ClientId, ResourceId)>();
     let now = Instant::now();
+    let mut tracker = enabled_tracker::<(ClientId, ResourceId)>(now);
 
     let client = ClientId::from_u128(1);
     let resource = ResourceId::from_u128(2);
@@ -131,7 +136,7 @@ fn tracked_packets_spool_open_and_completed_reports() {
     assert_eq!(
         open["outers"],
         serde_json::json!([
-            {"src_ip": "198.51.100.1", "src_port": 45000, "dst_ip": "203.0.113.1", "dst_port": 51820}
+            {"src_ip": "198.51.100.1", "src_port": 45000, "dst_ip": "203.0.113.1", "dst_port": 51820, "path_selected_at": "2023-11-14T22:13:20Z"}
         ])
     );
     assert!(open.get("flow_end").is_none());
@@ -148,8 +153,8 @@ fn tracked_packets_spool_open_and_completed_reports() {
 fn syn_retransmit_updates_flow_instead_of_splitting() {
     let authz_id = "33333333-3333-3333-3333-333333333333";
     let spool = SpoolObserver::new(authz_id);
-    let mut tracker = enabled_tracker();
     let t0 = Instant::now();
+    let mut tracker = enabled_tracker(t0);
 
     spool.observe(|| {
         drive_tx(&mut tracker, &tcp_packet(syn(), &[]), authz_id, t0);
@@ -174,8 +179,8 @@ fn syn_retransmit_updates_flow_instead_of_splitting() {
 fn syn_retransmit_after_syn_ack_updates_flow() {
     let authz_id = "44444444-4444-4444-4444-444444444444";
     let spool = SpoolObserver::new(authz_id);
-    let mut tracker = enabled_tracker();
     let t0 = Instant::now();
+    let mut tracker = enabled_tracker(t0);
 
     spool.observe(|| {
         drive_tx(&mut tracker, &tcp_packet(syn(), &[]), authz_id, t0);
@@ -205,8 +210,8 @@ fn syn_retransmit_after_syn_ack_updates_flow() {
 fn syn_after_established_connection_splits_flow() {
     let authz_id = "88888888-8888-8888-8888-888888888888";
     let spool = SpoolObserver::new(authz_id);
-    let mut tracker = enabled_tracker();
     let t0 = Instant::now();
+    let mut tracker = enabled_tracker(t0);
 
     spool.observe(|| {
         drive_tx(&mut tracker, &tcp_packet(syn(), &[]), authz_id, t0);
@@ -239,11 +244,47 @@ fn syn_after_established_connection_splits_flow() {
 }
 
 #[test]
+fn context_change_stamps_the_path_selection_time() {
+    let authz_id = "99999999-9999-9999-9999-999999999999";
+    let spool = SpoolObserver::new(authz_id);
+    let t0 = Instant::now();
+    let mut tracker = enabled_tracker(t0);
+
+    spool.observe(|| {
+        drive_tx(&mut tracker, &tcp_packet(syn(), &[]), authz_id, t0);
+        // A packet on the unchanged path keeps the original stamp.
+        drive_tx(
+            &mut tracker,
+            &tcp_packet(ack(), &[0; 10]),
+            authz_id,
+            t0 + Duration::from_secs(5),
+        );
+        drive_tx_from(
+            &mut tracker,
+            "203.0.113.7:52000",
+            &tcp_packet(ack(), &[0; 10]),
+            authz_id,
+            t0 + Duration::from_secs(9),
+        );
+        tracker.close_all(t0 + Duration::from_secs(10));
+    });
+
+    let [flow]: [serde_json::Value; 1] = spool.completed_flows().try_into().unwrap();
+    assert_eq!(
+        flow["outers"],
+        serde_json::json!([
+            {"src_ip": "203.0.113.7", "src_port": 51820, "dst_ip": "198.51.100.1", "dst_port": 51820, "path_selected_at": "2023-11-14T22:13:20Z"},
+            {"src_ip": "203.0.113.7", "src_port": 52000, "dst_ip": "198.51.100.1", "dst_port": 51820, "path_selected_at": "2023-11-14T22:13:29Z"},
+        ])
+    );
+}
+
+#[test]
 fn context_change_past_the_cap_splits_flow() {
     let authz_id = "77777777-7777-7777-7777-777777777777";
     let spool = SpoolObserver::new(authz_id);
-    let mut tracker = enabled_tracker();
     let t0 = Instant::now();
+    let mut tracker = enabled_tracker(t0);
 
     spool.observe(|| {
         // The 17th distinct tuple does not fit the cap of 16 and splits the flow.
@@ -270,8 +311,8 @@ fn context_change_past_the_cap_splits_flow() {
 fn bare_ack_does_not_create_flow() {
     let authz_id = "55555555-5555-5555-5555-555555555555";
     let spool = SpoolObserver::new(authz_id);
-    let mut tracker = enabled_tracker();
     let t0 = Instant::now();
+    let mut tracker = enabled_tracker(t0);
 
     spool.observe(|| {
         drive_tx(&mut tracker, &tcp_packet(ack(), &[]), authz_id, t0);
@@ -285,8 +326,8 @@ fn bare_ack_does_not_create_flow() {
 fn data_packet_creates_flow_without_syn() {
     let authz_id = "66666666-6666-6666-6666-666666666666";
     let spool = SpoolObserver::new(authz_id);
-    let mut tracker = enabled_tracker();
     let t0 = Instant::now();
+    let mut tracker = enabled_tracker(t0);
 
     spool.observe(|| {
         drive_tx(&mut tracker, &tcp_packet(ack(), &[0; 100]), authz_id, t0);
@@ -296,8 +337,9 @@ fn data_packet_creates_flow_without_syn() {
     assert_eq!(packet_counts(&spool.completed_flows()), vec![(1, 0)]);
 }
 
-fn enabled_tracker<S>() -> Tracker<S> {
-    let mut tracker = Tracker::new(Instant::now(), Duration::from_secs(1_700_000_000));
+/// A tracker whose UTC clock reads exactly 1_700_000_000 at `now`.
+fn enabled_tracker<S>(now: Instant) -> Tracker<S> {
+    let mut tracker = Tracker::new(now, Duration::from_secs(1_700_000_000));
     tracker.set_enabled(true);
 
     tracker


### PR DESCRIPTION
Each entry in a flow's outer-path history now carries a `path_selected_at` timestamp: the flow's first packet stamps the initial path, and the first packet after a change stamps every later one. The timestamp rides inside each `outers` entry of the emitted record, so flow logs can show when a flow roamed or switched relays. The portal ignores the new key at ingest, so storing and exposing it there is a follow-up.

Related: #14508