### PR TITLE
fix(connlib): drop traffic to unmapped DNS sentinels

### DIFF
--- a/rust/libs/connlib/tunnel-proto/src/client.rs
+++ b/rust/libs/connlib/tunnel-proto/src/client.rs
@@ -1354,6 +1354,16 @@ impl ClientState {
         }
 
         let Some(upstream) = self.dns_config.mapping().upstream_by_sentinel(dst) else {
+            // We route the entire sentinel range, so traffic to an address in it is
+            // ours even once the mapping no longer contains that address, e.g. after
+            // the resolvers changed. Nothing else can serve it and routing it to a
+            // Resource would leak an internal address to the Gateway.
+            if is_dns_sentinel(dst) {
+                tracing::debug!(%dst, "Dropping packet for unmapped DNS sentinel");
+
+                return ControlFlow::Break(());
+            }
+
             return ControlFlow::Continue(packet); // Not for our DNS resolver.
         };
 
@@ -2705,6 +2715,13 @@ fn is_llmnr(dst: IpAddr) -> bool {
     match dst {
         IpAddr::V4(ip) => ip == LLMNR_IPV4,
         IpAddr::V6(ip) => ip == LLMNR_IPV6,
+    }
+}
+
+fn is_dns_sentinel(dst: IpAddr) -> bool {
+    match dst {
+        IpAddr::V4(ip) => DNS_SENTINELS_V4.contains(ip),
+        IpAddr::V6(ip) => DNS_SENTINELS_V6.contains(ip),
     }
 }
 


### PR DESCRIPTION
connlib routes the entire sentinel range, so the OS hands it every packet addressed to it. Once the DNS mapping changes, e.g. because the system resolvers changed, in-flight traffic to a previously valid sentinel no longer resolves to an upstream and fell through to regular routing. With an Internet Resource active, that catch-all then tunnelled a connlib-internal address to the Gateway, which rejects it as a private range and answers with an ICMP error that surfaces on an otherwise healthy TCP DNS connection.

Nothing other than the stub resolver can serve an address in that range, so dropping is the only correct outcome and no bookkeeping of previously valid addresses is needed.