### PR TITLE
fix(portal): accept outer paths on open flow logs

### DIFF
--- a/elixir/lib/portal/flow_log.ex
+++ b/elixir/lib/portal/flow_log.ex
@@ -205,10 +205,10 @@ defmodule Portal.FlowLog do
                             initiator_device_firebase_installation_id domain]a
 
   # The attribution snapshot, inner tunnel tuple, protocol, and flow_start are
-  # all known when a flow side opens, so they are required. The accumulated
-  # outer paths, flow_end, last_packet, and byte/packet counters arrive only on
-  # close and are nullable to support open-then-close reporting; domain is
-  # nullable because only DNS resources carry one,
+  # all known when a flow side opens, so they are required. Outer paths may be
+  # included on open and are replaced by the complete accumulated path list on
+  # close. flow_end, last_packet, and byte/packet counters are nullable to
+  # support open-then-close reporting; domain is nullable because only DNS resources carry one,
   # resource_address because internet and device-pool resources have none, and
   # initiator_actor_email / initiator_auth_provider_id because not every actor
   # or credential has one.
@@ -310,8 +310,7 @@ defmodule Portal.FlowLog do
 
   defp validate_outers_match_flow_state(changeset) do
     case {get_field(changeset, :flow_end), get_field(changeset, :outers)} do
-      {nil, []} -> changeset
-      {nil, _outers} -> add_error(changeset, :outers, "must be absent while the flow is open")
+      {nil, _outers} -> changeset
       {_flow_end, []} -> add_error(changeset, :outers, "can't be blank")
       {_flow_end, _outers} -> changeset
     end

--- a/elixir/lib/portal_api/controllers/flow_log_controller.ex
+++ b/elixir/lib/portal_api/controllers/flow_log_controller.ex
@@ -186,9 +186,10 @@ defmodule PortalAPI.FlowLogController do
   end
 
   defp outers_for_storage(changeset) do
-    if is_nil(get_field(changeset, :flow_end)),
-      do: nil,
-      else: get_field(changeset, :outers)
+    case get_field(changeset, :outers) do
+      [] -> nil
+      outers -> outers
+    end
   end
 
   defp render_validation_errors(errors) do

--- a/elixir/priv/repo/migrations/20260805120000_allow_flow_log_open_outers.exs
+++ b/elixir/priv/repo/migrations/20260805120000_allow_flow_log_open_outers.exs
@@ -1,0 +1,39 @@
+defmodule Portal.Repo.Migrations.AllowFlowLogOpenOuters do
+  use Ecto.Migration
+
+  def up do
+    replace_constraint(open_outers_check())
+  end
+
+  def down do
+    replace_constraint(closed_outers_check())
+  end
+
+  defp replace_constraint(check) do
+    drop(constraint(:flow_logs, :flow_logs_outers_match_flow_state))
+
+    create(
+      constraint(:flow_logs, :flow_logs_outers_match_flow_state,
+        check: check
+      )
+    )
+  end
+
+  defp open_outers_check do
+    """
+    (flow_end IS NULL AND outers IS NULL) OR
+    (outers IS NOT NULL AND
+     jsonb_typeof(outers) = 'array' AND
+     jsonb_array_length(outers) > 0)
+    """
+  end
+
+  defp closed_outers_check do
+    """
+    (flow_end IS NULL AND outers IS NULL) OR
+    (flow_end IS NOT NULL AND
+     jsonb_typeof(outers) = 'array' AND
+     jsonb_array_length(outers) > 0)
+    """
+  end
+end

--- a/elixir/test/portal/elastic/sync_test.exs
+++ b/elixir/test/portal/elastic/sync_test.exs
@@ -141,6 +141,14 @@ defmodule Portal.Elastic.SyncTest do
             seq: fragment("nextval('flow_logs_seq_seq')"),
             flow_end: ^flow_end,
             last_packet: ^flow_end,
+            outers: ^[
+              %FlowLog.Outer{
+                src_ip: "203.0.113.10",
+                src_port: 51_820,
+                dst_ip: "198.51.100.5",
+                dst_port: 51_820
+              }
+            ],
             rx_packets: 1,
             tx_packets: 1,
             rx_bytes: 1,

--- a/elixir/test/portal/flow_log_test.exs
+++ b/elixir/test/portal/flow_log_test.exs
@@ -165,10 +165,11 @@ defmodule Portal.FlowLogTest do
       end
     end
 
-    test "invalid with outer paths on an open flow" do
+    test "valid with outer paths on an open flow" do
       cs = changeset(%{flow_end: nil})
-      refute cs.valid?
-      assert Map.has_key?(errors_on(cs), :outers)
+
+      assert cs.valid?
+      assert [%FlowLog.Outer{dst_ip: "203.0.113.7"}] = get_field(cs, :outers)
     end
 
     test "invalid with malformed outer endpoints" do

--- a/elixir/test/portal/splunk/sync_test.exs
+++ b/elixir/test/portal/splunk/sync_test.exs
@@ -663,6 +663,14 @@ defmodule Portal.Splunk.SyncTest do
           seq: fragment("nextval('flow_logs_seq_seq')"),
           flow_end: ^flow_end,
           last_packet: ^flow_end,
+          outers: ^[
+            %FlowLog.Outer{
+              src_ip: "203.0.113.10",
+              src_port: 51_820,
+              dst_ip: "198.51.100.5",
+              dst_port: 51_820
+            }
+          ],
           rx_packets: 10,
           tx_packets: 12,
           rx_bytes: 1024,

--- a/elixir/test/portal_api/controllers/flow_log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/flow_log_controller_test.exs
@@ -628,12 +628,14 @@ defmodule PortalAPI.FlowLogControllerTest do
       assert errors["0"]["outers"] == ["can't be blank"]
     end
 
-    test "returns 422 when an open includes outer paths", %{conn: conn, account: account} do
+    test "accepts an open with outer paths known so far", %{conn: conn, account: account} do
       record = build_record(%{"flow_end" => nil})
-      conn = conn |> authorize(account) |> post_logs([record])
 
-      assert %{"status" => 422, "validation_errors" => errors} = json_response(conn, 422)
-      assert errors["0"]["outers"] == ["must be absent while the flow is open"]
+      assert %{"data" => %{"status" => "ok"}} =
+               conn |> authorize(account) |> post_logs([record]) |> json_response(200)
+
+      [log] = Repo.all(FlowLog)
+      assert Enum.map(log.outers, & &1.dst_ip) == ["203.0.113.7"]
     end
 
     test "accepts a skewed flow_end before flow_start", %{conn: conn, account: account} do


### PR DESCRIPTION
## Summary

- accept and persist outer paths reported while a flow is open
- continue replacing them with the complete accumulated path list on close
- require a non-empty outer path list for closed flows at both changeset and database layers
- update direct-close tests to construct complete close records

## Context

Split out of #14521. Rust reports the paths known so far on both open and close records; #14521 keeps only the generated OpenAPI contract and its cross-language enforcement.

## Testing

- MIX_ENV=test mix test: 4426 passed
- focused Portal tests: 90 passed
- migration verified up, down, and up
- mix format --check-formatted
- MIX_ENV=test mix credo --strict