### PR TITLE
feat(relay): gate binary-only dependencies behind a feature

### DIFF
--- a/rust/relay/server/Cargo.toml
+++ b/rust/relay/server/Cargo.toml
@@ -5,8 +5,16 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [features]
-default = ["ebpf"]
+default = ["ebpf", "binary"]
 ebpf = ["dep:aya", "dep:aya-log", "dep:ebpf-shared"]
+# Everything only the `firezone-relay` binary needs. The library exposes the
+# TURN server itself, e.g. for simulating a relay without portal connectivity.
+binary = ["dep:bin-shared", "dep:phoenix-channel", "dep:socket-factory", "dep:telemetry"]
+
+[[bin]]
+name = "firezone-relay"
+path = "src/main.rs"
+required-features = ["binary"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -14,7 +22,7 @@ axum = { workspace = true, features = ["http1", "tokio", "query"] }
 backoff = { workspace = true }
 base64 = { workspace = true }
 bimap = { workspace = true }
-bin-shared = { workspace = true }
+bin-shared = { workspace = true, optional = true }
 bytecodec = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
@@ -29,7 +37,7 @@ once_cell = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 opentelemetry-otlp = { workspace = true, features = ["metrics", "grpc-tonic"] }
 opentelemetry_sdk = { workspace = true }
-phoenix-channel = { workspace = true }
+phoenix-channel = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 rand = { workspace = true }
 rustls = { workspace = true }
@@ -37,10 +45,10 @@ secrecy = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 sha2 = { workspace = true }
 smallvec = { workspace = true }
-socket-factory = { workspace = true }
+socket-factory = { workspace = true, optional = true }
 socket2 = { workspace = true }
 stun_codec = { workspace = true }
-telemetry = { workspace = true }
+telemetry = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "time", "signal"] }
 tracing = { workspace = true, features = ["log"] }

--- a/rust/tests/fuzz/Cargo.toml
+++ b/rust/tests/fuzz/Cargo.toml
@@ -31,7 +31,7 @@ connlib-model = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
 dns-over-tcp = { workspace = true }
 dns-types = { workspace = true }
-firezone-relay = { workspace = true }
+firezone-relay = { workspace = true, default-features = false }
 flow-tracker = { workspace = true }
 hex = { workspace = true }
 ip-packet = { workspace = true, features = ["arbitrary"] }


### PR DESCRIPTION
The library target exposes the TURN server for simulations, but the crate unconditionally carried everything only `main.rs` needs: the portal channel, telemetry and its delivery stack, and the socket factory. Any consumer of the library compiled all of it, and the fuzz targets additionally compiled the eBPF toolchain via the default features.

Move those dependencies behind a default-on `binary` feature required by the binary target. Production builds use default features and are unchanged; the fuzz harness opts out and now compiles without the telemetry stack, sentry, or aya.
