### PR TITLE
test(fuzz): model PTR queries from DNS answers

### DIFF
--- a/rust/tests/fuzz/src/arb/dns_queries.rs
+++ b/rust/tests/fuzz/src/arb/dns_queries.rs
@@ -10,13 +10,19 @@ use tunnel_proto::dns;
 use super::context::Generator;
 use super::packets::{host_in_v4, host_in_v6};
 use crate::reference::ReferenceState;
-use crate::transition::{DnsQuery, DnsTransport, Transition};
+use crate::transition::{DnsQuery, DnsTransport, IpFamily, Transition};
 
 #[derive(Clone)]
 pub(super) struct DnsQueryTarget {
     client_id: ClientId,
     dns_server: dns::Upstream,
     name: DnsNameSpec,
+}
+
+struct KnownPtrTarget {
+    record_domain: DomainName,
+    family: IpFamily,
+    address_index: u32,
 }
 
 #[derive(Clone)]
@@ -98,7 +104,11 @@ pub(super) fn targets(state: &ReferenceState, now: Instant) -> Vec<DnsQueryTarge
         .collect::<Vec<_>>()
 }
 
-pub(super) fn generate(g: &mut Generator, target: DnsQueryTarget) -> Transition {
+pub(super) fn generate(
+    g: &mut Generator,
+    target: DnsQueryTarget,
+    state: &ReferenceState,
+) -> Transition {
     let (domain, rtypes) = match target.name {
         DnsNameSpec::Concrete { domain, rtypes } => (domain, rtypes),
         DnsNameSpec::Wildcard { base } => {
@@ -128,9 +138,33 @@ pub(super) fn generate(g: &mut Generator, target: DnsQueryTarget) -> Transition 
     };
 
     let r_type = arb_maybe_available_response_rtype(g, &rtypes);
-    let domain = matches!(r_type, RecordType::PTR)
-        .then(|| DomainName::reverse_from_addr(arb_ptr_query_ip(g)).unwrap())
-        .unwrap_or(domain);
+    let known_ptr_target = (r_type == RecordType::PTR)
+        .then(|| arb_known_ptr_target(g, state, target.client_id))
+        .flatten();
+
+    if let Some(KnownPtrTarget {
+        record_domain,
+        family,
+        address_index,
+    }) = known_ptr_target
+    {
+        return Transition::SendDnsResourcePtrQuery {
+            client_id: target.client_id,
+            record_domain,
+            family,
+            address_index,
+            query_id: arb_dns_query_id(g),
+            dns_server: target.dns_server,
+            transport: arb_dns_transport(g),
+        };
+    }
+
+    let domain = if r_type == RecordType::PTR {
+        DomainName::reverse_from_addr(arb_unassigned_ptr_query_ip(g))
+            .expect("reverse DNS names always fit")
+    } else {
+        domain
+    };
 
     Transition::SendDnsQuery {
         client_id: target.client_id,
@@ -142,6 +176,44 @@ pub(super) fn generate(g: &mut Generator, target: DnsQueryTarget) -> Transition 
             transport: arb_dns_transport(g),
         },
     }
+}
+
+fn arb_known_ptr_target(
+    g: &mut Generator,
+    state: &ReferenceState,
+    client_id: ClientId,
+) -> Option<KnownPtrTarget> {
+    let client = state.clients[&client_id].inner();
+    let resolved_v4_domains = client
+        .resolved_v4_domains()
+        .into_iter()
+        .map(|(domain, _)| domain)
+        .collect::<Vec<_>>();
+    let resolved_v6_domains = client
+        .resolved_v6_domains()
+        .into_iter()
+        .map(|(domain, _)| domain)
+        .collect::<Vec<_>>();
+
+    if (resolved_v4_domains.is_empty() && resolved_v6_domains.is_empty()) || g.bool() {
+        return None;
+    }
+
+    let select_ipv4 = g.bool();
+    let (domains, family) =
+        if (select_ipv4 && !resolved_v4_domains.is_empty()) || resolved_v6_domains.is_empty() {
+            (resolved_v4_domains, IpFamily::Ipv4)
+        } else {
+            (resolved_v6_domains, IpFamily::Ipv6)
+        };
+    let address_index = g.u32();
+    let record_domain = domains[address_index as usize % domains.len()].clone();
+
+    Some(KnownPtrTarget {
+        record_domain,
+        family,
+        address_index,
+    })
 }
 
 fn arb_dns_transport(g: &mut Generator) -> DnsTransport {
@@ -183,7 +255,21 @@ fn arb_maybe_available_response_rtype(g: &mut Generator, available: &[RecordType
     }
 }
 
-/// Generate a PTR target inside a resource range or anywhere in the IP space.
+fn arb_unassigned_ptr_query_ip(g: &mut Generator) -> IpAddr {
+    use tunnel_proto::{IPV4_RESOURCES, IPV6_RESOURCES};
+
+    match arb_ptr_query_ip(g) {
+        IpAddr::V4(ip) if IPV4_RESOURCES.contains(ip) => {
+            IpAddr::V4(Ipv4Addr::from(u32::from(ip) ^ (1u32 << 31)))
+        }
+        IpAddr::V6(ip) if IPV6_RESOURCES.contains(ip) => {
+            IpAddr::V6(Ipv6Addr::from(u128::from(ip) ^ (1u128 << 127)))
+        }
+        IpAddr::V4(ip) => IpAddr::V4(ip),
+        IpAddr::V6(ip) => IpAddr::V6(ip),
+    }
+}
+
 fn arb_ptr_query_ip(g: &mut Generator) -> IpAddr {
     use tunnel_proto::{IPV4_RESOURCES, IPV6_RESOURCES};
     match g.choose_index(3) {

--- a/rust/tests/fuzz/src/arb/transitions.rs
+++ b/rust/tests/fuzz/src/arb/transitions.rs
@@ -235,7 +235,7 @@ pub(super) fn generate(
         }
         K::SendDnsQuery => {
             let target = dns_query_targets[g.choose_index(dns_query_targets.len())].clone();
-            dns_queries::generate(g, target)
+            dns_queries::generate(g, target, state)
         }
         K::UpdateStaticDevicePool => {
             let pool = static_device_pools[g.choose_index(static_device_pools.len())].clone();

--- a/rust/tests/fuzz/src/ref_client.rs
+++ b/rust/tests/fuzz/src/ref_client.rs
@@ -808,7 +808,7 @@ impl RefClient {
         if self.is_local_dns_resource_query(query)
             && !self.local_dns_resource_query_has_records(query)
         {
-            self.expect_dns_handshake(query);
+            self.expect_dns_handshake(&query.dns_server, query.query_id, query.transport);
             return;
         }
 
@@ -840,7 +840,7 @@ impl RefClient {
             if self.resolver_is_unreachable(query, icmp_error_hosts) {
                 // The resolver answers with an ICMP error; connlib fails the query
                 // and responds with SERVFAIL, so no records are learned.
-                self.expect_dns_handshake(query);
+                self.expect_dns_handshake(&query.dns_server, query.query_id, query.transport);
             } else {
                 self.expect_dns_response(query);
             }
@@ -852,6 +852,15 @@ impl RefClient {
         }
 
         self.expect_dns_response(query);
+    }
+
+    pub(crate) fn on_dns_resource_ptr_query(
+        &mut self,
+        dns_server: &dns::Upstream,
+        query_id: u16,
+        transport: DnsTransport,
+    ) {
+        self.expect_dns_handshake(dns_server, query_id, transport);
     }
 
     /// Returns whether the query's resolver answers tunnelled traffic with ICMP errors.
@@ -870,22 +879,27 @@ impl RefClient {
             .or_default()
             .insert(query.r_type);
 
-        self.expect_dns_handshake(query);
+        self.expect_dns_handshake(&query.dns_server, query.query_id, query.transport);
     }
 
     /// Expects a response for the query without learning any records from it, e.g. a SERVFAIL.
-    fn expect_dns_handshake(&mut self, query: &DnsQuery) {
-        match query.transport {
+    fn expect_dns_handshake(
+        &mut self,
+        dns_server: &dns::Upstream,
+        query_id: u16,
+        transport: DnsTransport,
+    ) {
+        match transport {
             DnsTransport::Udp { local_port } => {
                 self.expected_udp_dns_handshakes.push_back((
-                    query.dns_server.clone(),
-                    query.query_id,
+                    dns_server.clone(),
+                    query_id,
                     local_port,
                 ));
             }
             DnsTransport::Tcp => {
                 self.expected_tcp_dns_handshakes
-                    .push_back((query.dns_server.clone(), query.query_id));
+                    .push_back((dns_server.clone(), query_id));
             }
         }
     }

--- a/rust/tests/fuzz/src/reference.rs
+++ b/rust/tests/fuzz/src/reference.rs
@@ -246,6 +246,17 @@ impl ReferenceState {
                     c.on_dns_query(query, upstream_do53, icmp_error_hosts, now);
                 });
             }
+            Transition::SendDnsResourcePtrQuery {
+                client_id,
+                query_id,
+                dns_server,
+                transport,
+                ..
+            } => {
+                state.clients.get_mut(client_id).unwrap().exec_mut(|c| {
+                    c.on_dns_resource_ptr_query(dns_server, *query_id, *transport);
+                });
+            }
             Transition::SendIcmpPacket {
                 client_id,
                 src,

--- a/rust/tests/fuzz/src/sim_client.rs
+++ b/rust/tests/fuzz/src/sim_client.rs
@@ -9,7 +9,7 @@ use super::{
     reference::PrivateKey,
     sim_net::{ExecMutScope, Host},
     sim_relay::{SimRelay, map_explode},
-    transition::{DPort, DnsTransport, Identifier, SPort, Seq},
+    transition::{DPort, DnsTransport, Identifier, IpFamily, SPort, Seq},
 };
 use chrono::{DateTime, Utc};
 use connlib_model::{ClientId, RelayId, ResourceList};
@@ -156,6 +156,41 @@ impl SimClient {
 
     pub(crate) fn dns_mapping(&self) -> &DnsMapping {
         &self.dns_by_sentinel
+    }
+
+    pub(crate) fn send_dns_resource_ptr_query_for(
+        &mut self,
+        record_domain: DomainName,
+        family: IpFamily,
+        address_index: u32,
+        query_id: u16,
+        upstream: dns::Upstream,
+        dns_transport: DnsTransport,
+        now: Instant,
+    ) -> Option<Transmit> {
+        let ips = self
+            .dns_records
+            .get(&record_domain)
+            .expect("resolved domain should have DNS records")
+            .iter()
+            .filter(|ip| match family {
+                IpFamily::Ipv4 => ip.is_ipv4(),
+                IpFamily::Ipv6 => ip.is_ipv6(),
+            })
+            .copied()
+            .collect::<Vec<_>>();
+        let ip = ips[address_index as usize % ips.len()];
+        let reverse_domain =
+            DomainName::reverse_from_addr(ip).expect("reverse DNS names always fit");
+
+        self.send_dns_query_for(
+            reverse_domain,
+            RecordType::PTR,
+            query_id,
+            upstream,
+            dns_transport,
+            now,
+        )
     }
 
     pub(crate) fn send_dns_query_for(

--- a/rust/tests/fuzz/src/sut.rs
+++ b/rust/tests/fuzz/src/sut.rs
@@ -393,6 +393,30 @@ impl TunnelTest {
 
                 buffered_transmits.push_from(transmit, client, now);
             }
+            Transition::SendDnsResourcePtrQuery {
+                client_id,
+                record_domain,
+                family,
+                address_index,
+                query_id,
+                dns_server,
+                transport,
+            } => {
+                let client = state.clients.get_mut(&client_id).unwrap();
+                let transmit = client.exec_mut(|sim| {
+                    sim.send_dns_resource_ptr_query_for(
+                        record_domain,
+                        family,
+                        address_index,
+                        query_id,
+                        dns_server,
+                        transport,
+                        now,
+                    )
+                });
+
+                buffered_transmits.push_from(transmit, client, now);
+            }
             Transition::UpdateSystemDnsServers { servers } => {
                 for client in state.clients.values_mut() {
                     client.exec_mut(|c| c.sut.update_system_resolvers(servers.clone()));

--- a/rust/tests/fuzz/src/transition.rs
+++ b/rust/tests/fuzz/src/transition.rs
@@ -74,6 +74,15 @@ pub enum Transition {
         client_id: ClientId,
         query: DnsQuery,
     },
+    SendDnsResourcePtrQuery {
+        client_id: ClientId,
+        record_domain: DomainName,
+        family: IpFamily,
+        address_index: u32,
+        query_id: u16,
+        dns_server: dns::Upstream,
+        transport: DnsTransport,
+    },
     UpdateSystemDnsServers {
         servers: Vec<IpAddr>,
     },
@@ -122,6 +131,7 @@ impl Transition {
             Transition::SendUdpPacket { .. } => false,
             Transition::ConnectTcp { .. } => false,
             Transition::SendDnsQuery { .. } => false,
+            Transition::SendDnsResourcePtrQuery { .. } => false,
             Transition::UpdateSystemDnsServers { .. } => false,
             Transition::UpdateUpstreamDo53Servers(_) => false,
             Transition::UpdateUpstreamDoHServers(_) => false,
@@ -146,6 +156,12 @@ pub(crate) struct DnsQuery {
     pub(crate) query_id: u16,
     pub(crate) dns_server: dns::Upstream,
     pub(crate) transport: DnsTransport,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum IpFamily {
+    Ipv4,
+    Ipv6,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
An arbitrary generated PTR target can accidentally be one of connlib's assigned DNS proxy addresses. Connlib then answers it locally, while the reference model treats it as a recursive query and can predict an unrelated resource status change.

Represent known proxy PTR lookups as `SendDnsResourcePtrQuery`. The generator selects them only from A or AAAA answers already learned by the reference client, while the simulation materializes the concrete proxy address from the DNS response connlib emitted. Ordinary PTR targets are kept outside the proxy ranges.

This keeps proxy allocation details out of the reference model while making the expected DNS exchange explicit.
