### PR TITLE
refactor: make telemetry optional in tunnel-proto and logging

### DIFF
--- a/rust/client-ffi/Cargo.toml
+++ b/rust/client-ffi/Cargo.toml
@@ -20,7 +20,7 @@ ip-packet = { workspace = true }
 ip_network = { workspace = true }
 itertools = { workspace = true }
 libc = { workspace = true }
-logging = { workspace = true }
+logging = { workspace = true, features = ["telemetry"] }
 opentelemetry = { workspace = true }
 otel-attributes = { workspace = true }
 otel-instruments = { workspace = true }

--- a/rust/libs/bin-shared/Cargo.toml
+++ b/rust/libs/bin-shared/Cargo.toml
@@ -21,7 +21,7 @@ hex-literal = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true, features = ["serde"] }
 known-dirs = { workspace = true }
-logging = { workspace = true }
+logging = { workspace = true, features = ["telemetry"] }
 otel-attributes = { workspace = true }
 otel-instruments = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/rust/libs/connlib/phoenix-channel/Cargo.toml
+++ b/rust/libs/connlib/phoenix-channel/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 backoff = { workspace = true }
-base64 = { workspace = true }
+base64 = { workspace = true, features = ["std"] }
 chrono = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }

--- a/rust/libs/connlib/tunnel-proto/Cargo.toml
+++ b/rust/libs/connlib/tunnel-proto/Cargo.toml
@@ -9,6 +9,9 @@ divan = ["dep:divan"]
 # Allows callers to bypass client-side resource filters. Only used by the
 # tunnel fuzzer to exercise the remote filtering path.
 malicious-behaviour = []
+# Consult telemetry's feature flags and report their use. Without this,
+# every flag keeps its default value.
+telemetry = ["dep:telemetry"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -42,7 +45,7 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 smallvec = { workspace = true, features = ["const_generics"] }
 snownet = { workspace = true }
-telemetry = { workspace = true }
+telemetry = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 

--- a/rust/libs/connlib/tunnel-proto/Cargo.toml
+++ b/rust/libs/connlib/tunnel-proto/Cargo.toml
@@ -11,7 +11,7 @@ divan = ["dep:divan"]
 malicious-behaviour = []
 # Consult telemetry's feature flags and report their use. Without this,
 # every flag keeps its default value.
-telemetry = ["dep:telemetry"]
+telemetry = ["dep:telemetry", "logging/telemetry"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/rust/libs/connlib/tunnel-proto/src/client.rs
+++ b/rust/libs/connlib/tunnel-proto/src/client.rs
@@ -887,10 +887,8 @@ impl ClientState {
                 if telemetry::feature_flags::icmp_error_unreachable_prohibited_create_new_flow()
                     && let Ok(Some((failed_packet, error))) = packet.icmp_error()
                     && error.is_unreachable_prohibited()
-                {
-                    let internet_resource = self.active_internet_resource().map(|r| r.id);
-
-                    if let Some(resource) = self
+                    && let internet_resource = self.active_internet_resource().map(|r| r.id)
+                    && let Some(resource) = self
                         .routing_tables
                         .resolve_resource(
                             failed_packet.dst(),
@@ -898,18 +896,17 @@ impl ClientState {
                             internet_resource,
                         )
                         .map(|route| route.resource_id())
-                    {
-                        telemetry::analytics::feature_flag_called(
-                            "icmp-error-unreachable-prohibited-create-new-flow",
-                        );
+                {
+                    telemetry::analytics::feature_flag_called(
+                        "icmp-error-unreachable-prohibited-create-new-flow",
+                    );
 
-                        self.pending_authorizations.on_not_authorized_resource(
-                            resource,
-                            pending_authorizations::Trigger::IcmpDestinationUnreachableProhibited,
-                            &self.resources_by_id,
-                            now,
-                        );
-                    }
+                    self.pending_authorizations.on_not_authorized_resource(
+                        resource,
+                        pending_authorizations::Trigger::IcmpDestinationUnreachableProhibited,
+                        &self.resources_by_id,
+                        now,
+                    );
                 }
             }
         }

--- a/rust/libs/connlib/tunnel-proto/src/client.rs
+++ b/rust/libs/connlib/tunnel-proto/src/client.rs
@@ -16,8 +16,6 @@ use resource::{InternetResource, Resource, StaticDevicePoolResource};
 use crate::client::client_on_client::InboundResult;
 use crate::client::dns_cache::DnsCache;
 use crate::client::dns_config::DnsConfig;
-#[cfg(feature = "telemetry")]
-use crate::client::pending_authorizations::Trigger;
 use crate::client::pending_authorizations::{DnsQueryForSite, PendingAuthorizations};
 use crate::client::routing::{Route, RoutingTables};
 use crate::client::tracked_state::TrackedState;
@@ -47,8 +45,6 @@ use connlib_model::{
 use connlib_model::{Site, SiteId};
 use dns_resource_nat::DnsResourceNat;
 use dns_types::DomainName;
-#[cfg(feature = "telemetry")]
-use dns_types::ResponseCode;
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use ip_packet::{IpPacket, MAX_UDP_PAYLOAD, Protocol};
 use itertools::Itertools;
@@ -891,19 +887,29 @@ impl ClientState {
                 if telemetry::feature_flags::icmp_error_unreachable_prohibited_create_new_flow()
                     && let Ok(Some((failed_packet, error))) = packet.icmp_error()
                     && error.is_unreachable_prohibited()
-                    && let Some(resource) = self
-                        .get_resource_by_destination(failed_packet.dst(), failed_packet.dst_proto())
                 {
-                    telemetry::analytics::feature_flag_called(
-                        "icmp-error-unreachable-prohibited-create-new-flow",
-                    );
+                    let internet_resource = self.active_internet_resource().map(|r| r.id);
 
-                    self.pending_authorizations.on_not_authorized_resource(
-                        resource,
-                        Trigger::IcmpDestinationUnreachableProhibited,
-                        &self.resources_by_id,
-                        now,
-                    );
+                    if let Some(resource) = self
+                        .routing_tables
+                        .resolve_resource(
+                            failed_packet.dst(),
+                            failed_packet.dst_proto(),
+                            internet_resource,
+                        )
+                        .map(|route| route.resource_id())
+                    {
+                        telemetry::analytics::feature_flag_called(
+                            "icmp-error-unreachable-prohibited-create-new-flow",
+                        );
+
+                        self.pending_authorizations.on_not_authorized_resource(
+                            resource,
+                            pending_authorizations::Trigger::IcmpDestinationUnreachableProhibited,
+                            &self.resources_by_id,
+                            now,
+                        );
+                    }
                 }
             }
         }
@@ -1530,19 +1536,6 @@ impl ClientState {
             )
     }
 
-    #[cfg_attr(not(feature = "telemetry"), allow(dead_code))]
-    fn get_resource_by_destination(
-        &mut self,
-        destination: IpAddr,
-        protocol: Protocol,
-    ) -> Option<ResourceId> {
-        let internet_resource = self.active_internet_resource().map(|resource| resource.id);
-
-        self.routing_tables
-            .resolve_resource(destination, protocol, internet_resource)
-            .map(|route| route.resource_id())
-    }
-
     fn active_internet_resource(&self) -> Option<&InternetResource> {
         if !self.is_internet_resource_active {
             return None;
@@ -1902,7 +1895,7 @@ impl ClientState {
         match self.resource_stub_resolver.handle_query(&message) {
             resource_stub_resolver::ResolveStrategy::LocalResponse(response) => {
                 #[cfg(feature = "telemetry")]
-                if response.response_code() == ResponseCode::NXDOMAIN
+                if response.response_code() == dns_types::ResponseCode::NXDOMAIN
                     && telemetry::feature_flags::drop_llmnr_nxdomain_responses()
                 {
                     return;

--- a/rust/libs/connlib/tunnel-proto/src/client.rs
+++ b/rust/libs/connlib/tunnel-proto/src/client.rs
@@ -58,7 +58,27 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::ops::ControlFlow;
 use std::time::{Duration, Instant};
 use std::{io, iter};
+
+#[cfg(feature = "telemetry")]
 use telemetry::{analytics, feature_flags};
+
+/// Without the `telemetry` feature, every flag keeps its default value: off.
+#[cfg(not(feature = "telemetry"))]
+mod feature_flags {
+    pub fn icmp_error_unreachable_prohibited_create_new_flow() -> bool {
+        false
+    }
+
+    pub fn drop_llmnr_nxdomain_responses() -> bool {
+        false
+    }
+}
+
+/// Without the `telemetry` feature, there is nowhere to report flag use to.
+#[cfg(not(feature = "telemetry"))]
+mod analytics {
+    pub fn feature_flag_called(_: impl Into<String>) {}
+}
 
 pub const IPV4_RESOURCES: Ipv4Network = match Ipv4Network::new(Ipv4Addr::new(100, 96, 0, 0), 11) {
     Ok(n) => n,
@@ -1897,7 +1917,7 @@ impl ClientState {
         match self.resource_stub_resolver.handle_query(&message) {
             resource_stub_resolver::ResolveStrategy::LocalResponse(response) => {
                 if response.response_code() == ResponseCode::NXDOMAIN
-                    && telemetry::feature_flags::drop_llmnr_nxdomain_responses()
+                    && feature_flags::drop_llmnr_nxdomain_responses()
                 {
                     return;
                 }

--- a/rust/libs/connlib/tunnel-proto/src/client.rs
+++ b/rust/libs/connlib/tunnel-proto/src/client.rs
@@ -16,7 +16,9 @@ use resource::{InternetResource, Resource, StaticDevicePoolResource};
 use crate::client::client_on_client::InboundResult;
 use crate::client::dns_cache::DnsCache;
 use crate::client::dns_config::DnsConfig;
-use crate::client::pending_authorizations::{DnsQueryForSite, PendingAuthorizations, Trigger};
+#[cfg(feature = "telemetry")]
+use crate::client::pending_authorizations::Trigger;
+use crate::client::pending_authorizations::{DnsQueryForSite, PendingAuthorizations};
 use crate::client::routing::{Route, RoutingTables};
 use crate::client::tracked_state::TrackedState;
 use crate::conn_track::Originator;
@@ -44,7 +46,9 @@ use connlib_model::{
 };
 use connlib_model::{Site, SiteId};
 use dns_resource_nat::DnsResourceNat;
-use dns_types::{DomainName, ResponseCode};
+use dns_types::DomainName;
+#[cfg(feature = "telemetry")]
+use dns_types::ResponseCode;
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use ip_packet::{IpPacket, MAX_UDP_PAYLOAD, Protocol};
 use itertools::Itertools;
@@ -58,27 +62,6 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::ops::ControlFlow;
 use std::time::{Duration, Instant};
 use std::{io, iter};
-
-#[cfg(feature = "telemetry")]
-use telemetry::{analytics, feature_flags};
-
-/// Without the `telemetry` feature, every flag keeps its default value: off.
-#[cfg(not(feature = "telemetry"))]
-mod feature_flags {
-    pub fn icmp_error_unreachable_prohibited_create_new_flow() -> bool {
-        false
-    }
-
-    pub fn drop_llmnr_nxdomain_responses() -> bool {
-        false
-    }
-}
-
-/// Without the `telemetry` feature, there is nowhere to report flag use to.
-#[cfg(not(feature = "telemetry"))]
-mod analytics {
-    pub fn feature_flag_called(_: impl Into<String>) {}
-}
 
 pub const IPV4_RESOURCES: Ipv4Network = match Ipv4Network::new(Ipv4Addr::new(100, 96, 0, 0), 11) {
     Ok(n) => n,
@@ -904,13 +887,14 @@ impl ClientState {
                 // borrow is free for the `&mut self` calls below.
                 drop(_guard);
 
-                if feature_flags::icmp_error_unreachable_prohibited_create_new_flow()
+                #[cfg(feature = "telemetry")]
+                if telemetry::feature_flags::icmp_error_unreachable_prohibited_create_new_flow()
                     && let Ok(Some((failed_packet, error))) = packet.icmp_error()
                     && error.is_unreachable_prohibited()
                     && let Some(resource) = self
                         .get_resource_by_destination(failed_packet.dst(), failed_packet.dst_proto())
                 {
-                    analytics::feature_flag_called(
+                    telemetry::analytics::feature_flag_called(
                         "icmp-error-unreachable-prohibited-create-new-flow",
                     );
 
@@ -1546,6 +1530,7 @@ impl ClientState {
             )
     }
 
+    #[cfg_attr(not(feature = "telemetry"), allow(dead_code))]
     fn get_resource_by_destination(
         &mut self,
         destination: IpAddr,
@@ -1916,8 +1901,9 @@ impl ClientState {
 
         match self.resource_stub_resolver.handle_query(&message) {
             resource_stub_resolver::ResolveStrategy::LocalResponse(response) => {
+                #[cfg(feature = "telemetry")]
                 if response.response_code() == ResponseCode::NXDOMAIN
-                    && feature_flags::drop_llmnr_nxdomain_responses()
+                    && telemetry::feature_flags::drop_llmnr_nxdomain_responses()
                 {
                     return;
                 }

--- a/rust/libs/connlib/tunnel-proto/src/client/pending_authorizations.rs
+++ b/rust/libs/connlib/tunnel-proto/src/client/pending_authorizations.rs
@@ -219,7 +219,7 @@ pub enum Trigger {
     /// We have received an ICMP error that is marked as "access prohibited".
     ///
     /// Most likely, the Gateway is filtering these packets because the Client doesn't have access (anymore).
-    #[cfg_attr(not(feature = "telemetry"), allow(dead_code))]
+    #[cfg_attr(not(feature = "telemetry"), expect(dead_code))]
     IcmpDestinationUnreachableProhibited,
 }
 

--- a/rust/libs/connlib/tunnel-proto/src/client/pending_authorizations.rs
+++ b/rust/libs/connlib/tunnel-proto/src/client/pending_authorizations.rs
@@ -219,6 +219,7 @@ pub enum Trigger {
     /// We have received an ICMP error that is marked as "access prohibited".
     ///
     /// Most likely, the Gateway is filtering these packets because the Client doesn't have access (anymore).
+    #[cfg_attr(not(feature = "telemetry"), allow(dead_code))]
     IcmpDestinationUnreachableProhibited,
 }
 

--- a/rust/libs/connlib/tunnel-proto/src/client/routing.rs
+++ b/rust/libs/connlib/tunnel-proto/src/client/routing.rs
@@ -26,6 +26,7 @@ pub(super) enum Route {
 }
 
 impl Route {
+    #[cfg_attr(not(feature = "telemetry"), expect(dead_code))]
     pub(super) fn resource_id(&self) -> ResourceId {
         match self {
             Self::Client { resource_id, .. } | Self::Gateway { resource_id, .. } => *resource_id,

--- a/rust/libs/connlib/tunnel/Cargo.toml
+++ b/rust/libs/connlib/tunnel/Cargo.toml
@@ -29,7 +29,7 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 tun = { workspace = true }
-tunnel-proto = { workspace = true }
+tunnel-proto = { workspace = true, features = ["telemetry"] }
 
 [dev-dependencies]
 ip-packet = { workspace = true, features = ["proptest"] }

--- a/rust/libs/logging/Cargo.toml
+++ b/rust/libs/logging/Cargo.toml
@@ -7,6 +7,11 @@ publish = false
 license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+# Consult telemetry's feature flags when deciding which events to stream.
+# Without this, log streaming stays at its default: off.
+telemetry = ["dep:telemetry"]
+
 [dependencies]
 anyhow = { workspace = true }
 nu-ansi-term = { workspace = true }
@@ -14,7 +19,7 @@ output_vt100 = { workspace = true }
 parking_lot = { workspace = true }
 sentry-tracing = { workspace = true }
 supports-color = { workspace = true }
-telemetry = { workspace = true }
+telemetry = { workspace = true, optional = true }
 time = { workspace = true, features = ["formatting", "macros"] }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }

--- a/rust/libs/logging/src/lib.rs
+++ b/rust/libs/logging/src/lib.rs
@@ -21,7 +21,17 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use event_message_contains_filter::EventMessageContains;
 use sentry_tracing::EventFilter;
+
+#[cfg(feature = "telemetry")]
 use telemetry::feature_flags;
+
+/// Without the `telemetry` feature, log streaming stays at its default: off.
+#[cfg(not(feature = "telemetry"))]
+mod feature_flags {
+    pub fn stream_logs(_: &tracing::Metadata<'_>) -> bool {
+        false
+    }
+}
 use tracing::{Subscriber, subscriber::DefaultGuard};
 use tracing_log::LogTracer;
 use tracing_subscriber::{

--- a/rust/libs/logging/src/lib.rs
+++ b/rust/libs/logging/src/lib.rs
@@ -21,17 +21,6 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use event_message_contains_filter::EventMessageContains;
 use sentry_tracing::EventFilter;
-
-#[cfg(feature = "telemetry")]
-use telemetry::feature_flags;
-
-/// Without the `telemetry` feature, log streaming stays at its default: off.
-#[cfg(not(feature = "telemetry"))]
-mod feature_flags {
-    pub fn stream_logs(_: &tracing::Metadata<'_>) -> bool {
-        false
-    }
-}
 use tracing::{Subscriber, subscriber::DefaultGuard};
 use tracing_log::LogTracer;
 use tracing_subscriber::{
@@ -255,7 +244,8 @@ where
                 event_filter |= EventFilter::Breadcrumb;
             }
 
-            if feature_flags::stream_logs(md) {
+            #[cfg(feature = "telemetry")]
+            if telemetry::feature_flags::stream_logs(md) {
                 event_filter |= EventFilter::Log
             }
 


### PR DESCRIPTION
`tunnel-proto` reads two feature flags and reports their use; `logging` consults one when deciding which events to stream. Those calls were the last reason the sans-IO crates hard-depended on `telemetry`, whose Sentry and PostHog machinery they never drive.

Gate the dependency behind a `telemetry` feature on both crates. With it off, every flag keeps its default value, which is also what the flags evaluate to in builds that never talk to the portal. `tunnel` and the binaries enable it, so production behaviour is unchanged. The fuzz targets do not, sparing them the delivery stack.
