### PR TITLE
chore(portal): enable device pools for all accounts

### DIFF
--- a/elixir/lib/portal/accounts/features.ex
+++ b/elixir/lib/portal/accounts/features.ex
@@ -9,7 +9,6 @@ defmodule Portal.Accounts.Features do
     field :idp_sync, :boolean
     field :rest_api, :boolean
     field :internet_resource, :boolean
-    field :client_to_client, :boolean
     field :iceless, :boolean
     field :log_sinks, :boolean
   end
@@ -21,7 +20,6 @@ defmodule Portal.Accounts.Features do
       idp_sync
       rest_api
       internet_resource
-      client_to_client
       iceless
       log_sinks
     ]a

--- a/elixir/lib/portal/features.ex
+++ b/elixir/lib/portal/features.ex
@@ -5,7 +5,7 @@ defmodule Portal.Features do
   @primary_key false
 
   schema "features" do
-    field :feature, Ecto.Enum, values: [:client_to_client, :trust_anchors, :flow_logs]
+    field :feature, Ecto.Enum, values: [:trust_anchors, :flow_logs]
     field :enabled, :boolean, default: false
   end
 end

--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -1043,26 +1043,12 @@ defmodule PortalAPI.Client.Channel.Shared do
         %{"candidates" => candidates, "client_id" => target_client_id},
         socket
       ) do
-    with true <- client_to_client_enabled?(socket.assigns.subject.account),
-         :ok <-
-           PG.deliver(
-             target_client_id,
-             {:client_ice_candidates, socket.assigns.client.id, candidates}
-           ) do
-      {:noreply, socket}
-    else
-      false ->
-        Logger.warning("Client-to-client communication is disabled, cannot send ICE candidates",
-          client_id: socket.assigns.client.id,
-          account_id: socket.assigns.client.account_id,
-          account_slug: socket.assigns.subject.account.slug,
-          target_client_id: target_client_id
-        )
-
-        {:noreply, socket}
-
-      {:error, :not_found} ->
-        {:noreply, socket}
+    case PG.deliver(
+           target_client_id,
+           {:client_ice_candidates, socket.assigns.client.id, candidates}
+         ) do
+      :ok -> {:noreply, socket}
+      {:error, :not_found} -> {:noreply, socket}
     end
   end
 
@@ -1071,20 +1057,11 @@ defmodule PortalAPI.Client.Channel.Shared do
         %{"candidates" => candidates, "client_id" => target_client_id},
         socket
       ) do
-    with true <- client_to_client_enabled?(socket.assigns.subject.account),
-         :ok <-
-           PG.deliver(
-             target_client_id,
-             {:invalidate_client_ice_candidates, socket.assigns.client.id, candidates}
-           ) do
-      {:noreply, socket}
-    else
-      false ->
-        push(socket, "client_ice_candidate_error", %{
-          client_id: target_client_id,
-          reason: :disabled
-        })
-
+    case PG.deliver(
+           target_client_id,
+           {:invalidate_client_ice_candidates, socket.assigns.client.id, candidates}
+         ) do
+      :ok ->
         {:noreply, socket}
 
       {:error, :not_found} ->
@@ -1172,8 +1149,6 @@ defmodule PortalAPI.Client.Channel.Shared do
 
     {:reply, {:error, %{reason: :unknown_message}}, socket}
   end
-
-  defp client_to_client_enabled?(account), do: Database.client_to_client_enabled?(account)
 
   # Reject peer connections when:
   #   - the target client predates `client_device_access_authorized` / `_denied`
@@ -1398,8 +1373,7 @@ defmodule PortalAPI.Client.Channel.Shared do
        ) do
     account_id = socket.assigns.client.account_id
 
-    with true <- client_to_client_enabled?(socket.assigns.subject.account),
-         {:ok, target} <- parse_target_address(payload),
+    with {:ok, target} <- parse_target_address(payload),
          {:ok, target_device_id} <-
            authorize_pool_target(
              resource,
@@ -1434,15 +1408,6 @@ defmodule PortalAPI.Client.Channel.Shared do
           {:noreply, socket}
       end
     else
-      false ->
-        push(socket, "client_device_access_denied", %{
-          ipv4: payload["ipv4"],
-          ipv6: payload["ipv6"],
-          reason: :disabled
-        })
-
-        {:noreply, socket}
-
       {:error, :ambiguous_address} ->
         Logger.warning("request_authorization for pool included both ipv4 and ipv6",
           client_id: socket.assigns.client.id,
@@ -2641,14 +2606,6 @@ defmodule PortalAPI.Client.Channel.Shared do
     import Ecto.Query, only: [from: 2]
 
     alias Portal.Features
-
-    def client_to_client_enabled?(account) do
-      query = from(f in Features, where: f.feature == :client_to_client and f.enabled == true)
-
-      account_feature_enabled? = account.features.client_to_client == true
-
-      Portal.Safe.unscoped(query) |> Portal.Safe.exists?() and account_feature_enabled?
-    end
 
     def flow_logs_feature_enabled? do
       query = from(f in Features, where: f.feature == :flow_logs and f.enabled == true)

--- a/elixir/lib/portal_api/controllers/resource_controller.ex
+++ b/elixir/lib/portal_api/controllers/resource_controller.ex
@@ -201,13 +201,12 @@ defmodule PortalAPI.ResourceController do
     changeset
     |> Ecto.Changeset.validate_required(required)
     |> Portal.Resource.validate_site_matches_type(subject)
-    |> Database.validate_static_device_pool_feature_enabled(subject.account)
     |> Database.validate_traffic_filters_feature_enabled(subject.account)
   end
 
   defmodule Database do
     import Ecto.Query
-    alias Portal.{Features, Safe}
+    alias Portal.Safe
 
     def list_resources(subject, opts \\ []) do
       from(r in Portal.Resource, as: :resources)
@@ -225,27 +224,6 @@ defmodule PortalAPI.ResourceController do
         nil -> {:error, :not_found}
         resource -> {:ok, resource}
       end
-    end
-
-    def validate_static_device_pool_feature_enabled(changeset, account) do
-      if Ecto.Changeset.get_field(changeset, :type) == :static_device_pool and
-           not client_to_client_enabled?(account) do
-        Ecto.Changeset.add_error(
-          changeset,
-          :type,
-          "device pools are not enabled for this account"
-        )
-      else
-        changeset
-      end
-    end
-
-    def client_to_client_enabled?(account) do
-      query = from(f in Features, where: f.feature == :client_to_client and f.enabled == true)
-
-      account_feature_enabled? = account.features.client_to_client == true
-
-      Safe.unscoped(query) |> Safe.exists?() and account_feature_enabled?
     end
 
     def validate_traffic_filters_feature_enabled(changeset, account) do
@@ -301,7 +279,6 @@ defmodule PortalAPI.ResourceController do
       changeset
       |> Ecto.Changeset.validate_required(required_fields)
       |> Portal.Resource.validate_site_matches_type(subject)
-      |> validate_static_device_pool_feature_enabled(subject.account)
       |> validate_traffic_filters_feature_enabled(subject.account)
     end
 

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -65,7 +65,6 @@ defmodule PortalWeb.Resources do
         ],
         callback: &handle_resources_update!/2
       )
-      |> maybe_hide_static_device_pool_filter_value()
 
     {:ok, socket}
   end
@@ -202,8 +201,7 @@ defmodule PortalWeb.Resources do
       %{
         view: :list,
         tab: :groups,
-        timezone: Map.get(connect_params, "timezone", "UTC"),
-        client_to_client_enabled?: Database.client_to_client_enabled?(socket.assigns.account)
+        timezone: Map.get(connect_params, "timezone", "UTC")
       }
     )
   end
@@ -1324,7 +1322,6 @@ defmodule PortalWeb.Resources do
       resource_form_selected_clients: assigns.resource_form.selected_clients,
       resource_form_client_search: assigns.resource_form.client_search,
       resource_form_client_search_results: assigns.resource_form.client_search_results,
-      client_to_client_enabled: assigns.resource_panel.client_to_client_enabled?,
       filter_ports: resource_filter_ports(assigns.resource_form.form),
       filter_errors: resource_filter_errors(assigns.resource_form.form)
     }
@@ -1337,32 +1334,6 @@ defmodule PortalWeb.Resources do
   defp resource_panel_ui_state(assigns) do
     assigns.resource_ui
   end
-
-  defp maybe_hide_static_device_pool_filter_value(socket) do
-    if socket.assigns.resource_panel.client_to_client_enabled? do
-      socket
-    else
-      filters =
-        Enum.map(socket.assigns.filters_by_table_id["resources"], &drop_static_device_pool/1)
-
-      assign(socket,
-        filters_by_table_id:
-          Map.put(socket.assigns.filters_by_table_id, "resources", filters)
-      )
-    end
-  end
-
-  defp drop_static_device_pool(%Portal.Repo.Filter{name: :type} = filter) do
-    values =
-      Enum.reject(filter.values, fn
-        {_label, "static_device_pool"} -> true
-        _ -> false
-      end)
-
-    %{filter | values: values}
-  end
-
-  defp drop_static_device_pool(filter), do: filter
 
   defp mark_stale_if_unreflected(socket, change) do
     if PortalWeb.LiveTable.view_reflects_change?(socket.assigns.resources, change),
@@ -1434,7 +1405,6 @@ defmodule PortalWeb.Resources do
     alias Portal.Directory
     alias PortalWeb.Resources.Components
 
-    defdelegate client_to_client_enabled?(account), to: Components.Database
     defdelegate get_client(client_id, subject), to: Components.Database
     defdelegate search_clients(search_term, subject, selected_clients), to: Components.Database
 
@@ -1470,7 +1440,6 @@ defmodule PortalWeb.Resources do
       changeset =
         new_resource(subject, attrs)
         |> maybe_validate_required_fields()
-        |> Components.Database.validate_static_device_pool_feature_enabled(subject.account)
 
       with {:ok, validated_clients} <-
              Components.Database.validate_selected_clients(selected_clients, subject),
@@ -1515,9 +1484,7 @@ defmodule PortalWeb.Resources do
     end
 
     def update_resource(resource, attrs, selected_clients, subject) do
-      changeset =
-        change_resource(resource, subject, attrs)
-        |> Components.Database.validate_static_device_pool_feature_enabled(subject.account)
+      changeset = change_resource(resource, subject, attrs)
 
       with {:ok, validated_clients} <-
              Components.Database.validate_selected_clients(selected_clients, subject),

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -354,7 +354,6 @@ defmodule PortalWeb.Resources.Components do
 
   attr :form, :any, required: true
   attr :resource, :any, default: nil
-  attr :client_to_client_enabled, :boolean, default: false
 
   def resource_type_picker(assigns) do
     ~H"""
@@ -362,7 +361,7 @@ defmodule PortalWeb.Resources.Components do
       <span class="block text-xs font-medium text-body mb-1.5">
         Type <span class="text-error">*</span>
       </span>
-      <ul class={"grid w-full gap-3 #{if @client_to_client_enabled, do: "grid-cols-4", else: "grid-cols-3"}"}>
+      <ul class="grid w-full gap-3 grid-cols-4">
         <li>
           <.input
             id="resource-form-type--dns"
@@ -432,7 +431,7 @@ defmodule PortalWeb.Resources.Components do
             </div>
           </label>
         </li>
-        <li :if={@client_to_client_enabled}>
+        <li>
           <.input
             id="resource-form-type--static-device-pool"
             type="radio_button_group"
@@ -984,11 +983,7 @@ defmodule PortalWeb.Resources.Components do
         class="flex flex-col flex-1 min-h-0 overflow-hidden"
       >
         <div class="flex-1 overflow-y-auto px-5 py-4 space-y-4">
-          <.resource_type_picker
-            form={@resource_form}
-            resource={@resource}
-            client_to_client_enabled={@client_to_client_enabled}
-          />
+          <.resource_type_picker form={@resource_form} resource={@resource} />
 
           <.resource_core_fields form={@resource_form} resource={@resource} />
 
@@ -2150,7 +2145,7 @@ defmodule PortalWeb.Resources.Components do
 
   defmodule Database do
     import Ecto.Query
-    alias Portal.{Device, Features, Resource, Safe, StaticDevicePoolMember}
+    alias Portal.{Device, Resource, Safe, StaticDevicePoolMember}
 
     def get_resource!(id, subject) do
       from(r in Resource, as: :resources)
@@ -2163,14 +2158,6 @@ defmodule PortalWeb.Resources.Components do
       from(r in Resource, as: :resources)
       |> Safe.scoped(subject)
       |> Safe.list(Database.ListQuery, opts)
-    end
-
-    def client_to_client_enabled?(account) do
-      query = from(f in Features, where: f.feature == :client_to_client and f.enabled == true)
-
-      account_feature_enabled? = account.features.client_to_client == true
-
-      Safe.unscoped(query) |> Safe.exists?() and account_feature_enabled?
     end
 
     def all_sites(subject) do
@@ -2256,19 +2243,6 @@ defmodule PortalWeb.Resources.Components do
 
         _ ->
           {:error, :invalid_clients}
-      end
-    end
-
-    def validate_static_device_pool_feature_enabled(changeset, account) do
-      if Ecto.Changeset.get_field(changeset, :type) == :static_device_pool and
-           not client_to_client_enabled?(account) do
-        Ecto.Changeset.add_error(
-          changeset,
-          :type,
-          "device pools are not enabled for this account"
-        )
-      else
-        changeset
       end
     end
 

--- a/elixir/lib/portal_web/live/settings/account.ex
+++ b/elixir/lib/portal_web/live/settings/account.ex
@@ -123,10 +123,6 @@ defmodule PortalWeb.Settings.Account do
               enabled={feature_enabled?(@account, :traffic_filters)}
             />
             <.feature_row
-              label="Client-to-Client"
-              enabled={feature_enabled?(@account, :client_to_client)}
-            />
-            <.feature_row
               label="Internet Resource"
               enabled={feature_enabled?(@account, :internet_resource)}
             />

--- a/elixir/priv/repo/migrations/20260805000000_remove_client_to_client_feature.exs
+++ b/elixir/priv/repo/migrations/20260805000000_remove_client_to_client_feature.exs
@@ -1,0 +1,19 @@
+defmodule Portal.Repo.Migrations.RemoveClientToClientFeature do
+  use Ecto.Migration
+
+  def up do
+    execute("DELETE FROM features WHERE feature = 'client_to_client'")
+
+    execute("""
+    UPDATE accounts
+    SET features = features - 'client_to_client'
+    WHERE features ? 'client_to_client'
+    """)
+  end
+
+  # Restores the global flag only. Which accounts had the per-account feature is
+  # not recoverable, and every account is entitled to device pools now anyway.
+  def down do
+    execute("INSERT INTO features (feature, enabled) VALUES ('client_to_client', true)")
+  end
+end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -947,10 +947,6 @@ defmodule Portal.Repo.Seeds do
     :rand.seed(:exsss, {1, 2, 3})
 
     Repo.query!(
-      "INSERT INTO features (feature, enabled) VALUES ('client_to_client', true) ON CONFLICT (feature) DO UPDATE SET enabled = true"
-    )
-
-    Repo.query!(
       "INSERT INTO features (feature, enabled) VALUES ('trust_anchors', true) ON CONFLICT (feature) DO UPDATE SET enabled = true"
     )
 
@@ -980,7 +976,6 @@ defmodule Portal.Repo.Seeds do
         idp_sync: true,
         rest_api: true,
         internet_resource: true,
-        client_to_client: true,
         iceless: System.get_env("FEATURE_ICELESS_ENABLED") == "true",
         log_sinks: true
       })

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -162,7 +162,6 @@ defmodule PortalAPI.Client.ChannelTest do
         },
         features: %{
           internet_resource: true,
-          client_to_client: true,
           iceless: true
         }
       )
@@ -2876,13 +2875,11 @@ defmodule PortalAPI.Client.ChannelTest do
   end
 
   describe "handle_in/3 new_client_ice_candidates" do
-    test "forwards ice candidates to target client when c2c is enabled", %{
+    test "forwards ice candidates to target client", %{
       account: account,
       client: client,
       subject: subject
     } do
-      enable_feature(:client_to_client)
-
       socket = join_channel(client, subject)
       assert_push "init", _
       candidates = ["cand1", "cand2"]
@@ -2901,31 +2898,11 @@ defmodule PortalAPI.Client.ChannelTest do
       assert sending_client_id == client.id
     end
 
-    test "does nothing when c2c is globally disabled", %{
-      client: client,
-      subject: subject
-    } do
-      # Global feature off (no enable_feature call) — account already has client_to_client: true
-      socket = join_channel(client, subject)
-      assert_push "init", _
-      candidates = ["cand1"]
-      target_client_id = Ecto.UUID.generate()
-
-      push(socket, "new_client_ice_candidates", %{
-        "candidates" => candidates,
-        "client_id" => target_client_id
-      })
-
-      refute_receive {:client_ice_candidates, _, _}
-    end
-
     test "does nothing when target client is offline", %{
       account: account,
       client: client,
       subject: subject
     } do
-      enable_feature(:client_to_client)
-
       socket = join_channel(client, subject)
       assert_push "init", _
 
@@ -2948,8 +2925,6 @@ defmodule PortalAPI.Client.ChannelTest do
       client: client,
       subject: subject
     } do
-      enable_feature(:client_to_client)
-
       socket = join_channel(client, subject)
       assert_push "init", _
       candidates = ["cand1", "cand2"]
@@ -2967,32 +2942,11 @@ defmodule PortalAPI.Client.ChannelTest do
       assert sending_client_id == client.id
     end
 
-    test "pushes client_ice_candidate_error :disabled when c2c is globally disabled", %{
-      client: client,
-      subject: subject
-    } do
-      socket = join_channel(client, subject)
-      assert_push "init", _
-      target_client_id = Ecto.UUID.generate()
-
-      push(socket, "invalidate_client_ice_candidates", %{
-        "candidates" => ["cand1"],
-        "client_id" => target_client_id
-      })
-
-      assert_push "client_ice_candidate_error", %{
-        client_id: ^target_client_id,
-        reason: :disabled
-      }
-    end
-
     test "pushes client_ice_candidate_error :offline when target client is not in PG", %{
       account: account,
       client: client,
       subject: subject
     } do
-      enable_feature(:client_to_client)
-
       socket = join_channel(client, subject)
       assert_push "init", _
 
@@ -5394,8 +5348,6 @@ defmodule PortalAPI.Client.ChannelTest do
 
   describe "handle_in/3 create_flow for static_device_pool" do
     setup %{account: account, group: group, actor: actor, subject: subject} do
-      enable_feature(:client_to_client)
-
       # Override the default subject's user_agent so static_device_pool resources
       # are eligible for the connectable list (apple >= 1.5.16).
       subject = %{
@@ -5617,29 +5569,6 @@ defmodule PortalAPI.Client.ChannelTest do
       assert_push "flow_creation_failed", %{reason: :not_found}
     end
 
-    test "sends denied with :disabled when account feature is off", %{
-      account: account,
-      client: client,
-      subject: subject,
-      target_client: target_client,
-      pool_resource: pool_resource
-    } do
-      account = update_account(account, %{features: %{client_to_client: false}})
-      subject = %{subject | account: account}
-
-      initiating_socket = join_channel(client, subject)
-      assert_push "init", _
-
-      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
-
-      push(initiating_socket, "create_flow", %{
-        "resource_id" => pool_resource.id,
-        "ipv4" => target_ip
-      })
-
-      assert_push "client_device_access_denied", %{ipv4: ^target_ip, reason: :disabled}
-    end
-
     test "sends denied with :ambiguous_address when both ipv4 and ipv6 are provided",
          %{client: client, subject: subject, pool_resource: pool_resource} do
       socket = join_channel(client, subject)
@@ -5850,8 +5779,6 @@ defmodule PortalAPI.Client.ChannelTest do
 
   describe "handle_in/3 create_flow for dynamic_device_pool" do
     setup %{account: account, group: group, subject: subject} do
-      enable_feature(:client_to_client)
-
       subject = put_user_agent(subject, "Mac OS/14 apple-client/1.5.16")
 
       target_actor = actor_fixture(account: account)
@@ -7001,8 +6928,6 @@ defmodule PortalAPI.Client.ChannelTest do
 
   describe "authorizations cache (inbound client-to-client)" do
     setup %{account: account, group: group, subject: subject} do
-      enable_feature(:client_to_client)
-
       subject = put_user_agent(subject, "Mac OS/14 apple-client/1.5.16")
 
       target_actor = actor_fixture(account: account)

--- a/elixir/test/portal_api/controllers/resource_controller_test.exs
+++ b/elixir/test/portal_api/controllers/resource_controller_test.exs
@@ -230,9 +230,6 @@ defmodule PortalAPI.ResourceControllerTest do
       account: account,
       actor: actor
     } do
-      enable_feature(:client_to_client)
-      update_account(account, features: %{client_to_client: true})
-
       attrs = %{
         "name" => "Shared Devices",
         "type" => "static_device_pool"
@@ -303,30 +300,6 @@ defmodule PortalAPI.ResourceControllerTest do
                "status" => 422,
                "validation_errors" => %{
                  "filters" => ["traffic filters are not enabled for this account"]
-               }
-             } = json_response(conn, 422)
-    end
-
-    test "returns 422 when creating static_device_pool with feature disabled", %{
-      conn: conn,
-      actor: actor
-    } do
-      attrs = %{
-        "name" => "Shared Devices",
-        "type" => "static_device_pool"
-      }
-
-      conn =
-        conn
-        |> authorize_conn(actor)
-        |> put_req_header("content-type", "application/json")
-        |> post("/resources", resource: attrs)
-
-      assert %{
-               "type" => "about:blank",
-               "status" => 422,
-               "validation_errors" => %{
-                 "type" => ["device pools are not enabled for this account"]
                }
              } = json_response(conn, 422)
     end
@@ -639,7 +612,7 @@ defmodule PortalAPI.ResourceControllerTest do
       assert reloaded.type == :dns
     end
 
-    test "returns 422 when updating resource to static_device_pool type with feature disabled", %{
+    test "updates a resource to the static_device_pool type", %{
       conn: conn,
       account: account,
       actor: actor
@@ -653,13 +626,9 @@ defmodule PortalAPI.ResourceControllerTest do
         |> put_req_header("content-type", "application/json")
         |> put("/resources/#{resource.id}", resource: %{"type" => "static_device_pool"})
 
-      assert %{
-               "type" => "about:blank",
-               "status" => 422,
-               "validation_errors" => %{
-                 "type" => ["device pools are not enabled for this account"]
-               }
-             } = json_response(conn, 422)
+      assert resp = json_response(conn, 200)
+      assert resp["data"]["type"] == "static_device_pool"
+      assert resp["data"]["address"] == nil
     end
   end
 

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -126,8 +126,7 @@ defmodule PortalWeb.PoliciesTest do
             policy_conditions: false,
             traffic_filters: true,
             idp_sync: true,
-            rest_api: true,
-            client_to_client: false
+            rest_api: true
           }
         )
 
@@ -156,8 +155,7 @@ defmodule PortalWeb.PoliciesTest do
             policy_conditions: true,
             traffic_filters: true,
             idp_sync: true,
-            rest_api: true,
-            client_to_client: false
+            rest_api: true
           }
         )
 
@@ -182,8 +180,7 @@ defmodule PortalWeb.PoliciesTest do
             policy_conditions: true,
             traffic_filters: true,
             idp_sync: true,
-            rest_api: true,
-            client_to_client: false
+            rest_api: true
           }
         )
 
@@ -528,8 +525,7 @@ defmodule PortalWeb.PoliciesTest do
             policy_conditions: false,
             traffic_filters: true,
             idp_sync: true,
-            rest_api: true,
-            client_to_client: false
+            rest_api: true
           }
         )
 
@@ -659,8 +655,7 @@ defmodule PortalWeb.PoliciesTest do
             policy_conditions: true,
             traffic_filters: true,
             idp_sync: true,
-            rest_api: true,
-            client_to_client: false
+            rest_api: true
           }
         )
 
@@ -687,8 +682,7 @@ defmodule PortalWeb.PoliciesTest do
             policy_conditions: true,
             traffic_filters: true,
             idp_sync: true,
-            rest_api: true,
-            client_to_client: false
+            rest_api: true
           }
         )
 
@@ -728,8 +722,7 @@ defmodule PortalWeb.PoliciesTest do
             policy_conditions: true,
             traffic_filters: true,
             idp_sync: true,
-            rest_api: true,
-            client_to_client: false
+            rest_api: true
           }
         )
 

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -126,22 +126,8 @@ defmodule PortalWeb.ResourcesTest do
       assert html =~ "0 / 2 online"
     end
 
-    test "hides device pool option from the type filter when client_to_client is disabled",
+    test "shows device pool option in the type filter",
          %{conn: conn, account: account, actor: actor} do
-      {:ok, lv, _html} =
-        conn
-        |> authorize_conn(actor)
-        |> live(~p"/#{account}/resources")
-
-      refute has_element?(lv, "#resources-type-static_device_pool")
-      assert has_element?(lv, "#resources-type-dns")
-    end
-
-    test "shows device pool option in the type filter when client_to_client is enabled",
-         %{conn: conn, account: account, actor: actor} do
-      enable_feature(:client_to_client)
-      account = update_account(account, features: %{client_to_client: true})
-
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
@@ -149,6 +135,17 @@ defmodule PortalWeb.ResourcesTest do
 
       assert has_element?(lv, "#resources-type-static_device_pool")
       assert has_element?(lv, "#resources-type-dns")
+    end
+
+    test "offers the device pool type when creating a resource",
+         %{conn: conn, account: account, actor: actor} do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/new")
+
+      assert has_element?(lv, "#resource-form-type--static-device-pool")
+      assert has_element?(lv, "#resource-form-type--dns")
     end
 
     test "hides Internet Resource row for starter accounts without the feature", %{conn: conn} do
@@ -159,8 +156,7 @@ defmodule PortalWeb.ResourcesTest do
             policy_conditions: true,
             traffic_filters: true,
             idp_sync: true,
-            rest_api: true,
-            client_to_client: false
+            rest_api: true
           }
         )
 
@@ -272,9 +268,6 @@ defmodule PortalWeb.ResourcesTest do
       account: account,
       actor: actor
     } do
-      enable_feature(:client_to_client)
-      account = update_account(account, features: %{client_to_client: true})
-
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
@@ -399,12 +392,9 @@ defmodule PortalWeb.ResourcesTest do
            account: account,
            actor: actor
          } do
-      enable_feature(:client_to_client)
-
       features =
         account.features
         |> Map.from_struct()
-        |> Map.put(:client_to_client, true)
 
       account = update_account(account, features: features)
 
@@ -457,8 +447,6 @@ defmodule PortalWeb.ResourcesTest do
       account: account,
       actor: actor
     } do
-      enable_feature(:client_to_client)
-      account = update_account(account, features: %{client_to_client: true})
       client = client_fixture(account: account, actor: actor, name: "Workstation Alpha")
 
       {:ok, lv, _html} =
@@ -681,8 +669,7 @@ defmodule PortalWeb.ResourcesTest do
             policy_conditions: false,
             traffic_filters: true,
             idp_sync: true,
-            rest_api: true,
-            client_to_client: false
+            rest_api: true
           }
         )
 

--- a/elixir/test/portal_web/live/sites_test.exs
+++ b/elixir/test/portal_web/live/sites_test.exs
@@ -120,8 +120,7 @@ defmodule PortalWeb.SitesTest do
             policy_conditions: true,
             traffic_filters: true,
             idp_sync: true,
-            rest_api: true,
-            client_to_client: false
+            rest_api: true
           }
         )
 

--- a/elixir/test/support/fixtures/account_fixtures.ex
+++ b/elixir/test/support/fixtures/account_fixtures.ex
@@ -32,7 +32,6 @@ defmodule Portal.AccountFixtures do
         traffic_filters: true,
         idp_sync: true,
         rest_api: true,
-        client_to_client: false,
         iceless: false
       },
       limits: %{


### PR DESCRIPTION
While device pools were being built they sat behind two switches: a row in the global features table, and a per-account feature bit. Both had to be on for an account to see the Device Pool resource type or for two clients to connect to each other. They are ready to ship, so both switches go away and every account gets them.

The migration removes the global flag and strips the now-dead key out of existing account feature blobs.

Worth knowing for review: clients could previously be told a peer connection was refused because the feature was off. That answer no longer exists, so the portal never sends it.

Related: #14528
