### PR TITLE
fix(connlib): preserve DNS routes on resolution timeout

### DIFF
--- a/rust/libs/connlib/tunnel-proto/src/gateway.rs
+++ b/rust/libs/connlib/tunnel-proto/src/gateway.rs
@@ -363,7 +363,7 @@ impl GatewayState {
             peer.setup_nat(
                 entry.domain,
                 resource.id(),
-                BTreeSet::from_iter(entry.resolved_ips),
+                Some(BTreeSet::from_iter(entry.resolved_ips)),
                 BTreeSet::from_iter(entry.proxy_ips),
             )?;
         }
@@ -405,11 +405,14 @@ impl GatewayState {
         use p2p_control::dns_resource_nat;
 
         let (addresses, desired_status) = match resolve_result {
-            Ok(addresses) => (addresses, dns_resource_nat::NatStatus::Active),
+            Ok(addresses) => (
+                Some(BTreeSet::from_iter(addresses)),
+                dns_resource_nat::NatStatus::Active,
+            ),
             Err(error) => {
                 tracing::warn!("Failed to resolve DNS resource: {error:#}");
 
-                (Vec::new(), dns_resource_nat::NatStatus::Inactive)
+                (None, dns_resource_nat::NatStatus::Inactive)
             }
         };
         let nat_status = self
@@ -420,7 +423,7 @@ impl GatewayState {
                 peer.setup_nat(
                     req.domain.clone(),
                     req.resource,
-                    BTreeSet::from_iter(addresses),
+                    addresses,
                     BTreeSet::from_iter(req.proxy_ips),
                 )?;
 

--- a/rust/libs/connlib/tunnel-proto/src/gateway.rs
+++ b/rust/libs/connlib/tunnel-proto/src/gateway.rs
@@ -363,8 +363,8 @@ impl GatewayState {
             peer.setup_nat(
                 entry.domain,
                 resource.id(),
-                Some(BTreeSet::from_iter(entry.resolved_ips)),
-                BTreeSet::from_iter(entry.proxy_ips),
+                Ok(entry.resolved_ips),
+                entry.proxy_ips.into_iter().collect(),
             )?;
         }
 
@@ -404,17 +404,6 @@ impl GatewayState {
     ) -> anyhow::Result<()> {
         use p2p_control::dns_resource_nat;
 
-        let (addresses, desired_status) = match resolve_result {
-            Ok(addresses) => (
-                Some(BTreeSet::from_iter(addresses)),
-                dns_resource_nat::NatStatus::Active,
-            ),
-            Err(error) => {
-                tracing::warn!("Failed to resolve DNS resource: {error:#}");
-
-                (None, dns_resource_nat::NatStatus::Inactive)
-            }
-        };
         let nat_status = self
             .peers
             .peer_by_id_mut(&req.client)
@@ -423,11 +412,9 @@ impl GatewayState {
                 peer.setup_nat(
                     req.domain.clone(),
                     req.resource,
-                    addresses,
-                    BTreeSet::from_iter(req.proxy_ips),
-                )?;
-
-                Ok(desired_status)
+                    resolve_result,
+                    req.proxy_ips.into_iter().collect(),
+                )
             })
             .unwrap_or_else(|e| {
                 tracing::warn!("Failed to setup DNS resource NAT: {e:#}");

--- a/rust/libs/connlib/tunnel-proto/src/gateway.rs
+++ b/rust/libs/connlib/tunnel-proto/src/gateway.rs
@@ -404,19 +404,27 @@ impl GatewayState {
     ) -> anyhow::Result<()> {
         use p2p_control::dns_resource_nat;
 
-        let nat_status = resolve_result
-            .and_then(|addresses| {
-                self.peers
-                    .peer_by_id_mut(&req.client)
-                    .context("Unknown peer")?
-                    .setup_nat(
-                        req.domain.clone(),
-                        req.resource,
-                        BTreeSet::from_iter(addresses),
-                        BTreeSet::from_iter(req.proxy_ips),
-                    )?;
+        let (addresses, desired_status) = match resolve_result {
+            Ok(addresses) => (addresses, dns_resource_nat::NatStatus::Active),
+            Err(error) => {
+                tracing::warn!("Failed to resolve DNS resource: {error:#}");
 
-                Ok(dns_resource_nat::NatStatus::Active)
+                (Vec::new(), dns_resource_nat::NatStatus::Inactive)
+            }
+        };
+        let nat_status = self
+            .peers
+            .peer_by_id_mut(&req.client)
+            .context("Unknown peer")
+            .and_then(|peer| {
+                peer.setup_nat(
+                    req.domain.clone(),
+                    req.resource,
+                    BTreeSet::from_iter(addresses),
+                    BTreeSet::from_iter(req.proxy_ips),
+                )?;
+
+                Ok(desired_status)
             })
             .unwrap_or_else(|e| {
                 tracing::warn!("Failed to setup DNS resource NAT: {e:#}");

--- a/rust/libs/connlib/tunnel-proto/src/gateway/client_on_gateway.rs
+++ b/rust/libs/connlib/tunnel-proto/src/gateway/client_on_gateway.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::iter;
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Instant;
 
@@ -45,6 +46,11 @@ pub struct ClientOnGateway {
 pub enum TranslateOutboundResult {
     Send(IpPacket),
     IcmpError(IpPacket),
+}
+
+enum AllowedOutbound {
+    GatewayTun,
+    Resource(ResourceId),
 }
 
 impl ClientOnGateway {
@@ -124,21 +130,41 @@ impl ClientOnGateway {
 
         tracing::debug!(domain = %name, ?resolved_ips, ?proxy_ips, "Setting up DNS resource NAT");
 
-        for proxy_ip in proxy_ips {
-            let maybe_real_ip = match proxy_ip {
-                IpAddr::V4(_) => resolved_ipv4.next(),
-                IpAddr::V6(_) => resolved_ipv6.next(),
-            };
+        let translations = proxy_ips
+            .into_iter()
+            .map(|proxy_ip| {
+                let resolved_ip = match proxy_ip {
+                    IpAddr::V4(_) => resolved_ipv4.next(),
+                    IpAddr::V6(_) => resolved_ipv6.next(),
+                };
 
-            tracing::debug!(%name, %proxy_ip, real_ip = ?maybe_real_ip);
+                (proxy_ip, resolved_ip.copied())
+            })
+            .collect::<Vec<_>>();
+        let unresolved_proxy_ips = translations
+            .iter()
+            .filter_map(|(proxy_ip, resolved_ip)| {
+                self.permanent_translations
+                    .get(proxy_ip)
+                    .is_some_and(|state| {
+                        state.resolved_ip(resource_id).is_some() && resolved_ip.is_none()
+                    })
+                    .then_some(*proxy_ip)
+            })
+            .collect();
+
+        self.nat_table
+            .expire_resource_inside_ips(resource_id, &unresolved_proxy_ips);
+
+        for (proxy_ip, resolved_ip) in translations {
+            tracing::debug!(%name, %proxy_ip, real_ip = ?resolved_ip);
 
             let state = self
                 .permanent_translations
                 .entry(proxy_ip)
                 .or_insert_with(|| TranslationState::new(name.clone()));
 
-            state.resources.insert(resource_id);
-            state.resolved_ip = maybe_real_ip.copied();
+            state.resolved_ips.insert(resource_id, resolved_ip);
         }
 
         domains.insert(name, resolved_ips);
@@ -159,13 +185,17 @@ impl ClientOnGateway {
         self.nat_table.handle_timeout(now);
         self.resources.handle_timeout(now);
 
+        let expired_resources = iter::from_fn(|| self.resources.poll_event())
+            .map(|event| match event {
+                expiring_map::Event::EntryExpired { key, value } => (key, value),
+            })
+            .collect::<Vec<_>>();
+        let any_expired = !expired_resources.is_empty();
         let cid = self.id;
-        let mut any_expired = false;
-        while let Some(expiring_map::Event::EntryExpired { key, .. }) = self.resources.poll_event()
-        {
+
+        for (key, resource) in expired_resources {
             tracing::info!(%cid, rid = %key, "Access to resource expired");
-            self.ingest_tokens.remove(&key);
-            any_expired = true;
+            self.cleanup_removed_authorization(key, resource);
         }
 
         if any_expired {
@@ -174,8 +204,10 @@ impl ClientOnGateway {
     }
 
     pub(crate) fn remove_resource(&mut self, resource: &ResourceId) {
-        self.resources.remove(resource);
-        self.ingest_tokens.remove(resource);
+        if let Some(entry) = self.resources.remove(resource) {
+            self.cleanup_removed_authorization(*resource, entry.value);
+        }
+
         self.recalculate_filters();
     }
 
@@ -233,15 +265,39 @@ impl ClientOnGateway {
     }
 
     pub(crate) fn retain_authorizations(&mut self, authorization: BTreeSet<ResourceId>) {
-        for (rid, _) in self
+        let revoked = self
             .resources
             .extract_if(|rid, _| !authorization.contains(rid))
-        {
+            .collect::<Vec<_>>();
+
+        for (rid, resource) in revoked {
             tracing::info!(%rid, "Revoking resource authorization");
-            self.ingest_tokens.remove(&rid);
+            self.cleanup_removed_authorization(rid, resource);
         }
 
         self.recalculate_filters();
+    }
+
+    fn cleanup_removed_authorization(
+        &mut self,
+        resource_id: ResourceId,
+        resource: ResourceOnGateway,
+    ) {
+        match resource {
+            ResourceOnGateway::Dns { .. } => {
+                self.permanent_translations
+                    .extract_if(.., |_, state| {
+                        state.resolved_ips.remove(&resource_id);
+                        state.resolved_ips.is_empty()
+                    })
+                    .for_each(drop);
+                self.nat_table.expire_resource(resource_id);
+            }
+            ResourceOnGateway::Cidr { .. } => {}
+            ResourceOnGateway::Internet => {}
+        }
+
+        self.ingest_tokens.remove(&resource_id);
     }
 
     /// Checks if the given proxy IPs assigned for a domain are consistent with what we have stored.
@@ -298,8 +354,8 @@ impl ClientOnGateway {
     }
 
     fn recalculate_dns_filters(&mut self) {
-        for (addr, TranslationState { resources, .. }) in &self.permanent_translations {
-            for resource_id in resources {
+        for (addr, TranslationState { resolved_ips, .. }) in &self.permanent_translations {
+            for resource_id in resolved_ips.keys() {
                 let Some(entry) = self.resources.get(resource_id) else {
                     continue;
                 };
@@ -328,20 +384,23 @@ impl ClientOnGateway {
             bail!(UnroutablePacket::outbound_icmp_error(&packet))
         }
 
-        if let Err(error) = self.ensure_allowed_outbound(&packet) {
-            tracing::debug!(filtered_packet = ?packet, "{error:#}");
+        let allowed_outbound = match self.ensure_allowed_outbound(&packet) {
+            Ok(allowed_outbound) => allowed_outbound,
+            Err(error) => {
+                tracing::debug!(filtered_packet = ?packet, "{error:#}");
 
-            let reply = match error.any_downcast_ref::<InternetResourceRejectedAddress>() {
-                Some(InternetResourceRejectedAddress(_)) => {
-                    ip_packet::make::icmp_dest_unreachable_network(&packet)?
-                }
-                None => ip_packet::make::icmp_dest_unreachable_prohibited(&packet)?,
-            };
+                let reply = match error.any_downcast_ref::<InternetResourceRejectedAddress>() {
+                    Some(InternetResourceRejectedAddress(_)) => {
+                        ip_packet::make::icmp_dest_unreachable_network(&packet)?
+                    }
+                    None => ip_packet::make::icmp_dest_unreachable_prohibited(&packet)?,
+                };
 
-            return Ok(TranslateOutboundResult::IcmpError(reply));
-        }
+                return Ok(TranslateOutboundResult::IcmpError(reply));
+            }
+        };
 
-        let result = self.transform_network_to_tun(packet, now)?;
+        let result = self.transform_network_to_tun(packet, allowed_outbound, now)?;
 
         Ok(result)
     }
@@ -381,14 +440,14 @@ impl ClientOnGateway {
     fn transform_network_to_tun(
         &mut self,
         mut packet: IpPacket,
+        allowed_outbound: AllowedOutbound,
         now: Instant,
     ) -> anyhow::Result<TranslateOutboundResult> {
+        let resource_id = match allowed_outbound {
+            AllowedOutbound::GatewayTun => return Ok(TranslateOutboundResult::Send(packet)),
+            AllowedOutbound::Resource(resource_id) => resource_id,
+        };
         let dst = packet.destination();
-
-        // Packets to the TUN interface don't get transformed.
-        if self.gateway_tun.is_ip(dst) {
-            return Ok(TranslateOutboundResult::Send(packet));
-        }
 
         // Packets for CIDR resources / Internet resource are forwarded as is.
         if !is_dns_addr(dst) {
@@ -403,7 +462,7 @@ impl ClientOnGateway {
             ));
         };
 
-        let Some(resolved_ip) = state.resolved_ip else {
+        let Some(resolved_ip) = state.resolved_ip(resource_id) else {
             return Ok(TranslateOutboundResult::IcmpError(
                 ip_packet::make::icmp_dest_unreachable_network(&packet)?,
             ));
@@ -425,7 +484,7 @@ impl ClientOnGateway {
 
         let (source_protocol, real_ip) =
             self.nat_table
-                .translate_outgoing(&packet, resolved_ip, now)?;
+                .translate_outgoing(&packet, resolved_ip, resource_id, now)?;
 
         packet
             .translate_destination(source_protocol, real_ip)
@@ -471,12 +530,12 @@ impl ClientOnGateway {
         self.resources.contains_key(&resource)
     }
 
-    fn ensure_allowed_outbound(&mut self, packet: &IpPacket) -> anyhow::Result<()> {
+    fn ensure_allowed_outbound(&mut self, packet: &IpPacket) -> anyhow::Result<AllowedOutbound> {
         self.ensure_client_ip(packet.source())?;
 
         // Traffic to our own IP is allowed.
         if self.gateway_tun.is_ip(packet.destination()) {
-            return Ok(());
+            return Ok(AllowedOutbound::GatewayTun);
         }
 
         ensure_not_peer_ip(packet.destination())?;
@@ -485,12 +544,12 @@ impl ClientOnGateway {
 
         if !self.resources.contains_key(&rid) {
             tracing::warn!(%rid, "Internal state mismatch: No resource for ID");
-            return Ok(());
+            return Ok(AllowedOutbound::Resource(rid));
         }
         flow_tracker::record_resource(rid);
         flow_tracker::record_ingest_token(self.ingest_tokens.get(&rid).cloned());
 
-        Ok(())
+        Ok(AllowedOutbound::Resource(rid))
     }
 
     fn ensure_client_ip(&self, ip: IpAddr) -> anyhow::Result<()> {
@@ -659,10 +718,8 @@ impl routing_table::RouteEntry for RouteEntry {
 // Current state of a translation for a given proxy ip
 #[derive(Debug)]
 struct TranslationState {
-    /// Which (DNS) resources we belong to.
-    resources: BTreeSet<ResourceId>,
-    /// The IP we have resolved for the domain.
-    resolved_ip: Option<IpAddr>,
+    /// The IP each DNS resource resolved for the domain.
+    resolved_ips: BTreeMap<ResourceId, Option<IpAddr>>,
     /// The domain we have resolved.
     domain: DomainName,
 }
@@ -670,10 +727,13 @@ struct TranslationState {
 impl TranslationState {
     fn new(domain: DomainName) -> Self {
         Self {
-            resources: BTreeSet::default(),
-            resolved_ip: None,
+            resolved_ips: BTreeMap::default(),
             domain,
         }
+    }
+
+    fn resolved_ip(&self, resource: ResourceId) -> Option<IpAddr> {
+        self.resolved_ips.get(&resource).copied().flatten()
     }
 }
 

--- a/rust/libs/connlib/tunnel-proto/src/gateway/client_on_gateway.rs
+++ b/rust/libs/connlib/tunnel-proto/src/gateway/client_on_gateway.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::iter;
 use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::{Context, ErrorExt, Result, bail};
@@ -16,6 +17,7 @@ use crate::filter_engine::FilterEngine;
 use crate::gateway::nat_table::{NatTable, TranslateIncomingResult};
 use crate::messages::gateway::ResourceDescription;
 use crate::messages::{Filter, IngestToken};
+use crate::p2p_control::dns_resource_nat::NatStatus;
 use crate::routing_table::{self, RoutingTable};
 use crate::unroutable_packet::UnroutablePacket;
 use crate::{GatewayEvent, IpConfig, NotAllowedResource, NotClientIp};
@@ -87,9 +89,9 @@ impl ClientOnGateway {
         &mut self,
         name: DomainName,
         resource_id: ResourceId,
-        resolved_ips: Option<BTreeSet<IpAddr>>,
+        resolve_result: Result<Vec<IpAddr>, Arc<anyhow::Error>>,
         proxy_ips: BTreeSet<IpAddr>,
-    ) -> Result<()> {
+    ) -> Result<NatStatus> {
         // Proxy IPs are chosen by the Client; anything we accept here ends up in our routing table.
         for proxy_ip in &proxy_ips {
             anyhow::ensure!(
@@ -118,6 +120,15 @@ impl ClientOnGateway {
         };
 
         anyhow::ensure!(crate::dns::is_subdomain(&name, address));
+
+        let (resolved_ips, nat_status) = match resolve_result {
+            Ok(resolved_ips) => (Some(resolved_ips.into_iter().collect()), NatStatus::Active),
+            Err(error) => {
+                tracing::warn!("Failed to resolve DNS resource: {error:#}");
+
+                (None, NatStatus::Inactive)
+            }
+        };
 
         if resolved_ips.as_ref().is_some_and(BTreeSet::is_empty) {
             tracing::debug!(domain = %name, %resource_id, "No A / AAAA records for domain");
@@ -164,7 +175,7 @@ impl ClientOnGateway {
         }
         self.recalculate_filters();
 
-        Ok(())
+        Ok(nat_status)
     }
 
     pub(crate) fn is_empty(&self) -> bool {
@@ -993,7 +1004,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
@@ -1059,7 +1070,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
@@ -1155,7 +1166,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
@@ -1223,7 +1234,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
         )
         .unwrap();
@@ -1245,7 +1256,7 @@ mod tests {
             peer.setup_nat(
                 foo_name().parse().unwrap(),
                 foo_resource_id(),
-                Some(BTreeSet::from([foo_real_ip2().into()])), // Setting up with a new IP!
+                Ok(vec![foo_real_ip2().into()]), // Setting up with a new IP!
                 BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
             )
             .unwrap();
@@ -1313,7 +1324,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
         )
         .unwrap();
@@ -1340,7 +1351,7 @@ mod tests {
         peer.setup_nat(
             baz_name().parse().unwrap(),
             baz_resource_id(),
-            Some(BTreeSet::from([baz_real_ip1().into()])),
+            Ok(vec![baz_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
         )
         .unwrap();
@@ -1364,7 +1375,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2(), proxy_ip6_1(), proxy_ip6_2()]),
         )
         .unwrap();
@@ -1415,14 +1426,14 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource2_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();

--- a/rust/libs/connlib/tunnel-proto/src/gateway/client_on_gateway.rs
+++ b/rust/libs/connlib/tunnel-proto/src/gateway/client_on_gateway.rs
@@ -48,11 +48,6 @@ pub enum TranslateOutboundResult {
     IcmpError(IpPacket),
 }
 
-enum AllowedOutbound {
-    GatewayTun,
-    Resource(ResourceId),
-}
-
 impl ClientOnGateway {
     pub(crate) fn new(
         id: ClientId,
@@ -83,13 +78,16 @@ impl ClientOnGateway {
         ]
     }
 
-    /// Setup the NAT for a domain of a DNS resource.
+    /// Sets up NAT for a DNS resource domain.
+    ///
+    /// A missing resolution registers the proxy addresses without replacing the last successful
+    /// destination. A completed resolution replaces it, including when it contains no addresses.
     #[tracing::instrument(level = "debug", skip_all, fields(cid = %self.id))]
     pub(crate) fn setup_nat(
         &mut self,
         name: DomainName,
         resource_id: ResourceId,
-        resolved_ips: BTreeSet<IpAddr>,
+        resolved_ips: Option<BTreeSet<IpAddr>>,
         proxy_ips: BTreeSet<IpAddr>,
     ) -> Result<()> {
         // Proxy IPs are chosen by the Client; anything we accept here ends up in our routing table.
@@ -121,53 +119,49 @@ impl ClientOnGateway {
 
         anyhow::ensure!(crate::dns::is_subdomain(&name, address));
 
-        if resolved_ips.is_empty() {
+        if resolved_ips.as_ref().is_some_and(BTreeSet::is_empty) {
             tracing::debug!(domain = %name, %resource_id, "No A / AAAA records for domain");
         }
 
-        let mut resolved_ipv4 = resolved_ips.iter().filter(|ip| ip.is_ipv4()).cycle();
-        let mut resolved_ipv6 = resolved_ips.iter().filter(|ip| ip.is_ipv6()).cycle();
-
         tracing::debug!(domain = %name, ?resolved_ips, ?proxy_ips, "Setting up DNS resource NAT");
 
-        let translations = proxy_ips
-            .into_iter()
-            .map(|proxy_ip| {
+        {
+            let mut resolved_ipv4 = resolved_ips
+                .iter()
+                .flatten()
+                .filter(|ip| ip.is_ipv4())
+                .cycle();
+            let mut resolved_ipv6 = resolved_ips
+                .iter()
+                .flatten()
+                .filter(|ip| ip.is_ipv6())
+                .cycle();
+
+            for proxy_ip in proxy_ips {
                 let resolved_ip = match proxy_ip {
                     IpAddr::V4(_) => resolved_ipv4.next(),
                     IpAddr::V6(_) => resolved_ipv6.next(),
-                };
+                }
+                .copied();
+                let update = resolved_ips
+                    .as_ref()
+                    .map(|_| ResolutionUpdate::Succeeded(resolved_ip))
+                    .unwrap_or(ResolutionUpdate::Failed);
 
-                (proxy_ip, resolved_ip.copied())
-            })
-            .collect::<Vec<_>>();
-        let unresolved_proxy_ips = translations
-            .iter()
-            .filter_map(|(proxy_ip, resolved_ip)| {
-                self.permanent_translations
-                    .get(proxy_ip)
-                    .is_some_and(|state| {
-                        state.resolved_ip(resource_id).is_some() && resolved_ip.is_none()
-                    })
-                    .then_some(*proxy_ip)
-            })
-            .collect();
+                tracing::debug!(%name, %proxy_ip, real_ip = ?resolved_ip);
 
-        self.nat_table
-            .expire_resource_inside_ips(resource_id, &unresolved_proxy_ips);
+                let state = self
+                    .permanent_translations
+                    .entry(proxy_ip)
+                    .or_insert_with(|| TranslationState::new(name.clone()));
 
-        for (proxy_ip, resolved_ip) in translations {
-            tracing::debug!(%name, %proxy_ip, real_ip = ?resolved_ip);
-
-            let state = self
-                .permanent_translations
-                .entry(proxy_ip)
-                .or_insert_with(|| TranslationState::new(name.clone()));
-
-            state.resolved_ips.insert(resource_id, resolved_ip);
+                state.update(resource_id, update);
+            }
         }
 
-        domains.insert(name, resolved_ips);
+        if let Some(resolved_ips) = resolved_ips {
+            domains.insert(name, resolved_ips);
+        }
         self.recalculate_filters();
 
         Ok(())
@@ -285,13 +279,9 @@ impl ClientOnGateway {
     ) {
         match resource {
             ResourceOnGateway::Dns { .. } => {
-                self.permanent_translations
-                    .extract_if(.., |_, state| {
-                        state.resolved_ips.remove(&resource_id);
-                        state.resolved_ips.is_empty()
-                    })
-                    .for_each(drop);
-                self.nat_table.expire_resource(resource_id);
+                for state in self.permanent_translations.values_mut() {
+                    state.detach_resource(resource_id);
+                }
             }
             ResourceOnGateway::Cidr { .. } => {}
             ResourceOnGateway::Internet => {}
@@ -354,8 +344,8 @@ impl ClientOnGateway {
     }
 
     fn recalculate_dns_filters(&mut self) {
-        for (addr, TranslationState { resolved_ips, .. }) in &self.permanent_translations {
-            for resource_id in resolved_ips.keys() {
+        for (addr, TranslationState { resources, .. }) in &self.permanent_translations {
+            for resource_id in resources {
                 let Some(entry) = self.resources.get(resource_id) else {
                     continue;
                 };
@@ -384,23 +374,20 @@ impl ClientOnGateway {
             bail!(UnroutablePacket::outbound_icmp_error(&packet))
         }
 
-        let allowed_outbound = match self.ensure_allowed_outbound(&packet) {
-            Ok(allowed_outbound) => allowed_outbound,
-            Err(error) => {
-                tracing::debug!(filtered_packet = ?packet, "{error:#}");
+        if let Err(error) = self.ensure_allowed_outbound(&packet) {
+            tracing::debug!(filtered_packet = ?packet, "{error:#}");
 
-                let reply = match error.any_downcast_ref::<InternetResourceRejectedAddress>() {
-                    Some(InternetResourceRejectedAddress(_)) => {
-                        ip_packet::make::icmp_dest_unreachable_network(&packet)?
-                    }
-                    None => ip_packet::make::icmp_dest_unreachable_prohibited(&packet)?,
-                };
+            let reply = match error.any_downcast_ref::<InternetResourceRejectedAddress>() {
+                Some(InternetResourceRejectedAddress(_)) => {
+                    ip_packet::make::icmp_dest_unreachable_network(&packet)?
+                }
+                None => ip_packet::make::icmp_dest_unreachable_prohibited(&packet)?,
+            };
 
-                return Ok(TranslateOutboundResult::IcmpError(reply));
-            }
-        };
+            return Ok(TranslateOutboundResult::IcmpError(reply));
+        }
 
-        let result = self.transform_network_to_tun(packet, allowed_outbound, now)?;
+        let result = self.transform_network_to_tun(packet, now)?;
 
         Ok(result)
     }
@@ -440,14 +427,14 @@ impl ClientOnGateway {
     fn transform_network_to_tun(
         &mut self,
         mut packet: IpPacket,
-        allowed_outbound: AllowedOutbound,
         now: Instant,
     ) -> anyhow::Result<TranslateOutboundResult> {
-        let resource_id = match allowed_outbound {
-            AllowedOutbound::GatewayTun => return Ok(TranslateOutboundResult::Send(packet)),
-            AllowedOutbound::Resource(resource_id) => resource_id,
-        };
         let dst = packet.destination();
+
+        // Packets to the TUN interface don't get transformed.
+        if self.gateway_tun.is_ip(dst) {
+            return Ok(TranslateOutboundResult::Send(packet));
+        }
 
         // Packets for CIDR resources / Internet resource are forwarded as is.
         if !is_dns_addr(dst) {
@@ -462,7 +449,7 @@ impl ClientOnGateway {
             ));
         };
 
-        let Some(resolved_ip) = state.resolved_ip(resource_id) else {
+        let Some(resolved_ip) = state.resolved_ip else {
             return Ok(TranslateOutboundResult::IcmpError(
                 ip_packet::make::icmp_dest_unreachable_network(&packet)?,
             ));
@@ -484,7 +471,7 @@ impl ClientOnGateway {
 
         let (source_protocol, real_ip) =
             self.nat_table
-                .translate_outgoing(&packet, resolved_ip, resource_id, now)?;
+                .translate_outgoing(&packet, resolved_ip, now)?;
 
         packet
             .translate_destination(source_protocol, real_ip)
@@ -530,12 +517,12 @@ impl ClientOnGateway {
         self.resources.contains_key(&resource)
     }
 
-    fn ensure_allowed_outbound(&mut self, packet: &IpPacket) -> anyhow::Result<AllowedOutbound> {
+    fn ensure_allowed_outbound(&mut self, packet: &IpPacket) -> anyhow::Result<()> {
         self.ensure_client_ip(packet.source())?;
 
         // Traffic to our own IP is allowed.
         if self.gateway_tun.is_ip(packet.destination()) {
-            return Ok(AllowedOutbound::GatewayTun);
+            return Ok(());
         }
 
         ensure_not_peer_ip(packet.destination())?;
@@ -544,12 +531,12 @@ impl ClientOnGateway {
 
         if !self.resources.contains_key(&rid) {
             tracing::warn!(%rid, "Internal state mismatch: No resource for ID");
-            return Ok(AllowedOutbound::Resource(rid));
+            return Ok(());
         }
         flow_tracker::record_resource(rid);
         flow_tracker::record_ingest_token(self.ingest_tokens.get(&rid).cloned());
 
-        Ok(AllowedOutbound::Resource(rid))
+        Ok(())
     }
 
     fn ensure_client_ip(&self, ip: IpAddr) -> anyhow::Result<()> {
@@ -718,22 +705,40 @@ impl routing_table::RouteEntry for RouteEntry {
 // Current state of a translation for a given proxy ip
 #[derive(Debug)]
 struct TranslationState {
-    /// The IP each DNS resource resolved for the domain.
-    resolved_ips: BTreeMap<ResourceId, Option<IpAddr>>,
+    /// Which DNS resources use this translation.
+    resources: BTreeSet<ResourceId>,
+    /// The latest IP resolved for the domain.
+    resolved_ip: Option<IpAddr>,
     /// The domain we have resolved.
     domain: DomainName,
+}
+
+#[derive(Clone, Copy)]
+enum ResolutionUpdate {
+    Failed,
+    Succeeded(Option<IpAddr>),
 }
 
 impl TranslationState {
     fn new(domain: DomainName) -> Self {
         Self {
-            resolved_ips: BTreeMap::default(),
+            resources: BTreeSet::default(),
+            resolved_ip: None,
             domain,
         }
     }
 
-    fn resolved_ip(&self, resource: ResourceId) -> Option<IpAddr> {
-        self.resolved_ips.get(&resource).copied().flatten()
+    fn update(&mut self, resource: ResourceId, resolution: ResolutionUpdate) {
+        self.resources.insert(resource);
+
+        match resolution {
+            ResolutionUpdate::Failed => {}
+            ResolutionUpdate::Succeeded(resolved_ip) => self.resolved_ip = resolved_ip,
+        }
+    }
+
+    fn detach_resource(&mut self, resource: ResourceId) {
+        self.resources.remove(&resource);
     }
 }
 
@@ -801,6 +806,53 @@ mod tests {
         messages::{Filter, PortRange, gateway::ResourceDescriptionCidr},
         unroutable_packet::RoutingError,
     };
+
+    #[test]
+    fn failed_resolution_preserves_last_success() {
+        let resource = foo_resource_id();
+        let mut state = TranslationState::new(foo_name().parse().unwrap());
+
+        state.update(resource, ResolutionUpdate::Failed);
+        assert_eq!(state.resolved_ip, None);
+        assert_eq!(state.resources, BTreeSet::from([resource]));
+
+        state.update(
+            resource,
+            ResolutionUpdate::Succeeded(Some(foo_real_ip1().into())),
+        );
+        state.update(resource, ResolutionUpdate::Failed);
+
+        assert_eq!(state.resolved_ip, Some(foo_real_ip1().into()));
+    }
+
+    #[test]
+    fn successful_empty_resolution_clears_last_success() {
+        let resource = foo_resource_id();
+        let mut state = TranslationState::new(foo_name().parse().unwrap());
+        state.update(
+            resource,
+            ResolutionUpdate::Succeeded(Some(foo_real_ip1().into())),
+        );
+
+        state.update(resource, ResolutionUpdate::Succeeded(None));
+
+        assert_eq!(state.resolved_ip, None);
+    }
+
+    #[test]
+    fn detaching_resource_preserves_shared_resolution() {
+        let resource = foo_resource_id();
+        let other_resource = foo_resource2_id();
+        let resolved_ip = foo_real_ip1().into();
+        let mut state = TranslationState::new(foo_name().parse().unwrap());
+        state.update(resource, ResolutionUpdate::Succeeded(Some(resolved_ip)));
+        state.update(other_resource, ResolutionUpdate::Failed);
+
+        state.detach_resource(resource);
+
+        assert_eq!(state.resolved_ip, Some(resolved_ip));
+        assert_eq!(state.resources, BTreeSet::from([other_resource]));
+    }
 
     #[test]
     fn gateway_filters_expire_individually() {
@@ -941,7 +993,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
@@ -1007,7 +1059,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
@@ -1103,7 +1155,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
@@ -1171,7 +1223,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
         )
         .unwrap();
@@ -1193,7 +1245,7 @@ mod tests {
             peer.setup_nat(
                 foo_name().parse().unwrap(),
                 foo_resource_id(),
-                BTreeSet::from([foo_real_ip2().into()]), // Setting up with a new IP!
+                Some(BTreeSet::from([foo_real_ip2().into()])), // Setting up with a new IP!
                 BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
             )
             .unwrap();
@@ -1261,7 +1313,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
         )
         .unwrap();
@@ -1288,7 +1340,7 @@ mod tests {
         peer.setup_nat(
             baz_name().parse().unwrap(),
             baz_resource_id(),
-            BTreeSet::from([baz_real_ip1().into()]),
+            Some(BTreeSet::from([baz_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
         )
         .unwrap();
@@ -1312,7 +1364,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2(), proxy_ip6_1(), proxy_ip6_2()]),
         )
         .unwrap();
@@ -1363,14 +1415,14 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource2_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();

--- a/rust/libs/connlib/tunnel-proto/src/gateway/client_on_gateway.rs
+++ b/rust/libs/connlib/tunnel-proto/src/gateway/client_on_gateway.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::iter;
 use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::{Context, ErrorExt, Result, bail};
@@ -16,6 +17,7 @@ use crate::filter_engine::FilterEngine;
 use crate::gateway::nat_table::{NatTable, TranslateIncomingResult};
 use crate::messages::gateway::ResourceDescription;
 use crate::messages::{Filter, IngestToken};
+use crate::p2p_control::dns_resource_nat::NatStatus;
 use crate::routing_table::{self, RoutingTable};
 use crate::unroutable_packet::UnroutablePacket;
 use crate::{GatewayEvent, IpConfig, NotAllowedResource, NotClientIp};
@@ -87,9 +89,9 @@ impl ClientOnGateway {
         &mut self,
         name: DomainName,
         resource_id: ResourceId,
-        resolved_ips: Option<BTreeSet<IpAddr>>,
+        resolve_result: Result<Vec<IpAddr>, Arc<anyhow::Error>>,
         proxy_ips: BTreeSet<IpAddr>,
-    ) -> Result<()> {
+    ) -> Result<NatStatus> {
         if self.have_proxy_ips_been_reassigned(&name, &proxy_ips) {
             tracing::info!("Client has re-assigned proxy IPs, resetting DNS resource NAT");
 
@@ -110,6 +112,15 @@ impl ClientOnGateway {
         };
 
         anyhow::ensure!(crate::dns::is_subdomain(&name, address));
+
+        let (resolved_ips, nat_status) = match resolve_result {
+            Ok(resolved_ips) => (Some(resolved_ips.into_iter().collect()), NatStatus::Active),
+            Err(error) => {
+                tracing::warn!("Failed to resolve DNS resource: {error:#}");
+
+                (None, NatStatus::Inactive)
+            }
+        };
 
         if resolved_ips.as_ref().is_some_and(BTreeSet::is_empty) {
             tracing::debug!(domain = %name, %resource_id, "No A / AAAA records for domain");
@@ -156,7 +167,7 @@ impl ClientOnGateway {
         }
         self.recalculate_filters();
 
-        Ok(())
+        Ok(nat_status)
     }
 
     pub(crate) fn is_empty(&self) -> bool {
@@ -991,7 +1002,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
@@ -1057,7 +1068,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
@@ -1153,7 +1164,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
@@ -1221,7 +1232,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
         )
         .unwrap();
@@ -1243,7 +1254,7 @@ mod tests {
             peer.setup_nat(
                 foo_name().parse().unwrap(),
                 foo_resource_id(),
-                Some(BTreeSet::from([foo_real_ip2().into()])), // Setting up with a new IP!
+                Ok(vec![foo_real_ip2().into()]), // Setting up with a new IP!
                 BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
             )
             .unwrap();
@@ -1311,7 +1322,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
         )
         .unwrap();
@@ -1338,7 +1349,7 @@ mod tests {
         peer.setup_nat(
             baz_name().parse().unwrap(),
             baz_resource_id(),
-            Some(BTreeSet::from([baz_real_ip1().into()])),
+            Ok(vec![baz_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
         )
         .unwrap();
@@ -1362,7 +1373,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2(), proxy_ip6_1(), proxy_ip6_2()]),
         )
         .unwrap();
@@ -1413,14 +1424,14 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource2_id(),
-            Some(BTreeSet::from([foo_real_ip1().into()])),
+            Ok(vec![foo_real_ip1().into()]),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();

--- a/rust/libs/connlib/tunnel-proto/src/gateway/client_on_gateway.rs
+++ b/rust/libs/connlib/tunnel-proto/src/gateway/client_on_gateway.rs
@@ -48,11 +48,6 @@ pub enum TranslateOutboundResult {
     IcmpError(IpPacket),
 }
 
-enum AllowedOutbound {
-    GatewayTun,
-    Resource(ResourceId),
-}
-
 impl ClientOnGateway {
     pub(crate) fn new(
         id: ClientId,
@@ -83,13 +78,16 @@ impl ClientOnGateway {
         ]
     }
 
-    /// Setup the NAT for a domain of a DNS resource.
+    /// Sets up NAT for a DNS resource domain.
+    ///
+    /// A missing resolution registers the proxy addresses without replacing the last successful
+    /// destination. A completed resolution replaces it, including when it contains no addresses.
     #[tracing::instrument(level = "debug", skip_all, fields(cid = %self.id))]
     pub(crate) fn setup_nat(
         &mut self,
         name: DomainName,
         resource_id: ResourceId,
-        resolved_ips: BTreeSet<IpAddr>,
+        resolved_ips: Option<BTreeSet<IpAddr>>,
         proxy_ips: BTreeSet<IpAddr>,
     ) -> Result<()> {
         if self.have_proxy_ips_been_reassigned(&name, &proxy_ips) {
@@ -113,53 +111,49 @@ impl ClientOnGateway {
 
         anyhow::ensure!(crate::dns::is_subdomain(&name, address));
 
-        if resolved_ips.is_empty() {
+        if resolved_ips.as_ref().is_some_and(BTreeSet::is_empty) {
             tracing::debug!(domain = %name, %resource_id, "No A / AAAA records for domain");
         }
 
-        let mut resolved_ipv4 = resolved_ips.iter().filter(|ip| ip.is_ipv4()).cycle();
-        let mut resolved_ipv6 = resolved_ips.iter().filter(|ip| ip.is_ipv6()).cycle();
-
         tracing::debug!(domain = %name, ?resolved_ips, ?proxy_ips, "Setting up DNS resource NAT");
 
-        let translations = proxy_ips
-            .into_iter()
-            .map(|proxy_ip| {
+        {
+            let mut resolved_ipv4 = resolved_ips
+                .iter()
+                .flatten()
+                .filter(|ip| ip.is_ipv4())
+                .cycle();
+            let mut resolved_ipv6 = resolved_ips
+                .iter()
+                .flatten()
+                .filter(|ip| ip.is_ipv6())
+                .cycle();
+
+            for proxy_ip in proxy_ips {
                 let resolved_ip = match proxy_ip {
                     IpAddr::V4(_) => resolved_ipv4.next(),
                     IpAddr::V6(_) => resolved_ipv6.next(),
-                };
+                }
+                .copied();
+                let update = resolved_ips
+                    .as_ref()
+                    .map(|_| ResolutionUpdate::Succeeded(resolved_ip))
+                    .unwrap_or(ResolutionUpdate::Failed);
 
-                (proxy_ip, resolved_ip.copied())
-            })
-            .collect::<Vec<_>>();
-        let unresolved_proxy_ips = translations
-            .iter()
-            .filter_map(|(proxy_ip, resolved_ip)| {
-                self.permanent_translations
-                    .get(proxy_ip)
-                    .is_some_and(|state| {
-                        state.resolved_ip(resource_id).is_some() && resolved_ip.is_none()
-                    })
-                    .then_some(*proxy_ip)
-            })
-            .collect();
+                tracing::debug!(%name, %proxy_ip, real_ip = ?resolved_ip);
 
-        self.nat_table
-            .expire_resource_inside_ips(resource_id, &unresolved_proxy_ips);
+                let state = self
+                    .permanent_translations
+                    .entry(proxy_ip)
+                    .or_insert_with(|| TranslationState::new(name.clone()));
 
-        for (proxy_ip, resolved_ip) in translations {
-            tracing::debug!(%name, %proxy_ip, real_ip = ?resolved_ip);
-
-            let state = self
-                .permanent_translations
-                .entry(proxy_ip)
-                .or_insert_with(|| TranslationState::new(name.clone()));
-
-            state.resolved_ips.insert(resource_id, resolved_ip);
+                state.update(resource_id, update);
+            }
         }
 
-        domains.insert(name, resolved_ips);
+        if let Some(resolved_ips) = resolved_ips {
+            domains.insert(name, resolved_ips);
+        }
         self.recalculate_filters();
 
         Ok(())
@@ -277,13 +271,9 @@ impl ClientOnGateway {
     ) {
         match resource {
             ResourceOnGateway::Dns { .. } => {
-                self.permanent_translations
-                    .extract_if(.., |_, state| {
-                        state.resolved_ips.remove(&resource_id);
-                        state.resolved_ips.is_empty()
-                    })
-                    .for_each(drop);
-                self.nat_table.expire_resource(resource_id);
+                for state in self.permanent_translations.values_mut() {
+                    state.detach_resource(resource_id);
+                }
             }
             ResourceOnGateway::Cidr { .. } => {}
             ResourceOnGateway::Internet => {}
@@ -346,8 +336,8 @@ impl ClientOnGateway {
     }
 
     fn recalculate_dns_filters(&mut self) {
-        for (addr, TranslationState { resolved_ips, .. }) in &self.permanent_translations {
-            for resource_id in resolved_ips.keys() {
+        for (addr, TranslationState { resources, .. }) in &self.permanent_translations {
+            for resource_id in resources {
                 let Some(entry) = self.resources.get(resource_id) else {
                     continue;
                 };
@@ -376,23 +366,20 @@ impl ClientOnGateway {
             bail!(UnroutablePacket::outbound_icmp_error(&packet))
         }
 
-        let allowed_outbound = match self.ensure_allowed_outbound(&packet) {
-            Ok(allowed_outbound) => allowed_outbound,
-            Err(error) => {
-                tracing::debug!(filtered_packet = ?packet, "{error:#}");
+        if let Err(error) = self.ensure_allowed_outbound(&packet) {
+            tracing::debug!(filtered_packet = ?packet, "{error:#}");
 
-                let reply = match error.any_downcast_ref::<InternetResourceRejectedAddress>() {
-                    Some(InternetResourceRejectedAddress(_)) => {
-                        ip_packet::make::icmp_dest_unreachable_network(&packet)?
-                    }
-                    None => ip_packet::make::icmp_dest_unreachable_prohibited(&packet)?,
-                };
+            let reply = match error.any_downcast_ref::<InternetResourceRejectedAddress>() {
+                Some(InternetResourceRejectedAddress(_)) => {
+                    ip_packet::make::icmp_dest_unreachable_network(&packet)?
+                }
+                None => ip_packet::make::icmp_dest_unreachable_prohibited(&packet)?,
+            };
 
-                return Ok(TranslateOutboundResult::IcmpError(reply));
-            }
-        };
+            return Ok(TranslateOutboundResult::IcmpError(reply));
+        }
 
-        let result = self.transform_network_to_tun(packet, allowed_outbound, now)?;
+        let result = self.transform_network_to_tun(packet, now)?;
 
         Ok(result)
     }
@@ -432,14 +419,14 @@ impl ClientOnGateway {
     fn transform_network_to_tun(
         &mut self,
         mut packet: IpPacket,
-        allowed_outbound: AllowedOutbound,
         now: Instant,
     ) -> anyhow::Result<TranslateOutboundResult> {
-        let resource_id = match allowed_outbound {
-            AllowedOutbound::GatewayTun => return Ok(TranslateOutboundResult::Send(packet)),
-            AllowedOutbound::Resource(resource_id) => resource_id,
-        };
         let dst = packet.destination();
+
+        // Packets to the TUN interface don't get transformed.
+        if self.gateway_tun.is_ip(dst) {
+            return Ok(TranslateOutboundResult::Send(packet));
+        }
 
         // Packets for CIDR resources / Internet resource are forwarded as is.
         if !is_dns_addr(dst) {
@@ -454,7 +441,7 @@ impl ClientOnGateway {
             ));
         };
 
-        let Some(resolved_ip) = state.resolved_ip(resource_id) else {
+        let Some(resolved_ip) = state.resolved_ip else {
             return Ok(TranslateOutboundResult::IcmpError(
                 ip_packet::make::icmp_dest_unreachable_network(&packet)?,
             ));
@@ -476,7 +463,7 @@ impl ClientOnGateway {
 
         let (source_protocol, real_ip) =
             self.nat_table
-                .translate_outgoing(&packet, resolved_ip, resource_id, now)?;
+                .translate_outgoing(&packet, resolved_ip, now)?;
 
         packet
             .translate_destination(source_protocol, real_ip)
@@ -522,12 +509,12 @@ impl ClientOnGateway {
         self.resources.contains_key(&resource)
     }
 
-    fn ensure_allowed_outbound(&mut self, packet: &IpPacket) -> anyhow::Result<AllowedOutbound> {
+    fn ensure_allowed_outbound(&mut self, packet: &IpPacket) -> anyhow::Result<()> {
         self.ensure_client_ip(packet.source())?;
 
         // Traffic to our own IP is allowed.
         if self.gateway_tun.is_ip(packet.destination()) {
-            return Ok(AllowedOutbound::GatewayTun);
+            return Ok(());
         }
 
         ensure_not_peer_ip(packet.destination())?;
@@ -536,12 +523,12 @@ impl ClientOnGateway {
 
         if !self.resources.contains_key(&rid) {
             tracing::warn!(%rid, "Internal state mismatch: No resource for ID");
-            return Ok(AllowedOutbound::Resource(rid));
+            return Ok(());
         }
         flow_tracker::record_resource(rid);
         flow_tracker::record_ingest_token(self.ingest_tokens.get(&rid).cloned());
 
-        Ok(AllowedOutbound::Resource(rid))
+        Ok(())
     }
 
     fn ensure_client_ip(&self, ip: IpAddr) -> anyhow::Result<()> {
@@ -710,22 +697,40 @@ impl routing_table::RouteEntry for RouteEntry {
 // Current state of a translation for a given proxy ip
 #[derive(Debug)]
 struct TranslationState {
-    /// The IP each DNS resource resolved for the domain.
-    resolved_ips: BTreeMap<ResourceId, Option<IpAddr>>,
+    /// Which DNS resources use this translation.
+    resources: BTreeSet<ResourceId>,
+    /// The latest IP resolved for the domain.
+    resolved_ip: Option<IpAddr>,
     /// The domain we have resolved.
     domain: DomainName,
+}
+
+#[derive(Clone, Copy)]
+enum ResolutionUpdate {
+    Failed,
+    Succeeded(Option<IpAddr>),
 }
 
 impl TranslationState {
     fn new(domain: DomainName) -> Self {
         Self {
-            resolved_ips: BTreeMap::default(),
+            resources: BTreeSet::default(),
+            resolved_ip: None,
             domain,
         }
     }
 
-    fn resolved_ip(&self, resource: ResourceId) -> Option<IpAddr> {
-        self.resolved_ips.get(&resource).copied().flatten()
+    fn update(&mut self, resource: ResourceId, resolution: ResolutionUpdate) {
+        self.resources.insert(resource);
+
+        match resolution {
+            ResolutionUpdate::Failed => {}
+            ResolutionUpdate::Succeeded(resolved_ip) => self.resolved_ip = resolved_ip,
+        }
+    }
+
+    fn detach_resource(&mut self, resource: ResourceId) {
+        self.resources.remove(&resource);
     }
 }
 
@@ -793,6 +798,53 @@ mod tests {
         messages::{Filter, PortRange, gateway::ResourceDescriptionCidr},
         unroutable_packet::RoutingError,
     };
+
+    #[test]
+    fn failed_resolution_preserves_last_success() {
+        let resource = foo_resource_id();
+        let mut state = TranslationState::new(foo_name().parse().unwrap());
+
+        state.update(resource, ResolutionUpdate::Failed);
+        assert_eq!(state.resolved_ip, None);
+        assert_eq!(state.resources, BTreeSet::from([resource]));
+
+        state.update(
+            resource,
+            ResolutionUpdate::Succeeded(Some(foo_real_ip1().into())),
+        );
+        state.update(resource, ResolutionUpdate::Failed);
+
+        assert_eq!(state.resolved_ip, Some(foo_real_ip1().into()));
+    }
+
+    #[test]
+    fn successful_empty_resolution_clears_last_success() {
+        let resource = foo_resource_id();
+        let mut state = TranslationState::new(foo_name().parse().unwrap());
+        state.update(
+            resource,
+            ResolutionUpdate::Succeeded(Some(foo_real_ip1().into())),
+        );
+
+        state.update(resource, ResolutionUpdate::Succeeded(None));
+
+        assert_eq!(state.resolved_ip, None);
+    }
+
+    #[test]
+    fn detaching_resource_preserves_shared_resolution() {
+        let resource = foo_resource_id();
+        let other_resource = foo_resource2_id();
+        let resolved_ip = foo_real_ip1().into();
+        let mut state = TranslationState::new(foo_name().parse().unwrap());
+        state.update(resource, ResolutionUpdate::Succeeded(Some(resolved_ip)));
+        state.update(other_resource, ResolutionUpdate::Failed);
+
+        state.detach_resource(resource);
+
+        assert_eq!(state.resolved_ip, Some(resolved_ip));
+        assert_eq!(state.resources, BTreeSet::from([other_resource]));
+    }
 
     #[test]
     fn gateway_filters_expire_individually() {
@@ -939,7 +991,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
@@ -1005,7 +1057,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
@@ -1101,7 +1153,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
@@ -1169,7 +1221,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
         )
         .unwrap();
@@ -1191,7 +1243,7 @@ mod tests {
             peer.setup_nat(
                 foo_name().parse().unwrap(),
                 foo_resource_id(),
-                BTreeSet::from([foo_real_ip2().into()]), // Setting up with a new IP!
+                Some(BTreeSet::from([foo_real_ip2().into()])), // Setting up with a new IP!
                 BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
             )
             .unwrap();
@@ -1259,7 +1311,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
         )
         .unwrap();
@@ -1286,7 +1338,7 @@ mod tests {
         peer.setup_nat(
             baz_name().parse().unwrap(),
             baz_resource_id(),
-            BTreeSet::from([baz_real_ip1().into()]),
+            Some(BTreeSet::from([baz_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2()]),
         )
         .unwrap();
@@ -1310,7 +1362,7 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1(), proxy_ip4_2(), proxy_ip6_1(), proxy_ip6_2()]),
         )
         .unwrap();
@@ -1361,14 +1413,14 @@ mod tests {
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();
         peer.setup_nat(
             foo_name().parse().unwrap(),
             foo_resource2_id(),
-            BTreeSet::from([foo_real_ip1().into()]),
+            Some(BTreeSet::from([foo_real_ip1().into()])),
             BTreeSet::from([proxy_ip4_1()]),
         )
         .unwrap();

--- a/rust/libs/connlib/tunnel-proto/src/gateway/client_on_gateway.rs
+++ b/rust/libs/connlib/tunnel-proto/src/gateway/client_on_gateway.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::iter;
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Instant;
 
@@ -45,6 +46,11 @@ pub struct ClientOnGateway {
 pub enum TranslateOutboundResult {
     Send(IpPacket),
     IcmpError(IpPacket),
+}
+
+enum AllowedOutbound {
+    GatewayTun,
+    Resource(ResourceId),
 }
 
 impl ClientOnGateway {
@@ -116,21 +122,41 @@ impl ClientOnGateway {
 
         tracing::debug!(domain = %name, ?resolved_ips, ?proxy_ips, "Setting up DNS resource NAT");
 
-        for proxy_ip in proxy_ips {
-            let maybe_real_ip = match proxy_ip {
-                IpAddr::V4(_) => resolved_ipv4.next(),
-                IpAddr::V6(_) => resolved_ipv6.next(),
-            };
+        let translations = proxy_ips
+            .into_iter()
+            .map(|proxy_ip| {
+                let resolved_ip = match proxy_ip {
+                    IpAddr::V4(_) => resolved_ipv4.next(),
+                    IpAddr::V6(_) => resolved_ipv6.next(),
+                };
 
-            tracing::debug!(%name, %proxy_ip, real_ip = ?maybe_real_ip);
+                (proxy_ip, resolved_ip.copied())
+            })
+            .collect::<Vec<_>>();
+        let unresolved_proxy_ips = translations
+            .iter()
+            .filter_map(|(proxy_ip, resolved_ip)| {
+                self.permanent_translations
+                    .get(proxy_ip)
+                    .is_some_and(|state| {
+                        state.resolved_ip(resource_id).is_some() && resolved_ip.is_none()
+                    })
+                    .then_some(*proxy_ip)
+            })
+            .collect();
+
+        self.nat_table
+            .expire_resource_inside_ips(resource_id, &unresolved_proxy_ips);
+
+        for (proxy_ip, resolved_ip) in translations {
+            tracing::debug!(%name, %proxy_ip, real_ip = ?resolved_ip);
 
             let state = self
                 .permanent_translations
                 .entry(proxy_ip)
                 .or_insert_with(|| TranslationState::new(name.clone()));
 
-            state.resources.insert(resource_id);
-            state.resolved_ip = maybe_real_ip.copied();
+            state.resolved_ips.insert(resource_id, resolved_ip);
         }
 
         domains.insert(name, resolved_ips);
@@ -151,13 +177,17 @@ impl ClientOnGateway {
         self.nat_table.handle_timeout(now);
         self.resources.handle_timeout(now);
 
+        let expired_resources = iter::from_fn(|| self.resources.poll_event())
+            .map(|event| match event {
+                expiring_map::Event::EntryExpired { key, value } => (key, value),
+            })
+            .collect::<Vec<_>>();
+        let any_expired = !expired_resources.is_empty();
         let cid = self.id;
-        let mut any_expired = false;
-        while let Some(expiring_map::Event::EntryExpired { key, .. }) = self.resources.poll_event()
-        {
+
+        for (key, resource) in expired_resources {
             tracing::info!(%cid, rid = %key, "Access to resource expired");
-            self.ingest_tokens.remove(&key);
-            any_expired = true;
+            self.cleanup_removed_authorization(key, resource);
         }
 
         if any_expired {
@@ -166,8 +196,10 @@ impl ClientOnGateway {
     }
 
     pub(crate) fn remove_resource(&mut self, resource: &ResourceId) {
-        self.resources.remove(resource);
-        self.ingest_tokens.remove(resource);
+        if let Some(entry) = self.resources.remove(resource) {
+            self.cleanup_removed_authorization(*resource, entry.value);
+        }
+
         self.recalculate_filters();
     }
 
@@ -225,15 +257,39 @@ impl ClientOnGateway {
     }
 
     pub(crate) fn retain_authorizations(&mut self, authorization: BTreeSet<ResourceId>) {
-        for (rid, _) in self
+        let revoked = self
             .resources
             .extract_if(|rid, _| !authorization.contains(rid))
-        {
+            .collect::<Vec<_>>();
+
+        for (rid, resource) in revoked {
             tracing::info!(%rid, "Revoking resource authorization");
-            self.ingest_tokens.remove(&rid);
+            self.cleanup_removed_authorization(rid, resource);
         }
 
         self.recalculate_filters();
+    }
+
+    fn cleanup_removed_authorization(
+        &mut self,
+        resource_id: ResourceId,
+        resource: ResourceOnGateway,
+    ) {
+        match resource {
+            ResourceOnGateway::Dns { .. } => {
+                self.permanent_translations
+                    .extract_if(.., |_, state| {
+                        state.resolved_ips.remove(&resource_id);
+                        state.resolved_ips.is_empty()
+                    })
+                    .for_each(drop);
+                self.nat_table.expire_resource(resource_id);
+            }
+            ResourceOnGateway::Cidr { .. } => {}
+            ResourceOnGateway::Internet => {}
+        }
+
+        self.ingest_tokens.remove(&resource_id);
     }
 
     /// Checks if the given proxy IPs assigned for a domain are consistent with what we have stored.
@@ -290,8 +346,8 @@ impl ClientOnGateway {
     }
 
     fn recalculate_dns_filters(&mut self) {
-        for (addr, TranslationState { resources, .. }) in &self.permanent_translations {
-            for resource_id in resources {
+        for (addr, TranslationState { resolved_ips, .. }) in &self.permanent_translations {
+            for resource_id in resolved_ips.keys() {
                 let Some(entry) = self.resources.get(resource_id) else {
                     continue;
                 };
@@ -320,20 +376,23 @@ impl ClientOnGateway {
             bail!(UnroutablePacket::outbound_icmp_error(&packet))
         }
 
-        if let Err(error) = self.ensure_allowed_outbound(&packet) {
-            tracing::debug!(filtered_packet = ?packet, "{error:#}");
+        let allowed_outbound = match self.ensure_allowed_outbound(&packet) {
+            Ok(allowed_outbound) => allowed_outbound,
+            Err(error) => {
+                tracing::debug!(filtered_packet = ?packet, "{error:#}");
 
-            let reply = match error.any_downcast_ref::<InternetResourceRejectedAddress>() {
-                Some(InternetResourceRejectedAddress(_)) => {
-                    ip_packet::make::icmp_dest_unreachable_network(&packet)?
-                }
-                None => ip_packet::make::icmp_dest_unreachable_prohibited(&packet)?,
-            };
+                let reply = match error.any_downcast_ref::<InternetResourceRejectedAddress>() {
+                    Some(InternetResourceRejectedAddress(_)) => {
+                        ip_packet::make::icmp_dest_unreachable_network(&packet)?
+                    }
+                    None => ip_packet::make::icmp_dest_unreachable_prohibited(&packet)?,
+                };
 
-            return Ok(TranslateOutboundResult::IcmpError(reply));
-        }
+                return Ok(TranslateOutboundResult::IcmpError(reply));
+            }
+        };
 
-        let result = self.transform_network_to_tun(packet, now)?;
+        let result = self.transform_network_to_tun(packet, allowed_outbound, now)?;
 
         Ok(result)
     }
@@ -373,14 +432,14 @@ impl ClientOnGateway {
     fn transform_network_to_tun(
         &mut self,
         mut packet: IpPacket,
+        allowed_outbound: AllowedOutbound,
         now: Instant,
     ) -> anyhow::Result<TranslateOutboundResult> {
+        let resource_id = match allowed_outbound {
+            AllowedOutbound::GatewayTun => return Ok(TranslateOutboundResult::Send(packet)),
+            AllowedOutbound::Resource(resource_id) => resource_id,
+        };
         let dst = packet.destination();
-
-        // Packets to the TUN interface don't get transformed.
-        if self.gateway_tun.is_ip(dst) {
-            return Ok(TranslateOutboundResult::Send(packet));
-        }
 
         // Packets for CIDR resources / Internet resource are forwarded as is.
         if !is_dns_addr(dst) {
@@ -395,7 +454,7 @@ impl ClientOnGateway {
             ));
         };
 
-        let Some(resolved_ip) = state.resolved_ip else {
+        let Some(resolved_ip) = state.resolved_ip(resource_id) else {
             return Ok(TranslateOutboundResult::IcmpError(
                 ip_packet::make::icmp_dest_unreachable_network(&packet)?,
             ));
@@ -417,7 +476,7 @@ impl ClientOnGateway {
 
         let (source_protocol, real_ip) =
             self.nat_table
-                .translate_outgoing(&packet, resolved_ip, now)?;
+                .translate_outgoing(&packet, resolved_ip, resource_id, now)?;
 
         packet
             .translate_destination(source_protocol, real_ip)
@@ -463,12 +522,12 @@ impl ClientOnGateway {
         self.resources.contains_key(&resource)
     }
 
-    fn ensure_allowed_outbound(&mut self, packet: &IpPacket) -> anyhow::Result<()> {
+    fn ensure_allowed_outbound(&mut self, packet: &IpPacket) -> anyhow::Result<AllowedOutbound> {
         self.ensure_client_ip(packet.source())?;
 
         // Traffic to our own IP is allowed.
         if self.gateway_tun.is_ip(packet.destination()) {
-            return Ok(());
+            return Ok(AllowedOutbound::GatewayTun);
         }
 
         ensure_not_peer_ip(packet.destination())?;
@@ -477,12 +536,12 @@ impl ClientOnGateway {
 
         if !self.resources.contains_key(&rid) {
             tracing::warn!(%rid, "Internal state mismatch: No resource for ID");
-            return Ok(());
+            return Ok(AllowedOutbound::Resource(rid));
         }
         flow_tracker::record_resource(rid);
         flow_tracker::record_ingest_token(self.ingest_tokens.get(&rid).cloned());
 
-        Ok(())
+        Ok(AllowedOutbound::Resource(rid))
     }
 
     fn ensure_client_ip(&self, ip: IpAddr) -> anyhow::Result<()> {
@@ -651,10 +710,8 @@ impl routing_table::RouteEntry for RouteEntry {
 // Current state of a translation for a given proxy ip
 #[derive(Debug)]
 struct TranslationState {
-    /// Which (DNS) resources we belong to.
-    resources: BTreeSet<ResourceId>,
-    /// The IP we have resolved for the domain.
-    resolved_ip: Option<IpAddr>,
+    /// The IP each DNS resource resolved for the domain.
+    resolved_ips: BTreeMap<ResourceId, Option<IpAddr>>,
     /// The domain we have resolved.
     domain: DomainName,
 }
@@ -662,10 +719,13 @@ struct TranslationState {
 impl TranslationState {
     fn new(domain: DomainName) -> Self {
         Self {
-            resources: BTreeSet::default(),
-            resolved_ip: None,
+            resolved_ips: BTreeMap::default(),
             domain,
         }
+    }
+
+    fn resolved_ip(&self, resource: ResourceId) -> Option<IpAddr> {
+        self.resolved_ips.get(&resource).copied().flatten()
     }
 }
 

--- a/rust/libs/connlib/tunnel-proto/src/gateway/nat_table.rs
+++ b/rust/libs/connlib/tunnel-proto/src/gateway/nat_table.rs
@@ -1,18 +1,15 @@
 //! A stateful symmetric NAT table that performs conversion between a client's picked proxy ip and the actual resource's IP.
 use anyhow::{Context, Result};
 use bimap::BiMap;
-use connlib_model::ResourceId;
 use ip_packet::{FailedPacket, IcmpError, IpPacket, Protocol};
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::time::{Duration, Instant};
 
 /// This stateful NAT table converts a client's proxy IP for a domain name into a real IP for the domain.
 ///
-/// Outbound sessions are keyed by the resource, the source Layer-4 protocol and the proxy IP.
+/// Outbound sessions are keyed by the source Layer-4 protocol and the proxy IP.
 /// The Layer-4 value includes a UDP or TCP source port, or an ICMP echo identifier.
-/// Resource identity prevents DNS resources that share the same proxy IP and Layer-4 value from
-/// aliasing one another's NAT sessions.
 #[derive(Default, Debug)]
 pub(crate) struct NatTable {
     table: BiMap<Inside, Outside>,
@@ -23,11 +20,11 @@ pub(crate) struct NatTable {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Copy)]
-struct Inside(ResourceId, Protocol, IpAddr);
+struct Inside(Protocol, IpAddr);
 
 impl Inside {
     fn into_inner(self) -> (Protocol, IpAddr) {
-        (self.1, self.2)
+        (self.0, self.1)
     }
 }
 
@@ -53,7 +50,7 @@ impl NatTable {
     pub(crate) fn handle_timeout(&mut self, now: Instant) {
         let expired = self.state_by_inside.extract_if(.., |inside, state| {
             state
-                .remove_at(inside.1)
+                .remove_at(inside.0)
                 .is_some_and(|remove_at| now >= remove_at)
         });
 
@@ -81,45 +78,16 @@ impl NatTable {
         }
     }
 
-    pub(crate) fn expire_resource_inside_ips(
-        &mut self,
-        resource: ResourceId,
-        ips: &BTreeSet<IpAddr>,
-    ) {
-        self.expire_inside(|inside| inside.0 == resource && ips.contains(&inside.2));
-    }
-
-    pub(crate) fn expire_resource(&mut self, resource: ResourceId) {
-        self.expire_inside(|inside| inside.0 == resource);
-    }
-
-    fn expire_inside(&mut self, predicate: impl Fn(&Inside) -> bool) {
-        let expired = self
-            .state_by_inside
-            .extract_if(.., |inside, _| predicate(inside))
-            .map(|(inside, _)| inside)
-            .collect::<Vec<_>>();
-
-        for inside in expired {
-            let Some((_, outside)) = self.table.remove_by_left(&inside) else {
-                continue;
-            };
-
-            self.expired.insert(outside);
-        }
-    }
-
     pub(crate) fn translate_outgoing(
         &mut self,
         packet: &IpPacket,
         outside_dst: IpAddr,
-        resource: ResourceId,
         now: Instant,
     ) -> Result<(Protocol, IpAddr)> {
         let src = packet.source_protocol()?;
         let dst = packet.destination();
 
-        let inside = Inside(resource, src, dst);
+        let inside = Inside(src, dst);
 
         if let Some(outside) = self.table.get_by_left(&inside).copied()
             && let Some(state) = self.state_by_inside.get_mut(&inside)
@@ -164,7 +132,7 @@ impl NatTable {
         if let Some((failed_packet, icmp_error)) = packet.icmp_error()? {
             let outside = Outside(failed_packet.src_proto(), failed_packet.dst());
 
-            if let Some(Inside(_, inside_proto, inside_dst)) =
+            if let Some(Inside(inside_proto, inside_dst)) =
                 self.translate_incoming_inner(&outside, now)
             {
                 return Ok(TranslateIncomingResult::IcmpError(IcmpErrorPrototype {
@@ -369,9 +337,6 @@ mod tests {
     use ip_packet::{IpPacket, make::TcpFlags, proptest::*};
     use proptest::prelude::*;
 
-    const RESOURCE: ResourceId = ResourceId::from_u128(1);
-    const OTHER_RESOURCE: ResourceId = ResourceId::from_u128(2);
-
     #[test_strategy::proptest(ProptestConfig { max_local_rejects: 10_000, max_global_rejects: 10_000, ..ProptestConfig::default() })]
     fn translates_back_and_forth_packet(
         #[strategy(udp_or_tcp_or_icmp_packet())] packet: IpPacket,
@@ -389,9 +354,8 @@ mod tests {
         let dst = packet.destination();
 
         // Translate out
-        let (new_source_protocol, new_dst_ip) = table
-            .translate_outgoing(&packet, outside_dst, RESOURCE, now)
-            .unwrap();
+        let (new_source_protocol, new_dst_ip) =
+            table.translate_outgoing(&packet, outside_dst, now).unwrap();
 
         // Pretend we are getting a response.
         let mut response = packet.clone();
@@ -456,11 +420,9 @@ mod tests {
             .map(|(p, _)| (p.source_protocol().unwrap(), p.destination()));
 
         // Translate out
-        let new_src_p_and_dst = packets.clone().map(|(p, d)| {
-            table
-                .translate_outgoing(&p, d, RESOURCE, Instant::now())
-                .unwrap()
-        });
+        let new_src_p_and_dst = packets
+            .clone()
+            .map(|(p, d)| table.translate_outgoing(&p, d, Instant::now()).unwrap());
 
         // Pretend we are getting a response.
         for ((p, _), (new_src_p, new_d)) in packets.iter_mut().zip(new_src_p_and_dst) {
@@ -501,9 +463,7 @@ mod tests {
         let mut table = NatTable::default();
         let mut now = Instant::now();
 
-        let outside = table
-            .translate_outgoing(&req, outside_dst, RESOURCE, now)
-            .unwrap();
+        let outside = table.translate_outgoing(&req, outside_dst, now).unwrap();
 
         let mut response = req.clone();
         response.set_destination_protocol(outside.0.value());
@@ -520,9 +480,7 @@ mod tests {
 
         now += Duration::from_secs(1);
 
-        table
-            .translate_outgoing(&rst, outside_dst, RESOURCE, now)
-            .unwrap();
+        table.translate_outgoing(&rst, outside_dst, now).unwrap();
 
         now += Duration::from_secs(1);
         table.handle_timeout(now);
@@ -533,91 +491,5 @@ mod tests {
             | TranslateIncomingResult::Ok { .. }
             | TranslateIncomingResult::IcmpError(_)) => panic!("Wrong result: {result:?}"),
         };
-    }
-
-    #[test]
-    fn expired_inside_ip_uses_new_outside_destination() {
-        let now = Instant::now();
-        let client = Ipv4Addr::new(100, 64, 0, 1);
-        let proxy = Ipv4Addr::new(100, 96, 0, 1);
-        let old_destination = Ipv4Addr::new(192, 0, 2, 1);
-        let new_destination = Ipv4Addr::new(192, 0, 2, 2);
-        let packet = ip_packet::make::udp_packet(client, proxy, 1000, 2000, &[]).unwrap();
-        let mut table = NatTable::default();
-
-        let (_, destination) = table
-            .translate_outgoing(&packet, old_destination.into(), RESOURCE, now)
-            .unwrap();
-        table.expire_resource_inside_ips(RESOURCE, &BTreeSet::from([proxy.into()]));
-        let (_, refreshed_destination) = table
-            .translate_outgoing(&packet, new_destination.into(), RESOURCE, now)
-            .unwrap();
-
-        assert_eq!(destination, IpAddr::V4(old_destination));
-        assert_eq!(refreshed_destination, IpAddr::V4(new_destination));
-    }
-
-    #[test]
-    fn packet_for_expired_inside_ip_is_expired() {
-        let now = Instant::now();
-        let client = Ipv4Addr::new(100, 64, 0, 1);
-        let proxy = Ipv4Addr::new(100, 96, 0, 1);
-        let destination = Ipv4Addr::new(192, 0, 2, 1);
-        let packet = ip_packet::make::udp_packet(client, proxy, 1000, 2000, &[]).unwrap();
-        let mut table = NatTable::default();
-        let (outside_protocol, outside_destination) = table
-            .translate_outgoing(&packet, destination.into(), RESOURCE, now)
-            .unwrap();
-        let response = ip_packet::make::udp_packet(
-            outside_destination,
-            client,
-            2000,
-            outside_protocol.value(),
-            &[],
-        )
-        .unwrap();
-
-        table.expire_resource(RESOURCE);
-        let result = table.translate_incoming(&response, now).unwrap();
-
-        assert_eq!(result, TranslateIncomingResult::ExpiredNatSession);
-    }
-
-    #[test]
-    fn resources_have_distinct_sessions_for_same_inside_tuple() {
-        let now = Instant::now();
-        let client = Ipv4Addr::new(100, 64, 0, 1);
-        let proxy = Ipv4Addr::new(100, 96, 0, 1);
-        let first_destination = Ipv4Addr::new(192, 0, 2, 1);
-        let second_destination = Ipv4Addr::new(192, 0, 2, 2);
-        let refreshed_destination = Ipv4Addr::new(192, 0, 2, 3);
-        let packet = ip_packet::make::udp_packet(client, proxy, 1000, 2000, &[]).unwrap();
-        let mut table = NatTable::default();
-
-        let (_, first) = table
-            .translate_outgoing(&packet, first_destination.into(), RESOURCE, now)
-            .unwrap();
-        let (_, second) = table
-            .translate_outgoing(&packet, second_destination.into(), OTHER_RESOURCE, now)
-            .unwrap();
-        let (_, first_after_refresh) = table
-            .translate_outgoing(&packet, refreshed_destination.into(), RESOURCE, now)
-            .unwrap();
-
-        assert_eq!(first, IpAddr::V4(first_destination));
-        assert_eq!(second, IpAddr::V4(second_destination));
-        assert_eq!(first_after_refresh, IpAddr::V4(first_destination));
-
-        table.expire_resource(RESOURCE);
-
-        let (_, first_after_expiry) = table
-            .translate_outgoing(&packet, refreshed_destination.into(), RESOURCE, now)
-            .unwrap();
-        let (_, second_after_expiry) = table
-            .translate_outgoing(&packet, refreshed_destination.into(), OTHER_RESOURCE, now)
-            .unwrap();
-
-        assert_eq!(first_after_expiry, IpAddr::V4(refreshed_destination));
-        assert_eq!(second_after_expiry, IpAddr::V4(second_destination));
     }
 }

--- a/rust/libs/connlib/tunnel-proto/src/gateway/nat_table.rs
+++ b/rust/libs/connlib/tunnel-proto/src/gateway/nat_table.rs
@@ -1,19 +1,18 @@
 //! A stateful symmetric NAT table that performs conversion between a client's picked proxy ip and the actual resource's IP.
 use anyhow::{Context, Result};
 use bimap::BiMap;
+use connlib_model::ResourceId;
 use ip_packet::{FailedPacket, IcmpError, IpPacket, Protocol};
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::time::{Duration, Instant};
 
-/// This stateful NAT table converts a client's proxy OP for a domain name into a real IP for the domain.
+/// This stateful NAT table converts a client's proxy IP for a domain name into a real IP for the domain.
 ///
-/// The NAT operates on tuples of "source protocol" and IP.
-/// "source protocol" here is a component from OSI-4, i.e. UDP, TCP or ICMP.
-/// NATing packets with a different protocol is not supported.
-///
-/// We need to include the L4 component because multiple DNS resources could resolve to the same IP on the Internet.
-/// Thus, purely an L3 NAT would not be sufficient as it would be impossible to map back to the proxy IP.
+/// Outbound sessions are keyed by the resource, the source Layer-4 protocol and the proxy IP.
+/// The Layer-4 value includes a UDP or TCP source port, or an ICMP echo identifier.
+/// Resource identity prevents DNS resources that share the same proxy IP and Layer-4 value from
+/// aliasing one another's NAT sessions.
 #[derive(Default, Debug)]
 pub(crate) struct NatTable {
     table: BiMap<Inside, Outside>,
@@ -24,11 +23,11 @@ pub(crate) struct NatTable {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Copy)]
-struct Inside(Protocol, IpAddr);
+struct Inside(ResourceId, Protocol, IpAddr);
 
 impl Inside {
     fn into_inner(self) -> (Protocol, IpAddr) {
-        (self.0, self.1)
+        (self.1, self.2)
     }
 }
 
@@ -54,7 +53,7 @@ impl NatTable {
     pub(crate) fn handle_timeout(&mut self, now: Instant) {
         let expired = self.state_by_inside.extract_if(.., |inside, state| {
             state
-                .remove_at(inside.0)
+                .remove_at(inside.1)
                 .is_some_and(|remove_at| now >= remove_at)
         });
 
@@ -82,16 +81,45 @@ impl NatTable {
         }
     }
 
+    pub(crate) fn expire_resource_inside_ips(
+        &mut self,
+        resource: ResourceId,
+        ips: &BTreeSet<IpAddr>,
+    ) {
+        self.expire_inside(|inside| inside.0 == resource && ips.contains(&inside.2));
+    }
+
+    pub(crate) fn expire_resource(&mut self, resource: ResourceId) {
+        self.expire_inside(|inside| inside.0 == resource);
+    }
+
+    fn expire_inside(&mut self, predicate: impl Fn(&Inside) -> bool) {
+        let expired = self
+            .state_by_inside
+            .extract_if(.., |inside, _| predicate(inside))
+            .map(|(inside, _)| inside)
+            .collect::<Vec<_>>();
+
+        for inside in expired {
+            let Some((_, outside)) = self.table.remove_by_left(&inside) else {
+                continue;
+            };
+
+            self.expired.insert(outside);
+        }
+    }
+
     pub(crate) fn translate_outgoing(
         &mut self,
         packet: &IpPacket,
         outside_dst: IpAddr,
+        resource: ResourceId,
         now: Instant,
     ) -> Result<(Protocol, IpAddr)> {
         let src = packet.source_protocol()?;
         let dst = packet.destination();
 
-        let inside = Inside(src, dst);
+        let inside = Inside(resource, src, dst);
 
         if let Some(outside) = self.table.get_by_left(&inside).copied()
             && let Some(state) = self.state_by_inside.get_mut(&inside)
@@ -136,7 +164,7 @@ impl NatTable {
         if let Some((failed_packet, icmp_error)) = packet.icmp_error()? {
             let outside = Outside(failed_packet.src_proto(), failed_packet.dst());
 
-            if let Some(Inside(inside_proto, inside_dst)) =
+            if let Some(Inside(_, inside_proto, inside_dst)) =
                 self.translate_incoming_inner(&outside, now)
             {
                 return Ok(TranslateIncomingResult::IcmpError(IcmpErrorPrototype {
@@ -341,6 +369,9 @@ mod tests {
     use ip_packet::{IpPacket, make::TcpFlags, proptest::*};
     use proptest::prelude::*;
 
+    const RESOURCE: ResourceId = ResourceId::from_u128(1);
+    const OTHER_RESOURCE: ResourceId = ResourceId::from_u128(2);
+
     #[test_strategy::proptest(ProptestConfig { max_local_rejects: 10_000, max_global_rejects: 10_000, ..ProptestConfig::default() })]
     fn translates_back_and_forth_packet(
         #[strategy(udp_or_tcp_or_icmp_packet())] packet: IpPacket,
@@ -358,8 +389,9 @@ mod tests {
         let dst = packet.destination();
 
         // Translate out
-        let (new_source_protocol, new_dst_ip) =
-            table.translate_outgoing(&packet, outside_dst, now).unwrap();
+        let (new_source_protocol, new_dst_ip) = table
+            .translate_outgoing(&packet, outside_dst, RESOURCE, now)
+            .unwrap();
 
         // Pretend we are getting a response.
         let mut response = packet.clone();
@@ -424,9 +456,11 @@ mod tests {
             .map(|(p, _)| (p.source_protocol().unwrap(), p.destination()));
 
         // Translate out
-        let new_src_p_and_dst = packets
-            .clone()
-            .map(|(p, d)| table.translate_outgoing(&p, d, Instant::now()).unwrap());
+        let new_src_p_and_dst = packets.clone().map(|(p, d)| {
+            table
+                .translate_outgoing(&p, d, RESOURCE, Instant::now())
+                .unwrap()
+        });
 
         // Pretend we are getting a response.
         for ((p, _), (new_src_p, new_d)) in packets.iter_mut().zip(new_src_p_and_dst) {
@@ -467,7 +501,9 @@ mod tests {
         let mut table = NatTable::default();
         let mut now = Instant::now();
 
-        let outside = table.translate_outgoing(&req, outside_dst, now).unwrap();
+        let outside = table
+            .translate_outgoing(&req, outside_dst, RESOURCE, now)
+            .unwrap();
 
         let mut response = req.clone();
         response.set_destination_protocol(outside.0.value());
@@ -484,7 +520,9 @@ mod tests {
 
         now += Duration::from_secs(1);
 
-        table.translate_outgoing(&rst, outside_dst, now).unwrap();
+        table
+            .translate_outgoing(&rst, outside_dst, RESOURCE, now)
+            .unwrap();
 
         now += Duration::from_secs(1);
         table.handle_timeout(now);
@@ -495,5 +533,91 @@ mod tests {
             | TranslateIncomingResult::Ok { .. }
             | TranslateIncomingResult::IcmpError(_)) => panic!("Wrong result: {result:?}"),
         };
+    }
+
+    #[test]
+    fn expired_inside_ip_uses_new_outside_destination() {
+        let now = Instant::now();
+        let client = Ipv4Addr::new(100, 64, 0, 1);
+        let proxy = Ipv4Addr::new(100, 96, 0, 1);
+        let old_destination = Ipv4Addr::new(192, 0, 2, 1);
+        let new_destination = Ipv4Addr::new(192, 0, 2, 2);
+        let packet = ip_packet::make::udp_packet(client, proxy, 1000, 2000, &[]).unwrap();
+        let mut table = NatTable::default();
+
+        let (_, destination) = table
+            .translate_outgoing(&packet, old_destination.into(), RESOURCE, now)
+            .unwrap();
+        table.expire_resource_inside_ips(RESOURCE, &BTreeSet::from([proxy.into()]));
+        let (_, refreshed_destination) = table
+            .translate_outgoing(&packet, new_destination.into(), RESOURCE, now)
+            .unwrap();
+
+        assert_eq!(destination, IpAddr::V4(old_destination));
+        assert_eq!(refreshed_destination, IpAddr::V4(new_destination));
+    }
+
+    #[test]
+    fn packet_for_expired_inside_ip_is_expired() {
+        let now = Instant::now();
+        let client = Ipv4Addr::new(100, 64, 0, 1);
+        let proxy = Ipv4Addr::new(100, 96, 0, 1);
+        let destination = Ipv4Addr::new(192, 0, 2, 1);
+        let packet = ip_packet::make::udp_packet(client, proxy, 1000, 2000, &[]).unwrap();
+        let mut table = NatTable::default();
+        let (outside_protocol, outside_destination) = table
+            .translate_outgoing(&packet, destination.into(), RESOURCE, now)
+            .unwrap();
+        let response = ip_packet::make::udp_packet(
+            outside_destination,
+            client,
+            2000,
+            outside_protocol.value(),
+            &[],
+        )
+        .unwrap();
+
+        table.expire_resource(RESOURCE);
+        let result = table.translate_incoming(&response, now).unwrap();
+
+        assert_eq!(result, TranslateIncomingResult::ExpiredNatSession);
+    }
+
+    #[test]
+    fn resources_have_distinct_sessions_for_same_inside_tuple() {
+        let now = Instant::now();
+        let client = Ipv4Addr::new(100, 64, 0, 1);
+        let proxy = Ipv4Addr::new(100, 96, 0, 1);
+        let first_destination = Ipv4Addr::new(192, 0, 2, 1);
+        let second_destination = Ipv4Addr::new(192, 0, 2, 2);
+        let refreshed_destination = Ipv4Addr::new(192, 0, 2, 3);
+        let packet = ip_packet::make::udp_packet(client, proxy, 1000, 2000, &[]).unwrap();
+        let mut table = NatTable::default();
+
+        let (_, first) = table
+            .translate_outgoing(&packet, first_destination.into(), RESOURCE, now)
+            .unwrap();
+        let (_, second) = table
+            .translate_outgoing(&packet, second_destination.into(), OTHER_RESOURCE, now)
+            .unwrap();
+        let (_, first_after_refresh) = table
+            .translate_outgoing(&packet, refreshed_destination.into(), RESOURCE, now)
+            .unwrap();
+
+        assert_eq!(first, IpAddr::V4(first_destination));
+        assert_eq!(second, IpAddr::V4(second_destination));
+        assert_eq!(first_after_refresh, IpAddr::V4(first_destination));
+
+        table.expire_resource(RESOURCE);
+
+        let (_, first_after_expiry) = table
+            .translate_outgoing(&packet, refreshed_destination.into(), RESOURCE, now)
+            .unwrap();
+        let (_, second_after_expiry) = table
+            .translate_outgoing(&packet, refreshed_destination.into(), OTHER_RESOURCE, now)
+            .unwrap();
+
+        assert_eq!(first_after_expiry, IpAddr::V4(refreshed_destination));
+        assert_eq!(second_after_expiry, IpAddr::V4(second_destination));
     }
 }


### PR DESCRIPTION
When a gateway DNS lookup failed, `handle_domain_resolved` skipped `setup_nat` and only sent an Inactive status to the client. The gateway therefore failed to install the unresolved proxy state needed to keep subsequent packets classified as DNS-resource traffic.

Treat the lookup result as an address set plus the desired status. Successful lookups install their resolved addresses and become Active. Failed lookups install an empty address set and become Inactive, preserving the proxy route while making application packets correctly unreachable.

The minimized fuzz regression replays cleanly with this change. Formatting, strict Clippy, and all 238 `tunnel-proto` tests pass.
