### PR TITLE
fix(gui-client): send well-formed user-agent in update check

### DIFF
--- a/rust/gui-client/src-tauri/src/updates.rs
+++ b/rust/gui-client/src-tauri/src/updates.rs
@@ -218,8 +218,7 @@ pub(crate) async fn check() -> Result<Release> {
     let arch = std::env::consts::ARCH;
     let os = std::env::consts::OS;
 
-    let current_version = current_version()?;
-    let user_agent = format!("Firezone Client/{current_version} ({os}; {arch})");
+    let user_agent = format!("Firezone Client/{} ({os}; {arch})", current_version()?);
 
     let api_url = format!("{BASE_URL}/api/releases");
 

--- a/rust/gui-client/src-tauri/src/updates.rs
+++ b/rust/gui-client/src-tauri/src/updates.rs
@@ -218,7 +218,8 @@ pub(crate) async fn check() -> Result<Release> {
     let arch = std::env::consts::ARCH;
     let os = std::env::consts::OS;
 
-    let user_agent = format!("Firezone Client/{:?} ({os}; {arch})", current_version());
+    let current_version = current_version()?;
+    let user_agent = format!("Firezone Client/{current_version} ({os}; {arch})");
 
     let api_url = format!("{BASE_URL}/api/releases");
 


### PR DESCRIPTION
The user-agent header of the update check formatted the `Result` of `current_version()` with `Debug`, producing a header like `Firezone Client/Ok(Version("1.5.16")) (windows; x86_64)`. Format the version itself instead, yielding `Firezone Client/1.5.16 (windows; x86_64)`.