### PR TITLE
ci(fuzz): grind past crashes and commit the failing inputs

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -59,18 +59,26 @@ jobs:
       - uses: ./.github/actions/free-disk-space
       - name: Grow, minimize and re-baseline the corpus
         run: mise run //rust/tests/fuzz:grow ${{ matrix.fuzz-target }}
-      - name: Save corpus and coverage baseline
+      # A crash fails the step above, but what it produced is exactly what the
+      # run is for: the grown corpus and the input that provoked the crash both
+      # still need to reach the branch.
+      - name: Save corpus, coverage baseline and failing inputs
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-${{ matrix.fuzz-target }}
           path: |
             rust/tests/fuzz/corpora/${{ matrix.fuzz-target }}.tar.gz
             rust/tests/fuzz/expected-coverage/${{ matrix.fuzz-target }}.json
+            rust/tests/fuzz/crashes/${{ matrix.fuzz-target }}
           if-no-files-found: error
 
   propose:
     name: propose-corpus-update
     needs: [discover]
+    # A crashed target leaves `discover` red, and its findings are the ones
+    # most worth pushing.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -93,17 +101,44 @@ jobs:
         run: |
           set -euo pipefail
 
+          branch="chore/fuzz-corpora"
+
           git config --local user.email "github-bot@firezone.dev"
           git config --local user.name "Firezone Bot"
           git config --local user.signingkey "${{ steps.setup-gpg.outputs.key_id }}"
           git config --local commit.gpgsign true
 
-          git add -A tests/fuzz/corpora tests/fuzz/expected-coverage
+          # `download-artifact` only recreates this directory when a target
+          # crashed, and `git add` rejects a pathspec that matches nothing.
+          mkdir -p tests/fuzz/crashes
+
+          # The corpus branch is rebuilt from the default branch every night and
+          # a crash is not necessarily rediscovered, so carry over the inputs its
+          # open pull request already holds rather than force-pushing them away.
+          # A branch dispatch commits onto the branch itself and keeps them.
+          if [ "$REF" = "$DEFAULT_BRANCH" ] && [ -n "$(git ls-remote origin "refs/heads/$branch")" ]; then
+            git fetch origin "$branch"
+
+            if [ -n "$(git ls-tree -d --name-only FETCH_HEAD tests/fuzz/crashes)" ]; then
+              git checkout FETCH_HEAD -- tests/fuzz/crashes
+            fi
+          fi
+
+          git add -A tests/fuzz/corpora tests/fuzz/expected-coverage tests/fuzz/crashes
           if git diff --cached --quiet; then
             echo "Corpora unchanged; nothing to push."
             exit 0
           fi
-          git commit -m "chore(fuzz): grow committed corpora"
+
+          if git diff --cached --name-only | grep -q '^rust/tests/fuzz/crashes/'; then
+            title="chore(fuzz): commit crashing inputs"
+            body="A nightly fuzz job crashed. Replay its input with \`mise run //rust/tests/fuzz:replay-crashes <target>\`."
+          else
+            title="chore(fuzz): grow committed corpora"
+            body="The nightly fuzz jobs discovered new coverage and refreshed each target's uncovered-region ceiling."
+          fi
+
+          git commit -m "$title"
 
           # Do not use checkout's GITHUB_TOKEN for the push: pushes made with
           # it do not trigger the pull request's workflows.
@@ -119,13 +154,15 @@ jobs:
             exit 0
           fi
 
-          branch="chore/fuzz-corpora"
           git checkout -B "$branch"
           git push -u origin HEAD --force
 
-          if [ -z "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
-            gh pr create \
-              --title "chore(fuzz): grow committed corpora" \
-              --body "The nightly fuzz jobs discovered new coverage and refreshed each target's uncovered-region ceiling." \
-              --reviewer firezone/engineering
+          number="$(gh pr list --head "$branch" --state open --json number --jq '.[].number')"
+
+          if [ -z "$number" ]; then
+            gh pr create --title "$title" --body "$body" --reviewer firezone/engineering
+          else
+            # The open PR describes last night's push, which tonight's force
+            # push has just replaced.
+            gh pr edit "$number" --title "$title" --body "$body"
           fi

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -59,10 +59,9 @@ jobs:
       - uses: ./.github/actions/free-disk-space
       - name: Grow, minimize and re-baseline the corpus
         run: mise run //rust/tests/fuzz:grow ${{ matrix.fuzz-target }}
-      # A crash fails the step above, but what it produced is exactly what the
-      # run is for: the grown corpus and the input that provoked the crash both
-      # still need to reach the branch.
-      - name: Save corpus, coverage baseline and failing inputs
+      # A step of `grow` can fail on a corpus that already carries a crashing
+      # input, and what the run discovered on top of it is worth pushing anyway.
+      - name: Save corpus and coverage baseline
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -70,14 +69,11 @@ jobs:
           path: |
             rust/tests/fuzz/corpora/${{ matrix.fuzz-target }}.tar.gz
             rust/tests/fuzz/expected-coverage/${{ matrix.fuzz-target }}.json
-            rust/tests/fuzz/crashes/${{ matrix.fuzz-target }}
           if-no-files-found: error
 
   propose:
     name: propose-corpus-update
     needs: [discover]
-    # A crashed target leaves `discover` red, and its findings are the ones
-    # most worth pushing.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     steps:
@@ -101,44 +97,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          branch="chore/fuzz-corpora"
-
           git config --local user.email "github-bot@firezone.dev"
           git config --local user.name "Firezone Bot"
           git config --local user.signingkey "${{ steps.setup-gpg.outputs.key_id }}"
           git config --local commit.gpgsign true
 
-          # `download-artifact` only recreates this directory when a target
-          # crashed, and `git add` rejects a pathspec that matches nothing.
-          mkdir -p tests/fuzz/crashes
-
-          # The corpus branch is rebuilt from the default branch every night and
-          # a crash is not necessarily rediscovered, so carry over the inputs its
-          # open pull request already holds rather than force-pushing them away.
-          # A branch dispatch commits onto the branch itself and keeps them.
-          if [ "$REF" = "$DEFAULT_BRANCH" ] && [ -n "$(git ls-remote origin "refs/heads/$branch")" ]; then
-            git fetch origin "$branch"
-
-            if [ -n "$(git ls-tree -d --name-only FETCH_HEAD tests/fuzz/crashes)" ]; then
-              git checkout FETCH_HEAD -- tests/fuzz/crashes
-            fi
-          fi
-
-          git add -A tests/fuzz/corpora tests/fuzz/expected-coverage tests/fuzz/crashes
+          git add -A tests/fuzz/corpora tests/fuzz/expected-coverage
           if git diff --cached --quiet; then
             echo "Corpora unchanged; nothing to push."
             exit 0
           fi
-
-          if git diff --cached --name-only | grep -q '^rust/tests/fuzz/crashes/'; then
-            title="chore(fuzz): commit crashing inputs"
-            body="A nightly fuzz job crashed. Replay its input with \`mise run //rust/tests/fuzz:replay-crashes <target>\`."
-          else
-            title="chore(fuzz): grow committed corpora"
-            body="The nightly fuzz jobs discovered new coverage and refreshed each target's uncovered-region ceiling."
-          fi
-
-          git commit -m "$title"
+          git commit -m "chore(fuzz): grow committed corpora"
 
           # Do not use checkout's GITHUB_TOKEN for the push: pushes made with
           # it do not trigger the pull request's workflows.
@@ -154,15 +123,13 @@ jobs:
             exit 0
           fi
 
+          branch="chore/fuzz-corpora"
           git checkout -B "$branch"
           git push -u origin HEAD --force
 
-          number="$(gh pr list --head "$branch" --state open --json number --jq '.[].number')"
-
-          if [ -z "$number" ]; then
-            gh pr create --title "$title" --body "$body" --reviewer firezone/engineering
-          else
-            # The open PR describes last night's push, which tonight's force
-            # push has just replaced.
-            gh pr edit "$number" --title "$title" --body "$body"
+          if [ -z "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+            gh pr create \
+              --title "chore(fuzz): grow committed corpora" \
+              --body "The nightly fuzz jobs discovered new coverage and refreshed each target's uncovered-region ceiling." \
+              --reviewer firezone/engineering
           fi

--- a/rust/tests/fuzz/.gitignore
+++ b/rust/tests/fuzz/.gitignore
@@ -3,4 +3,5 @@ corpus
 artifacts
 coverage
 crash-*
+!crashes/**
 *.profraw

--- a/rust/tests/fuzz/.gitignore
+++ b/rust/tests/fuzz/.gitignore
@@ -3,5 +3,4 @@ corpus
 artifacts
 coverage
 crash-*
-!crashes/**
 *.profraw

--- a/rust/tests/fuzz/README.md
+++ b/rust/tests/fuzz/README.md
@@ -16,6 +16,7 @@ Pull-request CI only replays these inputs, making fuzz regression and coverage c
 It never performs random coverage discovery.
 
 The nightly `fuzz-nightly.yml` workflow runs every target from `targets.json` on `main`, minimizes and repacks the grown corpora, refreshes their coverage baselines, and opens one bot PR with the results.
+A crash does not cost the run its findings: the workflow pushes the grown corpus either way and commits the input that provoked the crash alongside it.
 
 Tunnel inputs are decoded positionally with `arbitrary::Unstructured`.
 Changing the generator in `src/arb/` can therefore reinterpret existing inputs; after a substantial generator change, re-minimize and grow the corpus before updating the archive.
@@ -39,13 +40,20 @@ mise run //rust/tests/fuzz:fuzz tunnel-proto -fork=4
 
 ## Reproducing a crash
 
+A local run leaves its failing inputs in the ignored `artifacts/<target>` directory.
+Inputs under `crashes/<target>` are committed instead: they are what a fuzz job found and had no chance to fix.
+`replay-crashes` replays both, building the target first if nothing has yet.
+
 ```console
 mise run //rust/tests/fuzz:replay-crashes tunnel-proto
-mise run //rust/tests/fuzz:tmin tunnel-proto artifacts/tunnel-proto/crash-<hash>
+mise run //rust/tests/fuzz:tmin tunnel-proto crashes/tunnel-proto/crash-<hash>
 mise run //rust/tests/fuzz:repro tunnel-proto <reduced-input> 2> repro.log
 ```
 
 Set `RUST_LOG=trace` for detailed scenario and connlib traces.
+
+Delete a committed input in the change that fixes it.
+Nothing else prunes them, and only the corpus guards against the bug coming back, so add the input there in the same change if it reaches code the corpus does not.
 
 ## Coverage
 
@@ -75,6 +83,9 @@ Expect it to take a while: it fuzzes for 30 minutes before the remaining steps e
 It spreads that across three quarters of the cores, leaving you some to work with, and across all of them when `CI` is set.
 Pass libFuzzer arguments to override both the parallelism and the duration, e.g. `-fork=8 -max_total_time=300`.
 Be wary of shortening it much for `tunnel-proto`: `-fork` re-merges the whole seed corpus before it discovers anything, `-max_total_time` does not bound that startup, and a short budget is spent entirely inside it.
+
+A failing step does not stop the ones behind it; `grow` runs them all and reports the failure at the end.
+A crash therefore still leaves a grown corpus behind, and moves the input that provoked it to `crashes/<target>` to be committed.
 
 The measurement is taken on the machine that runs it.
 A local run that gets luckier than CI writes a ceiling CI cannot meet, so re-run `coverage-check` before pushing.

--- a/rust/tests/fuzz/README.md
+++ b/rust/tests/fuzz/README.md
@@ -16,7 +16,6 @@ Pull-request CI only replays these inputs, making fuzz regression and coverage c
 It never performs random coverage discovery.
 
 The nightly `fuzz-nightly.yml` workflow runs every target from `targets.json` on `main`, minimizes and repacks the grown corpora, refreshes their coverage baselines, and opens one bot PR with the results.
-An input that made the target fail is packed into the corpus with the rest, so the commit the workflow pushes is what reports the bug: the run itself stays green, and replaying that corpus turns CI red until the bug is fixed.
 
 Tunnel inputs are decoded positionally with `arbitrary::Unstructured`.
 Changing the generator in `src/arb/` can therefore reinterpret existing inputs; after a substantial generator change, re-minimize and grow the corpus before updating the archive.
@@ -40,8 +39,6 @@ mise run //rust/tests/fuzz:fuzz tunnel-proto -fork=4
 
 ## Reproducing a crash
 
-A local run leaves its failing inputs in the ignored `artifacts/<target>` directory.
-
 ```console
 mise run //rust/tests/fuzz:replay-crashes tunnel-proto
 mise run //rust/tests/fuzz:tmin tunnel-proto artifacts/tunnel-proto/crash-<hash>
@@ -50,10 +47,8 @@ mise run //rust/tests/fuzz:repro tunnel-proto <reduced-input> 2> repro.log
 
 Set `RUST_LOG=trace` for detailed scenario and connlib traces.
 
-A fuzz job's findings arrive in the corpus instead, keeping the `crash-` name libFuzzer gave them.
-`coverage` names the one it died on, and `repro` and `tmin` take that path like any other input.
-Nothing needs pruning once the bug is fixed: the input stops failing and the next `cmin` re-emits it under its content hash, where it goes on covering the code that used to crash.
-Until then the corpus cannot be minimized at all, since minimizing means running every input; `cargo-fuzz` reports the failed merge and leaves the corpus as it was.
+A fuzz job's findings arrive in the corpus instead, under the `crash-` name libFuzzer gave them, so they keep CI red until the bug is fixed.
+`coverage` names the one it died on and nothing needs pruning afterwards.
 
 ## Coverage
 
@@ -72,6 +67,7 @@ A fuzz build instruments the dependencies too, so a target that drives `tunnel-p
 Which lines a crate contributes is visible in the HTML coverage report.
 
 When the ceiling is genuinely exceeded, `grow` runs the whole recovery locally: it fuzzes for new coverage, minimizes the corpus, refreshes the baseline from what the grown corpus actually reaches, then repacks it.
+It fuzzes past a crash rather than stopping at the first, and runs its remaining steps even when one of them fails, so a run ends with a repacked corpus carrying what it found either way.
 
 ```console
 mise run //rust/tests/fuzz:grow tunnel-proto
@@ -83,14 +79,6 @@ Expect it to take a while: it fuzzes for 30 minutes before the remaining steps e
 It spreads that across three quarters of the cores, leaving you some to work with, and across all of them when `CI` is set.
 Pass libFuzzer arguments to override both the parallelism and the duration, e.g. `-fork=8 -max_total_time=300`.
 Be wary of shortening it much for `tunnel-proto`: `-fork` re-merges the whole seed corpus before it discovers anything, `-max_total_time` does not bound that startup, and a short budget is spent entirely inside it.
-
-`grow` passes `-ignore_crashes=1`, so a crash no longer ends the run: it grinds for the whole budget and collects every input that fails, not just the first.
-libFuzzer honours that in fork mode only, where it already ignores timeouts and OOMs.
-Those inputs join the corpus once the coverage measurement is done, which is late enough that a crash cannot cost the run its refreshed ceiling.
-A run adds at most ten of them: a bug the fuzzer reaches easily yields a distinct input on every hit, and one backtrace does not need hundreds of variations committed.
-
-A failing step does not stop the ones behind it either; `grow` runs them all and reports the failure at the end.
-Whichever step broke, the run still ends with a repacked corpus carrying what it found.
 
 The measurement is taken on the machine that runs it.
 A local run that gets luckier than CI writes a ceiling CI cannot meet, so re-run `coverage-check` before pushing.

--- a/rust/tests/fuzz/README.md
+++ b/rust/tests/fuzz/README.md
@@ -16,7 +16,7 @@ Pull-request CI only replays these inputs, making fuzz regression and coverage c
 It never performs random coverage discovery.
 
 The nightly `fuzz-nightly.yml` workflow runs every target from `targets.json` on `main`, minimizes and repacks the grown corpora, refreshes their coverage baselines, and opens one bot PR with the results.
-A crash does not cost the run its findings: the workflow pushes the grown corpus either way and commits the input that provoked the crash alongside it.
+An input that made the target fail is packed into the corpus with the rest, so the commit the workflow pushes is what reports the bug: the run itself stays green, and replaying that corpus turns CI red until the bug is fixed.
 
 Tunnel inputs are decoded positionally with `arbitrary::Unstructured`.
 Changing the generator in `src/arb/` can therefore reinterpret existing inputs; after a substantial generator change, re-minimize and grow the corpus before updating the archive.
@@ -41,19 +41,19 @@ mise run //rust/tests/fuzz:fuzz tunnel-proto -fork=4
 ## Reproducing a crash
 
 A local run leaves its failing inputs in the ignored `artifacts/<target>` directory.
-Inputs under `crashes/<target>` are committed instead: they are what a fuzz job found and had no chance to fix.
-`replay-crashes` replays both, building the target first if nothing has yet.
 
 ```console
 mise run //rust/tests/fuzz:replay-crashes tunnel-proto
-mise run //rust/tests/fuzz:tmin tunnel-proto crashes/tunnel-proto/crash-<hash>
+mise run //rust/tests/fuzz:tmin tunnel-proto artifacts/tunnel-proto/crash-<hash>
 mise run //rust/tests/fuzz:repro tunnel-proto <reduced-input> 2> repro.log
 ```
 
 Set `RUST_LOG=trace` for detailed scenario and connlib traces.
 
-Delete a committed input in the change that fixes it.
-Nothing else prunes them, and only the corpus guards against the bug coming back, so add the input there in the same change if it reaches code the corpus does not.
+A fuzz job's findings arrive in the corpus instead, keeping the `crash-` name libFuzzer gave them.
+`coverage` names the one it died on, and `repro` and `tmin` take that path like any other input.
+Nothing needs pruning once the bug is fixed: the input stops failing and the next `cmin` re-emits it under its content hash, where it goes on covering the code that used to crash.
+Until then the corpus cannot be minimized at all, since minimizing means running every input; `cargo-fuzz` reports the failed merge and leaves the corpus as it was.
 
 ## Coverage
 
@@ -71,7 +71,7 @@ The ceiling spans every workspace crate the target links, not just the one shari
 A fuzz build instruments the dependencies too, so a target that drives `tunnel-proto` reports what it reached in `snownet`, `dns-types` and the rest as one number.
 Which lines a crate contributes is visible in the HTML coverage report.
 
-When the ceiling is genuinely exceeded, `grow` runs the whole recovery locally: it fuzzes for new coverage, minimizes and repacks the corpus, then refreshes the baseline from what the grown corpus actually reaches.
+When the ceiling is genuinely exceeded, `grow` runs the whole recovery locally: it fuzzes for new coverage, minimizes the corpus, refreshes the baseline from what the grown corpus actually reaches, then repacks it.
 
 ```console
 mise run //rust/tests/fuzz:grow tunnel-proto
@@ -84,8 +84,13 @@ It spreads that across three quarters of the cores, leaving you some to work wit
 Pass libFuzzer arguments to override both the parallelism and the duration, e.g. `-fork=8 -max_total_time=300`.
 Be wary of shortening it much for `tunnel-proto`: `-fork` re-merges the whole seed corpus before it discovers anything, `-max_total_time` does not bound that startup, and a short budget is spent entirely inside it.
 
-A failing step does not stop the ones behind it; `grow` runs them all and reports the failure at the end.
-A crash therefore still leaves a grown corpus behind, and moves the input that provoked it to `crashes/<target>` to be committed.
+`grow` passes `-ignore_crashes=1`, so a crash no longer ends the run: it grinds for the whole budget and collects every input that fails, not just the first.
+libFuzzer honours that in fork mode only, where it already ignores timeouts and OOMs.
+Those inputs join the corpus once the coverage measurement is done, which is late enough that a crash cannot cost the run its refreshed ceiling.
+A run adds at most ten of them: a bug the fuzzer reaches easily yields a distinct input on every hit, and one backtrace does not need hundreds of variations committed.
+
+A failing step does not stop the ones behind it either; `grow` runs them all and reports the failure at the end.
+Whichever step broke, the run still ends with a repacked corpus carrying what it found.
 
 The measurement is taken on the machine that runs it.
 A local run that gets luckier than CI writes a ceiling CI cannot meet, so re-run `coverage-check` before pushing.
@@ -93,9 +98,10 @@ A local run that gets luckier than CI writes a ceiling CI cannot meet, so re-run
 After growing and minimizing a corpus yourself, the remaining steps run individually; `update-baseline` records the measurement without the risk of truncating the committed file on a failed one:
 
 ```console
-mise run //rust/tests/fuzz:pack-corpus tunnel-proto
 mise run //rust/tests/fuzz:coverage tunnel-proto
 mise run //rust/tests/fuzz:update-baseline tunnel-proto
+mise run //rust/tests/fuzz:save-crashes tunnel-proto
+mise run //rust/tests/fuzz:pack-corpus tunnel-proto
 ```
 
 For a local browsable report:

--- a/rust/tests/fuzz/mise.toml
+++ b/rust/tests/fuzz/mise.toml
@@ -82,7 +82,7 @@ set -euo pipefail
 '''
 
 [tasks.grow]
-description = "Fuzz a target, then preserve its crashes, minimize, repack and re-baseline its corpus"
+description = "Fuzz a target, then minimize, re-baseline and repack its corpus, crashes included"
 shell = "bash -c"
 usage = '''
 arg "<target>"
@@ -115,14 +115,25 @@ else
   set -- "-fork=$fork" -max_total_time=1800
 fi
 
+# In fork mode a crash ends the run, so the first bug would keep the budget from
+# reaching any other one. libFuzzer already ignores timeouts and OOMs there;
+# this treats crashes the same, so the run grinds for its whole budget and
+# collects every input that fails rather than just the first. Prepended rather
+# than appended because libFuzzer takes a flag's last occurrence, so an explicit
+# override still wins.
+set -- -ignore_crashes=1 "$@"
+
 # Each step consumes what the previous one wrote, so they are invoked in order
 # rather than declared as `depends`, which mise runs in parallel.
 #
-# A crash is the fuzzer doing its job, so a failing step does not abandon the
-# ones behind it: the half hour of growth that preceded it and the input that
-# provoked it are both worth keeping. Every step that can still run does, and
-# the failure is re-raised once they have. The steps write through temporaries,
-# so one that fails leaves the committed file it owns untouched.
+# `save-crashes` comes after the corpus has been measured: the inputs it adds
+# crash the target by definition, so a `coverage` run that included them could
+# not produce a profile, and the ceiling would go unrefreshed for the night.
+#
+# A failing step does not abandon the ones behind it either. The findings are
+# worth committing whichever step broke, so every one that can still run does
+# and the failure is re-raised at the end. They write through temporaries, so a
+# failed step leaves the committed file it owns untouched.
 failed=()
 
 step() {
@@ -132,11 +143,11 @@ step() {
 }
 
 step fuzz "$target" "$@"
-step save-crashes "$target"
 step cmin "$target"
-step pack-corpus "$target"
 step coverage "$target"
 step update-baseline "$target"
+step save-crashes "$target"
+step pack-corpus "$target"
 
 if [ "${#failed[@]}" -gt 0 ]; then
   echo "error: ${#failed[@]} step(s) failed: ${failed[*]}" >&2
@@ -145,7 +156,7 @@ fi
 '''
 
 [tasks.save-crashes]
-description = "Move a fuzz target's failing inputs into the committed crashes directory"
+description = "Move a fuzz target's failing inputs into its corpus so they get committed"
 shell = "bash -c"
 usage = 'arg "<target>"'
 raw = true
@@ -153,10 +164,23 @@ run = '''
 set -euo pipefail
 
 target="$usage_target"
-crashes="crashes/$target"
+corpus="corpus/$target"
+
+# The corpus is the only thing this directory commits, and pull-request CI
+# replays all of it, so an input parked here reproduces the crash on every run
+# until the bug behind it is fixed. It keeps its `crash-` name to say why it is
+# there; the next `cmin` after the fix re-emits it under its content hash like
+# any other input.
+#
+# One easily reached bug yields a distinct input on every hit and the run no
+# longer stops at the first, so cap what a run adds rather than committing
+# hundreds of variations on the same backtrace.
+limit=10
+kept=0
+dropped=0
 
 # `slow-unit-*` is deliberately absent: libFuzzer writes those while carrying
-# on, so committing them would accumulate inputs that nothing is wrong with.
+# on, so adding them would accumulate inputs that nothing is wrong with.
 for artifact in \
   "artifacts/$target"/crash-* \
   "artifacts/$target"/timeout-* \
@@ -165,13 +189,31 @@ for artifact in \
 do
   [ -e "$artifact" ] || continue
 
+  if [ "$kept" -ge "$limit" ]; then
+    dropped=$((dropped + 1))
+    continue
+  fi
+
   name="${artifact##*/}"
 
-  mkdir -p "$crashes"
-  mv -f "$artifact" "$crashes/$name"
-  chmod 0644 "$crashes/$name"
-  echo "Preserved $name in $crashes"
+  mkdir -p "$corpus"
+  mv -f "$artifact" "$corpus/$name"
+  chmod 0644 "$corpus/$name"
+  kept=$((kept + 1))
+
+  echo "Added $name to $corpus"
 done
+
+if [ "$kept" -eq 0 ]; then
+  echo "No failing input to add."
+  exit 0
+fi
+
+echo "Added $kept failing input(s) to $corpus."
+
+if [ "$dropped" -gt 0 ]; then
+  echo "Dropped $dropped more: a run adds at most $limit."
+fi
 '''
 
 [tasks.update-baseline]
@@ -278,9 +320,8 @@ raw = true
 run = 'RUST_LOG="${RUST_LOG:-debug}" cargo fuzz run --sanitizer none --target x86_64-unknown-linux-gnu --fuzz-dir . --target-dir ../../target "$usage_target" "$usage_testcase"'
 
 [tasks.replay-crashes]
-description = "Replay a fuzz target's committed and locally produced crash artifacts with tracing"
+description = "Replay all crash artifacts for a fuzz target with tracing"
 shell = "bash -c"
-depends = ["install-toolchain"]
 usage = 'arg "<target>"'
 raw = true
 run = '''
@@ -290,13 +331,7 @@ target="$usage_target"
 bin="../../target/x86_64-unknown-linux-gnu/release/$target"
 found=false
 
-# `save-crashes` moves what it preserves, so the two directories never hold the
-# same input and nothing is replayed twice.
 for artifact in \
-  "crashes/$target"/crash-* \
-  "crashes/$target"/timeout-* \
-  "crashes/$target"/oom-* \
-  "crashes/$target"/leak-* \
   "artifacts/$target"/crash-* \
   "artifacts/$target"/timeout-* \
   "artifacts/$target"/oom-* \
@@ -307,9 +342,8 @@ do
 
   if [ "$found" = false ]; then
     if [ ! -x "$bin" ]; then
-      # A committed input is replayed from a checkout where nothing has built
-      # the target yet.
-      cargo fuzz build --sanitizer none --target x86_64-unknown-linux-gnu --fuzz-dir . --target-dir ../../target "$target"
+      echo "Fuzz target binary does not exist or is not executable: $bin" >&2
+      exit 1
     fi
     found=true
   fi

--- a/rust/tests/fuzz/mise.toml
+++ b/rust/tests/fuzz/mise.toml
@@ -82,7 +82,7 @@ set -euo pipefail
 '''
 
 [tasks.grow]
-description = "Fuzz a target, then minimize, repack and re-baseline its corpus"
+description = "Fuzz a target, then preserve its crashes, minimize, repack and re-baseline its corpus"
 shell = "bash -c"
 usage = '''
 arg "<target>"
@@ -117,11 +117,61 @@ fi
 
 # Each step consumes what the previous one wrote, so they are invoked in order
 # rather than declared as `depends`, which mise runs in parallel.
-mise run //rust/tests/fuzz:fuzz "$target" "$@"
-mise run //rust/tests/fuzz:cmin "$target"
-mise run //rust/tests/fuzz:pack-corpus "$target"
-mise run //rust/tests/fuzz:coverage "$target"
-mise run //rust/tests/fuzz:update-baseline "$target"
+#
+# A crash is the fuzzer doing its job, so a failing step does not abandon the
+# ones behind it: the half hour of growth that preceded it and the input that
+# provoked it are both worth keeping. Every step that can still run does, and
+# the failure is re-raised once they have. The steps write through temporaries,
+# so one that fails leaves the committed file it owns untouched.
+failed=()
+
+step() {
+  if ! mise run "//rust/tests/fuzz:$1" "${@:2}"; then
+    failed+=("$1")
+  fi
+}
+
+step fuzz "$target" "$@"
+step save-crashes "$target"
+step cmin "$target"
+step pack-corpus "$target"
+step coverage "$target"
+step update-baseline "$target"
+
+if [ "${#failed[@]}" -gt 0 ]; then
+  echo "error: ${#failed[@]} step(s) failed: ${failed[*]}" >&2
+  exit 1
+fi
+'''
+
+[tasks.save-crashes]
+description = "Move a fuzz target's failing inputs into the committed crashes directory"
+shell = "bash -c"
+usage = 'arg "<target>"'
+raw = true
+run = '''
+set -euo pipefail
+
+target="$usage_target"
+crashes="crashes/$target"
+
+# `slow-unit-*` is deliberately absent: libFuzzer writes those while carrying
+# on, so committing them would accumulate inputs that nothing is wrong with.
+for artifact in \
+  "artifacts/$target"/crash-* \
+  "artifacts/$target"/timeout-* \
+  "artifacts/$target"/oom-* \
+  "artifacts/$target"/leak-*
+do
+  [ -e "$artifact" ] || continue
+
+  name="${artifact##*/}"
+
+  mkdir -p "$crashes"
+  mv -f "$artifact" "$crashes/$name"
+  chmod 0644 "$crashes/$name"
+  echo "Preserved $name in $crashes"
+done
 '''
 
 [tasks.update-baseline]
@@ -228,8 +278,9 @@ raw = true
 run = 'RUST_LOG="${RUST_LOG:-debug}" cargo fuzz run --sanitizer none --target x86_64-unknown-linux-gnu --fuzz-dir . --target-dir ../../target "$usage_target" "$usage_testcase"'
 
 [tasks.replay-crashes]
-description = "Replay all crash artifacts for a fuzz target with tracing"
+description = "Replay a fuzz target's committed and locally produced crash artifacts with tracing"
 shell = "bash -c"
+depends = ["install-toolchain"]
 usage = 'arg "<target>"'
 raw = true
 run = '''
@@ -239,7 +290,13 @@ target="$usage_target"
 bin="../../target/x86_64-unknown-linux-gnu/release/$target"
 found=false
 
+# `save-crashes` moves what it preserves, so the two directories never hold the
+# same input and nothing is replayed twice.
 for artifact in \
+  "crashes/$target"/crash-* \
+  "crashes/$target"/timeout-* \
+  "crashes/$target"/oom-* \
+  "crashes/$target"/leak-* \
   "artifacts/$target"/crash-* \
   "artifacts/$target"/timeout-* \
   "artifacts/$target"/oom-* \
@@ -250,8 +307,9 @@ do
 
   if [ "$found" = false ]; then
     if [ ! -x "$bin" ]; then
-      echo "Fuzz target binary does not exist or is not executable: $bin" >&2
-      exit 1
+      # A committed input is replayed from a checkout where nothing has built
+      # the target yet.
+      cargo fuzz build --sanitizer none --target x86_64-unknown-linux-gnu --fuzz-dir . --target-dir ../../target "$target"
     fi
     found=true
   fi


### PR DESCRIPTION
A crash ended the fuzz run at its first find and aborted `grow` on the spot, so most of the half hour of coverage discovery was thrown away along with the input that provoked it: the nightly job pushed nothing and the artifact died with the runner.

`-ignore_crashes=1` keeps the run going for its whole budget now, and the inputs that failed are packed into the corpus once the coverage measurement is done. That commit is what reports the bug, so the run itself has no need to fail: replaying the pushed corpus turns CI red on the branch until the crash is fixed, and the input goes on covering that code afterwards.

Related: #14494
