### PR TITLE
fix(connlib): route resolved device-pool traffic

### DIFF
--- a/rust/libs/connlib/tunnel-proto/src/client.rs
+++ b/rust/libs/connlib/tunnel-proto/src/client.rs
@@ -17,7 +17,7 @@ use crate::client::client_on_client::InboundResult;
 use crate::client::dns_cache::DnsCache;
 use crate::client::dns_config::DnsConfig;
 use crate::client::pending_authorizations::{DnsQueryForSite, PendingAuthorizations};
-use crate::client::routing::{Route, RoutingTables};
+use crate::client::routing::{ClientTarget, Route, RoutingTables};
 use crate::client::tracked_state::TrackedState;
 use crate::conn_track::Originator;
 use crate::dns::{
@@ -425,8 +425,44 @@ impl ClientState {
         domain: DomainName,
         result: Result<(Ipv4Addr, Ipv6Addr), FailReason>,
     ) {
-        self.device_stub_resolver
-            .handle_device_domain_resolved(resource_id, domain, result);
+        let outcome =
+            self.device_stub_resolver
+                .handle_device_domain_resolved(resource_id, domain, result);
+
+        match (outcome, self.resources_by_id.get(&resource_id)) {
+            (
+                device_stub_resolver::ResolutionOutcome::Resolved { ipv4, ipv6 },
+                Some(Resource::DynamicDevicePool(pool)),
+            ) => {
+                let filter = FilterEngine::new(&pool.filters);
+
+                self.routing_tables.upsert_resolved_device(
+                    ipv4.into(),
+                    resource_id,
+                    filter.clone(),
+                );
+                self.routing_tables
+                    .upsert_resolved_device(ipv6.into(), resource_id, filter);
+            }
+            (
+                device_stub_resolver::ResolutionOutcome::Resolved { .. },
+                Some(
+                    Resource::Dns(_)
+                    | Resource::Cidr(_)
+                    | Resource::Internet(_)
+                    | Resource::StaticDevicePool(_),
+                )
+                | None,
+            ) => {
+                tracing::warn!(%resource_id, "Resolved device pool domain for unknown resource");
+            }
+            (
+                device_stub_resolver::ResolutionOutcome::Ignored
+                | device_stub_resolver::ResolutionOutcome::Failed,
+                _,
+            ) => {}
+        }
+
         self.drain_device_stub_resolver_events();
     }
 
@@ -654,7 +690,7 @@ impl ClientState {
                 Some(Route::Client {
                     filter,
                     resource_id: rid,
-                    client_id: cid,
+                    target,
                 }),
             ) => {
                 // A new direct-client flow must be permitted and authorized before it is sent.
@@ -662,6 +698,19 @@ impl ClientState {
                     reply_with_icmp_prohibited(&mut self.buffered_packets, packet);
                     return Ok(());
                 }
+
+                let cid = match target {
+                    ClientTarget::Known(cid) => cid,
+                    ClientTarget::Resolved => {
+                        let Some((cid, _)) = self.clients.peer_by_ip(dst) else {
+                            pending_authorizations
+                                .on_not_authorized_device(rid, dst, packet, resources, now);
+                            return Ok(());
+                        };
+
+                        cid
+                    }
+                };
 
                 let already_authorised = self
                     .authorized_resources

--- a/rust/libs/connlib/tunnel-proto/src/client.rs
+++ b/rust/libs/connlib/tunnel-proto/src/client.rs
@@ -17,7 +17,7 @@ use crate::client::client_on_client::InboundResult;
 use crate::client::dns_cache::DnsCache;
 use crate::client::dns_config::DnsConfig;
 use crate::client::pending_authorizations::{DnsQueryForSite, PendingAuthorizations};
-use crate::client::routing::{ClientTarget, Route, RoutingTables};
+use crate::client::routing::{Route, RoutingTables};
 use crate::client::tracked_state::TrackedState;
 use crate::conn_track::Originator;
 use crate::dns::{
@@ -425,43 +425,8 @@ impl ClientState {
         domain: DomainName,
         result: Result<(Ipv4Addr, Ipv6Addr), FailReason>,
     ) {
-        let outcome =
-            self.device_stub_resolver
-                .handle_device_domain_resolved(resource_id, domain, result);
-
-        match (outcome, self.resources_by_id.get(&resource_id)) {
-            (
-                device_stub_resolver::ResolutionOutcome::Resolved { ipv4, ipv6 },
-                Some(Resource::DynamicDevicePool(pool)),
-            ) => {
-                let filter = FilterEngine::new(&pool.filters);
-
-                self.routing_tables.upsert_resolved_device(
-                    ipv4.into(),
-                    resource_id,
-                    filter.clone(),
-                );
-                self.routing_tables
-                    .upsert_resolved_device(ipv6.into(), resource_id, filter);
-            }
-            (
-                device_stub_resolver::ResolutionOutcome::Resolved { .. },
-                Some(
-                    Resource::Dns(_)
-                    | Resource::Cidr(_)
-                    | Resource::Internet(_)
-                    | Resource::StaticDevicePool(_),
-                )
-                | None,
-            ) => {
-                tracing::warn!(%resource_id, "Resolved device pool domain for unknown resource");
-            }
-            (
-                device_stub_resolver::ResolutionOutcome::Ignored
-                | device_stub_resolver::ResolutionOutcome::Failed,
-                _,
-            ) => {}
-        }
+        self.device_stub_resolver
+            .handle_device_domain_resolved(resource_id, domain, result);
 
         self.drain_device_stub_resolver_events();
     }
@@ -658,9 +623,6 @@ impl ClientState {
                 return Ok(());
             }
         };
-        let pending_authorizations = &mut self.pending_authorizations;
-        let resources = &self.resources_by_id;
-
         let route = self
             .routing_tables
             .resolve(dst, dst_proto, internet_resource);
@@ -690,7 +652,7 @@ impl ClientState {
                 Some(Route::Client {
                     filter,
                     resource_id: rid,
-                    target,
+                    client_id: cid,
                 }),
             ) => {
                 // A new direct-client flow must be permitted and authorized before it is sent.
@@ -699,39 +661,59 @@ impl ClientState {
                     return Ok(());
                 }
 
-                let cid = match target {
-                    ClientTarget::Known(cid) => cid,
-                    ClientTarget::Resolved => {
-                        let Some((cid, _)) = self.clients.peer_by_ip(dst) else {
-                            pending_authorizations
-                                .on_not_authorized_device(rid, dst, packet, resources, now);
-                            return Ok(());
-                        };
-
-                        cid
-                    }
+                let Some(packet) = Self::prepare_client_packet(
+                    packet,
+                    rid,
+                    cid,
+                    now,
+                    &self.authorized_resources,
+                    &mut self.pending_authorizations,
+                    &self.resources_by_id,
+                    &mut self.clients,
+                )?
+                else {
+                    return Ok(());
                 };
 
-                let already_authorised = self
-                    .authorized_resources
-                    .get(&rid)
-                    .is_some_and(|p| p.has_client(cid));
-
-                if !already_authorised {
-                    // Not yet authorized: Buffer + send request.
-                    pending_authorizations
-                        .on_not_authorized_device(rid, dst, packet, resources, now);
+                (packet, cid.into())
+            }
+            (
+                None,
+                None,
+                Some(Route::ResolvedDevice {
+                    filter,
+                    resource_id: rid,
+                }),
+            ) => {
+                if !filter_allows(&filter, dst_proto) {
+                    reply_with_icmp_prohibited(&mut self.buffered_packets, packet);
                     return Ok(());
                 }
 
-                let peer = self
-                    .clients
-                    .peer_by_id_mut(&cid)
-                    .with_context(|| UnroutablePacket::no_peer_state(&packet))?;
+                let Some((cid, _)) = self.clients.peer_by_ip(dst) else {
+                    self.pending_authorizations.on_not_authorized_device(
+                        rid,
+                        dst,
+                        packet,
+                        &self.resources_by_id,
+                        now,
+                    );
+                    return Ok(());
+                };
 
-                peer.record_outbound_as_originator(&packet, now);
-                flow_tracker::record_peer(cid, flow_tracker::Role::Initiator);
-                flow_tracker::record_ingest_token(peer.ingest_token(&rid));
+                let Some(packet) = Self::prepare_client_packet(
+                    packet,
+                    rid,
+                    cid,
+                    now,
+                    &self.authorized_resources,
+                    &mut self.pending_authorizations,
+                    &self.resources_by_id,
+                    &mut self.clients,
+                )?
+                else {
+                    return Ok(());
+                };
 
                 (packet, cid.into())
             }
@@ -756,7 +738,12 @@ impl ClientState {
                     .copied()
                 else {
                     // Not yet authorized: Buffer + send intent.
-                    pending_authorizations.on_not_authorized_resource(rid, packet, resources, now);
+                    self.pending_authorizations.on_not_authorized_resource(
+                        rid,
+                        packet,
+                        &self.resources_by_id,
+                        now,
+                    );
                     return Ok(());
                 };
 
@@ -801,6 +788,42 @@ impl ClientState {
         )?;
 
         Ok(())
+    }
+
+    fn prepare_client_packet(
+        packet: IpPacket,
+        resource_id: ResourceId,
+        client_id: ClientId,
+        now: Instant,
+        authorized_resources: &HashMap<ResourceId, AccessPath>,
+        pending_authorizations: &mut PendingAuthorizations,
+        resources_by_id: &BTreeMap<ResourceId, Resource>,
+        clients: &mut PeerStore<ClientId, ClientOnClient>,
+    ) -> Result<Option<IpPacket>> {
+        let already_authorised = authorized_resources
+            .get(&resource_id)
+            .is_some_and(|path| path.has_client(client_id));
+
+        if !already_authorised {
+            pending_authorizations.on_not_authorized_device(
+                resource_id,
+                packet.destination(),
+                packet,
+                resources_by_id,
+                now,
+            );
+            return Ok(None);
+        }
+
+        let peer = clients
+            .peer_by_id_mut(&client_id)
+            .with_context(|| UnroutablePacket::no_peer_state(&packet))?;
+
+        peer.record_outbound_as_originator(&packet, now);
+        flow_tracker::record_peer(client_id, flow_tracker::Role::Initiator);
+        flow_tracker::record_ingest_token(peer.ingest_token(&resource_id));
+
+        Ok(Some(packet))
     }
 
     /// Feed an internally-produced or previously-buffered IP packet through normal TUN routing
@@ -2273,6 +2296,43 @@ impl ClientState {
         }
     }
 
+    fn update_resolved_device_routes(
+        &mut self,
+        resource_id: ResourceId,
+        ipv4: Ipv4Addr,
+        ipv6: Ipv6Addr,
+    ) {
+        let filters = match self.resources_by_id.get(&resource_id) {
+            Some(Resource::DynamicDevicePool(pool)) => &pool.filters,
+            Some(Resource::Dns(_)) => {
+                tracing::warn!(%resource_id, "Resolved device for DNS resource");
+                return;
+            }
+            Some(Resource::Cidr(_)) => {
+                tracing::warn!(%resource_id, "Resolved device for CIDR resource");
+                return;
+            }
+            Some(Resource::Internet(_)) => {
+                tracing::warn!(%resource_id, "Resolved device for Internet Resource");
+                return;
+            }
+            Some(Resource::StaticDevicePool(_)) => {
+                tracing::warn!(%resource_id, "Resolved device for static device pool");
+                return;
+            }
+            None => {
+                tracing::warn!(%resource_id, "Resolved device for unknown resource");
+                return;
+            }
+        };
+        let filter = FilterEngine::new(filters);
+
+        self.routing_tables
+            .upsert_resolved_device(ipv4.into(), resource_id, filter.clone());
+        self.routing_tables
+            .upsert_resolved_device(ipv6.into(), resource_id, filter);
+    }
+
     fn drain_resource_stub_resolver_events(&mut self) {
         while let Some(resource_stub_resolver::Event::RecordsChanged(records)) =
             self.resource_stub_resolver.poll_event()
@@ -2294,6 +2354,13 @@ impl ClientState {
                             resource_id,
                             domain,
                         });
+                }
+                device_stub_resolver::Event::ResolvedDevice {
+                    resource_id,
+                    ipv4,
+                    ipv6,
+                } => {
+                    self.update_resolved_device_routes(resource_id, ipv4, ipv6);
                 }
                 device_stub_resolver::Event::SendResponse {
                     local,

--- a/rust/libs/connlib/tunnel-proto/src/client/resource.rs
+++ b/rust/libs/connlib/tunnel-proto/src/client/resource.rs
@@ -98,6 +98,7 @@ pub struct DynamicDevicePoolResource {
     pub name: String,
     /// DNS pattern for the pool (e.g. `*.devices.example.com`).
     pub address: String,
+    pub filters: Vec<Filter>,
 }
 
 impl Resource {
@@ -200,7 +201,7 @@ impl Resource {
             Resource::Cidr(r) => &r.filters,
             Resource::StaticDevicePool(r) => &r.filters,
             Resource::Internet(_) => &[],
-            Resource::DynamicDevicePool(_) => &[],
+            Resource::DynamicDevicePool(r) => &r.filters,
         }
     }
 
@@ -332,6 +333,7 @@ impl DynamicDevicePoolResource {
             id: resource.id,
             name: resource.name,
             address: resource.address,
+            filters: resource.filters,
         }
     }
 }
@@ -438,6 +440,33 @@ mod tests {
         };
 
         assert_eq!(dns.ip_stack, IpStack::Dual)
+    }
+
+    #[test]
+    fn can_deserialize_dynamic_device_pool_filters() {
+        let resource =
+            Resource::from_description(ResourceDescription::DynamicDevicePool(serde_json::json!({
+                "address": "*.devices.example.com",
+                "filters": [{
+                    "protocol": "tcp",
+                    "port_range_start": 22,
+                    "port_range_end": 22
+                }],
+                "id": "03000143-e25e-45c7-aafb-144990e57dce",
+                "name": "devices",
+                "type": "dynamic_device_pool"
+            })))
+            .unwrap();
+
+        let Resource::DynamicDevicePool(pool) = resource else {
+            panic!("Unexpected resource")
+        };
+        let [Filter::Tcp(filter)] = pool.filters.as_slice() else {
+            panic!("Unexpected filters")
+        };
+
+        assert_eq!(filter.port_range_start, 22);
+        assert_eq!(filter.port_range_end, 22);
     }
 
     #[test]

--- a/rust/libs/connlib/tunnel-proto/src/client/routing.rs
+++ b/rust/libs/connlib/tunnel-proto/src/client/routing.rs
@@ -16,13 +16,18 @@ pub(super) enum Route {
     Client {
         filter: FilterEngine,
         resource_id: ResourceId,
-        client_id: ClientId,
+        target: ClientTarget,
     },
     Gateway {
         filter: FilterEngine,
         resource_id: ResourceId,
         domain: Option<DomainName>,
     },
+}
+
+pub(super) enum ClientTarget {
+    Known(ClientId),
+    Resolved,
 }
 
 impl Route {
@@ -40,6 +45,7 @@ pub(super) struct RoutingTables {
     cidr: RoutingTable<CidrEntry>,
     dns: RoutingTable<DnsEntry>,
     client: RoutingTable<ClientEntry>,
+    resolved_device: RoutingTable<ResolvedDeviceEntry>,
 }
 
 impl RoutingTables {
@@ -54,7 +60,19 @@ impl RoutingTables {
             return Some(Route::Client {
                 filter: entry.filter,
                 resource_id: entry.resource_id,
-                client_id: entry.client_id,
+                target: ClientTarget::Known(entry.client_id),
+            });
+        }
+
+        if let Some(entry) = self
+            .resolved_device
+            .matches(destination, Ok(protocol))
+            .cloned()
+        {
+            return Some(Route::Client {
+                filter: entry.filter,
+                resource_id: entry.resource_id,
+                target: ClientTarget::Resolved,
             });
         }
 
@@ -180,10 +198,26 @@ impl RoutingTables {
         )
     }
 
+    pub(super) fn upsert_resolved_device(
+        &mut self,
+        network: IpNetwork,
+        resource_id: ResourceId,
+        filter: FilterEngine,
+    ) -> bool {
+        self.resolved_device.upsert(
+            network,
+            ResolvedDeviceEntry {
+                filter,
+                resource_id,
+            },
+        )
+    }
+
     pub(super) fn remove_by_id(&mut self, resource_id: ResourceId) {
         self.cidr.remove_by_id(resource_id);
         self.dns.remove_by_id(resource_id);
         self.client.remove_by_id(resource_id);
+        self.resolved_device.remove_by_id(resource_id);
     }
 
     pub(super) fn remove_client(
@@ -219,6 +253,22 @@ struct ClientEntry {
     filter: FilterEngine,
     resource_id: ResourceId,
     client_id: ClientId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ResolvedDeviceEntry {
+    filter: FilterEngine,
+    resource_id: ResourceId,
+}
+
+impl RouteEntry for ResolvedDeviceEntry {
+    fn filter(&self) -> &FilterEngine {
+        &self.filter
+    }
+
+    fn resource_id(&self) -> ResourceId {
+        self.resource_id
+    }
 }
 
 impl RouteEntry for ClientEntry {
@@ -289,7 +339,39 @@ mod tests {
             Some(internet_resource_id()),
         );
 
-        assert!(matches!(route, Some(Route::Client { client_id: c, .. }) if c == client_id));
+        assert!(matches!(
+            route,
+            Some(Route::Client {
+                target: ClientTarget::Known(c),
+                ..
+            }) if c == client_id
+        ));
+    }
+
+    #[test]
+    fn resolved_device_routes_to_an_unknown_client() {
+        let mut tables = RoutingTables::default();
+        let resource_id = ResourceId::from_u128(2);
+        tables.upsert_resolved_device(
+            IpNetwork::from(other_client_tun_ip()),
+            resource_id,
+            FilterEngine::PermitAll,
+        );
+
+        let route = tables.resolve(
+            other_client_tun_ip(),
+            Protocol::Tcp(80),
+            Some(internet_resource_id()),
+        );
+
+        assert!(matches!(
+            route,
+            Some(Route::Client {
+                target: ClientTarget::Resolved,
+                resource_id: rid,
+                ..
+            }) if rid == resource_id
+        ));
     }
 
     fn other_client_tun_ip() -> IpAddr {

--- a/rust/libs/connlib/tunnel-proto/src/client/routing.rs
+++ b/rust/libs/connlib/tunnel-proto/src/client/routing.rs
@@ -16,7 +16,11 @@ pub(super) enum Route {
     Client {
         filter: FilterEngine,
         resource_id: ResourceId,
-        target: ClientTarget,
+        client_id: ClientId,
+    },
+    ResolvedDevice {
+        filter: FilterEngine,
+        resource_id: ResourceId,
     },
     Gateway {
         filter: FilterEngine,
@@ -25,16 +29,13 @@ pub(super) enum Route {
     },
 }
 
-pub(super) enum ClientTarget {
-    Known(ClientId),
-    Resolved,
-}
-
 impl Route {
     #[cfg_attr(not(feature = "telemetry"), expect(dead_code))]
     pub(super) fn resource_id(&self) -> ResourceId {
         match self {
-            Self::Client { resource_id, .. } | Self::Gateway { resource_id, .. } => *resource_id,
+            Self::Client { resource_id, .. } => *resource_id,
+            Self::ResolvedDevice { resource_id, .. } => *resource_id,
+            Self::Gateway { resource_id, .. } => *resource_id,
         }
     }
 }
@@ -60,7 +61,7 @@ impl RoutingTables {
             return Some(Route::Client {
                 filter: entry.filter,
                 resource_id: entry.resource_id,
-                target: ClientTarget::Known(entry.client_id),
+                client_id: entry.client_id,
             });
         }
 
@@ -69,10 +70,9 @@ impl RoutingTables {
             .matches(destination, Ok(protocol))
             .cloned()
         {
-            return Some(Route::Client {
+            return Some(Route::ResolvedDevice {
                 filter: entry.filter,
                 resource_id: entry.resource_id,
-                target: ClientTarget::Resolved,
             });
         }
 
@@ -342,7 +342,7 @@ mod tests {
         assert!(matches!(
             route,
             Some(Route::Client {
-                target: ClientTarget::Known(c),
+                client_id: c,
                 ..
             }) if c == client_id
         ));
@@ -366,8 +366,7 @@ mod tests {
 
         assert!(matches!(
             route,
-            Some(Route::Client {
-                target: ClientTarget::Resolved,
+            Some(Route::ResolvedDevice {
                 resource_id: rid,
                 ..
             }) if rid == resource_id

--- a/rust/libs/connlib/tunnel-proto/src/dns/device_stub_resolver.rs
+++ b/rust/libs/connlib/tunnel-proto/src/dns/device_stub_resolver.rs
@@ -43,6 +43,12 @@ pub(crate) enum ResolveStrategy {
     Pending,
 }
 
+pub(crate) enum ResolutionOutcome {
+    Ignored,
+    Failed,
+    Resolved { ipv4: Ipv4Addr, ipv6: Ipv6Addr },
+}
+
 #[derive(Debug)]
 pub(crate) enum Event {
     QueryDomain {
@@ -194,7 +200,7 @@ impl DeviceStubResolver {
         resource_id: ResourceId,
         domain: DomainName,
         result: Result<(Ipv4Addr, Ipv6Addr), FailReason>,
-    ) {
+    ) -> ResolutionOutcome {
         let pending = self
             .pending
             .extract_if(|(rid, dom, _), _| *rid == resource_id && *dom == domain)
@@ -203,26 +209,26 @@ impl DeviceStubResolver {
 
         if pending.is_empty() {
             tracing::debug!(%resource_id, %domain, "Received device pool resolution for unknown query");
-            return;
+            return ResolutionOutcome::Ignored;
         }
 
         tracing::debug!(%resource_id, %domain, ?result, "Device FQDN resolved");
 
-        if let Ok((ipv4, ipv6)) = result {
+        if let Ok((ipv4, ipv6)) = &result {
             self.resolved.insert(
-                domain,
+                domain.clone(),
                 CachedResolution {
                     resource_id,
-                    ipv4,
-                    ipv6,
+                    ipv4: *ipv4,
+                    ipv6: *ipv6,
                 },
             );
         }
 
         for pending in pending {
-            let response = match result {
+            let response = match &result {
                 Ok((ipv4, ipv6)) => {
-                    build_response(&pending.query, pending.query.domain(), ipv4, ipv6)
+                    build_response(&pending.query, pending.query.domain(), *ipv4, *ipv6)
                 }
                 Err(FailReason::NotFound) => dns_types::Response::nxdomain(&pending.query),
                 Err(
@@ -243,6 +249,21 @@ impl DeviceStubResolver {
                 transport: pending.transport,
                 response,
             });
+        }
+
+        match result {
+            Ok((ipv4, ipv6)) => ResolutionOutcome::Resolved { ipv4, ipv6 },
+            Err(
+                FailReason::NotFound
+                | FailReason::Offline
+                | FailReason::VersionMismatch
+                | FailReason::Forbidden
+                | FailReason::Disabled
+                | FailReason::AmbiguousAddress
+                | FailReason::MissingAddress
+                | FailReason::InvalidAddress
+                | FailReason::Unknown,
+            ) => ResolutionOutcome::Failed,
         }
     }
 

--- a/rust/libs/connlib/tunnel-proto/src/dns/device_stub_resolver.rs
+++ b/rust/libs/connlib/tunnel-proto/src/dns/device_stub_resolver.rs
@@ -43,17 +43,16 @@ pub(crate) enum ResolveStrategy {
     Pending,
 }
 
-pub(crate) enum ResolutionOutcome {
-    Ignored,
-    Failed,
-    Resolved { ipv4: Ipv4Addr, ipv6: Ipv6Addr },
-}
-
 #[derive(Debug)]
 pub(crate) enum Event {
     QueryDomain {
         resource_id: ResourceId,
         domain: DomainName,
+    },
+    ResolvedDevice {
+        resource_id: ResourceId,
+        ipv4: Ipv4Addr,
+        ipv6: Ipv6Addr,
     },
     SendResponse {
         local: SocketAddr,
@@ -200,7 +199,7 @@ impl DeviceStubResolver {
         resource_id: ResourceId,
         domain: DomainName,
         result: Result<(Ipv4Addr, Ipv6Addr), FailReason>,
-    ) -> ResolutionOutcome {
+    ) {
         let pending = self
             .pending
             .extract_if(|(rid, dom, _), _| *rid == resource_id && *dom == domain)
@@ -209,7 +208,7 @@ impl DeviceStubResolver {
 
         if pending.is_empty() {
             tracing::debug!(%resource_id, %domain, "Received device pool resolution for unknown query");
-            return ResolutionOutcome::Ignored;
+            return;
         }
 
         tracing::debug!(%resource_id, %domain, ?result, "Device FQDN resolved");
@@ -223,6 +222,11 @@ impl DeviceStubResolver {
                     ipv6: *ipv6,
                 },
             );
+            self.events.push_back(Event::ResolvedDevice {
+                resource_id,
+                ipv4: *ipv4,
+                ipv6: *ipv6,
+            });
         }
 
         for pending in pending {
@@ -249,21 +253,6 @@ impl DeviceStubResolver {
                 transport: pending.transport,
                 response,
             });
-        }
-
-        match result {
-            Ok((ipv4, ipv6)) => ResolutionOutcome::Resolved { ipv4, ipv6 },
-            Err(
-                FailReason::NotFound
-                | FailReason::Offline
-                | FailReason::VersionMismatch
-                | FailReason::Forbidden
-                | FailReason::Disabled
-                | FailReason::AmbiguousAddress
-                | FailReason::MissingAddress
-                | FailReason::InvalidAddress
-                | FailReason::Unknown,
-            ) => ResolutionOutcome::Failed,
         }
     }
 
@@ -470,7 +459,8 @@ mod tests {
         let responses = iter::from_fn(|| resolver.poll_event())
             .filter_map(|e| match e {
                 Event::SendResponse { response, .. } => Some(response),
-                _ => None,
+                Event::QueryDomain { .. } => None,
+                Event::ResolvedDevice { .. } => None,
             })
             .collect::<Vec<_>>();
         assert_eq!(responses.len(), 2);
@@ -523,6 +513,18 @@ mod tests {
             Ok((TEST_IPV4, TEST_IPV6)),
         );
 
+        let Some(Event::ResolvedDevice {
+            resource_id,
+            ipv4,
+            ipv6,
+        }) = resolver.poll_event()
+        else {
+            panic!("expected ResolvedDevice event")
+        };
+        assert_eq!(resource_id, rid);
+        assert_eq!(ipv4, TEST_IPV4);
+        assert_eq!(ipv6, TEST_IPV6);
+
         let Some(Event::SendResponse { response, .. }) = resolver.poll_event() else {
             panic!("expected SendResponse event")
         };
@@ -552,6 +554,9 @@ mod tests {
             Ok((TEST_IPV4, TEST_IPV6)),
         );
 
+        let Some(Event::ResolvedDevice { .. }) = resolver.poll_event() else {
+            panic!("expected ResolvedDevice event")
+        };
         let Some(Event::SendResponse { response, .. }) = resolver.poll_event() else {
             panic!("expected SendResponse event")
         };
@@ -637,7 +642,7 @@ mod tests {
             POOL_DOMAIN.parse().unwrap(),
             Ok((TEST_IPV4, TEST_IPV6)),
         );
-        resolver.poll_event();
+        iter::from_fn(|| resolver.poll_event()).for_each(drop);
 
         // Repeat A query hits the cache.
         let s = resolver.handle_query(
@@ -681,7 +686,7 @@ mod tests {
             POOL_DOMAIN.parse().unwrap(),
             Ok((TEST_IPV4, TEST_IPV6)),
         );
-        resolver.poll_event();
+        iter::from_fn(|| resolver.poll_event()).for_each(drop);
 
         resolver.remove_resource(rid);
         resolver.add_resource(rid, POOL_PATTERN.to_owned());

--- a/rust/libs/connlib/tunnel-proto/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel-proto/src/messages/client.rs
@@ -101,6 +101,8 @@ pub struct ResourceDescriptionDynamicDevicePool {
     pub name: String,
     /// DNS pattern for the pool (e.g. `*.devices.example.com`).
     pub address: String,
+    #[serde(default)]
+    pub filters: Vec<Filter>,
 }
 
 /// Description of an internet resource.
@@ -1013,7 +1015,14 @@ mod tests {
                 "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
                 "type": "dynamic_device_pool",
                 "name": "Employee Laptops",
-                "address": "*.laptops.example.com"
+                "address": "*.laptops.example.com",
+                "filters": [
+                    {
+                        "protocol": "tcp",
+                        "port_range_start": 22,
+                        "port_range_end": 22
+                    }
+                ]
             }
         ]"#;
 
@@ -1030,6 +1039,13 @@ mod tests {
         let desc = ResourceDescriptionDynamicDevicePool::deserialize(json).unwrap();
         assert_eq!(desc.name, "Employee Laptops");
         assert_eq!(desc.address, "*.laptops.example.com");
+        assert_eq!(
+            desc.filters,
+            vec![Filter::Tcp(crate::messages::PortRange {
+                port_range_start: 22,
+                port_range_end: 22,
+            })]
+        );
     }
 
     #[test]

--- a/rust/libs/connlib/tunnel-proto/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel-proto/src/messages/client.rs
@@ -95,6 +95,8 @@ pub struct ResourceDescriptionDynamicDevicePool {
     pub name: String,
     /// DNS pattern for the pool (e.g. `*.devices.example.com`).
     pub address: String,
+    #[serde(default)]
+    pub filters: Vec<Filter>,
 }
 
 /// Description of an internet resource.
@@ -927,7 +929,14 @@ mod tests {
                 "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
                 "type": "dynamic_device_pool",
                 "name": "Employee Laptops",
-                "address": "*.laptops.example.com"
+                "address": "*.laptops.example.com",
+                "filters": [
+                    {
+                        "protocol": "tcp",
+                        "port_range_start": 22,
+                        "port_range_end": 22
+                    }
+                ]
             }
         ]"#;
 
@@ -944,6 +953,13 @@ mod tests {
         let desc = ResourceDescriptionDynamicDevicePool::deserialize(json).unwrap();
         assert_eq!(desc.name, "Employee Laptops");
         assert_eq!(desc.address, "*.laptops.example.com");
+        assert_eq!(
+            desc.filters,
+            vec![Filter::Tcp(crate::messages::PortRange {
+                port_range_start: 22,
+                port_range_end: 22,
+            })]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Dynamic device-pool resources were incomplete in two connected ways. Their portal-provided filters were discarded during deserialization, and a successful device-domain resolution was cached only inside `DeviceStubResolver`. No client route was installed for the returned peer tunnel IP, so the first application packet fell through as an unknown resource and could never request device authorization.

Carry dynamic-pool filters through the wire and internal resource types. After an accepted pending resolution, install a resource-scoped exact-IP route that preserves static-pool precedence, applies the dynamic-pool filter, and produces a device authorization request carrying the resolved IP. Existing resource cleanup removes these routes on edits and deletion.

The expanded fuzz model sends application traffic through resolved dynamic pools and checks both client and peer filters.