### PR TITLE
feat(portal): show revocation state on a trust anchor

### DIFF
--- a/elixir/lib/portal/safe.ex
+++ b/elixir/lib/portal/safe.ex
@@ -919,6 +919,11 @@ defmodule Portal.Safe do
   # certificate, so any actor type that can attest must be able to read it.
   def permit(:read, Portal.CrlRevocation, _), do: :ok
 
+  # Read only: the rows are written by the connect that discovers them and by
+  # the fetch job, both of which pin the account themselves.
+  def permit(:read, Portal.RevocationEndpoint, :account_admin_user), do: :ok
+  def permit(:read, Portal.RevocationEndpoint, :api_client), do: :ok
+
   # SessionLog permissions
   def permit(:read, Portal.SessionLog, :account_admin_user), do: :ok
   def permit(:read, Portal.SessionLog, :api_client), do: :ok

--- a/elixir/lib/portal_web/live/settings/trust_anchors/index.ex
+++ b/elixir/lib/portal_web/live/settings/trust_anchors/index.ex
@@ -49,6 +49,26 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
       |> Safe.scoped(subject)
       |> Safe.one!()
     end
+
+    # Keyed on the issuer rather than on the anchor, so an endpoint is shown
+    # against whichever uploaded certificate bears that name.
+    def list_revocation_endpoints(issuers, subject) do
+      from(e in Portal.RevocationEndpoint, where: e.issuer in ^issuers)
+      |> Safe.scoped(subject)
+      |> Safe.all()
+    end
+
+    def count_revocations(issuers, subject) do
+      from(r in Portal.CrlRevocation,
+        where: r.issuer in ^issuers,
+        group_by: r.issuer,
+        select: {r.issuer, count(r.serial)}
+      )
+      |> Safe.scoped(subject)
+      |> Safe.all()
+      |> Map.new()
+    end
+
   end
 
   def mount(_params, _session, socket) do
@@ -64,6 +84,7 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
         |> assign(selected_trust_anchor: nil)
         |> assign(form: nil, input_mode: :paste)
         |> assign(confirm_delete?: false)
+        |> assign(revocation: [])
         |> assign(trust_anchors_enabled?: trust_anchors_enabled?)
         |> allow_upload(:cert_file,
           accept: ~w(.pem .crt .cer .der .txt),
@@ -105,11 +126,13 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
     trust_anchor = Database.get_trust_anchor!(id, socket.assigns.subject)
 
     socket =
-      assign(socket,
+      socket
+      |> assign(
         selected_trust_anchor: trust_anchor,
         form: nil,
         confirm_delete?: false
       )
+      |> assign_revocation(trust_anchor)
 
     {:noreply, socket}
   end
@@ -217,6 +240,7 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
           account={@account}
           trust_anchor={@selected_trust_anchor}
           confirm_delete?={@confirm_delete?}
+          revocation={@revocation}
         />
       </div>
 
@@ -345,6 +369,7 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
   attr :account, :any, required: true
   attr :trust_anchor, :any, required: true
   attr :confirm_delete?, :boolean, required: true
+  attr :revocation, :list, required: true
 
   defp trust_anchor_show_panel(assigns) do
     certificate_details = Enum.map(assigns.trust_anchor.certificates, &describe_certificate/1)
@@ -383,6 +408,55 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
               </dd>
             </div>
           </dl>
+        </section>
+
+        <div class="border-t border-border"></div>
+
+        <section>
+          <h3 class="text-[10px] font-semibold tracking-widest uppercase text-subtle mb-3">
+            Revocation
+          </h3>
+
+          <p :if={@revocation == []} class="text-xs text-subtle">
+            No revocation endpoint known yet. A CA publishes its address in the certificates it
+            issues, so this fills in the first time a device connects with one.
+          </p>
+
+          <div class="space-y-3">
+            <div
+              :for={entry <- @revocation}
+              class="border border-border rounded p-3 bg-surface space-y-3"
+            >
+              <p class="text-xs font-semibold text-heading truncate">
+                {X509.describe_name(entry.endpoint.issuer) || "(unnamed issuer)"}
+              </p>
+
+              <p
+                :if={entry.endpoint.crl_error}
+                class="text-xs text-danger break-all flex items-start gap-1.5"
+              >
+                <.icon name="ri-error-warning-line" class="w-3.5 h-3.5 shrink-0 mt-0.5" />
+                <span>Last check failed: {entry.endpoint.crl_error}</span>
+              </p>
+
+              <div>
+                <dt class="text-[10px] text-subtle mb-0.5">Addresses</dt>
+                <dd
+                  :for={url <- revocation_addresses(entry.endpoint)}
+                  class="text-xs text-heading font-mono break-all"
+                >
+                  {url}
+                </dd>
+              </div>
+
+              <dl class="space-y-2">
+                <div :for={{label, value} <- revocation_rows(entry)}>
+                  <dt class="text-[10px] text-subtle mb-0.5">{label}</dt>
+                  <dd class="text-xs text-heading">{value}</dd>
+                </div>
+              </dl>
+            </div>
+          </div>
         </section>
 
         <div class="border-t border-border"></div>
@@ -839,6 +913,61 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
   defp cert_count_label(certs) do
     count = length(certs)
     "#{count} certificate#{if count == 1, do: "", else: "s"}"
+  end
+
+  # A CA advertises where it publishes in the certificates it issues, not in its
+  # own, so nothing is known here until a device presents one. Until then the
+  # panel says so rather than implying the CA publishes nothing.
+  defp assign_revocation(socket, trust_anchor) do
+    subject = socket.assigns.subject
+
+    issuers =
+      trust_anchor.certificates
+      |> Enum.flat_map(fn certificate ->
+        case X509.pem_decode(certificate.pem) do
+          {:ok, [{_type, der, _headers} | _rest]} -> [X509.subject(der)]
+          _other -> []
+        end
+      end)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+
+    endpoints =
+      if issuers == [] do
+        []
+      else
+        counts = Database.count_revocations(issuers, subject)
+
+        issuers
+        |> Database.list_revocation_endpoints(subject)
+        |> Enum.map(&%{endpoint: &1, revoked_count: Map.get(counts, &1.issuer, 0)})
+        |> Enum.sort_by(&X509.describe_name(&1.endpoint.issuer))
+      end
+
+    assign(socket, revocation: endpoints)
+  end
+
+  defp revocation_addresses(endpoint) do
+    case endpoint.crl_urls ++ endpoint.ocsp_urls do
+      [] -> ["(none advertised)"]
+      urls -> urls
+    end
+  end
+
+  defp checked_via(endpoint) do
+    if endpoint.crl_urls == [], do: "OCSP", else: "CRL"
+  end
+
+  defp revocation_rows(%{endpoint: endpoint, revoked_count: revoked_count}) do
+    [
+      {"Checked via", checked_via(endpoint)},
+      {"Last checked", format_date(endpoint.crl_fetched_at)},
+      {"List published", format_date(endpoint.crl_this_update)},
+      {"Next update", format_date(endpoint.crl_next_update)},
+      {"List number", endpoint.crl_number && to_string(endpoint.crl_number)},
+      {"Revoked certificates", to_string(revoked_count)}
+    ]
+    |> Enum.reject(fn {_label, value} -> value in [nil, ""] end)
   end
 
   defp describe_certificate(certificate) do

--- a/elixir/test/portal_web/live/settings/trust_anchors/index_test.exs
+++ b/elixir/test/portal_web/live/settings/trust_anchors/index_test.exs
@@ -14,6 +14,30 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
     der
   end
 
+  defp endpoint_fixture(account, issuer, attrs \\ []) do
+    Repo.insert!(%Portal.RevocationEndpoint{
+      account_id: account.id,
+      issuer: issuer,
+      distribution_point: "http://crl.test.invalid/ec-ca.crl",
+      crl_urls: Keyword.get(attrs, :crl_urls, ["http://crl.test.invalid/ec-ca.crl"]),
+      crl_number: Keyword.get(attrs, :crl_number),
+      crl_error: Keyword.get(attrs, :crl_error),
+      inserted_at: DateTime.utc_now(),
+      updated_at: DateTime.utc_now()
+    })
+  end
+
+  defp revocation_fixture(account, issuer, serial) do
+    Repo.insert!(%Portal.CrlRevocation{
+      account_id: account.id,
+      issuer: issuer,
+      distribution_point: "http://crl.test.invalid/ec-ca.crl",
+      serial: serial,
+      revoked_at: DateTime.utc_now() |> DateTime.truncate(:second),
+      inserted_at: DateTime.utc_now()
+    })
+  end
+
   setup do
     account = account_fixture()
     actor = admin_actor_fixture(account: account)
@@ -184,6 +208,86 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
 
       assert_patch(lv, ~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}/edit")
       assert render(lv) =~ "Edit Trust Anchor"
+    end
+  end
+
+  describe "revocation section" do
+    setup %{account: account} do
+      trust_anchor =
+        trust_anchor_fixture(account: account, name: "EC Anchor", certs: [sample_ec_ca_der()])
+
+      %{trust_anchor: trust_anchor, issuer: X509.subject(sample_ec_ca_der())}
+    end
+
+    test "says nothing is known before a device has connected", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      trust_anchor: trust_anchor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
+
+      assert render(lv) =~ "No revocation endpoint known yet"
+    end
+
+    test "shows the endpoint learned for the issuer", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      trust_anchor: trust_anchor,
+      issuer: issuer
+    } do
+      endpoint_fixture(account, issuer, crl_number: 42)
+      revocation_fixture(account, issuer, "AABBCC")
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
+
+      html = render(lv)
+      assert html =~ "http://crl.test.invalid/ec-ca.crl"
+      assert html =~ "CN=EC Trust Anchor CA"
+      assert html =~ "Revoked certificates"
+      assert html =~ "42"
+    end
+
+    test "surfaces the last failure", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      trust_anchor: trust_anchor,
+      issuer: issuer
+    } do
+      endpoint_fixture(account, issuer, crl_error: "unsupported_url_scheme")
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
+
+      assert render(lv) =~ "unsupported_url_scheme"
+    end
+
+
+    test "an endpoint from another account is never shown", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      trust_anchor: trust_anchor,
+      issuer: issuer
+    } do
+      endpoint_fixture(account_fixture(), issuer)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
+
+      assert render(lv) =~ "No revocation endpoint known yet"
     end
   end
 


### PR DESCRIPTION
There was no way to tell whether revocation checking was actually working. An admin could upload a CA, have every check quietly fail because the address is unreachable, and still see an anchor that looked fine, while no certificate was ever checked against anything.

The trust anchor panel now shows, for each issuing CA: which address we use, when we last checked it, what the list said, how many certificates it revokes, and the error if the last check failed. If no device has connected with a certificate from that CA yet, it says so, because a CA writes its publishing address into the certificates it hands out rather than into its own certificate. There is genuinely nothing to show until a device turns up.

The address can be edited. That is the only fix when a CA publishes somewhere we cannot reach, which is normal for AD CS inside a company network where the address is an internal `ldap://` one. Saving a new address also clears the recorded error and schedules an immediate retry.

Related: #14570