### PR TITLE
fix(nix): keep the pinned cargo ahead of cargo-tauri's

### DIFF
--- a/scripts/nix/lib.nix
+++ b/scripts/nix/lib.nix
@@ -86,16 +86,23 @@ rec {
         ''
         + (args.postPatch or "");
 
-        nativeBuildInputs =
-          (args.nativeBuildInputs or [ ])
-          ++ [
-            pkgs.rsync
-            pkgs.zstd
-          ]
-          ++ lib.optionals (args ? cargoArtifacts) [
-            craneLib.inheritCargoArtifactsHook
-            pkgs.removeReferencesTo
-          ];
+        # The pinned toolchain goes first: `buildRustPackage` appends its own
+        # cargo last, so anything in `args.nativeBuildInputs` that propagates a
+        # cargo of its own would shadow it. `cargo-tauri` propagates one, and a
+        # cargo version mismatch between this build and the dependency-only one
+        # makes cargo reject every artifact with `ConfigSettingsChanged`.
+        nativeBuildInputs = [
+          toolchain
+        ]
+        ++ (args.nativeBuildInputs or [ ])
+        ++ [
+          pkgs.rsync
+          pkgs.zstd
+        ]
+        ++ lib.optionals (args ? cargoArtifacts) [
+          craneLib.inheritCargoArtifactsHook
+          pkgs.removeReferencesTo
+        ];
 
         env = cargoEnv // (args.env or { });
       }


### PR DESCRIPTION
`cargo-tauri` propagates a cargo of its own, and `buildRustPackage` appends the pinned toolchain's cargo last, so the GUI client was compiled by whichever cargo `cargo-tauri` happened to carry rather than the one `rust-toolchain.toml` names. That has been true of every GUI client build this packaging has produced, not just recent ones.

It surfaced as a cache miss: cargo folds the resolved config into every unit's fingerprint and two cargo versions compute it differently, so the GUI client rejected the entire dependency closure it had just substituted and recompiled 565 crates. The gateway and headless client were unaffected because nothing there brings a second cargo.

Ordering the toolchain first leaves 42 crates rebuilding, all of them GTK and D-Bus `-sys` packages whose build scripts read `PKG_CONFIG_PATH`. That is set on the package side by `wrapGAppsHook3` and not on the dependency-only side, so cargo re-runs them correctly; closing that last gap is not worth giving the dependency build a GTK environment.

Related: #14532
