### PR TITLE
test(fuzz): record DNS resolution on gateway rejection

### DIFF
--- a/rust/tests/fuzz/src/reference.rs
+++ b/rust/tests/fuzz/src/reference.rs
@@ -475,17 +475,27 @@ impl ReferenceState {
         sent_at: Instant,
     ) -> PacketRoute {
         let route = self.route_for_packet(origin, source, destination, protocol);
-        let PacketRoute::Resource { resource, gateway } = route else {
-            return route;
-        };
         let Destination::DomainName { name, .. } = destination else {
             return route;
+        };
+        let (resource, gateway) = match route {
+            PacketRoute::Resource { resource, gateway } => (resource, Some(gateway)),
+            PacketRoute::ResourceRejectedByGateway { resource, .. } => (resource, None),
+            PacketRoute::Drop => return route,
+            PacketRoute::RejectedByClient => return route,
+            PacketRoute::ResourceUnreachableByGateway { .. } => return route,
+            PacketRoute::Gateway(_) => return route,
+            PacketRoute::Peer(_) => return route,
+            PacketRoute::PeerRejectedByPeer(_) => return route,
         };
 
         let resolved_at = self.clients.get_mut(&origin).unwrap().exec_mut(|client| {
             client.prepare_dns_resource_connection(resource, sent_at);
             client.dns_resource_resolution(resource, name)
         });
+        let Some(gateway) = gateway else {
+            return route;
+        };
         let has_compatible_record = resolved_at.is_some_and(|resolved_at| {
             self.global_dns_records
                 .domain_ips_iter(name, resolved_at)


### PR DESCRIPTION
The reference model prepared a DNS resource resolution only for packets it expected the gateway to forward. A client configured to bypass local filters can establish the resource connection before the gateway rejects its packet, leaving the reference without the resolution that connlib established.

Prepare DNS connection state for both allowed resource routes and routes rejected by the gateway. Record compatible-record reachability only for the allowed route, so later packets use the same connection state without treating a rejected packet as delivered.
