### PR TITLE
feat(portal): add a device-attested policy condition

### DIFF
--- a/elixir/assets/js/app.js
+++ b/elixir/assets/js/app.js
@@ -17,12 +17,14 @@ import {
   PageSizePreference,
   getPageSizePreference,
 } from "./hooks/page_size_preference";
+import { DeviceTrustConditions } from "./hooks/device_trust_conditions";
 import "./event_listeners";
 
 Hooks.ThemeToggle = ThemeToggle;
 Hooks.SidebarCollapse = SidebarCollapse;
 Hooks.DatetimeRangeFilter = DatetimeRangeFilter;
 Hooks.PageSizePreference = PageSizePreference;
+Hooks.DeviceTrustConditions = DeviceTrustConditions;
 
 // Read CSRF token from the meta tag and use it in the LiveSocket params
 let csrfToken = document

--- a/elixir/assets/js/hooks/device_trust_conditions.js
+++ b/elixir/assets/js/hooks/device_trust_conditions.js
@@ -1,0 +1,39 @@
+/* Attestation is strong x509 device identity, so it supersedes the manual
+ * verification an administrator does by hand. Turning it on shows verification
+ * as satisfied and takes it out of the operator's hands. A disabled checkbox is
+ * not submitted, so the saved policy carries the attestation condition alone
+ * rather than both. */
+export const DeviceTrustConditions = {
+  mounted() {
+    this.attested = this.el.querySelector("[data-device-trust='attested']");
+    this.verified = this.el.querySelector("[data-device-trust='verified']");
+
+    if (!this.attested || !this.verified) return;
+
+    this.wasChecked = this.verified.checked;
+
+    this.syncVerified = () => {
+      if (this.attested.checked) {
+        this.verified.checked = true;
+        this.verified.disabled = true;
+      } else {
+        this.verified.disabled = false;
+        this.verified.checked = this.wasChecked;
+      }
+    };
+
+    this.rememberVerified = () => {
+      if (!this.verified.disabled) this.wasChecked = this.verified.checked;
+    };
+
+    this.attested.addEventListener("change", this.syncVerified);
+    this.verified.addEventListener("change", this.rememberVerified);
+
+    this.syncVerified();
+  },
+
+  destroyed() {
+    this.attested?.removeEventListener("change", this.syncVerified);
+    this.verified?.removeEventListener("change", this.rememberVerified);
+  },
+};

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -148,6 +148,8 @@ config :portal, Portal.Changes.Consumer,
     gateway_tokens
     sites
     policies
+    trust_anchors
+    trust_anchor_certificates
     resources
     static_device_pool_members
     client_tokens

--- a/elixir/lib/portal/cache/cacheable/policy.ex
+++ b/elixir/lib/portal/cache/cacheable/policy.ex
@@ -13,7 +13,8 @@ defmodule Portal.Cache.Cacheable.Policy do
             | :remote_ip
             | :provider_id
             | :current_utc_datetime
-            | :client_verified,
+            | :client_verified
+            | :device_attested,
           operator:
             :contains
             | :does_not_contain

--- a/elixir/lib/portal/changes/consumer.ex
+++ b/elixir/lib/portal/changes/consumer.ex
@@ -25,6 +25,8 @@ defmodule Portal.Changes.Consumer do
     "gateway_tokens" => Hooks.GatewayTokens,
     "sites" => Hooks.Sites,
     "policies" => Hooks.Policies,
+    "trust_anchors" => Hooks.TrustAnchors,
+    "trust_anchor_certificates" => Hooks.TrustAnchorCertificates,
     "resources" => Hooks.Resources,
     "static_device_pool_members" => Hooks.StaticDevicePoolMembers,
     "client_tokens" => Hooks.ClientTokens,

--- a/elixir/lib/portal/changes/hooks/trust_anchor_certificates.ex
+++ b/elixir/lib/portal/changes/hooks/trust_anchor_certificates.ex
@@ -1,0 +1,30 @@
+defmodule Portal.Changes.Hooks.TrustAnchorCertificates do
+  @moduledoc """
+  Broadcasts trust anchor certificate changes so connected clients re-evaluate
+  policy.
+
+  Separate from the anchor's own hook because editing an anchor's certificates
+  replaces these rows without necessarily writing to the anchor row itself, so
+  the anchor hook alone would miss the material actually changing underneath it.
+  """
+  @behaviour Portal.Changes.Hooks
+
+  alias Portal.{Changes.Change, PubSub, TrustAnchorCertificate}
+  import Portal.SchemaHelpers
+
+  @impl true
+  def on_insert(lsn, data), do: broadcast(lsn, :insert, data)
+
+  @impl true
+  def on_update(lsn, _old_data, data), do: broadcast(lsn, :update, data)
+
+  @impl true
+  def on_delete(lsn, old_data), do: broadcast(lsn, :delete, old_data)
+
+  defp broadcast(lsn, op, data) do
+    certificate = struct_from_params(TrustAnchorCertificate, data)
+    change = %Change{lsn: lsn, op: op, struct: certificate}
+
+    PubSub.Changes.broadcast(certificate.account_id, :trust_anchor_certificates, change)
+  end
+end

--- a/elixir/lib/portal/changes/hooks/trust_anchors.ex
+++ b/elixir/lib/portal/changes/hooks/trust_anchors.ex
@@ -1,0 +1,35 @@
+defmodule Portal.Changes.Hooks.TrustAnchors do
+  @moduledoc """
+  Broadcasts trust anchor changes so connected clients re-evaluate policy.
+
+  A policy condition can name the anchors a device's certificate has to chain
+  to, so adding, removing or re-uploading one changes which resources a
+  connected device may reach. Without this the change would only take effect the
+  next time each device reconnected.
+
+  Certificates are broadcast as a change to the anchor that holds them, since
+  the condition names anchors and a certificate is only ever reachable through
+  one. Editing an anchor replaces its certificate rows, so the certificate hooks
+  are what fire when the material behind an unchanged anchor is swapped.
+  """
+  @behaviour Portal.Changes.Hooks
+
+  alias Portal.{Changes.Change, PubSub, TrustAnchor}
+  import Portal.SchemaHelpers
+
+  @impl true
+  def on_insert(lsn, data), do: broadcast(lsn, :insert, data)
+
+  @impl true
+  def on_update(lsn, _old_data, data), do: broadcast(lsn, :update, data)
+
+  @impl true
+  def on_delete(lsn, old_data), do: broadcast(lsn, :delete, old_data)
+
+  defp broadcast(lsn, op, data) do
+    trust_anchor = struct_from_params(TrustAnchor, data)
+    change = %Change{lsn: lsn, op: op, struct: trust_anchor}
+
+    PubSub.Changes.broadcast(trust_anchor.account_id, :trust_anchors, change)
+  end
+end

--- a/elixir/lib/portal/policies/condition.ex
+++ b/elixir/lib/portal/policies/condition.ex
@@ -11,7 +11,8 @@ defmodule Portal.Policies.Condition do
             | :remote_ip
             | :auth_provider_id
             | :current_utc_datetime
-            | :client_verified,
+            | :client_verified
+            | :device_attested,
           operator:
             :contains
             | :does_not_contain
@@ -31,6 +32,7 @@ defmodule Portal.Policies.Condition do
         auth_provider_id
         current_utc_datetime
         client_verified
+        device_attested
       ]a
 
     field :operator, Ecto.Enum, values: ~w[
@@ -72,6 +74,7 @@ defmodule Portal.Policies.Condition do
   def valid_operators_for_property(:auth_provider_id), do: [:is_in, :is_not_in]
   def valid_operators_for_property(:current_utc_datetime), do: [:is_in_day_of_week_time_ranges]
   def valid_operators_for_property(:client_verified), do: [:is]
+  def valid_operators_for_property(:device_attested), do: [:is]
 
   defp validate_operator(changeset) do
     case fetch_field(changeset, :property) do
@@ -105,6 +108,13 @@ defmodule Portal.Policies.Condition do
         changeset
         |> validate_required(:operator)
         |> validate_inclusion(:operator, valid_operators_for_property(:client_verified))
+        |> validate_length(:values, min: 1, max: 1)
+        |> validate_list(:values, :boolean)
+
+      {_data_or_changes, :device_attested} ->
+        changeset
+        |> validate_required(:operator)
+        |> validate_inclusion(:operator, valid_operators_for_property(:device_attested))
         |> validate_length(:values, min: 1, max: 1)
         |> validate_list(:values, :boolean)
 

--- a/elixir/lib/portal/policies/evaluator.ex
+++ b/elixir/lib/portal/policies/evaluator.ex
@@ -167,6 +167,37 @@ defmodule Portal.Policies.Evaluator do
     {:ok, nil}
   end
 
+  # Reads the live connection state, not the row's last_attested_at: a device
+  # that attested last week but connected without a certificate today has not
+  # proved anything for this session.
+  def fetch_conformation_expiration(
+        %{
+          property: :device_attested,
+          operator: :is,
+          values: ["true"]
+        },
+        %Device{type: :client, attested?: attested?},
+        _auth_provider_id
+      ) do
+    if attested? do
+      {:ok, nil}
+    else
+      :error
+    end
+  end
+
+  def fetch_conformation_expiration(
+        %{
+          property: :device_attested,
+          operator: :is,
+          values: _other
+        },
+        %Device{type: :client},
+        _auth_provider_id
+      ) do
+    {:ok, nil}
+  end
+
   def fetch_conformation_expiration(
         %{
           property: :current_utc_datetime,

--- a/elixir/lib/portal/pubsub.ex
+++ b/elixir/lib/portal/pubsub.ex
@@ -57,6 +57,8 @@ defmodule Portal.PubSub do
             | :resources
             | :sites
             | :static_device_pool_members
+            | :trust_anchor_certificates
+            | :trust_anchors
 
     @spec subscribe(String.t()) :: :ok | {:error, term()}
     def subscribe(account_id) do

--- a/elixir/lib/portal_api/schemas/policy_schema.ex
+++ b/elixir/lib/portal_api/schemas/policy_schema.ex
@@ -27,7 +27,13 @@ defmodule PortalAPI.Schemas.Policy do
         comma-separated list of `HH:MM-HH:MM` ranges, and `TIMEZONE` is an
         IANA timezone name, e.g. `"M/09:00-17:00/America/New_York"`.
       * `client_verified` with `is`: `values` is a single-element list
-        containing `"true"` or `"false"`.
+        containing `"true"` or `"false"`. An administrator marks a Client
+        verified by hand.
+      * `device_attested` with `is`: `values` is a single-element list
+        containing `"true"` or `"false"`. A device is attested when the
+        connection itself proved possession of an MDM-issued client
+        certificate, so this is evaluated per connection rather than from
+        anything stored on the device. It supersedes `client_verified`.
       """,
       type: :object,
       properties: %{
@@ -39,7 +45,8 @@ defmodule PortalAPI.Schemas.Policy do
             "remote_ip",
             "auth_provider_id",
             "current_utc_datetime",
-            "client_verified"
+            "client_verified",
+            "device_attested"
           ]
         },
         operator: %Schema{

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -18,6 +18,7 @@ defmodule PortalWeb.Policies.Components do
     :remote_ip,
     :auth_provider_id,
     :client_verified,
+    :device_attested,
     :current_utc_datetime
   ]
 
@@ -1328,6 +1329,7 @@ defmodule PortalWeb.Policies.Components do
 
   @spec condition_short_label(atom()) :: String.t()
   def condition_short_label(:client_verified), do: "Verified"
+  def condition_short_label(:device_attested), do: "Attested"
   def condition_short_label(:auth_provider_id), do: "Auth"
   def condition_short_label(:remote_ip_location_region), do: "Location"
   def condition_short_label(:remote_ip), do: "IP Range"
@@ -1356,7 +1358,7 @@ defmodule PortalWeb.Policies.Components do
       "inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-mono font-medium tracking-wider uppercase bg-raised text-body"
 
   @spec condition_type_badge_class(atom()) :: String.t()
-  defp condition_type_badge_class(:client_verified),
+  defp condition_type_badge_class(property) when property in [:client_verified, :device_attested],
     do:
       "inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0 text-success bg-success-light"
 
@@ -1383,6 +1385,9 @@ defmodule PortalWeb.Policies.Components do
   @spec condition_values_display(map(), list(), any()) :: String.t()
   defp condition_values_display(%{property: :client_verified}, _providers, _account),
     do: "Client must be verified"
+
+  defp condition_values_display(%{property: :device_attested}, _providers, _account),
+    do: "Client must be attested"
 
   defp condition_values_display(
          %{property: :auth_provider_id, values: values},
@@ -1561,6 +1566,16 @@ defmodule PortalWeb.Policies.Components do
     """
   end
 
+  defp condition(%{property: :device_attested} = assigns) do
+    ~H"""
+    <span :if={@values != []} class="mr-1">
+      <span>by clients that are</span>
+      <span :if={@values == ["true"]}>attested</span>
+      <span :if={@values == ["false"]}>not attested</span>
+    </span>
+    """
+  end
+
   defp condition(%{property: :current_utc_datetime, values: values} = assigns) do
     assigns =
       assign_new(assigns, :tz_time_ranges_by_dow, fn ->
@@ -1693,8 +1708,8 @@ defmodule PortalWeb.Policies.Components do
             providers={@providers}
             disabled={@policy_conditions_enabled? == false}
           />
-          <.client_verified_condition_form
-            :if={:client_verified in @enabled_conditions}
+          <.device_trust_condition_form
+            :if={:device_attested in @enabled_conditions}
             form={@form}
             disabled={@policy_conditions_enabled? == false}
           />
@@ -1971,14 +1986,31 @@ defmodule PortalWeb.Policies.Components do
     """
   end
 
-  defp client_verified_condition_form(assigns) do
+  defp device_trust_condition_form(assigns) do
     ~H"""
     <fieldset class="mb-4">
-      <% condition_form = find_condition_form(@form[:conditions], :client_verified) %>
+      <% attested_form = find_condition_form(@form[:conditions], :device_attested) %>
+      <% verified_form = find_condition_form(@form[:conditions], :client_verified) %>
 
       <.input
         type="hidden"
-        field={condition_form[:property]}
+        field={attested_form[:property]}
+        name="policy[conditions][device_attested][property]"
+        id="policy_conditions_device_attested_property"
+        value="device_attested"
+      />
+
+      <.input
+        type="hidden"
+        name="policy[conditions][device_attested][operator]"
+        id="policy_conditions_device_attested_operator"
+        field={attested_form[:operator]}
+        value={:is}
+      />
+
+      <.input
+        type="hidden"
+        field={verified_form[:property]}
         name="policy[conditions][client_verified][property]"
         id="policy_conditions_client_verified_property"
         value="client_verified"
@@ -1988,7 +2020,7 @@ defmodule PortalWeb.Policies.Components do
         type="hidden"
         name="policy[conditions][client_verified][operator]"
         id="policy_conditions_client_verified_operator"
-        field={condition_form[:operator]}
+        field={verified_form[:operator]}
         value={:is}
       />
 
@@ -1996,24 +2028,24 @@ defmodule PortalWeb.Policies.Components do
         class="hover:bg-neutral-100 cursor-pointer border border-neutral-200 shadow-b rounded-t px-4 py-2"
         phx-click={
           JS.toggle_class("hidden",
-            to: "#policy_conditions_client_verified_condition"
+            to: "#policy_conditions_device_trust_condition"
           )
           |> JS.toggle_class("bg-neutral-50")
           |> JS.toggle_class("ri-arrow-down-s-line",
-            to: "#policy_conditions_client_verified_chevron"
+            to: "#policy_conditions_device_trust_chevron"
           )
           |> JS.toggle_class("ri-arrow-up-s-line",
-            to: "#policy_conditions_client_verified_chevron"
+            to: "#policy_conditions_device_trust_chevron"
           )
         }
       >
         <legend class="flex justify-between items-center text-neutral-700">
           <span class="flex items-center">
-            <.icon name="ri-shield-check-line" class="w-5 h-5 mr-2" /> Client verification
+            <.icon name="ri-shield-keyhole-line" class="w-5 h-5 mr-2" /> Device Trust
           </span>
           <span class="shadow-sm bg-white w-6 h-6 flex items-center justify-center rounded-full">
             <.icon
-              id="policy_conditions_client_verified_chevron"
+              id="policy_conditions_device_trust_chevron"
               name="ri-arrow-down-s-line"
               class="w-5 h-5"
             />
@@ -2022,24 +2054,49 @@ defmodule PortalWeb.Policies.Components do
       </div>
 
       <div
-        id="policy_conditions_client_verified_condition"
+        id="policy_conditions_device_trust_condition"
         class={[
           "p-4 border-neutral-200 border-l border-r border-b rounded-b",
-          condition_values_empty?(condition_form) && "hidden"
+          condition_values_empty?(attested_form) && condition_values_empty?(verified_form) &&
+            "hidden"
         ]}
       >
-        <p class="text-sm text-neutral-500 mb-4">
-          Allow access when the Client is manually verified by the administrator.
-        </p>
-        <div class="space-y-2" phx-update="ignore" id="conditions-client-verified-values">
-          <.toggle
-            label="Require client verification"
-            name="policy[conditions][client_verified][values][]"
-            id="policy_conditions_client_verified_value"
-            value="true"
-            disabled={@disabled}
-            checked={List.first(List.wrap(condition_form[:values].value)) == "true"}
-          />
+        <div
+          class="space-y-4"
+          phx-update="ignore"
+          id="conditions-device-trust-values"
+          phx-hook="DeviceTrustConditions"
+        >
+          <div>
+            <.toggle
+              label="Require attestation"
+              name="policy[conditions][device_attested][values][]"
+              id="policy_conditions_device_attested_value"
+              value="true"
+              disabled={@disabled}
+              checked={List.first(List.wrap(attested_form[:values].value)) == "true"}
+              data-device-trust="attested"
+            />
+            <p class="text-sm text-neutral-500 mt-1">
+              Allow access only when the connection itself proved possession of an MDM-issued
+              client certificate. This is strong device identity, so it supersedes verification.
+            </p>
+          </div>
+
+          <div>
+            <.toggle
+              label="Require client verification"
+              name="policy[conditions][client_verified][values][]"
+              id="policy_conditions_client_verified_value"
+              value="true"
+              disabled={@disabled}
+              checked={List.first(List.wrap(verified_form[:values].value)) == "true"}
+              data-device-trust="verified"
+            />
+            <p class="text-sm text-neutral-500 mt-1">
+              Allow access when the Client is manually verified by the administrator.
+            </p>
+          </div>
         </div>
       </div>
     </fieldset>

--- a/elixir/priv/static/openapi.json
+++ b/elixir/priv/static/openapi.json
@@ -3570,7 +3570,7 @@
         "type": "object"
       },
       "PolicyCondition": {
-        "description": "A condition that must be satisfied for the Policy to grant access.\n\nAll conditions on a Policy must evaluate to true for access to be\ngranted. A condition is made up of a `property`, an `operator`, and a\nlist of `values`. The valid operators and the meaning of `values`\ndepend on the `property`:\n\n* `remote_ip_location_region` with `is_in` / `is_not_in`: `values` are\n  ISO 3166-1 alpha-2 country codes, e.g. `[\"US\", \"CA\"]`.\n* `remote_ip` with `is_in_cidr` / `is_not_in_cidr`: `values` are CIDR\n  ranges (IPv4 or IPv6), e.g. `[\"10.0.0.0/8\", \"2607:f8b0::/32\"]`.\n* `auth_provider_id` with `is_in` / `is_not_in`: `values` are\n  authentication provider IDs (UUIDs).\n* `current_utc_datetime` with `is_in_day_of_week_time_ranges`: each\n  value is a `DAY/TIME_RANGES/TIMEZONE` string where `DAY` is one of\n  `M T W R F S U` (Monday through Sunday), `TIME_RANGES` is a\n  comma-separated list of `HH:MM-HH:MM` ranges, and `TIMEZONE` is an\n  IANA timezone name, e.g. `\"M/09:00-17:00/America/New_York\"`.\n* `client_verified` with `is`: `values` is a single-element list\n  containing `\"true\"` or `\"false\"`.\n",
+        "description": "A condition that must be satisfied for the Policy to grant access.\n\nAll conditions on a Policy must evaluate to true for access to be\ngranted. A condition is made up of a `property`, an `operator`, and a\nlist of `values`. The valid operators and the meaning of `values`\ndepend on the `property`:\n\n* `remote_ip_location_region` with `is_in` / `is_not_in`: `values` are\n  ISO 3166-1 alpha-2 country codes, e.g. `[\"US\", \"CA\"]`.\n* `remote_ip` with `is_in_cidr` / `is_not_in_cidr`: `values` are CIDR\n  ranges (IPv4 or IPv6), e.g. `[\"10.0.0.0/8\", \"2607:f8b0::/32\"]`.\n* `auth_provider_id` with `is_in` / `is_not_in`: `values` are\n  authentication provider IDs (UUIDs).\n* `current_utc_datetime` with `is_in_day_of_week_time_ranges`: each\n  value is a `DAY/TIME_RANGES/TIMEZONE` string where `DAY` is one of\n  `M T W R F S U` (Monday through Sunday), `TIME_RANGES` is a\n  comma-separated list of `HH:MM-HH:MM` ranges, and `TIMEZONE` is an\n  IANA timezone name, e.g. `\"M/09:00-17:00/America/New_York\"`.\n* `client_verified` with `is`: `values` is a single-element list\n  containing `\"true\"` or `\"false\"`. An administrator marks a Client\n  verified by hand.\n* `device_attested` with `is`: `values` is a single-element list\n  containing `\"true\"` or `\"false\"`. A device is attested when the\n  connection itself proved possession of an MDM-issued client\n  certificate, so this is evaluated per connection rather than from\n  anything stored on the device. It supersedes `client_verified`.\n",
         "example": {
           "operator": "is_in",
           "property": "remote_ip_location_region",
@@ -3599,7 +3599,8 @@
               "remote_ip",
               "auth_provider_id",
               "current_utc_datetime",
-              "client_verified"
+              "client_verified",
+              "device_attested"
             ],
             "type": "string"
           },

--- a/elixir/test/portal/changes/hooks/trust_anchors_test.exs
+++ b/elixir/test/portal/changes/hooks/trust_anchors_test.exs
@@ -1,0 +1,55 @@
+defmodule Portal.Changes.Hooks.TrustAnchorsTest do
+  use Portal.DataCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.TrustAnchorFixtures
+
+  alias Portal.Changes.Change
+  alias Portal.Changes.Hooks.TrustAnchorCertificates
+  alias Portal.Changes.Hooks.TrustAnchors
+
+  setup do
+    account = account_fixture()
+    trust_anchor = trust_anchor_fixture(account: account)
+
+    %{account: account, trust_anchor: trust_anchor}
+  end
+
+  describe "trust anchors" do
+    test "broadcasts every operation", %{account: account, trust_anchor: trust_anchor} do
+      :ok = Portal.PubSub.Changes.subscribe(account.id, :trust_anchors)
+      data = %{"id" => trust_anchor.id, "account_id" => account.id, "name" => trust_anchor.name}
+
+      assert TrustAnchors.on_insert(0, data) == :ok
+      assert_receive %Change{op: :insert}
+
+      assert TrustAnchors.on_update(1, data, data) == :ok
+      assert_receive %Change{op: :update}
+
+      # A deleted anchor is the case that matters: a policy naming it has to
+      # stop granting access without waiting for each device to reconnect.
+      assert TrustAnchors.on_delete(2, data) == :ok
+      assert_receive %Change{op: :delete, old_struct: nil, struct: %Portal.TrustAnchor{}}
+    end
+  end
+
+  describe "trust anchor certificates" do
+    test "broadcasts when the material behind an anchor changes", %{
+      account: account,
+      trust_anchor: trust_anchor
+    } do
+      # Replacing an anchor's certificates need not write to the anchor row, so
+      # the anchor's own hook would not fire for it.
+      :ok = Portal.PubSub.Changes.subscribe(account.id, :trust_anchor_certificates)
+
+      data = %{
+        "id" => Ecto.UUID.generate(),
+        "account_id" => account.id,
+        "trust_anchor_id" => trust_anchor.id
+      }
+
+      assert TrustAnchorCertificates.on_delete(0, data) == :ok
+      assert_receive %Change{op: :delete, struct: %Portal.TrustAnchorCertificate{}}
+    end
+  end
+end

--- a/elixir/test/portal/policies/condition/evaluator_test.exs
+++ b/elixir/test/portal/policies/condition/evaluator_test.exs
@@ -324,6 +324,46 @@ defmodule Portal.Policies.EvaluatorTest do
     end
   end
 
+  describe "fetch_conformation_expiration/3 with device_attested" do
+    test "is with values [\"true\"] returns ok when the connection is attested" do
+      attested_client = %Portal.Device{type: :client, attested?: true}
+
+      condition = %{property: :device_attested, operator: :is, values: ["true"]}
+
+      assert fetch_conformation_expiration(condition, attested_client, nil) == {:ok, nil}
+    end
+
+    test "is with values [\"true\"] returns error when the connection is not attested" do
+      unattested_client = %Portal.Device{type: :client, attested?: false}
+
+      condition = %{property: :device_attested, operator: :is, values: ["true"]}
+
+      assert fetch_conformation_expiration(condition, unattested_client, nil) == :error
+    end
+
+    test "reads live connection state rather than the row's attestation history" do
+      previously_attested = %Portal.Device{
+        type: :client,
+        attested?: false,
+        last_attested_at: DateTime.utc_now()
+      }
+
+      condition = %{property: :device_attested, operator: :is, values: ["true"]}
+
+      assert fetch_conformation_expiration(condition, previously_attested, nil) == :error
+    end
+
+    test "is with values other than [\"true\"] always returns ok" do
+      attested_client = %Portal.Device{type: :client, attested?: true}
+      unattested_client = %Portal.Device{type: :client, attested?: false}
+
+      condition = %{property: :device_attested, operator: :is, values: ["false"]}
+
+      assert fetch_conformation_expiration(condition, attested_client, nil) == {:ok, nil}
+      assert fetch_conformation_expiration(condition, unattested_client, nil) == {:ok, nil}
+    end
+  end
+
   describe "fetch_conformation_expiration/3 with remote_ip_location_region" do
     test "returns error when region is nil regardless of operator" do
       client = %Portal.Device{type: :client, last_seen_remote_ip_location_region: nil}

--- a/elixir/test/portal/policies/condition_test.exs
+++ b/elixir/test/portal/policies/condition_test.exs
@@ -176,4 +176,30 @@ defmodule Portal.Policies.ConditionTest do
       assert cs.errors[:values]
     end
   end
+  describe "changeset/3 with device_attested" do
+    test "valid with is and true" do
+      cs = changeset(%{property: :device_attested, operator: :is, values: ["true"]})
+      assert cs.valid?
+    end
+
+    test "valid with is and false" do
+      cs = changeset(%{property: :device_attested, operator: :is, values: ["false"]})
+      assert cs.valid?
+    end
+
+    test "invalid operator returns error" do
+      cs = changeset(%{property: :device_attested, operator: :is_in, values: ["true"]})
+      assert cs.errors[:operator]
+    end
+
+    test "more than one value returns length error" do
+      cs = changeset(%{property: :device_attested, operator: :is, values: ["true", "false"]})
+      assert cs.errors[:values]
+    end
+
+    test "empty values list returns length error" do
+      cs = changeset(%{property: :device_attested, operator: :is, values: []})
+      assert cs.errors[:values]
+    end
+  end
 end


### PR DESCRIPTION
A policy could already require a Client to be verified. That means an administrator looked at what the Client says about itself and ticked a box saying they believe it. It is a person vouching for a device.

A Client that connects with an MDM-issued certificate does not need vouching for, because it proved what it is during the handshake. Policies had no way to ask for that, so this adds a second condition that does.

The two now sit together in a Device Trust section of the policy form. Attestation is the stronger of the two, so turning it on shows verification as already satisfied and greys it out. The saved policy then asks for attestation only, rather than both.

The condition looks at the connection in front of it, not at the device's history. A laptop that attested last week but connected today without its certificate does not pass. That matters because a device row remembers the last time it attested, and reading that instead would let a device coast on something it proved once.

Related: #14507

