### PR TITLE
fix(fuzz): restore relay update compilation

### DIFF
--- a/rust/tests/fuzz/src/sut.rs
+++ b/rust/tests/fuzz/src/sut.rs
@@ -23,7 +23,7 @@ use snownet::{NoTurnServers, Transmit};
 use std::iter;
 use std::net::SocketAddr;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     net::IpAddr,
     time::{Duration, Instant},
 };


### PR DESCRIPTION
`DeployNewRelays` collects retained relay IDs into a `BTreeSet`, but the merged fuzz harness imports only `BTreeMap`. This leaves the fuzz crate unable to compile on `main`.

Import `BTreeSet` so the tunnel-proto fuzz harness builds again.