### PR TITLE
feat(portal): cut off a device whose certificate is revoked

### DIFF
--- a/elixir/lib/portal/crl/sync.ex
+++ b/elixir/lib/portal/crl/sync.ex
@@ -38,13 +38,15 @@ defmodule Portal.Crl.Sync do
   defp refresh(endpoint) do
     case fetch_and_verify(endpoint) do
       {:ok, crl} ->
-        {:ok, count} = Database.replace_revocations(endpoint, crl)
+        {:ok, {count, newly_revoked}} = Database.replace_revocations(endpoint, crl)
+        notify_revoked(endpoint, newly_revoked)
 
         Logger.info("Refreshed certificate revocation list",
           account_id: endpoint.account_id,
           issuer: X509.describe_name(endpoint.issuer),
           distribution_point: endpoint.distribution_point,
-          revoked_count: count
+          revoked_count: count,
+          newly_revoked_count: MapSet.size(newly_revoked)
         )
 
         {:ok, :refreshed}
@@ -61,6 +63,37 @@ defmodule Portal.Crl.Sync do
 
         {:ok, :failed}
     end
+  end
+
+  # The connect path refuses a revoked certificate, but only at the next
+  # connect. A device already holding a session would keep it until then, which
+  # for a long-lived tunnel can be days, so the sessions are cut here instead.
+  #
+  # Only serials that were not already cached are acted on: a device revoked in
+  # an earlier run cannot have reconnected attested, so re-notifying it every
+  # hour would deliver to nobody.
+  #
+  # The certificate is named in the message rather than acted on here, because
+  # the device columns record the last certificate a device ever presented, not
+  # the one the current session is riding on. Only the channel knows that, so it
+  # is left to decide whether the revocation is about it.
+  defp notify_revoked(endpoint, newly_revoked) do
+    if MapSet.size(newly_revoked) > 0 do
+      Enum.each(Database.devices_with_serials(endpoint, newly_revoked), fn device ->
+        notify(device, endpoint.issuer)
+      end)
+    end
+  end
+
+  # Delivered on the device id, which is what the channel registers under. The
+  # token would work today but not once a certificate can authenticate a user on
+  # its own, and it is written by the batched session flush so it can lag a
+  # reconnect by seconds.
+  defp notify(device, issuer) do
+    Portal.PG.deliver(
+      device.id,
+      {:certificate_revoked, issuer, device.last_attested_cert_serial}
+    )
   end
 
   # The addresses are alternates for the same list, so a transport failure moves
@@ -243,6 +276,22 @@ defmodule Portal.Crl.Sync do
         end)
 
       Safe.transact(fn ->
+        # Read before the replace so the rows this fetch adds can be told from
+        # the ones already cached. Everything is rewritten either way, so the
+        # difference is not recoverable afterwards.
+        already_revoked =
+          endpoint
+          |> partition_query()
+          |> select([r], r.serial)
+          |> Safe.unscoped()
+          |> Safe.all()
+          |> MapSet.new()
+
+        newly_revoked =
+          rows
+          |> MapSet.new(& &1.serial)
+          |> MapSet.difference(already_revoked)
+
         endpoint
         |> partition_query()
         |> Safe.unscoped()
@@ -265,8 +314,21 @@ defmodule Portal.Crl.Sync do
         |> Safe.unscoped()
         |> Safe.update_all([])
 
-        {:ok, length(rows)}
+        {:ok, {length(rows), newly_revoked}}
       end)
+    end
+
+    # Matched on the issuer as well as the serial: a serial only identifies a
+    # certificate together with whoever issued it, so a device holding the same
+    # serial from a different CA is a different certificate entirely.
+    def devices_with_serials(endpoint, serials) do
+      from(d in Portal.Device,
+        where: d.account_id == ^endpoint.account_id,
+        where: d.last_attested_cert_issuer == ^endpoint.issuer,
+        where: d.last_attested_cert_serial in ^MapSet.to_list(serials)
+      )
+      |> Safe.unscoped()
+      |> Safe.all()
     end
 
     def record_error(endpoint, reason) do

--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -576,6 +576,36 @@ defmodule PortalAPI.Client.Channel.Shared do
     handle_info(:disconnect, socket)
   end
 
+  # A CA revoked a certificate. The session is only cut if it is the one this
+  # connection actually presented: the device columns the sync job matched on
+  # record the last certificate a device ever showed, so a device that attested
+  # once and has since been connecting without a certificate would otherwise be
+  # dropped over a certificate it is not using.
+  #
+  # Its authorizations go too. The tunnel is being torn down either way, so the
+  # client has to re-authorize on its next connect regardless, and nothing else
+  # clears them when a channel stops.
+  #
+  # A reason of its own rather than "token_expired": the token is fine, and a
+  # client that knows the difference can say so instead of reporting a sign-in
+  # problem. A client that does not recognize the reason ignores the payload and
+  # still sees the socket close, so it is cut either way.
+  def handle_info({:certificate_revoked, issuer, serial}, socket) do
+    if socket.assigns[:attestation] == %{issuer: issuer, serial: serial} do
+      Logger.info("Disconnecting device: its certificate was revoked",
+        account_id: socket.assigns.client.account_id,
+        device_id: socket.assigns.client.id,
+        cert_serial: serial
+      )
+
+      Database.delete_policy_authorizations(socket.assigns.client)
+      push(socket, "disconnect", %{reason: "certificate_revoked"})
+      {:stop, :shutdown, socket}
+    else
+      {:noreply, socket}
+    end
+  end
+
   # A monitored process crashed — determine which subsystem it belongs to and recover.
   def handle_info({:DOWN, _ref, :process, pid, _reason}, socket) do
     cond do
@@ -2610,6 +2640,17 @@ defmodule PortalAPI.Client.Channel.Shared do
     import Ecto.Query, only: [from: 2]
 
     alias Portal.Features
+
+    # Nothing else clears these when a channel stops, so a cut session would
+    # otherwise leave its grants behind.
+    def delete_policy_authorizations(client) do
+      from(a in Portal.PolicyAuthorization,
+        where: a.account_id == ^client.account_id,
+        where: a.initiating_device_id == ^client.id
+      )
+      |> Portal.Safe.unscoped()
+      |> Portal.Safe.delete_all()
+    end
 
     def flow_logs_feature_enabled? do
       query = from(f in Features, where: f.feature == :flow_logs and f.enabled == true)

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -70,7 +70,7 @@ defmodule PortalAPI.Client.Socket do
       client = apply_session(client, token_id, public_key, subject, version)
       set_connect_attributes(token_id, client, subject, version)
 
-      {:ok, assign_connect(socket, subject, client, version, attested?)}
+      {:ok, assign_connect(socket, subject, client, version, attested?, proof)}
     else
       {:error, :invalid_token} ->
         OpenTelemetry.Tracer.set_status(:error, "invalid_token")
@@ -249,15 +249,26 @@ defmodule PortalAPI.Client.Socket do
     })
   end
 
-  defp assign_connect(socket, subject, client, version, attested?) do
+  defp assign_connect(socket, subject, client, version, attested?, proof) do
     socket
     |> assign(:subject, subject)
     |> assign(:client, %{client | attested?: attested?})
+    |> assign(:attestation, attestation(attested?, proof))
     |> assign(:session_ref, make_ref())
     |> assign(:client_version, version)
     |> assign(:opentelemetry_span_ctx, OpenTelemetry.Tracer.current_span_ctx())
     |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
   end
+
+  # The certificate this session is riding on, so a revocation learned later can
+  # be matched against the connection rather than against the device's history.
+  # A device that attested last week but connected without a certificate today
+  # holds nothing here, and a revocation of that old certificate leaves it alone.
+  defp attestation(true, %{} = proof) do
+    %{issuer: proof.last_attested_cert_issuer, serial: proof.last_attested_cert_serial}
+  end
+
+  defp attestation(_attested?, _proof), do: nil
 
   defp insert_changeset(actor, subject, attrs) do
     required_fields = ~w[firezone_id name]a

--- a/elixir/test/portal/crl/sync_test.exs
+++ b/elixir/test/portal/crl/sync_test.exs
@@ -5,6 +5,7 @@ defmodule Portal.Crl.SyncTest do
   import Portal.TrustAnchorFixtures
   import Portal.FeaturesFixtures
   import Portal.DeviceTrustFixtures
+  import ExUnit.CaptureLog
 
   alias Portal.Crl.Sync
   alias Portal.Crypto.X509
@@ -216,6 +217,57 @@ defmodule Portal.Crl.SyncTest do
       assert failure(endpoint) =~ "crl_issuer_mismatch"
     end
 
+    test "notifies the session of a certificate that has just been revoked", %{
+      account: account,
+      pki: pki
+    } do
+      leaf = leaf(pki, :rsa)
+      device = attested_device(account, pki, leaf)
+      endpoint = endpoint_fixture(account, pki.ca_der)
+      issuer = X509.subject(pki.ca_der)
+      serial = cert_serial_hex(leaf)
+
+      Portal.PG.register(device.id)
+      stub_crl(crl(pki.ca, revoked: [leaf]))
+
+      assert perform(endpoint) == {:ok, :refreshed}
+
+      # Named rather than acted on: the device columns record the last
+      # certificate a device ever presented, so only the session knows whether
+      # this revocation is about the certificate it is actually using.
+      assert_receive {:certificate_revoked, ^issuer, ^serial}
+    end
+
+    test "leaves a device holding the same serial from another CA alone", %{
+      account: account,
+      pki: pki
+    } do
+      leaf = leaf(pki, :rsa)
+      device = attested_device(account, pki, leaf, issuer_der: pki.untrusted_ca_der)
+      endpoint = endpoint_fixture(account, pki.ca_der)
+
+      Portal.PG.register(device.id)
+      stub_crl(crl(pki.ca, revoked: [leaf]))
+
+      assert perform(endpoint) == {:ok, :refreshed}
+      refute_receive {:certificate_revoked, _issuer, _serial}
+    end
+
+    test "does not notify again for a serial already cached", %{account: account, pki: pki} do
+      leaf = leaf(pki, :rsa)
+      device = attested_device(account, pki, leaf)
+      endpoint = endpoint_fixture(account, pki.ca_der)
+
+      stub_crl(crl(pki.ca, revoked: [leaf]))
+      assert perform(endpoint) == {:ok, :refreshed}
+
+      Portal.PG.register(device.id)
+      stub_crl(crl(pki.ca, revoked: [leaf], number: 2))
+
+      assert perform(endpoint) == {:ok, :refreshed}
+      refute_receive {:certificate_revoked, _issuer, _serial}
+    end
+
     test "does nothing when the endpoint is gone", %{account: account, pki: pki} do
       endpoint = endpoint_fixture(account, pki.ca_der)
       Repo.delete_all(Portal.RevocationEndpoint)
@@ -242,6 +294,19 @@ defmodule Portal.Crl.SyncTest do
 
     assert Repo.one!(Portal.RevocationEndpoint).crl_error
     log
+  end
+
+  defp attested_device(account, pki, leaf, attrs \\ []) do
+    issuer_der = Keyword.get(attrs, :issuer_der, pki.ca_der)
+    token = Portal.TokenFixtures.client_token_fixture(account: account)
+
+    Portal.DeviceFixtures.client_fixture(
+      account: account,
+      last_attested_cert_issuer: X509.subject(issuer_der),
+      last_attested_cert_serial: cert_serial_hex(leaf)
+    )
+    |> Ecto.Changeset.change(client_token_id: token.id)
+    |> Repo.update!()
   end
 
   defp endpoint_fixture(account, issuer_der, attrs \\ []) do

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -62,7 +62,8 @@ defmodule PortalAPI.Client.ChannelTest do
         client: device,
         session_ref: session_ref,
         subject: subject,
-        client_version: client_version
+        client_version: client_version,
+        attestation: Keyword.get(opts, :attestation)
       })
       |> subscribe_and_join(channel, "client")
 
@@ -1044,6 +1045,64 @@ defmodule PortalAPI.Client.ChannelTest do
 
       assert_push "disconnect", %{reason: "token_expired"}
       assert_receive {:EXIT, _pid, :shutdown}
+    end
+
+    test "cuts the session when its own certificate is revoked", %{
+      account: account,
+      client: client,
+      subject: subject
+    } do
+      Process.flag(:trap_exit, true)
+      attestation = %{issuer: <<"issuer-der">>, serial: "AABBCC"}
+
+      authorization =
+        Portal.PolicyAuthorizationFixtures.policy_authorization_fixture(
+          account: account,
+          client: client
+        )
+
+      socket = join_channel(client, subject, attestation: attestation)
+      assert_push "init", _init_payload
+
+      send(socket.channel_pid, {:certificate_revoked, attestation.issuer, attestation.serial})
+
+      # Distinct from "token_expired": the token is fine, and a client that
+      # knows the difference can say so rather than report a sign-in problem.
+      assert_push "disconnect", %{reason: "certificate_revoked"}
+
+      refute Repo.get_by(Portal.PolicyAuthorization,
+               account_id: account.id,
+               id: authorization.id
+             )
+    end
+
+    test "ignores a revocation of a certificate this session is not using", %{
+      client: client,
+      subject: subject
+    } do
+      # The device attested at some point, so its row carries a certificate, but
+      # this connection presented none. Revoking that certificate says nothing
+      # about a session that is not riding on it.
+      socket = join_channel(client, subject, attestation: nil)
+      assert_push "init", _init_payload
+
+      send(socket.channel_pid, {:certificate_revoked, <<"issuer-der">>, "AABBCC"})
+
+      refute_push "disconnect", %{}
+      assert Process.alive?(socket.channel_pid)
+    end
+
+    test "ignores a revocation of a superseded certificate", %{
+      client: client,
+      subject: subject
+    } do
+      socket = join_channel(client, subject, attestation: %{issuer: <<"i">>, serial: "NEW"})
+      assert_push "init", _init_payload
+
+      send(socket.channel_pid, {:certificate_revoked, <<"i">>, "OLD"})
+
+      refute_push "disconnect", %{}
+      assert Process.alive?(socket.channel_pid)
     end
 
     test "duplicate connection evicts the first client", %{

--- a/elixir/test/support/fixtures/device_fixtures.ex
+++ b/elixir/test/support/fixtures/device_fixtures.ex
@@ -142,6 +142,7 @@ defmodule Portal.DeviceFixtures do
         :last_attested_mdm_device_id,
         :last_attested_cert_serial,
         :last_attested_cert_fingerprint,
+        :last_attested_cert_issuer,
         :last_attested_at,
         :verified_at
       ])


### PR DESCRIPTION
Revoking a certificate only stopped the device the next time it tried to connect. If it was already connected, it stayed connected. For a tunnel that stays up for days, revoking a lost laptop did nothing until the laptop reconnected on its own.

Now, when we fetch a CA's revocation list and find certificates on it that we had not seen before, we cut those devices off right away. We drop the access they had been granted and tell their client to disconnect, which is the same thing the portal already does when an admin un-verifies a client.

We only act on certificates that are newly revoked. Every fetch rewrites the whole list, so without checking what was already there we would try to disconnect a laptop revoked weeks ago, every hour, forever.

Related: #14566