### PR TITLE
chore(gui-client): drop the unused `custom-protocol` feature

### DIFF
--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -11,13 +11,6 @@ license = { workspace = true }
 [package.metadata.tslink]
 enum_representation = "discriminated"
 
-[features]
-# this feature is used for production builds or when `devPath` points to the filesystem
-# DO NOT REMOVE!!
-# TODO: We can probably remove this, per <https://github.com/tauri-apps/tauri/releases/tag/tauri-v2.0.0-beta.8>
-# I don't know how to verify this change, so I won't do it right now.
-custom-protocol = ["tauri/custom-protocol"]
-
 [dependencies]
 anyhow = { workspace = true }
 arboard = { workspace = true }


### PR DESCRIPTION
The `firezone-gui-client` package declared a `custom-protocol` feature that nothing ever enabled. Since Tauri 2, the CLI passes `tauri/custom-protocol` on the command line for `tauri build` and only filters it out of `default` for `tauri dev`, so the package-level passthrough was never part of either path. Production bundles keep embedding the frontend assets exactly as before.