### PR TITLE
fix(connlib): rename `path_selected_at` to `path_activated_at`

### DIFF
--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -1252,7 +1252,7 @@ impl FlowStats {
 /// The outer (transport) 4-tuple a flow is tunneled over.
 ///
 /// The source is unknown for relayed sends; it is `None` there and omitted
-/// from the serialised tuple. `path_selected_at` is the time of the packet
+/// from the serialised tuple. `path_activated_at` is the time of the packet
 /// that revealed the tuple: the flow's first packet for the initial entry of
 /// [`Record::outers`], the first packet after a change for every later one.
 #[derive(Debug, Clone, Copy, serde::Serialize)]
@@ -1263,7 +1263,7 @@ pub struct FlowContext {
     pub src_port: Option<u16>,
     pub dst_ip: IpAddr,
     pub dst_port: u16,
-    pub path_selected_at: DateTime<Utc>,
+    pub path_activated_at: DateTime<Utc>,
 }
 
 impl FlowContext {
@@ -1272,7 +1272,7 @@ impl FlowContext {
     pub fn new(
         initiator: impl Into<Option<SocketAddr>>,
         responder: SocketAddr,
-        path_selected_at: DateTime<Utc>,
+        path_activated_at: DateTime<Utc>,
     ) -> Self {
         let initiator = initiator.into();
 
@@ -1281,12 +1281,12 @@ impl FlowContext {
             src_port: initiator.map(|initiator| initiator.port()),
             dst_ip: responder.ip(),
             dst_port: responder.port(),
-            path_selected_at,
+            path_activated_at,
         }
     }
 }
 
-/// Contexts compare by their tuple alone; `path_selected_at` only records when
+/// Contexts compare by their tuple alone; `path_activated_at` only records when
 /// the flow started using it.
 impl PartialEq for FlowContext {
     fn eq(&self, other: &Self) -> bool {
@@ -1295,7 +1295,7 @@ impl PartialEq for FlowContext {
             src_port,
             dst_ip,
             dst_port,
-            path_selected_at: _,
+            path_activated_at: _,
         } = self;
 
         (*src_ip, *src_port, *dst_ip, *dst_port)

--- a/rust/libs/connlib/flow-tracker/tests/writer.rs
+++ b/rust/libs/connlib/flow-tracker/tests/writer.rs
@@ -65,8 +65,8 @@ fn emitted_records_spool_via_flow_log_writer_layer() {
     assert_eq!(
         payload["outers"],
         serde_json::json!([
-            {"src_ip": "198.51.100.1", "src_port": 51820, "dst_ip": "203.0.113.7", "dst_port": 51820, "path_selected_at": "2023-11-14T22:13:20.000000500Z"},
-            {"dst_ip": "203.0.113.7", "dst_port": 51820, "path_selected_at": "2023-11-14T22:13:50Z"},
+            {"src_ip": "198.51.100.1", "src_port": 51820, "dst_ip": "203.0.113.7", "dst_port": 51820, "path_activated_at": "2023-11-14T22:13:20.000000500Z"},
+            {"dst_ip": "203.0.113.7", "dst_port": 51820, "path_activated_at": "2023-11-14T22:13:50Z"},
         ])
     );
     assert_eq!(payload["flow_start"], format!("{:?}", record.flow_start));
@@ -136,7 +136,7 @@ fn tracked_packets_spool_open_and_completed_reports() {
     assert_eq!(
         open["outers"],
         serde_json::json!([
-            {"src_ip": "198.51.100.1", "src_port": 45000, "dst_ip": "203.0.113.1", "dst_port": 51820, "path_selected_at": "2023-11-14T22:13:20Z"}
+            {"src_ip": "198.51.100.1", "src_port": 45000, "dst_ip": "203.0.113.1", "dst_port": 51820, "path_activated_at": "2023-11-14T22:13:20Z"}
         ])
     );
     assert!(open.get("flow_end").is_none());
@@ -244,7 +244,7 @@ fn syn_after_established_connection_splits_flow() {
 }
 
 #[test]
-fn context_change_stamps_the_path_selection_time() {
+fn context_change_stamps_the_path_activation_time() {
     let authz_id = "99999999-9999-9999-9999-999999999999";
     let spool = SpoolObserver::new(authz_id);
     let t0 = Instant::now();
@@ -273,8 +273,8 @@ fn context_change_stamps_the_path_selection_time() {
     assert_eq!(
         flow["outers"],
         serde_json::json!([
-            {"src_ip": "203.0.113.7", "src_port": 51820, "dst_ip": "198.51.100.1", "dst_port": 51820, "path_selected_at": "2023-11-14T22:13:20Z"},
-            {"src_ip": "203.0.113.7", "src_port": 52000, "dst_ip": "198.51.100.1", "dst_port": 51820, "path_selected_at": "2023-11-14T22:13:29Z"},
+            {"src_ip": "203.0.113.7", "src_port": 51820, "dst_ip": "198.51.100.1", "dst_port": 51820, "path_activated_at": "2023-11-14T22:13:20Z"},
+            {"src_ip": "203.0.113.7", "src_port": 52000, "dst_ip": "198.51.100.1", "dst_port": 51820, "path_activated_at": "2023-11-14T22:13:29Z"},
         ])
     );
 }


### PR DESCRIPTION
The portal stores each outer path's timestamp under `path_activated_at`, so the tracker has to emit that key for the value to survive ingest.

Related: #14513
Related: #14514