### PR TITLE
feat(clients): support managed X.509 identities over mTLS

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3290,9 +3290,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1294,6 +1294,7 @@ dependencies = [
  "tun",
  "tunnel-bypass-resolver",
  "uniffi",
+ "url",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5606,6 +5606,7 @@ dependencies = [
  "logging",
  "os_info",
  "rand 0.10.2",
+ "rustls",
  "secrecy",
  "serde",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1294,7 +1294,6 @@ dependencies = [
  "tun",
  "tunnel-bypass-resolver",
  "uniffi",
- "url",
 ]
 
 [[package]]

--- a/rust/client-ffi/Cargo.toml
+++ b/rust/client-ffi/Cargo.toml
@@ -37,7 +37,6 @@ tracing-subscriber = { workspace = true }
 tun = { workspace = true }
 tunnel-bypass-resolver = { workspace = true }
 uniffi = { workspace = true }
-url = { workspace = true }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 oslog = { version = "0.2.0", default-features = false }

--- a/rust/client-ffi/Cargo.toml
+++ b/rust/client-ffi/Cargo.toml
@@ -26,6 +26,7 @@ otel-attributes = { workspace = true }
 otel-instruments = { workspace = true }
 phoenix-channel = { workspace = true }
 rustls = { workspace = true }
+rustls-platform-verifier = { workspace = true }
 secrecy = { workspace = true }
 socket-factory = { workspace = true }
 telemetry = { workspace = true }
@@ -36,6 +37,7 @@ tracing-subscriber = { workspace = true }
 tun = { workspace = true }
 tunnel-bypass-resolver = { workspace = true }
 uniffi = { workspace = true }
+url = { workspace = true }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 oslog = { version = "0.2.0", default-features = false }
@@ -48,7 +50,6 @@ mimalloc = { workspace = true }
 android_log-sys = "0.3.2"
 jni = { workspace = true }
 mimalloc = { workspace = true, features = ["local_dynamic_tls"] } # The Android `cdylib` is `dlopen`-ed, so it needs the dynamic TLS model.
-rustls-platform-verifier = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/client-ffi/src/client_auth.rs
+++ b/rust/client-ffi/src/client_auth.rs
@@ -1,0 +1,210 @@
+use std::{fmt, sync::Arc};
+
+use anyhow::{Context as _, Result, bail};
+use rustls::{
+    SignatureAlgorithm, SignatureScheme,
+    pki_types::CertificateDer,
+    sign::{CertifiedKey, Signer, SigningKey},
+};
+
+use crate::{ClientTlsIdentity, TlsSignatureScheme};
+
+pub(crate) fn certified_key(identity: Arc<dyn ClientTlsIdentity>) -> Result<Arc<CertifiedKey>> {
+    let certificates = identity
+        .certificate_chain()
+        .context("Failed to read the platform client certificate chain")?;
+    if certificates.is_empty() {
+        bail!("The platform client certificate chain is empty");
+    }
+
+    let signing_key = Arc::new(PlatformSigningKey::new(identity)?);
+    let certificates = certificates.into_iter().map(CertificateDer::from).collect();
+
+    Ok(Arc::new(CertifiedKey::new(certificates, signing_key)))
+}
+
+#[derive(Debug)]
+struct PlatformSigningKey {
+    identity: Arc<dyn ClientTlsIdentity>,
+    schemes: Vec<TlsSignatureScheme>,
+    algorithm: SignatureAlgorithm,
+}
+
+impl PlatformSigningKey {
+    fn new(identity: Arc<dyn ClientTlsIdentity>) -> Result<Self> {
+        let schemes = identity.supported_signature_schemes();
+        let Some(first) = schemes.first() else {
+            bail!("The platform client certificate key supports no TLS signature schemes");
+        };
+        let algorithm = first.algorithm();
+
+        if schemes.iter().any(|scheme| scheme.algorithm() != algorithm) {
+            bail!("The platform client certificate returned mixed key algorithms");
+        }
+
+        Ok(Self {
+            identity,
+            schemes,
+            algorithm,
+        })
+    }
+}
+
+impl SigningKey for PlatformSigningKey {
+    fn choose_scheme(&self, offered: &[SignatureScheme]) -> Option<Box<dyn Signer>> {
+        self.schemes
+            .iter()
+            .copied()
+            .find(|scheme| offered.contains(&scheme.rustls()))
+            .map(|scheme| {
+                Box::new(PlatformSigner {
+                    identity: self.identity.clone(),
+                    scheme,
+                }) as Box<dyn Signer>
+            })
+    }
+
+    fn algorithm(&self) -> SignatureAlgorithm {
+        self.algorithm
+    }
+}
+
+struct PlatformSigner {
+    identity: Arc<dyn ClientTlsIdentity>,
+    scheme: TlsSignatureScheme,
+}
+
+impl fmt::Debug for PlatformSigner {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PlatformSigner")
+            .field("scheme", &self.scheme)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Signer for PlatformSigner {
+    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
+        self.identity
+            .sign(self.scheme, message.to_vec())
+            .map_err(|error| {
+                rustls::Error::General(format!("Platform TLS signing failed: {error}"))
+            })
+    }
+
+    fn scheme(&self) -> SignatureScheme {
+        self.scheme.rustls()
+    }
+}
+
+impl TlsSignatureScheme {
+    fn rustls(self) -> SignatureScheme {
+        match self {
+            Self::RsaPkcs1Sha256 => SignatureScheme::RSA_PKCS1_SHA256,
+            Self::RsaPkcs1Sha384 => SignatureScheme::RSA_PKCS1_SHA384,
+            Self::RsaPkcs1Sha512 => SignatureScheme::RSA_PKCS1_SHA512,
+            Self::RsaPssSha256 => SignatureScheme::RSA_PSS_SHA256,
+            Self::RsaPssSha384 => SignatureScheme::RSA_PSS_SHA384,
+            Self::RsaPssSha512 => SignatureScheme::RSA_PSS_SHA512,
+            Self::EcdsaNistp256Sha256 => SignatureScheme::ECDSA_NISTP256_SHA256,
+            Self::EcdsaNistp384Sha384 => SignatureScheme::ECDSA_NISTP384_SHA384,
+            Self::EcdsaNistp521Sha512 => SignatureScheme::ECDSA_NISTP521_SHA512,
+        }
+    }
+
+    fn algorithm(self) -> SignatureAlgorithm {
+        match self {
+            Self::RsaPkcs1Sha256
+            | Self::RsaPkcs1Sha384
+            | Self::RsaPkcs1Sha512
+            | Self::RsaPssSha256
+            | Self::RsaPssSha384
+            | Self::RsaPssSha512 => SignatureAlgorithm::RSA,
+            Self::EcdsaNistp256Sha256 | Self::EcdsaNistp384Sha384 | Self::EcdsaNistp521Sha512 => {
+                SignatureAlgorithm::ECDSA
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CallbackError;
+
+    #[derive(Debug)]
+    struct MockIdentity {
+        schemes: Vec<TlsSignatureScheme>,
+    }
+
+    impl ClientTlsIdentity for MockIdentity {
+        fn certificate_chain(&self) -> Result<Vec<Vec<u8>>, CallbackError> {
+            Ok(vec![vec![1, 2, 3]])
+        }
+
+        fn supported_signature_schemes(&self) -> Vec<TlsSignatureScheme> {
+            self.schemes.clone()
+        }
+
+        fn sign(
+            &self,
+            scheme: TlsSignatureScheme,
+            mut message: Vec<u8>,
+        ) -> Result<Vec<u8>, CallbackError> {
+            assert_eq!(scheme, TlsSignatureScheme::RsaPssSha256);
+            message.extend_from_slice(&[0x08, 0x04]);
+            Ok(message)
+        }
+    }
+
+    #[test]
+    fn chooses_a_mutually_supported_scheme_and_delegates_signing() {
+        let certified_key = certified_key(Arc::new(MockIdentity {
+            schemes: vec![
+                TlsSignatureScheme::RsaPssSha512,
+                TlsSignatureScheme::RsaPssSha256,
+            ],
+        }))
+        .expect("mock identity should produce a certified key");
+
+        let signer = certified_key
+            .key
+            .choose_scheme(&[
+                SignatureScheme::ECDSA_NISTP256_SHA256,
+                SignatureScheme::RSA_PSS_SHA256,
+            ])
+            .expect("RSA-PSS SHA-256 should be mutually supported");
+
+        assert_eq!(signer.scheme(), SignatureScheme::RSA_PSS_SHA256);
+        assert_eq!(
+            signer.sign(&[4, 5]).expect("mock signing should succeed"),
+            vec![4, 5, 0x08, 0x04]
+        );
+    }
+
+    #[test]
+    fn rejects_an_empty_certificate_chain() {
+        #[derive(Debug)]
+        struct EmptyIdentity;
+
+        impl ClientTlsIdentity for EmptyIdentity {
+            fn certificate_chain(&self) -> Result<Vec<Vec<u8>>, CallbackError> {
+                Ok(Vec::new())
+            }
+
+            fn supported_signature_schemes(&self) -> Vec<TlsSignatureScheme> {
+                vec![TlsSignatureScheme::EcdsaNistp256Sha256]
+            }
+
+            fn sign(
+                &self,
+                _scheme: TlsSignatureScheme,
+                _message: Vec<u8>,
+            ) -> Result<Vec<u8>, CallbackError> {
+                unreachable!()
+            }
+        }
+
+        assert!(certified_key(Arc::new(EmptyIdentity)).is_err());
+    }
+}

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -218,6 +218,10 @@ impl DisconnectError {
         self.0.is_authentication_error()
     }
 
+    pub fn is_certificate_revoked(&self) -> bool {
+        self.0.is_certificate_revoked()
+    }
+
     pub fn is_device_trust_error(&self) -> bool {
         self.0.is_device_trust_error()
     }

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -4,6 +4,7 @@
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+mod client_auth;
 mod fd;
 mod platform;
 
@@ -47,6 +48,32 @@ pub struct ConnlibError(anyhow::Error);
 pub enum CallbackError {
     #[error("{0}")]
     Failed(String),
+}
+
+/// TLS handshake signature schemes supported by a platform-managed client identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum TlsSignatureScheme {
+    RsaPkcs1Sha256,
+    RsaPkcs1Sha384,
+    RsaPkcs1Sha512,
+    RsaPssSha256,
+    RsaPssSha384,
+    RsaPssSha512,
+    EcdsaNistp256Sha256,
+    EcdsaNistp384Sha384,
+    EcdsaNistp521Sha512,
+}
+
+/// A certificate chain and non-exportable platform key used for mutual TLS.
+#[uniffi::export(with_foreign)]
+pub trait ClientTlsIdentity: Send + Sync + fmt::Debug {
+    /// DER-encoded certificate chain, leaf first.
+    fn certificate_chain(&self) -> Result<Vec<Vec<u8>>, CallbackError>;
+
+    fn supported_signature_schemes(&self) -> Vec<TlsSignatureScheme>;
+
+    /// Signs the unhashed TLS handshake message with the requested scheme.
+    fn sign(&self, scheme: TlsSignatureScheme, message: Vec<u8>) -> Result<Vec<u8>, CallbackError>;
 }
 
 #[derive(uniffi::Object, Debug)]
@@ -190,6 +217,10 @@ impl DisconnectError {
     pub fn is_authentication_error(&self) -> bool {
         self.0.is_authentication_error()
     }
+
+    pub fn is_device_trust_error(&self) -> bool {
+        self.0.is_device_trust_error()
+    }
 }
 
 #[uniffi::export(with_foreign)]
@@ -231,6 +262,8 @@ impl Session {
             flow_logs_dir,
             device_info,
             is_internet_resource_active,
+            None,
+            None,
             tcp_socket_factory,
             udp_socket_factory,
         )
@@ -272,6 +305,8 @@ impl Session {
             flow_logs_dir,
             device_info,
             is_internet_resource_active,
+            None,
+            None,
             tcp_socket_factory,
             udp_socket_factory,
         )?;
@@ -318,6 +353,8 @@ impl Session {
             flow_logs_dir,
             device_info,
             is_internet_resource_active,
+            None,
+            None,
             tcp_socket_factory,
             udp_socket_factory,
         )?;
@@ -524,6 +561,8 @@ fn connect(
     flow_logs_dir: Option<String>,
     device_info: DeviceInfo,
     is_internet_resource_active: bool,
+    mdm_device_id: Option<String>,
+    tls_client_config: Option<Arc<rustls::ClientConfig>>,
     tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
 ) -> Result<Session, ConnlibError> {
@@ -556,11 +595,13 @@ fn connect(
     telemetry::start(&api_url, RELEASE, platform::DSN);
     telemetry::set_firezone_id(device_id.clone());
     telemetry::set_account_slug(account_slug.clone());
+    telemetry::set_mdm_device_id(mdm_device_id);
 
     analytics::identify(RELEASE.to_owned(), Some(account_slug));
 
+    let portal_api_url = portal_api_url(&api_url, tls_client_config.is_some())?;
     let url = LoginUrl::client(
-        api_url.as_str(),
+        portal_api_url.as_str(),
         device_id.clone(),
         device_name,
         device_info,
@@ -582,6 +623,10 @@ fn connect(
         },
         tcp_socket_factory.clone(),
     );
+    let portal = match tls_client_config {
+        Some(config) => portal.with_tls_client_config(config),
+        None => portal,
+    };
     // The uploader lives and dies with the session (idle, it would only poll
     // and dial); registered so `drain_flow_logs` nudges it instead of racing it.
     let uploader = flow_logs_dir.clone().map(|dir| {
@@ -611,6 +656,43 @@ fn connect(
         runtime: Some(runtime),
         uploader,
     })
+}
+
+#[doc(hidden)]
+pub fn tls_client_config(
+    identity: Arc<dyn ClientTlsIdentity>,
+) -> Result<Arc<rustls::ClientConfig>> {
+    use rustls::sign::SingleCertAndKey;
+    use rustls_platform_verifier::BuilderVerifierExt as _;
+
+    install_rustls_crypto_provider();
+    let certified_key = client_auth::certified_key(identity)?;
+    let resolver = Arc::new(SingleCertAndKey::from(certified_key));
+    let config = rustls::ClientConfig::builder()
+        .with_platform_verifier()
+        .context("Failed to configure the TLS server certificate verifier")?
+        .with_client_cert_resolver(resolver);
+
+    Ok(Arc::new(config))
+}
+
+fn portal_api_url(api_url: &str, use_client_certificate: bool) -> Result<String> {
+    if !use_client_certificate {
+        return Ok(api_url.to_owned());
+    }
+
+    let mut url = url::Url::parse(api_url).context("Failed to parse the API URL")?;
+    let mtls_host = match url.host_str() {
+        Some("api.firez.one") => Some("mtls.firez.one"),
+        Some("api.firezone.dev") => Some("mtls.firezone.dev"),
+        _ => None,
+    };
+    if let Some(host) = mtls_host {
+        url.set_host(Some(host))
+            .map_err(|_| anyhow!("Failed to set the mTLS API host"))?;
+    }
+
+    Ok(url.into())
 }
 
 fn start_telemetry_inner(tcp: Arc<dyn SocketFactory<TcpSocket>>) {
@@ -905,5 +987,36 @@ impl From<anyhow::Error> for ConnlibError {
 impl From<uniffi::UnexpectedUniFFICallbackError> for CallbackError {
     fn from(value: uniffi::UnexpectedUniFFICallbackError) -> Self {
         Self::Failed(format!("Callback failed: {}", value.reason))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_certificate_uses_mtls_api_host() {
+        assert_eq!(
+            portal_api_url("wss://api.firez.one:444/custom?foo=bar", true)
+                .expect("valid production API URL"),
+            "wss://mtls.firez.one:444/custom?foo=bar"
+        );
+        assert_eq!(
+            portal_api_url("wss://api.firezone.dev/custom?foo=bar", true)
+                .expect("valid staging API URL"),
+            "wss://mtls.firezone.dev/custom?foo=bar"
+        );
+    }
+
+    #[test]
+    fn unattested_and_custom_api_urls_are_unchanged() {
+        assert_eq!(
+            portal_api_url("wss://api.firezone.dev", false).expect("valid API URL"),
+            "wss://api.firezone.dev"
+        );
+        assert_eq!(
+            portal_api_url("wss://portal.example.com/client", true).expect("valid custom API URL"),
+            "wss://portal.example.com/client"
+        );
     }
 }

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -22,7 +22,7 @@ use backoff::ExponentialBackoffBuilder;
 use ip_network::IpNetwork;
 use itertools::Itertools as _;
 use logging::sentry_layer;
-use phoenix_channel::{LoginUrl, PhoenixChannel, get_user_agent};
+use phoenix_channel::{ClientCertificate, LoginUrl, PhoenixChannel, get_user_agent};
 use platform::RELEASE;
 use secrecy::SecretString;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
@@ -603,12 +603,12 @@ fn connect(
 
     analytics::identify(RELEASE.to_owned(), Some(account_slug));
 
-    let portal_api_url = portal_api_url(&api_url, tls_client_config.is_some())?;
     let url = LoginUrl::client(
-        portal_api_url.as_str(),
+        api_url.as_str(),
         device_id.clone(),
         device_name,
         device_info,
+        tls_client_config.map(|tls_config| ClientCertificate { tls_config }),
     )
     .context("Failed to create login URL")?;
 
@@ -627,10 +627,6 @@ fn connect(
         },
         tcp_socket_factory.clone(),
     );
-    let portal = match tls_client_config {
-        Some(config) => portal.with_tls_client_config(config),
-        None => portal,
-    };
     // The uploader lives and dies with the session (idle, it would only poll
     // and dial); registered so `drain_flow_logs` nudges it instead of racing it.
     let uploader = flow_logs_dir.clone().map(|dir| {
@@ -678,25 +674,6 @@ pub fn tls_client_config(
         .with_client_cert_resolver(resolver);
 
     Ok(Arc::new(config))
-}
-
-fn portal_api_url(api_url: &str, use_client_certificate: bool) -> Result<String> {
-    if !use_client_certificate {
-        return Ok(api_url.to_owned());
-    }
-
-    let mut url = url::Url::parse(api_url).context("Failed to parse the API URL")?;
-    let mtls_host = match url.host_str() {
-        Some("api.firez.one") => Some("mtls.firez.one"),
-        Some("api.firezone.dev") => Some("mtls.firezone.dev"),
-        _ => None,
-    };
-    if let Some(host) = mtls_host {
-        url.set_host(Some(host))
-            .map_err(|_| anyhow!("Failed to set the mTLS API host"))?;
-    }
-
-    Ok(url.into())
 }
 
 fn start_telemetry_inner(tcp: Arc<dyn SocketFactory<TcpSocket>>) {
@@ -991,36 +968,5 @@ impl From<anyhow::Error> for ConnlibError {
 impl From<uniffi::UnexpectedUniFFICallbackError> for CallbackError {
     fn from(value: uniffi::UnexpectedUniFFICallbackError) -> Self {
         Self::Failed(format!("Callback failed: {}", value.reason))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn client_certificate_uses_mtls_api_host() {
-        assert_eq!(
-            portal_api_url("wss://api.firez.one:444/custom?foo=bar", true)
-                .expect("valid production API URL"),
-            "wss://mtls.firez.one:444/custom?foo=bar"
-        );
-        assert_eq!(
-            portal_api_url("wss://api.firezone.dev/custom?foo=bar", true)
-                .expect("valid staging API URL"),
-            "wss://mtls.firezone.dev/custom?foo=bar"
-        );
-    }
-
-    #[test]
-    fn unattested_and_custom_api_urls_are_unchanged() {
-        assert_eq!(
-            portal_api_url("wss://api.firezone.dev", false).expect("valid API URL"),
-            "wss://api.firezone.dev"
-        );
-        assert_eq!(
-            portal_api_url("wss://portal.example.com/client", true).expect("valid custom API URL"),
-            "wss://portal.example.com/client"
-        );
     }
 }

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -773,6 +773,7 @@ impl<'a> Handler<'a> {
                 device_uuid: device_info::uuid(),
                 ..Default::default()
             },
+            None,
         )
         .context("Failed to create `LoginUrl`")?;
 

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -373,6 +373,7 @@ fn try_main() -> Result<()> {
             device_uuid: device_info::uuid(),
             ..Default::default()
         },
+        None,
     )?;
 
     if cli.check {

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -126,6 +126,14 @@ impl DisconnectError {
         e.is_authentication_error()
     }
 
+    pub fn is_certificate_revoked(&self) -> bool {
+        let Some(e) = self.0.any_downcast_ref::<phoenix_channel::Error>() else {
+            return false;
+        };
+
+        e.is_certificate_revoked()
+    }
+
     pub fn is_device_trust_error(&self) -> bool {
         phoenix_channel::http_error_body(&self.0)
             .is_some_and(|body| body.contains("device_untrusted"))

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -125,6 +125,11 @@ impl DisconnectError {
 
         e.is_authentication_error()
     }
+
+    pub fn is_device_trust_error(&self) -> bool {
+        phoenix_channel::http_error_body(&self.0)
+            .is_some_and(|body| body.contains("device_untrusted"))
+    }
 }
 
 impl Eventloop {

--- a/rust/libs/connlib/phoenix-channel/Cargo.toml
+++ b/rust/libs/connlib/phoenix-channel/Cargo.toml
@@ -17,6 +17,7 @@ libc = { workspace = true }
 logging = { workspace = true }
 os_info = { workspace = true }
 rand = { workspace = true }
+rustls = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -33,7 +33,9 @@ use tokio_tungstenite::{
 use url::Url;
 
 pub use get_user_agent::get_user_agent;
-pub use login_url::{DeviceInfo, LoginUrl, LoginUrlError, NoParams, PublicKeyParam};
+pub use login_url::{
+    ClientCertificate, DeviceInfo, LoginUrl, LoginUrlError, NoParams, PublicKeyParam,
+};
 pub use tokio_tungstenite::tungstenite::http::StatusCode;
 
 const MAX_BUFFERED_MESSAGES: usize = 32; // Chosen pretty arbitrarily. If we are connected, these should never build up.
@@ -57,7 +59,6 @@ pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     url_prototype: LoginUrl<TFinish>,
     last_url: Option<Url>,
     user_agent: String,
-    tls_client_config: Option<Arc<rustls::ClientConfig>>,
     /// The authentication token, sent via X-Authorization header.
     token: SecretString,
     make_initial_backoff: Box<dyn Fn() -> ExponentialBackoff + Send>,
@@ -393,7 +394,6 @@ where
             was_connected: false,
             url_prototype: url,
             user_agent,
-            tls_client_config: None,
             token,
             state: State::Closed,
             socket_factory,
@@ -403,16 +403,6 @@ where
             init_req,
             last_url: None,
         }
-    }
-
-    /// Uses the supplied rustls configuration for TLS connections.
-    ///
-    /// This allows callers to configure client certificate authentication, including
-    /// certificate resolvers backed by platform-managed, non-exportable private keys.
-    /// Without this, the channel uses its existing default TLS configuration.
-    pub fn with_tls_client_config(mut self, config: Arc<rustls::ClientConfig>) -> Self {
-        self.tls_client_config = Some(config);
-        self
     }
 
     /// Join our room.
@@ -501,7 +491,7 @@ where
             let user_agent = self.user_agent.clone();
             let token = self.token.clone();
             let socket_factory = self.socket_factory.clone();
-            let tls_client_config = self.tls_client_config.clone();
+            let tls_client_config = self.url_prototype.tls_client_config();
 
             async move {
                 if let Err(e) = closing.await {

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -25,11 +25,11 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use socket_factory::{SocketFactory, TcpSocket, TcpStream};
 use std::task::{Context, Poll, Waker};
 use tokio_tungstenite::tungstenite::http::header::RETRY_AFTER;
+use tokio_tungstenite::{Connector, client_async_tls_with_config, tungstenite};
 use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream,
     tungstenite::{Message, handshake::client::Request},
 };
-use tokio_tungstenite::{client_async_tls, tungstenite};
 use url::Url;
 
 pub use get_user_agent::get_user_agent;
@@ -57,6 +57,7 @@ pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     url_prototype: LoginUrl<TFinish>,
     last_url: Option<Url>,
     user_agent: String,
+    tls_client_config: Option<Arc<rustls::ClientConfig>>,
     /// The authentication token, sent via X-Authorization header.
     token: SecretString,
     make_initial_backoff: Box<dyn Fn() -> ExponentialBackoff + Send>,
@@ -99,6 +100,7 @@ async fn create_and_connect_websocket(
     token: SecretString,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     connect_timeout: Duration,
+    tls_client_config: Option<Arc<rustls::ClientConfig>>,
 ) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, InternalError> {
     tracing::debug!(%host, ?addresses, %user_agent, "Connecting to portal");
 
@@ -115,9 +117,15 @@ async fn create_and_connect_websocket(
                 )
             })??;
 
-        let (stream, _) = client_async_tls(make_request(url, host, user_agent, &token), socket)
-            .await
-            .map_err(InternalError::WebSocket)?;
+        let connector = tls_client_config.map(Connector::Rustls);
+        let (stream, _) = client_async_tls_with_config(
+            make_request(url, host, user_agent, &token),
+            socket,
+            None,
+            connector,
+        )
+        .await
+        .map_err(InternalError::WebSocket)?;
 
         Ok(stream)
     })
@@ -378,6 +386,7 @@ where
             was_connected: false,
             url_prototype: url,
             user_agent,
+            tls_client_config: None,
             token,
             state: State::Closed,
             socket_factory,
@@ -387,6 +396,16 @@ where
             init_req,
             last_url: None,
         }
+    }
+
+    /// Uses the supplied rustls configuration for TLS connections.
+    ///
+    /// This allows callers to configure client certificate authentication, including
+    /// certificate resolvers backed by platform-managed, non-exportable private keys.
+    /// Without this, the channel uses its existing default TLS configuration.
+    pub fn with_tls_client_config(mut self, config: Arc<rustls::ClientConfig>) -> Self {
+        self.tls_client_config = Some(config);
+        self
     }
 
     /// Join our room.
@@ -475,6 +494,7 @@ where
             let user_agent = self.user_agent.clone();
             let token = self.token.clone();
             let socket_factory = self.socket_factory.clone();
+            let tls_client_config = self.tls_client_config.clone();
 
             async move {
                 if let Err(e) = closing.await {
@@ -490,6 +510,7 @@ where
                     token,
                     socket_factory,
                     CONNECT_TIMEOUT,
+                    tls_client_config,
                 )
                 .await
             }
@@ -1349,6 +1370,7 @@ mod tests {
             SecretString::from("test-token".to_string()),
             Arc::new(socket_factory::tcp),
             Duration::from_secs(2),
+            None,
         )
         .await;
 

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -186,6 +186,8 @@ async fn connect(
 pub enum Error {
     #[error("Authentication token invalid")]
     InvalidToken,
+    #[error("X.509 device identity certificate was revoked")]
+    CertificateRevoked,
     #[error(
         "Got disconnected from portal and hit the max-retry limit. Last connection error: {final_error}"
     )]
@@ -200,10 +202,15 @@ impl Error {
     pub fn is_authentication_error(&self) -> bool {
         match self {
             Error::InvalidToken => true,
+            Error::CertificateRevoked => false,
             Error::MaxRetriesReached { .. } => false,
             Error::LoginFailed(_) => false,
             Error::FatalIo(_) => false,
         }
+    }
+
+    pub fn is_certificate_revoked(&self) -> bool {
+        matches!(self, Error::CertificateRevoked)
     }
 }
 
@@ -860,6 +867,14 @@ where
                         ) => {
                             return Poll::Ready(Err(Error::InvalidToken));
                         }
+                        (
+                            Payload::Disconnect {
+                                reason: DisconnectReason::CertificateRevoked,
+                            },
+                            _,
+                        ) => {
+                            return Poll::Ready(Err(Error::CertificateRevoked));
+                        }
                     }
                 }
                 Poll::Ready(Some(Ok(Message::Binary(_)))) => {
@@ -1032,6 +1047,7 @@ impl fmt::Display for ErrorReply {
 #[serde(rename_all = "snake_case")]
 pub enum DisconnectReason {
     TokenExpired,
+    CertificateRevoked,
 }
 
 impl<T> PhoenixMessage<T> {
@@ -1220,6 +1236,23 @@ mod tests {
         let actual_reply = serde_json::from_str::<Payload<()>>(actual_reply).unwrap();
         let expected_reply = Payload::<()>::Disconnect {
             reason: DisconnectReason::TokenExpired,
+        };
+        assert_eq!(actual_reply, expected_reply);
+    }
+
+    #[test]
+    fn certificate_revoked() {
+        let actual_reply = r#"
+        {
+          "event": "disconnect",
+          "ref": null,
+          "topic": "client",
+          "payload": { "reason": "certificate_revoked" }
+        }
+        "#;
+        let actual_reply = serde_json::from_str::<Payload<()>>(actual_reply).unwrap();
+        let expected_reply = Payload::<()>::Disconnect {
+            reason: DisconnectReason::CertificateRevoked,
         };
         assert_eq!(actual_reply, expected_reply);
     }

--- a/rust/libs/connlib/phoenix-channel/src/login_url.rs
+++ b/rust/libs/connlib/phoenix-channel/src/login_url.rs
@@ -6,6 +6,7 @@ use std::{
     marker::PhantomData,
     net::{Ipv4Addr, Ipv6Addr},
     str::FromStr as _,
+    sync::Arc,
 };
 use url::Url;
 use uuid::Uuid;
@@ -40,7 +41,18 @@ pub struct LoginUrl<TFinish> {
     host: String,
     port: u16,
 
+    certificate: Option<ClientCertificate>,
+
     phantom: PhantomData<TFinish>,
+}
+
+/// An X.509 client certificate presented to the portal during the TLS handshake.
+///
+/// Constructing a [`LoginUrl`] with a certificate dials the portal's mTLS endpoint instead of the regular one.
+/// Platform code builds the [`rustls::ClientConfig`], typically with a certificate resolver backed by a keystore-managed, non-exportable private key, and hands it in here.
+#[derive(Clone)]
+pub struct ClientCertificate {
+    pub tls_config: Arc<rustls::ClientConfig>,
 }
 
 #[derive(Debug, Clone)]
@@ -73,7 +85,14 @@ impl LoginUrl<PublicKeyParam> {
         device_id: String,
         device_name: Option<String>,
         device_info: DeviceInfo,
+        certificate: Option<ClientCertificate>,
     ) -> Result<Self, LoginUrlError<E>> {
+        let mut url = url.try_into().map_err(LoginUrlError::InvalidUrl)?;
+
+        if certificate.is_some() {
+            set_mtls_host(&mut url);
+        }
+
         let external_id = if uuid::Uuid::from_str(&device_id).is_ok() {
             hex::encode(sha2::Sha256::digest(device_id))
         } else {
@@ -85,7 +104,7 @@ impl LoginUrl<PublicKeyParam> {
             .unwrap_or_else(|| Uuid::new_v4().to_string());
 
         let url = get_websocket_path(
-            url.try_into().map_err(LoginUrlError::InvalidUrl)?,
+            url,
             "client",
             Some("v2"),
             Some(external_id),
@@ -102,6 +121,7 @@ impl LoginUrl<PublicKeyParam> {
             host,
             port,
             url,
+            certificate,
             phantom: PhantomData,
         })
     }
@@ -138,6 +158,7 @@ impl LoginUrl<PublicKeyParam> {
             host,
             port,
             url,
+            certificate: None,
             phantom: PhantomData,
         })
     }
@@ -169,6 +190,7 @@ impl LoginUrl<NoParams> {
             host,
             port,
             url,
+            certificate: None,
             phantom: PhantomData,
         })
     }
@@ -200,6 +222,26 @@ impl<TFinish> LoginUrl<TFinish> {
 
         url.to_string()
     }
+
+    pub(crate) fn tls_client_config(&self) -> Option<Arc<rustls::ClientConfig>> {
+        let certificate = self.certificate.as_ref()?;
+
+        Some(certificate.tls_config.clone())
+    }
+}
+
+/// Replaces a SaaS API host with its mTLS counterpart, leaving other hosts untouched.
+///
+/// The portal requests a client certificate based on the host we dial, so presenting a certificate implies dialing the mTLS host.
+fn set_mtls_host(url: &mut Url) {
+    let mtls_host = match url.host_str() {
+        Some("api.firez.one") => "mtls.firez.one",
+        Some("api.firezone.dev") => "mtls.firezone.dev",
+        _ => return,
+    };
+
+    url.set_host(Some(mtls_host))
+        .expect("hard-coded hostname is valid");
 }
 
 /// Parse the host from a URL, including port if present. e.g. `example.com:8080`.
@@ -325,6 +367,7 @@ mod tests {
             "some-id".to_owned(),
             None,
             DeviceInfo::default(),
+            None,
         )
         .unwrap();
 
@@ -340,6 +383,7 @@ mod tests {
             "some-id".to_owned(),
             Some("some-name".to_owned()),
             DeviceInfo::default(),
+            None,
         )
         .unwrap();
 
@@ -347,6 +391,65 @@ mod tests {
             login_url.to_url(PublicKeyParam([0; 32])).path(),
             "/client/v2/websocket"
         )
+    }
+
+    #[test]
+    fn client_with_certificate_uses_mtls_api_host() {
+        let login_url = LoginUrl::client(
+            "wss://api.firez.one:444",
+            "some-id".to_owned(),
+            Some("some-name".to_owned()),
+            DeviceInfo::default(),
+            Some(certificate()),
+        )
+        .unwrap();
+
+        assert_eq!(login_url.host_and_port(), ("mtls.firez.one", 444));
+        assert!(login_url.tls_client_config().is_some());
+    }
+
+    #[test]
+    fn client_with_certificate_uses_mtls_staging_api_host() {
+        let login_url = LoginUrl::client(
+            "wss://api.firezone.dev",
+            "some-id".to_owned(),
+            Some("some-name".to_owned()),
+            DeviceInfo::default(),
+            Some(certificate()),
+        )
+        .unwrap();
+
+        assert_eq!(login_url.host_and_port(), ("mtls.firezone.dev", 443));
+    }
+
+    #[test]
+    fn client_with_certificate_keeps_custom_api_host() {
+        let login_url = LoginUrl::client(
+            "wss://portal.example.com",
+            "some-id".to_owned(),
+            Some("some-name".to_owned()),
+            DeviceInfo::default(),
+            Some(certificate()),
+        )
+        .unwrap();
+
+        assert_eq!(login_url.host_and_port(), ("portal.example.com", 443));
+        assert!(login_url.tls_client_config().is_some());
+    }
+
+    #[test]
+    fn client_without_certificate_keeps_api_host() {
+        let login_url = LoginUrl::client(
+            "wss://api.firezone.dev",
+            "some-id".to_owned(),
+            Some("some-name".to_owned()),
+            DeviceInfo::default(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(login_url.host_and_port(), ("api.firezone.dev", 443));
+        assert!(login_url.tls_client_config().is_none());
     }
 
     #[test]
@@ -376,5 +479,19 @@ mod tests {
         .unwrap();
 
         assert_eq!(login_url.to_url(NoParams).path(), "/relay/websocket")
+    }
+
+    fn certificate() -> ClientCertificate {
+        let tls_config = rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .with_root_certificates(rustls::RootCertStore::empty())
+        .with_no_client_auth();
+
+        ClientCertificate {
+            tls_config: Arc::new(tls_config),
+        }
     }
 }

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -631,6 +631,7 @@ fn make_test_channel(
         "test-device-id".to_string(),
         Some("test-device".to_string()),
         DeviceInfo::default(),
+        None,
     )
     .unwrap();
 

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -319,6 +319,24 @@ pub fn set_firezone_id(firezone_id: String) {
     feature_flags::reevaluate_current();
 }
 
+/// Attaches the MDM's device identifier to the active Sentry session.
+///
+/// This identifier comes from the client certificate and allows an event to be
+/// correlated with the device attested by the Portal even when multiple
+/// installations share a Firezone ID.
+pub fn set_mdm_device_id(mdm_device_id: Option<String>) {
+    let _ = STATE.try_write(|state| state.set_mdm_device_id(mdm_device_id.clone()));
+
+    update_user(|user| match mdm_device_id {
+        Some(id) => {
+            user.other.insert("mdm_device_id".to_owned(), id.into());
+        }
+        None => {
+            user.other.remove("mdm_device_id");
+        }
+    });
+}
+
 #[doc(hidden)] // Only public for testing.
 pub fn current_env() -> Option<Env> {
     STATE.try_read(|state| state.env()).ok().flatten()
@@ -332,6 +350,11 @@ pub fn current_user() -> Option<String> {
 #[doc(hidden)] // Only public for testing.
 pub fn current_account_slug() -> Option<String> {
     STATE.try_read(|state| state.account_slug()).ok().flatten()
+}
+
+#[doc(hidden)] // Only public for testing.
+pub fn current_mdm_device_id() -> Option<String> {
+    STATE.try_read(|state| state.mdm_device_id()).ok().flatten()
 }
 
 /// The identity feature flags are evaluated for: the current user and environment.

--- a/rust/libs/telemetry/src/state.rs
+++ b/rust/libs/telemetry/src/state.rs
@@ -33,6 +33,7 @@ pub(crate) struct State {
     env: Option<Env>,
     firezone_id: Option<String>,
     account_slug: Option<String>,
+    mdm_device_id: Option<String>,
     sentry_guard: Option<sentry::ClientInitGuard>,
 }
 
@@ -42,6 +43,7 @@ impl State {
             env: None,
             firezone_id: None,
             account_slug: None,
+            mdm_device_id: None,
             sentry_guard: None,
         }
     }
@@ -56,6 +58,10 @@ impl State {
 
     pub(crate) fn account_slug(&self) -> Option<String> {
         self.account_slug.clone()
+    }
+
+    pub(crate) fn mdm_device_id(&self) -> Option<String> {
+        self.mdm_device_id.clone()
     }
 
     /// Whether a Sentry session is currently active.
@@ -84,6 +90,10 @@ impl State {
         self.firezone_id = firezone_id;
     }
 
+    pub(crate) fn set_mdm_device_id(&mut self, mdm_device_id: Option<String>) {
+        self.mdm_device_id = mdm_device_id;
+    }
+
     pub(crate) fn set_guard(&mut self, guard: sentry::ClientInitGuard) {
         self.sentry_guard = Some(guard);
     }
@@ -97,6 +107,7 @@ impl State {
     pub(crate) fn clear_identity(&mut self) {
         self.firezone_id = None;
         self.account_slug = None;
+        self.mdm_device_id = None;
     }
 }
 

--- a/rust/libs/telemetry/tests/set_account_before_id.rs
+++ b/rust/libs/telemetry/tests/set_account_before_id.rs
@@ -8,8 +8,16 @@ async fn set_account_slug_before_set_firezone_id_preserves_both() {
     telemetry::start("entrypoint", "1.0.0", TESTING);
 
     telemetry::set_account_slug("acme".to_owned());
+    telemetry::set_mdm_device_id(Some("intune-device-123".to_owned()));
     telemetry::set_firezone_id("device-xyz".to_owned());
 
     assert_eq!(telemetry::current_user().as_deref(), Some("device-xyz"));
     assert_eq!(telemetry::current_account_slug().as_deref(), Some("acme"));
+    assert_eq!(
+        telemetry::current_mdm_device_id().as_deref(),
+        Some("intune-device-123")
+    );
+
+    telemetry::set_mdm_device_id(None);
+    assert_eq!(telemetry::current_mdm_device_id(), None);
 }

--- a/rust/tests/loadtest/src/portal.rs
+++ b/rust/tests/loadtest/src/portal.rs
@@ -59,8 +59,14 @@ pub async fn fetch_relay(
     let token = load_token(token_path)?;
 
     let device_id = uuid::Uuid::new_v4().to_string();
-    let url = LoginUrl::client(portal_url.clone(), device_id, None, DeviceInfo::default())
-        .map_err(|e| anyhow!("invalid portal URL: {e:?}"))?;
+    let url = LoginUrl::client(
+        portal_url.clone(),
+        device_id,
+        None,
+        DeviceInfo::default(),
+        None,
+    )
+    .map_err(|e| anyhow!("invalid portal URL: {e:?}"))?;
 
     let socket_factory = Arc::new(socket_factory::tcp) as Arc<dyn SocketFactory<TcpSocket>>;
 


### PR DESCRIPTION
Depends on #14507.

## Summary

- carries an optional client certificate inside `LoginUrl` so the mTLS host and the rustls client configuration are chosen together, and preserves it across reconnects
- adds a common UniFFI callback interface for platform certificate chains and handshake signing without exporting private keys
- keeps clients on /client/v2 and rewrites api.firez.one or api.firezone.dev to the corresponding mtls host only when a client certificate is present
- carries mdm_device_id across FFI and adds it to Rust Sentry user context alongside firezone_id
- recognizes device_untrusted disconnect responses for native client error handling

Client implementations are stacked in #14449, #14450, and #14476.

## Validation

- cargo test -p client-ffi --lib -p telemetry -p phoenix-channel
- cargo test -p telemetry --test set_account_before_id
- cargo clippy -p client-ffi -p telemetry -p phoenix-channel --all-targets -- -D warnings