### PR TITLE
feat(portal): polish device pools for release

### DIFF
--- a/elixir/lib/portal/version.ex
+++ b/elixir/lib/portal/version.ex
@@ -74,7 +74,7 @@ defmodule Portal.Version do
   #   apple    >= 1.5.16
   #   gui      >= 1.5.13 (windows / linux gui)
   #   headless >= 1.5.9  (windows / linux headless)
-  #   android  -- not yet supported
+  #   android  >= 1.5.11
   def client_supports_static_device_pools?(%Device{type: :client, last_seen_version: nil}),
     do: false
 
@@ -95,7 +95,7 @@ defmodule Portal.Version do
       case ComponentVersions.get_component_type_from_user_agent(client.last_seen_user_agent) do
         :apple -> Version.compare(client.last_seen_version, "1.5.16") != :lt
         :gui -> Version.compare(client.last_seen_version, "1.5.13") != :lt
-        :android -> false
+        :android -> Version.compare(client.last_seen_version, "1.5.11") != :lt
       end
     end
   end

--- a/elixir/lib/portal_web/components/navigation_components.ex
+++ b/elixir/lib/portal_web/components/navigation_components.ex
@@ -214,6 +214,7 @@ defmodule PortalWeb.NavigationComponents do
               current_path={@current_path}
               navigate={~p"/#{@account}/resources"}
               icon="ri-server-line"
+              badge="NEW"
             >
               Resources
             </.sidebar_item>

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -23,6 +23,7 @@ defmodule PortalWeb.Clients do
       |> assign(stale: false)
       |> assign_async(:clients_count, fn -> {:ok, %{clients_count: Database.count_clients(subject)}} end)
       |> assign(
+        client_device_pools: [],
         policy_authorizations: [],
         policy_authorizations_page: 1,
         policy_authorizations_has_next: false,
@@ -63,6 +64,7 @@ defmodule PortalWeb.Clients do
          |> assign(selected_client: client)
          |> assign(show_client_assigns(tab))
          |> assign(
+           client_device_pools: Database.list_device_pools_for_client(client, socket.assigns.subject),
            policy_authorizations: policy_authorizations,
            policy_authorizations_page: page,
            policy_authorizations_has_next: has_next,
@@ -93,7 +95,7 @@ defmodule PortalWeb.Clients do
 
     {:noreply,
      socket
-     |> assign(selected_client: nil)
+     |> assign(selected_client: nil, client_device_pools: [])
      |> assign(base_client_assigns())}
   end
 
@@ -239,6 +241,7 @@ defmodule PortalWeb.Clients do
         panel={client_panel_state(assigns)}
         confirm_state={client_confirm_state(assigns)}
         query_params={@query_params}
+        device_pools={@client_device_pools}
         policy_authorizations={@policy_authorizations}
         policy_authorizations_page={@policy_authorizations_page}
         policy_authorizations_has_next={@policy_authorizations_has_next}
@@ -564,6 +567,7 @@ defmodule PortalWeb.Clients do
     alias Portal.PolicyAuthorization
     alias Portal.Group
     alias Portal.Resource
+    alias Portal.StaticDevicePoolMember
     alias Portal.Repo.Filter
     alias Portal.Repo.OffsetPaginator
 
@@ -727,6 +731,27 @@ defmodule PortalWeb.Clients do
 
         _ ->
           nil
+      end
+    end
+
+    @spec list_device_pools_for_client(Portal.Device.t(), Portal.Authentication.Subject.t()) ::
+            [Resource.t()]
+    def list_device_pools_for_client(%Device{} = client, subject) do
+      from(r in Resource, as: :resources)
+      |> join(:inner, [resources: r], m in StaticDevicePoolMember,
+        on: m.resource_id == r.id and m.account_id == r.account_id,
+        as: :members
+      )
+      |> where([members: m], m.device_id == ^client.id)
+      # The REST API can retype a pool without clearing its members, so filter on
+      # the resource rather than trusting the membership rows alone.
+      |> where([resources: r], r.type == :static_device_pool)
+      |> order_by([resources: r], asc: r.name)
+      |> Safe.scoped(subject)
+      |> Safe.all()
+      |> case do
+        {:error, _} -> []
+        resources -> resources
       end
     end
 

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -199,6 +199,7 @@ defmodule PortalWeb.Clients.Components do
   attr :panel, :map, required: true
   attr :confirm_state, :map, required: true
   attr :query_params, :map, default: %{}
+  attr :device_pools, :list, default: []
   attr :policy_authorizations, :list, default: []
   attr :policy_authorizations_page, :integer, default: 1
   attr :policy_authorizations_has_next, :boolean, default: false
@@ -236,6 +237,7 @@ defmodule PortalWeb.Clients.Components do
           tab={@panel_tab}
           confirm_delete_client={@confirm_delete_client}
           confirm_unverify_client={@confirm_unverify_client}
+          device_pools={@device_pools}
           policy_authorizations={@policy_authorizations}
           policy_authorizations_page={@policy_authorizations_page}
           policy_authorizations_has_next={@policy_authorizations_has_next}
@@ -309,6 +311,7 @@ defmodule PortalWeb.Clients.Components do
   attr :tab, :atom, default: :overview
   attr :confirm_delete_client, :boolean, default: false
   attr :confirm_unverify_client, :boolean, default: false
+  attr :device_pools, :list, default: []
   attr :policy_authorizations, :list, default: []
   attr :policy_authorizations_page, :integer, default: 1
   attr :policy_authorizations_has_next, :boolean, default: false
@@ -357,6 +360,11 @@ defmodule PortalWeb.Clients.Components do
           </div>
           <div :if={@tab == :overview} class="flex-1 overflow-y-auto">
             <.client_owner_section account={@account} client={@client} />
+            <.client_device_pools_section
+              :if={@device_pools != []}
+              account={@account}
+              device_pools={@device_pools}
+            />
             <.client_device_section client={@client} />
             <.client_network_section client={@client} />
           </div>
@@ -579,6 +587,33 @@ defmodule PortalWeb.Clients.Components do
           </p>
         </div>
       </.link>
+    </div>
+    """
+  end
+
+  attr :account, :any, required: true
+  attr :device_pools, :list, required: true
+
+  def client_device_pools_section(assigns) do
+    ~H"""
+    <div class="px-5 pt-4 pb-3 border-b border-border">
+      <.section_heading title="Device Pools" />
+      <p class="mb-2 text-xs text-subtle">
+        Anyone granted access to these pools can reach this Client directly on its tunnel address.
+      </p>
+      <ul class="space-y-1">
+        <li :for={pool <- @device_pools}>
+          <.link
+            navigate={~p"/#{@account}/resources/#{pool.id}"}
+            class="flex items-center gap-2 px-3 py-2 rounded border border-border bg-raised hover:border-border-strong transition-colors group"
+          >
+            <.icon name="ri-computer-line" class="w-4 h-4 shrink-0 text-subtle" />
+            <span class="text-sm text-heading group-hover:text-brand truncate transition-colors">
+              {pool.name}
+            </span>
+          </.link>
+        </li>
+      </ul>
     </div>
     """
   end

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -446,11 +446,14 @@ defmodule PortalWeb.Resources.Components do
             class="inline-flex items-center justify-between w-full p-3 text-body bg-surface border border-border rounded cursor-pointer peer-checked:border-brand peer-checked:text-brand hover:text-heading hover:bg-raised transition-colors"
           >
             <div class="block">
-              <div class="w-full font-semibold mb-1 text-xs">
+              <div class="w-full font-semibold mb-1 text-xs flex items-center">
                 <.icon name="ri-computer-line" class="w-4 h-4 mr-1" /> Device Pool
+                <span class="ml-1.5 px-1 py-px rounded text-[9px] font-semibold tracking-wider bg-brand-muted text-brand">
+                  NEW
+                </span>
               </div>
               <div class="w-full text-[10px]">
-                Direct client access
+                Peer-to-peer, no Site
               </div>
             </div>
           </label>
@@ -1233,10 +1236,14 @@ defmodule PortalWeb.Resources.Components do
     <div class="flex-1 flex flex-col overflow-hidden">
       <div
         :if={@clients == []}
-        class="flex flex-col items-center justify-center h-full gap-2 text-subtle"
+        class="flex flex-col items-center justify-center h-full gap-2 px-6 text-center"
       >
-        <.icon name="ri-computer-line" class="w-8 h-8" />
-        <p class="text-sm">No clients in this pool</p>
+        <.icon name="ri-error-warning-line" class="w-8 h-8 text-warning" />
+        <p class="text-sm font-medium text-heading">No devices in this pool</p>
+        <p class="text-xs text-subtle max-w-sm">
+          An empty pool has nothing to connect to, so any Policy granting access to it has no
+          effect. Edit this Resource to add Clients.
+        </p>
       </div>
       <div :if={@clients != []} class="flex-1 overflow-y-auto">
         <table class="w-full text-xs">
@@ -1269,7 +1276,12 @@ defmodule PortalWeb.Resources.Components do
                   {if client.actor, do: client.actor.name, else: "—"}
                 </td>
                 <td class="px-4 py-2 text-subtle font-mono">
-                  {client.ipv4}
+                  <.copy
+                    id={"pool-member-#{client.id}-ipv4"}
+                    class="flex items-center gap-1.5"
+                  >
+                    {client.ipv4}
+                  </.copy>
                 </td>
                 <td class="px-4 py-2">
                   <.client_status_badge online?={MapSet.member?(@online_client_ids, client.id)} />
@@ -1306,11 +1318,21 @@ defmodule PortalWeb.Resources.Components do
                     </div>
                     <div>
                       <p class="text-subtle font-medium mb-1">Tunnel IPv4</p>
-                      <p class="text-heading font-mono">{client.ipv4}</p>
+                      <.copy
+                        id={"pool-member-#{client.id}-detail-ipv4"}
+                        class="flex items-center gap-1.5 text-heading font-mono"
+                      >
+                        {client.ipv4}
+                      </.copy>
                     </div>
                     <div>
                       <p class="text-subtle font-medium mb-1">Tunnel IPv6</p>
-                      <p class="text-heading font-mono break-all">{client.ipv6}</p>
+                      <.copy
+                        id={"pool-member-#{client.id}-detail-ipv6"}
+                        class="flex items-start gap-1.5 text-heading font-mono break-all"
+                      >
+                        {client.ipv6}
+                      </.copy>
                     </div>
                     <div :if={client.last_seen_at}>
                       <p class="text-subtle font-medium mb-1">Last Seen</p>
@@ -2074,7 +2096,10 @@ defmodule PortalWeb.Resources.Components do
     assigns = assign(assigns, online: online, total: length(assigns.pool_member_ids))
 
     ~H"""
-    <.status_badge style={if @online > 0, do: :success, else: :neutral}>
+    <.status_badge :if={@total == 0} style={:warning}>
+      No devices
+    </.status_badge>
+    <.status_badge :if={@total > 0} style={if @online > 0, do: :success, else: :neutral}>
       {@online} / {@total} online
     </.status_badge>
     """

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1242,7 +1242,7 @@ defmodule PortalWeb.Resources.Components do
         <p class="text-sm font-medium text-heading">No devices in this pool</p>
         <p class="text-xs text-subtle max-w-sm">
           An empty pool has nothing to connect to, so any Policy granting access to it has no
-          effect. Edit this Resource to add Clients.
+          effect. Edit this Resource to add devices.
         </p>
       </div>
       <div :if={@clients != []} class="flex-1 overflow-y-auto">

--- a/elixir/test/portal/version_test.exs
+++ b/elixir/test/portal/version_test.exs
@@ -214,6 +214,45 @@ defmodule Portal.VersionTest do
     end
   end
 
+  describe "client_supports_static_device_pools?/1" do
+    test "uses component-specific minimum versions" do
+      cases = [
+        {"Mac OS/15.1.1 apple-client/1.5.16 (arm64; 24.1.0)", "1.5.15", "1.5.16"},
+        {"Fedora/42.0.0 headless-client/1.5.9 (arm64; 24.1.0)", "1.5.8", "1.5.9"},
+        {"Android/14 android-client/1.5.11 (arm64; 24.1.0)", "1.5.10", "1.5.11"},
+        {"Windows/10.0.22631 gui-client/1.5.13 (arm64; 24.1.0)", "1.5.12", "1.5.13"}
+      ]
+
+      for {user_agent, unsupported_version, supported_version} <- cases do
+        refute Portal.Version.client_supports_static_device_pools?(%Portal.Device{
+                 type: :client,
+                 last_seen_version: unsupported_version,
+                 last_seen_user_agent: user_agent
+               })
+
+        assert Portal.Version.client_supports_static_device_pools?(%Portal.Device{
+                 type: :client,
+                 last_seen_version: supported_version,
+                 last_seen_user_agent: user_agent
+               })
+      end
+    end
+
+    test "returns false for nil last_seen_version or last_seen_user_agent" do
+      refute Portal.Version.client_supports_static_device_pools?(%Portal.Device{
+               type: :client,
+               last_seen_version: nil,
+               last_seen_user_agent: "Android/14 android-client/1.5.11"
+             })
+
+      refute Portal.Version.client_supports_static_device_pools?(%Portal.Device{
+               type: :client,
+               last_seen_version: "1.5.11",
+               last_seen_user_agent: nil
+             })
+    end
+  end
+
   describe "supports_device_access?/1" do
     test "uses component-specific minimum versions" do
       cases = [

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -200,6 +200,45 @@ defmodule PortalWeb.ClientsTest do
       assert_patch(lv, ~p"/#{account}/clients")
     end
 
+    test "lists the device pools the client belongs to", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor)
+
+      pool =
+        static_device_pool_resource_fixture(
+          account: account,
+          name: "Engineering Laptops",
+          clients: [client]
+        )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}")
+
+      assert html =~ "Device Pools"
+      assert html =~ pool.name
+      assert html =~ ~p"/#{account}/resources/#{pool.id}"
+    end
+
+    test "omits the device pools section when the client is in no pools", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}")
+
+      refute html =~ "Device Pools"
+    end
+
     test "ignores a tab switch queued while the client panel is closing", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -1416,7 +1416,7 @@ defmodule PortalWeb.ResourcesTest do
       assert html =~ "1 / 1 online"
     end
 
-    test "shows an empty state when the pool has no clients", %{
+    test "warns when the pool has no clients", %{
       conn: conn,
       account: account,
       actor: actor
@@ -1428,7 +1428,24 @@ defmodule PortalWeb.ResourcesTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/resources/#{resource.id}")
 
-      assert html =~ "No clients in this pool"
+      assert html =~ "No devices in this pool"
+      assert html =~ "An empty pool has nothing to connect to"
+    end
+
+    test "warns in the resources list when the pool has no clients", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      static_device_pool_resource_fixture(account: account)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources")
+
+      assert html =~ "No devices"
+      refute html =~ "0 / 0 online"
     end
 
     test "expands and collapses a client row to reveal details", %{

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -1416,7 +1416,7 @@ defmodule PortalWeb.ResourcesTest do
       assert html =~ "1 / 1 online"
     end
 
-    test "warns when the pool has no clients", %{
+    test "warns when the pool has no devices", %{
       conn: conn,
       account: account,
       actor: actor


### PR DESCRIPTION
Static device pools are shipping, so this cleans up the rough edges an admin would hit first.

Android could not use device pools at all. The version gate in #13010 was written before any client supported the feature, so each platform's number was a guess at its next release. Android's slot was left as "not yet supported" and never revisited, even though android-client 1.5.11 shipped the same connlib support as everyone else. Android now uses that version like the other platforms do.

The rest is polish. A pool with no members can never connect, so any policy granting access to it silently does nothing; that now reads as a warning instead of "0 / 0 online". Member tunnel addresses are the whole point of the feature and were buried behind an expand click, so they are copyable now. And a client's pool memberships show on its own page, which is the only way to answer "why is this laptop reachable?" without opening every resource.

One bug fell out of that last change: the REST API can retype a device pool without clearing its member rows, so a query that trusts membership alone can surface a resource that is no longer a pool.

Related: #13010
