### PR TITLE
ci: install dump_syms via mise instead of install-action

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -13,6 +13,7 @@ env:
 permissions:
   contents: "read"
   id-token: "write" # OIDC auth
+  security-events: "write" # trivy SARIF upload from setup-mise
 
 jobs:
   update-release-draft:
@@ -76,15 +77,15 @@ jobs:
         timeout-minutes: 15
         with:
           runtime: true
+      - uses: ./.github/actions/setup-mise
+        with:
+          install_args: "--cd rust github:mozilla/dump_syms"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm install
       - run: pnpm vite build
       - name: Build client
         run: cargo build -p firezone-gui-client --all-targets
-      - uses: taiki-e/install-action@91ddec75689c4c78665b598d188dc821c5a43e5c # v2.85.9
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tool: dump_syms
       - name: Run smoke test
         working-directory: ./rust
         run: cargo run -p gui-smoke-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,7 @@ jobs:
     permissions:
       contents: write # release draft and build artifact uploads
       id-token: write # OIDC auth
+      security-events: write # trivy SARIF upload from setup-mise
 
   monitor-tauri:
     needs: [tauri]

--- a/rust/mise.lock
+++ b/rust/mise.lock
@@ -193,6 +193,30 @@ url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/ca
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392416"
 provenance = "github-attestations"
 
+[[tools."github:mozilla/dump_syms"]]
+version = "2.3.7"
+backend = "github:mozilla/dump_syms"
+
+[tools."github:mozilla/dump_syms"."platforms.linux-x64"]
+checksum = "sha256:928f9902244f63be4b3b0acf56963ecad97b7227ecfd9ee645d73683f75a9285"
+url = "https://github.com/mozilla/dump_syms/releases/download/v2.3.7/dump_syms-x86_64-unknown-linux-gnu.tar.xz"
+
+[tools."github:mozilla/dump_syms"."platforms.linux-x64-musl"]
+checksum = "sha256:928f9902244f63be4b3b0acf56963ecad97b7227ecfd9ee645d73683f75a9285"
+url = "https://github.com/mozilla/dump_syms/releases/download/v2.3.7/dump_syms-x86_64-unknown-linux-gnu.tar.xz"
+
+[tools."github:mozilla/dump_syms"."platforms.macos-arm64"]
+checksum = "sha256:a96949068ccc62d5dfe9f642e15ecc62910217c661e256eb91e2d0e6266895e7"
+url = "https://github.com/mozilla/dump_syms/releases/download/v2.3.7/dump_syms-aarch64-apple-darwin.tar.xz"
+
+[tools."github:mozilla/dump_syms"."platforms.macos-x64"]
+checksum = "sha256:4aded3cddac80aed06db65bab1c3d8228c0608296d7fa4168ab0eb12f2022683"
+url = "https://github.com/mozilla/dump_syms/releases/download/v2.3.7/dump_syms-x86_64-apple-darwin.tar.xz"
+
+[tools."github:mozilla/dump_syms"."platforms.windows-x64"]
+checksum = "sha256:bd42a87409c39be18709b788f793fcdbfe1fde79511404112358b18511bb24f8"
+url = "https://github.com/mozilla/dump_syms/releases/download/v2.3.7/dump_syms-x86_64-pc-windows-msvc.zip"
+
 [[tools."github:taiki-e/cargo-llvm-cov"]]
 version = "0.6.21"
 backend = "github:taiki-e/cargo-llvm-cov"

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -9,10 +9,6 @@ auto_install = false
 "github:aya-rs/bpf-linker" = { version = "0.10.3", os = ["linux"] }
 "cargo:cargo-deb" = { version = "3.7.0", os = ["linux"] }
 "github:taiki-e/cargo-llvm-cov" = "0.6.21"
-# Turns the built GUI client into Breakpad symbols for the smoke test.
-#
-# Upstream only publishes x86_64 binaries for Linux, so this does not install on
-# arm64 Linux.
 "github:mozilla/dump_syms" = "2.3.7"
 "github:tauri-apps/tauri" = { version = "2.11.2", version_prefix = "tauri-cli-v" }
 

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -9,6 +9,11 @@ auto_install = false
 "github:aya-rs/bpf-linker" = { version = "0.10.3", os = ["linux"] }
 "cargo:cargo-deb" = { version = "3.7.0", os = ["linux"] }
 "github:taiki-e/cargo-llvm-cov" = "0.6.21"
+# Turns the built GUI client into Breakpad symbols for the smoke test.
+#
+# Upstream only publishes x86_64 binaries for Linux, so this does not install on
+# arm64 Linux.
+"github:mozilla/dump_syms" = "2.3.7"
 "github:tauri-apps/tauri" = { version = "2.11.2", version_prefix = "tauri-cli-v" }
 
 # The eBPF program is compiled with this exact nightly toolchain: `aya_build`


### PR DESCRIPTION
`taiki-e/install-action` was the only tool installer in CI outside of mise. Declaring `dump_syms` in `rust/mise.toml` pins it in `rust/mise.lock` like every other tool, so its version and checksum are managed in one place.