### PR TITLE
fix(portal): set Enterprise seat limit from Stripe quantity

### DIFF
--- a/elixir/lib/portal/billing.ex
+++ b/elixir/lib/portal/billing.ex
@@ -100,9 +100,14 @@ defmodule Portal.Billing do
   Returns the plan type for the account based on the Stripe product name.
   Returns :enterprise, :team, :starter, or :unknown.
   """
-  @spec plan_type(Portal.Account.t()) :: :enterprise | :team | :starter | :unknown
-  def plan_type(%Portal.Account{metadata: %{stripe: %{product_name: product_name}}})
-      when is_binary(product_name) do
+  @spec plan_type(Portal.Account.t() | String.t() | nil) ::
+          :enterprise | :team | :starter | :unknown
+  def plan_type(%Portal.Account{metadata: %{stripe: %{product_name: product_name}}}),
+    do: plan_type(product_name)
+
+  def plan_type(%Portal.Account{}), do: :unknown
+
+  def plan_type(product_name) when is_binary(product_name) do
     cond do
       String.starts_with?(product_name, "Enterprise") -> :enterprise
       product_name == "Team" -> :team
@@ -111,7 +116,7 @@ defmodule Portal.Billing do
     end
   end
 
-  def plan_type(%Portal.Account{}), do: :unknown
+  def plan_type(nil), do: :unknown
 
   @spec paid_plan?(Portal.Account.t()) :: boolean()
   def paid_plan?(%Portal.Account{} = account), do: plan_type(account) in [:team, :enterprise]

--- a/elixir/lib/portal/billing/event_handler.ex
+++ b/elixir/lib/portal/billing/event_handler.ex
@@ -592,7 +592,10 @@ defmodule Portal.Billing.EventHandler do
     {limits, params} = Map.split(params, limit_fields)
     {features, _} = Map.split(params, feature_fields)
 
-    limits = Map.merge(limits, %{"users_count" => users_count})
+    limits =
+      limits
+      |> Map.put("users_count", users_count)
+      |> put_seat_limit(Billing.plan_type(stripe_metadata["product_name"]), seats)
 
     %{
       features: features,
@@ -600,6 +603,14 @@ defmodule Portal.Billing.EventHandler do
       metadata: %{stripe: Map.merge(metadata, stripe_metadata)}
     }
   end
+
+  # Enterprise seats are sold as monthly active users, so the limit comes from
+  # the subscription quantity and never from the Stripe metadata.
+  defp put_seat_limit(limits, :enterprise, seats),
+    do: Map.put(limits, "monthly_active_users_count", seats)
+
+  defp put_seat_limit(limits, _plan_type, _seats),
+    do: Map.delete(limits, "monthly_active_users_count")
 
   defp parse_metadata_params(metadata, limit_fields, metadata_fields) do
     metadata

--- a/elixir/test/portal/billing/event_handler_test.exs
+++ b/elixir/test/portal/billing/event_handler_test.exs
@@ -342,6 +342,51 @@ defmodule Portal.Billing.EventHandlerTest do
       assert {:error, :no_plan_product} = EventHandler.handle_event(event)
     end
 
+    test "sets the monthly active users limit from Enterprise seats", %{
+      account: account,
+      customer: customer
+    } do
+      {product, _price, subscription} =
+        Stripe.build_all(:enterprise, account.metadata.stripe.customer_id, 42, %{
+          "monthly_active_users_count" => "7"
+        })
+
+      event = Stripe.build_event("customer.subscription.updated", subscription)
+
+      Stripe.stub(
+        Stripe.fetch_customer_endpoint(customer) ++
+          Stripe.fetch_product_endpoint(product)
+      )
+
+      assert {:ok, _event} = EventHandler.handle_event(event)
+
+      updated = Portal.Repo.get!(Portal.Account, account.id)
+      assert updated.limits.monthly_active_users_count == 42
+    end
+
+    test "leaves the monthly active users limit unset for Team seats", %{
+      account: account,
+      customer: customer
+    } do
+      {product, _price, subscription} =
+        Stripe.build_all(:team, account.metadata.stripe.customer_id, 42, %{
+          "monthly_active_users_count" => "7"
+        })
+
+      event = Stripe.build_event("customer.subscription.updated", subscription)
+
+      Stripe.stub(
+        Stripe.fetch_customer_endpoint(customer) ++
+          Stripe.fetch_product_endpoint(product)
+      )
+
+      assert {:ok, _event} = EventHandler.handle_event(event)
+
+      updated = Portal.Repo.get!(Portal.Account, account.id)
+      assert updated.limits.monthly_active_users_count == nil
+      assert updated.limits.users_count == 42
+    end
+
     test "clears account limit flags when subscription update increases limits", %{
       account: account,
       customer: customer

--- a/elixir/test/portal/billing/event_handler_test.exs
+++ b/elixir/test/portal/billing/event_handler_test.exs
@@ -364,10 +364,12 @@ defmodule Portal.Billing.EventHandlerTest do
       assert updated.limits.monthly_active_users_count == 42
     end
 
-    test "leaves the monthly active users limit unset for Team seats", %{
+    test "clears the monthly active users limit for Team seats", %{
       account: account,
       customer: customer
     } do
+      update_account(account, %{limits: %{monthly_active_users_count: 99}})
+
       {product, _price, subscription} =
         Stripe.build_all(:team, account.metadata.stripe.customer_id, 42, %{
           "monthly_active_users_count" => "7"


### PR DESCRIPTION
Enterprise plans are sold by monthly active users, but that limit came from a number typed into the subscription's Stripe metadata. Keeping it in step with what the customer actually pays for was a manual step.

The limit now follows the seat quantity on the Enterprise subscription item, the same way the user limit already follows quantity on Team plans. Nothing reads the metadata field any more, on any plan.

Enterprise subscriptions in Stripe need the right quantity before this ships. An account left at a quantity of one ends up with a limit of one and cannot add users.

Related: #14427 #14440
