### PR TITLE
ci(rust): build coverage for the explicit host target

### DIFF
--- a/.github/actions/setup-rust-stable/action.yml
+++ b/.github/actions/setup-rust-stable/action.yml
@@ -26,6 +26,12 @@ outputs:
       (runner.os == 'Linux' && '--workspace') ||
       (runner.os == 'macOS' && '--workspace --exclude bin-shared --exclude firezone-gui-client') ||
       (runner.os == 'Windows' && '--workspace') }}
+  host-target:
+    description: Host target triple for the current OS
+    value: ${{
+      (runner.os == 'Linux' && 'x86_64-unknown-linux-gnu') ||
+      (runner.os == 'macOS' && 'aarch64-apple-darwin') ||
+      (runner.os == 'Windows' && 'x86_64-pc-windows-msvc') }}
 
 runs:
   using: "composite"

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -93,7 +93,11 @@ jobs:
       - uses: ./.github/actions/free-disk-space
       - name: "cargo test"
         shell: bash
-        run: cargo llvm-cov --all-features ${{ steps.setup-rust.outputs.test-packages }} --lcov --output-path lcov.info -- --include-ignored --nocapture
+        # `--target` is deliberately set to the host triple: without it, cargo
+        # treats the build as native and applies the coverage `RUSTFLAGS` to
+        # build scripts and proc-macros too. Each of those then emits its own
+        # `.profraw`, which `llvm-profdata merge` has to read for nothing.
+        run: cargo llvm-cov --all-features ${{ steps.setup-rust.outputs.test-packages }} --target ${{ steps.setup-rust.outputs.host-target }} --lcov --output-path lcov.info -- --include-ignored --nocapture
         env:
           # <https://github.com/rust-lang/cargo/issues/5999>
           # Needed to create tunnel interfaces in unit tests


### PR DESCRIPTION
The coverage build does not name a target triple, so cargo treats it as native and applies the instrumentation `RUSTFLAGS` to build scripts and proc-macros as well. Each of those processes emits its own `.profraw` that `llvm-profdata merge` then has to read, none of which contributes any coverage.

Naming the host triple confines instrumentation to the units that are actually reported on. On `test-windows-2025` that cuts the coverage report phase from 90s to 53s, reproduced across two runs.

It does not pay for itself. Splitting host from target units stops cargo unifying crates that are both a build-dependency and a normal dependency, which takes the workspace from 870 to 953 compilations and adds back 28s on Windows. Net is 9s on a 632s job, inside run-to-run noise, and `test-macos-26` regresses by 50s because it has the fewest test binaries and so the least report time to recover.