### PR TITLE
test(fuzz): model relay presence refreshes

### DIFF
--- a/rust/tests/fuzz/src/arb/topology.rs
+++ b/rust/tests/fuzz/src/arb/topology.rs
@@ -84,7 +84,15 @@ pub(super) fn pick_site<'a>(g: &mut Generator, sites: &'a [Site]) -> &'a Site {
 pub(super) fn arb_relays(g: &mut Generator) -> BTreeMap<RelayId, Host<u64>> {
     let n = g.count(1, 2);
 
-    (0..n)
+    arb_relays_with_count(g, n)
+}
+
+pub(super) fn arb_two_relays(g: &mut Generator) -> BTreeMap<RelayId, Host<u64>> {
+    arb_relays_with_count(g, 2)
+}
+
+fn arb_relays_with_count(g: &mut Generator, count: usize) -> BTreeMap<RelayId, Host<u64>> {
+    (0..count)
         .map(|_| {
             let id = g.fresh_relay_id();
             let seed = g.u64();
@@ -93,7 +101,7 @@ pub(super) fn arb_relays(g: &mut Generator) -> BTreeMap<RelayId, Host<u64>> {
             let host = with_interface(host, Some(g.socket_ip4()), Some(g.socket_ip6()));
             (id, host)
         })
-        .collect::<BTreeMap<_, _>>()
+        .collect()
 }
 
 pub(super) fn with_interface<T>(

--- a/rust/tests/fuzz/src/arb/topology.rs
+++ b/rust/tests/fuzz/src/arb/topology.rs
@@ -84,15 +84,7 @@ pub(super) fn pick_site<'a>(g: &mut Generator, sites: &'a [Site]) -> &'a Site {
 pub(super) fn arb_relays(g: &mut Generator) -> BTreeMap<RelayId, Host<u64>> {
     let n = g.count(1, 2);
 
-    arb_relays_with_count(g, n)
-}
-
-pub(super) fn arb_two_relays(g: &mut Generator) -> BTreeMap<RelayId, Host<u64>> {
-    arb_relays_with_count(g, 2)
-}
-
-fn arb_relays_with_count(g: &mut Generator, count: usize) -> BTreeMap<RelayId, Host<u64>> {
-    (0..count)
+    (0..n)
         .map(|_| {
             let id = g.fresh_relay_id();
             let seed = g.u64();

--- a/rust/tests/fuzz/src/arb/transitions.rs
+++ b/rust/tests/fuzz/src/arb/transitions.rs
@@ -9,7 +9,7 @@ use smallvec::SmallVec;
 
 use super::context::Generator;
 use super::topology::{
-    arb_dns_record_set, arb_relays, arb_socket_ip_stack, pick_site, with_interface,
+    arb_dns_record_set, arb_relays, arb_socket_ip_stack, arb_two_relays, pick_site, with_interface,
 };
 use super::values::{
     arb_address_description, arb_cidr_resource_address, arb_compatible_upstream_do53_servers,
@@ -150,7 +150,22 @@ pub(super) fn generate(
                 portal_window,
             }
         }
-        K::DeployNewRelays => Transition::DeployNewRelays(arb_relays(g)),
+        K::DeployNewRelays => {
+            if state.relays.len() >= 2 && g.bool() {
+                let relay_id = state
+                    .relays
+                    .keys()
+                    .nth(g.choose_index(state.relays.len()))
+                    .unwrap();
+
+                Transition::UpdateRelayPresence {
+                    disconnected: [*relay_id].into_iter().collect(),
+                    connected: arb_two_relays(g),
+                }
+            } else {
+                Transition::DeployNewRelays(arb_relays(g))
+            }
+        }
         K::PartitionRelaysFromPortal => Transition::PartitionRelaysFromPortal,
         K::RebootRelaysWhilePartitioned => {
             // Reboot the *existing* relays with fresh credentials (same ids).

--- a/rust/tests/fuzz/src/arb/transitions.rs
+++ b/rust/tests/fuzz/src/arb/transitions.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::BTreeMap,
+    iter,
     time::{Duration, Instant},
 };
 
@@ -9,7 +10,7 @@ use smallvec::SmallVec;
 
 use super::context::Generator;
 use super::topology::{
-    arb_dns_record_set, arb_relays, arb_socket_ip_stack, arb_two_relays, pick_site, with_interface,
+    arb_dns_record_set, arb_relays, arb_socket_ip_stack, pick_site, with_interface,
 };
 use super::values::{
     arb_address_description, arb_cidr_resource_address, arb_compatible_upstream_do53_servers,
@@ -151,20 +152,20 @@ pub(super) fn generate(
             }
         }
         K::DeployNewRelays => {
-            if state.relays.len() >= 2 && g.bool() {
-                let relay_id = state
+            // An ICEless connection survives relay deployment changes. Retaining one relay
+            // without selecting it exercises refreshing an unmentioned live allocation.
+            let retained = if state.portal.iceless() && state.relays.len() >= 2 {
+                state
                     .relays
-                    .keys()
-                    .nth(g.choose_index(state.relays.len()))
-                    .unwrap();
-
-                Transition::UpdateRelayPresence {
-                    disconnected: [*relay_id].into_iter().collect(),
-                    connected: arb_two_relays(g),
-                }
+                    .first_key_value()
+                    .map(|(relay_id, relay)| (*relay_id, relay.clone()))
             } else {
-                Transition::DeployNewRelays(arb_relays(g))
-            }
+                None
+            };
+
+            let relays = iter::empty().chain(retained).chain(arb_relays(g)).collect();
+
+            Transition::DeployNewRelays(relays)
         }
         K::PartitionRelaysFromPortal => Transition::PartitionRelaysFromPortal,
         K::RebootRelaysWhilePartitioned => {

--- a/rust/tests/fuzz/src/arb/transitions.rs
+++ b/rust/tests/fuzz/src/arb/transitions.rs
@@ -152,13 +152,13 @@ pub(super) fn generate(
             }
         }
         K::DeployNewRelays => {
-            // An ICEless connection survives relay deployment changes. Retaining one relay
-            // without selecting it exercises refreshing an unmentioned live allocation.
+            // An ICEless connection survives relay deployment changes. Keeping one deployed
+            // relay out of `connected` exercises refreshing an unmentioned live allocation.
             let retained = if state.portal.iceless() && state.relays.len() >= 2 {
-                state
-                    .relays
-                    .first_key_value()
-                    .map(|(relay_id, relay)| (*relay_id, relay.clone()))
+                let index = g.choose_index(state.relays.len());
+                let (relay_id, relay) = state.relays.iter().nth(index).unwrap();
+
+                Some((*relay_id, relay.clone()))
             } else {
                 None
             };

--- a/rust/tests/fuzz/src/reference.rs
+++ b/rust/tests/fuzz/src/reference.rs
@@ -358,6 +358,10 @@ impl ReferenceState {
                     .exec_mut(|c| c.readd_all_resources());
             }
             Transition::DeployNewRelays(new_relays) => state.deploy_new_relays(new_relays),
+            Transition::UpdateRelayPresence {
+                disconnected,
+                connected,
+            } => state.update_relay_presence(disconnected, connected),
             Transition::RebootRelaysWhilePartitioned(new_relays) => {
                 state.deploy_new_relays(new_relays)
             }
@@ -1109,6 +1113,27 @@ impl ReferenceState {
             let added = self.network.add_host(*rid, new_relay);
             debug_assert!(added);
         }
+    }
+
+    fn update_relay_presence(
+        &mut self,
+        disconnected: &BTreeSet<RelayId>,
+        connected: &BTreeMap<RelayId, Host<u64>>,
+    ) {
+        for relay_id in disconnected {
+            let Some(relay) = self.relays.remove(relay_id) else {
+                continue;
+            };
+
+            self.network.remove_host(&relay);
+        }
+
+        for (relay_id, relay) in connected {
+            let added = self.network.add_host(*relay_id, relay);
+            debug_assert!(added);
+        }
+
+        self.relays.extend(connected.clone());
     }
 }
 

--- a/rust/tests/fuzz/src/reference.rs
+++ b/rust/tests/fuzz/src/reference.rs
@@ -358,12 +358,8 @@ impl ReferenceState {
                     .exec_mut(|c| c.readd_all_resources());
             }
             Transition::DeployNewRelays(new_relays) => state.deploy_new_relays(new_relays),
-            Transition::UpdateRelayPresence {
-                disconnected,
-                connected,
-            } => state.update_relay_presence(disconnected, connected),
             Transition::RebootRelaysWhilePartitioned(new_relays) => {
-                state.deploy_new_relays(new_relays)
+                state.reboot_relays_while_partitioned(new_relays)
             }
             Transition::Idle => {}
             Transition::PartitionRelaysFromPortal => {
@@ -1102,7 +1098,25 @@ impl ReferenceState {
     }
 
     fn deploy_new_relays(&mut self, new_relays: &BTreeMap<RelayId, Host<u64>>) {
-        // Always take down all relays because we can't know which one was sampled for the connection.
+        for (_, relay) in self
+            .relays
+            .extract_if(.., |relay_id, _| !new_relays.contains_key(relay_id))
+        {
+            self.network.remove_host(&relay);
+        }
+
+        for (rid, new_relay) in new_relays {
+            if self.relays.contains_key(rid) {
+                continue;
+            }
+
+            self.relays.insert(*rid, new_relay.clone());
+            let added = self.network.add_host(*rid, new_relay);
+            debug_assert!(added);
+        }
+    }
+
+    fn reboot_relays_while_partitioned(&mut self, new_relays: &BTreeMap<RelayId, Host<u64>>) {
         for relay in self.relays.values() {
             self.network.remove_host(relay);
         }
@@ -1113,27 +1127,6 @@ impl ReferenceState {
             let added = self.network.add_host(*rid, new_relay);
             debug_assert!(added);
         }
-    }
-
-    fn update_relay_presence(
-        &mut self,
-        disconnected: &BTreeSet<RelayId>,
-        connected: &BTreeMap<RelayId, Host<u64>>,
-    ) {
-        for relay_id in disconnected {
-            let Some(relay) = self.relays.remove(relay_id) else {
-                continue;
-            };
-
-            self.network.remove_host(&relay);
-        }
-
-        for (relay_id, relay) in connected {
-            let added = self.network.add_host(*relay_id, relay);
-            debug_assert!(added);
-        }
-
-        self.relays.extend(connected.clone());
     }
 }
 

--- a/rust/tests/fuzz/src/sut.rs
+++ b/rust/tests/fuzz/src/sut.rs
@@ -538,6 +538,10 @@ impl TunnelTest {
 
                 state.deploy_new_relays(new_relays, now, to_remove);
             }
+            Transition::UpdateRelayPresence {
+                disconnected,
+                connected,
+            } => state.update_relay_presence(disconnected, connected, now),
             Transition::Idle => {
                 const IDLE_DURATION: Duration = Duration::from_secs(6 * 60); // Ensure idling twice in a row puts us in the 10-15 minute window where TURN data channels are cooling down.
                 let cut_off = state.flux_capacitor.now::<Instant>() + IDLE_DURATION;
@@ -1458,6 +1462,49 @@ impl TunnelTest {
             gateway.exec_mut(|g| g.update_relays(to_remove.iter().copied(), online.iter(), now));
         }
         self.relays = online; // Override all relays.
+    }
+
+    fn update_relay_presence(
+        &mut self,
+        disconnected: BTreeSet<RelayId>,
+        connected: BTreeMap<RelayId, Host<u64>>,
+        now: Instant,
+    ) {
+        for relay_id in &disconnected {
+            let Some(relay) = self.relays.remove(relay_id) else {
+                continue;
+            };
+
+            self.network.remove_host(&relay);
+        }
+
+        let connected = connected
+            .into_iter()
+            .map(|(relay_id, relay)| {
+                (
+                    relay_id,
+                    relay.map(SimRelay::new, debug_span!("relay", %relay_id)),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        for (relay_id, relay) in &connected {
+            let added = self.network.add_host(*relay_id, relay);
+            debug_assert!(added);
+        }
+
+        for client in self.clients.values_mut() {
+            client.exec_mut(|client| {
+                client.update_relays(disconnected.iter().copied(), connected.iter(), now)
+            });
+        }
+        for gateway in self.gateways.values_mut() {
+            gateway.exec_mut(|gateway| {
+                gateway.update_relays(disconnected.iter().copied(), connected.iter(), now)
+            });
+        }
+
+        self.relays.extend(connected);
     }
 }
 

--- a/rust/tests/fuzz/src/sut.rs
+++ b/rust/tests/fuzz/src/sut.rs
@@ -533,15 +533,8 @@ impl TunnelTest {
                 });
             }
             Transition::DeployNewRelays(new_relays) => {
-                // If we are connected to the portal, we will learn, which ones went down, i.e. `relays_presence`.
-                let to_remove = state.relays.keys().copied().collect();
-
-                state.deploy_new_relays(new_relays, now, to_remove);
+                state.deploy_new_relays(new_relays, now);
             }
-            Transition::UpdateRelayPresence {
-                disconnected,
-                connected,
-            } => state.update_relay_presence(disconnected, connected, now),
             Transition::Idle => {
                 const IDLE_DURATION: Duration = Duration::from_secs(6 * 60); // Ensure idling twice in a row puts us in the 10-15 minute window where TURN data channels are cooling down.
                 let cut_off = state.flux_capacitor.now::<Instant>() + IDLE_DURATION;
@@ -579,9 +572,7 @@ impl TunnelTest {
             }
             Transition::RebootRelaysWhilePartitioned(new_relays) => {
                 // If we are partitioned from the portal, we will only learn which relays to use, potentially replacing existing ones.
-                let to_remove = Vec::default();
-
-                state.deploy_new_relays(new_relays, now, to_remove);
+                state.reboot_relays_while_partitioned(new_relays, now);
             }
             Transition::DeauthorizeWhileGatewayIsPartitioned(rid) => {
                 for (client_id, client) in &mut state.clients {
@@ -1433,11 +1424,51 @@ impl TunnelTest {
         response
     }
 
-    fn deploy_new_relays(
+    fn deploy_new_relays(&mut self, new_relays: BTreeMap<RelayId, Host<u64>>, now: Instant) {
+        let disconnected = self
+            .relays
+            .keys()
+            .filter(|relay_id| !new_relays.contains_key(relay_id))
+            .copied()
+            .collect::<BTreeSet<_>>();
+        let connected = new_relays
+            .into_iter()
+            .filter(|(relay_id, _)| !self.relays.contains_key(relay_id))
+            .map(|(relay_id, relay)| {
+                (
+                    relay_id,
+                    relay.map(SimRelay::new, debug_span!("relay", %relay_id)),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        for relay_id in &disconnected {
+            let relay = self.relays.remove(relay_id).unwrap();
+            self.network.remove_host(&relay);
+        }
+
+        for (relay_id, relay) in &connected {
+            let added = self.network.add_host(*relay_id, relay);
+            debug_assert!(added);
+        }
+
+        for client in self.clients.values_mut() {
+            client.exec_mut(|c| {
+                c.update_relays(disconnected.iter().copied(), connected.iter(), now);
+            });
+        }
+        for gateway in self.gateways.values_mut() {
+            gateway
+                .exec_mut(|g| g.update_relays(disconnected.iter().copied(), connected.iter(), now));
+        }
+
+        self.relays.extend(connected);
+    }
+
+    fn reboot_relays_while_partitioned(
         &mut self,
         new_relays: BTreeMap<RelayId, Host<u64>>,
         now: Instant,
-        to_remove: Vec<RelayId>,
     ) {
         for relay in self.relays.values() {
             self.network.remove_host(relay);
@@ -1454,57 +1485,12 @@ impl TunnelTest {
         }
 
         for client in self.clients.values_mut() {
-            client.exec_mut(|c| {
-                c.update_relays(to_remove.iter().copied(), online.iter(), now);
-            });
+            client.exec_mut(|c| c.update_relays(iter::empty(), online.iter(), now));
         }
         for gateway in self.gateways.values_mut() {
-            gateway.exec_mut(|g| g.update_relays(to_remove.iter().copied(), online.iter(), now));
+            gateway.exec_mut(|g| g.update_relays(iter::empty(), online.iter(), now));
         }
-        self.relays = online; // Override all relays.
-    }
-
-    fn update_relay_presence(
-        &mut self,
-        disconnected: BTreeSet<RelayId>,
-        connected: BTreeMap<RelayId, Host<u64>>,
-        now: Instant,
-    ) {
-        for relay_id in &disconnected {
-            let Some(relay) = self.relays.remove(relay_id) else {
-                continue;
-            };
-
-            self.network.remove_host(&relay);
-        }
-
-        let connected = connected
-            .into_iter()
-            .map(|(relay_id, relay)| {
-                (
-                    relay_id,
-                    relay.map(SimRelay::new, debug_span!("relay", %relay_id)),
-                )
-            })
-            .collect::<BTreeMap<_, _>>();
-
-        for (relay_id, relay) in &connected {
-            let added = self.network.add_host(*relay_id, relay);
-            debug_assert!(added);
-        }
-
-        for client in self.clients.values_mut() {
-            client.exec_mut(|client| {
-                client.update_relays(disconnected.iter().copied(), connected.iter(), now)
-            });
-        }
-        for gateway in self.gateways.values_mut() {
-            gateway.exec_mut(|gateway| {
-                gateway.update_relays(disconnected.iter().copied(), connected.iter(), now)
-            });
-        }
-
-        self.relays.extend(connected);
+        self.relays = online;
     }
 }
 

--- a/rust/tests/fuzz/src/transition.rs
+++ b/rust/tests/fuzz/src/transition.rs
@@ -96,6 +96,10 @@ pub enum Transition {
         key: PrivateKey,
     },
     DeployNewRelays(BTreeMap<RelayId, Host<u64>>),
+    UpdateRelayPresence {
+        disconnected: BTreeSet<RelayId>,
+        connected: BTreeMap<RelayId, Host<u64>>,
+    },
     PartitionRelaysFromPortal,
     Idle,
     RebootRelaysWhilePartitioned(BTreeMap<RelayId, Host<u64>>),
@@ -130,6 +134,7 @@ impl Transition {
             Transition::ReconnectPortal { .. } => false,
             Transition::RestartClient { .. } => false,
             Transition::DeployNewRelays(_) => false,
+            Transition::UpdateRelayPresence { .. } => false,
             Transition::PartitionRelaysFromPortal => false,
             Transition::Idle => false,
             Transition::RebootRelaysWhilePartitioned(_) => false,

--- a/rust/tests/fuzz/src/transition.rs
+++ b/rust/tests/fuzz/src/transition.rs
@@ -96,10 +96,6 @@ pub enum Transition {
         key: PrivateKey,
     },
     DeployNewRelays(BTreeMap<RelayId, Host<u64>>),
-    UpdateRelayPresence {
-        disconnected: BTreeSet<RelayId>,
-        connected: BTreeMap<RelayId, Host<u64>>,
-    },
     PartitionRelaysFromPortal,
     Idle,
     RebootRelaysWhilePartitioned(BTreeMap<RelayId, Host<u64>>),
@@ -134,7 +130,6 @@ impl Transition {
             Transition::ReconnectPortal { .. } => false,
             Transition::RestartClient { .. } => false,
             Transition::DeployNewRelays(_) => false,
-            Transition::UpdateRelayPresence { .. } => false,
             Transition::PartitionRelaysFromPortal => false,
             Transition::Idle => false,
             Transition::RebootRelaysWhilePartitioned(_) => false,


### PR DESCRIPTION
`DeployNewRelays` previously replaced the entire relay deployment, so the fuzzer could not exercise `Node::update_relays` only replacing a subset of relays. Prior to ICEless, removing a relay could fail a connection in certain cases and to simplify the modelling of the harness, we essentially expected all connections to fail.

With ICEless, this is no longer necessary as we will retain the WireGuard tunnel even when our assigned relay disappears.

This allows us to exercise the `Allocation::refresh` code path as part of the fuzzer, increasing our region coverage.