### PR TITLE
perf(nix): reuse compiled cargo dependencies across builds

### DIFF
--- a/.github/workflows/_nix.yml
+++ b/.github/workflows/_nix.yml
@@ -84,9 +84,18 @@ jobs:
           set -o pipefail
 
           build() {
+            # The dependency-only closure is a build-time input, so it is not
+            # part of ./result's runtime closure and the cache upload below
+            # would never see it. Realising it under its own out-link is what
+            # lets later builds substitute the compiled dependency graph
+            # instead of recompiling it.
             nix build \
-              .#${{ matrix.package }} \
-              --print-build-logs 2>&1 | tee build.log
+              --out-link result-cargo-artifacts \
+              .#${{ matrix.package }}.cargoArtifacts \
+              --print-build-logs 2>&1 | tee build.log &&
+              nix build \
+                .#${{ matrix.package }} \
+                --print-build-logs 2>&1 | tee -a build.log
           }
 
           if build; then

--- a/.github/workflows/_nix.yml
+++ b/.github/workflows/_nix.yml
@@ -70,10 +70,12 @@ jobs:
         with:
           determinate: false
           diagnostic-endpoint: ""
-          # Substitute from the first-party cache (kept warm by main and
-          # release builds) instead of rebuilding.
+          # Substitute from the first-party caches (kept warm by main and
+          # release builds) instead of rebuilding. `nix-ci` holds the compiled
+          # Cargo dependency snapshots and is only ever read here, never by
+          # anyone installing Firezone from the flake.
           extra-conf: |
-            extra-substituters = https://artifacts.firezone.dev/nix
+            extra-substituters = https://artifacts.firezone.dev/nix https://artifacts.firezone.dev/nix-ci
             extra-trusted-public-keys = artifacts.firezone.dev/nix-1:T4LHdL1HeA6LE9qgu0Po0j3RIlelKZz8pzqnzEAIRfI=
       - name: Check flake
         run: nix flake check --no-build

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1785782307,
+        "narHash": "sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "2c71e194474d13de031d729b729c968ddbe3507f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1781216227,
@@ -18,6 +33,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+    crane.url = "github:ipetkov/crane";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -23,6 +24,7 @@
     {
       self,
       nixpkgs,
+      crane,
       rust-overlay,
     }:
     let
@@ -47,7 +49,7 @@
     {
       overlays.default = lib.composeManyExtensions [
         rust-overlay.overlays.default
-        (import ./scripts/nix/overlay.nix)
+        (import ./scripts/nix/overlay.nix { inherit crane; })
       ];
 
       packages = forAllSystems (pkgs: {

--- a/scripts/nix/lib.nix
+++ b/scripts/nix/lib.nix
@@ -51,72 +51,24 @@ rec {
   # delete because its per-target rustflags conflict with buildRustPackage).
   rustflags = "--cfg system_certs -C force-frame-pointers=yes";
 
-  # Everything cargo folds into a unit's fingerprint has to match between the
-  # dependency-only build below and the package build, or nothing is reused.
+  # `cargoBuildHook` always passes `--target`, and sets `strip` so that stdenv
+  # does the stripping instead of cargo. `strip` is part of the profile and the
+  # profile is hashed into every unit's fingerprint, so the dependency-only
+  # build below has to agree or nothing it produces is reused.
   cargoEnv = {
     RUSTFLAGS = rustflags;
-
-    # `cargoBuildHook` always passes `--target`; matching it keeps the target
-    # directory layout the same on both sides.
     CARGO_BUILD_TARGET = pkgs.stdenv.hostPlatform.rust.rustcTarget;
-
-    # `cargoBuildHook` sets this so stdenv handles stripping instead of cargo.
-    # `strip` is part of the profile, and the profile is part of every unit's
-    # fingerprint.
     CARGO_PROFILE_RELEASE_STRIP = "false";
   };
 
-  # Dependency-only build of one workspace member.
-  #
-  # `buildRustPackage` compiles the whole dependency graph inside the package
-  # derivation, whose hash covers all of rust/, so any source change recompiles
-  # ~900 crates from scratch and the binary cache never helps. crane builds the
-  # same graph against a stubbed-out copy of the workspace instead: the result
-  # depends only on Cargo.lock, the manifests, the toolchain and the flags
-  # above, so it survives ordinary source changes and is substituted from the
-  # cache.
-  #
-  # Scoped per member rather than once for the whole workspace: the resolver
-  # unifies features across all members of a `--workspace` build, and artifacts
-  # compiled under a different feature set get recompiled anyway.
-  cargoArtifactsFor =
-    {
-      crate,
-      features ? [ ],
-      ...
-    }@args:
-    craneLib.buildDepsOnly (
-      {
-        inherit src;
-
-        cargoVendorDir = craneVendorDir;
-
-        pname = crate;
-        # Deliberately fixed: `versions` below moves on every release, and
-        # naming these after it would miss the cache each time.
-        version = "0";
-
-        cargoExtraArgs =
-          "--locked -p ${crate}"
-          + lib.optionalString (features != [ ]) " --features ${lib.concatStringsSep "," features}";
-
-        env = cargoEnv;
-
-        postPatch = "rm -f .cargo/config.toml";
-      }
-      // builtins.removeAttrs args [
-        "crate"
-        "features"
-      ]
-    );
-
-  # `buildRustPackage`, wired up to reuse the artifacts above.
+  # Common wiring for every Rust derivation here: the vendored sources above
+  # and, when `cargoArtifacts` is given, the pre-built target directory.
   buildRustPackage =
     args:
     rustPlatform.buildRustPackage (
       args
       // {
-        inherit src;
+        src = args.src or src;
 
         # Relative to the source root, where postUnpack links it into place.
         cargoVendorDir = "vendor";
@@ -126,13 +78,68 @@ rec {
         ''
         + (args.postUnpack or "");
 
-        nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
-          craneLib.inheritCargoArtifactsHook
-          pkgs.rsync
-          pkgs.zstd
-        ];
+        # Its per-target rustflags conflict with the ones set below, and cargo
+        # folds the resolved config into every unit's fingerprint, so both
+        # sides of the dependency split have to drop it alike.
+        postPatch = ''
+          rm -f .cargo/config.toml
+        ''
+        + (args.postPatch or "");
+
+        nativeBuildInputs =
+          (args.nativeBuildInputs or [ ])
+          ++ [
+            pkgs.rsync
+            pkgs.zstd
+          ]
+          ++ lib.optional (args ? cargoArtifacts) craneLib.inheritCargoArtifactsHook;
 
         env = cargoEnv // (args.env or { });
+      }
+    );
+
+  # Dependency-only build of one workspace member.
+  #
+  # `buildRustPackage` compiles the whole dependency graph inside the package
+  # derivation, whose hash covers all of rust/, so any source change recompiles
+  # ~900 crates from scratch and the binary cache never helps. crane's
+  # `mkDummySrc` stubs out every workspace member, leaving the manifests,
+  # Cargo.lock and .cargo/config.toml, so the same graph can be compiled by a
+  # derivation that ignores ordinary source changes and is substituted from the
+  # cache instead.
+  #
+  # Deliberately still `buildRustPackage`: cargo folds the resolved cargo
+  # config into every unit's fingerprint, and `cargoSetupHook` writes a
+  # `[target.<triple>]` block of its own. Anything that assembled the build
+  # differently would have to reproduce that block to be reusable.
+  #
+  # Scoped per member rather than once for the whole workspace: the resolver
+  # unifies features across all members of a `--workspace` build, and artifacts
+  # compiled under a different feature set get recompiled anyway.
+  cargoArtifactsFor =
+    args:
+    buildRustPackage (
+      args
+      // {
+        pname = "${args.pname}-deps";
+        # Deliberately fixed: `versions` below moves on every release, and
+        # naming these after it would miss the cache each time.
+        version = "0";
+
+        src = craneLib.mkDummySrc { inherit src; };
+
+        nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
+          craneLib.installCargoArtifactsHook
+        ];
+
+        # Only the target directory is wanted; the stub binaries are garbage.
+        doInstallCargoArtifacts = true;
+        dontCargoInstall = true;
+        installPhase = ''
+          runHook preInstall
+          mkdir -p $out
+          runHook postInstall
+        '';
       }
     );
 

--- a/scripts/nix/lib.nix
+++ b/scripts/nix/lib.nix
@@ -92,9 +92,25 @@ rec {
             pkgs.rsync
             pkgs.zstd
           ]
-          ++ lib.optional (args ? cargoArtifacts) craneLib.inheritCargoArtifactsHook;
+          ++ lib.optionals (args ? cargoArtifacts) [
+            craneLib.inheritCargoArtifactsHook
+            pkgs.removeReferencesTo
+          ];
 
         env = cargoEnv // (args.env or { });
+      }
+      # Reading the vendored sources straight from the store (rather than from
+      # a copy in the build tree, as `cargoDeps` would) bakes their paths into
+      # the binaries via panic strings, so Nix keeps the whole ~1G of crate
+      # sources as a runtime dependency of the package.
+      #
+      # Set only where it applies, so the dependency-only build's derivation
+      # stays untouched: its output is a compressed archive that legitimately
+      # contains those paths, and rewriting bytes inside it would corrupt it.
+      // lib.optionalAttrs (args ? cargoArtifacts) {
+        postInstall = (args.postInstall or "") + ''
+          find "$out" -type f -exec remove-references-to -t ${craneVendorDir} '{}' +
+        '';
       }
     );
 

--- a/scripts/nix/lib.nix
+++ b/scripts/nix/lib.nix
@@ -1,5 +1,9 @@
 # Shared helpers for the Firezone package derivations.
-{ lib, pkgs }:
+{
+  crane,
+  lib,
+  pkgs,
+}:
 rec {
   # Pin the Rust toolchain to the same channel the rest of the repo uses.
   # Bumping rust-toolchain.toml therefore needs no Nix changes (at most a
@@ -13,25 +17,124 @@ rec {
     rustc = toolchain;
   };
 
+  craneLib = (crane.mkLib pkgs).overrideToolchain toolchain;
+
   # Only the Rust workspace; changes elsewhere in the monorepo don't rebuild.
   # Flake sources contain only git-tracked files, so build artifacts like
   # gui-client/dist and target/ are already excluded.
   src = ../../rust;
 
   # `cargo update --workspace` runs on every release, so any fixed-output
-  # vendor hash would need bumping each time. Importing the lockfile with
-  # builtin git fetching keeps the Rust dependency set hash-free: revs are
-  # pinned by Cargo.lock and fetched at evaluation time.
-  cargoLock = {
-    lockFile = ../../rust/Cargo.lock;
-    allowBuiltinFetchGit = true;
-  };
+  # vendor hash would need bumping each time. crane resolves the git
+  # dependencies with `builtins.fetchGit` at the revs pinned in Cargo.lock,
+  # which keeps the Rust dependency set hash-free.
+  craneVendorDir = craneLib.vendorCargoDeps { cargoLock = ../../rust/Cargo.lock; };
+
+  # The same vendored sources, re-exported under the layout `cargoSetupHook`
+  # expects: it reads the source replacement config from `.cargo/` below the
+  # vendor directory, crane writes it to the top level. crane's config names
+  # the crate directories by absolute store path, so the symlink is enough to
+  # point both builds at the very same sources.
+  #
+  # They have to agree: cargo compares the mtime of every source file against
+  # the artifacts inherited from `cargoArtifacts`, and passing `cargoDeps`
+  # instead would copy the vendor directory into the build tree, dating every
+  # source after every rlib and recompiling the lot.
+  vendorDir = pkgs.runCommandLocal "firezone-cargo-vendor-dir" { } ''
+    mkdir -p $out/.cargo
+    ln -s ${craneVendorDir}/config.toml $out/.cargo/config.toml
+  '';
 
   # `system_certs` switches phoenix-channel to the platform TLS verifier
   # (NixOS provides roots via security.pki). Frame pointers match the
   # official release builds (rust/.cargo/config.toml, which the derivations
   # delete because its per-target rustflags conflict with buildRustPackage).
   rustflags = "--cfg system_certs -C force-frame-pointers=yes";
+
+  # Everything cargo folds into a unit's fingerprint has to match between the
+  # dependency-only build below and the package build, or nothing is reused.
+  cargoEnv = {
+    RUSTFLAGS = rustflags;
+
+    # `cargoBuildHook` always passes `--target`; matching it keeps the target
+    # directory layout the same on both sides.
+    CARGO_BUILD_TARGET = pkgs.stdenv.hostPlatform.rust.rustcTarget;
+
+    # `cargoBuildHook` sets this so stdenv handles stripping instead of cargo.
+    # `strip` is part of the profile, and the profile is part of every unit's
+    # fingerprint.
+    CARGO_PROFILE_RELEASE_STRIP = "false";
+  };
+
+  # Dependency-only build of one workspace member.
+  #
+  # `buildRustPackage` compiles the whole dependency graph inside the package
+  # derivation, whose hash covers all of rust/, so any source change recompiles
+  # ~900 crates from scratch and the binary cache never helps. crane builds the
+  # same graph against a stubbed-out copy of the workspace instead: the result
+  # depends only on Cargo.lock, the manifests, the toolchain and the flags
+  # above, so it survives ordinary source changes and is substituted from the
+  # cache.
+  #
+  # Scoped per member rather than once for the whole workspace: the resolver
+  # unifies features across all members of a `--workspace` build, and artifacts
+  # compiled under a different feature set get recompiled anyway.
+  cargoArtifactsFor =
+    {
+      crate,
+      features ? [ ],
+      ...
+    }@args:
+    craneLib.buildDepsOnly (
+      {
+        inherit src;
+
+        cargoVendorDir = craneVendorDir;
+
+        pname = crate;
+        # Deliberately fixed: `versions` below moves on every release, and
+        # naming these after it would miss the cache each time.
+        version = "0";
+
+        cargoExtraArgs =
+          "--locked -p ${crate}"
+          + lib.optionalString (features != [ ]) " --features ${lib.concatStringsSep "," features}";
+
+        env = cargoEnv;
+
+        postPatch = "rm -f .cargo/config.toml";
+      }
+      // builtins.removeAttrs args [
+        "crate"
+        "features"
+      ]
+    );
+
+  # `buildRustPackage`, wired up to reuse the artifacts above.
+  buildRustPackage =
+    args:
+    rustPlatform.buildRustPackage (
+      args
+      // {
+        inherit src;
+
+        # Relative to the source root, where postUnpack links it into place.
+        cargoVendorDir = "vendor";
+
+        postUnpack = ''
+          ln -s ${vendorDir} "$sourceRoot/vendor"
+        ''
+        + (args.postUnpack or "");
+
+        nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
+          craneLib.inheritCargoArtifactsHook
+          pkgs.rsync
+          pkgs.zstd
+        ];
+
+        env = cargoEnv // (args.env or { });
+      }
+    );
 
   # Current released version of each component we package. Read from the
   # sentinel comments here (kept in sync by scripts/bump-versions.sh) rather

--- a/scripts/nix/overlay.nix
+++ b/scripts/nix/overlay.nix
@@ -1,6 +1,8 @@
+{ crane }:
 final: prev:
 let
   fzLib = import ./lib.nix {
+    inherit crane;
     inherit (final) lib;
     pkgs = final;
   };

--- a/scripts/nix/packages/firezone-gateway.nix
+++ b/scripts/nix/packages/firezone-gateway.nix
@@ -1,14 +1,12 @@
 { lib, fzLib }:
 
-fzLib.rustPlatform.buildRustPackage {
+fzLib.buildRustPackage {
   pname = "firezone-gateway";
   version = fzLib.versions.gateway;
 
-  inherit (fzLib) src cargoLock;
+  cargoArtifacts = fzLib.cargoArtifactsFor { crate = "firezone-gateway"; };
 
   buildAndTestSubdir = "gateway";
-
-  env.RUSTFLAGS = fzLib.rustflags;
 
   postPatch = ''
     rm .cargo/config.toml

--- a/scripts/nix/packages/firezone-gateway.nix
+++ b/scripts/nix/packages/firezone-gateway.nix
@@ -1,19 +1,23 @@
 { lib, fzLib }:
 
-fzLib.buildRustPackage {
-  pname = "firezone-gateway";
-  version = fzLib.versions.gateway;
-
-  cargoArtifacts = fzLib.cargoArtifactsFor { crate = "firezone-gateway"; };
-
-  buildAndTestSubdir = "gateway";
-
-  postPatch = ''
-    rm .cargo/config.toml
-  '';
-
-  meta = fzLib.meta // {
-    description = "Gateway for the Firezone zero-trust access platform";
-    mainProgram = "firezone-gateway";
+let
+  # Shared with the dependency-only build so the two cannot drift: cargo
+  # reuses artifacts only for an identical invocation.
+  common = {
+    pname = "firezone-gateway";
+    buildAndTestSubdir = "gateway";
   };
-}
+in
+fzLib.buildRustPackage (
+  common
+  // {
+    version = fzLib.versions.gateway;
+
+    cargoArtifacts = fzLib.cargoArtifactsFor common;
+
+    meta = fzLib.meta // {
+      description = "Gateway for the Firezone zero-trust access platform";
+      mainProgram = "firezone-gateway";
+    };
+  }
+)

--- a/scripts/nix/packages/firezone-gui-client/package.nix
+++ b/scripts/nix/packages/firezone-gui-client/package.nix
@@ -21,11 +21,35 @@
   kdePackages,
 }:
 
-fzLib.rustPlatform.buildRustPackage {
+let
+  # The `*-sys` build scripts need these on both sides of the dependency split.
+  buildInputs = [
+    dbus
+    gdk-pixbuf
+    glib
+    gobject-introspection
+    gtk3
+    libayatana-appindicator
+    libsoup_3
+    openssl
+    webkitgtk_4_1
+  ];
+in
+fzLib.buildRustPackage {
   pname = "firezone-gui-client";
   version = fzLib.versions.gui;
 
-  inherit (fzLib) src cargoLock;
+  cargoArtifacts = fzLib.cargoArtifactsFor {
+    crate = "firezone-gui-client";
+    # What `cargo tauri build` adds to a desktop release build (see
+    # tauri-cli's `Rust::build_options`); the dependency graph has to be
+    # resolved with the same features to be reusable.
+    features = [ "tauri/custom-protocol" ];
+    doCheck = false;
+
+    nativeBuildInputs = [ pkg-config ];
+    inherit buildInputs;
+  };
 
   # The workspace Cargo.lock lives at the source root, so cargoRoot stays
   # unset; the Tauri hook cd's into the project via buildAndTestSubdir.
@@ -38,20 +62,9 @@ fzLib.rustPlatform.buildRustPackage {
     copyDesktopItems
   ];
 
-  buildInputs = [
-    dbus
-    gdk-pixbuf
-    glib
-    gobject-introspection
-    gtk3
-    libayatana-appindicator
-    libsoup_3
-    openssl
-    webkitgtk_4_1
-  ];
+  inherit buildInputs;
 
   env = {
-    RUSTFLAGS = fzLib.rustflags;
     # The tunnel daemon only accepts IPC connections from this exact
     # executable path (see gui-client/src-tauri/src/ipc/unix/peer_check).
     # wrapGAppsHook3 turns bin/firezone-client-gui into a shell wrapper, so

--- a/scripts/nix/packages/firezone-gui-client/package.nix
+++ b/scripts/nix/packages/firezone-gui-client/package.nix
@@ -22,149 +22,147 @@
 }:
 
 let
-  # The `*-sys` build scripts need these on both sides of the dependency split.
-  buildInputs = [
-    dbus
-    gdk-pixbuf
-    glib
-    gobject-introspection
-    gtk3
-    libayatana-appindicator
-    libsoup_3
-    openssl
-    webkitgtk_4_1
-  ];
-in
-fzLib.buildRustPackage {
-  pname = "firezone-gui-client";
-  version = fzLib.versions.gui;
+  # Shared with the dependency-only build so the two cannot drift: cargo
+  # reuses artifacts only for an identical invocation.
+  common = {
+    pname = "firezone-gui-client";
 
-  cargoArtifacts = fzLib.cargoArtifactsFor {
-    crate = "firezone-gui-client";
+    # The workspace Cargo.lock lives at the source root, so cargoRoot stays
+    # unset; the Tauri hook cd's into the project via buildAndTestSubdir.
+    buildAndTestSubdir = "gui-client/src-tauri";
+
     # What `cargo tauri build` adds to a desktop release build (see
-    # tauri-cli's `Rust::build_options`); the dependency graph has to be
-    # resolved with the same features to be reusable.
-    features = [ "tauri/custom-protocol" ];
+    # tauri-cli's `Rust::build_options`).
+    buildFeatures = [ "tauri/custom-protocol" ];
+
+    # The workspace pulls Apple-specific crates into the test graph.
     doCheck = false;
 
     nativeBuildInputs = [ pkg-config ];
-    inherit buildInputs;
+
+    buildInputs = [
+      dbus
+      gdk-pixbuf
+      glib
+      gobject-introspection
+      gtk3
+      libayatana-appindicator
+      libsoup_3
+      openssl
+      webkitgtk_4_1
+    ];
   };
+in
+fzLib.buildRustPackage (
+  common
+  // {
+    version = fzLib.versions.gui;
 
-  # The workspace Cargo.lock lives at the source root, so cargoRoot stays
-  # unset; the Tauri hook cd's into the project via buildAndTestSubdir.
-  buildAndTestSubdir = "gui-client/src-tauri";
+    cargoArtifacts = fzLib.cargoArtifactsFor common;
 
-  nativeBuildInputs = [
-    cargo-tauri.hook
-    pkg-config
-    wrapGAppsHook3
-    copyDesktopItems
-  ];
+    nativeBuildInputs = common.nativeBuildInputs ++ [
+      cargo-tauri.hook
+      wrapGAppsHook3
+      copyDesktopItems
+    ];
 
-  inherit buildInputs;
+    env = {
+      # The tunnel daemon only accepts IPC connections from this exact
+      # executable path (see gui-client/src-tauri/src/ipc/unix/peer_check).
+      # wrapGAppsHook3 turns bin/firezone-client-gui into a shell wrapper, so
+      # /proc/<pid>/exe of the running GUI resolves to the `.…-wrapped` ELF.
+      FIREZONE_GUI_PEER_EXE = "${placeholder "out"}/bin/.firezone-client-gui-wrapped";
+    };
 
-  env = {
-    # The tunnel daemon only accepts IPC connections from this exact
-    # executable path (see gui-client/src-tauri/src/ipc/unix/peer_check).
-    # wrapGAppsHook3 turns bin/firezone-client-gui into a shell wrapper, so
-    # /proc/<pid>/exe of the running GUI resolves to the `.…-wrapped` ELF.
-    FIREZONE_GUI_PEER_EXE = "${placeholder "out"}/bin/.firezone-client-gui-wrapped";
-  };
+    postPatch = ''
+      # frontendDist in tauri.conf.json points at ../dist; the checked-in
+      # directory only holds a .gitkeep.
+      rm -rf gui-client/dist
+      ln -s ${firezone-gui-client-frontend} gui-client/dist
 
-  postPatch = ''
-    rm .cargo/config.toml
+      # The Nix Tauri hook installs from the deb bundle, which copies the
+      # tunnel binary from a path that assumes no --target triple in the
+      # cargo target directory.
+      substituteInPlace gui-client/src-tauri/tauri.conf.json \
+        --replace-fail '../../target/release/firezone-client-tunnel' \
+          '../../target/${stdenv.hostPlatform.rust.rustcTarget}/release/firezone-client-tunnel'
+    '';
 
-    # frontendDist in tauri.conf.json points at ../dist; the checked-in
-    # directory only holds a .gitkeep.
-    rm -rf gui-client/dist
-    ln -s ${firezone-gui-client-frontend} gui-client/dist
+    # wrapGAppsHook3 wraps every executable in $out/bin, which would stamp the
+    # GUI-only --add-flags (notably --no-deep-links) onto the bundled
+    # firezone-client-tunnel daemon, crashing it on startup with an
+    # "unexpected argument '--no-deep-links'" error. Disable the blanket
+    # wrapping and wrap only the GUI binary ourselves in postFixup.
+    dontWrapGApps = true;
 
-    # The Nix Tauri hook installs from the deb bundle, which copies the
-    # tunnel binary from a path that assumes no --target triple in the
-    # cargo target directory.
-    substituteInPlace gui-client/src-tauri/tauri.conf.json \
-      --replace-fail '../../target/release/firezone-client-tunnel' \
-        '../../target/${stdenv.hostPlatform.rust.rustcTarget}/release/firezone-client-tunnel'
-  '';
+    postInstall = ''
+      # register-sparse only does anything on Windows.
+      rm -f $out/bin/register-sparse
 
-  # The workspace pulls Apple-specific crates into the test graph.
-  doCheck = false;
+      # Cargo names the binary after the crate (firezone-gui-client); the
+      # packaged name everywhere else is the Tauri mainBinaryName.
+      if [ -e $out/bin/firezone-gui-client ] && [ ! -e $out/bin/firezone-client-gui ]; then
+        mv $out/bin/firezone-gui-client $out/bin/firezone-client-gui
+      fi
 
-  # wrapGAppsHook3 wraps every executable in $out/bin, which would stamp the
-  # GUI-only --add-flags (notably --no-deep-links) onto the bundled
-  # firezone-client-tunnel daemon, crashing it on startup with an
-  # "unexpected argument '--no-deep-links'" error. Disable the blanket
-  # wrapping and wrap only the GUI binary ourselves in postFixup.
-  dontWrapGApps = true;
+      install -Dm644 gui-client/src-tauri/icons/32x32.png \
+        $out/share/icons/hicolor/32x32/apps/firezone-client-gui.png
+      install -Dm644 gui-client/src-tauri/icons/128x128.png \
+        $out/share/icons/hicolor/128x128/apps/firezone-client-gui.png
+      install -Dm644 "gui-client/src-tauri/icons/128x128@2x.png" \
+        $out/share/icons/hicolor/256x256/apps/firezone-client-gui.png
+    '';
 
-  postInstall = ''
-    # register-sparse only does anything on Windows.
-    rm -f $out/bin/register-sparse
+    # dontWrapGApps disables the automatic wrapping, so wrap only the GUI
+    # binary here. gappsWrapperArgs is populated in preFixup below.
+    postFixup = ''
+      wrapProgram $out/bin/firezone-client-gui "''${gappsWrapperArgs[@]}"
+    '';
 
-    # Cargo names the binary after the crate (firezone-gui-client); the
-    # packaged name everywhere else is the Tauri mainBinaryName.
-    if [ -e $out/bin/firezone-gui-client ] && [ ! -e $out/bin/firezone-client-gui ]; then
-      mv $out/bin/firezone-gui-client $out/bin/firezone-client-gui
-    fi
+    desktopItems = [
+      (makeDesktopItem {
+        name = "firezone-client-gui";
+        desktopName = "Firezone";
+        comment = "Firezone GUI Client";
+        exec = "firezone-client-gui";
+        icon = "firezone-client-gui";
+        categories = [ "Network" ];
+        terminal = false;
+      })
+      # Handler for the browser-based sign-in deep link.
+      (makeDesktopItem {
+        name = "firezone-client-gui-deep-link";
+        desktopName = "Firezone deep-link handler";
+        exec = "firezone-client-gui open-deep-link %U";
+        icon = "firezone-client-gui";
+        noDisplay = true;
+        mimeTypes = [ "x-scheme-handler/firezone-fd0020211111" ];
+      })
+    ];
 
-    install -Dm644 gui-client/src-tauri/icons/32x32.png \
-      $out/share/icons/hicolor/32x32/apps/firezone-client-gui.png
-    install -Dm644 gui-client/src-tauri/icons/128x128.png \
-      $out/share/icons/hicolor/128x128/apps/firezone-client-gui.png
-    install -Dm644 "gui-client/src-tauri/icons/128x128@2x.png" \
-      $out/share/icons/hicolor/256x256/apps/firezone-client-gui.png
-  '';
+    preFixup = ''
+      gappsWrapperArgs+=(
+        --prefix PATH : ${
+          lib.makeBinPath [
+            zenity
+            kdePackages.kdialog
+          ]
+        }
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libayatana-appindicator ]}
+        # Suppress runtime deep-link self-registration. On startup the GUI
+        # otherwise writes a per-user handler pointing at the unwrapped
+        # .firezone-client-gui-wrapped ELF, which overrides the packaged
+        # wrapper-based handler and drops the wrapper environment on
+        # cold-start callbacks. The packaged desktop item is the only
+        # handler we want; this flag gates only registration, not callback
+        # handling, so browser sign-in still works.
+        --add-flags "--no-deep-links"
+      )
+    '';
 
-  # dontWrapGApps disables the automatic wrapping, so wrap only the GUI
-  # binary here. gappsWrapperArgs is populated in preFixup below.
-  postFixup = ''
-    wrapProgram $out/bin/firezone-client-gui "''${gappsWrapperArgs[@]}"
-  '';
-
-  desktopItems = [
-    (makeDesktopItem {
-      name = "firezone-client-gui";
-      desktopName = "Firezone";
-      comment = "Firezone GUI Client";
-      exec = "firezone-client-gui";
-      icon = "firezone-client-gui";
-      categories = [ "Network" ];
-      terminal = false;
-    })
-    # Handler for the browser-based sign-in deep link.
-    (makeDesktopItem {
-      name = "firezone-client-gui-deep-link";
-      desktopName = "Firezone deep-link handler";
-      exec = "firezone-client-gui open-deep-link %U";
-      icon = "firezone-client-gui";
-      noDisplay = true;
-      mimeTypes = [ "x-scheme-handler/firezone-fd0020211111" ];
-    })
-  ];
-
-  preFixup = ''
-    gappsWrapperArgs+=(
-      --prefix PATH : ${
-        lib.makeBinPath [
-          zenity
-          kdePackages.kdialog
-        ]
-      }
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libayatana-appindicator ]}
-      # Suppress runtime deep-link self-registration. On startup the GUI
-      # otherwise writes a per-user handler pointing at the unwrapped
-      # .firezone-client-gui-wrapped ELF, which overrides the packaged
-      # wrapper-based handler and drops the wrapper environment on
-      # cold-start callbacks. The packaged desktop item is the only
-      # handler we want; this flag gates only registration, not callback
-      # handling, so browser sign-in still works.
-      --add-flags "--no-deep-links"
-    )
-  '';
-
-  meta = fzLib.meta // {
-    description = "GUI client for the Firezone zero-trust access platform";
-    mainProgram = "firezone-client-gui";
-  };
-}
+    meta = fzLib.meta // {
+      description = "GUI client for the Firezone zero-trust access platform";
+      mainProgram = "firezone-client-gui";
+    };
+  }
+)

--- a/scripts/nix/packages/firezone-headless-client.nix
+++ b/scripts/nix/packages/firezone-headless-client.nix
@@ -1,32 +1,36 @@
 { lib, fzLib }:
 
-fzLib.buildRustPackage {
-  pname = "firezone-headless-client";
-  version = fzLib.versions.headless;
-
-  cargoArtifacts = fzLib.cargoArtifactsFor { crate = "firezone-headless-client"; };
-
-  buildAndTestSubdir = "headless-client";
-
-  postPatch = ''
-    rm .cargo/config.toml
-  '';
-
-  preCheck = ''
-    export XDG_RUNTIME_DIR=$(mktemp -d)
-  '';
-
-  checkFlags = [
-    # These chown the token file to root; the sandbox builds unprivileged.
-    "--skip=tests::set_token_permissions_satisfies_check"
-    "--skip=tests::token_roundtrip_write_and_read"
-    "--skip=tests::write_token_creates_file_with_content"
-    "--skip=tests::write_token_creates_parent_directories"
-    "--skip=tests::write_token_overwrites_existing"
-  ];
-
-  meta = fzLib.meta // {
-    description = "Headless Linux client for the Firezone zero-trust access platform";
-    mainProgram = "firezone-headless-client";
+let
+  # Shared with the dependency-only build so the two cannot drift: cargo
+  # reuses artifacts only for an identical invocation.
+  common = {
+    pname = "firezone-headless-client";
+    buildAndTestSubdir = "headless-client";
   };
-}
+in
+fzLib.buildRustPackage (
+  common
+  // {
+    version = fzLib.versions.headless;
+
+    cargoArtifacts = fzLib.cargoArtifactsFor common;
+
+    preCheck = ''
+      export XDG_RUNTIME_DIR=$(mktemp -d)
+    '';
+
+    checkFlags = [
+      # These chown the token file to root; the sandbox builds unprivileged.
+      "--skip=tests::set_token_permissions_satisfies_check"
+      "--skip=tests::token_roundtrip_write_and_read"
+      "--skip=tests::write_token_creates_file_with_content"
+      "--skip=tests::write_token_creates_parent_directories"
+      "--skip=tests::write_token_overwrites_existing"
+    ];
+
+    meta = fzLib.meta // {
+      description = "Headless Linux client for the Firezone zero-trust access platform";
+      mainProgram = "firezone-headless-client";
+    };
+  }
+)

--- a/scripts/nix/packages/firezone-headless-client.nix
+++ b/scripts/nix/packages/firezone-headless-client.nix
@@ -1,14 +1,12 @@
 { lib, fzLib }:
 
-fzLib.rustPlatform.buildRustPackage {
+fzLib.buildRustPackage {
   pname = "firezone-headless-client";
   version = fzLib.versions.headless;
 
-  inherit (fzLib) src cargoLock;
+  cargoArtifacts = fzLib.cargoArtifactsFor { crate = "firezone-headless-client"; };
 
   buildAndTestSubdir = "headless-client";
-
-  env.RUSTFLAGS = fzLib.rustflags;
 
   postPatch = ''
     rm .cargo/config.toml

--- a/scripts/upload/nix-cache.sh
+++ b/scripts/upload/nix-cache.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 
-# Signs the runtime closures of ./result* with the Firezone Nix cache key
-# and syncs them to the `nix` container of the `firezoneartifacts` Azure
-# storage account, served at https://artifacts.firezone.dev/nix.
+# Signs the runtime closures of the built out-links with the Firezone Nix cache
+# key and syncs them to the `firezoneartifacts` Azure storage account, served at
+# https://artifacts.firezone.dev.
+#
+# Two caches, because they have opposite retention needs:
+#   nix     the packages, consumed by anyone installing Firezone from the flake.
+#           Pinned release tags must keep resolving, so it is never pruned.
+#   nix-ci  the compiled Cargo dependency snapshots CI substitutes instead of
+#           recompiling. Nothing outside CI reads them and a snapshot stops
+#           being reachable as soon as Cargo.lock or a workspace manifest
+#           changes, so a lifecycle rule expires them (see the azure-cdn
+#           Terraform workspace).
 #
 # Required environment:
 #   NIX_CACHE_SIGNING_KEY    ed25519 secret key (nix key generate-secret)
@@ -12,48 +21,83 @@
 
 set -euo pipefail
 
-staging_dir=$(mktemp -d)
-
-# Sign the full runtime closures so every path in the cache carries our
-# signature, including dependencies substituted from cache.nixos.org.
-nix store sign --recursive --key-file <(printenv NIX_CACHE_SIGNING_KEY) ./result*
-
-# Nix has no Azure backend, so stage a local binary cache and sync it.
-nix copy --to "file://$staging_dir?compression=zstd" ./result*
-
-# Priority below cache.nixos.org (40) so clients prefer upstream for
-# shared paths.
-printf 'StoreDir: /nix/store\nWantMassQuery: 1\nPriority: 41\n' >"$staging_dir/nix-cache-info"
-
-# Compare contents instead of mtimes: this staging directory is freshly
-# created, so AzCopy's default mtime comparison would re-upload the entire
-# closure on every run. Existing blobs without MD5 metadata are uploaded once
-# to seed it. Concurrent matrix jobs can still race on those initial uploads,
-# so retry the sync to re-enumerate the destination after the winner finishes.
-#
-# `az storage blob sync` defaults --delete-destination to true, which would
-# prune every NAR not in this single-closure staging dir: prior releases and
-# the other arch's matrix job. The cache is content-addressed and shared across
-# releases, so it must never be pruned by sync.
 max_sync_attempts=3
 
-for ((attempt = 1; attempt <= max_sync_attempts; attempt++)); do
-    if az storage blob sync \
-        --account-name firezoneartifacts \
-        --auth-mode login \
-        --container nix \
-        --source "$staging_dir" \
-        --delete-destination false \
-        -- \
-        --compare-hash=MD5; then
-        break
-    fi
+# Drops every path cache.nixos.org already serves. Besides keeping our caches to
+# what only we can provide, this is what makes expiring `nix-ci` by last access
+# safe: we publish at priority 41, so for a path upstream also has, clients read
+# our .narinfo but fetch the NAR from upstream. That .narinfo would stay warm
+# while its NAR went cold and got swept, leaving a dangling entry that fails
+# builds outright. Dropping both here means it never enters the cache at all.
+drop_upstream_paths() {
+    local staging_dir="$1"
 
-    if ((attempt == max_sync_attempts)); then
-        printf 'Nix cache sync failed after %d attempts.\n' "$max_sync_attempts" >&2
-        exit 1
-    fi
+    # shellcheck disable=SC2016 # the inner script must expand in the child, not here
+    find "$staging_dir" -maxdepth 1 -name '*.narinfo' -print0 |
+        xargs -0 -r -P 16 -I{} bash -c '
+            narinfo="$1"
+            hash=$(basename "$narinfo" .narinfo)
+            if curl --silent --fail --head --max-time 30 \
+                --output /dev/null "https://cache.nixos.org/${hash}.narinfo"; then
+                nar=$(awk "/^URL: /{print \$2}" "$narinfo")
+                rm -f "$narinfo" "$(dirname "$narinfo")/${nar}"
+            fi
+        ' _ {}
+}
 
-    printf 'Nix cache sync attempt %d failed; retrying.\n' "$attempt" >&2
-    sleep $((attempt * 5))
-done
+publish() {
+    local container="$1"
+    shift
+
+    local staging_dir
+    staging_dir=$(mktemp -d)
+
+    # Nix has no Azure backend, so stage a local binary cache and sync it.
+    nix copy --to "file://$staging_dir?compression=zstd" "$@"
+
+    drop_upstream_paths "$staging_dir"
+
+    # Priority below cache.nixos.org (40) so clients prefer upstream for
+    # shared paths.
+    printf 'StoreDir: /nix/store\nWantMassQuery: 1\nPriority: 41\n' >"$staging_dir/nix-cache-info"
+
+    # Compare contents instead of mtimes: this staging directory is freshly
+    # created, so AzCopy's default mtime comparison would re-upload the entire
+    # closure on every run. Existing blobs without MD5 metadata are uploaded once
+    # to seed it. Concurrent matrix jobs can still race on those initial uploads,
+    # so retry the sync to re-enumerate the destination after the winner finishes.
+    #
+    # `az storage blob sync` defaults --delete-destination to true, which would
+    # prune every NAR not in this single-closure staging dir: prior releases and
+    # the other arch's matrix job. Both caches are content-addressed and shared
+    # across releases, so neither may be pruned by sync.
+    local attempt
+    for ((attempt = 1; attempt <= max_sync_attempts; attempt++)); do
+        if az storage blob sync \
+            --account-name firezoneartifacts \
+            --auth-mode login \
+            --container "$container" \
+            --source "$staging_dir" \
+            --delete-destination false \
+            -- \
+            --compare-hash=MD5; then
+            return 0
+        fi
+
+        if ((attempt == max_sync_attempts)); then
+            printf 'Sync to %s failed after %d attempts.\n' "$container" "$max_sync_attempts" >&2
+            exit 1
+        fi
+
+        printf 'Sync to %s attempt %d failed; retrying.\n' "$container" "$attempt" >&2
+        sleep $((attempt * 5))
+    done
+}
+
+# Sign the full runtime closures so every path in the caches carries our
+# signature.
+nix store sign --recursive --key-file <(printenv NIX_CACHE_SIGNING_KEY) \
+    ./result ./result-cargo-artifacts
+
+publish nix ./result
+publish nix-ci ./result-cargo-artifacts


### PR DESCRIPTION
`buildRustPackage` compiles the whole dependency graph inside the package derivation, whose hash covers all of `rust/`. Any source change therefore invalidates it and recompiles the full graph from scratch, which is why the binary cache never helps the `nix` CI job: the planner only schedules that job when something under `rust/` changed in the first place.

Split the dependency graph into a derivation of its own, built over crane's stubbed-out copy of the workspace so that it depends only on `Cargo.lock`, the manifests, the toolchain and the build flags. It survives ordinary source changes and is substituted from the cache instead of rebuilt. Both sides stay on `buildRustPackage` and share one invocation: cargo folds the resolved cargo config into every unit's fingerprint, so a dependency build assembled any differently produces artifacts the package build discards.