### PR TITLE
test(fuzz): exercise flow tracking

### DIFF
--- a/rust/tests/fuzz/src/sim_client.rs
+++ b/rust/tests/fuzz/src/sim_client.rs
@@ -79,10 +79,12 @@ pub(crate) struct SimClient {
 impl SimClient {
     pub(crate) fn new(
         id: ClientId,
-        sut: ClientState,
+        mut sut: ClientState,
         malicious_behaviour: MaliciousBehaviour,
         now: Instant,
     ) -> Self {
+        sut.set_flow_logs_enabled(true);
+
         Self {
             id,
             sut,
@@ -130,6 +132,7 @@ impl SimClient {
                 .to_std()
                 .unwrap(),
         );
+        self.sut.set_flow_logs_enabled(true);
 
         self.search_domain = None;
         self.dns_by_sentinel = DnsMapping::default();

--- a/rust/tests/fuzz/src/sim_gateway.rs
+++ b/rust/tests/fuzz/src/sim_gateway.rs
@@ -42,11 +42,13 @@ pub(crate) struct SimGateway {
 impl SimGateway {
     pub(crate) fn new(
         id: GatewayId,
-        sut: GatewayState,
+        mut sut: GatewayState,
         tcp_resources: BTreeSet<SocketAddr>,
         site_specific_dns_records: DnsRecords,
         now: Instant,
     ) -> Self {
+        sut.set_flow_logs_enabled(true);
+
         Self {
             id,
             sut,


### PR DESCRIPTION
The production client and gateway enable flow tracking from their portal configuration, but the simulated states never enabled it. As a result, the fuzzer exercised packet routing without running most of connlib's flow-observer path.

Enable flow tracking on every simulated client and gateway, including newly constructed client state after a restart.

For now, we don't assert on the emitted flows. This will be done later once we simulate application flows using the fuzzer.