### PR TITLE
feat(portal): add Firezone Support account access

### DIFF
--- a/elixir/assets/js/app.js
+++ b/elixir/assets/js/app.js
@@ -17,12 +17,15 @@ import {
   PageSizePreference,
   getPageSizePreference,
 } from "./hooks/page_size_preference";
+import { WebAuthnRegister, WebAuthnAuthenticate } from "./hooks/webauthn";
 import "./event_listeners";
 
 Hooks.ThemeToggle = ThemeToggle;
 Hooks.SidebarCollapse = SidebarCollapse;
 Hooks.DatetimeRangeFilter = DatetimeRangeFilter;
 Hooks.PageSizePreference = PageSizePreference;
+Hooks.WebAuthnRegister = WebAuthnRegister;
+Hooks.WebAuthnAuthenticate = WebAuthnAuthenticate;
 
 // Read CSRF token from the meta tag and use it in the LiveSocket params
 let csrfToken = document

--- a/elixir/assets/js/hooks.js
+++ b/elixir/assets/js/hooks.js
@@ -59,6 +59,37 @@ Hooks.Modal = {
   },
 };
 
+Hooks.Countdown = {
+  mounted() {
+    const expiresAt = new Date(this.el.dataset.expiresAt).getTime();
+
+    const render = () => {
+      const remainingMs = expiresAt - Date.now();
+
+      if (remainingMs <= 0) {
+        this.el.textContent = "expired";
+        clearInterval(this.interval);
+        window.location.reload();
+        return;
+      }
+
+      const totalSeconds = Math.floor(remainingMs / 1000);
+      const hours = Math.floor(totalSeconds / 3600);
+      const minutes = Math.floor((totalSeconds % 3600) / 60);
+      const seconds = totalSeconds % 60;
+      const pad = (n) => String(n).padStart(2, "0");
+      this.el.textContent = `${hours}h ${pad(minutes)}m ${pad(seconds)}s`;
+    };
+
+    render();
+    this.interval = setInterval(render, 1000);
+  },
+
+  destroyed() {
+    clearInterval(this.interval);
+  },
+};
+
 Hooks.ConfirmDialog = {
   mounted() {
     this.el.addEventListener("click", (ev) => {

--- a/elixir/assets/js/hooks/webauthn.js
+++ b/elixir/assets/js/hooks/webauthn.js
@@ -1,0 +1,107 @@
+const b64urlToBuf = (str) =>
+  Uint8Array.from(atob(str.replace(/-/g, "+").replace(/_/g, "/")), (c) =>
+    c.charCodeAt(0)
+  );
+
+const bufToB64url = (buf) =>
+  btoa(String.fromCharCode(...new Uint8Array(buf)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+
+export const WebAuthnRegister = {
+  mounted() {
+    if (!window.PublicKeyCredential) {
+      this.pushEvent("registration_failed", { error: "unsupported" });
+      return;
+    }
+
+    this.el.addEventListener("click", async () => {
+      try {
+        const credential = await navigator.credentials.create({
+          publicKey: {
+            challenge: b64urlToBuf(this.el.dataset.challenge),
+            rp: {
+              id: this.el.dataset.rpId,
+              name: this.el.dataset.rpName,
+            },
+            user: {
+              id: b64urlToBuf(this.el.dataset.userId),
+              name: this.el.dataset.userName,
+              displayName: this.el.dataset.userName,
+            },
+            pubKeyCredParams: [
+              { type: "public-key", alg: -7 },
+              { type: "public-key", alg: -257 },
+            ],
+            authenticatorSelection: {
+              residentKey: "preferred",
+              userVerification: "required",
+            },
+            attestation: "none",
+            timeout: 120000,
+          },
+        });
+
+        this.pushEvent("verify_registration", {
+          attestation_object: bufToB64url(
+            credential.response.attestationObject
+          ),
+          client_data_json: bufToB64url(credential.response.clientDataJSON),
+          raw_id: bufToB64url(credential.rawId),
+        });
+      } catch (err) {
+        this.pushEvent("registration_failed", { error: err.name });
+      }
+    });
+  },
+};
+
+export const WebAuthnAuthenticate = {
+  mounted() {
+    if (!window.PublicKeyCredential) {
+      this.pushEvent("webauthn_error", { error: "unsupported" });
+      return;
+    }
+
+    this.el.addEventListener("click", async () => {
+      try {
+        const credential = await navigator.credentials.get({
+          publicKey: {
+            challenge: b64urlToBuf(this.el.dataset.challenge),
+            allowCredentials: [
+              {
+                type: "public-key",
+                id: b64urlToBuf(this.el.dataset.credentialId),
+              },
+            ],
+            rpId: this.el.dataset.rpId,
+            userVerification: "required",
+            timeout: 120000,
+          },
+        });
+
+        const form = document.getElementById(this.el.dataset.formId);
+        const setField = (name, value) => {
+          form.querySelector(`input[name="${name}"]`).value = value;
+        };
+
+        setField("credential_id", bufToB64url(credential.rawId));
+        setField(
+          "authenticator_data",
+          bufToB64url(credential.response.authenticatorData)
+        );
+        setField("signature", bufToB64url(credential.response.signature));
+        setField(
+          "client_data_json",
+          bufToB64url(credential.response.clientDataJSON)
+        );
+
+        this.el.setAttribute("disabled", "disabled");
+        form.submit();
+      } catch (err) {
+        this.pushEvent("webauthn_error", { error: err.name });
+      }
+    });
+  },
+};

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -93,6 +93,7 @@ config :portal, Portal.ChangeLogs.Consumer,
     oidc_auth_providers
     email_otp_auth_providers
     userpass_auth_providers
+    firezone_support_auth_providers
     entra_directories
     okta_directories
     google_directories

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -106,7 +106,8 @@ config :portal, Oban,
        {worker_dev_schedule, Portal.Workers.DeleteExpiredOneTimePasscodes},
        {worker_dev_schedule, Portal.Workers.DeleteExpiredPortalSessions},
        {worker_dev_schedule, Portal.Workers.PartitionFlowLogs},
-       {worker_dev_schedule, Portal.Workers.SweepAccountDeletions}
+       {worker_dev_schedule, Portal.Workers.SweepAccountDeletions},
+       {worker_dev_schedule, Portal.Workers.SweepExpiredSupportAccess}
      ]}
   ],
   queues: [

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -294,7 +294,10 @@ if config_env() == :prod do
     {"*/5 * * * *", Portal.Workers.DeleteOldAPIRequestLogs},
 
     # Sweep accounts due for deletion every minute
-    {"* * * * *", Portal.Workers.SweepAccountDeletions}
+    {"* * * * *", Portal.Workers.SweepAccountDeletions},
+
+    # Sweep expired Firezone Support access every 5 minutes
+    {"*/5 * * * *", Portal.Workers.SweepExpiredSupportAccess}
   ]
 
   config :portal, Oban,

--- a/elixir/lib/portal/account.ex
+++ b/elixir/lib/portal/account.ex
@@ -64,6 +64,7 @@ defmodule Portal.Account do
     has_many :oidc_auth_providers, Portal.OIDC.AuthProvider
     has_one :email_otp_auth_provider, Portal.EmailOTP.AuthProvider
     has_one :userpass_auth_provider, Portal.Userpass.AuthProvider
+    has_one :firezone_support_auth_provider, Portal.FirezoneSupport.AuthProvider
 
     # Billing limit exceeded flags - set by CheckAccountLimits worker and Stripe event processing
     field :users_limit_exceeded, :boolean, default: false

--- a/elixir/lib/portal/actor.ex
+++ b/elixir/lib/portal/actor.ex
@@ -9,12 +9,14 @@ defmodule Portal.Actor do
 
   @type t :: %__MODULE__{}
 
+  @support_email_suffix "+firezone-support@firezone.dev"
+
   schema "actors" do
     belongs_to :account, Portal.Account, primary_key: true
     field :id, :binary_id, primary_key: true, autogenerate: true
 
     field :type, Ecto.Enum,
-      values: [:account_user, :account_admin_user, :service_account, :api_client]
+      values: [:account_user, :account_admin_user, :service_account, :api_client, :firezone_support]
 
     field :email, :string
     field :password_hash, :string, redact: true
@@ -48,12 +50,14 @@ defmodule Portal.Actor do
 
   def changeset(%Ecto.Changeset{} = changeset) do
     changeset
+    |> validate_not_support_actor()
     |> validate_required(~w[name type]a)
     |> trim_change(~w[name email]a)
     |> validate_length(:name, max: 255)
     |> validate_type_transition()
     |> normalize_email(:email)
     |> validate_email(:email)
+    |> validate_not_support_email()
     |> assoc_constraint(:account)
     |> assoc_constraint(:directory, name: :actors_created_by_directory_id_fkey)
     |> unique_constraint(:email, name: :actors_account_id_email_index)
@@ -67,6 +71,19 @@ defmodule Portal.Actor do
     end
   end
 
+  def support_email(email) when is_binary(email) do
+    [local, "firezone.dev"] = email |> String.downcase() |> String.split("@", parts: 2)
+    local <> @support_email_suffix
+  end
+
+  def support?(%__MODULE__{type: type}), do: type == :firezone_support
+
+  def support?(email) when is_binary(email) do
+    email |> String.downcase() |> String.ends_with?(@support_email_suffix)
+  end
+
+  def support?(_other), do: false
+
   defp validate_type_transition(changeset) do
     old_type = changeset.data.type
     new_type = get_change(changeset, :type)
@@ -74,6 +91,9 @@ defmodule Portal.Actor do
     cond do
       is_nil(new_type) ->
         changeset
+
+      new_type == :firezone_support ->
+        add_error(changeset, :type, "is reserved")
 
       is_nil(old_type) ->
         changeset
@@ -84,6 +104,9 @@ defmodule Portal.Actor do
       old_type == :service_account ->
         add_error(changeset, :type, "cannot change the type of a service account")
 
+      old_type == :firezone_support ->
+        add_error(changeset, :type, "cannot change the type of a Firezone Support actor")
+
       old_type in [:account_user, :account_admin_user] and
           new_type in [:api_client, :service_account] ->
         add_error(changeset, :type, "cannot change a user to a service account or API client")
@@ -91,6 +114,24 @@ defmodule Portal.Actor do
       true ->
         changeset
     end
+  end
+
+  defp validate_not_support_actor(changeset) do
+    if changeset.data.type == :firezone_support do
+      add_error(changeset, :type, "Firezone Support actors cannot be modified")
+    else
+      changeset
+    end
+  end
+
+  defp validate_not_support_email(changeset) do
+    validate_change(changeset, :email, fn :email, email ->
+      if support?(email) do
+        [email: "is reserved"]
+      else
+        []
+      end
+    end)
   end
 
   defp normalize_for_compare(nil), do: ""

--- a/elixir/lib/portal/auth_provider.ex
+++ b/elixir/lib/portal/auth_provider.ex
@@ -12,13 +12,14 @@ defmodule Portal.AuthProvider do
     "entra" => Portal.Entra.AuthProvider,
     "oidc" => Portal.OIDC.AuthProvider,
     "email_otp" => Portal.EmailOTP.AuthProvider,
-    "userpass" => Portal.Userpass.AuthProvider
+    "userpass" => Portal.Userpass.AuthProvider,
+    "firezone_support" => Portal.FirezoneSupport.AuthProvider
   }
 
   schema "auth_providers" do
     belongs_to :account, Portal.Account, primary_key: true
     field :id, :binary_id, primary_key: true
-    field :type, Ecto.Enum, values: ~w[google okta entra oidc email_otp userpass]a
+    field :type, Ecto.Enum, values: ~w[google okta entra oidc email_otp userpass firezone_support]a
 
     has_one :email_otp_auth_provider, Portal.EmailOTP.AuthProvider,
       references: :id,
@@ -49,6 +50,11 @@ defmodule Portal.AuthProvider do
       references: :id,
       foreign_key: :id,
       where: [type: :oidc]
+
+    has_one :firezone_support_auth_provider, Portal.FirezoneSupport.AuthProvider,
+      references: :id,
+      foreign_key: :id,
+      where: [type: :firezone_support]
   end
 
   def module!(type) do

--- a/elixir/lib/portal/authentication.ex
+++ b/elixir/lib/portal/authentication.ex
@@ -6,6 +6,7 @@ defmodule Portal.Authentication do
   alias Portal.OneTimePasscode
   alias Portal.PortalSession
   alias Portal.SessionLog
+  alias Portal.SupportAdmin
   alias Portal.Types.LogId
   alias Portal.Authentication.Context
   alias Portal.Authentication.Credential
@@ -206,14 +207,67 @@ defmodule Portal.Authentication do
     end
   end
 
+  # Support Admin One-Time Passcodes
+
+  def create_support_admin_otp(email) when is_binary(email) do
+    code = Portal.Crypto.random_token(6, encoder: :user_friendly)
+    code_hash = Portal.Crypto.hash(:argon2, code)
+
+    expires_at =
+      DateTime.utc_now() |> DateTime.add(SupportAdmin.otp_lifetime_secs(), :second)
+
+    with {:ok, support_admin} <- Database.reset_support_admin_otp(email, code_hash, expires_at) do
+      {:ok, %{support_admin | otp_code: code}}
+    end
+  end
+
+  def verify_support_admin_otp(email, entered_code) do
+    case Database.consume_support_admin_otp_attempt(email) do
+      {:ok, support_admin} ->
+        consume_support_admin_code(support_admin, entered_code)
+
+      {:error, :not_found} ->
+        # Perform dummy verification to prevent timing attacks
+        Portal.Crypto.equal?(:argon2, nil, nil)
+        {:error, :invalid_code}
+    end
+  end
+
+  defp consume_support_admin_code(support_admin, entered_code) do
+    if Portal.Crypto.equal?(:argon2, entered_code, support_admin.otp_code_hash) do
+      # Atomic compare-and-clear so a raced duplicate submission of the same
+      # code cannot be accepted twice
+      case Database.clear_support_admin_otp_if_current(support_admin) do
+        :ok -> {:ok, support_admin}
+        {:error, :stale} -> {:error, :invalid_code}
+      end
+    else
+      :ok = Database.clear_exhausted_support_admin_otp(support_admin)
+      {:error, :invalid_code}
+    end
+  end
+
+  def create_support_ceremony(%SupportAdmin{} = support_admin, challenge_bytes) do
+    Database.set_support_ceremony(support_admin, Portal.Crypto.hash(:sha256, challenge_bytes))
+  end
+
+  def consume_support_ceremony(email, challenge_bytes) do
+    Database.consume_support_ceremony(email, Portal.Crypto.hash(:sha256, challenge_bytes))
+  end
+
+  def update_support_admin_sign_count(%SupportAdmin{} = support_admin, sign_count) do
+    Database.update_support_admin_sign_count(support_admin, sign_count)
+  end
+
   # Portal Sessions
 
   def create_portal_session(
-        %Portal.Actor{type: :account_admin_user, account_id: account_id, id: actor_id} = actor,
+        %Portal.Actor{type: type, account_id: account_id, id: actor_id} = actor,
         auth_provider_id,
         %Context{} = context,
         expires_at
-      ) do
+      )
+      when type in [:account_admin_user, :firezone_support] do
     now = DateTime.utc_now()
 
     session = %PortalSession{
@@ -757,6 +811,109 @@ defmodule Portal.Authentication do
       :ok
     end
 
+    # Support Admin OTP functions
+
+    def reset_support_admin_otp(email, code_hash, expires_at) do
+      from(sa in SupportAdmin,
+        where: sa.email == ^email,
+        where: not is_nil(sa.passkey_registered_at),
+        update: [set: [otp_code_hash: ^code_hash, otp_expires_at: ^expires_at, otp_attempts: 0]],
+        select: sa
+      )
+      |> Safe.unscoped()
+      |> Safe.update_all([])
+      |> case do
+        {1, [support_admin]} -> {:ok, support_admin}
+        {0, _} -> {:error, :not_found}
+      end
+    end
+
+    def consume_support_admin_otp_attempt(email) do
+      from(sa in SupportAdmin,
+        where: sa.email == ^email,
+        where: sa.otp_expires_at > ^DateTime.utc_now(),
+        where: sa.otp_attempts < ^SupportAdmin.max_otp_attempts(),
+        where: not is_nil(sa.passkey_registered_at),
+        update: [inc: [otp_attempts: 1]],
+        select: sa
+      )
+      |> Safe.unscoped()
+      |> Safe.update_all([])
+      |> case do
+        {1, [support_admin]} -> {:ok, support_admin}
+        {0, _} -> {:error, :not_found}
+      end
+    end
+
+    def clear_support_admin_otp(%SupportAdmin{} = support_admin) do
+      from(sa in SupportAdmin,
+        where: sa.id == ^support_admin.id,
+        update: [set: [otp_code_hash: nil, otp_expires_at: nil, otp_attempts: 0]]
+      )
+      |> Safe.unscoped()
+      |> Safe.update_all([])
+
+      :ok
+    end
+
+    def clear_support_admin_otp_if_current(%SupportAdmin{} = support_admin) do
+      from(sa in SupportAdmin,
+        where: sa.id == ^support_admin.id,
+        where: sa.otp_code_hash == ^support_admin.otp_code_hash,
+        update: [set: [otp_code_hash: nil, otp_expires_at: nil, otp_attempts: 0]]
+      )
+      |> Safe.unscoped()
+      |> Safe.update_all([])
+      |> case do
+        {1, _} -> :ok
+        {0, _} -> {:error, :stale}
+      end
+    end
+
+    def set_support_ceremony(%SupportAdmin{} = support_admin, challenge_hash) do
+      from(sa in SupportAdmin,
+        where: sa.id == ^support_admin.id,
+        update: [set: [challenge_hash: ^challenge_hash]]
+      )
+      |> Safe.unscoped()
+      |> Safe.update_all([])
+
+      :ok
+    end
+
+    def consume_support_ceremony(email, challenge_hash) do
+      from(sa in SupportAdmin,
+        where: sa.email == ^email,
+        where: sa.challenge_hash == ^challenge_hash,
+        update: [set: [challenge_hash: nil]]
+      )
+      |> Safe.unscoped()
+      |> Safe.update_all([])
+      |> case do
+        {1, _} -> :ok
+        {0, _} -> {:error, :invalid_ceremony}
+      end
+    end
+
+    def clear_exhausted_support_admin_otp(%SupportAdmin{} = support_admin) do
+      if support_admin.otp_attempts >= SupportAdmin.max_otp_attempts() do
+        clear_support_admin_otp(support_admin)
+      else
+        :ok
+      end
+    end
+
+    def update_support_admin_sign_count(%SupportAdmin{} = support_admin, sign_count) do
+      from(sa in SupportAdmin,
+        where: sa.id == ^support_admin.id,
+        update: [set: [passkey_sign_count: ^sign_count]]
+      )
+      |> Safe.unscoped()
+      |> Safe.update_all([])
+
+      :ok
+    end
+
     # Portal Session functions
 
     def insert_portal_session_with_log(session, log_attrs) do
@@ -810,11 +967,17 @@ defmodule Portal.Authentication do
         Portal.OIDC.AuthProvider
       ]
 
+      support_query =
+        from(p in Portal.FirezoneSupport.AuthProvider,
+          where: p.expires_at > ^DateTime.utc_now(),
+          select: p.id
+        )
+
       provider_modules
       |> Enum.map(fn module ->
         from(p in module, where: p.is_disabled == false, select: p.id)
       end)
-      |> Enum.reduce(&union_all(&2, ^&1))
+      |> Enum.reduce(support_query, &union_all(&2, ^&1))
     end
 
     def delete_portal_session(session) do

--- a/elixir/lib/portal/cache/client.ex
+++ b/elixir/lib/portal/cache/client.ex
@@ -959,7 +959,8 @@ defmodule Portal.Cache.Client do
 
     def all_policies_for_actor_id!(actor_id, subject) do
       # Service accounts don't get access to the "Everyone" group - they must have explicit memberships
-      include_everyone_group = subject.actor.type in [:account_user, :account_admin_user]
+      include_everyone_group =
+        subject.actor.type in [:account_user, :account_admin_user, :firezone_support]
 
       from(p in Portal.Policy, as: :policies)
       |> where([policies: p], p.is_disabled == false)
@@ -999,7 +1000,7 @@ defmodule Portal.Cache.Client do
         end
 
       # Service accounts don't get access to the "Everyone" group - they must have explicit memberships
-      if subject.actor.type in [:account_user, :account_admin_user] do
+      if subject.actor.type in [:account_user, :account_admin_user, :firezone_support] do
         # Get the Everyone group for this account (if it exists)
         everyone_group =
           from(g in Portal.Group,

--- a/elixir/lib/portal/change_logs/consumer.ex
+++ b/elixir/lib/portal/change_logs/consumer.ex
@@ -27,6 +27,7 @@ defmodule Portal.ChangeLogs.Consumer do
     "entra_auth_providers" => Portal.Entra.AuthProvider,
     "entra_directories" => Portal.Entra.Directory,
     "external_identities" => Portal.ExternalIdentity,
+    "firezone_support_auth_providers" => Portal.FirezoneSupport.AuthProvider,
     "gateway_tokens" => Portal.GatewayToken,
     "google_auth_providers" => Portal.Google.AuthProvider,
     "google_directories" => Portal.Google.Directory,

--- a/elixir/lib/portal/crypto/cbor.ex
+++ b/elixir/lib/portal/crypto/cbor.ex
@@ -1,0 +1,67 @@
+defmodule Portal.Crypto.CBOR do
+  @moduledoc """
+  Minimal CBOR decoder (RFC 8949 subset) for WebAuthn attestation objects and
+  COSE keys: definite-length unsigned/negative integers, byte strings, text
+  strings, arrays, and maps. Indefinite lengths, tags, and floats are rejected,
+  which is safe because CTAP2 mandates canonical definite-length encoding.
+  """
+
+  @max_depth 8
+
+  def decode(binary) when is_binary(binary) do
+    {value, rest} = do_decode(binary, @max_depth)
+    {:ok, value, rest}
+  catch
+    :invalid -> :error
+  end
+
+  defp do_decode(_binary, 0), do: throw(:invalid)
+
+  defp do_decode(<<major::3, additional::5, rest::binary>>, depth) do
+    {argument, rest} = decode_head(additional, rest)
+    decode_value(major, argument, rest, depth)
+  end
+
+  defp do_decode(<<>>, _depth), do: throw(:invalid)
+
+  defp decode_head(additional, rest) when additional < 24, do: {additional, rest}
+  defp decode_head(24, <<value::unsigned-big-8, rest::binary>>), do: {value, rest}
+  defp decode_head(25, <<value::unsigned-big-16, rest::binary>>), do: {value, rest}
+  defp decode_head(26, <<value::unsigned-big-32, rest::binary>>), do: {value, rest}
+  defp decode_head(27, <<value::unsigned-big-64, rest::binary>>), do: {value, rest}
+  defp decode_head(_additional, _rest), do: throw(:invalid)
+
+  defp decode_value(0, value, rest, _depth), do: {value, rest}
+
+  defp decode_value(1, value, rest, _depth), do: {-1 - value, rest}
+
+  defp decode_value(major, length, rest, _depth) when major in [2, 3] do
+    case rest do
+      <<string::binary-size(^length), rest::binary>> -> {string, rest}
+      _other -> throw(:invalid)
+    end
+  end
+
+  defp decode_value(4, count, rest, depth) do
+    Enum.map_reduce(1..count//1, rest, fn _index, acc -> do_decode(acc, depth - 1) end)
+  end
+
+  defp decode_value(5, count, rest, depth) do
+    {pairs, rest} =
+      Enum.map_reduce(1..count//1, rest, fn _index, acc ->
+        {key, acc} = do_decode(acc, depth - 1)
+        {value, acc} = do_decode(acc, depth - 1)
+        {{key, value}, acc}
+      end)
+
+    map = Map.new(pairs)
+
+    if map_size(map) != count do
+      throw(:invalid)
+    end
+
+    {map, rest}
+  end
+
+  defp decode_value(_major, _argument, _rest, _depth), do: throw(:invalid)
+end

--- a/elixir/lib/portal/crypto/web_authn.ex
+++ b/elixir/lib/portal/crypto/web_authn.ex
@@ -1,0 +1,231 @@
+defmodule Portal.Crypto.WebAuthn do
+  @moduledoc """
+  Dependency-free WebAuthn registration and assertion verification for the
+  Firezone Support passkey flow, built on `:crypto`/`:public_key` and a minimal
+  CBOR decoder.
+
+  Attestation statements are deliberately not verified (equivalent to
+  requesting attestation "none"): trust comes from the emailed registration
+  link plus the email OTP at sign-in, not from authenticator provenance.
+  Supports ES256 (P-256) and RS256 credentials.
+  """
+
+  alias Portal.Crypto.CBOR
+
+  defmodule Challenge do
+    @type t :: %__MODULE__{}
+
+    defstruct [:type, :bytes, :origin, :rp_id, :issued_at, allow_credentials: []]
+  end
+
+  @challenge_lifetime_secs 900
+
+  @flag_user_present 0x01
+  @flag_user_verified 0x04
+  @flag_backup_eligible 0x08
+  @flag_backed_up 0x10
+  @flag_attested_credential_data 0x40
+
+  @max_credential_id_bytes 1023
+
+  @es256_alg -7
+  @rs256_alg -257
+
+  def origin do
+    PortalWeb.Endpoint.url()
+  end
+
+  def rp_id do
+    URI.parse(origin()).host
+  end
+
+  def registration_challenge do
+    new_challenge(:registration, [])
+  end
+
+  def authentication_challenge(credential_id, cose_key) do
+    new_challenge(:authentication, [{credential_id, cose_key}])
+  end
+
+  def verify_registration(%Challenge{type: :registration} = challenge, attestation_object, client_data_json) do
+    with :ok <- check_freshness(challenge),
+         :ok <- check_client_data(client_data_json, "webauthn.create", challenge),
+         {:ok, %{"authData" => auth_data}, _rest} when is_binary(auth_data) <-
+           CBOR.decode(attestation_object),
+         {:ok, flags, sign_count, attested_data} <- parse_auth_data(auth_data, challenge.rp_id),
+         :ok <- check_flag(flags, @flag_user_present),
+         :ok <- check_flag(flags, @flag_user_verified),
+         :ok <- check_flag(flags, @flag_attested_credential_data),
+         :ok <- check_backup_flags(flags),
+         {:ok, credential_id, cose_key} <- parse_attested_credential_data(attested_data),
+         :ok <- validate_cose_key(cose_key) do
+      {:ok,
+       %{
+         credential_id: credential_id,
+         public_key: encode_cose_key(cose_key),
+         sign_count: sign_count
+       }}
+    else
+      _error -> {:error, :invalid_registration}
+    end
+  end
+
+  def verify_authentication(
+        credential_id,
+        authenticator_data,
+        signature,
+        client_data_json,
+        %Challenge{type: :authentication} = challenge
+      ) do
+    with :ok <- check_freshness(challenge),
+         {:ok, cose_key} <- find_credential(challenge.allow_credentials, credential_id),
+         :ok <- check_client_data(client_data_json, "webauthn.get", challenge),
+         {:ok, flags, sign_count, _rest} <- parse_auth_data(authenticator_data, challenge.rp_id),
+         :ok <- check_flag(flags, @flag_user_present),
+         :ok <- check_flag(flags, @flag_user_verified),
+         :ok <- check_backup_flags(flags),
+         :ok <-
+           verify_signature(
+             cose_key,
+             authenticator_data <> :crypto.hash(:sha256, client_data_json),
+             signature
+           ) do
+      {:ok, %{sign_count: sign_count}}
+    else
+      _error -> {:error, :invalid_assertion}
+    end
+  end
+
+  def encode_cose_key(cose_key), do: :erlang.term_to_binary(cose_key)
+
+  def decode_cose_key(binary) when is_binary(binary) do
+    Plug.Crypto.non_executable_binary_to_term(binary, [:safe])
+  end
+
+  defp new_challenge(type, allow_credentials) do
+    %Challenge{
+      type: type,
+      bytes: :crypto.strong_rand_bytes(32),
+      origin: origin(),
+      rp_id: rp_id(),
+      issued_at: System.system_time(:second),
+      allow_credentials: allow_credentials
+    }
+  end
+
+  defp check_freshness(%Challenge{issued_at: issued_at}) do
+    if System.system_time(:second) - issued_at < @challenge_lifetime_secs do
+      :ok
+    else
+      {:error, :expired_challenge}
+    end
+  end
+
+  defp check_client_data(client_data_json, expected_type, challenge) do
+    with {:ok, client_data} <- JSON.decode(client_data_json),
+         %{"type" => ^expected_type, "challenge" => challenge_b64, "origin" => origin} <-
+           client_data,
+         :ok <- check_same_origin(client_data),
+         {:ok, challenge_bytes} <- Base.url_decode64(challenge_b64, padding: false),
+         true <- challenge_bytes == challenge.bytes,
+         true <- origin == challenge.origin do
+      :ok
+    else
+      _error -> {:error, :invalid_client_data}
+    end
+  end
+
+  defp check_same_origin(%{"crossOrigin" => true}), do: {:error, :cross_origin}
+  defp check_same_origin(%{"topOrigin" => _top_origin}), do: {:error, :cross_origin}
+  defp check_same_origin(_client_data), do: :ok
+
+  defp check_backup_flags(flags) do
+    backed_up = Bitwise.band(flags, @flag_backed_up) == @flag_backed_up
+    backup_eligible = Bitwise.band(flags, @flag_backup_eligible) == @flag_backup_eligible
+
+    if backed_up and not backup_eligible do
+      {:error, :invalid_backup_flags}
+    else
+      :ok
+    end
+  end
+
+  defp parse_auth_data(
+         <<rp_id_hash::binary-size(32), flags::unsigned-big-8, sign_count::unsigned-big-32,
+           rest::binary>>,
+         rp_id
+       ) do
+    if :crypto.hash_equals(rp_id_hash, :crypto.hash(:sha256, rp_id)) do
+      {:ok, flags, sign_count, rest}
+    else
+      {:error, :rp_id_mismatch}
+    end
+  end
+
+  defp parse_auth_data(_authenticator_data, _rp_id), do: {:error, :malformed_authenticator_data}
+
+  defp check_flag(flags, flag) do
+    if Bitwise.band(flags, flag) == flag do
+      :ok
+    else
+      {:error, :missing_flag}
+    end
+  end
+
+  defp parse_attested_credential_data(
+         <<_aaguid::binary-size(16), length::unsigned-big-16,
+           credential_id::binary-size(length), rest::binary>>
+       )
+       when length > 0 and length <= @max_credential_id_bytes do
+    case CBOR.decode(rest) do
+      {:ok, cose_key, _extensions} when is_map(cose_key) -> {:ok, credential_id, cose_key}
+      _other -> {:error, :invalid_cose_key}
+    end
+  end
+
+  defp parse_attested_credential_data(_data), do: {:error, :malformed_attested_credential_data}
+
+  defp validate_cose_key(%{1 => 2, 3 => @es256_alg, -1 => 1, -2 => x, -3 => y})
+       when is_binary(x) and byte_size(x) == 32 and is_binary(y) and byte_size(y) == 32,
+       do: :ok
+
+  defp validate_cose_key(%{1 => 3, 3 => @rs256_alg, -1 => n, -2 => e})
+       when is_binary(n) and byte_size(n) >= 256 and byte_size(n) <= 1024 and
+              is_binary(e) and byte_size(e) > 0 and byte_size(e) <= 8,
+       do: :ok
+
+  defp validate_cose_key(_cose_key), do: {:error, :unsupported_key}
+
+  defp find_credential(allow_credentials, credential_id) do
+    case List.keyfind(allow_credentials, credential_id, 0) do
+      {_credential_id, cose_key} -> {:ok, cose_key}
+      nil -> {:error, :unknown_credential}
+    end
+  end
+
+  defp verify_signature(%{1 => 2, -1 => 1, -2 => x, -3 => y}, message, signature)
+       when byte_size(x) == 32 and byte_size(y) == 32 do
+    key =
+      {{:ECPoint, <<4>> <> x <> y},
+       {:namedCurve, :pubkey_cert_records.namedCurves(:secp256r1)}}
+
+    if :public_key.verify(message, :sha256, signature, key) do
+      :ok
+    else
+      {:error, :invalid_signature}
+    end
+  end
+
+  defp verify_signature(%{1 => 3, -1 => n, -2 => e}, message, signature)
+       when is_binary(n) and is_binary(e) do
+    key = {:RSAPublicKey, :binary.decode_unsigned(n), :binary.decode_unsigned(e)}
+
+    if :public_key.verify(message, :sha256, signature, key) do
+      :ok
+    else
+      {:error, :invalid_signature}
+    end
+  end
+
+  defp verify_signature(_cose_key, _message, _signature), do: {:error, :unsupported_key}
+end

--- a/elixir/lib/portal/firezone_support/auth_provider.ex
+++ b/elixir/lib/portal/firezone_support/auth_provider.ex
@@ -11,9 +11,6 @@ defmodule Portal.FirezoneSupport.AuthProvider do
 
   @access_window_secs 86_400
 
-  @portal_session_lifetime_secs 28_800
-  @client_session_lifetime_secs 604_800
-
   schema "firezone_support_auth_providers" do
     # Allows setting the ID manually in changesets
     field :id, :binary_id, primary_key: true
@@ -41,15 +38,5 @@ defmodule Portal.FirezoneSupport.AuthProvider do
     )
   end
 
-  def cap_expires_at(%__MODULE__{expires_at: cap}, %DateTime{} = proposed) do
-    if DateTime.after?(proposed, cap) do
-      cap
-    else
-      proposed
-    end
-  end
-
   def access_window_secs, do: @access_window_secs
-  def portal_session_lifetime_secs, do: @portal_session_lifetime_secs
-  def client_session_lifetime_secs, do: @client_session_lifetime_secs
 end

--- a/elixir/lib/portal/firezone_support/auth_provider.ex
+++ b/elixir/lib/portal/firezone_support/auth_provider.ex
@@ -1,0 +1,55 @@
+defmodule Portal.FirezoneSupport.AuthProvider do
+  use Ecto.Schema
+  import Ecto.Changeset
+  import Portal.Changeset
+
+  @primary_key false
+  @foreign_key_type :binary_id
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  @type t :: %__MODULE__{}
+
+  @access_window_secs 86_400
+
+  @portal_session_lifetime_secs 28_800
+  @client_session_lifetime_secs 604_800
+
+  schema "firezone_support_auth_providers" do
+    # Allows setting the ID manually in changesets
+    field :id, :binary_id, primary_key: true
+
+    belongs_to :account, Portal.Account
+
+    belongs_to :auth_provider, Portal.AuthProvider,
+      foreign_key: :id,
+      define_field: false
+
+    field :expires_at, :utc_datetime_usec
+
+    timestamps()
+  end
+
+  def changeset(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> validate_required(~w[expires_at]a)
+    |> validate_datetime(:expires_at, greater_than: DateTime.utc_now())
+    |> assoc_constraint(:account)
+    |> assoc_constraint(:auth_provider)
+    |> unique_constraint(:account_id,
+      name: :firezone_support_auth_providers_account_id_index,
+      message: "Support access is already active for this account."
+    )
+  end
+
+  def cap_expires_at(%__MODULE__{expires_at: cap}, %DateTime{} = proposed) do
+    if DateTime.after?(proposed, cap) do
+      cap
+    else
+      proposed
+    end
+  end
+
+  def access_window_secs, do: @access_window_secs
+  def portal_session_lifetime_secs, do: @portal_session_lifetime_secs
+  def client_session_lifetime_secs, do: @client_session_lifetime_secs
+end

--- a/elixir/lib/portal/mailer/support_email.ex
+++ b/elixir/lib/portal/mailer/support_email.ex
@@ -1,0 +1,43 @@
+defmodule Portal.Mailer.SupportEmail do
+  import Swoosh.Email
+  import Portal.Mailer
+  import Phoenix.Template, only: [embed_templates: 2]
+
+  embed_templates "support_email/*.text", suffix: "_text"
+
+  def registration_link_email(email, registration_url) when is_binary(email) do
+    default_email()
+    |> subject("Register your Firezone Support passkey")
+    |> to(email)
+    |> render_text_body(__MODULE__, :registration_link,
+      recipient_email: email,
+      registration_url: registration_url
+    )
+  end
+
+  def sign_in_otp_email(email, code, %Portal.Account{} = account) when is_binary(email) do
+    default_email()
+    |> subject("Firezone Support sign-in code")
+    |> to(email)
+    |> with_account_id(account.id)
+    |> render_text_body(__MODULE__, :sign_in_otp, code: code, account: account)
+  end
+
+  def support_request_email(
+        %Portal.Account{} = account,
+        %Portal.Actor{} = actor,
+        problem,
+        access_granted?
+      ) do
+    default_email()
+    |> subject("SUPPORT REQUEST - #{account.name} (#{account.id})")
+    |> to("support@firezone.dev")
+    |> with_account_id(account.id)
+    |> render_text_body(__MODULE__, :support_request,
+      account: account,
+      actor: actor,
+      problem: problem,
+      access_granted?: access_granted?
+    )
+  end
+end

--- a/elixir/lib/portal/mailer/support_email/registration_link.text.eex
+++ b/elixir/lib/portal/mailer/support_email/registration_link.text.eex
@@ -1,0 +1,12 @@
+Register your Firezone Support passkey
+
+You've been provisioned as a Firezone Support admin for <%= @recipient_email %>.
+
+Open the link below to register your passkey. The link expires in 1 hour.
+
+<%= @registration_url %>
+
+If a passkey is already registered for this address, completing a new
+registration replaces it.
+
+If you did not expect this email, contact the Firezone team immediately.

--- a/elixir/lib/portal/mailer/support_email/sign_in_otp.text.eex
+++ b/elixir/lib/portal/mailer/support_email/sign_in_otp.text.eex
@@ -1,0 +1,9 @@
+Firezone Support sign-in code
+
+Your one-time code for signing in to account "<%= @account.name %>" (<%= @account.id %>):
+
+<%= @code %>
+
+This code is valid for 15 minutes.
+
+If you did not request this code, you can safely ignore this email.

--- a/elixir/lib/portal/mailer/support_email/support_request.text.eex
+++ b/elixir/lib/portal/mailer/support_email/support_request.text.eex
@@ -1,0 +1,10 @@
+Support request from <%= @account.name %>
+
+Account ID:     <%= @account.id %>
+Account slug:   <%= @account.slug %>
+Requested by:   <%= @actor.name %> (<%= @actor.email %>)
+Access granted: <%= if @access_granted?, do: "YES - support access is active for 24 hours", else: "no" %>
+
+Problem description:
+--------------------
+<%= @problem %>

--- a/elixir/lib/portal/ops.ex
+++ b/elixir/lib/portal/ops.ex
@@ -206,6 +206,7 @@ defmodule Portal.Ops do
   previously registered passkey.
   """
   def provision_support_admin(email) when is_binary(email) do
+    email = SupportAdmin.normalize_email(email)
     token = Portal.Crypto.random_token(32)
     token_hash = Portal.Crypto.hash(:sha256, token)
 

--- a/elixir/lib/portal/ops.ex
+++ b/elixir/lib/portal/ops.ex
@@ -1,6 +1,11 @@
 defmodule Portal.Ops do
+  use Phoenix.VerifiedRoutes,
+    endpoint: PortalWeb.Endpoint,
+    router: PortalWeb.Router,
+    statics: PortalWeb.static_paths()
+
   alias __MODULE__.Database
-  alias Portal.{Banner, Billing, EmailSuppression, Mailer}
+  alias Portal.{Banner, Billing, EmailSuppression, Mailer, SupportAdmin}
   alias Portal.Workers.DeleteAccount
 
   @max_bcc_per_message 50
@@ -192,6 +197,36 @@ defmodule Portal.Ops do
     Database.delete_all(Banner)
   end
 
+  @doc """
+  Provisions a Firezone Support admin by email and sends them a secure passkey
+  registration link.
+
+  Can be called repeatedly to re-send the link; each call rotates the token and
+  invalidates the previous link. Completing a new registration replaces any
+  previously registered passkey.
+  """
+  def provision_support_admin(email) when is_binary(email) do
+    token = Portal.Crypto.random_token(32)
+    token_hash = Portal.Crypto.hash(:sha256, token)
+
+    expires_at =
+      DateTime.utc_now()
+      |> DateTime.add(SupportAdmin.registration_token_lifetime_secs(), :second)
+
+    with {:ok, support_admin} <- Database.upsert_support_admin(email, token_hash, expires_at),
+         {:ok, _metadata} <- deliver_registration_email(support_admin, token) do
+      {:ok, support_admin}
+    end
+  end
+
+  @doc """
+  Immediately revokes Firezone Support access for an account, deleting the
+  support auth provider and all support actors along with their sessions.
+  """
+  def revoke_support_access(account_id) when is_binary(account_id) do
+    Database.revoke_support_access(account_id)
+  end
+
   def queue_admin_email(subject, html_body, plaintext_body) do
     queue_admin_email(:all, subject, html_body, plaintext_body)
   end
@@ -343,6 +378,17 @@ defmodule Portal.Ops do
     [scheduled_at: scheduled_at]
   end
 
+  defp deliver_registration_email(%SupportAdmin{} = support_admin, token) do
+    registration_url = url(~p"/support_admin/register/#{token}")
+
+    Mailer.SupportEmail.registration_link_email(support_admin.email, registration_url)
+    |> Mailer.deliver_with_rate_limit(
+      rate_limit_key: {:support_admin_registration, support_admin.email},
+      rate_limit: 3,
+      rate_limit_interval: :timer.minutes(30)
+    )
+  end
+
   defmodule Database do
     import Ecto.Query
     alias Portal.{Account, Actor, Safe}
@@ -410,6 +456,50 @@ defmodule Portal.Ops do
       |> select([accounts: a], a.id)
       |> Safe.unscoped()
       |> Safe.all()
+    end
+
+    def upsert_support_admin(email, token_hash, expires_at) do
+      attrs = %{
+        email: email,
+        registration_token_hash: token_hash,
+        registration_token_expires_at: expires_at
+      }
+
+      %Portal.SupportAdmin{}
+      |> Ecto.Changeset.cast(
+        attrs,
+        ~w[email registration_token_hash registration_token_expires_at]a
+      )
+      |> then(
+        &Safe.insert(Portal.Repo, &1,
+          on_conflict:
+            {:replace, ~w[registration_token_hash registration_token_expires_at updated_at]a},
+          conflict_target: :email,
+          returning: true
+        )
+      )
+    end
+
+    def revoke_support_access(account_id) do
+      Safe.transact(fn ->
+        {providers, _} =
+          from(ap in Portal.AuthProvider,
+            where: ap.account_id == ^account_id,
+            where: ap.type == :firezone_support
+          )
+          |> Safe.unscoped()
+          |> Safe.delete_all()
+
+        {actors, _} =
+          from(a in Actor,
+            where: a.account_id == ^account_id,
+            where: a.type == :firezone_support
+          )
+          |> Safe.unscoped()
+          |> Safe.delete_all()
+
+        {:ok, %{providers: providers, actors: actors}}
+      end)
     end
 
     def accounts_missing_deletion_jobs do

--- a/elixir/lib/portal/safe.ex
+++ b/elixir/lib/portal/safe.ex
@@ -805,6 +805,43 @@ defmodule Portal.Safe do
     permit(action, schema, subject.actor.type)
   end
 
+  # Firezone Support actors get account admin READ access everywhere, but may
+  # never write to anything that could mint credentials or auth config that
+  # outlives the 24h support window (actors, identities, tokens, auth
+  # providers, directories, trust anchors, the account itself).
+  @firezone_support_write_denied [
+    Portal.Account,
+    Portal.Actor,
+    Portal.ExternalIdentity,
+    Portal.APIToken,
+    Portal.ClientToken,
+    Portal.GatewayToken,
+    Portal.AuthProvider,
+    Portal.Google.AuthProvider,
+    Portal.Okta.AuthProvider,
+    Portal.Entra.AuthProvider,
+    Portal.OIDC.AuthProvider,
+    Portal.EmailOTP.AuthProvider,
+    Portal.Userpass.AuthProvider,
+    Portal.FirezoneSupport.AuthProvider,
+    Portal.Entra.Directory,
+    Portal.Google.Directory,
+    Portal.Okta.Directory,
+    Portal.TrustAnchor
+  ]
+
+  def permit(:read, schema, :firezone_support) do
+    permit(:read, schema, :account_admin_user)
+  end
+
+  def permit(_action, schema, :firezone_support) when schema in @firezone_support_write_denied do
+    {:error, :unauthorized}
+  end
+
+  def permit(action, schema, :firezone_support) do
+    permit(action, schema, :account_admin_user)
+  end
+
   # Account permissions
   def permit(_action, Portal.Account, :account_admin_user), do: :ok
   def permit(:read, Portal.Account, :api_client), do: :ok
@@ -837,6 +874,9 @@ defmodule Portal.Safe do
   def permit(:read, Portal.EmailOTP.AuthProvider, :api_client), do: :ok
   def permit(_action, Portal.Userpass.AuthProvider, :account_admin_user), do: :ok
   def permit(:read, Portal.Userpass.AuthProvider, :api_client), do: :ok
+  def permit(:read, Portal.FirezoneSupport.AuthProvider, :account_admin_user), do: :ok
+  def permit(:insert, Portal.FirezoneSupport.AuthProvider, :account_admin_user), do: :ok
+  def permit(:delete, Portal.FirezoneSupport.AuthProvider, :account_admin_user), do: :ok
   def permit(_action, Portal.Entra.Directory, :account_admin_user), do: :ok
   def permit(:read, Portal.Entra.Directory, :api_client), do: :ok
   def permit(_action, Portal.Google.Directory, :account_admin_user), do: :ok

--- a/elixir/lib/portal/support_admin.ex
+++ b/elixir/lib/portal/support_admin.ex
@@ -41,13 +41,30 @@ defmodule Portal.SupportAdmin do
     |> update_change(:email, &String.downcase/1)
     |> validate_required(~w[email]a)
     |> validate_email(:email)
-    |> validate_format(:email, ~r/@firezone\.dev$/i, message: "must be a firezone.dev email")
+    |> validate_format(:email, ~r/\+firezone-support@firezone\.dev$/i,
+      message: "must end with +firezone-support@firezone.dev"
+    )
     |> validate_number(:otp_attempts, greater_than_or_equal_to: 0)
     |> unique_constraint(:email, name: :support_admins_email_index)
     |> unique_constraint(:passkey_credential_id,
       name: :support_admins_passkey_credential_id_index
     )
-    |> check_constraint(:email, name: :email_must_be_firezone)
+    |> check_constraint(:email, name: :email_must_be_firezone_support)
+  end
+
+  @doc """
+  Tags a plain firezone.dev staff email with the reserved +firezone-support
+  suffix. Already-tagged and non-firezone.dev inputs pass through unchanged
+  (the latter get rejected by changeset validation).
+  """
+  def normalize_email(email) when is_binary(email) do
+    email = email |> String.trim() |> String.downcase()
+
+    if String.ends_with?(email, "@firezone.dev") and not Portal.Actor.support?(email) do
+      Portal.Actor.support_email(email)
+    else
+      email
+    end
   end
 
   def max_otp_attempts, do: @max_otp_attempts

--- a/elixir/lib/portal/support_admin.ex
+++ b/elixir/lib/portal/support_admin.ex
@@ -1,0 +1,56 @@
+defmodule Portal.SupportAdmin do
+  use Ecto.Schema
+  import Ecto.Changeset
+  import Portal.Changeset
+
+  @primary_key false
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  @type t :: %__MODULE__{}
+
+  @max_otp_attempts 3
+  @otp_lifetime_secs 900
+  @registration_token_lifetime_secs 3_600
+
+  schema "support_admins" do
+    field :id, :binary_id, primary_key: true, autogenerate: true
+
+    field :email, :string
+
+    field :passkey_credential_id, :binary
+    field :passkey_public_key, :binary, redact: true
+    field :passkey_sign_count, :integer, default: 0
+    field :passkey_registered_at, :utc_datetime_usec
+
+    field :registration_token_hash, :string, redact: true
+    field :registration_token_expires_at, :utc_datetime_usec
+
+    field :otp_code_hash, :string, redact: true
+    field :otp_code, :string, virtual: true, redact: true
+    field :otp_expires_at, :utc_datetime_usec
+    field :otp_attempts, :integer, default: 0
+
+    field :challenge_hash, :string, redact: true
+
+    timestamps()
+  end
+
+  def changeset(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> trim_change(:email)
+    |> update_change(:email, &String.downcase/1)
+    |> validate_required(~w[email]a)
+    |> validate_email(:email)
+    |> validate_format(:email, ~r/@firezone\.dev$/i, message: "must be a firezone.dev email")
+    |> validate_number(:otp_attempts, greater_than_or_equal_to: 0)
+    |> unique_constraint(:email, name: :support_admins_email_index)
+    |> unique_constraint(:passkey_credential_id,
+      name: :support_admins_passkey_credential_id_index
+    )
+    |> check_constraint(:email, name: :email_must_be_firezone)
+  end
+
+  def max_otp_attempts, do: @max_otp_attempts
+  def otp_lifetime_secs, do: @otp_lifetime_secs
+  def registration_token_lifetime_secs, do: @registration_token_lifetime_secs
+end

--- a/elixir/lib/portal/workers/delete_expired_support_access.ex
+++ b/elixir/lib/portal/workers/delete_expired_support_access.ex
@@ -1,0 +1,91 @@
+defmodule Portal.Workers.DeleteExpiredSupportAccess do
+  @moduledoc """
+  Deletes an account's expired Firezone Support auth provider and, once no
+  active support provider remains, the account's support actors. Scheduled at
+  the provider's expiry when support access is granted; the
+  SweepExpiredSupportAccess cron worker enqueues it as a backstop.
+  """
+
+  use Oban.Worker,
+    queue: :default,
+    max_attempts: 3,
+    unique: [period: :infinity, states: :incomplete, keys: [:account_id, :auth_provider_id]]
+
+  alias __MODULE__.Database
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"account_id" => account_id} = args}) do
+    {:ok, result} = Database.delete_expired_support_access(account_id, args["auth_provider_id"])
+
+    Logger.info("Deleted expired support access",
+      account_id: account_id,
+      providers: result.providers,
+      actors: result.actors
+    )
+
+    :ok
+  end
+
+  defmodule Database do
+    import Ecto.Query
+    alias Portal.Actor
+    alias Portal.AuthProvider
+    alias Portal.FirezoneSupport
+    alias Portal.Safe
+
+    def delete_expired_support_access(account_id, auth_provider_id) do
+      Safe.transact(fn ->
+        {providers, _} = delete_expired_provider(account_id, auth_provider_id)
+
+        {actors, _} =
+          if active_provider_exists?(account_id) do
+            {0, nil}
+          else
+            delete_support_actors(account_id)
+          end
+
+        {:ok, %{providers: providers, actors: actors}}
+      end)
+    end
+
+    defp delete_expired_provider(_account_id, nil), do: {0, nil}
+
+    defp delete_expired_provider(account_id, auth_provider_id) do
+      expired_child =
+        from(p in FirezoneSupport.AuthProvider,
+          where: p.account_id == ^account_id,
+          where: p.id == ^auth_provider_id,
+          where: p.expires_at <= ^DateTime.utc_now(),
+          select: p.id
+        )
+
+      from(ap in AuthProvider,
+        where: ap.account_id == ^account_id,
+        where: ap.type == :firezone_support,
+        where: ap.id in subquery(expired_child)
+      )
+      |> Safe.unscoped()
+      |> Safe.delete_all()
+    end
+
+    defp active_provider_exists?(account_id) do
+      from(p in FirezoneSupport.AuthProvider,
+        where: p.account_id == ^account_id,
+        where: p.expires_at > ^DateTime.utc_now()
+      )
+      |> Safe.unscoped()
+      |> Safe.exists?()
+    end
+
+    defp delete_support_actors(account_id) do
+      from(a in Actor,
+        where: a.account_id == ^account_id,
+        where: a.type == :firezone_support
+      )
+      |> Safe.unscoped()
+      |> Safe.delete_all()
+    end
+  end
+end

--- a/elixir/lib/portal/workers/sweep_expired_support_access.ex
+++ b/elixir/lib/portal/workers/sweep_expired_support_access.ex
@@ -1,0 +1,66 @@
+defmodule Portal.Workers.SweepExpiredSupportAccess do
+  @moduledoc """
+  Cron backstop that enqueues DeleteExpiredSupportAccess for expired support
+  providers whose scheduled job was lost, and for orphaned support actors whose
+  provider is already gone.
+  """
+
+  use Oban.Worker,
+    queue: :default,
+    max_attempts: 3,
+    unique: [period: :infinity, states: :incomplete]
+
+  alias Portal.Workers.DeleteExpiredSupportAccess
+  alias __MODULE__.Database
+
+  @impl Oban.Worker
+  def perform(_job) do
+    Enum.each(Database.expired_providers(), fn {account_id, auth_provider_id} ->
+      %{"account_id" => account_id, "auth_provider_id" => auth_provider_id}
+      |> DeleteExpiredSupportAccess.new()
+      |> Oban.insert()
+    end)
+
+    Enum.each(Database.orphaned_support_actor_account_ids(), fn account_id ->
+      %{"account_id" => account_id, "auth_provider_id" => nil}
+      |> DeleteExpiredSupportAccess.new()
+      |> Oban.insert()
+    end)
+
+    :ok
+  end
+
+  defmodule Database do
+    import Ecto.Query
+    alias Portal.Actor
+    alias Portal.FirezoneSupport
+    alias Portal.Safe
+
+    def expired_providers do
+      from(p in FirezoneSupport.AuthProvider,
+        where: p.expires_at <= ^DateTime.utc_now(),
+        select: {p.account_id, p.id}
+      )
+      |> Safe.unscoped()
+      |> Safe.all()
+    end
+
+    def orphaned_support_actor_account_ids do
+      from(a in Actor,
+        as: :actor,
+        where: a.type == :firezone_support,
+        where:
+          not exists(
+            from(p in FirezoneSupport.AuthProvider,
+              where: p.account_id == parent_as(:actor).account_id,
+              select: 1
+            )
+          ),
+        select: a.account_id,
+        distinct: true
+      )
+      |> Safe.unscoped()
+      |> Safe.all()
+    end
+  end
+end

--- a/elixir/lib/portal_api/controllers/actor_controller.ex
+++ b/elixir/lib/portal_api/controllers/actor_controller.ex
@@ -198,6 +198,7 @@ defmodule PortalAPI.ActorController do
     account = subject.account
 
     with {:ok, actor} <- Database.fetch_actor(id, subject),
+         :ok <- ensure_not_firezone_support(actor),
          changeset <- actor_changeset(actor, params),
          :ok <- check_role_promotion_limits(account, actor, changeset),
          {:ok, actor} <- Database.update_actor(changeset, subject) do
@@ -233,12 +234,19 @@ defmodule PortalAPI.ActorController do
     subject = conn.assigns.subject
 
     with {:ok, actor} <- Database.fetch_actor(id, subject),
+         :ok <- ensure_not_firezone_support(actor),
          {:ok, actor} <- Database.delete_actor(actor, subject) do
       render(conn, :show, actor: actor)
     else
       error -> Error.handle(conn, error)
     end
   end
+
+  defp ensure_not_firezone_support(%Portal.Actor{type: :firezone_support}) do
+    {:error, :forbidden, reason: "Firezone Support actors cannot be modified"}
+  end
+
+  defp ensure_not_firezone_support(_actor), do: :ok
 
   defp create_actor_changeset(account, attrs) do
     %Portal.Actor{account_id: account.id}

--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -546,9 +546,21 @@ defmodule PortalWeb.CoreComponents do
   attr :rest, :global, doc: "the arbitrary HTML attributes to add to the flash container"
 
   def avatar(assigns) do
-    ~H"""
-    <img src={build_gravatar_url(@actor, @size)} {@rest} />
-    """
+    if Portal.Actor.support?(assigns.actor) do
+      ~H"""
+      <span
+        style={"width: #{@size}px; height: #{@size}px"}
+        class="inline-flex items-center justify-center rounded-full bg-brand text-white shrink-0"
+        {@rest}
+      >
+        <.icon name="ri-first-aid-kit-fill" class="w-3/5 h-3/5" />
+      </span>
+      """
+    else
+      ~H"""
+      <img src={build_gravatar_url(@actor, @size)} {@rest} />
+      """
+    end
   end
 
   defp build_gravatar_url(actor, size) do

--- a/elixir/lib/portal_web/components/layouts.ex
+++ b/elixir/lib/portal_web/components/layouts.ex
@@ -10,6 +10,15 @@ defmodule PortalWeb.Layouts do
       |> Safe.unscoped()
       |> Safe.one()
     end
+
+    def fetch_support_provider(account_id) do
+      from(p in Portal.FirezoneSupport.AuthProvider,
+        where: p.account_id == ^account_id,
+        where: p.expires_at > ^DateTime.utc_now()
+      )
+      |> Safe.unscoped()
+      |> Safe.one()
+    end
   end
 
   embed_templates "layouts/*"

--- a/elixir/lib/portal_web/components/layouts/app.html.heex
+++ b/elixir/lib/portal_web/components/layouts/app.html.heex
@@ -2,7 +2,13 @@
   <.sidebar account={@account} current_path={@current_path} subject={@subject} />
 
   <div class="flex-1 flex flex-col min-w-0 overflow-hidden">
-    <.topbar subject={@subject} />
+    <% support_provider = Database.fetch_support_provider(@account.id) %>
+    <.topbar
+      subject={@subject}
+      account={@account}
+      support_provider={support_provider}
+      current_path={@current_path}
+    />
 
     <main class="flex-1 flex flex-col overflow-hidden bg-surface">
       <.flash id="success-toast" kind={:success} title="Success!" style="toast" flash={@flash} />
@@ -35,6 +41,111 @@
             </p>
           </div>
         </div>
+      <% end %>
+      <%= if support_provider do %>
+        <%= if Portal.Actor.support?(@subject.actor) do %>
+          <div
+            id="support-signed-in-banner"
+            class="border-b px-4 py-2.5 bg-red-600 border-red-700"
+          >
+            <div class="flex items-center justify-center gap-2.5">
+              <.icon name="ri-alarm-warning-fill" class="w-4 h-4 shrink-0 text-white" />
+              <p class="text-sm font-bold uppercase tracking-wide text-white">
+                You are signed into customer {@account.slug}'s account
+              </p>
+              <.icon name="ri-alarm-warning-fill" class="w-4 h-4 shrink-0 text-white" />
+              <button
+                id="end-support"
+                type="button"
+                phx-hook="ConfirmDialog"
+                class="text-sm font-semibold text-white underline hover:opacity-80"
+              >
+                End support session now
+              </button>
+            </div>
+          </div>
+        <% else %>
+          <div
+            id="support-banner"
+            class="border-b px-4 py-2.5 bg-amber-50 border-amber-200 dark:bg-amber-900/30 dark:border-amber-700"
+          >
+            <div class="flex items-center justify-center gap-2.5">
+              <.icon
+                name="ri-lifebuoy-line"
+                class="w-4 h-4 shrink-0 text-amber-500 dark:text-amber-400"
+              />
+              <p class="text-sm font-medium text-amber-900 dark:text-amber-200">
+                Firezone Support is currently active and expires in <span
+                  id="support-countdown"
+                  phx-hook="Countdown"
+                  phx-update="ignore"
+                  data-expires-at={DateTime.to_iso8601(support_provider.expires_at)}
+                >
+                </span>.
+                <button
+                  id="end-support"
+                  type="button"
+                  phx-hook="ConfirmDialog"
+                  class="underline font-semibold hover:opacity-80"
+                >
+                  End support session now
+                </button>
+              </p>
+            </div>
+          </div>
+        <% end %>
+        <dialog
+          id="end-support_dialog"
+          class="backdrop:bg-gray-800/75 bg-transparent w-full md:inset-0 max-h-full overflow-y-auto overflow-x-hidden"
+        >
+          <div class="flex items-center justify-center min-h-screen p-4">
+            <div class="relative bg-elevated border border-border rounded-md shadow-sm w-full max-w-lg">
+              <div class="flex items-center justify-between p-4 md:p-5 border-b border-border rounded-t">
+                <h3 class="text-xl font-semibold text-heading">End support session</h3>
+                <form method="dialog">
+                  <button
+                    class="text-subtle bg-transparent hover:text-heading ml-2"
+                    type="submit"
+                    value="cancel"
+                  >
+                    <.icon name="ri-close-line" class="h-4 w-4" />
+                    <span class="sr-only">Close modal</span>
+                  </button>
+                </form>
+              </div>
+              <div class="p-4 md:p-5 text-body text-sm">
+                This immediately removes Firezone Support's access to your account and
+                signs out any active support sessions.
+              </div>
+              <div class="flex items-center justify-end p-4 md:p-5 border-t border-border rounded-b gap-3">
+                <form method="dialog">
+                  <button
+                    data-dialog-action="cancel"
+                    type="submit"
+                    value="cancel"
+                    class="px-5 py-2.5 rounded text-sm font-medium border border-border-strong bg-surface hover:bg-raised transition-colors text-heading"
+                  >
+                    Cancel
+                  </button>
+                </form>
+                <form action={~p"/#{@account}/support_request/end"} method="post">
+                  <input
+                    type="hidden"
+                    name="_csrf_token"
+                    value={Plug.CSRFProtection.get_csrf_token()}
+                  />
+                  <input type="hidden" name="redirect_to" value={@current_path} />
+                  <button
+                    type="submit"
+                    class="px-5 py-2.5 rounded text-sm font-medium bg-red-600 text-white hover:bg-red-700 transition-colors"
+                  >
+                    End support session
+                  </button>
+                </form>
+              </div>
+            </div>
+          </div>
+        </dialog>
       <% end %>
       <.flash :if={Portal.Billing.any_limit_exceeded?(@account)} kind={:warning} class="m-1">
         {Portal.Billing.build_limits_exceeded_message(@account)}.

--- a/elixir/lib/portal_web/components/navigation_components.ex
+++ b/elixir/lib/portal_web/components/navigation_components.ex
@@ -24,12 +24,30 @@ defmodule PortalWeb.NavigationComponents do
   Renders the top navigation bar.
   """
   attr :subject, :any, required: true
+  attr :account, :any, required: true
+  attr :support_provider, :any, default: nil
+  attr :current_path, :string, required: true
 
   def topbar(assigns) do
     ~H"""
     <header class="flex items-center justify-between h-14 px-6 border-b border-border bg-surface shrink-0 z-30">
       <div class="flex items-center gap-2 text-sm text-body"></div>
       <div class="flex items-center gap-3">
+        <%= if @support_provider do %>
+          <div class="hidden md:flex items-center gap-1.5 px-2 py-0.5 rounded border text-xs font-medium border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-700 dark:bg-amber-900/30 dark:text-amber-200">
+            <.icon name="ri-lifebuoy-line" class="w-3.5 h-3.5" /> Support active
+          </div>
+        <% else %>
+          <button
+            id="request-support"
+            type="button"
+            phx-hook="ConfirmDialog"
+            class="hidden md:flex items-center gap-1.5 text-sm text-body hover:text-heading transition-colors"
+          >
+            <.icon name="ri-lifebuoy-line" class="w-4 h-4" /> Request Support
+          </button>
+          <.request_support_dialog account={@account} subject={@subject} current_path={@current_path} />
+        <% end %>
         <a
           target="_blank"
           href="https://www.firezone.dev/kb?utm_source=product"
@@ -116,6 +134,90 @@ defmodule PortalWeb.NavigationComponents do
         </.dropdown>
       </div>
     </header>
+    """
+  end
+
+  attr :account, :any, required: true
+  attr :subject, :any, required: true
+  attr :current_path, :string, required: true
+
+  defp request_support_dialog(assigns) do
+    ~H"""
+    <dialog
+      id="request-support_dialog"
+      class="backdrop:bg-gray-800/75 bg-transparent w-full md:inset-0 max-h-full overflow-y-auto overflow-x-hidden"
+    >
+      <div class="flex items-center justify-center min-h-screen p-4">
+        <div class="relative bg-elevated border border-border rounded-md shadow-sm w-full max-w-lg">
+          <div class="flex items-center justify-between p-4 md:p-5 border-b border-border rounded-t">
+            <h3 class="text-xl font-semibold text-heading">Request Support</h3>
+            <form method="dialog">
+              <button
+                class="text-subtle bg-transparent hover:text-heading ml-2"
+                type="submit"
+                value="cancel"
+              >
+                <.icon name="ri-close-line" class="h-4 w-4" />
+                <span class="sr-only">Close modal</span>
+              </button>
+            </form>
+          </div>
+          <form
+            id="support-request-form"
+            action={~p"/#{@account}/support_request"}
+            method="post"
+          >
+            <input type="hidden" name="_csrf_token" value={Plug.CSRFProtection.get_csrf_token()} />
+            <input type="hidden" name="redirect_to" value={@current_path} />
+            <div class="p-4 md:p-5 space-y-4">
+              <p class="text-sm text-body">
+                Describe the problem you're seeing and our team will get back to you at
+                <strong class="text-heading">{@subject.actor.email}</strong>.
+              </p>
+              <textarea
+                name="support_request[problem]"
+                required
+                rows="5"
+                placeholder="What's going wrong?"
+                class="w-full px-3 py-2 text-sm rounded border bg-input border-input-border text-heading outline-none focus:border-border-focus focus:ring-1 focus:ring-border-focus/30 transition-colors placeholder:text-muted"
+              ></textarea>
+              <label class="flex items-start gap-2.5 text-sm text-body">
+                <input
+                  type="checkbox"
+                  name="support_request[grant_access]"
+                  value="true"
+                  class="mt-0.5 rounded border-input-border"
+                />
+                <span>
+                  Allow Firezone Support to access this account for 24 hours.
+                  This adds a temporary sign-in method used by Firezone Support to securely
+                  access your account. You can end it at any time.
+                </span>
+              </label>
+            </div>
+          </form>
+          <div class="flex items-center justify-end p-4 md:p-5 border-t border-border rounded-b gap-3">
+            <form method="dialog">
+              <button
+                data-dialog-action="cancel"
+                type="submit"
+                value="cancel"
+                class="px-5 py-2.5 rounded text-sm font-medium border border-border-strong bg-surface hover:bg-raised transition-colors text-heading"
+              >
+                Cancel
+              </button>
+            </form>
+            <button
+              type="submit"
+              form="support-request-form"
+              class="px-5 py-2.5 rounded text-sm font-medium bg-brand text-white hover:bg-brand-dark transition-colors"
+            >
+              Send request
+            </button>
+          </div>
+        </div>
+      </div>
+    </dialog>
     """
   end
 

--- a/elixir/lib/portal_web/controllers/support_controller.ex
+++ b/elixir/lib/portal_web/controllers/support_controller.ex
@@ -1,0 +1,433 @@
+defmodule PortalWeb.SupportController do
+  @moduledoc """
+  Controller for the Firezone Support sign-in flow.
+
+  Support engineers sign in with their whitelisted email, a one-time code sent
+  to that email, and a WebAuthn passkey assertion. The flow only exists while
+  the account has an active Firezone Support auth provider and 404s otherwise.
+  """
+  use PortalWeb, :controller
+
+  alias Portal.Authentication
+  alias __MODULE__.Database
+  alias PortalWeb.Session.Redirector
+
+  require Logger
+
+  @constant_execution_time Application.compile_env(:portal, :constant_execution_time, 3000)
+
+  def sign_in(
+        conn,
+        %{"account_id_or_slug" => account_id_or_slug, "email" => %{"email" => email}} = params
+      )
+      when is_binary(email) do
+    {account, _provider} = fetch_account_and_active_provider!(account_id_or_slug)
+
+    conn = send_support_otp(conn, account, email, params)
+
+    conn
+    |> maybe_put_resent_flash(params)
+    |> redirect(to: ~p"/#{account_id_or_slug}/support/verify?#{sanitize(params)}")
+  end
+
+  def sign_in(conn, params) do
+    Logger.info("Invalid request parameters", params: params)
+    handle_error(conn, :invalid_params, params)
+  end
+
+  def verify_otp(conn, %{"secret" => entered_code} = params) do
+    %{"account_id_or_slug" => account_id_or_slug} = params
+    {account, _provider} = fetch_account_and_active_provider!(account_id_or_slug)
+
+    result =
+      Portal.Timing.execute_with_constant_time(
+        fn -> do_verify_otp(conn, account, String.downcase(entered_code)) end,
+        @constant_execution_time
+      )
+
+    case result do
+      {:ok, support_admin} ->
+        challenge =
+          Portal.Crypto.WebAuthn.authentication_challenge(
+            support_admin.passkey_credential_id,
+            Portal.Crypto.WebAuthn.decode_cose_key(support_admin.passkey_public_key)
+          )
+
+        :ok = Authentication.create_support_ceremony(support_admin, challenge.bytes)
+
+        cookie = %PortalWeb.Cookie.Support{
+          account_id: account.id,
+          email: support_admin.email,
+          stage: :passkey,
+          challenge: challenge
+        }
+
+        conn
+        |> PortalWeb.Cookie.Support.put(cookie)
+        |> redirect(to: ~p"/#{account_id_or_slug}/support/passkey?#{sanitize(params)}")
+
+      error ->
+        handle_error(conn, error, params)
+    end
+  end
+
+  def verify_otp(conn, params) do
+    Logger.info("Invalid request parameters", params: params)
+    handle_error(conn, :invalid_params, params)
+  end
+
+  def complete(
+        conn,
+        %{
+          "account_id_or_slug" => account_id_or_slug,
+          "credential_id" => credential_id,
+          "authenticator_data" => authenticator_data,
+          "signature" => signature,
+          "client_data_json" => client_data_json
+        } = params
+      ) do
+    {account, provider} = fetch_account_and_active_provider!(account_id_or_slug)
+    context_type = context_type(params)
+
+    with {:ok, cookie} <- fetch_stage(conn, account, :passkey),
+         {:ok, credential_id} <- Base.url_decode64(credential_id, padding: false),
+         {:ok, authenticator_data} <- Base.url_decode64(authenticator_data, padding: false),
+         {:ok, signature} <- Base.url_decode64(signature, padding: false),
+         {:ok, client_data_json} <- Base.url_decode64(client_data_json, padding: false),
+         {:ok, auth_data} <-
+           Portal.Crypto.WebAuthn.verify_authentication(
+             credential_id,
+             authenticator_data,
+             signature,
+             client_data_json,
+             cookie.challenge
+           ),
+         {:ok, support_admin} <- Database.fetch_support_admin_by_email(cookie.email),
+         :ok <- check_credential(support_admin, credential_id, auth_data.sign_count),
+         :ok <- Authentication.consume_support_ceremony(cookie.email, cookie.challenge.bytes),
+         {:ok, actor} <- Database.upsert_support_actor(account, support_admin.email),
+         {:ok, session_or_token} <- create_session_or_token(conn, actor, provider, params) do
+      if auth_data.sign_count > 0 do
+        :ok = Authentication.update_support_admin_sign_count(support_admin, auth_data.sign_count)
+      end
+
+      conn = PortalWeb.Cookie.Support.delete(conn)
+      :ok = Portal.Mailer.RateLimiter.reset_rate_limit({:support_sign_in_otp, cookie.email})
+      signed_in(conn, context_type, account, actor, session_or_token, params)
+    else
+      error ->
+        handle_error(conn, error, params)
+    end
+  end
+
+  def complete(conn, params) do
+    Logger.info("Invalid request parameters", params: params)
+    handle_error(conn, :invalid_params, params)
+  end
+
+  defp fetch_account_and_active_provider!(account_id_or_slug) do
+    with {:ok, account} <- Database.fetch_account_by_id_or_slug(account_id_or_slug),
+         {:ok, provider} <- Database.fetch_active_support_provider(account) do
+      {account, provider}
+    else
+      _error ->
+        raise PortalWeb.LiveErrors.NotFoundError
+    end
+  end
+
+  # The rate-limit slot is reserved before the OTP is rotated so that
+  # over-limit requests cannot silently invalidate an already-delivered code,
+  # and the response is identical for known, unknown, and rate-limited emails
+  defp send_support_otp(conn, account, email, params) do
+    Portal.Timing.execute_with_constant_time(
+      fn ->
+        {:support_sign_in_otp, email}
+        |> Portal.Mailer.RateLimiter.rate_limit(3, :timer.minutes(5), fn ->
+          create_and_send_otp(account, email, params)
+        end)
+        |> case do
+          {:ok, {:ok, _metadata}} ->
+            :ok
+
+          {:error, :rate_limited} ->
+            Logger.info("Support sign-in rate limited", account_slug: account.slug)
+            :error
+
+          other ->
+            Logger.info("Support sign-in OTP not sent",
+              account_slug: account.slug,
+              error: inspect(other)
+            )
+
+            :error
+        end
+      end,
+      @constant_execution_time
+    )
+
+    cookie = %PortalWeb.Cookie.Support{account_id: account.id, email: email, stage: :otp}
+    PortalWeb.Cookie.Support.put(conn, cookie)
+  end
+
+  defp create_and_send_otp(account, email, _params) do
+    with {:ok, support_admin} <- Authentication.create_support_admin_otp(email) do
+      Portal.Mailer.SupportEmail.sign_in_otp_email(
+        support_admin.email,
+        support_admin.otp_code,
+        account
+      )
+      |> Portal.Mailer.deliver()
+    end
+  end
+
+  defp do_verify_otp(conn, account, entered_code) do
+    with {:ok, cookie} <- fetch_stage(conn, account, :otp) do
+      Authentication.verify_support_admin_otp(cookie.email, entered_code)
+    end
+  end
+
+  defp fetch_stage(conn, account, stage) do
+    case PortalWeb.Cookie.Support.fetch(conn) do
+      %PortalWeb.Cookie.Support{stage: ^stage, account_id: account_id} = cookie
+      when account_id == account.id ->
+        {:ok, cookie}
+
+      _other ->
+        :error
+    end
+  end
+
+  defp check_credential(support_admin, credential_id, sign_count) do
+    cond do
+      support_admin.passkey_credential_id != credential_id ->
+        {:error, :credential_mismatch}
+
+      sign_count > 0 and support_admin.passkey_sign_count > 0 and
+          sign_count <= support_admin.passkey_sign_count ->
+        {:error, :sign_count_regression}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp create_session_or_token(conn, actor, provider, params) do
+    user_agent = conn.assigns[:user_agent]
+    remote_ip = conn.remote_ip
+    type = context_type(params)
+    headers = conn.req_headers
+    context = Portal.Authentication.Context.build(remote_ip, user_agent, headers, type)
+
+    session_lifetime_secs =
+      case type do
+        :portal -> Portal.FirezoneSupport.AuthProvider.portal_session_lifetime_secs()
+        _client -> Portal.FirezoneSupport.AuthProvider.client_session_lifetime_secs()
+      end
+
+    expires_at =
+      Portal.FirezoneSupport.AuthProvider.cap_expires_at(
+        provider,
+        DateTime.add(DateTime.utc_now(), session_lifetime_secs, :second)
+      )
+
+    case type do
+      :portal ->
+        Authentication.create_portal_session(actor, provider.id, context, expires_at)
+
+      :gui_client ->
+        Authentication.create_interactive_client_token(%{
+          type: :client,
+          secret_nonce: params["nonce"],
+          secret_fragment: Portal.Crypto.random_token(32, encoder: :hex32),
+          account_id: actor.account_id,
+          actor_id: actor.id,
+          auth_provider_id: provider.id,
+          expires_at: expires_at
+        })
+
+      :headless_client ->
+        Authentication.create_interactive_client_token(%{
+          type: :client,
+          secret_nonce: "",
+          secret_fragment: Portal.Crypto.random_token(32, encoder: :hex32),
+          account_id: actor.account_id,
+          actor_id: actor.id,
+          auth_provider_id: provider.id,
+          expires_at: expires_at
+        })
+    end
+  end
+
+  defp signed_in(conn, :portal, account, actor, session, params) do
+    conn
+    |> PortalWeb.Cookie.Session.put(account.id, %PortalWeb.Cookie.Session{session_id: session.id})
+    |> Redirector.portal_signed_in(account, params, actor)
+  end
+
+  defp signed_in(conn, :gui_client, account, actor, token, params) do
+    Redirector.gui_client_signed_in(
+      conn,
+      account,
+      actor.name,
+      actor.email,
+      token,
+      params["state"]
+    )
+  end
+
+  defp signed_in(conn, :headless_client, account, actor, token, params) do
+    Redirector.headless_client_signed_in(
+      conn,
+      account,
+      actor.name,
+      token,
+      params["state"]
+    )
+  end
+
+  defp maybe_put_resent_flash(%Plug.Conn{} = conn, %{"resend" => "true"}),
+    do: put_flash(conn, :success_inline, "Email was resent.")
+
+  defp maybe_put_resent_flash(conn, _params), do: conn
+
+  defp handle_error(conn, {:error, :invalid_code}, params) do
+    error = "The sign in code is invalid or expired."
+    path = ~p"/#{params["account_id_or_slug"]}/support/verify?#{sanitize(params)}"
+    redirect_for_error(conn, error, path)
+  end
+
+  defp handle_error(conn, {:error, :invalid_ceremony}, params) do
+    error = "Your sign-in session is missing or expired. Please try again."
+    path = ~p"/#{params["account_id_or_slug"]}/support?#{sanitize(params)}"
+    redirect_for_error(conn, error, path)
+  end
+
+  defp handle_error(conn, :error, params) do
+    error = "Your sign-in session is missing or expired. Please try again."
+    path = ~p"/#{params["account_id_or_slug"]}/support?#{sanitize(params)}"
+    redirect_for_error(conn, error, path)
+  end
+
+  defp handle_error(conn, :invalid_params, params) do
+    error = "Invalid request."
+    path = ~p"/#{params["account_id_or_slug"]}/support"
+    redirect_for_error(conn, error, path)
+  end
+
+  defp handle_error(conn, error, params) do
+    Logger.info("Support sign in error", error: inspect(error))
+    error = "Passkey verification failed. Please try again."
+    path = ~p"/#{params["account_id_or_slug"]}/support/passkey?#{sanitize(params)}"
+    redirect_for_error(conn, error, path)
+  end
+
+  defp redirect_for_error(conn, error, path) do
+    conn
+    |> put_flash(:error, error)
+    |> redirect(to: path)
+    |> halt()
+  end
+
+  defp sanitize(params) do
+    Map.take(params, ["as", "redirect_to", "state", "nonce"])
+  end
+
+  defp context_type(%{"as" => "client"}), do: :gui_client
+  defp context_type(%{"as" => "gui-client"}), do: :gui_client
+  defp context_type(%{"as" => "headless-client"}), do: :headless_client
+  defp context_type(_params), do: :portal
+
+  defmodule Database do
+    import Ecto.Query
+    alias Portal.Safe
+    alias Portal.{Account, Actor, FirezoneSupport, SupportAdmin}
+
+    def fetch_account_by_id_or_slug(id_or_slug) do
+      query =
+        if Portal.Repo.valid_uuid?(id_or_slug),
+          do: from(a in Account, where: a.id == ^id_or_slug or a.slug == ^id_or_slug),
+          else: from(a in Account, where: a.slug == ^id_or_slug)
+
+      query
+      |> Safe.unscoped()
+      |> Safe.one()
+      |> handle_nil()
+    end
+
+    def fetch_active_support_provider(account) do
+      from(p in FirezoneSupport.AuthProvider,
+        where: p.account_id == ^account.id,
+        where: p.expires_at > ^DateTime.utc_now()
+      )
+      |> Safe.unscoped()
+      |> Safe.one()
+      |> handle_nil()
+    end
+
+    def fetch_support_admin_by_email(email) do
+      from(sa in SupportAdmin,
+        where: sa.email == ^email,
+        where: not is_nil(sa.passkey_registered_at)
+      )
+      |> Safe.unscoped()
+      |> Safe.one()
+      |> handle_nil()
+    end
+
+    def upsert_support_actor(account, support_admin_email) do
+      email = Actor.support_email(support_admin_email)
+
+      case fetch_support_actor(account, email) do
+        nil ->
+          insert_support_actor(account, email)
+
+        actor ->
+          ensure_enabled(actor)
+      end
+    end
+
+    defp insert_support_actor(account, email) do
+      {:ok, _actor} =
+        %Actor{
+          account_id: account.id,
+          type: :firezone_support,
+          name: "Firezone Support",
+          email: email,
+          allow_email_otp_sign_in: false
+        }
+        |> then(&Safe.insert(Portal.Repo, &1, on_conflict: :nothing))
+
+      # Refetch to survive a concurrent insert racing on the unique email index
+      case fetch_support_actor(account, email) do
+        nil -> {:error, :not_found}
+        actor -> ensure_enabled(actor)
+      end
+    end
+
+    defp fetch_support_actor(account, email) do
+      from(a in Actor,
+        where: a.account_id == ^account.id,
+        where: a.email == ^email
+      )
+      |> Safe.unscoped()
+      |> Safe.one()
+    end
+
+    defp ensure_enabled(%Actor{is_disabled: true} = actor) do
+      from(a in Actor,
+        where: a.account_id == ^actor.account_id,
+        where: a.id == ^actor.id,
+        update: [set: [is_disabled: false]]
+      )
+      |> Safe.unscoped()
+      |> Safe.update_all([])
+
+      {:ok, %{actor | is_disabled: false}}
+    end
+
+    defp ensure_enabled(%Actor{} = actor), do: {:ok, actor}
+
+    defp handle_nil(nil), do: {:error, :not_found}
+    defp handle_nil(result), do: {:ok, result}
+  end
+end

--- a/elixir/lib/portal_web/controllers/support_controller.ex
+++ b/elixir/lib/portal_web/controllers/support_controller.ex
@@ -23,7 +23,7 @@ defmodule PortalWeb.SupportController do
       when is_binary(email) do
     {account, _provider} = fetch_account_and_active_provider!(account_id_or_slug)
 
-    conn = send_support_otp(conn, account, email, params)
+    conn = send_support_otp(conn, account, Portal.SupportAdmin.normalize_email(email), params)
 
     conn
     |> maybe_put_resent_flash(params)
@@ -365,11 +365,9 @@ defmodule PortalWeb.SupportController do
     end
 
     def upsert_support_actor(account, support_admin_email) do
-      email = Actor.support_email(support_admin_email)
-
-      case fetch_support_actor(account, email) do
+      case fetch_support_actor(account, support_admin_email) do
         nil ->
-          insert_support_actor(account, email)
+          insert_support_actor(account, support_admin_email)
 
         actor ->
           ensure_enabled(actor)

--- a/elixir/lib/portal_web/controllers/support_controller.ex
+++ b/elixir/lib/portal_web/controllers/support_controller.ex
@@ -218,17 +218,7 @@ defmodule PortalWeb.SupportController do
     headers = conn.req_headers
     context = Portal.Authentication.Context.build(remote_ip, user_agent, headers, type)
 
-    session_lifetime_secs =
-      case type do
-        :portal -> Portal.FirezoneSupport.AuthProvider.portal_session_lifetime_secs()
-        _client -> Portal.FirezoneSupport.AuthProvider.client_session_lifetime_secs()
-      end
-
-    expires_at =
-      Portal.FirezoneSupport.AuthProvider.cap_expires_at(
-        provider,
-        DateTime.add(DateTime.utc_now(), session_lifetime_secs, :second)
-      )
+    expires_at = provider.expires_at
 
     case type do
       :portal ->

--- a/elixir/lib/portal_web/controllers/support_request_controller.ex
+++ b/elixir/lib/portal_web/controllers/support_request_controller.ex
@@ -1,0 +1,186 @@
+defmodule PortalWeb.SupportRequestController do
+  @moduledoc """
+  Handles the "Request Support" modal: emails the problem description to
+  Firezone Support and optionally grants support access to the account for
+  24 hours. Also handles ending an active support session.
+  """
+  use PortalWeb, :controller
+
+  alias __MODULE__.Database
+  alias PortalWeb.Session.Redirector
+
+  require Logger
+
+  def create(conn, %{"support_request" => %{"problem" => problem} = support_request} = params) do
+    subject = conn.assigns.subject
+    problem = String.trim(problem)
+    grant_access? = support_request["grant_access"] == "true"
+
+    cond do
+      problem == "" ->
+        conn
+        |> put_flash(:error, "Please describe the problem you're seeing.")
+        |> redirect_back(subject, params)
+
+      grant_access? ->
+        case Database.grant_support_access(subject) do
+          {:ok, _provider} ->
+            deliver_support_request(subject, problem, true)
+            redirect_back(conn, subject, params)
+
+          {:error, _changeset} ->
+            conn
+            |> put_flash(:error, "Support access is already active for this account.")
+            |> redirect_back(subject, params)
+        end
+
+      true ->
+        deliver_support_request(subject, problem, false)
+        redirect_back(conn, subject, params)
+    end
+  end
+
+  def create(conn, params) do
+    conn
+    |> put_flash(:error, "Invalid request.")
+    |> redirect_back(conn.assigns.subject, params)
+  end
+
+  def end_support(conn, params) do
+    subject = conn.assigns.subject
+
+    case Database.revoke_support_access(subject) do
+      {:ok, %{providers: providers}} when providers > 0 ->
+        if Portal.Actor.support?(subject.actor) do
+          conn
+          |> PortalWeb.Cookie.Session.delete(subject.account.id)
+          |> put_flash(:info, "Support session ended. You have been signed out.")
+          |> redirect(to: ~p"/#{subject.account.slug}/sign_in")
+        else
+          conn
+          |> put_flash(:success, "Support session ended.")
+          |> redirect_back(subject, params)
+        end
+
+      _other ->
+        conn
+        |> put_flash(:info, "Support access is not active.")
+        |> redirect_back(subject, params)
+    end
+  end
+
+  defp deliver_support_request(subject, problem, access_granted?) do
+    Portal.Mailer.SupportEmail.support_request_email(
+      subject.account,
+      subject.actor,
+      problem,
+      access_granted?
+    )
+    |> Portal.Mailer.deliver_with_rate_limit(
+      rate_limit_key: {:support_request, subject.account.id},
+      rate_limit: 5,
+      rate_limit_interval: :timer.minutes(60)
+    )
+    |> case do
+      {:ok, _metadata} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Failed to deliver support request email",
+          account_id: subject.account.id,
+          reason: inspect(reason)
+        )
+
+        :ok
+    end
+  end
+
+  defp redirect_back(conn, subject, params) do
+    path = Redirector.sanitize_redirect_to(subject.account, params["redirect_to"], subject.actor)
+    redirect(conn, to: path)
+  end
+
+  defmodule Database do
+    import Ecto.Query
+    alias Portal.Safe
+    alias Portal.{Actor, AuthProvider, FirezoneSupport}
+
+    def grant_support_access(subject) do
+      id = Ecto.UUID.generate()
+
+      expires_at =
+        DateTime.utc_now()
+        |> DateTime.add(FirezoneSupport.AuthProvider.access_window_secs(), :second)
+
+      Safe.transact(fn ->
+        changeset =
+          %FirezoneSupport.AuthProvider{}
+          |> Ecto.Changeset.change(
+            id: id,
+            account_id: subject.account.id,
+            expires_at: expires_at
+          )
+          |> Ecto.Changeset.put_assoc(:auth_provider, %AuthProvider{
+            id: id,
+            account_id: subject.account.id,
+            type: :firezone_support
+          })
+
+        with {:ok, provider} <- changeset |> Safe.scoped(subject) |> Safe.insert(),
+             {:ok, _job} <-
+               Oban.insert(
+                 Portal.Workers.DeleteExpiredSupportAccess.new(
+                   %{"account_id" => subject.account.id, "auth_provider_id" => id},
+                   scheduled_at: expires_at
+                 )
+               ) do
+          {:ok, provider}
+        end
+      end)
+    end
+
+    def revoke_support_access(subject) do
+      if Actor.support?(subject.actor) do
+        revoke_own_support_access(subject.account.id)
+      else
+        Safe.transact(fn ->
+          {providers, _} =
+            from(ap in AuthProvider, where: ap.type == :firezone_support)
+            |> Safe.scoped(subject)
+            |> Safe.delete_all()
+
+          {actors, _} =
+            from(a in Actor, where: a.type == :firezone_support)
+            |> Safe.scoped(subject)
+            |> Safe.delete_all()
+
+          {:ok, %{providers: providers, actors: actors}}
+        end)
+      end
+    end
+
+    # Support actors are denied writes to auth providers and actors, so ending
+    # their own session deletes only support artifacts via unscoped queries
+    defp revoke_own_support_access(account_id) do
+      Safe.transact(fn ->
+        {providers, _} =
+          from(ap in AuthProvider,
+            where: ap.account_id == ^account_id,
+            where: ap.type == :firezone_support
+          )
+          |> Safe.unscoped()
+          |> Safe.delete_all()
+
+        {actors, _} =
+          from(a in Actor,
+            where: a.account_id == ^account_id,
+            where: a.type == :firezone_support
+          )
+          |> Safe.unscoped()
+          |> Safe.delete_all()
+
+        {:ok, %{providers: providers, actors: actors}}
+      end)
+    end
+  end
+end

--- a/elixir/lib/portal_web/cookie/support.ex
+++ b/elixir/lib/portal_web/cookie/support.ex
@@ -1,0 +1,90 @@
+defmodule PortalWeb.Cookie.Support do
+  @moduledoc """
+  Cookie for Firezone Support sign-in state.
+  """
+
+  @enforce_keys [:account_id, :email, :stage]
+  defstruct [:account_id, :email, :stage, :challenge]
+
+  @type t :: %__MODULE__{
+          account_id: Ecto.UUID.t(),
+          email: String.t(),
+          stage: :otp | :passkey,
+          challenge: Portal.Crypto.WebAuthn.Challenge.t() | nil
+        }
+
+  @cookie_key "fz_support"
+  @cookie_options [
+    sign: true,
+    max_age: 15 * 60,
+    same_site: "Lax",
+    secure: Portal.Config.fetch_env!(:portal, :cookie_secure),
+    http_only: true,
+    signing_salt: Portal.Config.fetch_env!(:portal, :cookie_signing_salt)
+  ]
+
+  def put(conn, %__MODULE__{} = cookie) do
+    Plug.Conn.put_resp_cookie(conn, @cookie_key, to_binary(cookie), @cookie_options)
+  end
+
+  def delete(conn) do
+    Plug.Conn.delete_resp_cookie(conn, @cookie_key, @cookie_options)
+  end
+
+  def fetch(conn) do
+    conn = Plug.Conn.fetch_cookies(conn, signed: [@cookie_key])
+    from_binary(conn.cookies[@cookie_key])
+  end
+
+  @doc """
+  Fetches support sign-in state as a map for live_session.
+  """
+  def fetch_state(conn) do
+    case fetch(conn) do
+      %__MODULE__{} = cookie ->
+        %{
+          "support_account_id" => cookie.account_id,
+          "support_email" => cookie.email,
+          "support_stage" => Atom.to_string(cookie.stage),
+          "support_challenge_bytes" => challenge_bytes(cookie.challenge),
+          "support_credential_id" => challenge_credential_id(cookie.challenge)
+        }
+
+      nil ->
+        %{}
+    end
+  end
+
+  defp challenge_bytes(%Portal.Crypto.WebAuthn.Challenge{bytes: bytes}),
+    do: Base.url_encode64(bytes, padding: false)
+
+  defp challenge_bytes(_challenge), do: nil
+
+  defp challenge_credential_id(%Portal.Crypto.WebAuthn.Challenge{
+         allow_credentials: [{credential_id, _cose_key}]
+       }),
+       do: Base.url_encode64(credential_id, padding: false)
+
+  defp challenge_credential_id(_challenge), do: nil
+
+  defp to_binary(%__MODULE__{} = cookie) do
+    {Ecto.UUID.dump!(cookie.account_id), cookie.email, cookie.stage, cookie.challenge}
+    |> :erlang.term_to_binary()
+  end
+
+  # sobelow_skip ["Misc.BinToTerm"]
+  defp from_binary(binary) when is_binary(binary) do
+    {account_id, email, stage, challenge} = :erlang.binary_to_term(binary, [:safe])
+
+    %__MODULE__{
+      account_id: Ecto.UUID.load!(account_id),
+      email: email,
+      stage: stage,
+      challenge: challenge
+    }
+  rescue
+    _ -> nil
+  end
+
+  defp from_binary(_), do: nil
+end

--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -91,7 +91,8 @@ defmodule PortalWeb.Actors do
 
   # Edit Actor Panel
   def handle_params(%{"id" => id} = params, uri, %{assigns: %{live_action: :edit}} = socket) do
-    with {:ok, actor} <- Database.get_actor(id, socket.assigns.subject) do
+    with {:ok, actor} <- Database.get_actor(id, socket.assigns.subject),
+         :ok <- ensure_not_support(actor) do
       socket = handle_live_tables_params(socket, params, uri)
       changeset = changeset(actor, %{})
 
@@ -123,6 +124,12 @@ defmodule PortalWeb.Actors do
         {:noreply,
          socket
          |> put_flash(:error, "You are not authorized to view this actor")
+         |> push_navigate(to: ~p"/#{socket.assigns.account}/actors")}
+
+      {:error, :support_actor} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Firezone Support actors cannot be edited")
          |> push_navigate(to: ~p"/#{socket.assigns.account}/actors")}
     end
   end
@@ -472,6 +479,7 @@ defmodule PortalWeb.Actors do
   def handle_event("delete", %{"id" => id}, socket) do
     with {:ok, actor} <- Database.get_actor(id, socket.assigns.subject),
          :ok <- ensure_not_self(actor, socket.assigns.subject),
+         :ok <- ensure_not_support(actor),
          {:ok, _actor} <- Database.delete(actor, socket.assigns.subject) do
       {:noreply,
        socket
@@ -488,6 +496,14 @@ defmodule PortalWeb.Actors do
       {:error, :self_operation} ->
         {:noreply, put_flash(socket, :error, "You cannot delete yourself")}
 
+      {:error, :support_actor} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Firezone Support actors are removed by ending the support session"
+         )}
+
       {:error, _changeset} ->
         {:noreply, put_flash(socket, :error, "Failed to delete actor")}
     end
@@ -496,6 +512,7 @@ defmodule PortalWeb.Actors do
   def handle_event("disable", %{"id" => id}, socket) do
     with {:ok, actor} <- Database.get_actor(id, socket.assigns.subject),
          :ok <- ensure_not_self(actor, socket.assigns.subject),
+         :ok <- ensure_not_support(actor),
          {:ok, updated_actor} <-
            actor
            |> change()
@@ -518,6 +535,14 @@ defmodule PortalWeb.Actors do
       {:error, :self_operation} ->
         {:noreply, put_flash(socket, :error, "You cannot disable yourself")}
 
+      {:error, :support_actor} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Firezone Support actors are removed by ending the support session"
+         )}
+
       {:error, _changeset} ->
         {:noreply, put_flash(socket, :error, "Failed to disable actor")}
     end
@@ -525,6 +550,7 @@ defmodule PortalWeb.Actors do
 
   def handle_event("enable", %{"id" => id}, socket) do
     with {:ok, actor} <- Database.get_actor(id, socket.assigns.subject),
+         :ok <- ensure_not_support(actor),
          :ok <- Portal.Billing.check_actor_enable_limits(socket.assigns.account, actor) do
       case actor
            |> change()
@@ -553,6 +579,14 @@ defmodule PortalWeb.Actors do
 
       {:error, :admin_users_limit_reached} ->
         {:noreply, put_flash(socket, :error, "Admin user limit reached for your account")}
+
+      {:error, :support_actor} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Firezone Support actors are removed by ending the support session"
+         )}
     end
   end
 
@@ -766,7 +800,7 @@ defmodule PortalWeb.Actors do
   end
 
   def handle_info(%Change{op: :insert, struct: %Actor{type: type}}, socket)
-      when type in [:account_user, :account_admin_user] do
+      when type in [:account_user, :account_admin_user, :firezone_support] do
     {:noreply,
      update(socket, :actors_count, fn
        %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, ar.result + 1)
@@ -775,7 +809,7 @@ defmodule PortalWeb.Actors do
   end
 
   def handle_info(%Change{op: :delete, old_struct: %Actor{type: type}}, socket)
-      when type in [:account_user, :account_admin_user] do
+      when type in [:account_user, :account_admin_user, :firezone_support] do
     {:noreply,
      update(socket, :actors_count, fn
        %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, max(ar.result - 1, 0))
@@ -1212,6 +1246,10 @@ defmodule PortalWeb.Actors do
     if actor.id == subject.actor.id, do: {:error, :self_operation}, else: :ok
   end
 
+  defp ensure_not_support(actor) do
+    if actor.type == :firezone_support, do: {:error, :support_actor}, else: :ok
+  end
+
   # Changesets
   defp changeset(actor, attrs) do
     actor
@@ -1324,14 +1362,17 @@ defmodule PortalWeb.Actors do
 
     def count_actors(subject) do
       from(a in Actor, as: :actors)
-      |> where([actors: a], a.type in [:account_user, :account_admin_user])
+      |> where([actors: a], a.type in [:account_user, :account_admin_user, :firezone_support])
       |> Safe.scoped(subject)
       |> Safe.aggregate(:count)
     end
 
     defp index_query do
       from(actors in Actor, as: :actors)
-      |> where([actors: actors], actors.type in [:account_user, :account_admin_user])
+      |> where(
+        [actors: actors],
+        actors.type in [:account_user, :account_admin_user, :firezone_support]
+      )
     end
 
     def cursor_fields do

--- a/elixir/lib/portal_web/live/actors/components.ex
+++ b/elixir/lib/portal_web/live/actors/components.ex
@@ -127,7 +127,12 @@ defmodule PortalWeb.Actors.Components do
         </div>
         <%!-- Right: actions --%>
         <div class="flex items-center gap-1.5 shrink-0">
-          <.button type="button" phx-click="open_actor_edit_form" size="xs">
+          <.button
+            :if={not Portal.Actor.support?(@actor)}
+            type="button"
+            phx-click="open_actor_edit_form"
+            size="xs"
+          >
             <.icon name="ri-pencil-line" class="w-3.5 h-3.5" /> Edit
           </.button>
           <.icon_button icon="ri-close-line" title="Close (Esc)" phx-click="close_panel" />
@@ -923,7 +928,7 @@ defmodule PortalWeb.Actors.Components do
           <.action_button
             :if={
               !@actor.is_disabled and @actor.id != @subject.actor.id and
-                not @confirm_disable_actor
+                not @confirm_disable_actor and not Portal.Actor.support?(@actor)
             }
             style="warning"
             icon="ri-pause-line"
@@ -951,7 +956,7 @@ defmodule PortalWeb.Actors.Components do
             </div>
           </div>
           <.action_button
-            :if={@actor.is_disabled}
+            :if={@actor.is_disabled and not Portal.Actor.support?(@actor)}
             style="success"
             icon="ri-play-line"
             phx-click="enable"
@@ -962,8 +967,12 @@ defmodule PortalWeb.Actors.Components do
         </div>
       </section>
 
-      <div :if={@actor.id != @subject.actor.id} class="border-t border-border"></div>
-      <section :if={@actor.id != @subject.actor.id}>
+      <div
+        :if={@actor.id != @subject.actor.id and not Portal.Actor.support?(@actor)}
+        class="border-t border-border"
+      >
+      </div>
+      <section :if={@actor.id != @subject.actor.id and not Portal.Actor.support?(@actor)}>
         <h3 class="text-[10px] font-semibold tracking-widest uppercase text-error/60 mb-3">
           Danger Zone
         </h3>
@@ -1583,12 +1592,14 @@ defmodule PortalWeb.Actors.Components do
 
   defp actor_type_icon(assigns) do
     ~H"""
-    <%= case @actor.type do %>
-      <% :service_account -> %>
+    <%= cond do %>
+      <% Portal.Actor.support?(@actor) -> %>
+        <.icon name="ri-first-aid-kit-line" class={@class} />
+      <% @actor.type == :service_account -> %>
         <.icon name="ri-server-line" class={@class} />
-      <% :account_admin_user -> %>
+      <% @actor.type == :account_admin_user -> %>
         <.icon name="ri-shield-check-line" class={@class} />
-      <% _ -> %>
+      <% true -> %>
         <.icon name="ri-user-line" class={@class} />
     <% end %>
     """
@@ -1600,9 +1611,9 @@ defmodule PortalWeb.Actors.Components do
     ~H"""
     <div class={[
       "inline-flex items-center justify-center w-8 h-8 rounded-full",
-      actor_type_icon_bg_color(@actor.type)
+      actor_type_icon_bg_color(@actor)
     ]}>
-      <.actor_type_icon actor={@actor} class={"w-5 h-5 #{actor_type_icon_text_color(@actor.type)}"} />
+      <.actor_type_icon actor={@actor} class={"w-5 h-5 #{actor_type_icon_text_color(@actor)}"} />
     </div>
     """
   end
@@ -1614,9 +1625,9 @@ defmodule PortalWeb.Actors.Components do
     <div class="relative inline-flex shrink-0">
       <div class={[
         "inline-flex items-center justify-center w-8 h-8 rounded-full",
-        actor_type_icon_bg_color(@actor.type)
+        actor_type_icon_bg_color(@actor)
       ]}>
-        <.actor_type_icon actor={@actor} class={"w-5 h-5 #{actor_type_icon_text_color(@actor.type)}"} />
+        <.actor_type_icon actor={@actor} class={"w-5 h-5 #{actor_type_icon_text_color(@actor)}"} />
       </div>
       <span
         :if={@actor.identity_count > 0}
@@ -1634,7 +1645,7 @@ defmodule PortalWeb.Actors.Components do
     ~H"""
     <span class={[
       "inline-flex items-center gap-1 px-2 py-0.5 rounded-sm text-xs font-medium",
-      actor_type_badge_color(@actor.type)
+      actor_type_badge_color(@actor)
     ]}>
       <.actor_type_icon actor={@actor} class="w-3 h-3" />
       {actor_display_type(@actor)}
@@ -1642,22 +1653,43 @@ defmodule PortalWeb.Actors.Components do
     """
   end
 
-  defp actor_type_icon_bg_color(:service_account), do: "bg-blue-100"
-  defp actor_type_icon_bg_color(:account_admin_user), do: "bg-purple-100"
-  defp actor_type_icon_bg_color(_), do: "bg-neutral-100"
+  defp actor_type_icon_bg_color(actor) do
+    cond do
+      Portal.Actor.support?(actor) -> "bg-orange-100"
+      actor.type == :service_account -> "bg-blue-100"
+      actor.type == :account_admin_user -> "bg-purple-100"
+      true -> "bg-neutral-100"
+    end
+  end
 
-  defp actor_type_icon_text_color(:service_account), do: "text-blue-800"
-  defp actor_type_icon_text_color(:account_admin_user), do: "text-purple-800"
-  defp actor_type_icon_text_color(_), do: "text-neutral-800"
+  defp actor_type_icon_text_color(actor) do
+    cond do
+      Portal.Actor.support?(actor) -> "text-orange-800"
+      actor.type == :service_account -> "text-blue-800"
+      actor.type == :account_admin_user -> "text-purple-800"
+      true -> "text-neutral-800"
+    end
+  end
 
-  defp actor_type_badge_color(:service_account), do: "bg-blue-100 text-blue-800"
-  defp actor_type_badge_color(:account_admin_user), do: "bg-purple-100 text-purple-800"
-  defp actor_type_badge_color(_), do: "bg-neutral-100 text-neutral-800"
+  defp actor_type_badge_color(actor) do
+    cond do
+      Portal.Actor.support?(actor) -> "bg-orange-100 text-orange-800"
+      actor.type == :service_account -> "bg-blue-100 text-blue-800"
+      actor.type == :account_admin_user -> "bg-purple-100 text-purple-800"
+      true -> "bg-neutral-100 text-neutral-800"
+    end
+  end
 
-  defp actor_display_type(%{type: :service_account}), do: "Service Account"
-  defp actor_display_type(%{type: :account_admin_user}), do: "Admin"
-  defp actor_display_type(%{type: :account_user}), do: "User"
-  defp actor_display_type(_), do: "User"
+  defp actor_display_type(%{type: type} = actor) do
+    cond do
+      Portal.Actor.support?(actor) -> "Firezone Support"
+      type == :service_account -> "Service Account"
+      type == :account_admin_user -> "Admin"
+      true -> "User"
+    end
+  end
+
+  defp actor_display_type(_actor), do: "User"
 
   attr :device, :any, required: true
   attr :location, :string, default: nil

--- a/elixir/lib/portal_web/live/logs/change_logs.ex
+++ b/elixir/lib/portal_web/live/logs/change_logs.ex
@@ -423,6 +423,7 @@ defmodule PortalWeb.Logs.ChangeLogs do
       {"Entra directories", "entra_directories"},
       {"Email OTP auth providers", "email_otp_auth_providers"},
       {"External identities", "external_identities"},
+      {"Firezone Support auth providers", "firezone_support_auth_providers"},
       {"Gateway tokens", "gateway_tokens"},
       {"Google auth providers", "google_auth_providers"},
       {"Google directories", "google_directories"},

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -104,6 +104,14 @@ defmodule PortalWeb.Settings.Authentication do
      )}
   end
 
+  def handle_params(%{"type" => _type}, _url, %{assigns: %{live_action: :new}} = _socket) do
+    raise PortalWeb.LiveErrors.NotFoundError
+  end
+
+  def handle_params(%{"type" => _type}, _url, %{assigns: %{live_action: :edit}} = _socket) do
+    raise PortalWeb.LiveErrors.NotFoundError
+  end
+
   # Default handler
   def handle_params(_params, _url, socket) do
     {:noreply, clear_verification_state(socket)}

--- a/elixir/lib/portal_web/live/sign_in/support.ex
+++ b/elixir/lib/portal_web/live/sign_in/support.ex
@@ -1,0 +1,259 @@
+defmodule PortalWeb.SignIn.Support do
+  use PortalWeb, {:live_view, layout: {PortalWeb.Layouts, :auth}}
+  alias __MODULE__.Database
+
+  def mount(%{"account_id_or_slug" => account_id_or_slug} = params, session, socket) do
+    account = Database.get_account_by_id_or_slug(account_id_or_slug)
+
+    if is_nil(account) or is_nil(Database.get_active_support_provider(account)) do
+      raise PortalWeb.LiveErrors.NotFoundError
+    end
+
+    redirect_params = PortalWeb.Authentication.take_sign_in_params(params)
+
+    socket =
+      assign(socket,
+        account: account,
+        account_id_or_slug: account_id_or_slug,
+        redirect_params: redirect_params,
+        resent: params["resent"],
+        webauthn_error: nil,
+        page_title: "Firezone Support"
+      )
+
+    case check_stage(socket.assigns.live_action, session, account) do
+      :ok ->
+        {:ok, assign_stage(socket, session)}
+
+      :error ->
+        socket =
+          socket
+          |> put_flash(:error, "Please try to sign in again.")
+          |> redirect(to: ~p"/#{account_id_or_slug}/support?#{redirect_params}")
+
+        {:ok, socket}
+    end
+  end
+
+  def mount(_params, _session, _socket) do
+    raise PortalWeb.LiveErrors.NotFoundError
+  end
+
+  def render(%{live_action: :email} = assigns) do
+    ~H"""
+    <.flash flash={@flash} kind={:error} phx-click={JS.hide(transition: "fade-out")} />
+
+    <h1 class="text-xl font-semibold text-heading mb-2">
+      Firezone Support
+    </h1>
+    <p class="text-sm text-body mb-6">
+      This sign-in method is used by Firezone Support to securely access your account.
+    </p>
+
+    <.form
+      for={@form}
+      action={~p"/#{@account_id_or_slug}/support"}
+      id="support_email_form"
+      phx-update="ignore"
+      phx-hook="AttachDisableSubmit"
+      phx-submit={JS.dispatch("form:disable_and_submit", to: "#support_email_form")}
+    >
+      <.input :for={{key, value} <- @redirect_params} type="hidden" name={key} value={value} />
+      <div class="flex gap-2">
+        <input
+          type="email"
+          name="email[email]"
+          value={@form[:email].value}
+          placeholder="you@firezone.dev"
+          class="flex-1 px-3 py-2 text-sm rounded border bg-input border-input-border text-heading outline-none focus:border-border-focus focus:ring-1 focus:ring-border-focus/30 transition-colors placeholder:text-muted"
+          required
+        />
+        <button
+          type="submit"
+          class="px-4 py-2 rounded text-sm font-semibold bg-brand text-white hover:bg-brand-dark transition-colors whitespace-nowrap"
+        >
+          Send code →
+        </button>
+      </div>
+    </.form>
+    """
+  end
+
+  def render(%{live_action: :verify_otp} = assigns) do
+    ~H"""
+    <.flash flash={@flash} kind={:error} phx-click={JS.hide(transition: "fade-out")} />
+    <.flash flash={@flash} kind={:info} phx-click={JS.hide(transition: "fade-out")} />
+
+    <h1 class="text-xl font-semibold text-heading mb-2">
+      Check your email
+    </h1>
+    <p class="text-sm text-body mb-6">
+      If <strong class="text-heading">{@email}</strong>
+      is a registered support admin, a sign-in code has been sent.
+    </p>
+
+    <form
+      id="verify-support-code"
+      action={~p"/#{@account_id_or_slug}/support/verify"}
+      method="post"
+      phx-update="ignore"
+      phx-hook="AttachDisableSubmit"
+      phx-submit={JS.dispatch("form:disable_and_submit", to: "#verify-support-code")}
+    >
+      <input type="hidden" name="_csrf_token" value={Plug.CSRFProtection.get_csrf_token()} />
+      <.input :for={{key, value} <- @redirect_params} type="hidden" name={key} value={value} />
+
+      <div id="pin-input" phx-hook="PINInput" phx-update="ignore" class="flex gap-3 justify-center mb-6">
+        <input
+          :for={i <- 0..5}
+          data-pin-index={i}
+          type="text"
+          maxlength="1"
+          inputmode="text"
+          autocomplete="off"
+          class="w-12 h-14 text-center text-xl font-semibold rounded-md border bg-input border-input-border text-heading outline-none focus:border-border-focus focus:ring-2 focus:ring-border-focus/30 transition-colors uppercase"
+        />
+        <input type="hidden" name="secret" id="secret" />
+      </div>
+
+      <button
+        type="submit"
+        class="w-full px-3 py-2.5 rounded-md text-sm font-medium bg-brand text-white hover:bg-brand-dark transition-colors"
+      >
+        Verify code
+      </button>
+    </form>
+
+    <div class="mt-4">
+      <.form
+        for={%{}}
+        id="resend-support-email"
+        as={:email}
+        action={~p"/#{@account_id_or_slug}/support?resend=true"}
+        method="post"
+      >
+        <.input type="hidden" name="email[email]" value={@email} />
+        <.input :for={{key, value} <- @redirect_params} type="hidden" name={key} value={value} />
+        <button
+          type="submit"
+          class="relative w-full flex items-center justify-center px-4 py-2.5 rounded-md border border-border-strong bg-surface hover:bg-raised transition-colors text-sm font-medium text-heading"
+        >
+          <.icon name="ri-loop-left-line" class="absolute left-4 w-4 h-4 text-body" />
+          Resend email
+        </button>
+      </.form>
+    </div>
+    """
+  end
+
+  def render(%{live_action: :passkey} = assigns) do
+    ~H"""
+    <.flash flash={@flash} kind={:error} phx-click={JS.hide(transition: "fade-out")} />
+
+    <h1 class="text-xl font-semibold text-heading mb-2">
+      Verify your passkey
+    </h1>
+    <p class="text-sm text-body mb-6">
+      Complete sign-in for <strong class="text-heading">{@email}</strong> with your passkey.
+    </p>
+
+    <p :if={@webauthn_error} class="text-sm text-red-600 dark:text-red-400 mb-6">
+      {@webauthn_error}
+    </p>
+
+    <form id="support-passkey-form" action={~p"/#{@account_id_or_slug}/support/complete"} method="post">
+      <input type="hidden" name="_csrf_token" value={Plug.CSRFProtection.get_csrf_token()} />
+      <.input :for={{key, value} <- @redirect_params} type="hidden" name={key} value={value} />
+      <input type="hidden" name="credential_id" value="" />
+      <input type="hidden" name="authenticator_data" value="" />
+      <input type="hidden" name="signature" value="" />
+      <input type="hidden" name="client_data_json" value="" />
+    </form>
+
+    <button
+      id="webauthn-authenticate"
+      type="button"
+      phx-hook="WebAuthnAuthenticate"
+      phx-update="ignore"
+      data-challenge={@challenge_bytes}
+      data-credential-id={@credential_id}
+      data-rp-id={@rp_id}
+      data-form-id="support-passkey-form"
+      class="w-full px-3 py-2.5 rounded-md text-sm font-medium bg-brand text-white hover:bg-brand-dark transition-colors"
+    >
+      Use passkey
+    </button>
+    """
+  end
+
+  def handle_event("webauthn_error", %{"error" => error}, socket) do
+    {:noreply, assign(socket, webauthn_error: webauthn_error_message(error))}
+  end
+
+  defp check_stage(:email, _session, _account), do: :ok
+
+  defp check_stage(:verify_otp, session, account) do
+    if session["support_stage"] == "otp" and session["support_account_id"] == account.id do
+      :ok
+    else
+      :error
+    end
+  end
+
+  defp check_stage(:passkey, session, account) do
+    if session["support_stage"] == "passkey" and session["support_account_id"] == account.id and
+         is_binary(session["support_challenge_bytes"]) do
+      :ok
+    else
+      :error
+    end
+  end
+
+  defp assign_stage(%{assigns: %{live_action: :email}} = socket, _session) do
+    assign(socket, form: to_form(%{"email" => nil}, as: "email"))
+  end
+
+  defp assign_stage(%{assigns: %{live_action: :verify_otp}} = socket, session) do
+    assign(socket, email: session["support_email"])
+  end
+
+  defp assign_stage(%{assigns: %{live_action: :passkey}} = socket, session) do
+    assign(socket,
+      email: session["support_email"],
+      challenge_bytes: session["support_challenge_bytes"],
+      credential_id: session["support_credential_id"],
+      rp_id: Portal.Crypto.WebAuthn.rp_id()
+    )
+  end
+
+  defp webauthn_error_message("unsupported"), do: "This browser doesn't support passkeys."
+
+  defp webauthn_error_message("NotAllowedError"),
+    do: "Passkey verification was cancelled or timed out. Try again."
+
+  defp webauthn_error_message(_other), do: "Passkey verification failed. Try again."
+
+  defmodule Database do
+    import Ecto.Query
+    alias Portal.Safe
+    alias Portal.{Account, FirezoneSupport}
+
+    def get_account_by_id_or_slug(id_or_slug) do
+      query =
+        if Portal.Repo.valid_uuid?(id_or_slug),
+          do: from(a in Account, where: a.id == ^id_or_slug or a.slug == ^id_or_slug),
+          else: from(a in Account, where: a.slug == ^id_or_slug)
+
+      query |> Safe.unscoped() |> Safe.one()
+    end
+
+    def get_active_support_provider(account) do
+      from(p in FirezoneSupport.AuthProvider,
+        where: p.account_id == ^account.id,
+        where: p.expires_at > ^DateTime.utc_now()
+      )
+      |> Safe.unscoped()
+      |> Safe.one()
+    end
+  end
+end

--- a/elixir/lib/portal_web/live/support_admin_registration.ex
+++ b/elixir/lib/portal_web/live/support_admin_registration.ex
@@ -1,0 +1,177 @@
+defmodule PortalWeb.SupportAdminRegistration do
+  use PortalWeb, {:live_view, layout: {PortalWeb.Layouts, :auth}}
+  alias __MODULE__.Database
+
+  def mount(%{"token" => token}, _session, socket) do
+    token_hash = Portal.Crypto.hash(:sha256, token)
+
+    case Database.fetch_admin_by_registration_token(token_hash) do
+      nil ->
+        raise PortalWeb.LiveErrors.NotFoundError
+
+      support_admin ->
+        socket =
+          assign(socket,
+            support_admin: support_admin,
+            token_hash: token_hash,
+            challenge: Portal.Crypto.WebAuthn.registration_challenge(),
+            state: :ready,
+            error: nil,
+            page_title: "Register Passkey"
+          )
+
+        {:ok, socket}
+    end
+  end
+
+  def mount(_params, _session, _socket) do
+    raise PortalWeb.LiveErrors.NotFoundError
+  end
+
+  def render(assigns) do
+    ~H"""
+    <h1 class="text-xl font-semibold text-heading mb-2">
+      Firezone Support passkey
+    </h1>
+
+    <div :if={@state == :success}>
+      <p class="text-sm text-body mb-6">
+        Passkey registered for <strong class="text-heading">{@support_admin.email}</strong>.
+        You're now enabled for support sign-in. You can close this tab.
+      </p>
+    </div>
+
+    <div :if={@state == :ready}>
+      <p class="text-sm text-body mb-6">
+        Register a passkey for <strong class="text-heading">{@support_admin.email}</strong>
+        to enable support sign-in.
+      </p>
+
+      <p :if={@support_admin.passkey_registered_at} class="text-sm text-body mb-6">
+        A passkey is already registered for this address. Completing this registration
+        replaces it.
+      </p>
+
+      <p :if={@error} class="text-sm text-red-600 dark:text-red-400 mb-6">
+        {@error}
+      </p>
+
+      <button
+        id="webauthn-register"
+        type="button"
+        phx-hook="WebAuthnRegister"
+        phx-update="ignore"
+        data-challenge={Base.url_encode64(@challenge.bytes, padding: false)}
+        data-rp-id={@challenge.rp_id}
+        data-rp-name="Firezone"
+        data-user-id={Base.url_encode64(@support_admin.id, padding: false)}
+        data-user-name={@support_admin.email}
+        class="w-full px-3 py-2.5 rounded-md text-sm font-medium bg-brand text-white hover:bg-brand-dark transition-colors"
+      >
+        <%= if @support_admin.passkey_registered_at do %>
+          Replace passkey
+        <% else %>
+          Create passkey
+        <% end %>
+      </button>
+    </div>
+    """
+  end
+
+  def handle_event("verify_registration", params, socket) do
+    %{
+      "attestation_object" => attestation_object,
+      "client_data_json" => client_data_json
+    } = params
+
+    with {:ok, attestation_object} <- Base.url_decode64(attestation_object, padding: false),
+         {:ok, client_data_json} <- Base.url_decode64(client_data_json, padding: false),
+         {:ok, passkey} <-
+           Portal.Crypto.WebAuthn.verify_registration(
+             socket.assigns.challenge,
+             attestation_object,
+             client_data_json
+           ),
+         :ok <-
+           Database.complete_registration(
+             socket.assigns.support_admin,
+             socket.assigns.token_hash,
+             passkey
+           ) do
+      {:noreply, assign(socket, state: :success, error: nil)}
+    else
+      {:error, :stale_token} ->
+        raise PortalWeb.LiveErrors.NotFoundError
+
+      _other ->
+        socket =
+          assign(socket,
+            challenge: Portal.Crypto.WebAuthn.registration_challenge(),
+            error: "Passkey registration failed. Try again."
+          )
+
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("registration_failed", %{"error" => error}, socket) do
+    socket =
+      assign(socket,
+        challenge: Portal.Crypto.WebAuthn.registration_challenge(),
+        error: registration_error_message(error)
+      )
+
+    {:noreply, socket}
+  end
+
+  defp registration_error_message("unsupported"), do: "This browser doesn't support passkeys."
+
+  defp registration_error_message("NotAllowedError"),
+    do: "Passkey registration was cancelled or timed out. Try again."
+
+  defp registration_error_message("InvalidStateError"),
+    do: "This device already has a passkey registered for this address."
+
+  defp registration_error_message(_other), do: "Passkey registration failed. Try again."
+
+  defmodule Database do
+    import Ecto.Query
+    alias Portal.Safe
+    alias Portal.SupportAdmin
+
+    def fetch_admin_by_registration_token(token_hash) do
+      from(sa in SupportAdmin,
+        where: sa.registration_token_hash == ^token_hash,
+        where: sa.registration_token_expires_at > ^DateTime.utc_now()
+      )
+      |> Safe.unscoped()
+      |> Safe.one()
+    end
+
+    def complete_registration(%SupportAdmin{} = support_admin, token_hash, passkey) do
+      from(sa in SupportAdmin,
+        where: sa.id == ^support_admin.id,
+        where: sa.registration_token_hash == ^token_hash,
+        update: [
+          set: [
+            passkey_credential_id: ^passkey.credential_id,
+            passkey_public_key: ^passkey.public_key,
+            passkey_sign_count: ^passkey.sign_count,
+            passkey_registered_at: ^DateTime.utc_now(),
+            registration_token_hash: nil,
+            registration_token_expires_at: nil,
+            otp_code_hash: nil,
+            otp_expires_at: nil,
+            otp_attempts: 0
+          ]
+        ]
+      )
+      |> Safe.unscoped()
+      |> Safe.update_all([])
+      |> case do
+        {1, _} -> :ok
+        {0, _} -> {:error, :stale_token}
+      end
+    end
+  end
+end

--- a/elixir/lib/portal_web/live_hooks/ensure_admin.ex
+++ b/elixir/lib/portal_web/live_hooks/ensure_admin.ex
@@ -6,8 +6,9 @@ defmodule PortalWeb.LiveHooks.EnsureAdmin do
         :default,
         _params,
         _session,
-        %{assigns: %{subject: %Subject{actor: %Actor{type: :account_admin_user}}}} = socket
-      ) do
+        %{assigns: %{subject: %Subject{actor: %Actor{type: type}}}} = socket
+      )
+      when type in [:account_admin_user, :firezone_support] do
     {:cont, socket}
   end
 

--- a/elixir/lib/portal_web/plugs/ensure_admin.ex
+++ b/elixir/lib/portal_web/plugs/ensure_admin.ex
@@ -12,10 +12,11 @@ defmodule PortalWeb.Plugs.EnsureAdmin do
   @impl true
   def call(
         %Plug.Conn{
-          assigns: %{subject: %Subject{actor: %Actor{type: :account_admin_user}}}
+          assigns: %{subject: %Subject{actor: %Actor{type: type}}}
         } = conn,
         _opts
-      ) do
+      )
+      when type in [:account_admin_user, :firezone_support] do
     conn
   end
 

--- a/elixir/lib/portal_web/router.ex
+++ b/elixir/lib/portal_web/router.ex
@@ -99,6 +99,18 @@ defmodule PortalWeb.Router do
     get "/entra", VerificationController, :entra
   end
 
+  scope "/support_admin", PortalWeb do
+    pipe_through :public
+
+    live_session :support_admin_registration,
+      on_mount: [
+        PortalWeb.LiveHooks.PutDynamicRepo,
+        PortalWeb.LiveHooks.AllowEctoSandbox
+      ] do
+      live "/register/:token", SupportAdminRegistration
+    end
+  end
+
   # Legacy OIDC callback - must be outside RedirectIfAuthenticated scope
   # because IdP redirects don't include as=client param
   scope "/:account_id_or_slug", PortalWeb do
@@ -133,6 +145,11 @@ defmodule PortalWeb.Router do
     # Userpass auth entry point
     post "/sign_in/userpass/:auth_provider_id", UserpassController, :sign_in
 
+    # Firezone Support auth entry point
+    post "/support", SupportController, :sign_in
+    post "/support/verify", SupportController, :verify_otp
+    post "/support/complete", SupportController, :complete
+
     live_session :redirect_if_user_is_authenticated,
       on_mount: [
         PortalWeb.LiveHooks.PutDynamicRepo,
@@ -166,6 +183,20 @@ defmodule PortalWeb.Router do
         PortalWeb.LiveHooks.RedirectIfAuthenticated
       ] do
       live "/sign_in/oidc/:auth_provider_id/verify_identity", SignIn.Email, :pending_identity
+    end
+
+    live_session :support_sign_in,
+      session: {PortalWeb.Cookie.Support, :fetch_state, []},
+      on_mount: [
+        PortalWeb.LiveHooks.PutDynamicRepo,
+        PortalWeb.LiveHooks.AllowEctoSandbox,
+        PortalWeb.LiveHooks.FetchAccount,
+        PortalWeb.LiveHooks.FetchSubject,
+        PortalWeb.LiveHooks.RedirectIfAuthenticated
+      ] do
+      live "/support", SignIn.Support, :email
+      live "/support/verify", SignIn.Support, :verify_otp
+      live "/support/passkey", SignIn.Support, :passkey
     end
 
     # OIDC auth entry point (placed after LiveView routes to avoid conflicts)
@@ -204,6 +235,9 @@ defmodule PortalWeb.Router do
       PortalWeb.Plugs.EnsureAuthenticated,
       PortalWeb.Plugs.EnsureAdmin
     ]
+
+    post "/support_request", SupportRequestController, :create
+    post "/support_request/end", SupportRequestController, :end_support
 
     live_session :ensure_authenticated,
       on_mount: [

--- a/elixir/priv/repo/migrations/20260804120000_create_support_admins.exs
+++ b/elixir/priv/repo/migrations/20260804120000_create_support_admins.exs
@@ -1,0 +1,38 @@
+defmodule Portal.Repo.Migrations.CreateSupportAdmins do
+  use Ecto.Migration
+
+  def change do
+    create table(:support_admins, primary_key: false) do
+      add(:id, :binary_id, null: false, primary_key: true)
+      add(:email, :citext, null: false)
+      add(:passkey_credential_id, :binary)
+      add(:passkey_public_key, :binary)
+      add(:passkey_sign_count, :bigint, default: 0, null: false)
+      add(:passkey_registered_at, :timestamptz)
+      add(:registration_token_hash, :string)
+      add(:registration_token_expires_at, :timestamptz)
+      add(:otp_code_hash, :string)
+      add(:otp_expires_at, :timestamptz)
+      add(:otp_attempts, :integer, default: 0, null: false)
+      add(:challenge_hash, :string)
+
+      timestamps()
+    end
+
+    create_if_not_exists(
+      index(:support_admins, [:email], name: :support_admins_email_index, unique: true)
+    )
+
+    create_if_not_exists(
+      index(:support_admins, [:passkey_credential_id],
+        name: :support_admins_passkey_credential_id_index,
+        unique: true,
+        where: "passkey_credential_id IS NOT NULL"
+      )
+    )
+
+    create(
+      constraint(:support_admins, :email_must_be_firezone, check: "email LIKE '%@firezone.dev'")
+    )
+  end
+end

--- a/elixir/priv/repo/migrations/20260804120000_create_support_admins.exs
+++ b/elixir/priv/repo/migrations/20260804120000_create_support_admins.exs
@@ -32,7 +32,9 @@ defmodule Portal.Repo.Migrations.CreateSupportAdmins do
     )
 
     create(
-      constraint(:support_admins, :email_must_be_firezone, check: "email LIKE '%@firezone.dev'")
+      constraint(:support_admins, :email_must_be_firezone_support,
+        check: "email LIKE '%+firezone-support@firezone.dev'"
+      )
     )
   end
 end

--- a/elixir/priv/repo/migrations/20260804120001_widen_auth_providers_type_constraint.exs
+++ b/elixir/priv/repo/migrations/20260804120001_widen_auth_providers_type_constraint.exs
@@ -1,0 +1,24 @@
+defmodule Portal.Repo.Migrations.WidenAuthProvidersTypeConstraint do
+  use Ecto.Migration
+
+  def up do
+    drop(constraint(:auth_providers, :type_must_be_valid))
+
+    create(
+      constraint(:auth_providers, :type_must_be_valid,
+        check:
+          "type IN ('google', 'entra', 'okta', 'email_otp', 'oidc', 'userpass', 'firezone_support')"
+      )
+    )
+  end
+
+  def down do
+    drop(constraint(:auth_providers, :type_must_be_valid))
+
+    create(
+      constraint(:auth_providers, :type_must_be_valid,
+        check: "type IN ('google', 'entra', 'okta', 'email_otp', 'oidc', 'userpass')"
+      )
+    )
+  end
+end

--- a/elixir/priv/repo/migrations/20260804120002_create_firezone_support_auth_providers.exs
+++ b/elixir/priv/repo/migrations/20260804120002_create_firezone_support_auth_providers.exs
@@ -1,0 +1,36 @@
+defmodule Portal.Repo.Migrations.CreateFirezoneSupportAuthProviders do
+  use Ecto.Migration
+
+  def change do
+    create table(:firezone_support_auth_providers, primary_key: false) do
+      add(:account_id, references(:accounts, type: :binary_id, on_delete: :delete_all),
+        null: false
+      )
+
+      add(
+        :id,
+        references(:auth_providers,
+          column: :id,
+          with: [account_id: :account_id],
+          type: :binary_id,
+          on_delete: :delete_all
+        ),
+        null: false,
+        primary_key: true
+      )
+
+      add(:expires_at, :timestamptz, null: false)
+
+      timestamps()
+    end
+
+    create_if_not_exists(
+      index(:firezone_support_auth_providers, [:account_id],
+        name: :firezone_support_auth_providers_account_id_index,
+        unique: true
+      )
+    )
+
+    create_if_not_exists(index(:firezone_support_auth_providers, [:expires_at]))
+  end
+end

--- a/elixir/priv/repo/migrations/20260804120003_widen_actors_type_constraint.exs
+++ b/elixir/priv/repo/migrations/20260804120003_widen_actors_type_constraint.exs
@@ -1,0 +1,30 @@
+defmodule Portal.Repo.Migrations.WidenActorsTypeConstraint do
+  use Ecto.Migration
+
+  def up do
+    drop(constraint(:actors, :type_is_valid))
+
+    create(
+      constraint(:actors, :type_is_valid,
+        check: """
+          (type IN ('account_user', 'account_admin_user') AND email IS NOT NULL)
+          OR (type = 'firezone_support' AND email LIKE '%+firezone-support@firezone.dev')
+          OR (type IN ('service_account', 'api_client') AND email IS NULL)
+        """
+      )
+    )
+  end
+
+  def down do
+    drop(constraint(:actors, :type_is_valid))
+
+    create(
+      constraint(:actors, :type_is_valid,
+        check: """
+          (type IN ('account_user', 'account_admin_user') AND email IS NOT NULL)
+          OR (type IN ('service_account', 'api_client') AND email IS NULL)
+        """
+      )
+    )
+  end
+end

--- a/elixir/test/portal/actor_test.exs
+++ b/elixir/test/portal/actor_test.exs
@@ -268,4 +268,105 @@ defmodule Portal.ActorTest do
       assert Actor.email_meaningfully_changed?(changeset)
     end
   end
+
+  describe "support email helpers" do
+    test "support_email/1 tags the local part" do
+      assert Actor.support_email("thomas@firezone.dev") ==
+               "thomas+firezone-support@firezone.dev"
+    end
+
+    test "support_email/1 handles emails that already carry a plus tag" do
+      assert Actor.support_email("thomas+x@firezone.dev") ==
+               "thomas+x+firezone-support@firezone.dev"
+    end
+
+    test "support?/1 matches actors by type and emails by suffix" do
+      assert Actor.support?(%Actor{type: :firezone_support})
+      refute Actor.support?(%Actor{type: :account_admin_user})
+      assert Actor.support?("thomas+firezone-support@firezone.dev")
+      assert Actor.support?("Thomas+Firezone-Support@Firezone.DEV")
+      refute Actor.support?("thomas@firezone.dev")
+      refute Actor.support?(nil)
+    end
+  end
+
+  describe "changeset/1 firezone_support type protection" do
+    test "rejects creating an actor with the firezone_support type" do
+      changeset =
+        build_changeset(%{
+          name: "Sneaky",
+          type: :firezone_support,
+          email: "someone@example.com"
+        })
+
+      assert "is reserved" in errors_on(changeset).type
+    end
+
+    test "rejects transitioning an actor to firezone_support" do
+      changeset =
+        %Actor{type: :account_admin_user, name: "Alice"}
+        |> cast(%{type: :firezone_support}, [:type])
+        |> Actor.changeset()
+
+      assert "is reserved" in errors_on(changeset).type
+    end
+
+    test "rejects any modification of a firezone_support actor" do
+      changeset =
+        %Actor{type: :firezone_support, name: "Firezone Support"}
+        |> cast(%{name: "Renamed"}, [:name])
+        |> Actor.changeset()
+
+      assert "Firezone Support actors cannot be modified" in errors_on(changeset).type
+    end
+
+    test "database rejects firezone_support actors without the reserved email" do
+      account = account_fixture()
+
+      assert_raise Ecto.ConstraintError, ~r/type_is_valid/, fn ->
+        %Actor{
+          account_id: account.id,
+          type: :firezone_support,
+          name: "Firezone Support",
+          email: "untagged@firezone.dev"
+        }
+        |> Portal.Repo.insert!()
+      end
+    end
+  end
+
+  describe "changeset/1 reserved support suffix" do
+    test "rejects creating an actor with the reserved suffix" do
+      changeset =
+        build_changeset(%{
+          name: "Sneaky",
+          type: :account_user,
+          email: "someone+firezone-support@firezone.dev"
+        })
+
+      assert "is reserved" in errors_on(changeset).email
+    end
+
+    test "rejects updating an actor email into the reserved suffix" do
+      actor = actor_fixture(type: :account_user)
+
+      changeset =
+        actor
+        |> cast(%{email: "someone+firezone-support@firezone.dev"}, [:email])
+        |> Actor.changeset()
+
+      assert "is reserved" in errors_on(changeset).email
+    end
+
+    test "allows regular firezone.dev emails" do
+      changeset =
+        build_changeset(%{
+          name: "Staff",
+          type: :account_user,
+          email: "someone@firezone.dev"
+        })
+
+      refute errors_on(changeset)[:email]
+    end
+  end
 end

--- a/elixir/test/portal/authentication/support_admin_otp_test.exs
+++ b/elixir/test/portal/authentication/support_admin_otp_test.exs
@@ -1,0 +1,142 @@
+defmodule Portal.Authentication.SupportAdminOTPTest do
+  use Portal.DataCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.AuthProviderFixtures
+  import Portal.SupportAdminFixtures
+
+  alias Portal.Authentication
+  alias Portal.SupportAdmin
+
+  describe "create_support_admin_otp/1" do
+    test "creates an OTP for a registered support admin" do
+      {support_admin, _authenticator} = registered_support_admin_fixture()
+
+      assert {:ok, updated} = Authentication.create_support_admin_otp(support_admin.email)
+      assert is_binary(updated.otp_code)
+      assert String.length(updated.otp_code) == 6
+      assert updated.otp_attempts == 0
+      assert DateTime.after?(updated.otp_expires_at, DateTime.utc_now())
+      assert Portal.Crypto.equal?(:argon2, updated.otp_code, updated.otp_code_hash)
+    end
+
+    test "returns an error for an unknown email" do
+      assert {:error, :not_found} =
+               Authentication.create_support_admin_otp("unknown@firezone.dev")
+    end
+
+    test "returns an error when no passkey is registered" do
+      support_admin = support_admin_fixture()
+
+      assert {:error, :not_found} = Authentication.create_support_admin_otp(support_admin.email)
+    end
+  end
+
+  describe "verify_support_admin_otp/2" do
+    setup do
+      {support_admin, _authenticator} = registered_support_admin_fixture()
+      {:ok, support_admin} = Authentication.create_support_admin_otp(support_admin.email)
+      %{support_admin: support_admin}
+    end
+
+    test "verifies a valid code and clears OTP state", %{support_admin: support_admin} do
+      assert {:ok, verified} =
+               Authentication.verify_support_admin_otp(
+                 support_admin.email,
+                 support_admin.otp_code
+               )
+
+      assert verified.email == support_admin.email
+
+      reloaded = Portal.Repo.get!(SupportAdmin, support_admin.id)
+      assert is_nil(reloaded.otp_code_hash)
+      assert is_nil(reloaded.otp_expires_at)
+      assert reloaded.otp_attempts == 0
+    end
+
+    test "rejects a wrong code and counts the attempt", %{support_admin: support_admin} do
+      assert {:error, :invalid_code} =
+               Authentication.verify_support_admin_otp(support_admin.email, "wrong1")
+
+      reloaded = Portal.Repo.get!(SupportAdmin, support_admin.id)
+      assert reloaded.otp_attempts == 1
+    end
+
+    test "clears the OTP after three failed attempts", %{support_admin: support_admin} do
+      for _attempt <- 1..3 do
+        assert {:error, :invalid_code} =
+                 Authentication.verify_support_admin_otp(support_admin.email, "wrong1")
+      end
+
+      reloaded = Portal.Repo.get!(SupportAdmin, support_admin.id)
+      assert is_nil(reloaded.otp_code_hash)
+
+      assert {:error, :invalid_code} =
+               Authentication.verify_support_admin_otp(
+                 support_admin.email,
+                 support_admin.otp_code
+               )
+    end
+
+    test "rejects an expired code", %{support_admin: support_admin} do
+      Portal.Repo.get!(SupportAdmin, support_admin.id)
+      |> Ecto.Changeset.change(otp_expires_at: DateTime.add(DateTime.utc_now(), -60, :second))
+      |> Portal.Repo.update!()
+
+      assert {:error, :invalid_code} =
+               Authentication.verify_support_admin_otp(
+                 support_admin.email,
+                 support_admin.otp_code
+               )
+    end
+
+    test "rejects an unknown email" do
+      assert {:error, :invalid_code} =
+               Authentication.verify_support_admin_otp("unknown@firezone.dev", "abc123")
+    end
+  end
+
+  describe "fetch_portal_session/2 with a support provider" do
+    setup do
+      account = account_fixture()
+      provider = firezone_support_provider_fixture(account: account)
+      actor = support_actor_fixture(account: account)
+
+      context = %Authentication.Context{
+        type: :portal,
+        user_agent: "Test 1.0",
+        remote_ip: {127, 0, 0, 1}
+      }
+
+      {:ok, session} =
+        Authentication.create_portal_session(
+          actor,
+          provider.id,
+          context,
+          DateTime.add(DateTime.utc_now(), 3_600, :second)
+        )
+
+      %{account: account, provider: provider, session: session}
+    end
+
+    test "fetches a session while the provider is active", %{
+      account: account,
+      session: session
+    } do
+      assert {:ok, _session} = Authentication.fetch_portal_session(account.id, session.id)
+    end
+
+    test "rejects the session once the provider window has lapsed", %{
+      account: account,
+      provider: provider,
+      session: session
+    } do
+      Portal.Repo.get_by!(Portal.FirezoneSupport.AuthProvider, id: provider.id)
+      |> Ecto.Changeset.change(expires_at: DateTime.add(DateTime.utc_now(), -60, :second))
+      |> Portal.Repo.update!()
+
+      assert {:error, :not_found} = Authentication.fetch_portal_session(account.id, session.id)
+    end
+  end
+end

--- a/elixir/test/portal/billing/support_actor_exclusion_test.exs
+++ b/elixir/test/portal/billing/support_actor_exclusion_test.exs
@@ -1,0 +1,51 @@
+defmodule Portal.Billing.SupportActorExclusionTest do
+  use Portal.DataCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+
+  alias Portal.Billing
+
+  setup do
+    account = account_fixture()
+    {:ok, account: account}
+  end
+
+  test "support actors are excluded from the user count", %{account: account} do
+    actor_fixture(account: account, type: :account_user)
+    support_actor_fixture(account: account)
+
+    assert Billing.Database.count_users_for_account(account) == 1
+  end
+
+  test "support actors are excluded from the admin count", %{account: account} do
+    actor_fixture(account: account, type: :account_admin_user)
+    support_actor_fixture(account: account)
+
+    assert Billing.Database.count_account_admin_users_for_account(account) == 1
+  end
+
+  test "support actors are excluded from the MAU count", %{account: account} do
+    actor = actor_fixture(account: account, type: :account_user)
+    support_actor = support_actor_fixture(account: account)
+
+    for owner <- [actor, support_actor] do
+      Portal.DeviceFixtures.client_fixture(account: account, actor: owner)
+      |> Ecto.Changeset.change(last_seen_at: DateTime.utc_now())
+      |> Portal.Repo.update!()
+    end
+
+    assert Billing.Database.count_1m_active_users_for_account(account) == 1
+  end
+
+  test "support actors are excluded from ops admin email recipients", %{account: account} do
+    admin = actor_fixture(account: account, type: :account_admin_user)
+    support_actor_fixture(account: account)
+
+    emails =
+      Portal.Ops.Database.get_account_admin_emails_by_account([account.id])
+      |> Map.get(account.id, [])
+
+    assert emails == [admin.email]
+  end
+end

--- a/elixir/test/portal/crypto/web_authn_test.exs
+++ b/elixir/test/portal/crypto/web_authn_test.exs
@@ -1,0 +1,243 @@
+defmodule Portal.Crypto.WebAuthnTest do
+  use Portal.DataCase, async: true
+
+  import Portal.WebAuthnFixtures
+
+  describe "verify_registration/3" do
+    test "accepts a registration from the software authenticator" do
+      authenticator = generate_authenticator()
+      challenge = Portal.Crypto.WebAuthn.registration_challenge()
+      response = registration_response(authenticator, challenge)
+
+      assert {:ok, passkey} =
+               Portal.Crypto.WebAuthn.verify_registration(
+                 challenge,
+                 response.attestation_object,
+                 response.client_data_json
+               )
+
+      assert passkey.credential_id == authenticator.credential_id
+      assert Portal.Crypto.WebAuthn.decode_cose_key(passkey.public_key) == authenticator.cose_key
+      assert passkey.sign_count == 0
+    end
+
+    test "rejects a registration against a different challenge" do
+      authenticator = generate_authenticator()
+      challenge = Portal.Crypto.WebAuthn.registration_challenge()
+      other_challenge = Portal.Crypto.WebAuthn.registration_challenge()
+      response = registration_response(authenticator, other_challenge)
+
+      assert {:error, _reason} =
+               Portal.Crypto.WebAuthn.verify_registration(
+                 challenge,
+                 response.attestation_object,
+                 response.client_data_json
+               )
+    end
+  end
+
+  describe "hardening checks" do
+    test "rejects a registration without user verification" do
+      authenticator = generate_authenticator()
+      challenge = Portal.Crypto.WebAuthn.registration_challenge()
+      response = registration_response(authenticator, challenge, flags: 0x41)
+
+      assert {:error, :invalid_registration} =
+               Portal.Crypto.WebAuthn.verify_registration(
+                 challenge,
+                 response.attestation_object,
+                 response.client_data_json
+               )
+    end
+
+    test "rejects an assertion without user verification" do
+      authenticator = generate_authenticator()
+
+      challenge =
+        Portal.Crypto.WebAuthn.authentication_challenge(
+          authenticator.credential_id,
+          authenticator.cose_key
+        )
+
+      assertion = assertion_response(authenticator, challenge, flags: 0x01)
+
+      assert {:error, :invalid_assertion} =
+               Portal.Crypto.WebAuthn.verify_authentication(
+                 assertion.credential_id,
+                 assertion.authenticator_data,
+                 assertion.signature,
+                 assertion.client_data_json,
+                 challenge
+               )
+    end
+
+    test "rejects backed-up credentials that are not backup eligible" do
+      authenticator = generate_authenticator()
+
+      challenge =
+        Portal.Crypto.WebAuthn.authentication_challenge(
+          authenticator.credential_id,
+          authenticator.cose_key
+        )
+
+      assertion = assertion_response(authenticator, challenge, flags: 0x15)
+
+      assert {:error, :invalid_assertion} =
+               Portal.Crypto.WebAuthn.verify_authentication(
+                 assertion.credential_id,
+                 assertion.authenticator_data,
+                 assertion.signature,
+                 assertion.client_data_json,
+                 challenge
+               )
+    end
+
+    test "rejects a cross-origin assertion" do
+      authenticator = generate_authenticator()
+
+      challenge =
+        Portal.Crypto.WebAuthn.authentication_challenge(
+          authenticator.credential_id,
+          authenticator.cose_key
+        )
+
+      client_data_json =
+        JSON.encode!(%{
+          "type" => "webauthn.get",
+          "challenge" => Base.url_encode64(challenge.bytes, padding: false),
+          "origin" => challenge.origin,
+          "crossOrigin" => true
+        })
+
+      assertion = assertion_response(authenticator, challenge, client_data_json: client_data_json)
+
+      assert {:error, :invalid_assertion} =
+               Portal.Crypto.WebAuthn.verify_authentication(
+                 assertion.credential_id,
+                 assertion.authenticator_data,
+                 assertion.signature,
+                 assertion.client_data_json,
+                 challenge
+               )
+    end
+
+    test "rejects oversized credential ids" do
+      authenticator =
+        generate_authenticator()
+        |> Map.put(:credential_id, :crypto.strong_rand_bytes(1200))
+
+      challenge = Portal.Crypto.WebAuthn.registration_challenge()
+      response = registration_response(authenticator, challenge)
+
+      assert {:error, :invalid_registration} =
+               Portal.Crypto.WebAuthn.verify_registration(
+                 challenge,
+                 response.attestation_object,
+                 response.client_data_json
+               )
+    end
+  end
+
+  describe "CBOR decoder" do
+    test "decodes the subset produced by authenticators" do
+      encoded = cbor_encode(%{1 => 2, 3 => -7, "fmt" => "none", -2 => {:bytes, <<1, 2, 3>>}})
+
+      assert {:ok, %{1 => 2, 3 => -7, "fmt" => "none", -2 => <<1, 2, 3>>}, ""} =
+               Portal.Crypto.CBOR.decode(encoded)
+    end
+
+    test "rejects indefinite-length items" do
+      assert :error = Portal.Crypto.CBOR.decode(<<0x5F, 0x41, 0x01, 0xFF>>)
+    end
+
+    test "rejects tags and floats" do
+      assert :error = Portal.Crypto.CBOR.decode(<<0xC0, 0x00>>)
+      assert :error = Portal.Crypto.CBOR.decode(<<0xF9, 0x00, 0x00>>)
+    end
+
+    test "rejects truncated input" do
+      assert :error = Portal.Crypto.CBOR.decode(<<0x58, 0xFF, 0x01>>)
+      assert :error = Portal.Crypto.CBOR.decode(<<0xA2, 0x01>>)
+    end
+
+    test "rejects duplicate map keys" do
+      assert :error = Portal.Crypto.CBOR.decode(<<0xA2, 0x01, 0x02, 0x01, 0x03>>)
+    end
+
+    test "rejects deeply nested input" do
+      nested = Enum.reduce(1..20, <<0x01>>, fn _depth, acc -> <<0x81>> <> acc end)
+      assert :error = Portal.Crypto.CBOR.decode(nested)
+    end
+  end
+
+  describe "verify_authentication/5" do
+    test "accepts an assertion from the registered authenticator" do
+      authenticator = generate_authenticator()
+
+      challenge =
+        Portal.Crypto.WebAuthn.authentication_challenge(
+          authenticator.credential_id,
+          authenticator.cose_key
+        )
+
+      assertion = assertion_response(authenticator, challenge, sign_count: 7)
+
+      assert {:ok, auth_data} =
+               Portal.Crypto.WebAuthn.verify_authentication(
+                 assertion.credential_id,
+                 assertion.authenticator_data,
+                 assertion.signature,
+                 assertion.client_data_json,
+                 challenge
+               )
+
+      assert auth_data.sign_count == 7
+    end
+
+    test "rejects an assertion signed by a different key" do
+      authenticator = generate_authenticator()
+      other_authenticator = generate_authenticator()
+
+      challenge =
+        Portal.Crypto.WebAuthn.authentication_challenge(
+          authenticator.credential_id,
+          authenticator.cose_key
+        )
+
+      assertion =
+        other_authenticator
+        |> Map.put(:credential_id, authenticator.credential_id)
+        |> assertion_response(challenge)
+
+      assert {:error, _reason} =
+               Portal.Crypto.WebAuthn.verify_authentication(
+                 assertion.credential_id,
+                 assertion.authenticator_data,
+                 assertion.signature,
+                 assertion.client_data_json,
+                 challenge
+               )
+    end
+
+    test "rejects an assertion for an unknown credential id" do
+      authenticator = generate_authenticator()
+
+      challenge =
+        Portal.Crypto.WebAuthn.authentication_challenge(
+          authenticator.credential_id,
+          authenticator.cose_key
+        )
+
+      assertion = assertion_response(authenticator, challenge)
+
+      assert {:error, _reason} =
+               Portal.Crypto.WebAuthn.verify_authentication(
+                 :crypto.strong_rand_bytes(32),
+                 assertion.authenticator_data,
+                 assertion.signature,
+                 assertion.client_data_json,
+                 challenge
+               )
+    end
+  end
+end

--- a/elixir/test/portal/firezone_support/auth_provider_test.exs
+++ b/elixir/test/portal/firezone_support/auth_provider_test.exs
@@ -1,0 +1,84 @@
+defmodule Portal.FirezoneSupport.AuthProviderTest do
+  use Portal.DataCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.AuthProviderFixtures
+
+  alias Portal.FirezoneSupport
+
+  describe "provider creation" do
+    test "creates a provider with parent row and 24h expiry" do
+      provider = firezone_support_provider_fixture()
+
+      parent = Portal.Repo.get_by!(Portal.AuthProvider, id: provider.id)
+      assert parent.type == :firezone_support
+      assert parent.account_id == provider.account_id
+      assert DateTime.after?(provider.expires_at, DateTime.utc_now())
+    end
+
+    test "enforces one provider per account" do
+      account = account_fixture()
+      firezone_support_provider_fixture(account: account)
+
+      auth_provider = auth_provider_fixture(type: :firezone_support, account: account)
+
+      {:error, changeset} =
+        %FirezoneSupport.AuthProvider{}
+        |> Ecto.Changeset.cast(
+          %{expires_at: DateTime.add(DateTime.utc_now(), 86_400, :second)},
+          [:expires_at]
+        )
+        |> Ecto.Changeset.put_change(:id, auth_provider.id)
+        |> Ecto.Changeset.put_assoc(:account, account)
+        |> Ecto.Changeset.put_assoc(:auth_provider, auth_provider)
+        |> FirezoneSupport.AuthProvider.changeset()
+        |> Portal.Repo.insert()
+
+      assert "Support access is already active for this account." in
+               errors_on(changeset).account_id
+    end
+
+    test "requires a future expires_at" do
+      changeset =
+        %FirezoneSupport.AuthProvider{}
+        |> Ecto.Changeset.change(
+          id: Ecto.UUID.generate(),
+          account_id: Ecto.UUID.generate(),
+          expires_at: DateTime.add(DateTime.utc_now(), -60, :second)
+        )
+        |> FirezoneSupport.AuthProvider.changeset()
+
+      refute changeset.valid?
+    end
+  end
+
+  describe "cascade behavior" do
+    test "deleting the parent auth provider deletes the child row" do
+      provider = firezone_support_provider_fixture()
+
+      Portal.Repo.get_by!(Portal.AuthProvider, id: provider.id)
+      |> Portal.Repo.delete!()
+
+      refute Portal.Repo.get_by(FirezoneSupport.AuthProvider, id: provider.id)
+    end
+  end
+
+  describe "cap_expires_at/2" do
+    test "returns the proposed datetime when it is before the provider expiry" do
+      provider = %FirezoneSupport.AuthProvider{
+        expires_at: DateTime.add(DateTime.utc_now(), 86_400, :second)
+      }
+
+      proposed = DateTime.add(DateTime.utc_now(), 3_600, :second)
+      assert FirezoneSupport.AuthProvider.cap_expires_at(provider, proposed) == proposed
+    end
+
+    test "caps the proposed datetime at the provider expiry" do
+      expires_at = DateTime.add(DateTime.utc_now(), 600, :second)
+      provider = %FirezoneSupport.AuthProvider{expires_at: expires_at}
+
+      proposed = DateTime.add(DateTime.utc_now(), 28_800, :second)
+      assert FirezoneSupport.AuthProvider.cap_expires_at(provider, proposed) == expires_at
+    end
+  end
+end

--- a/elixir/test/portal/firezone_support/auth_provider_test.exs
+++ b/elixir/test/portal/firezone_support/auth_provider_test.exs
@@ -63,22 +63,4 @@ defmodule Portal.FirezoneSupport.AuthProviderTest do
     end
   end
 
-  describe "cap_expires_at/2" do
-    test "returns the proposed datetime when it is before the provider expiry" do
-      provider = %FirezoneSupport.AuthProvider{
-        expires_at: DateTime.add(DateTime.utc_now(), 86_400, :second)
-      }
-
-      proposed = DateTime.add(DateTime.utc_now(), 3_600, :second)
-      assert FirezoneSupport.AuthProvider.cap_expires_at(provider, proposed) == proposed
-    end
-
-    test "caps the proposed datetime at the provider expiry" do
-      expires_at = DateTime.add(DateTime.utc_now(), 600, :second)
-      provider = %FirezoneSupport.AuthProvider{expires_at: expires_at}
-
-      proposed = DateTime.add(DateTime.utc_now(), 28_800, :second)
-      assert FirezoneSupport.AuthProvider.cap_expires_at(provider, proposed) == expires_at
-    end
-  end
 end

--- a/elixir/test/portal/ops_test.exs
+++ b/elixir/test/portal/ops_test.exs
@@ -511,9 +511,9 @@ defmodule Portal.OpsTest do
       :ok
     end
 
-    test "creates a support admin and emails a registration link" do
+    test "creates a support admin with a tagged email and emails a registration link" do
       assert {:ok, support_admin} = provision_support_admin("thomas@firezone.dev")
-      assert support_admin.email == "thomas@firezone.dev"
+      assert support_admin.email == "thomas+firezone-support@firezone.dev"
       assert support_admin.registration_token_hash
 
       assert DateTime.after?(
@@ -523,7 +523,7 @@ defmodule Portal.OpsTest do
 
       assert_received {:email, email}
       assert email.subject == "Register your Firezone Support passkey"
-      assert "thomas@firezone.dev" in Enum.map(email.to, &elem(&1, 1))
+      assert "thomas+firezone-support@firezone.dev" in Enum.map(email.to, &elem(&1, 1))
       assert email.text_body =~ "/support_admin/register/"
     end
 
@@ -537,7 +537,7 @@ defmodule Portal.OpsTest do
 
     test "rejects non-firezone.dev emails" do
       assert {:error, changeset} = provision_support_admin("outsider@gmail.com")
-      assert "must be a firezone.dev email" in errors_on(changeset).email
+      assert "must end with +firezone-support@firezone.dev" in errors_on(changeset).email
       refute_received {:email, _email}
     end
   end

--- a/elixir/test/portal/ops_test.exs
+++ b/elixir/test/portal/ops_test.exs
@@ -505,6 +505,73 @@ defmodule Portal.OpsTest do
     end
   end
 
+  describe "provision_support_admin/1" do
+    setup do
+      Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
+      :ok
+    end
+
+    test "creates a support admin and emails a registration link" do
+      assert {:ok, support_admin} = provision_support_admin("thomas@firezone.dev")
+      assert support_admin.email == "thomas@firezone.dev"
+      assert support_admin.registration_token_hash
+
+      assert DateTime.after?(
+               support_admin.registration_token_expires_at,
+               DateTime.utc_now()
+             )
+
+      assert_received {:email, email}
+      assert email.subject == "Register your Firezone Support passkey"
+      assert "thomas@firezone.dev" in Enum.map(email.to, &elem(&1, 1))
+      assert email.text_body =~ "/support_admin/register/"
+    end
+
+    test "rotates the registration token on repeated provisioning" do
+      assert {:ok, first} = provision_support_admin("repeat@firezone.dev")
+      assert {:ok, second} = provision_support_admin("repeat@firezone.dev")
+
+      assert first.id == second.id
+      refute first.registration_token_hash == second.registration_token_hash
+    end
+
+    test "rejects non-firezone.dev emails" do
+      assert {:error, changeset} = provision_support_admin("outsider@gmail.com")
+      assert "must be a firezone.dev email" in errors_on(changeset).email
+      refute_received {:email, _email}
+    end
+  end
+
+  describe "revoke_support_access/1" do
+    test "deletes the support provider and support actors" do
+      account = account_fixture()
+      provider = Portal.AuthProviderFixtures.firezone_support_provider_fixture(account: account)
+      support_actor = support_actor_fixture(account: account)
+      regular_actor = actor_fixture(account: account, type: :account_admin_user)
+
+      assert {:ok, %{providers: 1, actors: 1}} = revoke_support_access(account.id)
+
+      refute Portal.Repo.get_by(Portal.AuthProvider, id: provider.id)
+      refute Portal.Repo.get_by(Portal.Actor, account_id: account.id, id: support_actor.id)
+      assert Portal.Repo.get_by(Portal.Actor, account_id: account.id, id: regular_actor.id)
+    end
+
+    test "does not touch other accounts" do
+      account = account_fixture()
+      other_account = account_fixture()
+
+      Portal.AuthProviderFixtures.firezone_support_provider_fixture(account: other_account)
+      other_actor = support_actor_fixture(account: other_account)
+
+      assert {:ok, %{providers: 0, actors: 0}} = revoke_support_access(account.id)
+
+      assert Portal.Repo.get_by(Portal.Actor,
+               account_id: other_account.id,
+               id: other_actor.id
+             )
+    end
+  end
+
   defp active_account_fixture(attrs \\ %{}) do
     account = account_fixture(attrs)
     session_log_fixture(account: account)

--- a/elixir/test/portal/safe/firezone_support_permit_test.exs
+++ b/elixir/test/portal/safe/firezone_support_permit_test.exs
@@ -1,0 +1,60 @@
+defmodule Portal.Safe.FirezoneSupportPermitTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Safe
+
+  test "reads delegate to account admin permissions" do
+    assert Safe.permit(:read, Portal.Actor, :firezone_support) == :ok
+    assert Safe.permit(:read, Portal.APIToken, :firezone_support) == :ok
+    assert Safe.permit(:read, Portal.OIDC.AuthProvider, :firezone_support) == :ok
+    assert Safe.permit(:read, Portal.ChangeLog, :firezone_support) == :ok
+    assert Safe.permit(:read, Portal.Account, :firezone_support) == :ok
+  end
+
+  test "writes to credential and auth surfaces are denied" do
+    denied = [
+      Portal.Account,
+      Portal.Actor,
+      Portal.ExternalIdentity,
+      Portal.APIToken,
+      Portal.ClientToken,
+      Portal.GatewayToken,
+      Portal.AuthProvider,
+      Portal.Google.AuthProvider,
+      Portal.Okta.AuthProvider,
+      Portal.Entra.AuthProvider,
+      Portal.OIDC.AuthProvider,
+      Portal.EmailOTP.AuthProvider,
+      Portal.Userpass.AuthProvider,
+      Portal.FirezoneSupport.AuthProvider,
+      Portal.Entra.Directory,
+      Portal.Google.Directory,
+      Portal.Okta.Directory,
+      Portal.TrustAnchor
+    ]
+
+    for schema <- denied, action <- [:insert, :update, :delete, :delete_all] do
+      assert Safe.permit(action, schema, :firezone_support) == {:error, :unauthorized},
+             "expected #{inspect(action)} on #{inspect(schema)} to be denied"
+    end
+  end
+
+  test "configuration writes remain allowed" do
+    for schema <- [
+          Portal.Policy,
+          Portal.Resource,
+          Portal.Site,
+          Portal.Group,
+          Portal.Membership,
+          Portal.Device
+        ] do
+      assert Safe.permit(:insert, schema, :firezone_support) == :ok,
+             "expected insert on #{inspect(schema)} to be allowed"
+    end
+  end
+
+  test "the support whitelist itself stays unreachable" do
+    assert Safe.permit(:read, Portal.SupportAdmin, :firezone_support) == {:error, :unauthorized}
+    assert Safe.permit(:insert, Portal.SupportAdmin, :firezone_support) == {:error, :unauthorized}
+  end
+end

--- a/elixir/test/portal/support_admin_test.exs
+++ b/elixir/test/portal/support_admin_test.exs
@@ -16,12 +16,17 @@ defmodule Portal.SupportAdminTest do
   describe "changeset/1" do
     test "rejects non-firezone.dev emails" do
       assert {:error, changeset} = insert_admin(%{email: "someone@gmail.com"})
-      assert "must be a firezone.dev email" in errors_on(changeset).email
+      assert "must end with +firezone-support@firezone.dev" in errors_on(changeset).email
+    end
+
+    test "rejects untagged firezone.dev emails" do
+      assert {:error, changeset} = insert_admin(%{email: "someone@firezone.dev"})
+      assert "must end with +firezone-support@firezone.dev" in errors_on(changeset).email
     end
 
     test "rejects lookalike domains" do
-      assert {:error, changeset} = insert_admin(%{email: "someone@fake-firezone.dev.evil.com"})
-      assert "must be a firezone.dev email" in errors_on(changeset).email
+      assert {:error, changeset} = insert_admin(%{email: "someone+firezone-support@fake-firezone.dev.evil.com"})
+      assert "must end with +firezone-support@firezone.dev" in errors_on(changeset).email
     end
 
     test "requires email" do
@@ -30,13 +35,16 @@ defmodule Portal.SupportAdminTest do
     end
 
     test "downcases and trims the email" do
-      assert {:ok, support_admin} = insert_admin(%{email: "  Thomas@Firezone.DEV  "})
-      assert support_admin.email == "thomas@firezone.dev"
+      assert {:ok, support_admin} = insert_admin(%{email: "  Thomas+Firezone-Support@Firezone.DEV  "})
+      assert support_admin.email == "thomas+firezone-support@firezone.dev"
     end
 
     test "enforces case-insensitive uniqueness" do
-      support_admin_fixture(email: "unique@firezone.dev")
-      assert {:error, changeset} = insert_admin(%{email: "UNIQUE@firezone.dev"})
+      support_admin_fixture(email: "unique+firezone-support@firezone.dev")
+
+      assert {:error, changeset} =
+               insert_admin(%{email: "UNIQUE+firezone-support@firezone.dev"})
+
       assert "has already been taken" in errors_on(changeset).email
     end
   end

--- a/elixir/test/portal/support_admin_test.exs
+++ b/elixir/test/portal/support_admin_test.exs
@@ -1,0 +1,43 @@
+defmodule Portal.SupportAdminTest do
+  use Portal.DataCase, async: true
+
+  import Portal.SupportAdminFixtures
+
+  alias Portal.Safe
+  alias Portal.SupportAdmin
+
+  defp insert_admin(attrs) do
+    %SupportAdmin{}
+    |> Ecto.Changeset.cast(attrs, [:email])
+    |> Safe.unscoped()
+    |> Safe.insert()
+  end
+
+  describe "changeset/1" do
+    test "rejects non-firezone.dev emails" do
+      assert {:error, changeset} = insert_admin(%{email: "someone@gmail.com"})
+      assert "must be a firezone.dev email" in errors_on(changeset).email
+    end
+
+    test "rejects lookalike domains" do
+      assert {:error, changeset} = insert_admin(%{email: "someone@fake-firezone.dev.evil.com"})
+      assert "must be a firezone.dev email" in errors_on(changeset).email
+    end
+
+    test "requires email" do
+      assert {:error, changeset} = insert_admin(%{})
+      assert "can't be blank" in errors_on(changeset).email
+    end
+
+    test "downcases and trims the email" do
+      assert {:ok, support_admin} = insert_admin(%{email: "  Thomas@Firezone.DEV  "})
+      assert support_admin.email == "thomas@firezone.dev"
+    end
+
+    test "enforces case-insensitive uniqueness" do
+      support_admin_fixture(email: "unique@firezone.dev")
+      assert {:error, changeset} = insert_admin(%{email: "UNIQUE@firezone.dev"})
+      assert "has already been taken" in errors_on(changeset).email
+    end
+  end
+end

--- a/elixir/test/portal/workers/delete_expired_support_access_test.exs
+++ b/elixir/test/portal/workers/delete_expired_support_access_test.exs
@@ -1,0 +1,80 @@
+defmodule Portal.Workers.DeleteExpiredSupportAccessTest do
+  use Portal.DataCase, async: true
+  use Oban.Testing, repo: Portal.Repo
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.AuthProviderFixtures
+
+  alias Portal.Actor
+  alias Portal.FirezoneSupport
+  alias Portal.Workers.DeleteExpiredSupportAccess
+
+  test "deletes an expired provider and the account's support actors" do
+    account = account_fixture()
+
+    provider =
+      firezone_support_provider_fixture(
+        account: account,
+        expires_at: DateTime.add(DateTime.utc_now(), -60, :second)
+      )
+
+    support_actor = support_actor_fixture(account: account)
+    regular_actor = actor_fixture(account: account, type: :account_admin_user)
+
+    assert :ok =
+             perform_job(DeleteExpiredSupportAccess, %{
+               "account_id" => account.id,
+               "auth_provider_id" => provider.id
+             })
+
+    refute Portal.Repo.get_by(Portal.AuthProvider, id: provider.id)
+    refute Portal.Repo.get_by(FirezoneSupport.AuthProvider, id: provider.id)
+    refute Portal.Repo.get_by(Actor, account_id: account.id, id: support_actor.id)
+    assert Portal.Repo.get_by(Actor, account_id: account.id, id: regular_actor.id)
+  end
+
+  test "leaves an unexpired provider and its actors untouched" do
+    account = account_fixture()
+    provider = firezone_support_provider_fixture(account: account)
+    support_actor = support_actor_fixture(account: account)
+
+    assert :ok =
+             perform_job(DeleteExpiredSupportAccess, %{
+               "account_id" => account.id,
+               "auth_provider_id" => provider.id
+             })
+
+    assert Portal.Repo.get_by(FirezoneSupport.AuthProvider, id: provider.id)
+    assert Portal.Repo.get_by(Actor, account_id: account.id, id: support_actor.id)
+  end
+
+  test "a stale job for a revoked provider leaves a re-granted window alone" do
+    account = account_fixture()
+    stale_provider_id = Ecto.UUID.generate()
+    active_provider = firezone_support_provider_fixture(account: account)
+    support_actor = support_actor_fixture(account: account)
+
+    assert :ok =
+             perform_job(DeleteExpiredSupportAccess, %{
+               "account_id" => account.id,
+               "auth_provider_id" => stale_provider_id
+             })
+
+    assert Portal.Repo.get_by(FirezoneSupport.AuthProvider, id: active_provider.id)
+    assert Portal.Repo.get_by(Actor, account_id: account.id, id: support_actor.id)
+  end
+
+  test "cleans up orphaned support actors when the provider id is nil" do
+    account = account_fixture()
+    support_actor = support_actor_fixture(account: account)
+
+    assert :ok =
+             perform_job(DeleteExpiredSupportAccess, %{
+               "account_id" => account.id,
+               "auth_provider_id" => nil
+             })
+
+    refute Portal.Repo.get_by(Actor, account_id: account.id, id: support_actor.id)
+  end
+end

--- a/elixir/test/portal/workers/sweep_expired_support_access_test.exs
+++ b/elixir/test/portal/workers/sweep_expired_support_access_test.exs
@@ -1,0 +1,51 @@
+defmodule Portal.Workers.SweepExpiredSupportAccessTest do
+  use Portal.DataCase, async: true
+  use Oban.Testing, repo: Portal.Repo
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.AuthProviderFixtures
+
+  alias Portal.Workers.DeleteExpiredSupportAccess
+  alias Portal.Workers.SweepExpiredSupportAccess
+
+  test "enqueues cleanup for expired providers" do
+    account = account_fixture()
+
+    provider =
+      firezone_support_provider_fixture(
+        account: account,
+        expires_at: DateTime.add(DateTime.utc_now(), -60, :second)
+      )
+
+    assert :ok = perform_job(SweepExpiredSupportAccess, %{})
+
+    assert_enqueued(
+      worker: DeleteExpiredSupportAccess,
+      args: %{"account_id" => account.id, "auth_provider_id" => provider.id}
+    )
+  end
+
+  test "enqueues cleanup for orphaned support actors" do
+    account = account_fixture()
+    support_actor_fixture(account: account)
+
+    assert :ok = perform_job(SweepExpiredSupportAccess, %{})
+
+    assert_enqueued(
+      worker: DeleteExpiredSupportAccess,
+      args: %{"account_id" => account.id, "auth_provider_id" => nil}
+    )
+  end
+
+  test "does not enqueue anything for active providers or regular actors" do
+    account = account_fixture()
+    firezone_support_provider_fixture(account: account)
+    support_actor_fixture(account: account)
+    actor_fixture(account: account)
+
+    assert :ok = perform_job(SweepExpiredSupportAccess, %{})
+
+    refute_enqueued(worker: DeleteExpiredSupportAccess)
+  end
+end

--- a/elixir/test/portal_api/controllers/actor_controller_test.exs
+++ b/elixir/test/portal_api/controllers/actor_controller_test.exs
@@ -790,6 +790,41 @@ defmodule PortalAPI.ActorControllerTest do
     end
   end
 
+  describe "firezone_support protection" do
+    test "rejects updating a Firezone Support actor", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      support_actor = support_actor_fixture(account: account)
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/actors/#{support_actor.id}", actor: %{"name" => "Renamed"})
+
+      assert %{"status" => 403} = json_response(conn, 403)
+      assert Portal.Repo.get_by!(Actor, id: support_actor.id).name == "Firezone Support"
+    end
+
+    test "rejects deleting a Firezone Support actor", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      support_actor = support_actor_fixture(account: account)
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> delete("/actors/#{support_actor.id}")
+
+      assert %{"status" => 403} = json_response(conn, 403)
+      assert Portal.Repo.get_by(Actor, id: support_actor.id)
+    end
+  end
+
   defp iso8601(%DateTime{} = dt) do
     DateTime.to_iso8601(dt)
   end

--- a/elixir/test/portal_web/controllers/support_controller_test.exs
+++ b/elixir/test/portal_web/controllers/support_controller_test.exs
@@ -290,7 +290,7 @@ defmodule PortalWeb.SupportControllerTest do
       assert session.auth_provider_id
     end
 
-    test "caps the portal session at the provider expiry", %{
+    test "portal sessions expire with the provider window", %{
       conn: conn,
       support_admin: support_admin,
       authenticator: authenticator

--- a/elixir/test/portal_web/controllers/support_controller_test.exs
+++ b/elixir/test/portal_web/controllers/support_controller_test.exs
@@ -1,0 +1,526 @@
+defmodule PortalWeb.SupportControllerTest do
+  use PortalWeb.ConnCase, async: true
+
+  import Ecto.Query, only: [from: 2]
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.AuthProviderFixtures
+  import Portal.SupportAdminFixtures
+  import Portal.WebAuthnFixtures
+
+  alias Portal.Actor
+  alias Portal.SupportAdmin
+
+  setup do
+    Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
+    account = account_fixture()
+    provider = firezone_support_provider_fixture(account: account)
+    {support_admin, authenticator} = registered_support_admin_fixture()
+
+    {:ok,
+     account: account,
+     provider: provider,
+     support_admin: support_admin,
+     authenticator: authenticator}
+  end
+
+  defp recycle_with_cookie(conn) do
+    conn =
+      if conn.state == :sent do
+        conn
+      else
+        Plug.Conn.send_resp(conn, 200, "")
+      end
+
+    conn
+    |> then(&Plug.Test.recycle_cookies(build_conn(), &1))
+    |> Map.put(:secret_key_base, PortalWeb.Endpoint.config(:secret_key_base))
+  end
+
+  defp fetch_support_cookie(conn) do
+    conn
+    |> recycle_with_cookie()
+    |> PortalWeb.Cookie.Support.fetch()
+  end
+
+  defp extract_code_from_email(email) do
+    case Regex.run(~r/\n([a-z0-9]{6})\n/, email.text_body) do
+      [_, code] -> code
+      _ -> raise "Could not extract code from email: #{email.text_body}"
+    end
+  end
+
+  defp start_sign_in(conn, account, support_admin, params \\ %{}) do
+    conn =
+      post(
+        conn,
+        ~p"/#{account.id}/support?#{params}",
+        %{"email" => %{"email" => support_admin.email}}
+      )
+
+    assert_received {:email, email}
+    {conn, extract_code_from_email(email)}
+  end
+
+  defp verify_otp(conn, account, code, params \\ %{}) do
+    conn
+    |> recycle_with_cookie()
+    |> post(~p"/#{account.id}/support/verify?#{params}", %{"secret" => code})
+  end
+
+  defp complete_sign_in(conn, account, authenticator, params \\ %{}, opts \\ []) do
+    cookie = fetch_support_cookie(conn)
+    assertion = assertion_response(authenticator, cookie.challenge, opts)
+
+    conn
+    |> recycle_with_cookie()
+    |> post(~p"/#{account.id}/support/complete?#{params}", encode_assertion_params(assertion))
+  end
+
+  describe "sign_in/2" do
+    test "404s when the account has no support provider", %{conn: conn, support_admin: sa} do
+      other_account = account_fixture()
+
+      assert_error_sent 404, fn ->
+        post(conn, ~p"/#{other_account.id}/support", %{"email" => %{"email" => sa.email}})
+      end
+    end
+
+    test "404s when the provider is expired", %{conn: conn, support_admin: sa} do
+      other_account = account_fixture()
+
+      firezone_support_provider_fixture(
+        account: other_account,
+        expires_at: DateTime.add(DateTime.utc_now(), -60, :second)
+      )
+
+      assert_error_sent 404, fn ->
+        post(conn, ~p"/#{other_account.id}/support", %{"email" => %{"email" => sa.email}})
+      end
+    end
+
+    test "sends an OTP email for a registered support admin", %{
+      conn: conn,
+      account: account,
+      support_admin: support_admin
+    } do
+      conn =
+        post(conn, ~p"/#{account.id}/support", %{"email" => %{"email" => support_admin.email}})
+
+      assert redirected_to(conn) == ~p"/#{account.id}/support/verify?"
+      assert_received {:email, email}
+      assert email.subject == "Firezone Support sign-in code"
+      assert support_admin.email in Enum.map(email.to, &elem(&1, 1))
+    end
+
+    test "responds identically for unknown emails without sending an email", %{
+      conn: conn,
+      account: account,
+      support_admin: support_admin
+    } do
+      known_conn =
+        post(conn, ~p"/#{account.id}/support", %{"email" => %{"email" => support_admin.email}})
+
+      assert_received {:email, _email}
+
+      unknown_conn =
+        post(build_conn(), ~p"/#{account.id}/support", %{
+          "email" => %{"email" => "nobody@firezone.dev"}
+        })
+
+      refute_received {:email, _email}
+
+      assert redirected_to(known_conn) == redirected_to(unknown_conn)
+      assert flash(known_conn, :error) == flash(unknown_conn, :error)
+
+      known_cookie = fetch_support_cookie(known_conn)
+      unknown_cookie = fetch_support_cookie(unknown_conn)
+      assert known_cookie.stage == :otp
+      assert unknown_cookie.stage == :otp
+      assert known_cookie.account_id == unknown_cookie.account_id
+    end
+
+    test "does not send an email for an admin without a registered passkey", %{
+      conn: conn,
+      account: account
+    } do
+      unregistered = support_admin_fixture()
+
+      conn =
+        post(conn, ~p"/#{account.id}/support", %{"email" => %{"email" => unregistered.email}})
+
+      refute_received {:email, _email}
+      assert redirected_to(conn) == ~p"/#{account.id}/support/verify?"
+    end
+
+    test "rate-limited requests do not rotate the stored OTP", %{
+      account: account,
+      support_admin: support_admin
+    } do
+      for _send <- 1..3 do
+        post(build_conn(), ~p"/#{account.id}/support", %{
+          "email" => %{"email" => support_admin.email}
+        })
+
+        assert_received {:email, _email}
+      end
+
+      hash_before = Portal.Repo.get!(SupportAdmin, support_admin.id).otp_code_hash
+
+      limited_conn =
+        post(build_conn(), ~p"/#{account.id}/support", %{
+          "email" => %{"email" => support_admin.email}
+        })
+
+      refute_received {:email, _email}
+      assert Portal.Repo.get!(SupportAdmin, support_admin.id).otp_code_hash == hash_before
+
+      unknown_conn =
+        post(build_conn(), ~p"/#{account.id}/support", %{
+          "email" => %{"email" => "nobody@firezone.dev"}
+        })
+
+      assert redirected_to(limited_conn) == redirected_to(unknown_conn)
+      assert flash(limited_conn, :error) == flash(unknown_conn, :error)
+    end
+
+    test "carries sign-in params through the redirect", %{
+      conn: conn,
+      account: account,
+      support_admin: support_admin
+    } do
+      params = %{"as" => "client", "state" => "STATE", "nonce" => "NONCE"}
+      {conn, _code} = start_sign_in(conn, account, support_admin, params)
+
+      assert redirected_to(conn) ==
+               ~p"/#{account.id}/support/verify?as=client&nonce=NONCE&state=STATE"
+    end
+  end
+
+  describe "verify_otp/2" do
+    test "advances to the passkey stage on a valid code", %{
+      conn: conn,
+      account: account,
+      support_admin: support_admin
+    } do
+      {conn, code} = start_sign_in(conn, account, support_admin)
+      conn = verify_otp(conn, account, code)
+
+      assert redirected_to(conn) == ~p"/#{account.id}/support/passkey?"
+
+      cookie = fetch_support_cookie(conn)
+      assert cookie.stage == :passkey
+      assert %Portal.Crypto.WebAuthn.Challenge{} = cookie.challenge
+      assert [{_credential_id, _cose_key}] = cookie.challenge.allow_credentials
+    end
+
+    test "rejects an invalid code and counts attempts", %{
+      conn: conn,
+      account: account,
+      support_admin: support_admin
+    } do
+      {conn, _code} = start_sign_in(conn, account, support_admin)
+      conn = verify_otp(conn, account, "wrong1")
+
+      assert redirected_to(conn) == ~p"/#{account.id}/support/verify?"
+      assert flash(conn, :error) =~ "invalid or expired"
+      assert Portal.Repo.get!(SupportAdmin, support_admin.id).otp_attempts == 1
+    end
+
+    test "rejects the correct code after three failed attempts", %{
+      conn: conn,
+      account: account,
+      support_admin: support_admin
+    } do
+      {conn, code} = start_sign_in(conn, account, support_admin)
+
+      conn =
+        Enum.reduce(1..3, conn, fn _attempt, conn ->
+          verify_otp(conn, account, "wrong1")
+        end)
+
+      conn = verify_otp(conn, account, code)
+      assert flash(conn, :error) =~ "invalid or expired"
+    end
+
+    test "redirects to the start when the cookie is missing", %{conn: conn, account: account} do
+      conn = post(conn, ~p"/#{account.id}/support/verify", %{"secret" => "abc123"})
+
+      assert redirected_to(conn) == ~p"/#{account.id}/support?"
+      assert flash(conn, :error) =~ "missing or expired"
+    end
+
+    test "404s when the provider is revoked mid-flow", %{
+      conn: conn,
+      account: account,
+      provider: provider,
+      support_admin: support_admin
+    } do
+      {conn, code} = start_sign_in(conn, account, support_admin)
+
+      Portal.Repo.get_by!(Portal.AuthProvider, id: provider.id) |> Portal.Repo.delete!()
+
+      assert_error_sent 404, fn ->
+        verify_otp(conn, account, code)
+      end
+    end
+  end
+
+  describe "complete/2" do
+    test "signs in to the portal and creates the support actor", %{
+      conn: conn,
+      account: account,
+      support_admin: support_admin,
+      authenticator: authenticator
+    } do
+      {conn, code} = start_sign_in(conn, account, support_admin)
+      conn = verify_otp(conn, account, code)
+      conn = complete_sign_in(conn, account, authenticator)
+
+      assert redirected_to(conn) =~ "/#{account.slug}/"
+      assert conn.resp_cookies["sess_#{account.id}"]
+
+      tagged_email = Actor.support_email(support_admin.email)
+      actor = Portal.Repo.get_by!(Actor, account_id: account.id, email: tagged_email)
+      assert actor.type == :firezone_support
+      assert actor.name == "Firezone Support"
+      assert Actor.support?(actor)
+
+      session = Portal.Repo.get_by!(Portal.PortalSession, actor_id: actor.id)
+      assert session.auth_provider_id
+    end
+
+    test "caps the portal session at the provider expiry", %{
+      conn: conn,
+      support_admin: support_admin,
+      authenticator: authenticator
+    } do
+      account = account_fixture()
+      expires_at = DateTime.add(DateTime.utc_now(), 600, :second)
+      firezone_support_provider_fixture(account: account, expires_at: expires_at)
+
+      {conn, code} = start_sign_in(conn, account, support_admin)
+      conn = verify_otp(conn, account, code)
+      complete_sign_in(conn, account, authenticator)
+
+      tagged_email = Actor.support_email(support_admin.email)
+      actor = Portal.Repo.get_by!(Actor, account_id: account.id, email: tagged_email)
+      session = Portal.Repo.get_by!(Portal.PortalSession, actor_id: actor.id)
+      assert DateTime.compare(session.expires_at, expires_at) == :eq
+    end
+
+    test "reuses the support actor across sign-ins", %{
+      conn: conn,
+      account: account,
+      support_admin: support_admin,
+      authenticator: authenticator
+    } do
+      {conn1, code} = start_sign_in(conn, account, support_admin)
+      conn1 = verify_otp(conn1, account, code)
+      complete_sign_in(conn1, account, authenticator)
+
+      {conn2, code} = start_sign_in(build_conn(), account, support_admin)
+      conn2 = verify_otp(conn2, account, code)
+      complete_sign_in(conn2, account, authenticator)
+
+      tagged_email = Actor.support_email(support_admin.email)
+
+      assert [_actor] =
+               Portal.Repo.all(
+                 from(a in Actor,
+                   where: a.account_id == ^account.id and a.email == ^tagged_email
+                 )
+               )
+    end
+
+    test "coexists with a real actor using the untagged staff email", %{
+      conn: conn,
+      account: account,
+      support_admin: support_admin,
+      authenticator: authenticator
+    } do
+      real_actor =
+        actor_fixture(account: account, type: :account_admin_user, email: support_admin.email)
+
+      {conn, code} = start_sign_in(conn, account, support_admin)
+      conn = verify_otp(conn, account, code)
+      conn = complete_sign_in(conn, account, authenticator)
+
+      assert redirected_to(conn) =~ "/#{account.slug}/"
+
+      tagged_email = Actor.support_email(support_admin.email)
+      support_actor = Portal.Repo.get_by!(Actor, account_id: account.id, email: tagged_email)
+      refute support_actor.id == real_actor.id
+      assert Portal.Repo.get_by(Actor, account_id: account.id, id: real_actor.id)
+    end
+
+    test "hands off to the GUI client with a capped token", %{
+      conn: conn,
+      support_admin: support_admin,
+      authenticator: authenticator
+    } do
+      account = account_fixture()
+      expires_at = DateTime.add(DateTime.utc_now(), 600, :second)
+      firezone_support_provider_fixture(account: account, expires_at: expires_at)
+
+      params = %{"as" => "client", "state" => "STATE", "nonce" => "NONCE"}
+      {conn, code} = start_sign_in(conn, account, support_admin, params)
+      conn = verify_otp(conn, account, code, params)
+      conn = complete_sign_in(conn, account, authenticator, params)
+
+      assert html_response(conn, 200) =~ "client_redirect"
+      assert conn.resp_cookies["client_auth"]
+
+      tagged_email = Actor.support_email(support_admin.email)
+      actor = Portal.Repo.get_by!(Actor, account_id: account.id, email: tagged_email)
+      token = Portal.Repo.get_by!(Portal.ClientToken, actor_id: actor.id)
+      assert token.auth_provider_id
+      assert DateTime.compare(token.expires_at, expires_at) == :eq
+    end
+
+    test "signs in from clients even when billing limits are exceeded", %{
+      conn: conn,
+      support_admin: support_admin,
+      authenticator: authenticator
+    } do
+      account = account_fixture()
+      firezone_support_provider_fixture(account: account)
+
+      Portal.Repo.get!(Portal.Account, account.id)
+      |> Ecto.Changeset.change(users_limit_exceeded: true)
+      |> Portal.Repo.update!()
+
+      params = %{"as" => "client", "state" => "STATE", "nonce" => "NONCE"}
+      {conn, code} = start_sign_in(conn, account, support_admin, params)
+      conn = verify_otp(conn, account, code, params)
+      conn = complete_sign_in(conn, account, authenticator, params)
+
+      assert html_response(conn, 200) =~ "client_redirect"
+    end
+
+    test "rejects a sign count regression", %{
+      conn: conn,
+      account: account,
+      support_admin: support_admin,
+      authenticator: authenticator
+    } do
+      support_admin
+      |> Ecto.Changeset.change(passkey_sign_count: 100)
+      |> Portal.Repo.update!()
+
+      {conn, code} = start_sign_in(conn, account, support_admin)
+      conn = verify_otp(conn, account, code)
+      conn = complete_sign_in(conn, account, authenticator, %{}, sign_count: 5)
+
+      assert redirected_to(conn) == ~p"/#{account.id}/support/passkey?"
+      assert flash(conn, :error) =~ "Passkey verification failed"
+
+      tagged_email = Actor.support_email(support_admin.email)
+      refute Portal.Repo.get_by(Actor, account_id: account.id, email: tagged_email)
+    end
+
+    test "updates the stored sign count on success", %{
+      conn: conn,
+      account: account,
+      support_admin: support_admin,
+      authenticator: authenticator
+    } do
+      {conn, code} = start_sign_in(conn, account, support_admin)
+      conn = verify_otp(conn, account, code)
+      complete_sign_in(conn, account, authenticator, %{}, sign_count: 42)
+
+      assert Portal.Repo.get!(SupportAdmin, support_admin.id).passkey_sign_count == 42
+    end
+
+    test "rejects a cookie minted for a different account", %{
+      conn: conn,
+      account: account,
+      support_admin: support_admin,
+      authenticator: authenticator
+    } do
+      other_account = account_fixture()
+      firezone_support_provider_fixture(account: other_account)
+
+      {conn, code} = start_sign_in(conn, account, support_admin)
+      conn = verify_otp(conn, account, code)
+      conn = complete_sign_in(conn, other_account, authenticator)
+
+      assert redirected_to(conn) == ~p"/#{other_account.id}/support?"
+      assert flash(conn, :error) =~ "missing or expired"
+    end
+
+    test "404s when the provider expires between passkey page and POST", %{
+      conn: conn,
+      account: account,
+      provider: provider,
+      support_admin: support_admin,
+      authenticator: authenticator
+    } do
+      {conn, code} = start_sign_in(conn, account, support_admin)
+      conn = verify_otp(conn, account, code)
+
+      Portal.Repo.get_by!(Portal.FirezoneSupport.AuthProvider, id: provider.id)
+      |> Ecto.Changeset.change(expires_at: DateTime.add(DateTime.utc_now(), -1, :second))
+      |> Portal.Repo.update!()
+
+      assert_error_sent 404, fn ->
+        complete_sign_in(conn, account, authenticator)
+      end
+    end
+
+    test "rejects replaying the exact same assertion and cookie", %{
+      conn: conn,
+      account: account,
+      support_admin: support_admin,
+      authenticator: authenticator
+    } do
+      {conn, code} = start_sign_in(conn, account, support_admin)
+      conn = verify_otp(conn, account, code)
+
+      cookie = fetch_support_cookie(conn)
+      assertion = assertion_response(authenticator, cookie.challenge, sign_count: 0)
+      params = encode_assertion_params(assertion)
+
+      first =
+        conn
+        |> recycle_with_cookie()
+        |> post(~p"/#{account.id}/support/complete", params)
+
+      assert redirected_to(first) =~ "/#{account.slug}/"
+
+      replay =
+        conn
+        |> recycle_with_cookie()
+        |> post(~p"/#{account.id}/support/complete", params)
+
+      assert redirected_to(replay) == ~p"/#{account.id}/support?"
+      assert flash(replay, :error) =~ "missing or expired"
+
+      tagged_email = Actor.support_email(support_admin.email)
+      actor = Portal.Repo.get_by!(Actor, account_id: account.id, email: tagged_email)
+      assert [_session] = Portal.Repo.all(from(s in Portal.PortalSession, where: s.actor_id == ^actor.id))
+    end
+
+    test "rejects a tampered assertion", %{
+      conn: conn,
+      account: account,
+      support_admin: support_admin,
+      authenticator: authenticator
+    } do
+      {conn, code} = start_sign_in(conn, account, support_admin)
+      conn = verify_otp(conn, account, code)
+
+      cookie = fetch_support_cookie(conn)
+      other_authenticator = Map.put(generate_authenticator(), :credential_id, authenticator.credential_id)
+      assertion = assertion_response(other_authenticator, cookie.challenge)
+
+      conn =
+        conn
+        |> recycle_with_cookie()
+        |> post(~p"/#{account.id}/support/complete", encode_assertion_params(assertion))
+
+      assert redirected_to(conn) == ~p"/#{account.id}/support/passkey?"
+      assert flash(conn, :error) =~ "Passkey verification failed"
+    end
+  end
+end

--- a/elixir/test/portal_web/controllers/support_controller_test.exs
+++ b/elixir/test/portal_web/controllers/support_controller_test.exs
@@ -280,7 +280,7 @@ defmodule PortalWeb.SupportControllerTest do
       assert redirected_to(conn) =~ "/#{account.slug}/"
       assert conn.resp_cookies["sess_#{account.id}"]
 
-      tagged_email = Actor.support_email(support_admin.email)
+      tagged_email = support_admin.email
       actor = Portal.Repo.get_by!(Actor, account_id: account.id, email: tagged_email)
       assert actor.type == :firezone_support
       assert actor.name == "Firezone Support"
@@ -303,7 +303,7 @@ defmodule PortalWeb.SupportControllerTest do
       conn = verify_otp(conn, account, code)
       complete_sign_in(conn, account, authenticator)
 
-      tagged_email = Actor.support_email(support_admin.email)
+      tagged_email = support_admin.email
       actor = Portal.Repo.get_by!(Actor, account_id: account.id, email: tagged_email)
       session = Portal.Repo.get_by!(Portal.PortalSession, actor_id: actor.id)
       assert DateTime.compare(session.expires_at, expires_at) == :eq
@@ -323,7 +323,7 @@ defmodule PortalWeb.SupportControllerTest do
       conn2 = verify_otp(conn2, account, code)
       complete_sign_in(conn2, account, authenticator)
 
-      tagged_email = Actor.support_email(support_admin.email)
+      tagged_email = support_admin.email
 
       assert [_actor] =
                Portal.Repo.all(
@@ -339,8 +339,10 @@ defmodule PortalWeb.SupportControllerTest do
       support_admin: support_admin,
       authenticator: authenticator
     } do
+      untagged_email = String.replace(support_admin.email, "+firezone-support@", "@")
+
       real_actor =
-        actor_fixture(account: account, type: :account_admin_user, email: support_admin.email)
+        actor_fixture(account: account, type: :account_admin_user, email: untagged_email)
 
       {conn, code} = start_sign_in(conn, account, support_admin)
       conn = verify_otp(conn, account, code)
@@ -348,7 +350,7 @@ defmodule PortalWeb.SupportControllerTest do
 
       assert redirected_to(conn) =~ "/#{account.slug}/"
 
-      tagged_email = Actor.support_email(support_admin.email)
+      tagged_email = support_admin.email
       support_actor = Portal.Repo.get_by!(Actor, account_id: account.id, email: tagged_email)
       refute support_actor.id == real_actor.id
       assert Portal.Repo.get_by(Actor, account_id: account.id, id: real_actor.id)
@@ -371,7 +373,7 @@ defmodule PortalWeb.SupportControllerTest do
       assert html_response(conn, 200) =~ "client_redirect"
       assert conn.resp_cookies["client_auth"]
 
-      tagged_email = Actor.support_email(support_admin.email)
+      tagged_email = support_admin.email
       actor = Portal.Repo.get_by!(Actor, account_id: account.id, email: tagged_email)
       token = Portal.Repo.get_by!(Portal.ClientToken, actor_id: actor.id)
       assert token.auth_provider_id
@@ -415,7 +417,7 @@ defmodule PortalWeb.SupportControllerTest do
       assert redirected_to(conn) == ~p"/#{account.id}/support/passkey?"
       assert flash(conn, :error) =~ "Passkey verification failed"
 
-      tagged_email = Actor.support_email(support_admin.email)
+      tagged_email = support_admin.email
       refute Portal.Repo.get_by(Actor, account_id: account.id, email: tagged_email)
     end
 
@@ -496,7 +498,7 @@ defmodule PortalWeb.SupportControllerTest do
       assert redirected_to(replay) == ~p"/#{account.id}/support?"
       assert flash(replay, :error) =~ "missing or expired"
 
-      tagged_email = Actor.support_email(support_admin.email)
+      tagged_email = support_admin.email
       actor = Portal.Repo.get_by!(Actor, account_id: account.id, email: tagged_email)
       assert [_session] = Portal.Repo.all(from(s in Portal.PortalSession, where: s.actor_id == ^actor.id))
     end

--- a/elixir/test/portal_web/controllers/support_request_controller_test.exs
+++ b/elixir/test/portal_web/controllers/support_request_controller_test.exs
@@ -1,0 +1,176 @@
+defmodule PortalWeb.SupportRequestControllerTest do
+  use PortalWeb.ConnCase, async: true
+  use Oban.Testing, repo: Portal.Repo
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.AuthProviderFixtures
+
+  alias Portal.Actor
+  alias Portal.FirezoneSupport
+  alias Portal.Workers.DeleteExpiredSupportAccess
+
+  setup %{conn: conn} do
+    Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
+    account = account_fixture()
+    actor = actor_fixture(account: account, type: :account_admin_user)
+    conn = authorize_conn(conn, actor)
+
+    {:ok, account: account, actor: actor, conn: conn}
+  end
+
+  describe "create/2" do
+    test "sends the problem report without granting access", %{conn: conn, account: account} do
+      conn =
+        post(conn, ~p"/#{account.slug}/support_request", %{
+          "support_request" => %{"problem" => "DNS is broken"},
+          "redirect_to" => "/#{account.slug}/sites"
+        })
+
+      assert redirected_to(conn) == "/#{account.slug}/sites"
+      refute flash(conn, :success)
+
+      assert_received {:email, email}
+      assert email.subject =~ "SUPPORT REQUEST"
+      assert "support@firezone.dev" in Enum.map(email.to, &elem(&1, 1))
+      assert email.text_body =~ "DNS is broken"
+      assert email.text_body =~ "Access granted: no"
+
+      refute Portal.Repo.get_by(FirezoneSupport.AuthProvider, account_id: account.id)
+      refute_enqueued(worker: DeleteExpiredSupportAccess)
+    end
+
+    test "grants access, creates the provider, and schedules cleanup", %{
+      conn: conn,
+      account: account
+    } do
+      conn =
+        post(conn, ~p"/#{account.slug}/support_request", %{
+          "support_request" => %{"problem" => "Need help", "grant_access" => "true"},
+          "redirect_to" => "/#{account.slug}/sites"
+        })
+
+      assert redirected_to(conn) == "/#{account.slug}/sites"
+      refute flash(conn, :success)
+
+      provider = Portal.Repo.get_by!(FirezoneSupport.AuthProvider, account_id: account.id)
+      parent = Portal.Repo.get_by!(Portal.AuthProvider, id: provider.id)
+      assert parent.type == :firezone_support
+
+      in_24h = DateTime.add(DateTime.utc_now(), 86_400, :second)
+      assert DateTime.diff(in_24h, provider.expires_at, :second) < 60
+
+      assert_enqueued(
+        worker: DeleteExpiredSupportAccess,
+        args: %{"account_id" => account.id, "auth_provider_id" => provider.id}
+      )
+
+      assert_received {:email, email}
+      assert email.text_body =~ "Access granted: YES"
+    end
+
+    test "rejects a second grant while one is active", %{conn: conn, account: account} do
+      firezone_support_provider_fixture(account: account)
+
+      conn =
+        post(conn, ~p"/#{account.slug}/support_request", %{
+          "support_request" => %{"problem" => "More help", "grant_access" => "true"}
+        })
+
+      assert flash(conn, :error) =~ "already active"
+      refute_received {:email, _email}
+    end
+
+    test "rejects an empty problem description", %{conn: conn, account: account} do
+      conn =
+        post(conn, ~p"/#{account.slug}/support_request", %{
+          "support_request" => %{"problem" => "   "}
+        })
+
+      assert flash(conn, :error) =~ "describe the problem"
+      refute_received {:email, _email}
+    end
+
+    test "sanitizes foreign redirect_to paths", %{conn: conn, account: account} do
+      conn =
+        post(conn, ~p"/#{account.slug}/support_request", %{
+          "support_request" => %{"problem" => "Help"},
+          "redirect_to" => "/some-other-account/sites"
+        })
+
+      assert redirected_to(conn) =~ "/#{account.slug}/"
+    end
+
+    test "requires authentication", %{account: account} do
+      conn =
+        post(build_conn(), ~p"/#{account.slug}/support_request", %{
+          "support_request" => %{"problem" => "Help"}
+        })
+
+      assert redirected_to(conn) =~ "/sign_in"
+    end
+  end
+
+  describe "end_support/2" do
+    test "deletes the provider, support actors, and their sessions", %{
+      conn: conn,
+      account: account
+    } do
+      provider = firezone_support_provider_fixture(account: account)
+      support_actor = support_actor_fixture(account: account)
+
+      context = %Portal.Authentication.Context{
+        type: :portal,
+        user_agent: "Test 1.0",
+        remote_ip: {127, 0, 0, 1}
+      }
+
+      {:ok, session} =
+        Portal.Authentication.create_portal_session(
+          support_actor,
+          provider.id,
+          context,
+          DateTime.add(DateTime.utc_now(), 3_600, :second)
+        )
+
+      conn = post(conn, ~p"/#{account.slug}/support_request/end", %{})
+
+      assert flash(conn, :success) =~ "Support session ended"
+      refute Portal.Repo.get_by(Portal.AuthProvider, id: provider.id)
+      refute Portal.Repo.get_by(FirezoneSupport.AuthProvider, id: provider.id)
+      refute Portal.Repo.get_by(Actor, account_id: account.id, id: support_actor.id)
+      refute Portal.Repo.get_by(Portal.PortalSession, id: session.id)
+    end
+
+    test "does not delete regular actors", %{conn: conn, account: account, actor: actor} do
+      firezone_support_provider_fixture(account: account)
+
+      post(conn, ~p"/#{account.slug}/support_request/end", %{})
+
+      assert Portal.Repo.get_by(Actor, account_id: account.id, id: actor.id)
+    end
+
+    test "no-ops gracefully when support is not active", %{conn: conn, account: account} do
+      conn = post(conn, ~p"/#{account.slug}/support_request/end", %{})
+
+      assert flash(conn, :info) =~ "not active"
+    end
+
+    test "signs the support actor out when they end their own session", %{account: account} do
+      provider = firezone_support_provider_fixture(account: account)
+      support_actor = support_actor_fixture(account: account)
+
+      conn =
+        build_conn()
+        |> Map.put(:secret_key_base, PortalWeb.Endpoint.config(:secret_key_base))
+        |> put_req_header("user-agent", "FooBar 1.1")
+        |> authorize_conn_with_provider(support_actor, provider)
+        |> post(~p"/#{account.slug}/support_request/end", %{})
+
+      assert redirected_to(conn) == ~p"/#{account.slug}/sign_in"
+      assert flash(conn, :info) =~ "signed out"
+      refute Portal.Repo.get_by(Portal.AuthProvider, id: provider.id)
+      refute Portal.Repo.get_by(Actor, account_id: account.id, id: support_actor.id)
+    end
+  end
+end

--- a/elixir/test/portal_web/live/sign_in/support_test.exs
+++ b/elixir/test/portal_web/live/sign_in/support_test.exs
@@ -1,0 +1,137 @@
+defmodule PortalWeb.SignIn.SupportTest do
+  use PortalWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Portal.AccountFixtures
+  import Portal.AuthProviderFixtures
+  import Portal.SupportAdminFixtures
+
+  setup do
+    account = account_fixture()
+    provider = firezone_support_provider_fixture(account: account)
+    {:ok, account: account, provider: provider}
+  end
+
+  defp put_support_cookie(conn, cookie) do
+    conn = PortalWeb.Cookie.Support.put(conn, cookie)
+    cookie_value = conn.resp_cookies["fz_support"].value
+    put_req_cookie(build_conn(), "fz_support", cookie_value)
+  end
+
+  describe ":email" do
+    test "404s when the account has no support provider", %{conn: conn} do
+      other_account = account_fixture()
+
+      assert_error_sent 404, fn ->
+        live(conn, ~p"/#{other_account.slug}/support")
+      end
+    end
+
+    test "404s when the provider is expired", %{conn: conn} do
+      other_account = account_fixture()
+
+      firezone_support_provider_fixture(
+        account: other_account,
+        expires_at: DateTime.add(DateTime.utc_now(), -60, :second)
+      )
+
+      assert_error_sent 404, fn ->
+        live(conn, ~p"/#{other_account.slug}/support")
+      end
+    end
+
+    test "renders the email form with sign-in params", %{conn: conn, account: account} do
+      {:ok, _lv, html} =
+        live(conn, ~p"/#{account.slug}/support?as=client&state=STATE&nonce=NONCE")
+
+      assert html =~ "Firezone Support"
+      assert html =~ ~s(action="/#{account.slug}/support")
+      assert html =~ ~s(value="STATE")
+      assert html =~ ~s(value="NONCE")
+    end
+  end
+
+  describe ":verify_otp" do
+    test "redirects to the start without a cookie", %{conn: conn, account: account} do
+      {:error, {:redirect, %{to: to}}} = live(conn, ~p"/#{account.slug}/support/verify")
+      assert to =~ ~p"/#{account.slug}/support"
+    end
+
+    test "renders the code entry form with a valid cookie", %{conn: conn, account: account} do
+      {support_admin, _authenticator} = registered_support_admin_fixture()
+
+      conn =
+        put_support_cookie(conn, %PortalWeb.Cookie.Support{
+          account_id: account.id,
+          email: support_admin.email,
+          stage: :otp
+        })
+
+      {:ok, _lv, html} = live(conn, ~p"/#{account.slug}/support/verify")
+
+      assert html =~ support_admin.email
+      assert html =~ "Verify code"
+      assert html =~ "Resend email"
+    end
+
+    test "redirects when the cookie belongs to another account", %{conn: conn, account: account} do
+      other_account = account_fixture()
+
+      conn =
+        put_support_cookie(conn, %PortalWeb.Cookie.Support{
+          account_id: other_account.id,
+          email: "someone@firezone.dev",
+          stage: :otp
+        })
+
+      {:error, {:redirect, %{to: to}}} = live(conn, ~p"/#{account.slug}/support/verify")
+      assert to =~ ~p"/#{account.slug}/support"
+    end
+  end
+
+  describe ":passkey" do
+    test "redirects when the cookie is still at the OTP stage", %{conn: conn, account: account} do
+      conn =
+        put_support_cookie(conn, %PortalWeb.Cookie.Support{
+          account_id: account.id,
+          email: "someone@firezone.dev",
+          stage: :otp
+        })
+
+      {:error, {:redirect, %{to: to}}} = live(conn, ~p"/#{account.slug}/support/passkey")
+      assert to =~ ~p"/#{account.slug}/support"
+    end
+
+    test "renders the passkey ceremony with a passkey-stage cookie", %{
+      conn: conn,
+      account: account
+    } do
+      {support_admin, authenticator} = registered_support_admin_fixture()
+
+      challenge =
+        Portal.Crypto.WebAuthn.authentication_challenge(
+          authenticator.credential_id,
+          authenticator.cose_key
+        )
+
+      conn =
+        put_support_cookie(conn, %PortalWeb.Cookie.Support{
+          account_id: account.id,
+          email: support_admin.email,
+          stage: :passkey,
+          challenge: challenge
+        })
+
+      {:ok, _lv, html} = live(conn, ~p"/#{account.slug}/support/passkey")
+
+      assert html =~ "Use passkey"
+      assert html =~ ~s(action="/#{account.slug}/support/complete")
+
+      assert html =~
+               ~s(data-challenge="#{Base.url_encode64(challenge.bytes, padding: false)}")
+
+      assert html =~
+               ~s(data-credential-id="#{Base.url_encode64(authenticator.credential_id, padding: false)}")
+    end
+  end
+end

--- a/elixir/test/portal_web/live/support_admin_registration_test.exs
+++ b/elixir/test/portal_web/live/support_admin_registration_test.exs
@@ -1,0 +1,154 @@
+defmodule PortalWeb.SupportAdminRegistrationTest do
+  use PortalWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Portal.SupportAdminFixtures
+  import Portal.WebAuthnFixtures
+
+  alias Portal.SupportAdmin
+
+  defp registration_payload(html, authenticator) do
+    [challenge_b64] = Regex.run(~r/data-challenge="([^"]+)"/, html, capture: :all_but_first)
+    challenge = challenge_stub(Base.url_decode64!(challenge_b64, padding: false))
+    response = registration_response(authenticator, challenge)
+
+    %{
+      "attestation_object" => Base.url_encode64(response.attestation_object, padding: false),
+      "client_data_json" => Base.url_encode64(response.client_data_json, padding: false),
+      "raw_id" => Base.url_encode64(authenticator.credential_id, padding: false)
+    }
+  end
+
+  describe "mount" do
+    test "404s for an unknown token", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        live(conn, ~p"/support_admin/register/#{Portal.Crypto.random_token(32)}")
+      end
+    end
+
+    test "404s for an expired token", %{conn: conn} do
+      {_support_admin, token} =
+        provisioned_support_admin_fixture(
+          registration_token_expires_at: DateTime.add(DateTime.utc_now(), -60, :second)
+        )
+
+      assert_error_sent 404, fn ->
+        live(conn, ~p"/support_admin/register/#{token}")
+      end
+    end
+
+    test "renders the registration page for a valid token", %{conn: conn} do
+      {support_admin, token} = provisioned_support_admin_fixture()
+
+      {:ok, _lv, html} = live(conn, ~p"/support_admin/register/#{token}")
+
+      assert html =~ support_admin.email
+      assert html =~ "Create passkey"
+      assert html =~ "data-challenge="
+    end
+
+    test "offers replacement when a passkey is already registered", %{conn: conn} do
+      {support_admin, _authenticator} = registered_support_admin_fixture()
+      token = Portal.Crypto.random_token(32)
+
+      support_admin
+      |> Ecto.Changeset.change(
+        registration_token_hash: Portal.Crypto.hash(:sha256, token),
+        registration_token_expires_at: DateTime.add(DateTime.utc_now(), 3_600, :second)
+      )
+      |> Portal.Repo.update!()
+
+      {:ok, _lv, html} = live(conn, ~p"/support_admin/register/#{token}")
+
+      assert html =~ "Replace passkey"
+      assert html =~ "replaces it"
+    end
+  end
+
+  describe "verify_registration" do
+    test "registers the passkey and consumes the token", %{conn: conn} do
+      {support_admin, token} = provisioned_support_admin_fixture()
+      authenticator = generate_authenticator()
+
+      {:ok, lv, _html} = live(conn, ~p"/support_admin/register/#{token}")
+
+      html = render_hook(lv, "verify_registration", registration_payload(render(lv), authenticator))
+
+      assert html =~ "You can close this tab"
+
+      reloaded = Portal.Repo.get!(SupportAdmin, support_admin.id)
+      assert reloaded.passkey_credential_id == authenticator.credential_id
+      assert Portal.Crypto.WebAuthn.decode_cose_key(reloaded.passkey_public_key) == authenticator.cose_key
+      assert reloaded.passkey_registered_at
+      assert is_nil(reloaded.registration_token_hash)
+      assert is_nil(reloaded.registration_token_expires_at)
+
+      assert_error_sent 404, fn ->
+        live(conn, ~p"/support_admin/register/#{token}")
+      end
+    end
+
+    test "replaces an existing passkey", %{conn: conn} do
+      {support_admin, old_authenticator} = registered_support_admin_fixture()
+      token = Portal.Crypto.random_token(32)
+
+      support_admin
+      |> Ecto.Changeset.change(
+        registration_token_hash: Portal.Crypto.hash(:sha256, token),
+        registration_token_expires_at: DateTime.add(DateTime.utc_now(), 3_600, :second)
+      )
+      |> Portal.Repo.update!()
+
+      new_authenticator = generate_authenticator()
+
+      {:ok, lv, _html} = live(conn, ~p"/support_admin/register/#{token}")
+      render_hook(lv, "verify_registration", registration_payload(render(lv), new_authenticator))
+
+      reloaded = Portal.Repo.get!(SupportAdmin, support_admin.id)
+      assert reloaded.passkey_credential_id == new_authenticator.credential_id
+      refute reloaded.passkey_credential_id == old_authenticator.credential_id
+    end
+
+    test "rejects a tampered attestation and offers retry", %{conn: conn} do
+      {support_admin, token} = provisioned_support_admin_fixture()
+      authenticator = generate_authenticator()
+
+      {:ok, lv, _html} = live(conn, ~p"/support_admin/register/#{token}")
+
+      payload =
+        render(lv)
+        |> registration_payload(authenticator)
+        |> Map.put(
+          "client_data_json",
+          Base.url_encode64(
+            JSON.encode!(%{
+              "type" => "webauthn.create",
+              "challenge" => Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false),
+              "origin" => Portal.Crypto.WebAuthn.origin()
+            }),
+            padding: false
+          )
+        )
+
+      html = render_hook(lv, "verify_registration", payload)
+
+      assert html =~ "Passkey registration failed"
+
+      reloaded = Portal.Repo.get!(SupportAdmin, support_admin.id)
+      assert is_nil(reloaded.passkey_credential_id)
+      assert reloaded.registration_token_hash
+    end
+
+    test "renders client-side error messages", %{conn: conn} do
+      {_support_admin, token} = provisioned_support_admin_fixture()
+
+      {:ok, lv, _html} = live(conn, ~p"/support_admin/register/#{token}")
+
+      html = render_hook(lv, "registration_failed", %{"error" => "NotAllowedError"})
+      assert html =~ "cancelled or timed out"
+
+      html = render_hook(lv, "registration_failed", %{"error" => "unsupported"})
+      assert html =~ "doesn&#39;t support passkeys"
+    end
+  end
+end

--- a/elixir/test/portal_web/live/support_visibility_test.exs
+++ b/elixir/test/portal_web/live/support_visibility_test.exs
@@ -1,0 +1,143 @@
+defmodule PortalWeb.SupportVisibilityTest do
+  use PortalWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.AuthProviderFixtures
+
+  setup do
+    account = account_fixture()
+    actor = admin_actor_fixture(account: account)
+    %{account: account, actor: actor}
+  end
+
+  describe "sign-in chooser" do
+    test "never lists the support provider", %{conn: conn, account: account} do
+      email_otp_provider_fixture(account: account)
+      firezone_support_provider_fixture(account: account)
+
+      {:ok, _lv, html} = live(conn, ~p"/#{account.slug}/sign_in")
+
+      refute html =~ "Firezone Support"
+      refute html =~ "/support"
+    end
+  end
+
+  describe "settings authentication" do
+    test "does not list the support provider", %{conn: conn, account: account, actor: actor} do
+      provider = firezone_support_provider_fixture(account: account)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account.slug}/settings/authentication")
+
+      refute html =~ provider.id
+    end
+
+    test "404s on firezone_support type tampering", %{conn: conn, account: account, actor: actor} do
+      provider = firezone_support_provider_fixture(account: account)
+      conn = authorize_conn(conn, actor)
+
+      assert_error_sent 404, fn ->
+        live(conn, ~p"/#{account.slug}/settings/authentication/firezone_support/new")
+      end
+
+      assert_error_sent 404, fn ->
+        live(conn, ~p"/#{account.slug}/settings/authentication/firezone_support/#{provider.id}/edit")
+      end
+    end
+  end
+
+  describe "support actor protection" do
+    test "redirects away from the edit page for support actors", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      support_actor = support_actor_fixture(account: account)
+
+      {:error, {:live_redirect, %{to: to, flash: flash}}} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account.slug}/actors/#{support_actor.id}/edit")
+
+      assert to == ~p"/#{account.slug}/actors"
+      assert flash["error"] =~ "cannot be edited"
+    end
+
+    test "hides edit, disable, welcome email, and danger zone for support actors", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      support_actor = support_actor_fixture(account: account)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account.slug}/actors/#{support_actor.id}")
+
+      refute html =~ "open_actor_edit_form"
+      refute html =~ "confirm_disable_actor"
+      refute html =~ "send_welcome_email"
+      refute html =~ "Danger Zone"
+      assert html =~ "Firezone Support"
+    end
+  end
+
+  describe "support actor's own view" do
+    test "shows the red signed-into-customer banner", %{conn: conn, account: account} do
+      provider = firezone_support_provider_fixture(account: account)
+      support_actor = support_actor_fixture(account: account)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn_with_provider(support_actor, provider)
+        |> live(~p"/#{account.slug}/sites")
+
+      assert html =~ "You are signed into customer #{account.slug}"
+      assert html =~ "End support session now"
+      refute html =~ "Firezone Support is currently active and expires in"
+    end
+  end
+
+  describe "support banner and topbar" do
+    test "shows the banner and active pill while support is active", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      provider = firezone_support_provider_fixture(account: account)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account.slug}/sites")
+
+      assert html =~ "Firezone Support is currently active and expires in"
+      assert html =~ "End support session now"
+      assert html =~ ~s(data-expires-at="#{DateTime.to_iso8601(provider.expires_at)}")
+      assert html =~ ~s(action="/#{account.slug}/support_request/end")
+      assert html =~ "Support active"
+      refute html =~ ">Request Support<"
+    end
+
+    test "shows the Request Support button when support is inactive", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account.slug}/sites")
+
+      refute html =~ "Firezone Support is currently active"
+      assert html =~ "Request Support"
+      assert html =~ ~s(action="/#{account.slug}/support_request")
+      assert html =~ "Allow Firezone Support to access this account for 24 hours"
+    end
+  end
+end

--- a/elixir/test/support/fixtures/actor_fixtures.ex
+++ b/elixir/test/support/fixtures/actor_fixtures.ex
@@ -117,4 +117,28 @@ defmodule Portal.ActorFixtures do
     |> Ecto.Changeset.change(is_disabled: true)
     |> Portal.Repo.update!()
   end
+
+  @doc """
+  Generate a Firezone Support actor (reserved plus-address email, inserted as a
+  bare struct since the base changeset rejects the reserved suffix).
+  """
+  def support_actor_fixture(attrs \\ %{}) do
+    attrs = Enum.into(attrs, %{})
+    account = Map.get(attrs, :account) || account_fixture()
+    unique_num = System.unique_integer([:positive, :monotonic])
+
+    email =
+      Map.get_lazy(attrs, :email, fn ->
+        Portal.Actor.support_email("support.actor.#{unique_num}@firezone.dev")
+      end)
+
+    %Portal.Actor{
+      account_id: account.id,
+      type: :firezone_support,
+      name: "Firezone Support",
+      email: email,
+      allow_email_otp_sign_in: false
+    }
+    |> Portal.Repo.insert!()
+  end
 end

--- a/elixir/test/support/fixtures/auth_provider_fixtures.ex
+++ b/elixir/test/support/fixtures/auth_provider_fixtures.ex
@@ -96,6 +96,58 @@ defmodule Portal.AuthProviderFixtures do
   end
 
   @doc """
+  Generate a Firezone Support auth provider.
+
+  This creates both the base AuthProvider and the FirezoneSupport.AuthProvider
+  records. Pass a past `expires_at` to create an already-expired provider.
+  """
+  def firezone_support_provider_fixture(attrs \\ %{}) do
+    attrs = Enum.into(attrs, %{})
+
+    account = Map.get(attrs, :account) || account_fixture()
+
+    auth_provider =
+      Map.get_lazy(attrs, :auth_provider, fn ->
+        auth_provider_fixture(type: :firezone_support, account: account)
+      end)
+
+    requested_expires_at =
+      Map.get_lazy(attrs, :expires_at, fn ->
+        DateTime.add(DateTime.utc_now(), 86_400, :second)
+      end)
+
+    insert_expires_at =
+      if DateTime.after?(requested_expires_at, DateTime.utc_now()) do
+        requested_expires_at
+      else
+        DateTime.add(DateTime.utc_now(), 86_400, :second)
+      end
+
+    support_attrs =
+      attrs
+      |> Map.delete(:account)
+      |> Map.delete(:auth_provider)
+      |> Map.put(:expires_at, insert_expires_at)
+
+    {:ok, provider} =
+      %Portal.FirezoneSupport.AuthProvider{}
+      |> Ecto.Changeset.cast(support_attrs, [:expires_at])
+      |> Ecto.Changeset.put_change(:id, auth_provider.id)
+      |> Ecto.Changeset.put_assoc(:account, account)
+      |> Ecto.Changeset.put_assoc(:auth_provider, auth_provider)
+      |> Portal.FirezoneSupport.AuthProvider.changeset()
+      |> Portal.Repo.insert()
+
+    if DateTime.compare(requested_expires_at, insert_expires_at) == :eq do
+      provider
+    else
+      provider
+      |> Ecto.Changeset.change(expires_at: requested_expires_at)
+      |> Portal.Repo.update!()
+    end
+  end
+
+  @doc """
   Generate a userpass auth provider.
 
   This creates both the base AuthProvider and the Userpass.AuthProvider records.

--- a/elixir/test/support/fixtures/support_admin_fixtures.ex
+++ b/elixir/test/support/fixtures/support_admin_fixtures.ex
@@ -1,0 +1,73 @@
+defmodule Portal.SupportAdminFixtures do
+  @moduledoc """
+  Test helpers for creating support admins.
+  """
+
+  def valid_support_admin_attrs(attrs \\ %{}) do
+    unique_num = System.unique_integer([:positive, :monotonic])
+    Enum.into(attrs, %{email: "support.admin.#{unique_num}@firezone.dev"})
+  end
+
+  def support_admin_fixture(attrs \\ %{}) do
+    attrs = attrs |> Enum.into(%{}) |> valid_support_admin_attrs()
+
+    %Portal.SupportAdmin{}
+    |> Ecto.Changeset.cast(attrs, [
+      :email,
+      :passkey_credential_id,
+      :passkey_public_key,
+      :passkey_sign_count,
+      :passkey_registered_at,
+      :registration_token_hash,
+      :registration_token_expires_at,
+      :otp_code_hash,
+      :otp_expires_at,
+      :otp_attempts
+    ])
+    |> Portal.SupportAdmin.changeset()
+    |> Portal.Repo.insert!()
+  end
+
+  @doc """
+  Creates a support admin with a pending registration link. Returns the admin
+  and the raw registration token.
+  """
+  def provisioned_support_admin_fixture(attrs \\ %{}) do
+    token = Portal.Crypto.random_token(32)
+
+    expires_at =
+      DateTime.add(
+        DateTime.utc_now(),
+        Portal.SupportAdmin.registration_token_lifetime_secs(),
+        :second
+      )
+
+    support_admin =
+      attrs
+      |> Enum.into(%{})
+      |> Map.put_new(:registration_token_hash, Portal.Crypto.hash(:sha256, token))
+      |> Map.put_new(:registration_token_expires_at, expires_at)
+      |> support_admin_fixture()
+
+    {support_admin, token}
+  end
+
+  @doc """
+  Creates a support admin with a registered passkey. Returns the admin and the
+  software authenticator holding the private key.
+  """
+  def registered_support_admin_fixture(attrs \\ %{}) do
+    authenticator = Portal.WebAuthnFixtures.generate_authenticator()
+
+    support_admin =
+      attrs
+      |> Enum.into(%{})
+      |> Map.put_new(:passkey_credential_id, authenticator.credential_id)
+      |> Map.put_new(:passkey_public_key, :erlang.term_to_binary(authenticator.cose_key))
+      |> Map.put_new(:passkey_sign_count, 0)
+      |> Map.put_new(:passkey_registered_at, DateTime.utc_now())
+      |> support_admin_fixture()
+
+    {support_admin, authenticator}
+  end
+end

--- a/elixir/test/support/fixtures/support_admin_fixtures.ex
+++ b/elixir/test/support/fixtures/support_admin_fixtures.ex
@@ -5,7 +5,7 @@ defmodule Portal.SupportAdminFixtures do
 
   def valid_support_admin_attrs(attrs \\ %{}) do
     unique_num = System.unique_integer([:positive, :monotonic])
-    Enum.into(attrs, %{email: "support.admin.#{unique_num}@firezone.dev"})
+    Enum.into(attrs, %{email: "support.admin.#{unique_num}+firezone-support@firezone.dev"})
   end
 
   def support_admin_fixture(attrs \\ %{}) do

--- a/elixir/test/support/fixtures/web_authn_fixtures.ex
+++ b/elixir/test/support/fixtures/web_authn_fixtures.ex
@@ -1,0 +1,128 @@
+defmodule Portal.WebAuthnFixtures do
+  @moduledoc """
+  Software WebAuthn authenticator for tests.
+
+  Generates a P-256 keypair and produces registration attestations and
+  authentication assertions in the wire format Portal.Crypto.WebAuthn verifies,
+  including a minimal CBOR encoder so tests stay dependency-free too.
+  """
+
+  def generate_authenticator do
+    {public_key, private_key} = :crypto.generate_key(:ecdh, :secp256r1)
+    <<4, x::binary-size(32), y::binary-size(32)>> = public_key
+
+    %{
+      credential_id: :crypto.strong_rand_bytes(32),
+      private_key: private_key,
+      cose_key: %{1 => 2, 3 => -7, -1 => 1, -2 => x, -3 => y}
+    }
+  end
+
+  def challenge_stub(bytes) do
+    %{bytes: bytes, origin: Portal.Crypto.WebAuthn.origin(), rp_id: Portal.Crypto.WebAuthn.rp_id()}
+  end
+
+  def registration_response(authenticator, challenge, opts \\ []) do
+    sign_count = Keyword.get(opts, :sign_count, 0)
+    flags = Keyword.get(opts, :flags, 0x45)
+
+    cose_key_cbor =
+      cbor_encode(%{
+        1 => 2,
+        3 => -7,
+        -1 => 1,
+        -2 => {:bytes, authenticator.cose_key[-2]},
+        -3 => {:bytes, authenticator.cose_key[-3]}
+      })
+
+    auth_data =
+      :crypto.hash(:sha256, challenge.rp_id) <>
+        <<flags>> <>
+        <<sign_count::unsigned-big-integer-size(32)>> <>
+        <<0::128>> <>
+        <<byte_size(authenticator.credential_id)::unsigned-big-integer-size(16)>> <>
+        authenticator.credential_id <>
+        cose_key_cbor
+
+    attestation_object =
+      cbor_encode(%{
+        "fmt" => "none",
+        "attStmt" => %{},
+        "authData" => {:bytes, auth_data}
+      })
+
+    %{
+      attestation_object: attestation_object,
+      client_data_json: client_data_json("webauthn.create", challenge)
+    }
+  end
+
+  def assertion_response(authenticator, challenge, opts \\ []) do
+    sign_count = Keyword.get(opts, :sign_count, 1)
+    flags = Keyword.get(opts, :flags, 0x05)
+    client_data_json = Keyword.get(opts, :client_data_json, client_data_json("webauthn.get", challenge))
+
+    authenticator_data =
+      :crypto.hash(:sha256, challenge.rp_id) <>
+        <<flags>> <>
+        <<sign_count::unsigned-big-integer-size(32)>>
+
+    signature =
+      :crypto.sign(
+        :ecdsa,
+        :sha256,
+        authenticator_data <> :crypto.hash(:sha256, client_data_json),
+        [authenticator.private_key, :secp256r1]
+      )
+
+    %{
+      credential_id: authenticator.credential_id,
+      authenticator_data: authenticator_data,
+      signature: signature,
+      client_data_json: client_data_json
+    }
+  end
+
+  def encode_assertion_params(assertion) do
+    %{
+      "credential_id" => Base.url_encode64(assertion.credential_id, padding: false),
+      "authenticator_data" => Base.url_encode64(assertion.authenticator_data, padding: false),
+      "signature" => Base.url_encode64(assertion.signature, padding: false),
+      "client_data_json" => Base.url_encode64(assertion.client_data_json, padding: false)
+    }
+  end
+
+  def cbor_encode(integer) when is_integer(integer) and integer >= 0,
+    do: cbor_head(0, integer)
+
+  def cbor_encode(integer) when is_integer(integer),
+    do: cbor_head(1, -1 - integer)
+
+  def cbor_encode({:bytes, binary}) when is_binary(binary),
+    do: cbor_head(2, byte_size(binary)) <> binary
+
+  def cbor_encode(string) when is_binary(string),
+    do: cbor_head(3, byte_size(string)) <> string
+
+  def cbor_encode(map) when is_map(map) do
+    map
+    |> Enum.map(fn {key, value} -> cbor_encode(key) <> cbor_encode(value) end)
+    |> Enum.reduce(cbor_head(5, map_size(map)), &(&2 <> &1))
+  end
+
+  defp cbor_head(major, value) when value < 24, do: <<major::3, value::5>>
+  defp cbor_head(major, value) when value < 256, do: <<major::3, 24::5, value::unsigned-big-8>>
+
+  defp cbor_head(major, value) when value < 65_536,
+    do: <<major::3, 25::5, value::unsigned-big-16>>
+
+  defp cbor_head(major, value), do: <<major::3, 26::5, value::unsigned-big-32>>
+
+  defp client_data_json(type, challenge) do
+    JSON.encode!(%{
+      "type" => type,
+      "challenge" => Base.url_encode64(challenge.bytes, padding: false),
+      "origin" => challenge.origin
+    })
+  end
+end


### PR DESCRIPTION
Customers had no built-in way to let Firezone staff into their account to help debug problems. This adds one, with the customer holding the on/off switch and a hard 24-hour limit.

**Asking for help.** A "Request Support" button in the portal opens a form where an admin describes their problem, with a checkbox that grants Firezone Support access to the account for 24 hours. The report is emailed to support@firezone.dev. While access is on, every admin sees an amber banner with a live countdown and an "End support session now" button that shuts everything off immediately.

**The switch itself.** Granting access creates a hidden auth provider of a new type, `firezone_support`, holding little more than an expiry time. It never appears in the sign-in chooser or auth settings. Revoking it (or the expiry) deletes the row, and deleting the row cascades away every support session and actor. An Oban job scheduled at the expiry time plus a cron sweeper make sure cleanup happens even if something goes wrong.

**Who gets in.** A new global `support_admins` table is the staff whitelist, managed only from the ops console via `Portal.Ops.provision_support_admin/1`. Provisioning emails a one-hour, single-use link where the staff member registers a passkey. Sign-in at `/<account>/support` is three steps: email, a 6-digit code sent to that email, then the passkey. The flow answers 404 unless the account has an active grant, and it deliberately looks identical for known and unknown emails so it cannot be used to probe the whitelist. Native clients reach the same flow by entering `<account-slug>/support` as the account override, and it works even when the account is over billing limits, since that is often why support is needed.

**The support actor.** Completing sign-in creates an actor with its own type, `firezone_support`, named "Firezone Support" with a reserved email like `alice+firezone-support@firezone.dev` (the plus tag avoids colliding with a real actor using the staff address). These actors can read everything an admin can, but a deny list in `Portal.Safe` blocks every write that could outlive the window: actors, identities, tokens of any kind, auth providers, directories, trust anchors, and the account itself. They cannot be edited or deleted from the UI or REST API, are excluded from all billing and seat counts, and the database itself refuses the type with any other email shape. While signed in, support staff see a red banner reminding them whose account they are in.

**Passkeys without dependencies.** WebAuthn verification lives in `Portal.Crypto.WebAuthn` on Erlang's `:crypto` and `:public_key` with a minimal CBOR decoder, instead of adding a library. User verification (Touch ID, PIN) is required, cross-origin responses are rejected, and every challenge is single use: a hash is stored server-side and atomically consumed at sign-in, so a captured response cannot be replayed. Attestation is deliberately not verified; trust comes from the whitelist, the emailed link, and the OTP, which also keeps password-manager passkeys working.

**Audit trail.** Grants, revokes, and expiry land in the customer's audit log through the change log pipeline, and support sign-ins show up in session logs like any other sign-in.
