### PR TITLE
test(fuzz): assert complete resource lists

### DIFF
--- a/rust/tests/fuzz/src/assertions.rs
+++ b/rust/tests/fuzz/src/assertions.rs
@@ -12,7 +12,7 @@ use super::{
     stub_portal::StubPortal,
     transition::Destination,
 };
-use connlib_model::{ClientId, GatewayId};
+use connlib_model::{ClientId, GatewayId, ResourceId, ResourceStatus, ResourceView};
 use dns_types::DomainName;
 use ip_packet::{Icmpv4Type, Icmpv6Type, IpPacket, Layer4Protocol};
 use itertools::Itertools;
@@ -586,37 +586,142 @@ pub(crate) fn assert_tcp_connections(ref_client: &RefClient, sim_client: &SimCli
     }
 }
 
-pub(crate) fn assert_resource_status(ref_client: &RefClient, sim_client: &SimClient) {
-    use connlib_model::ResourceStatus::*;
-
-    let expected_status_map = &ref_client.expected_resource_status();
-    let actual_status_map = &sim_client.resource_status;
+pub(crate) fn assert_resource_list(ref_client: &RefClient, sim_client: &SimClient) {
+    let expected_resources = ref_client.expected_resources();
+    let actual_resources = &sim_client.observed_resource_list.resources;
     let maybe_online_resources = ref_client.maybe_online_resources();
+    let expected_ids = expected_resources
+        .iter()
+        .map(ResourceView::id)
+        .collect_vec();
+    let actual_ids = actual_resources.iter().map(ResourceView::id).collect_vec();
 
-    if expected_status_map != actual_status_map {
-        for (resource, expected_status) in expected_status_map {
-            match actual_status_map.get(resource) {
-                Some(&Online)
-                    if expected_status == &Unknown && maybe_online_resources.contains(resource) => {
-                }
-                Some(&Unknown)
-                    if expected_status == &Online && maybe_online_resources.contains(resource) => {}
+    if expected_ids != actual_ids {
+        tracing::error!(target: "assertions", ?expected_ids, ?actual_ids, "Resource list order or membership doesn't match");
+    }
 
-                Some(actual_status) if actual_status != expected_status => {
-                    tracing::error!(target: "assertions", %expected_status, %actual_status, %resource, ?maybe_online_resources, "Resource status doesn't match");
-                }
-                Some(_) => {}
-                None => {
-                    tracing::error!(target: "assertions", %expected_status, %resource, "Missing resource status");
-                }
-            }
+    let actual_by_id = actual_resources
+        .iter()
+        .map(|resource| (resource.id(), resource))
+        .collect::<BTreeMap<_, _>>();
+
+    for expected in &expected_resources {
+        let resource = expected.id();
+        let Some(actual) = actual_by_id.get(&resource) else {
+            tracing::error!(target: "assertions", %resource, "Missing resource");
+            continue;
+        };
+
+        assert_resource_definition(expected, actual);
+        assert_resource_status(
+            resource,
+            expected.status(),
+            actual.status(),
+            maybe_online_resources.contains(&resource),
+        );
+    }
+
+    for actual in actual_resources {
+        if !expected_ids.contains(&actual.id()) {
+            tracing::error!(target: "assertions", resource = %actual.id(), "Unexpected resource");
         }
+    }
+}
 
-        for (resource, actual_status) in actual_status_map {
-            if expected_status_map.get(resource).is_none() {
-                tracing::error!(target: "assertions", %actual_status, %resource, "Unexpected resource status");
-            }
+fn assert_resource_definition(expected: &ResourceView, actual: &ResourceView) {
+    use ResourceView::*;
+
+    let resource = expected.id();
+
+    match (expected, actual) {
+        (Dns(expected), Dns(actual)) => {
+            assert_resource_field(resource, "address", &expected.address, &actual.address);
+            assert_resource_field(resource, "name", &expected.name, &actual.name);
+            assert_resource_field(
+                resource,
+                "address description",
+                &expected.address_description,
+                &actual.address_description,
+            );
+            assert_resource_field(resource, "sites", &expected.sites, &actual.sites);
         }
+        (Cidr(expected), Cidr(actual)) => {
+            assert_resource_field(resource, "address", &expected.address, &actual.address);
+            assert_resource_field(resource, "name", &expected.name, &actual.name);
+            assert_resource_field(
+                resource,
+                "address description",
+                &expected.address_description,
+                &actual.address_description,
+            );
+            assert_resource_field(resource, "sites", &expected.sites, &actual.sites);
+        }
+        (Internet(expected), Internet(actual)) => {
+            assert_resource_field(resource, "name", &expected.name, &actual.name);
+            assert_resource_field(resource, "sites", &expected.sites, &actual.sites);
+        }
+        (Dns(_), Cidr(_)) => {
+            tracing::error!(target: "assertions", %resource, "DNS resource was emitted as a CIDR resource");
+        }
+        (Dns(_), Internet(_)) => {
+            tracing::error!(target: "assertions", %resource, "DNS resource was emitted as an Internet resource");
+        }
+        (Cidr(_), Dns(_)) => {
+            tracing::error!(target: "assertions", %resource, "CIDR resource was emitted as a DNS resource");
+        }
+        (Cidr(_), Internet(_)) => {
+            tracing::error!(target: "assertions", %resource, "CIDR resource was emitted as an Internet resource");
+        }
+        (Internet(_), Dns(_)) => {
+            tracing::error!(target: "assertions", %resource, "Internet resource was emitted as a DNS resource");
+        }
+        (Internet(_), Cidr(_)) => {
+            tracing::error!(target: "assertions", %resource, "Internet resource was emitted as a CIDR resource");
+        }
+    }
+}
+
+fn assert_resource_field<T>(resource: ResourceId, field: &str, expected: &T, actual: &T)
+where
+    T: std::fmt::Debug + PartialEq,
+{
+    if expected != actual {
+        tracing::error!(target: "assertions", %resource, field, ?expected, ?actual, "Resource field doesn't match");
+    }
+}
+
+fn assert_resource_status(
+    resource: ResourceId,
+    expected: ResourceStatus,
+    actual: ResourceStatus,
+    maybe_online: bool,
+) {
+    use ResourceStatus::*;
+
+    match (expected, actual) {
+        (Unknown, Unknown) => {}
+        (Unknown, Online) if maybe_online => {}
+        (Unknown, Online) => {
+            tracing::error!(target: "assertions", %expected, %actual, %resource, "Resource status doesn't match");
+        }
+        (Unknown, Offline) => {
+            tracing::error!(target: "assertions", %expected, %actual, %resource, "Resource status doesn't match");
+        }
+        (Online, Unknown) if maybe_online => {}
+        (Online, Unknown) => {
+            tracing::error!(target: "assertions", %expected, %actual, %resource, "Resource status doesn't match");
+        }
+        (Online, Online) => {}
+        (Online, Offline) => {
+            tracing::error!(target: "assertions", %expected, %actual, %resource, "Resource status doesn't match");
+        }
+        (Offline, Unknown) => {
+            tracing::error!(target: "assertions", %expected, %actual, %resource, "Resource status doesn't match");
+        }
+        (Offline, Online) => {
+            tracing::error!(target: "assertions", %expected, %actual, %resource, "Resource status doesn't match");
+        }
+        (Offline, Offline) => {}
     }
 }
 

--- a/rust/tests/fuzz/src/ref_client.rs
+++ b/rust/tests/fuzz/src/ref_client.rs
@@ -18,7 +18,7 @@ use tunnel_proto::{
 };
 
 use chrono::{DateTime, Utc};
-use connlib_model::{ClientId, GatewayId, ResourceId, ResourceStatus, Site, SiteId};
+use connlib_model::{ClientId, GatewayId, ResourceId, ResourceStatus, ResourceView, Site, SiteId};
 use dns_types::{DomainName, RecordType};
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use ip_packet::Protocol;
@@ -448,19 +448,43 @@ impl RefClient {
         }
     }
 
-    pub(crate) fn expected_resource_status(&self) -> BTreeMap<ResourceId, ResourceStatus> {
+    pub(crate) fn expected_resources(&self) -> Vec<ResourceView> {
         self.resources
             .iter()
-            .filter_map(|r| {
-                let status = self
-                    .site_status
-                    .get(&r.site().ok()?.id)
-                    .copied()
-                    .unwrap_or(ResourceStatus::Unknown);
+            .cloned()
+            .filter_map(|resource| {
+                let status = self.expected_resource_status(&resource);
 
-                Some((r.id(), status))
+                resource.into_view(status)
             })
+            .sorted()
             .collect()
+    }
+
+    fn expected_resource_status(&self, resource: &Resource) -> ResourceStatus {
+        let sites = resource.sites();
+
+        if sites.is_empty() {
+            return ResourceStatus::Unknown;
+        }
+
+        if sites.iter().any(|site| {
+            self.site_status
+                .get(&site.id)
+                .is_some_and(|status| *status == ResourceStatus::Online)
+        }) {
+            return ResourceStatus::Online;
+        }
+
+        if sites.iter().all(|site| {
+            self.site_status
+                .get(&site.id)
+                .is_some_and(|status| *status == ResourceStatus::Offline)
+        }) {
+            return ResourceStatus::Offline;
+        }
+
+        ResourceStatus::Unknown
     }
 
     /// Returns the list of resources where we are not "sure" whether they are online or unknown.

--- a/rust/tests/fuzz/src/resource.rs
+++ b/rust/tests/fuzz/src/resource.rs
@@ -4,7 +4,10 @@
 //! model. The SUT only receives portal-facing [`ResourceDescription`] values,
 //! matching the production event loop and keeping the internal model private.
 
-use connlib_model::{IpStack, ResourceId, Site};
+use connlib_model::{
+    CidrResourceView, DnsResourceView, InternetResourceView, IpStack, ResourceId, ResourceStatus,
+    ResourceView, Site,
+};
 use ip_network::IpNetwork;
 use itertools::Itertools as _;
 use serde_json::{Value, json};
@@ -236,6 +239,35 @@ impl Resource {
                 "name": r.name,
                 "address": r.address,
             })),
+        }
+    }
+
+    pub(crate) fn into_view(self, status: ResourceStatus) -> Option<ResourceView> {
+        match self {
+            Resource::Dns(r) => Some(ResourceView::Dns(DnsResourceView {
+                id: r.id,
+                address: r.address,
+                name: r.name,
+                address_description: r.address_description,
+                sites: r.sites,
+                status,
+            })),
+            Resource::Cidr(r) => Some(ResourceView::Cidr(CidrResourceView {
+                id: r.id,
+                address: r.address,
+                name: r.name,
+                address_description: r.address_description,
+                sites: r.sites,
+                status,
+            })),
+            Resource::Internet(r) => Some(ResourceView::Internet(InternetResourceView {
+                name: r.name,
+                id: r.id,
+                sites: r.sites,
+                status,
+            })),
+            Resource::StaticDevicePool(_) => None,
+            Resource::DynamicDevicePool(_) => None,
         }
     }
 }

--- a/rust/tests/fuzz/src/sim_client.rs
+++ b/rust/tests/fuzz/src/sim_client.rs
@@ -12,7 +12,7 @@ use super::{
     transition::{DPort, DnsTransport, Identifier, SPort, Seq},
 };
 use chrono::{DateTime, Utc};
-use connlib_model::{ClientId, RelayId, ResourceId, ResourceStatus};
+use connlib_model::{ClientId, RelayId, ResourceList};
 use dns_types::{DomainName, Query, RecordData, RecordType};
 use ip_network::IpNetwork;
 use ip_packet::{IcmpEchoHeader, IcmpError, Icmpv4Type, Icmpv6Type, IpPacket, Layer4Protocol};
@@ -55,7 +55,8 @@ pub(crate) struct SimClient {
     /// The search-domain emitted by connlib.
     pub(crate) search_domain: Option<DomainName>,
 
-    pub(crate) resource_status: BTreeMap<ResourceId, ResourceStatus>,
+    /// The latest resource list emitted by connlib.
+    pub(crate) observed_resource_list: ResourceList,
 
     pub(crate) sent_udp_dns_queries: HashMap<(dns::Upstream, QueryId, u16), IpPacket>,
     pub(crate) received_udp_dns_responses: BTreeMap<(dns::Upstream, QueryId, u16), IpPacket>,
@@ -97,7 +98,7 @@ impl SimClient {
             sent_probes: Default::default(),
             routes: Default::default(),
             search_domain: Default::default(),
-            resource_status: Default::default(),
+            observed_resource_list: Default::default(),
             tcp_dns_client: dns_over_tcp::Client::new(now, Duration::from_secs(15), [0u8; 32]),
             tcp_client: crate::tcp::Client::new(now),
             failed_tcp_packets: Default::default(),

--- a/rust/tests/fuzz/src/sut.rs
+++ b/rust/tests/fuzz/src/sut.rs
@@ -688,7 +688,7 @@ impl TunnelTest {
             assert_dns_servers_are_valid(ref_client, sut_client, &ref_state.portal);
             assert_search_domain_is_valid(&ref_state.portal, sut_client);
             assert_routes_are_valid(ref_client, sut_client);
-            assert_resource_status(ref_client, sut_client);
+            assert_resource_list(ref_client, sut_client);
         }
     }
 
@@ -1340,11 +1340,7 @@ impl TunnelTest {
             ClientEvent::ResourcesChanged { resources } => {
                 let client = self.clients.get_mut(&src).unwrap();
                 client.exec_mut(|c| {
-                    c.resource_status = resources
-                        .resources
-                        .into_iter()
-                        .map(|r| (r.id(), r.status()))
-                        .collect();
+                    c.observed_resource_list = resources;
                 });
 
                 Ok(())


### PR DESCRIPTION
The fuzzer previously reduced each `ResourcesChanged` event to a map of resource IDs and statuses. That discarded the resource definitions and list ordering before assertions ran, so changes to an address, name, description, site, or resource variant could go unnoticed.

Retain the complete `ResourceList` observation and derive the expected portal-visible `ResourceView` values from the reference state. The assertion now checks membership, order, variant, definition fields, and status while preserving the existing narrow tolerance for connection-driven Unknown and Online races.
