### PR TITLE
feat(portal): apply delta CRLs on top of the complete list

### DIFF
--- a/elixir/lib/portal/crl/scheduler.ex
+++ b/elixir/lib/portal/crl/scheduler.ex
@@ -7,6 +7,10 @@ defmodule Portal.Crl.Scheduler do
   partitions with an address are queued, and only once the cached list is due: a
   CRL carries its own `nextUpdate`, so refreshing before then would fetch the
   same bytes.
+
+  A partition is due once either its complete list or the delta published on top
+  of it is, because a CA commonly leaves the complete list valid for a week while
+  replacing the delta daily.
   """
   use Oban.Worker, queue: :crl_scheduler, max_attempts: 1
   alias __MODULE__.Database
@@ -36,7 +40,12 @@ defmodule Portal.Crl.Scheduler do
           on: a.id == e.account_id,
           where: e.crl_urls != [],
           where: a.is_disabled == false,
-          where: is_nil(e.crl_next_update) or e.crl_next_update <= ^due_at
+          # A failed delta leaves the partition due, so a delta that is broken
+          # rather than absent is retried instead of waiting out the complete
+          # list's own validity.
+          where:
+            is_nil(e.crl_next_update) or e.crl_next_update <= ^due_at or
+              e.delta_next_update <= ^due_at or not is_nil(e.delta_error)
         )
         |> Safe.unscoped()
         |> Safe.stream()

--- a/elixir/lib/portal/crl/sync.ex
+++ b/elixir/lib/portal/crl/sync.ex
@@ -6,6 +6,11 @@ defmodule Portal.Crl.Sync do
   worker owns every outbound request. A fetch that fails leaves the previous
   list in place: a CA that is briefly unreachable should not silently un-revoke
   the certificates it already published.
+
+  Where the complete list names a delta, that delta is fetched too and applied
+  on top of it. A complete list is only current as of its own publication, and a
+  CA that reissues it weekly while publishing a delta daily would otherwise have
+  its revocations arrive here up to a week late.
   """
   use Oban.Worker, queue: :crl_sync, max_attempts: 3
   alias Portal.Crypto.X509
@@ -36,20 +41,9 @@ defmodule Portal.Crl.Sync do
   end
 
   defp refresh(endpoint) do
-    case fetch_and_verify(endpoint) do
+    case fetch_and_verify(endpoint.crl_urls, endpoint, :base) do
       {:ok, crl} ->
-        {:ok, {count, newly_revoked}} = Database.replace_revocations(endpoint, crl)
-        notify_revoked(endpoint, newly_revoked)
-
-        Logger.info("Refreshed certificate revocation list",
-          account_id: endpoint.account_id,
-          issuer: X509.describe_name(endpoint.issuer),
-          distribution_point: endpoint.distribution_point,
-          revoked_count: count,
-          newly_revoked_count: MapSet.size(newly_revoked)
-        )
-
-        {:ok, :refreshed}
+        apply_crl(endpoint, crl)
 
       {:error, reason} ->
         Database.record_error(endpoint, reason)
@@ -64,6 +58,51 @@ defmodule Portal.Crl.Sync do
         {:ok, :failed}
     end
   end
+
+  defp apply_crl(endpoint, crl) do
+    delta = fetch_delta(endpoint, crl)
+    {:ok, {count, newly_revoked}} = Database.replace_revocations(endpoint, crl, delta)
+    notify_revoked(endpoint, newly_revoked)
+
+    Logger.info(
+      "Refreshed certificate revocation list",
+      [
+        account_id: endpoint.account_id,
+        issuer: X509.describe_name(endpoint.issuer),
+        distribution_point: endpoint.distribution_point,
+        revoked_count: count,
+        newly_revoked_count: MapSet.size(newly_revoked)
+      ] ++ delta_metadata(delta)
+    )
+
+    {:ok, :refreshed}
+  end
+
+  defp fetch_delta(_endpoint, %{freshest_urls: []}), do: :none
+
+  # A delta that cannot be fetched or read is reported back and recorded rather
+  # than failing the refresh: the complete list on its own is a correct answer,
+  # only a staler one.
+  defp fetch_delta(endpoint, crl) do
+    with {:ok, delta} <- fetch_and_verify(crl.freshest_urls, endpoint, :delta),
+         :ok <- applies_to_this_list(delta, crl) do
+      {:ok, delta}
+    end
+  end
+
+  # A delta only says what changed since the list it names, so one built on a
+  # newer list than we hold describes a starting point we do not have.
+  defp applies_to_this_list(delta, crl) do
+    cond do
+      is_nil(crl.number) -> {:error, :crl_number_missing}
+      delta.scope.base_number > crl.number -> {:error, :delta_base_too_new}
+      true -> :ok
+    end
+  end
+
+  defp delta_metadata({:ok, delta}), do: [delta_number: delta.number]
+  defp delta_metadata({:error, reason}), do: [delta_error: inspect(reason)]
+  defp delta_metadata(:none), do: []
 
   # The connect path refuses a revoked certificate, but only at the next
   # connect. A device already holding a session would keep it until then, which
@@ -100,9 +139,9 @@ defmodule Portal.Crl.Sync do
   # on to the next while anything the list itself says about its contents is
   # final. Retrying a rejected list at another address would only fetch the same
   # bytes again.
-  defp fetch_and_verify(endpoint) do
-    Enum.reduce_while(endpoint.crl_urls, {:error, :no_crl_url}, fn url, _last ->
-      url |> fetch_one(endpoint) |> next_or_stop()
+  defp fetch_and_verify(urls, endpoint, kind) do
+    Enum.reduce_while(urls, {:error, :no_crl_url}, fn url, _last ->
+      url |> fetch_one(endpoint, kind) |> next_or_stop()
     end)
   end
 
@@ -125,13 +164,13 @@ defmodule Portal.Crl.Sync do
   defp address_fault?(reason) when is_binary(reason), do: true
   defp address_fault?(_reason), do: false
 
-  defp fetch_one(url, endpoint) do
+  defp fetch_one(url, endpoint, kind) do
     with :ok <- supported_scheme(url),
          {:ok, der} <- fetch(url),
          :ok <- issued_by_expected_ca(der, endpoint),
          :ok <- verify_signature(der, endpoint),
          {:ok, crl} <- decode(der),
-         :ok <- covers_this_partition(crl, url) do
+         :ok <- covers_this_partition(crl, url, endpoint, kind) do
       {:ok, crl}
     end
   end
@@ -209,7 +248,7 @@ defmodule Portal.Crl.Sync do
   # that genuinely exclude our leaves are rejected, and where the extension names
   # a distribution point it has to be the one we followed, or we would cache
   # another partition's serials under this one.
-  defp covers_this_partition(crl, url) do
+  defp covers_this_partition(crl, url, _endpoint, :base) do
     cond do
       crl.scope.delta? ->
         {:error, :crl_is_delta}
@@ -217,12 +256,36 @@ defmodule Portal.Crl.Sync do
       crl.scope.excludes != [] ->
         {:error, {:crl_excludes, crl.scope.excludes}}
 
-      crl.scope.distribution_points != [] and url not in crl.scope.distribution_points ->
+      not names_partition?(crl, [url]) ->
         {:error, :crl_wrong_partition}
 
       true ->
         :ok
     end
+  end
+
+  # RFC 5280 5.2.5 has a delta repeat the Issuing Distribution Point of the list
+  # it applies to, so the address the extension names is that list's rather than
+  # the delta's own, and either is accepted.
+  defp covers_this_partition(crl, url, endpoint, :delta) do
+    cond do
+      is_nil(crl.scope.base_number) ->
+        {:error, :crl_not_delta}
+
+      crl.scope.excludes != [] ->
+        {:error, {:crl_excludes, crl.scope.excludes}}
+
+      not names_partition?(crl, [url, endpoint.distribution_point]) ->
+        {:error, :crl_wrong_partition}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp names_partition?(crl, urls) do
+    crl.scope.distribution_points == [] or
+      Enum.any?(urls, &(&1 in crl.scope.distribution_points))
   end
 
   defp request_opts, do: Portal.Config.fetch_env!(:portal, __MODULE__)[:req_opts] || []
@@ -231,6 +294,8 @@ defmodule Portal.Crl.Sync do
     import Ecto.Query
     alias Portal.Crypto.X509
     alias Portal.Safe
+
+    @remove_from_crl "removeFromCRL"
 
     def fetch_endpoint(account_id, issuer, distribution_point) do
       from(e in Portal.RevocationEndpoint,
@@ -256,14 +321,17 @@ defmodule Portal.Crl.Sync do
       |> Enum.flat_map(&decode_pem/1)
     end
 
-    # The published list is the whole truth for its issuer, so the previous set
-    # is replaced rather than merged: a serial the CA drops stops being
-    # revoked, and one it adds starts.
-    def replace_revocations(endpoint, crl) do
+    # The published list is the whole truth for its issuer as of its own
+    # publication, so the previous set is replaced rather than merged: a serial
+    # the CA drops stops being revoked, and one it adds starts. What the delta
+    # published since then is then applied on top.
+    def replace_revocations(endpoint, crl, delta) do
       now = DateTime.utc_now()
 
       rows =
-        Enum.map(crl.revocations, fn revocation ->
+        crl
+        |> merge_delta(delta)
+        |> Enum.map(fn revocation ->
           %{
             account_id: endpoint.account_id,
             issuer: endpoint.issuer,
@@ -301,18 +369,8 @@ defmodule Portal.Crl.Sync do
 
         endpoint
         |> endpoint_query()
-        |> update(
-          set: [
-            crl_number: ^crl.number,
-            crl_this_update: ^crl.this_update,
-            crl_next_update: ^crl.next_update,
-            crl_fetched_at: ^now,
-            crl_error: nil,
-            updated_at: ^now
-          ]
-        )
         |> Safe.unscoped()
-        |> Safe.update_all([])
+        |> Safe.update_all(set: crl_fields(crl, now) ++ delta_fields(delta, now))
 
         {:ok, {length(rows), newly_revoked}}
       end)
@@ -341,6 +399,70 @@ defmodule Portal.Crl.Sync do
       )
       |> Safe.unscoped()
       |> Safe.update_all([])
+    end
+
+    defp merge_delta(crl, delta) do
+      crl.revocations
+      |> Map.new(&{&1.serial, &1})
+      |> apply_delta(delta)
+      |> Map.values()
+    end
+
+    defp apply_delta(revocations, {:ok, delta}) do
+      Enum.reduce(delta.revocations, revocations, &apply_delta_entry/2)
+    end
+
+    defp apply_delta(revocations, _delta), do: revocations
+
+    # CRLReason 8, removeFromCRL, is a delta saying a certificate is revoked no
+    # longer, and is the one entry that takes a serial out of the set instead of
+    # putting one in.
+    defp apply_delta_entry(%{reason: @remove_from_crl} = revocation, revocations) do
+      Map.delete(revocations, revocation.serial)
+    end
+
+    defp apply_delta_entry(revocation, revocations) do
+      Map.put(revocations, revocation.serial, revocation)
+    end
+
+    defp crl_fields(crl, now) do
+      [
+        crl_number: crl.number,
+        crl_this_update: crl.this_update,
+        crl_next_update: crl.next_update,
+        crl_fetched_at: now,
+        crl_error: nil,
+        updated_at: now
+      ]
+    end
+
+    defp delta_fields({:ok, delta}, now) do
+      [
+        delta_number: delta.number,
+        delta_this_update: delta.this_update,
+        delta_next_update: delta.next_update,
+        delta_fetched_at: now,
+        delta_error: nil
+      ]
+    end
+
+    # Only the attempt is recorded. The freshness columns keep describing the
+    # last delta that was read, and the error is what says the cache is standing
+    # on the complete list alone.
+    defp delta_fields({:error, reason}, now) do
+      [delta_fetched_at: now, delta_error: to_message(reason)]
+    end
+
+    # The list named no delta, so anything recorded for one is about a list this
+    # CA no longer publishes.
+    defp delta_fields(:none, _now) do
+      [
+        delta_number: nil,
+        delta_this_update: nil,
+        delta_next_update: nil,
+        delta_fetched_at: nil,
+        delta_error: nil
+      ]
     end
 
     # Scoped to one partition: replacing every row for the issuer would wipe the

--- a/elixir/lib/portal/crypto/x509.ex
+++ b/elixir/lib/portal/crypto/x509.ex
@@ -26,6 +26,9 @@ defmodule Portal.Crypto.X509 do
   @issuing_distribution_point_oid {2, 5, 29, 28}
   @delta_crl_indicator_oid {2, 5, 29, 27}
 
+  # Where a complete CRL says its delta is published.
+  @freshest_crl_oid {2, 5, 29, 46}
+
   # Other extensions surfaced for certificate debugging.
   @extended_key_usage_oid {2, 5, 29, 37}
   @subject_key_identifier_oid {2, 5, 29, 14}
@@ -818,6 +821,7 @@ defmodule Portal.Crypto.X509 do
              next_update: DateTime.t() | nil,
              number: integer() | nil,
              scope: map(),
+             freshest_urls: [String.t()],
              revocations: [map()]
            }}
           | {:error, :invalid}
@@ -853,25 +857,24 @@ defmodule Portal.Crypto.X509 do
     %{
       this_update: decode_time(this_update),
       next_update: decode_time(next_update),
-      number: crl_number(extensions),
+      number: extension_integer(extensions, @crl_number_oid, :CRLNumber),
       scope: crl_scope(extensions),
+      freshest_urls: freshest_crl_urls(extensions),
       revocations: crl_revocations(revoked)
     }
   end
 
-  defp crl_number(:asn1_NOVALUE), do: nil
-
-  defp crl_number(extensions) do
-    case find_extension(extensions, @crl_number_oid) do
-      {:Extension, @crl_number_oid, _critical, value} -> decode_crl_number(value)
+  defp extension_integer(extensions, oid, type) do
+    case find_extension(extensions, oid) do
+      {:Extension, ^oid, _critical, value} -> decode_integer(type, value)
       _other -> nil
     end
   end
 
-  defp decode_crl_number(value) when is_integer(value), do: value
+  defp decode_integer(_type, value) when is_integer(value), do: value
 
-  defp decode_crl_number(value) when is_binary(value) do
-    case :public_key.der_decode(:CRLNumber, value) do
+  defp decode_integer(type, value) when is_binary(value) do
+    case :public_key.der_decode(type, value) do
       number when is_integer(number) -> number
       _other -> nil
     end
@@ -879,7 +882,26 @@ defmodule Portal.Crypto.X509 do
     _error -> nil
   end
 
-  defp decode_crl_number(_other), do: nil
+  defp decode_integer(_type, _value), do: nil
+
+  # A delta names its own address nowhere; only the complete list it belongs to
+  # says where it is published, in the same shape as CRL Distribution Points.
+  defp freshest_crl_urls(extensions) do
+    case find_extension(extensions, @freshest_crl_oid) do
+      {:Extension, @freshest_crl_oid, _critical, value} -> decode_freshest_crl(value)
+      _other -> []
+    end
+  end
+
+  defp decode_freshest_crl(value) when is_binary(value) do
+    :FreshestCRL
+    |> :public_key.der_decode(value)
+    |> Enum.flat_map(&extract_crl_urls/1)
+  rescue
+    _error -> []
+  end
+
+  defp decode_freshest_crl(_other), do: []
 
   # What a CRL says about its own coverage. An Issuing Distribution Point does
   # not by itself mean the list is incomplete: a CA may stamp one on a complete
@@ -888,17 +910,26 @@ defmodule Portal.Crypto.X509 do
   #
   # `only_user_certs?` is deliberately absent: in X.509 a "user certificate" is
   # any end-entity certificate, which is exactly what devices hold.
-  defp crl_scope(:asn1_NOVALUE), do: %{delta?: false, excludes: [], distribution_points: []}
+  #
+  # `delta?` is the presence of the Delta CRL Indicator while `base_number` is
+  # the number it carries, so a list whose indicator cannot be read is still
+  # known to be a delta rather than being taken for a complete list.
+  defp crl_scope(:asn1_NOVALUE) do
+    %{delta?: false, base_number: nil, excludes: [], distribution_points: []}
+  end
 
   defp crl_scope(extensions) do
-    delta? = not is_nil(find_extension(extensions, @delta_crl_indicator_oid))
+    delta = %{
+      delta?: not is_nil(find_extension(extensions, @delta_crl_indicator_oid)),
+      base_number: extension_integer(extensions, @delta_crl_indicator_oid, :BaseCRLNumber)
+    }
 
     case find_extension(extensions, @issuing_distribution_point_oid) do
       {:Extension, @issuing_distribution_point_oid, _critical, value} ->
-        value |> decode_issuing_distribution_point() |> Map.put(:delta?, delta?)
+        value |> decode_issuing_distribution_point() |> Map.merge(delta)
 
       _other ->
-        %{delta?: delta?, excludes: [], distribution_points: []}
+        Map.merge(delta, %{excludes: [], distribution_points: []})
     end
   end
 

--- a/elixir/lib/portal/revocation_endpoint.ex
+++ b/elixir/lib/portal/revocation_endpoint.ex
@@ -40,6 +40,11 @@ defmodule Portal.RevocationEndpoint do
           crl_next_update: DateTime.t() | nil,
           crl_fetched_at: DateTime.t() | nil,
           crl_error: String.t() | nil,
+          delta_number: integer() | nil,
+          delta_this_update: DateTime.t() | nil,
+          delta_next_update: DateTime.t() | nil,
+          delta_fetched_at: DateTime.t() | nil,
+          delta_error: String.t() | nil,
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
@@ -60,6 +65,15 @@ defmodule Portal.RevocationEndpoint do
     field :crl_fetched_at, :utc_datetime_usec
     field :crl_error, :string
 
+    # The delta published on top of the list above, tracked separately because a
+    # CA commonly leaves the complete list valid for a week while replacing the
+    # delta daily.
+    field :delta_number, :integer
+    field :delta_this_update, :utc_datetime
+    field :delta_next_update, :utc_datetime
+    field :delta_fetched_at, :utc_datetime_usec
+    field :delta_error, :string
+
     timestamps()
   end
 
@@ -71,6 +85,7 @@ defmodule Portal.RevocationEndpoint do
     |> validate_urls(:crl_urls)
     |> validate_urls(:ocsp_urls)
     |> validate_length(:crl_error, max: 255)
+    |> validate_length(:delta_error, max: 255)
     |> assoc_constraint(:account)
   end
 

--- a/elixir/priv/repo/migrations/20260807130000_add_crl_revocation.exs
+++ b/elixir/priv/repo/migrations/20260807130000_add_crl_revocation.exs
@@ -40,6 +40,12 @@ defmodule Portal.Repo.Migrations.AddCrlRevocation do
 
   Serials are stored uppercase hex, matching `devices.last_attested_cert_serial`,
   so the two compare directly.
+
+  A CA may publish a delta alongside its complete list, naming it from the
+  complete list's Freshest CRL extension, and typically republishes the delta far
+  more often. The delta's own freshness is tracked in its own columns, because a
+  complete list that is still inside its own validity says nothing about whether
+  the delta on top of it has since been replaced.
   """
   use Ecto.Migration
 
@@ -72,6 +78,12 @@ defmodule Portal.Repo.Migrations.AddCrlRevocation do
       add(:crl_next_update, :timestamptz)
       add(:crl_fetched_at, :timestamptz)
       add(:crl_error, :string)
+
+      add(:delta_number, :bigint)
+      add(:delta_this_update, :timestamptz)
+      add(:delta_next_update, :timestamptz)
+      add(:delta_fetched_at, :timestamptz)
+      add(:delta_error, :string)
 
       timestamps()
     end

--- a/elixir/test/portal/crl/scheduler_test.exs
+++ b/elixir/test/portal/crl/scheduler_test.exs
@@ -31,6 +31,28 @@ defmodule Portal.Crl.SchedulerTest do
       assert all_sync_jobs() == []
     end
 
+    test "queues an issuer whose delta is due while its list is not", %{
+      account: account,
+      pki: pki
+    } do
+      # A CA that reissues its list weekly while replacing the delta daily would
+      # otherwise have a week of revocations wait on the list's own schedule.
+      endpoint_fixture(account, pki.ca_der,
+        crl_next_update: in_days(7),
+        delta_next_update: in_days(-1)
+      )
+
+      assert Scheduler.perform(%Oban.Job{}) == {:ok, :scheduled}
+      assert [_job] = all_sync_jobs()
+    end
+
+    test "queues an issuer whose last delta check failed", %{account: account, pki: pki} do
+      endpoint_fixture(account, pki.ca_der, crl_next_update: in_days(7), delta_error: "boom")
+
+      assert Scheduler.perform(%Oban.Job{}) == {:ok, :scheduled}
+      assert [_job] = all_sync_jobs()
+    end
+
     test "skips an issuer with no CRL address", %{account: account, pki: pki} do
       endpoint_fixture(account, pki.ca_der, crl_urls: [])
 
@@ -61,8 +83,14 @@ defmodule Portal.Crl.SchedulerTest do
       distribution_point: List.first(crl_urls) || "http://crl.example.test/ca.crl",
       crl_urls: crl_urls,
       crl_next_update: Keyword.get(attrs, :crl_next_update),
+      delta_next_update: Keyword.get(attrs, :delta_next_update),
+      delta_error: Keyword.get(attrs, :delta_error),
       inserted_at: DateTime.utc_now(),
       updated_at: DateTime.utc_now()
     })
+  end
+
+  defp in_days(days) do
+    DateTime.utc_now() |> DateTime.add(days, :day) |> DateTime.truncate(:second)
   end
 end

--- a/elixir/test/portal/crl/sync_test.exs
+++ b/elixir/test/portal/crl/sync_test.exs
@@ -12,6 +12,7 @@ defmodule Portal.Crl.SyncTest do
 
   @crl_url "http://crl.example.test/ca.crl"
   @mirror_url "http://mirror.example.test/ca.crl"
+  @delta_url "http://crl.example.test/delta.crl"
 
   setup do
     account = account_fixture()
@@ -268,6 +269,151 @@ defmodule Portal.Crl.SyncTest do
       refute_receive {:certificate_revoked, _issuer, _serial}
     end
 
+    test "applies the delta on top of the complete list", %{account: account, pki: pki} do
+      on_list = leaf(pki, :rsa)
+      on_delta = leaf(pki, :ec)
+      endpoint = endpoint_fixture(account, pki.ca_der)
+
+      stub_paths(%{
+        "/ca.crl" => crl(pki.ca, revoked: [on_list], number: 9, freshest: @delta_url),
+        "/delta.crl" => crl(pki.ca, revoked: [on_delta], number: 10, delta: 9)
+      })
+
+      assert perform(endpoint) == {:ok, :refreshed}
+
+      assert revoked_serials() ==
+               MapSet.new([cert_serial_hex(on_list), cert_serial_hex(on_delta)])
+
+      refreshed = Repo.one!(Portal.RevocationEndpoint)
+      assert refreshed.delta_number == 10
+      assert refreshed.delta_next_update
+      assert is_nil(refreshed.delta_error)
+    end
+
+    test "un-revokes a certificate the delta takes off the list", %{account: account, pki: pki} do
+      released = leaf(pki, :rsa)
+      still_revoked = leaf(pki, :ec)
+      endpoint = endpoint_fixture(account, pki.ca_der)
+
+      stub_paths(%{
+        "/ca.crl" =>
+          crl(pki.ca, revoked: [released, still_revoked], number: 9, freshest: @delta_url),
+        "/delta.crl" => crl(pki.ca, removed: [released], number: 10, delta: 9)
+      })
+
+      assert perform(endpoint) == {:ok, :refreshed}
+
+      # CRLReason removeFromCRL says the certificate is revoked no longer, so
+      # the serial has to leave the cache rather than be listed with a reason.
+      assert revoked_serials() == MapSet.new([cert_serial_hex(still_revoked)])
+    end
+
+    test "accepts a delta scoped to the address of the list it applies to", %{
+      account: account,
+      pki: pki
+    } do
+      on_delta = leaf(pki, :ec)
+      endpoint = endpoint_fixture(account, pki.ca_der)
+
+      stub_paths(%{
+        "/ca.crl" => crl(pki.ca, number: 9, freshest: @delta_url),
+        "/delta.crl" =>
+          crl(pki.ca,
+            revoked: [on_delta],
+            number: 10,
+            delta: 9,
+            idp: [distribution_point: @crl_url]
+          )
+      })
+
+      assert perform(endpoint) == {:ok, :refreshed}
+      assert revoked_serials() == MapSet.new([cert_serial_hex(on_delta)])
+    end
+
+    test "refuses a delta built on a newer list than the one it was served with", %{
+      account: account,
+      pki: pki
+    } do
+      on_list = leaf(pki, :rsa)
+      on_delta = leaf(pki, :ec)
+      endpoint = endpoint_fixture(account, pki.ca_der)
+
+      stub_paths(%{
+        "/ca.crl" => crl(pki.ca, revoked: [on_list], number: 9, freshest: @delta_url),
+        "/delta.crl" => crl(pki.ca, revoked: [on_delta], number: 11, delta: 10)
+      })
+
+      assert perform(endpoint) == {:ok, :refreshed}
+
+      assert revoked_serials() == MapSet.new([cert_serial_hex(on_list)])
+      assert Repo.one!(Portal.RevocationEndpoint).delta_error =~ "delta_base_too_new"
+    end
+
+    test "refuses a complete list served at the delta's address", %{account: account, pki: pki} do
+      on_list = leaf(pki, :rsa)
+      endpoint = endpoint_fixture(account, pki.ca_der)
+
+      stub_paths(%{
+        "/ca.crl" => crl(pki.ca, revoked: [on_list], number: 9, freshest: @delta_url),
+        "/delta.crl" => crl(pki.ca, revoked: [leaf(pki, :ec)], number: 10)
+      })
+
+      assert perform(endpoint) == {:ok, :refreshed}
+
+      assert revoked_serials() == MapSet.new([cert_serial_hex(on_list)])
+      assert Repo.one!(Portal.RevocationEndpoint).delta_error =~ "crl_not_delta"
+    end
+
+    test "refuses a delta served at the complete list's address", %{account: account, pki: pki} do
+      endpoint = endpoint_fixture(account, pki.ca_der)
+      stub_crl(crl(pki.ca, revoked: [leaf(pki, :rsa)], delta: 1))
+
+      # A delta lists only what changed, so caching it as the whole set would
+      # drop every serial the complete list carries.
+      assert failure(endpoint) =~ "crl_is_delta"
+      assert Repo.all(Portal.CrlRevocation) == []
+    end
+
+    test "keeps the complete list when the delta cannot be fetched", %{
+      account: account,
+      pki: pki
+    } do
+      on_list = leaf(pki, :rsa)
+      endpoint = endpoint_fixture(account, pki.ca_der)
+
+      stub_paths(%{"/ca.crl" => crl(pki.ca, revoked: [on_list], number: 9, freshest: @delta_url)})
+
+      assert perform(endpoint) == {:ok, :refreshed}
+
+      assert revoked_serials() == MapSet.new([cert_serial_hex(on_list)])
+
+      refreshed = Repo.one!(Portal.RevocationEndpoint)
+      assert refreshed.delta_error =~ "connection refused"
+      assert is_nil(refreshed.crl_error)
+      assert refreshed.crl_number == 9
+    end
+
+    test "forgets the delta once the list stops naming one", %{account: account, pki: pki} do
+      endpoint = endpoint_fixture(account, pki.ca_der)
+
+      stub_paths(%{
+        "/ca.crl" => crl(pki.ca, number: 9, freshest: @delta_url),
+        "/delta.crl" => crl(pki.ca, revoked: [leaf(pki, :ec)], number: 10, delta: 9)
+      })
+
+      assert perform(endpoint) == {:ok, :refreshed}
+      assert Repo.one!(Portal.RevocationEndpoint).delta_number == 10
+
+      stub_paths(%{"/ca.crl" => crl(pki.ca, number: 11)})
+
+      assert perform(endpoint) == {:ok, :refreshed}
+
+      refreshed = Repo.one!(Portal.RevocationEndpoint)
+      assert is_nil(refreshed.delta_number)
+      assert is_nil(refreshed.delta_next_update)
+      assert is_nil(refreshed.delta_error)
+    end
+
     test "does nothing when the endpoint is gone", %{account: account, pki: pki} do
       endpoint = endpoint_fixture(account, pki.ca_der)
       Repo.delete_all(Portal.RevocationEndpoint)
@@ -325,6 +471,21 @@ defmodule Portal.Crl.SyncTest do
 
   defp stub_crl(body) do
     Req.Test.stub(Sync, fn conn -> Plug.Conn.send_resp(conn, 200, body) end)
+  end
+
+  # A CA serves its complete list and the delta on top of it from the same host,
+  # so the two are told apart by path.
+  defp stub_paths(bodies) do
+    Req.Test.stub(Sync, fn conn ->
+      case Map.fetch(bodies, conn.request_path) do
+        {:ok, body} -> Plug.Conn.send_resp(conn, 200, body)
+        :error -> Req.Test.transport_error(conn, :econnrefused)
+      end
+    end)
+  end
+
+  defp revoked_serials do
+    Portal.CrlRevocation |> Repo.all() |> MapSet.new(& &1.serial)
   end
 
   defp cert_serial_hex(der) do

--- a/elixir/test/support/fixtures/device_trust_fixtures.ex
+++ b/elixir/test/support/fixtures/device_trust_fixtures.ex
@@ -149,18 +149,21 @@ defmodule Portal.DeviceTrustFixtures do
   or `pki.untrusted_ca`).
 
   Options: `:revoked` (list of certificate DERs whose serials go on the list),
-  `:number`, `:validity` in days as `{from, to}`, `:delta` to stamp a Delta CRL
-  Indicator, and `:idp` (a keyword list of `:distribution_point`,
-  `:only_ca_certs`, `:indirect`) to stamp an Issuing Distribution Point.
+  `:removed` (list of certificate DERs listed with CRLReason `removeFromCRL`),
+  `:number`, `:validity` in days as `{from, to}`, `:delta` (the base CRL number
+  the list applies to, stamped as a Delta CRL Indicator), `:freshest` (one URL
+  or a list of them, stamped as a Freshest CRL extension), and `:idp` (a keyword
+  list of `:distribution_point`, `:only_ca_certs`, `:indirect`) to stamp an
+  Issuing Distribution Point.
   """
   def crl(issuer, opts \\ []) do
     {from_days, to_days} = Keyword.get(opts, :validity, {-1, 7})
     now = DateTime.utc_now()
 
     revoked =
-      case Keyword.get(opts, :revoked, []) do
+      case revoked_entries(opts, now) do
         [] -> :asn1_NOVALUE
-        certs -> Enum.map(certs, &revoked_entry(&1, now))
+        entries -> entries
       end
 
     extensions =
@@ -178,10 +181,19 @@ defmodule Portal.DeviceTrustFixtures do
                :public_key.der_encode(:IssuingDistributionPoint, issuing_distribution_point(idp))}
             ]
         end ++
-        if Keyword.get(opts, :delta, false) do
-          [{:Extension, {2, 5, 29, 27}, true, :public_key.der_encode(:BaseCRLNumber, 1)}]
-        else
-          []
+        case Keyword.get(opts, :delta) do
+          nil ->
+            []
+
+          base_number ->
+            [
+              {:Extension, {2, 5, 29, 27}, true,
+               :public_key.der_encode(:BaseCRLNumber, base_number)}
+            ]
+        end ++
+        case Keyword.get(opts, :freshest) do
+          nil -> []
+          urls -> [{:Extension, {2, 5, 29, 46}, false, freshest_crl(urls)}]
         end
 
     algorithm = {:AlgorithmIdentifier, @ecdsa_sha256_oid, :asn1_NOVALUE}
@@ -194,6 +206,29 @@ defmodule Portal.DeviceTrustFixtures do
     signature = :public_key.sign(:public_key.der_encode(:TBSCertList, tbs), :sha256, issuer.key)
 
     :public_key.der_encode(:CertificateList, {:CertificateList, tbs, algorithm, signature})
+  end
+
+  defp freshest_crl(urls) do
+    urls
+    |> List.wrap()
+    |> Enum.map(
+      &{:DistributionPoint, {:fullName, [{:uniformResourceIdentifier, String.to_charlist(&1)}]},
+       :asn1_NOVALUE, :asn1_NOVALUE}
+    )
+    |> then(&:public_key.der_encode(:FreshestCRL, &1))
+  end
+
+  defp revoked_entries(opts, now) do
+    revoked = Enum.map(Keyword.get(opts, :revoked, []), &revoked_entry(&1, now, :asn1_NOVALUE))
+
+    removed =
+      Enum.map(Keyword.get(opts, :removed, []), &revoked_entry(&1, now, [crl_reason_extension()]))
+
+    revoked ++ removed
+  end
+
+  defp crl_reason_extension do
+    {:Extension, {2, 5, 29, 21}, false, :public_key.der_encode(:CRLReason, :removeFromCRL)}
   end
 
   defp issuing_distribution_point(opts) do
@@ -214,10 +249,10 @@ defmodule Portal.DeviceTrustFixtures do
     issuer.cert_der |> Portal.Crypto.X509.subject() |> then(&:public_key.der_decode(:Name, &1))
   end
 
-  defp revoked_entry(cert_der, now) do
+  defp revoked_entry(cert_der, now, extensions) do
     {:Certificate, tbs, _algorithm, _signature} = :public_key.der_decode(:Certificate, cert_der)
 
-    {:TBSCertList_revokedCertificates_SEQOF, elem(tbs, 2), utc_time(now), :asn1_NOVALUE}
+    {:TBSCertList_revokedCertificates_SEQOF, elem(tbs, 2), utc_time(now), extensions}
   end
 
   defp new_ca(common_name) do


### PR DESCRIPTION
A certificate revocation list is only up to date as of the moment the CA published it. Windows CA servers reissue that full list once a week by default and publish a small "delta" list every day, so before this we could keep accepting a certificate for up to a week after it was revoked.

We now read the delta as well. The full list tells us where its delta lives, we fetch it, check it as carefully as the full list, and apply the changes on top. Deltas can also un-revoke a certificate, which is how a CA releases one that was only on hold, so those come back out of our cache. The delta is checked on its own schedule, since it is republished far more often than the list it sits on top of.

If the delta cannot be fetched, we keep the full list and note the error. That answer is still correct, just older.

Related: #14606

