### PR TITLE
fix(gui-client): rework update notification

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1865,6 +1865,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "desktop-notifications"
+version = "0.1.0"
+dependencies = [
+ "anyhow-ext",
+ "futures",
+ "tokio",
+ "tracing",
+ "url",
+ "windows",
+ "zbus",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2452,7 @@ dependencies = [
  "connlib-model",
  "dbus-secret-service-keyring-store",
  "derive_more",
+ "desktop-notifications",
  "dirs",
  "embed-resource",
  "fd-lock",
@@ -2503,7 +2517,6 @@ dependencies = [
  "windows-security",
  "windows-service",
  "winreg 0.56.0",
- "zbus",
  "zip",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2431,7 +2431,6 @@ dependencies = [
  "admx-macro",
  "anyhow-ext",
  "arboard",
- "atomicwrites",
  "backoff",
  "bin-shared",
  "chrono",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2457,7 +2457,6 @@ dependencies = [
  "mimalloc",
  "native-dialog",
  "nix 0.31.3",
- "notify-rust",
  "opentelemetry",
  "output_vt100",
  "parking_lot",
@@ -2504,6 +2503,7 @@ dependencies = [
  "windows-security",
  "windows-service",
  "winreg 0.56.0",
+ "zbus",
  "zip",
 ]
 
@@ -4551,20 +4551,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mac-notification-sys"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
-dependencies = [
- "cc",
- "log",
- "objc2",
- "objc2-foundation",
- "time",
- "uuid",
-]
-
-[[package]]
 name = "macaddr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4879,20 +4865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "notify-rust"
-version = "4.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
-dependencies = [
- "futures-lite",
- "log",
- "mac-notification-sys",
- "serde",
- "tauri-winrt-notification",
- "zbus",
 ]
 
 [[package]]
@@ -7874,17 +7846,6 @@ dependencies = [
  "embed-resource",
  "indexmap 2.14.0",
  "toml 0.8.22",
-]
-
-[[package]]
-name = "tauri-winrt-notification"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
-dependencies = [
- "thiserror 2.0.19",
- "windows",
- "windows-version",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2486,7 +2486,6 @@ dependencies = [
  "tauri-runtime",
  "tauri-specta",
  "tauri-utils",
- "tauri-winrt-notification",
  "telemetry",
  "tempfile",
  "thiserror 2.0.19",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -155,7 +155,6 @@ netlink-packet-core = "0.8.1"
 netlink-packet-route = "0.29.0"
 network-types = { version = "0.2.0", default-features = false }
 nix = "0.31.3"
-notify-rust = "4.17.0"
 nu-ansi-term = "0.50.3"
 once_cell = "1.21.4"
 opentelemetry = "0.32.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "libs/connlib/tun",
     "libs/connlib/tunnel",
     "libs/connlib/tunnel-proto",
+    "libs/desktop-notifications",
     "libs/eventloop-budget",
     "libs/flow-log-spool",
     "libs/flow-log-upload",
@@ -96,6 +97,7 @@ crossbeam-queue = "0.3.12"
 dashmap = "6.2.1"
 dbus-secret-service-keyring-store = { version = "1.0.0", features = ["crypto-rust"] }
 derive_more = { version = "2.1.1", default-features = false }
+desktop-notifications = { path = "libs/desktop-notifications" }
 difference = "2.0.0"
 dirs = "6.0.0"
 divan = "0.1.21"

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 client-shared = { workspace = true }
 connlib-model = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
+desktop-notifications = { workspace = true }
 fd-lock = { workspace = true }
 flow-log-upload = { workspace = true }
 flow-log-writer = { workspace = true }
@@ -84,7 +85,6 @@ mimalloc = { workspace = true }
 nix = { workspace = true, features = ["user"] }
 sd-notify = { workspace = true }
 tracing-journald = { workspace = true }
-zbus = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mimalloc = { workspace = true }
@@ -128,10 +128,6 @@ features = [
     # a new external location.
     "ApplicationModel",
     "Foundation_Collections",
-    # `XmlDocument` and `ToastNotification` / `ToastNotificationManager`
-    # for the protocol-activated update toast.
-    "Data_Xml_Dom",
-    "UI_Notifications",
 ]
 
 [build-dependencies]

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -92,7 +92,6 @@ mimalloc = { workspace = true }
 [target.'cfg(target_os = "windows")'.dependencies]
 admx-macro = { workspace = true }
 mimalloc = { workspace = true }
-tauri-winrt-notification = "0.7.2"
 windows-native-keyring-store = { workspace = true }
 windows-security = { workspace = true }
 windows-service = { workspace = true }

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -14,7 +14,6 @@ enum_representation = "discriminated"
 [dependencies]
 anyhow = { workspace = true }
 arboard = { workspace = true }
-atomicwrites = { workspace = true }
 backoff = { workspace = true }
 bin-shared = { workspace = true }
 chrono = { workspace = true }
@@ -130,6 +129,10 @@ features = [
     # a new external location.
     "ApplicationModel",
     "Foundation_Collections",
+    # `XmlDocument` and `ToastNotification` / `ToastNotificationManager`
+    # for the protocol-activated update toast.
+    "Data_Xml_Dom",
+    "UI_Notifications",
 ]
 
 [build-dependencies]

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -82,9 +82,9 @@ ksni = { workspace = true } # Tray icon for Linux.
 libc = { workspace = true }
 mimalloc = { workspace = true }
 nix = { workspace = true, features = ["user"] }
-notify-rust = { workspace = true }
 sd-notify = { workspace = true }
 tracing-journald = { workspace = true }
+zbus = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mimalloc = { workspace = true }

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -81,11 +81,7 @@ pub trait GuiIntegration {
 
     fn set_tray_icon(&mut self, icon: system_tray::Icon);
     fn set_tray_menu(&mut self, app_state: system_tray::AppState);
-    fn show_notification(
-        &self,
-        title: impl Into<String>,
-        body: impl Into<String>,
-    ) -> Result<NotificationHandle>;
+    fn show_notification(&self, title: impl Into<String>, body: impl Into<String>) -> Result<()>;
 
     /// Shows a notification about a new release, opening `download_url` on click where the platform supports it.
     fn show_update_notification(&self, title: impl Into<String>, download_url: Url) -> Result<()>;
@@ -102,10 +98,6 @@ pub trait GuiIntegration {
         settings: AdvancedSettings,
     ) -> Result<()>;
     fn show_about_page(&self) -> Result<()>;
-}
-
-pub struct NotificationHandle {
-    pub on_click: futures::channel::oneshot::Receiver<()>,
 }
 
 #[derive(strum::Display)]
@@ -654,7 +646,7 @@ impl<I: GuiIntegration> Controller<I> {
         gui::set_autostart(self.general_settings.start_on_login.is_some_and(|v| v)).await?;
 
         self.notify_settings_changed()?;
-        let _ = self.integration.show_notification("Settings saved", "")?;
+        self.integration.show_notification("Settings saved", "")?;
 
         Ok(())
     }
@@ -688,7 +680,7 @@ impl<I: GuiIntegration> Controller<I> {
                 self.sign_out().await?;
                 if is_authentication_error {
                     tracing::info!(?error_msg, "Auth error");
-                    let _ = self.integration.show_notification(
+                    self.integration.show_notification(
                         "Firezone disconnected",
                         "To access resources, sign in again.",
                     )?;
@@ -705,7 +697,7 @@ impl<I: GuiIntegration> Controller<I> {
 
                 // If this is the first time we receive resources, show the notification that we are connected.
                 if let &Status::WaitingForTunnel = &self.status {
-                    let _ = self.integration.show_notification(
+                    self.integration.show_notification(
                         "Firezone connected",
                         "You are now signed in and able to access resources.",
                     )?;
@@ -726,7 +718,7 @@ impl<I: GuiIntegration> Controller<I> {
                 tracing::info!("Tunnel service exited gracefully");
                 self.integration
                     .set_tray_icon(system_tray::icon_terminating());
-                let _ = self.integration.show_notification(
+                self.integration.show_notification(
                     "Firezone disconnected",
                     "The Firezone Tunnel service was shut down, quitting GUI process.",
                 )?;
@@ -750,12 +742,11 @@ impl<I: GuiIntegration> Controller<I> {
                 self.notify_settings_changed()?;
                 self.refresh_ui_state();
 
-                let _ = self.integration.show_notification("Settings saved", "")?;
+                self.integration.show_notification("Settings saved", "")?;
             }
             service::ServerMsg::AdvancedSettingsApplied(Err(err)) => {
                 tracing::error!("Tunnel service failed to save advanced settings: {err}");
-                let _ = self
-                    .integration
+                self.integration
                     .show_notification("Failed to save settings", &err)?;
             }
             service::ServerMsg::GatewayVersionMismatch { resource_id } => {
@@ -1501,7 +1492,7 @@ mod tests {
         opened_urls: Vec<String>,
         tray_icons: Vec<system_tray::Icon>,
         tray_states: Vec<system_tray::AppState>,
-        notifications: Vec<(String, String, futures::channel::oneshot::Sender<()>)>,
+        notifications: Vec<(String, String)>,
         update_notifications: Vec<(String, Url)>,
         window_visibilities: Vec<bool>,
         shown_overview_page: Vec<SessionViewModel>,
@@ -1511,9 +1502,7 @@ mod tests {
 
     impl MockIntegration {
         fn nth_notification(&self, idx: usize) -> Option<(String, String)> {
-            let (title, body, _) = self.notifications.get(idx)?;
-
-            Some((title.clone(), body.clone()))
+            self.notifications.get(idx).cloned()
         }
     }
 
@@ -1563,14 +1552,10 @@ mod tests {
             &self,
             title: impl Into<String>,
             body: impl Into<String>,
-        ) -> Result<NotificationHandle> {
-            let (tx, rx) = futures::channel::oneshot::channel();
+        ) -> Result<()> {
+            self.lock().notifications.push((title.into(), body.into()));
 
-            self.lock()
-                .notifications
-                .push((title.into(), body.into(), tx));
-
-            Ok(NotificationHandle { on_click: rx })
+            Ok(())
         }
 
         fn show_update_notification(

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -44,7 +44,6 @@ pub struct Controller<I: GuiIntegration> {
     // Sign-in state with the portal / deep links
     auth: auth::Auth,
     clear_logs_callback: Option<oneshot::Sender<Result<(), String>>>,
-    ctrl_tx: mpsc::Sender<ControllerRequest>,
     ipc_client: ipc::ClientWrite<service::ClientMsg>,
     ipc_rx: ipc::ClientRead<service::ServerMsg>,
     integration: I,
@@ -55,7 +54,7 @@ pub struct Controller<I: GuiIntegration> {
     status: Status,
     quit_timeout: Option<Pin<Box<tokio::time::Sleep>>>,
     telemetry_allowed: bool,
-    updates_rx: Option<ReceiverStream<Option<updates::Notification>>>,
+    updates_rx: Option<ReceiverStream<Option<updates::Release>>>,
     uptime: uptime::Tracker,
 
     gui_ipc_clients: BoxStream<
@@ -87,6 +86,9 @@ pub trait GuiIntegration {
         title: impl Into<String>,
         body: impl Into<String>,
     ) -> Result<NotificationHandle>;
+
+    /// Shows a notification about a new release, opening `download_url` on click where the platform supports it.
+    fn show_update_notification(&self, title: impl Into<String>, download_url: Url) -> Result<()>;
 
     fn save_general_settings(&self, settings: &GeneralSettings)
     -> impl Future<Output = Result<()>>;
@@ -123,7 +125,6 @@ pub enum ControllerRequest {
     SignOut,
     UpdateState,
     SystemTrayMenu(system_tray::Event),
-    UpdateNotificationClicked(Url),
 }
 
 // The failure flags are all mutually exclusive
@@ -168,7 +169,7 @@ impl Status {
 enum EventloopTick {
     IpcMsg(Option<Result<service::ServerMsg>>),
     ControllerRequest(Option<ControllerRequest>),
-    UpdateNotification(Option<updates::Notification>),
+    UpdateNotification(Option<updates::Release>),
     NewInstanceLaunched(
         Option<
             Result<(
@@ -188,13 +189,12 @@ impl<I: GuiIntegration> Controller<I> {
     pub(crate) async fn start(
         socket: SocketId,
         integration: I,
-        ctrl_tx: mpsc::Sender<ControllerRequest>,
         ctrl_rx: mpsc::Receiver<ControllerRequest>,
         general_settings: GeneralSettings,
         legacy_advanced_settings_path: PathBuf,
         log_filter_reloader: FilterReloadHandle,
         telemetry_allowed: bool,
-        updates_rx: mpsc::Receiver<Option<updates::Notification>>,
+        updates_rx: mpsc::Receiver<Option<updates::Release>>,
         gui_ipc: ipc::Server,
     ) -> Result<()> {
         tracing::debug!("Starting new instance of `Controller`");
@@ -239,7 +239,6 @@ impl<I: GuiIntegration> Controller<I> {
             legacy_advanced_settings_path,
             auth,
             clear_logs_callback: None,
-            ctrl_tx,
             ipc_client,
             ipc_rx,
             integration,
@@ -633,12 +632,6 @@ impl<I: GuiIntegration> Controller<I> {
                 self.send_ipc(&service::ClientMsg::Disconnect).await?;
                 self.refresh_ui_state();
             }
-            UpdateNotificationClicked(download_url) => {
-                tracing::info!("UpdateNotificationClicked in run_controller!");
-                self.integration
-                    .open_url(&download_url)
-                    .context("Couldn't open update page")?;
-            }
             UpdateState => {
                 self.notify_settings_changed()?;
 
@@ -843,46 +836,21 @@ impl<I: GuiIntegration> Controller<I> {
     }
 
     /// Set (or clear) update notification
-    fn handle_update_notification(
-        &mut self,
-        notification: Option<updates::Notification>,
-    ) -> Result<()> {
-        let Some(notification) = notification else {
+    fn handle_update_notification(&mut self, release: Option<updates::Release>) -> Result<()> {
+        let Some(release) = release else {
             self.release = None;
             self.refresh_ui_state();
             return Ok(());
         };
 
-        let release = notification.release;
         self.release = Some(release.clone());
         self.refresh_ui_state();
 
-        if notification.tell_user {
-            #[cfg(target_os = "linux")]
-            let body = ""; // TODO: Clickable notifications don't work on Linux yet.
-            #[cfg(target_os = "macos")]
-            let body = "";
-            #[cfg(target_os = "windows")]
-            let body = "Click here to download the new version";
+        self.integration.show_update_notification(
+            format!("Firezone {} available for download", release.version),
+            release.download_url,
+        )?;
 
-            let NotificationHandle { on_click } = self.integration.show_notification(
-                format!("Firezone {} available for download", release.version),
-                body,
-            )?;
-            let ctrl_tx = self.ctrl_tx.clone();
-
-            tokio::spawn(async move {
-                if on_click.await.is_err() {
-                    return;
-                };
-
-                let _ = ctrl_tx
-                    .send(ControllerRequest::UpdateNotificationClicked(
-                        release.download_url,
-                    ))
-                    .await;
-            });
-        }
         Ok(())
     }
 
@@ -1207,6 +1175,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shows_update_notification() {
+        let _guard = logging::test("debug");
+        let mut test_controller = Controller::start_for_test();
+        let mut mock_tunnel = test_controller.tunnel_service_ipc_accept().await;
+        mock_tunnel.send_hello().await;
+
+        let release = updates::Release {
+            download_url: Url::parse(
+                "https://www.firezone.dev/dl/firezone-client-gui-windows/1.99.0/x86_64",
+            )
+            .unwrap(),
+            version: semver::Version::new(1, 99, 0),
+        };
+        test_controller
+            .updates_tx
+            .send(Some(release.clone()))
+            .await
+            .unwrap();
+
+        let (title, url) = test_controller
+            .wait_integration(|i| i.update_notifications.first().cloned())
+            .await;
+        assert_eq!(title, "Firezone 1.99.0 available for download");
+        assert_eq!(url, release.download_url);
+    }
+
+    #[tokio::test]
     async fn shows_offline_gateway_notification() {
         let _guard = logging::test("debug");
         let mut test_controller = Controller::start_for_test();
@@ -1420,12 +1415,11 @@ mod tests {
         }
     }
 
-    #[expect(dead_code, reason = "It is a test.")]
     struct TestController {
         join_handle: tokio::task::JoinHandle<Result<()>>,
         tunnel_server: ipc::Server,
         ctrl_tx: mpsc::Sender<ControllerRequest>,
-        updates_tx: mpsc::Sender<Option<updates::Notification>>,
+        updates_tx: mpsc::Sender<Option<updates::Release>>,
         integration: Arc<Mutex<MockIntegration>>,
         gui_id: u32,
         legacy_advanced_settings_path: PathBuf,
@@ -1508,6 +1502,7 @@ mod tests {
         tray_icons: Vec<system_tray::Icon>,
         tray_states: Vec<system_tray::AppState>,
         notifications: Vec<(String, String, futures::channel::oneshot::Sender<()>)>,
+        update_notifications: Vec<(String, Url)>,
         window_visibilities: Vec<bool>,
         shown_overview_page: Vec<SessionViewModel>,
         shown_settings_page: Vec<(MdmSettings, GeneralSettings, AdvancedSettings)>,
@@ -1576,6 +1571,18 @@ mod tests {
                 .push((title.into(), body.into(), tx));
 
             Ok(NotificationHandle { on_click: rx })
+        }
+
+        fn show_update_notification(
+            &self,
+            title: impl Into<String>,
+            download_url: Url,
+        ) -> Result<()> {
+            self.lock()
+                .update_notifications
+                .push((title.into(), download_url));
+
+            Ok(())
         }
 
         fn set_window_visible(&self, visible: bool) -> Result<()> {
@@ -1706,7 +1713,6 @@ mod tests {
             let join_handle = tokio::spawn(Self::start(
                 SocketId::Test(tunnel_id),
                 integration.clone(),
-                ctrl_tx.clone(),
                 ctrl_rx,
                 GeneralSettings::default(),
                 legacy_advanced_settings_path.clone(),

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -83,8 +83,8 @@ pub trait GuiIntegration {
     fn set_tray_menu(&mut self, app_state: system_tray::AppState);
     fn show_notification(&self, title: impl Into<String>, body: impl Into<String>) -> Result<()>;
 
-    /// Shows a notification about a new release, opening `download_url` on click where the platform supports it.
-    fn show_update_notification(&self, title: impl Into<String>, download_url: Url) -> Result<()>;
+    /// Shows a notification about a new release, opening its download URL on click where the platform supports it.
+    fn show_update_notification(&self, release: updates::Release) -> Result<()>;
 
     fn save_general_settings(&self, settings: &GeneralSettings)
     -> impl Future<Output = Result<()>>;
@@ -837,10 +837,7 @@ impl<I: GuiIntegration> Controller<I> {
         self.release = Some(release.clone());
         self.refresh_ui_state();
 
-        self.integration.show_update_notification(
-            format!("Firezone {} available for download", release.version),
-            release.download_url,
-        )?;
+        self.integration.show_update_notification(release)?;
 
         Ok(())
     }
@@ -1185,11 +1182,10 @@ mod tests {
             .await
             .unwrap();
 
-        let (title, url) = test_controller
+        let shown = test_controller
             .wait_integration(|i| i.update_notifications.first().cloned())
             .await;
-        assert_eq!(title, "Firezone 1.99.0 available for download");
-        assert_eq!(url, release.download_url);
+        assert_eq!(shown, release);
     }
 
     #[tokio::test]
@@ -1493,7 +1489,7 @@ mod tests {
         tray_icons: Vec<system_tray::Icon>,
         tray_states: Vec<system_tray::AppState>,
         notifications: Vec<(String, String)>,
-        update_notifications: Vec<(String, Url)>,
+        update_notifications: Vec<updates::Release>,
         window_visibilities: Vec<bool>,
         shown_overview_page: Vec<SessionViewModel>,
         shown_settings_page: Vec<(MdmSettings, GeneralSettings, AdvancedSettings)>,
@@ -1558,14 +1554,8 @@ mod tests {
             Ok(())
         }
 
-        fn show_update_notification(
-            &self,
-            title: impl Into<String>,
-            download_url: Url,
-        ) -> Result<()> {
-            self.lock()
-                .update_notifications
-                .push((title.into(), download_url));
+        fn show_update_notification(&self, release: updates::Release) -> Result<()> {
+            self.lock().update_notifications.push(release);
 
             Ok(())
         }

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -166,6 +166,14 @@ impl GuiIntegration for TauriIntegration {
         os::show_notification(title.into(), body.into())
     }
 
+    fn show_update_notification(
+        &self,
+        title: impl Into<String>,
+        download_url: url::Url,
+    ) -> Result<()> {
+        os::show_update_notification(title.into(), download_url)
+    }
+
     fn set_window_visible(&self, visible: bool) -> Result<()> {
         let win = self.main_window()?;
 
@@ -355,7 +363,6 @@ pub fn run(rt: &Runtime, config: RunConfig, reloader: logging::FilterReloadHandl
         let ctrl_task = tokio::spawn(Controller::start(
             SocketId::Tunnel,
             integration,
-            ctlr_tx,
             ctlr_rx,
             general_settings,
             legacy_advanced_settings_path,

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -164,15 +164,11 @@ impl GuiIntegration for TauriIntegration {
         Ok(())
     }
 
-    fn show_update_notification(
-        &self,
-        title: impl Into<String>,
-        download_url: url::Url,
-    ) -> Result<()> {
+    fn show_update_notification(&self, release: updates::Release) -> Result<()> {
         spawn_notification(
-            title.into(),
+            format!("Firezone {} available for download", release.version),
             "Click here to download the new version".to_owned(),
-            Some(download_url),
+            Some(release.download_url),
         );
 
         Ok(())

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -159,7 +159,9 @@ impl GuiIntegration for TauriIntegration {
     }
 
     fn show_notification(&self, title: impl Into<String>, body: impl Into<String>) -> Result<()> {
-        os::show_notification(title.into(), body.into())
+        spawn_notification(title.into(), body.into(), None);
+
+        Ok(())
     }
 
     fn show_update_notification(
@@ -167,7 +169,15 @@ impl GuiIntegration for TauriIntegration {
         title: impl Into<String>,
         download_url: url::Url,
     ) -> Result<()> {
-        os::show_update_notification(title.into(), download_url)
+        // Clickable notifications only work on Windows.
+        #[cfg(target_os = "windows")]
+        let body = "Click here to download the new version";
+        #[cfg(not(target_os = "windows"))]
+        let body = "";
+
+        spawn_notification(title.into(), body.to_owned(), Some(download_url));
+
+        Ok(())
     }
 
     fn set_window_visible(&self, visible: bool) -> Result<()> {
@@ -230,6 +240,21 @@ pub struct RunConfig {
     pub telemetry_allowed: bool,
     pub quit_after: Option<u64>,
     pub fail_with: Option<Failure>,
+}
+
+/// Shows a notification without blocking the caller.
+///
+/// Notifications are fire-and-forget: failures are only logged because
+/// there is nothing the caller could do about them.
+fn spawn_notification(title: String, body: String, open_url: Option<url::Url>) {
+    let notifier = desktop_notifications::Notifier::new(os::notification_app_id());
+
+    tokio::spawn(async move {
+        match notifier.show(&title, &body, open_url.as_ref()).await {
+            Ok(()) => tracing::debug!(%title, %body, "Showed notification"),
+            Err(e) => tracing::debug!(%title, "Failed to show notification: {e:#}"),
+        }
+    });
 }
 
 /// IPC messages that a newly launched instance may send to an already

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -241,10 +241,10 @@ pub struct RunConfig {
 /// Notifications are fire-and-forget: failures are only logged because
 /// there is nothing the caller could do about them.
 fn spawn_notification(title: String, body: String, open_url: Option<url::Url>) {
-    let notifier = desktop_notifications::Notifier::new(os::notification_app_id());
+    let app_id = os::notification_app_id();
 
     tokio::spawn(async move {
-        match notifier.show(&title, &body, open_url.as_ref()).await {
+        match desktop_notifications::show(&app_id, &title, &body, open_url.as_ref()).await {
             Ok(()) => tracing::debug!(%title, %body, "Showed notification"),
             Err(e) => tracing::debug!(%title, "Failed to show notification: {e:#}"),
         }

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -4,7 +4,7 @@
 //! The real macOS Client is in `swift/apple`
 
 use crate::{
-    controller::{Controller, ControllerRequest, Failure, GuiIntegration, NotificationHandle},
+    controller::{Controller, ControllerRequest, Failure, GuiIntegration},
     deep_link,
     ipc::{self, ClientRead, ClientWrite, SocketId},
     launch_lock::{self, FirstInstance, LaunchLock},
@@ -158,11 +158,7 @@ impl GuiIntegration for TauriIntegration {
         self.tray.update(app_state)
     }
 
-    fn show_notification(
-        &self,
-        title: impl Into<String>,
-        body: impl Into<String>,
-    ) -> Result<NotificationHandle> {
+    fn show_notification(&self, title: impl Into<String>, body: impl Into<String>) -> Result<()> {
         os::show_notification(title.into(), body.into())
     }
 

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -169,13 +169,11 @@ impl GuiIntegration for TauriIntegration {
         title: impl Into<String>,
         download_url: url::Url,
     ) -> Result<()> {
-        // Clickable notifications only work on Windows.
-        #[cfg(target_os = "windows")]
-        let body = "Click here to download the new version";
-        #[cfg(not(target_os = "windows"))]
-        let body = "";
-
-        spawn_notification(title.into(), body.to_owned(), Some(download_url));
+        spawn_notification(
+            title.into(),
+            "Click here to download the new version".to_owned(),
+            Some(download_url),
+        );
 
         Ok(())
     }

--- a/rust/gui-client/src-tauri/src/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_linux.rs
@@ -1,7 +1,5 @@
 use anyhow::{Context as _, Result};
 
-use crate::controller::NotificationHandle;
-
 pub async fn set_autostart(enabled: bool) -> Result<()> {
     let dir = dirs::config_local_dir()
         .context("Can't compute `config_local_dir`")?
@@ -36,9 +34,7 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
     clippy::unnecessary_wraps,
     reason = "Signature must match other platforms."
 )]
-pub(crate) fn show_notification(title: String, body: String) -> Result<NotificationHandle> {
-    let (_, rx) = futures::channel::oneshot::channel();
-
+pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
     tokio::spawn(async move {
         let notification = match notify_rust::Notification::new()
             .summary(&title)
@@ -58,7 +54,7 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<Notificat
         notification.wait_for_action_async(|_| {}).await;
     });
 
-    Ok(NotificationHandle { on_click: rx })
+    Ok(())
 }
 
 /// Show a notification about a new release
@@ -66,7 +62,7 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<Notificat
 /// Clickable notifications don't work on Linux yet, so the notification only
 /// announces the release and the user downloads it via the tray menu.
 pub(crate) fn show_update_notification(title: String, _download_url: url::Url) -> Result<()> {
-    let _ = show_notification(title, String::new())?;
+    show_notification(title, String::new())?;
 
     Ok(())
 }

--- a/rust/gui-client/src-tauri/src/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_linux.rs
@@ -1,4 +1,6 @@
 use anyhow::{Context as _, Result};
+use futures::StreamExt as _;
+use std::collections::HashMap;
 
 pub async fn set_autostart(enabled: bool) -> Result<()> {
     let dir = dirs::config_local_dir()
@@ -36,22 +38,9 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
 )]
 pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
     tokio::spawn(async move {
-        let notification = match notify_rust::Notification::new()
-            .summary(&title)
-            .body(&body)
-            .show_async()
-            .await
-        {
-            Ok(n) => n,
-            Err(e) => {
-                tracing::debug!(%title, "Failed to show notification: {e}");
-                return;
-            }
-        };
-
-        tracing::debug!(%title, %body, "Showing notification");
-
-        notification.wait_for_action_async(|_| {}).await;
+        if let Err(e) = notify(&title, &body).await {
+            tracing::debug!(%title, "Failed to show notification: {e:#}");
+        }
     });
 
     Ok(())
@@ -63,6 +52,65 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
 /// announces the release and the user downloads it via the tray menu.
 pub(crate) fn show_update_notification(title: String, _download_url: url::Url) -> Result<()> {
     show_notification(title, String::new())?;
+
+    Ok(())
+}
+
+/// Shows a notification via the [`org.freedesktop.Notifications`] D-Bus interface.
+///
+/// Resolves once the notification is closed: the D-Bus connection must stay
+/// open for as long as the notification is showing, otherwise it doesn't get
+/// displayed reliably on all desktops.
+///
+/// [`org.freedesktop.Notifications`]: https://specifications.freedesktop.org/notification-spec/latest/protocol.html
+async fn notify(summary: &str, body: &str) -> Result<()> {
+    let connection = zbus::Connection::session()
+        .await
+        .context("Failed to connect to session bus")?;
+    let proxy = zbus::Proxy::new(
+        &connection,
+        "org.freedesktop.Notifications",
+        "/org/freedesktop/Notifications",
+        "org.freedesktop.Notifications",
+    )
+    .await
+    .context("Failed to create proxy")?;
+
+    // Subscribe before `Notify` so we cannot miss the close signal.
+    let mut closed = proxy
+        .receive_signal("NotificationClosed")
+        .await
+        .context("Failed to subscribe to `NotificationClosed`")?;
+
+    let id: u32 = proxy
+        .call(
+            "Notify",
+            &(
+                "Firezone",
+                0_u32, // We are not replacing an existing notification.
+                "",    // No icon.
+                summary,
+                body,
+                Vec::<&str>::new(),                            // No actions.
+                HashMap::<&str, zbus::zvariant::Value>::new(), // No hints.
+                -1_i32, // Let the server pick an expiry timeout.
+            ),
+        )
+        .await
+        .context("Failed to call `Notify`")?;
+
+    tracing::debug!(%summary, %body, "Showing notification");
+
+    while let Some(message) = closed.next().await {
+        let (closed_id, _reason): (u32, u32) = message
+            .body()
+            .deserialize()
+            .context("Failed to deserialize `NotificationClosed`")?;
+
+        if closed_id == id {
+            break;
+        }
+    }
 
     Ok(())
 }

--- a/rust/gui-client/src-tauri/src/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_linux.rs
@@ -1,6 +1,4 @@
 use anyhow::{Context as _, Result};
-use futures::StreamExt as _;
-use std::collections::HashMap;
 
 pub async fn set_autostart(enabled: bool) -> Result<()> {
     let dir = dirs::config_local_dir()
@@ -32,85 +30,7 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
     Ok(())
 }
 
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "Signature must match other platforms."
-)]
-pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
-    tokio::spawn(async move {
-        if let Err(e) = notify(&title, &body).await {
-            tracing::debug!(%title, "Failed to show notification: {e:#}");
-        }
-    });
-
-    Ok(())
-}
-
-/// Show a notification about a new release
-///
-/// Clickable notifications don't work on Linux yet, so the notification only
-/// announces the release and the user downloads it via the tray menu.
-pub(crate) fn show_update_notification(title: String, _download_url: url::Url) -> Result<()> {
-    show_notification(title, String::new())?;
-
-    Ok(())
-}
-
-/// Shows a notification via the [`org.freedesktop.Notifications`] D-Bus interface.
-///
-/// Resolves once the notification is closed: the D-Bus connection must stay
-/// open for as long as the notification is showing, otherwise it doesn't get
-/// displayed reliably on all desktops.
-///
-/// [`org.freedesktop.Notifications`]: https://specifications.freedesktop.org/notification-spec/latest/protocol.html
-async fn notify(summary: &str, body: &str) -> Result<()> {
-    let connection = zbus::Connection::session()
-        .await
-        .context("Failed to connect to session bus")?;
-    let proxy = zbus::Proxy::new(
-        &connection,
-        "org.freedesktop.Notifications",
-        "/org/freedesktop/Notifications",
-        "org.freedesktop.Notifications",
-    )
-    .await
-    .context("Failed to create proxy")?;
-
-    // Subscribe before `Notify` so we cannot miss the close signal.
-    let mut closed = proxy
-        .receive_signal("NotificationClosed")
-        .await
-        .context("Failed to subscribe to `NotificationClosed`")?;
-
-    let id: u32 = proxy
-        .call(
-            "Notify",
-            &(
-                "Firezone",
-                0_u32, // We are not replacing an existing notification.
-                "",    // No icon.
-                summary,
-                body,
-                Vec::<&str>::new(),                            // No actions.
-                HashMap::<&str, zbus::zvariant::Value>::new(), // No hints.
-                -1_i32, // Let the server pick an expiry timeout.
-            ),
-        )
-        .await
-        .context("Failed to call `Notify`")?;
-
-    tracing::debug!(%summary, %body, "Showing notification");
-
-    while let Some(message) = closed.next().await {
-        let (closed_id, _reason): (u32, u32) = message
-            .body()
-            .deserialize()
-            .context("Failed to deserialize `NotificationClosed`")?;
-
-        if closed_id == id {
-            break;
-        }
-    }
-
-    Ok(())
+/// The application name that desktops use to group our notifications.
+pub(crate) fn notification_app_id() -> String {
+    "Firezone".to_owned()
 }

--- a/rust/gui-client/src-tauri/src/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_linux.rs
@@ -60,3 +60,13 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<Notificat
 
     Ok(NotificationHandle { on_click: rx })
 }
+
+/// Show a notification about a new release
+///
+/// Clickable notifications don't work on Linux yet, so the notification only
+/// announces the release and the user downloads it via the tray menu.
+pub(crate) fn show_update_notification(title: String, _download_url: url::Url) -> Result<()> {
+    let _ = show_notification(title, String::new())?;
+
+    Ok(())
+}

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -1,8 +1,6 @@
 //! This file is a stub only to do Tauri UI dev natively on a Mac.
 use anyhow::Result;
 
-use crate::controller::NotificationHandle;
-
 pub async fn set_autostart(_enabled: bool) -> Result<()> {
     tracing::warn!("set_autostart is not implemented on macOS; skipping");
 
@@ -13,12 +11,10 @@ pub async fn set_autostart(_enabled: bool) -> Result<()> {
     clippy::unnecessary_wraps,
     reason = "Signature must match other platforms."
 )]
-pub(crate) fn show_notification(_title: String, _body: String) -> Result<NotificationHandle> {
+pub(crate) fn show_notification(_title: String, _body: String) -> Result<()> {
     tracing::warn!("show_notification is not implemented on macOS; skipping");
 
-    let (_tx, on_click) = futures::channel::oneshot::channel();
-
-    Ok(NotificationHandle { on_click })
+    Ok(())
 }
 
 #[expect(

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -20,3 +20,13 @@ pub(crate) fn show_notification(_title: String, _body: String) -> Result<Notific
 
     Ok(NotificationHandle { on_click })
 }
+
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "Signature must match other platforms."
+)]
+pub(crate) fn show_update_notification(_title: String, _download_url: url::Url) -> Result<()> {
+    tracing::warn!("show_update_notification is not implemented on macOS; skipping");
+
+    Ok(())
+}

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -7,22 +7,6 @@ pub async fn set_autostart(_enabled: bool) -> Result<()> {
     Ok(())
 }
 
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "Signature must match other platforms."
-)]
-pub(crate) fn show_notification(_title: String, _body: String) -> Result<()> {
-    tracing::warn!("show_notification is not implemented on macOS; skipping");
-
-    Ok(())
-}
-
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "Signature must match other platforms."
-)]
-pub(crate) fn show_update_notification(_title: String, _download_url: url::Url) -> Result<()> {
-    tracing::warn!("show_update_notification is not implemented on macOS; skipping");
-
-    Ok(())
+pub(crate) fn notification_app_id() -> String {
+    crate::BUNDLE_ID.to_owned()
 }

--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -1,10 +1,5 @@
 use anyhow::{Context, Result};
 use std::env;
-use windows::{
-    Data::Xml::Dom::XmlDocument,
-    UI::Notifications::{ToastNotification, ToastNotificationManager},
-    core::HSTRING,
-};
 use winreg::RegKey;
 use winreg::enums::*;
 
@@ -43,73 +38,7 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
     Ok(())
 }
 
-/// Show a notification in the bottom right of the screen
-pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
-    let toast_xml = format!(
-        r#"<toast>
-    <visual>
-        <binding template="ToastGeneric">
-            <text id="1">{title}</text>
-            <text id="2">{body}</text>
-        </binding>
-    </visual>
-</toast>"#,
-        title = xml_escape(&title),
-        body = xml_escape(&body),
-    );
-
-    show_toast(&toast_xml).context("Failed to show notification")?;
-
-    tracing::debug!(%title, %body, "Showing notification");
-
-    Ok(())
-}
-
-/// Show a notification about a new release that opens `download_url` when activated
-///
-/// The toast declares `activationType="protocol"`, so the shell opens the URL
-/// itself. Unlike an in-process activation callback, this also works after the
-/// toast has moved into the notification center. `duration="long"` keeps the
-/// toast on screen for 25 seconds instead of the default ~6.
-pub(crate) fn show_update_notification(title: String, download_url: url::Url) -> Result<()> {
-    let toast_xml = format!(
-        r#"<toast duration="long" activationType="protocol" launch="{url}">
-    <visual>
-        <binding template="ToastGeneric">
-            <text id="1">{title}</text>
-            <text id="2">Click here to download the new version</text>
-        </binding>
-    </visual>
-</toast>"#,
-        url = xml_escape(download_url.as_str()),
-        title = xml_escape(&title),
-    );
-
-    show_toast(&toast_xml).context("Failed to show update notification")?;
-
-    tracing::debug!(%title, %download_url, "Showing update notification");
-
-    Ok(())
-}
-
-/// Displays a toast notification from the given [toast content XML].
-///
-/// [toast content XML]: https://learn.microsoft.com/en-us/uwp/schemas/tiles/toastschema/element-toast
-fn show_toast(toast_xml: &str) -> Result<()> {
-    let xml = XmlDocument::new()?;
-    xml.LoadXml(&HSTRING::from(toast_xml))
-        .context("Failed to load toast XML")?;
-    let toast =
-        ToastNotification::CreateToastNotification(&xml).context("Failed to create toast")?;
-    ToastNotificationManager::CreateToastNotifierWithId(&HSTRING::from(&app_id()))
-        .context("Failed to create toast notifier")?
-        .Show(&toast)
-        .context("Failed to show toast")?;
-
-    Ok(())
-}
-
-/// The AppUserModelID Windows attributes our toasts to
+/// The AppUserModelID Windows attributes our notifications to
 ///
 /// Windows silently drops a toast whose AUMID doesn't match the calling
 /// process's identity. Packaged builds run under the sparse MSIX identity, so
@@ -119,18 +48,10 @@ fn show_toast(toast_xml: &str) -> Result<()> {
 /// come from the manifest's `VisualElements`. Un-packaged dev builds (no
 /// package identity) fall back to [`crate::BUNDLE_ID`].
 /// <https://github.com/tauri-apps/winrt-notification/issues/17#issuecomment-1988715694>
-fn app_id() -> String {
+pub(crate) fn notification_app_id() -> String {
     if crate::package_identity::has_package_identity() {
         format!("{}!Firezone", crate::PACKAGE_FAMILY_NAME)
     } else {
         crate::BUNDLE_ID.to_owned()
     }
-}
-
-fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
 }

--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -1,9 +1,12 @@
 use anyhow::{Context, Result};
 use std::env;
+use windows::{
+    Data::Xml::Dom::XmlDocument,
+    UI::Notifications::{ToastNotification, ToastNotificationManager},
+    core::HSTRING,
+};
 use winreg::RegKey;
 use winreg::enums::*;
-
-use crate::controller::NotificationHandle;
 
 pub async fn set_autostart(enabled: bool) -> Result<()> {
     // Get path to the current executable
@@ -41,57 +44,34 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
 }
 
 /// Show a notification in the bottom right of the screen
-///
-/// Known issue: If the notification times out and goes into the notification center
-/// (the little thing that pops up when you click the bell icon), then we may not get the
-/// click signal.
-///
-/// I've seen this reported by people using Powershell, C#, etc., so I think it might
-/// be a Windows bug?
-/// - <https://superuser.com/questions/1488763/windows-10-notifications-not-activating-the-associated-app-when-clicking-on-it>
-/// - <https://stackoverflow.com/questions/65835196/windows-toast-notification-com-not-working>
-/// - <https://answers.microsoft.com/en-us/windows/forum/all/notifications-not-activating-the-associated-app/7a3b31b0-3a20-4426-9c88-c6e3f2ac62c6>
-///
-/// Firefox doesn't have this problem. Maybe they're using a different API.
-pub(crate) fn show_notification(title: String, body: String) -> Result<NotificationHandle> {
-    let (tx, rx) = futures::channel::oneshot::channel();
+pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
+    let toast_xml = format!(
+        r#"<toast>
+    <visual>
+        <binding template="ToastGeneric">
+            <text id="1">{title}</text>
+            <text id="2">{body}</text>
+        </binding>
+    </visual>
+</toast>"#,
+        title = xml_escape(&title),
+        body = xml_escape(&body),
+    );
 
-    // For some reason `on_activated` is FnMut
-    let mut tx = Some(tx);
-
-    tauri_winrt_notification::Toast::new(&app_id())
-        .title(&title)
-        .text1(&body)
-        .scenario(tauri_winrt_notification::Scenario::Reminder)
-        .on_activated(move |_| {
-            let Some(tx) = tx.take() else { return Ok(()) };
-
-            let _ = tx.send(());
-
-            Ok(())
-        })
-        .show()
-        .context("Failed to show notification")?;
+    show_toast(&toast_xml).context("Failed to show notification")?;
 
     tracing::debug!(%title, %body, "Showing notification");
 
-    Ok(NotificationHandle { on_click: rx })
+    Ok(())
 }
 
 /// Show a notification about a new release that opens `download_url` when activated
 ///
 /// The toast declares `activationType="protocol"`, so the shell opens the URL
-/// itself. Unlike the in-process activation callback used by
-/// [`show_notification`], this also works after the toast has moved into the
-/// notification center. `duration="long"` keeps the toast on screen for 25
-/// seconds instead of the default ~6.
+/// itself. Unlike an in-process activation callback, this also works after the
+/// toast has moved into the notification center. `duration="long"` keeps the
+/// toast on screen for 25 seconds instead of the default ~6.
 pub(crate) fn show_update_notification(title: String, download_url: url::Url) -> Result<()> {
-    use windows::{
-        Data::Xml::Dom::XmlDocument,
-        UI::Notifications::{ToastNotification, ToastNotificationManager},
-        core::HSTRING,
-    };
-
     let toast_xml = format!(
         r#"<toast duration="long" activationType="protocol" launch="{url}">
     <visual>
@@ -105,8 +85,19 @@ pub(crate) fn show_update_notification(title: String, download_url: url::Url) ->
         title = xml_escape(&title),
     );
 
+    show_toast(&toast_xml).context("Failed to show update notification")?;
+
+    tracing::debug!(%title, %download_url, "Showing update notification");
+
+    Ok(())
+}
+
+/// Displays a toast notification from the given [toast content XML].
+///
+/// [toast content XML]: https://learn.microsoft.com/en-us/uwp/schemas/tiles/toastschema/element-toast
+fn show_toast(toast_xml: &str) -> Result<()> {
     let xml = XmlDocument::new()?;
-    xml.LoadXml(&HSTRING::from(&toast_xml))
+    xml.LoadXml(&HSTRING::from(toast_xml))
         .context("Failed to load toast XML")?;
     let toast =
         ToastNotification::CreateToastNotification(&xml).context("Failed to create toast")?;
@@ -114,8 +105,6 @@ pub(crate) fn show_update_notification(title: String, download_url: url::Url) ->
         .context("Failed to create toast notifier")?
         .Show(&toast)
         .context("Failed to show toast")?;
-
-    tracing::debug!(%title, %download_url, "Showing update notification");
 
     Ok(())
 }

--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -42,13 +42,6 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
 
 /// Show a notification in the bottom right of the screen
 ///
-/// Windows silently drops a toast whose AUMID doesn't match the calling
-/// process's identity. Packaged builds run under the sparse MSIX
-/// identity, so we register under the package AUMID and the title and
-/// icon come from the manifest's `VisualElements`. Un-packaged dev
-/// builds (no package identity) fall back to [`crate::BUNDLE_ID`].
-/// <https://github.com/tauri-apps/winrt-notification/issues/17#issuecomment-1988715694>
-///
 /// Known issue: If the notification times out and goes into the notification center
 /// (the little thing that pops up when you click the bell icon), then we may not get the
 /// click signal.
@@ -66,16 +59,7 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<Notificat
     // For some reason `on_activated` is FnMut
     let mut tx = Some(tx);
 
-    // `Firezone` is the `<Application Id="Firezone">` from
-    // `win_files/AppxManifest.xml`; together with the package family
-    // name it forms the package AUMID Windows attributes toasts to.
-    let app_id = if crate::package_identity::has_package_identity() {
-        format!("{}!Firezone", crate::PACKAGE_FAMILY_NAME)
-    } else {
-        crate::BUNDLE_ID.to_owned()
-    };
-
-    tauri_winrt_notification::Toast::new(&app_id)
+    tauri_winrt_notification::Toast::new(&app_id())
         .title(&title)
         .text1(&body)
         .scenario(tauri_winrt_notification::Scenario::Reminder)
@@ -92,4 +76,72 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<Notificat
     tracing::debug!(%title, %body, "Showing notification");
 
     Ok(NotificationHandle { on_click: rx })
+}
+
+/// Show a notification about a new release that opens `download_url` when activated
+///
+/// The toast declares `activationType="protocol"`, so the shell opens the URL
+/// itself. Unlike the in-process activation callback used by
+/// [`show_notification`], this also works after the toast has moved into the
+/// notification center. `duration="long"` keeps the toast on screen for 25
+/// seconds instead of the default ~6.
+pub(crate) fn show_update_notification(title: String, download_url: url::Url) -> Result<()> {
+    use windows::{
+        Data::Xml::Dom::XmlDocument,
+        UI::Notifications::{ToastNotification, ToastNotificationManager},
+        core::HSTRING,
+    };
+
+    let toast_xml = format!(
+        r#"<toast duration="long" activationType="protocol" launch="{url}">
+    <visual>
+        <binding template="ToastGeneric">
+            <text id="1">{title}</text>
+            <text id="2">Click here to download the new version</text>
+        </binding>
+    </visual>
+</toast>"#,
+        url = xml_escape(download_url.as_str()),
+        title = xml_escape(&title),
+    );
+
+    let xml = XmlDocument::new()?;
+    xml.LoadXml(&HSTRING::from(&toast_xml))
+        .context("Failed to load toast XML")?;
+    let toast =
+        ToastNotification::CreateToastNotification(&xml).context("Failed to create toast")?;
+    ToastNotificationManager::CreateToastNotifierWithId(&HSTRING::from(&app_id()))
+        .context("Failed to create toast notifier")?
+        .Show(&toast)
+        .context("Failed to show toast")?;
+
+    tracing::debug!(%title, %download_url, "Showing update notification");
+
+    Ok(())
+}
+
+/// The AppUserModelID Windows attributes our toasts to
+///
+/// Windows silently drops a toast whose AUMID doesn't match the calling
+/// process's identity. Packaged builds run under the sparse MSIX identity, so
+/// we register under the package AUMID (`Firezone` is the
+/// `<Application Id="Firezone">` from `win_files/AppxManifest.xml`; together
+/// with the package family name it forms the AUMID) and the title and icon
+/// come from the manifest's `VisualElements`. Un-packaged dev builds (no
+/// package identity) fall back to [`crate::BUNDLE_ID`].
+/// <https://github.com/tauri-apps/winrt-notification/issues/17#issuecomment-1988715694>
+fn app_id() -> String {
+    if crate::package_identity::has_package_identity() {
+        format!("{}!Firezone", crate::PACKAGE_FAMILY_NAME)
+    } else {
+        crate::BUNDLE_ID.to_owned()
+    }
+}
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
 }

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@
 // TODO: remove once all clients have migrated.
 #[cfg(target_os = "windows")]
 mod mdm_migration;
-mod updates;
+pub mod updates;
 mod uptime;
 mod view;
 

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -34,7 +34,7 @@ pub mod settings;
 ///
 /// Note: under the sparse MSIX identity this is *not* the
 /// AppUserModelId Windows uses to label notifications; that is derived
-/// from [`PACKAGE_FAMILY_NAME`] in `gui::os::show_notification`. It is
+/// from [`PACKAGE_FAMILY_NAME`] in `gui::os::app_id`. It is
 /// still used as the toast AUMID for un-packaged dev builds, which have
 /// no package identity.
 pub const BUNDLE_ID: &str = "dev.firezone.client";
@@ -52,7 +52,7 @@ pub const FIREZONE_CLIENT_GROUP: &str = "firezone-client";
 /// `register-sparse.exe` to stage / provision / deprovision the
 /// package against the AppX deployment service, and to derive the
 /// package AUMID (`<PACKAGE_FAMILY_NAME>!Firezone`) that Windows uses to
-/// label toast notifications (see `gui::os::show_notification`).
+/// label toast notifications (see `gui::os::app_id`).
 pub const PACKAGE_FAMILY_NAME: &str = env!("FIREZONE_PACKAGE_FAMILY_NAME");
 
 #[cfg(target_os = "linux")]

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -34,7 +34,7 @@ pub mod settings;
 ///
 /// Note: under the sparse MSIX identity this is *not* the
 /// AppUserModelId Windows uses to label notifications; that is derived
-/// from [`PACKAGE_FAMILY_NAME`] in `gui::os::app_id`. It is
+/// from [`PACKAGE_FAMILY_NAME`] in `gui::os::notification_app_id`. It is
 /// still used as the toast AUMID for un-packaged dev builds, which have
 /// no package identity.
 pub const BUNDLE_ID: &str = "dev.firezone.client";
@@ -52,7 +52,7 @@ pub const FIREZONE_CLIENT_GROUP: &str = "firezone-client";
 /// `register-sparse.exe` to stage / provision / deprovision the
 /// package against the AppX deployment service, and to derive the
 /// package AUMID (`<PACKAGE_FAMILY_NAME>!Firezone`) that Windows uses to
-/// label toast notifications (see `gui::os::app_id`).
+/// label toast notifications (see `gui::os::notification_app_id`).
 pub const PACKAGE_FAMILY_NAME: &str = env!("FIREZONE_PACKAGE_FAMILY_NAME");
 
 #[cfg(target_os = "linux")]

--- a/rust/gui-client/src-tauri/src/updates.rs
+++ b/rust/gui-client/src-tauri/src/updates.rs
@@ -109,18 +109,11 @@ impl Checker {
 
     /// Call this when we just checked the network
     fn handle_check(&mut self, release: Release) {
-        let different_than_latest_notified = match &self.notification {
-            None => release.version != self.ours,
-            Some(notified) => release.version != notified.version,
-        };
+        let desired = (release.version > self.ours).then_some(release);
 
-        if different_than_latest_notified {
+        if desired != self.notification {
+            self.notification = desired;
             self.notification_dirty = true;
-            self.notification = if release.version == self.ours {
-                None
-            } else {
-                Some(release)
-            };
         }
     }
 
@@ -261,6 +254,17 @@ mod tests {
         assert_eq!(fsm.poll(), Event::CheckNetwork);
         fsm.handle_check(release(1, 0, 0));
         assert_eq!(fsm.poll(), Event::Notify(None));
+        assert_eq!(fsm.poll(), Event::WaitInterval);
+    }
+
+    #[test]
+    fn checker_ignores_older_release() {
+        let mut fsm = Checker::new(Version::new(1, 0, 1));
+        assert_eq!(fsm.poll(), Event::WaitRandom);
+        assert_eq!(fsm.poll(), Event::CheckNetwork);
+
+        // The website may advertise an older release than ours, e.g. right after we shipped a new one; don't notify.
+        fsm.handle_check(release(1, 0, 0));
         assert_eq!(fsm.poll(), Event::WaitInterval);
     }
 

--- a/rust/gui-client/src-tauri/src/updates.rs
+++ b/rust/gui-client/src-tauri/src/updates.rs
@@ -188,15 +188,57 @@ pub(crate) async fn check() -> Result<Release> {
     let version = api_response.gui;
     tracing::debug!(?version, "Latest GUI version from API");
 
-    let download_url = url::Url::parse(&format!(
-        "{BASE_URL}/dl/firezone-client-gui-{os}/{version}/{arch}"
-    ))
-    .context("Failed to construct download URL")?;
+    let download_url = download_url_for(os, arch, package_suffix(), &version)?;
 
     Ok(Release {
         download_url,
         version,
     })
+}
+
+fn download_url_for(
+    os: &str,
+    arch: &str,
+    package_suffix: &str,
+    version: &Version,
+) -> Result<url::Url> {
+    let url = url::Url::parse(&format!(
+        "{BASE_URL}/dl/firezone-client-gui-{os}/{version}/{arch}{package_suffix}"
+    ))
+    .context("Failed to construct download URL")?;
+
+    Ok(url)
+}
+
+/// The package-specific suffix of the download URL.
+///
+/// Linux is the only OS where a release consists of more than one package
+/// format per architecture: a `.deb` (the URL's default) and an `.rpm`.
+#[cfg(target_os = "linux")]
+fn package_suffix() -> &'static str {
+    match std::fs::read_to_string("/etc/os-release") {
+        Ok(os_release) if is_rpm_based(&os_release) => ".rpm",
+        Ok(_) => "",
+        Err(_) => "",
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn package_suffix() -> &'static str {
+    ""
+}
+
+/// Whether the given [`os-release`] contents describe an RPM-based distribution.
+///
+/// [`os-release`]: https://www.freedesktop.org/software/systemd/man/latest/os-release.html
+#[cfg(target_os = "linux")]
+fn is_rpm_based(os_release: &str) -> bool {
+    os_release
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .filter(|(key, _)| matches!(*key, "ID" | "ID_LIKE"))
+        .flat_map(|(_, value)| value.trim_matches('"').split_whitespace())
+        .any(|id| matches!(id, "fedora" | "rhel" | "centos" | "suse") || id.starts_with("opensuse"))
 }
 
 pub(crate) fn current_version() -> Result<Version> {
@@ -318,14 +360,44 @@ mod tests {
 
     #[test]
     fn download_url_construction() {
-        let arch = std::env::consts::ARCH;
-        let os = std::env::consts::OS;
-
-        let release = release(1, 5, 9);
-
         assert_eq!(
-            release.download_url.as_str(),
-            format!("{BASE_URL}/dl/firezone-client-gui-{os}/1.5.9/{arch}")
+            download_url_for("windows", "x86_64", "", &Version::new(1, 5, 9))
+                .unwrap()
+                .as_str(),
+            "https://www.firezone.dev/dl/firezone-client-gui-windows/1.5.9/x86_64"
         );
+        assert_eq!(
+            download_url_for("linux", "x86_64", ".rpm", &Version::new(1, 5, 9))
+                .unwrap()
+                .as_str(),
+            "https://www.firezone.dev/dl/firezone-client-gui-linux/1.5.9/x86_64.rpm"
+        );
+        assert_eq!(
+            download_url_for("linux", "aarch64", "", &Version::new(1, 5, 9))
+                .unwrap()
+                .as_str(),
+            "https://www.firezone.dev/dl/firezone-client-gui-linux/1.5.9/aarch64"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn rpm_detection() {
+        // Fedora has no `ID_LIKE`.
+        assert!(is_rpm_based("NAME=\"Fedora Linux\"\nID=fedora\n"));
+        // Derivatives reference their ancestry via `ID_LIKE`.
+        assert!(is_rpm_based(
+            "ID=\"rocky\"\nID_LIKE=\"rhel centos fedora\"\n"
+        ));
+        assert!(is_rpm_based(
+            "ID=\"opensuse-tumbleweed\"\nID_LIKE=\"opensuse suse\"\n"
+        ));
+        assert!(is_rpm_based(
+            "ID=almalinux\nID_LIKE=\"rhel centos fedora\"\n"
+        ));
+
+        assert!(!is_rpm_based("ID=ubuntu\nID_LIKE=debian\n"));
+        assert!(!is_rpm_based("ID=debian\n"));
+        assert!(!is_rpm_based(""));
     }
 }

--- a/rust/gui-client/src-tauri/src/updates.rs
+++ b/rust/gui-client/src-tauri/src/updates.rs
@@ -213,7 +213,7 @@ fn download_url_for(
 /// The package-specific suffix of the download URL.
 ///
 /// Linux is the only OS where a release consists of more than one package
-/// format per architecture: a `.deb` (the URL's default) and an `.rpm`.
+/// format per architecture: a `.deb` and an `.rpm`.
 #[cfg(target_os = "linux")]
 fn package_suffix() -> &'static str {
     // `/etc/os-release` takes precedence but is allowed to be absent:
@@ -223,8 +223,8 @@ fn package_suffix() -> &'static str {
 
     match os_release {
         Ok(os_release) if is_rpm_based(&os_release) => ".rpm",
-        Ok(_) => "",
-        Err(_) => "",
+        Ok(_) => ".deb",
+        Err(_) => ".deb",
     }
 }
 
@@ -378,10 +378,10 @@ mod tests {
             "https://www.firezone.dev/dl/firezone-client-gui-linux/1.5.9/x86_64.rpm"
         );
         assert_eq!(
-            download_url_for("linux", "aarch64", "", &Version::new(1, 5, 9))
+            download_url_for("linux", "aarch64", ".deb", &Version::new(1, 5, 9))
                 .unwrap()
                 .as_str(),
-            "https://www.firezone.dev/dl/firezone-client-gui-linux/1.5.9/aarch64"
+            "https://www.firezone.dev/dl/firezone-client-gui-linux/1.5.9/aarch64.deb"
         );
     }
 

--- a/rust/gui-client/src-tauri/src/updates.rs
+++ b/rust/gui-client/src-tauri/src/updates.rs
@@ -216,7 +216,12 @@ fn download_url_for(
 /// format per architecture: a `.deb` (the URL's default) and an `.rpm`.
 #[cfg(target_os = "linux")]
 fn package_suffix() -> &'static str {
-    match std::fs::read_to_string("/etc/os-release") {
+    // `/etc/os-release` takes precedence but is allowed to be absent:
+    // <https://www.freedesktop.org/software/systemd/man/latest/os-release.html>
+    let os_release = std::fs::read_to_string("/etc/os-release")
+        .or_else(|_| std::fs::read_to_string("/usr/lib/os-release"));
+
+    match os_release {
         Ok(os_release) if is_rpm_based(&os_release) => ".rpm",
         Ok(_) => "",
         Err(_) => "",

--- a/rust/gui-client/src-tauri/src/updates.rs
+++ b/rust/gui-client/src-tauri/src/updates.rs
@@ -29,6 +29,8 @@ struct ApiReleasesResponse {
 /// The last version we notified about is only kept in memory, so the user
 /// is reminded about a pending update once per GUI session.
 pub async fn checker_task(ctlr_tx: mpsc::Sender<Option<Release>>, debug_mode: bool) -> Result<()> {
+    delete_legacy_version_file().await;
+
     let (current_version, interval_in_seconds) = if debug_mode {
         (Version::new(1, 0, 0), 30)
     } else {
@@ -64,6 +66,20 @@ pub async fn checker_task(ctlr_tx: mpsc::Sender<Option<Release>>, debug_mode: bo
                 ctlr_tx.send(notification).await?;
             }
         }
+    }
+}
+
+/// Deletes the file where previous versions persisted the last version we notified about.
+// TODO: Remove this after a few releases.
+async fn delete_legacy_version_file() {
+    let Some(path) = known_dirs::session().map(|dir| dir.join("latest_version_seen.txt")) else {
+        return;
+    };
+
+    match tokio::fs::remove_file(&path).await {
+        Ok(()) => tracing::debug!(path = %path.display(), "Deleted legacy version file"),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => tracing::debug!("Failed to delete legacy version file: {e}"),
     }
 }
 

--- a/rust/gui-client/src-tauri/src/updates.rs
+++ b/rust/gui-client/src-tauri/src/updates.rs
@@ -4,22 +4,15 @@ use anyhow::{Context, Result};
 use rand::RngExt as _;
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use std::{io::Write, path::PathBuf, str::FromStr, time::Duration};
+use std::{str::FromStr, time::Duration};
 use tokio::sync::mpsc;
 
 const BASE_URL: &str = "https://www.firezone.dev";
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct Notification {
-    pub release: Release,
-    /// If true, show a pop-up notification and set the dot. If false, only set the dot.
-    pub tell_user: bool,
-}
-
 /// GUI-friendly release struct
 ///
 /// Serialize is derived for debugging
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Release {
     pub download_url: url::Url,
     pub version: Version,
@@ -31,19 +24,18 @@ struct ApiReleasesResponse {
     gui: Version,
 }
 
-pub async fn checker_task(
-    ctlr_tx: mpsc::Sender<Option<Notification>>,
-    debug_mode: bool,
-) -> Result<()> {
+/// Periodically checks the website for newer releases and notifies the GUI.
+///
+/// The last version we notified about is only kept in memory, so the user
+/// is reminded about a pending update once per GUI session.
+pub async fn checker_task(ctlr_tx: mpsc::Sender<Option<Release>>, debug_mode: bool) -> Result<()> {
     let (current_version, interval_in_seconds) = if debug_mode {
         (Version::new(1, 0, 0), 30)
     } else {
         (current_version()?, 86_400)
     };
 
-    // Always check the file first, then wait a random amount of time before entering the loop.
-    let latest_seen = read_latest_release_file().await;
-    let mut fsm = Checker::new(current_version, latest_seen);
+    let mut fsm = Checker::new(current_version);
     let mut interval = tokio::time::interval(Duration::from_secs(interval_in_seconds));
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -69,68 +61,31 @@ pub async fn checker_task(
             }
             Event::Notify(notification) => {
                 tracing::debug!("Notify");
-                write_latest_release_file(notification.as_ref().map(|n| &n.release)).await?;
                 ctlr_tx.send(notification).await?;
             }
         }
     }
 }
 
-/// Reads the latest version and download URL we've seen, from disk
-async fn read_latest_release_file() -> Option<Release> {
-    tokio::fs::read_to_string(version_file_path().ok()?)
-        .await
-        .ok()
-        .as_deref()
-        .map(serde_json::from_str)
-        .transpose()
-        .ok()
-        .flatten()
-}
-
-async fn write_latest_release_file(release: Option<&Release>) -> Result<()> {
-    let path = version_file_path()?;
-    let Some(release) = release else {
-        let _ = tokio::fs::remove_file(&path).await;
-        return Ok(());
-    };
-
-    // `atomicwrites` is sync so use `spawn_blocking` so we don't block an
-    // executor thread
-    let s = serde_json::to_string(release)?;
-    tokio::task::spawn_blocking(move || {
-        std::fs::create_dir_all(
-            path.parent()
-                .context("release file path should always have a parent.")?,
-        )?;
-        let f =
-            atomicwrites::AtomicFile::new(&path, atomicwrites::OverwriteBehavior::AllowOverwrite);
-        f.write(|f| f.write_all(s.as_bytes()))?;
-        Ok::<_, anyhow::Error>(())
-    })
-    .await??;
-    Ok(())
-}
-
 struct Checker {
     ours: Version,
     state: State,
-    /// The last notification we pushed to the GUI
-    notification: Option<Notification>,
+    /// The last release we notified the GUI about
+    notification: Option<Release>,
     /// Have we changed our desired notification since we last told the GUI about it?
     notification_dirty: bool,
 }
 
 #[derive(Debug, PartialEq)]
 enum Event {
-    /// Check the latest version from the Firezone website and write it to disk.
+    /// Check the latest version from the Firezone website.
     CheckNetwork,
     /// Wait approximately a day using `tokio::time::interval`.
     WaitInterval,
     /// Wait a random amount of time up to the full interval, to avoid the thundering herd problem. This is only used at startup.
     WaitRandom,
     /// Set / clear a GUI notification.
-    Notify(Option<Notification>),
+    Notify(Option<Release>),
 }
 
 enum State {
@@ -143,21 +98,12 @@ enum State {
 }
 
 impl Checker {
-    fn new(ours: Version, latest_seen: Option<Release>) -> Self {
-        let notification = latest_seen
-            .filter(|r| r.version > ours)
-            .map(|release| Notification {
-                release,
-                // Never show a pop-up right at startup.
-                tell_user: false,
-            });
-        let notification_dirty = notification.is_some();
-
+    fn new(ours: Version) -> Self {
         Self {
             ours,
             state: State::WaitRandom,
-            notification,
-            notification_dirty,
+            notification: None,
+            notification_dirty: false,
         }
     }
 
@@ -165,7 +111,7 @@ impl Checker {
     fn handle_check(&mut self, release: Release) {
         let different_than_latest_notified = match &self.notification {
             None => release.version != self.ours,
-            Some(notification) => release.version != notification.release.version,
+            Some(notified) => release.version != notified.version,
         };
 
         if different_than_latest_notified {
@@ -173,10 +119,7 @@ impl Checker {
             self.notification = if release.version == self.ours {
                 None
             } else {
-                Some(Notification {
-                    release,
-                    tell_user: true,
-                })
+                Some(release)
             };
         }
     }
@@ -202,12 +145,6 @@ impl Checker {
             }
         }
     }
-}
-
-fn version_file_path() -> Result<PathBuf> {
-    Ok(known_dirs::session()
-        .context("Couldn't find session dir")?
-        .join("latest_version_seen.txt"))
 }
 
 /// Returns the latest release, even if ours is already newer
@@ -263,8 +200,7 @@ mod tests {
 
     #[test]
     fn checker_happy_path() {
-        // There's no file, this is a new system
-        let mut fsm = Checker::new(Version::new(1, 0, 0), None);
+        let mut fsm = Checker::new(Version::new(1, 0, 0));
         // After our initial random sleep we always check the network
         assert_eq!(fsm.poll(), Event::WaitRandom);
         assert_eq!(fsm.poll(), Event::CheckNetwork);
@@ -284,7 +220,7 @@ mod tests {
 
         // There's a new version, so tell the UI
         fsm.handle_check(release(1, 0, 1));
-        assert_eq!(fsm.poll(), Event::Notify(Some(notification(1, 0, 1))));
+        assert_eq!(fsm.poll(), Event::Notify(Some(release(1, 0, 1))));
         assert_eq!(fsm.poll(), Event::WaitInterval);
         assert_eq!(fsm.poll(), Event::CheckNetwork);
 
@@ -295,67 +231,30 @@ mod tests {
 
         // There's an even newer version, so tell the UI
         fsm.handle_check(release(1, 0, 2));
-        assert_eq!(fsm.poll(), Event::Notify(Some(notification(1, 0, 2))));
-    }
-
-    #[test]
-    fn checker_existing_system() {
-        // We check the file and we're already up to date, so do nothing
-        let mut fsm = Checker::new(Version::new(1, 0, 0), Some(release(1, 0, 0)));
-        assert_eq!(fsm.poll(), Event::WaitRandom);
-        assert_eq!(fsm.poll(), Event::CheckNetwork);
-
-        // We're on the latest version, so do nothing
-        fsm.handle_check(release(1, 0, 0));
-        assert_eq!(fsm.poll(), Event::WaitInterval);
-        assert_eq!(fsm.poll(), Event::CheckNetwork);
-    }
-
-    #[test]
-    fn checker_ignored_update() {
-        // We check the file and Firezone has restarted when we already knew about an update, but we don't tell the user for that, we just show the dot
-        let mut fsm = Checker::new(Version::new(1, 0, 0), Some(release(1, 0, 1)));
-        assert_eq!(
-            fsm.poll(),
-            Event::Notify(Some(Notification {
-                release: release(1, 0, 1),
-                tell_user: false,
-            }))
-        );
-        assert_eq!(fsm.poll(), Event::WaitRandom);
-        assert_eq!(fsm.poll(), Event::CheckNetwork);
-
-        // Don't notify since we already have the dot up.
-        fsm.handle_check(release(1, 0, 1));
-        assert_eq!(fsm.poll(), Event::WaitInterval);
-        assert_eq!(fsm.poll(), Event::CheckNetwork);
-
-        // There's an even newer version, so tell the user
-        fsm.handle_check(release(1, 0, 2));
-        assert_eq!(fsm.poll(), Event::Notify(Some(notification(1, 0, 2))));
+        assert_eq!(fsm.poll(), Event::Notify(Some(release(1, 0, 2))));
     }
 
     #[test]
     fn checker_rollback() {
-        let mut fsm = Checker::new(Version::new(1, 0, 0), Some(release(1, 0, 0)));
+        let mut fsm = Checker::new(Version::new(1, 0, 0));
         assert_eq!(fsm.poll(), Event::WaitRandom);
 
         // We first hear about 1.0.2 and notify for that
         assert_eq!(fsm.poll(), Event::CheckNetwork);
         fsm.handle_check(release(1, 0, 2));
-        assert_eq!(fsm.poll(), Event::Notify(Some(notification(1, 0, 2))));
+        assert_eq!(fsm.poll(), Event::Notify(Some(release(1, 0, 2))));
         assert_eq!(fsm.poll(), Event::WaitInterval);
 
         // Then we hear it's actually just 1.0.1, we still notify
         assert_eq!(fsm.poll(), Event::CheckNetwork);
         fsm.handle_check(release(1, 0, 1));
-        assert_eq!(fsm.poll(), Event::Notify(Some(notification(1, 0, 1))));
+        assert_eq!(fsm.poll(), Event::Notify(Some(release(1, 0, 1))));
         assert_eq!(fsm.poll(), Event::WaitInterval);
 
         // When we hear about 1.0.2 again, we notify again.
         assert_eq!(fsm.poll(), Event::CheckNetwork);
         fsm.handle_check(release(1, 0, 2));
-        assert_eq!(fsm.poll(), Event::Notify(Some(notification(1, 0, 2))));
+        assert_eq!(fsm.poll(), Event::Notify(Some(release(1, 0, 2))));
         assert_eq!(fsm.poll(), Event::WaitInterval);
 
         // But if we hear about 1.0.0, our own version, we remove the notification
@@ -363,13 +262,6 @@ mod tests {
         fsm.handle_check(release(1, 0, 0));
         assert_eq!(fsm.poll(), Event::Notify(None));
         assert_eq!(fsm.poll(), Event::WaitInterval);
-    }
-
-    fn notification(major: u64, minor: u64, patch: u64) -> Notification {
-        Notification {
-            release: release(major, minor, patch),
-            tell_user: true,
-        }
     }
 
     fn release(major: u64, minor: u64, patch: u64) -> Release {

--- a/rust/libs/desktop-notifications/Cargo.toml
+++ b/rust/libs/desktop-notifications/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "desktop-notifications"
+version = "0.1.0"
+edition = { workspace = true }
+description = "Cross-platform desktop notifications for the Firezone GUI client"
+license = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+url = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+futures = { workspace = true }
+zbus = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+tracing = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies.windows]
+workspace = true
+features = [
+    # `XmlDocument` for building the toast XML
+    "Data_Xml_Dom",
+    # `ToastNotification` / `ToastNotificationManager` for showing toasts
+    "UI_Notifications",
+]
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+
+[lints]
+workspace = true

--- a/rust/libs/desktop-notifications/Cargo.toml
+++ b/rust/libs/desktop-notifications/Cargo.toml
@@ -11,6 +11,7 @@ url = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 futures = { workspace = true }
+tracing = { workspace = true }
 zbus = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/rust/libs/desktop-notifications/src/lib.rs
+++ b/rust/libs/desktop-notifications/src/lib.rs
@@ -1,0 +1,59 @@
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+#![cfg_attr(test, allow(clippy::unwrap_in_result))]
+
+//! Cross-platform desktop notifications.
+//!
+//! Notifications are shown natively: as toasts via WinRT on Windows and via
+//! the `org.freedesktop.Notifications` D-Bus interface on Linux. macOS only
+//! has a stub because the production macOS client is a native app; the stub
+//! exists so the Tauri UI can be developed on a Mac.
+
+use anyhow::Result;
+use url::Url;
+
+#[cfg(target_os = "linux")]
+#[path = "platform/linux.rs"]
+mod platform;
+
+#[cfg(target_os = "macos")]
+#[path = "platform/macos.rs"]
+mod platform;
+
+#[cfg(target_os = "windows")]
+#[path = "platform/windows.rs"]
+mod platform;
+
+/// Shows notifications under a fixed application identity.
+#[derive(Clone, Debug)]
+pub struct Notifier {
+    app_id: String,
+}
+
+impl Notifier {
+    /// Creates a notifier for the given application identity.
+    ///
+    /// On Windows, this is the AppUserModelID that toasts are attributed to;
+    /// Windows silently drops toasts whose AUMID doesn't match the calling
+    /// process's identity. On Linux, it is the application name that some
+    /// desktops use to group notifications.
+    pub fn new(app_id: impl Into<String>) -> Self {
+        Self {
+            app_id: app_id.into(),
+        }
+    }
+
+    /// Shows a notification.
+    ///
+    /// Activating the notification opens `open_url`; only Windows supports
+    /// this, other platforms ignore it.
+    ///
+    /// Resolves once the notification has been handled: on Windows right
+    /// after hand-off to the toast platform, on Linux once the notification
+    /// is closed. Callers that don't want to wait for that should spawn the
+    /// future into a task.
+    pub async fn show(&self, title: &str, body: &str, open_url: Option<&Url>) -> Result<()> {
+        platform::show(&self.app_id, title, body, open_url).await?;
+
+        Ok(())
+    }
+}

--- a/rust/libs/desktop-notifications/src/lib.rs
+++ b/rust/libs/desktop-notifications/src/lib.rs
@@ -23,36 +23,21 @@ mod platform;
 #[path = "platform/windows.rs"]
 mod platform;
 
-/// Shows notifications under a fixed application identity.
-#[derive(Clone, Debug)]
-pub struct Notifier {
-    app_id: String,
-}
+/// Shows a notification.
+///
+/// `app_id` is the application identity: on Windows, the AppUserModelID that
+/// toasts are attributed to (Windows silently drops toasts whose AUMID
+/// doesn't match the calling process's identity); on Linux, the application
+/// name that some desktops use to group notifications.
+///
+/// Clicking the notification opens `open_url` (ignored on macOS).
+///
+/// Resolves once the notification has been handled: on Windows right after
+/// hand-off to the toast platform, on Linux once the notification is closed.
+/// Callers that don't want to wait for that should spawn the future into a
+/// task.
+pub async fn show(app_id: &str, title: &str, body: &str, open_url: Option<&Url>) -> Result<()> {
+    platform::show(app_id, title, body, open_url).await?;
 
-impl Notifier {
-    /// Creates a notifier for the given application identity.
-    ///
-    /// On Windows, this is the AppUserModelID that toasts are attributed to;
-    /// Windows silently drops toasts whose AUMID doesn't match the calling
-    /// process's identity. On Linux, it is the application name that some
-    /// desktops use to group notifications.
-    pub fn new(app_id: impl Into<String>) -> Self {
-        Self {
-            app_id: app_id.into(),
-        }
-    }
-
-    /// Shows a notification.
-    ///
-    /// Clicking the notification opens `open_url` (ignored on macOS).
-    ///
-    /// Resolves once the notification has been handled: on Windows right
-    /// after hand-off to the toast platform, on Linux once the notification
-    /// is closed. Callers that don't want to wait for that should spawn the
-    /// future into a task.
-    pub async fn show(&self, title: &str, body: &str, open_url: Option<&Url>) -> Result<()> {
-        platform::show(&self.app_id, title, body, open_url).await?;
-
-        Ok(())
-    }
+    Ok(())
 }

--- a/rust/libs/desktop-notifications/src/lib.rs
+++ b/rust/libs/desktop-notifications/src/lib.rs
@@ -44,8 +44,7 @@ impl Notifier {
 
     /// Shows a notification.
     ///
-    /// Activating the notification opens `open_url`; only Windows supports
-    /// this, other platforms ignore it.
+    /// Clicking the notification opens `open_url` (ignored on macOS).
     ///
     /// Resolves once the notification has been handled: on Windows right
     /// after hand-off to the toast platform, on Linux once the notification

--- a/rust/libs/desktop-notifications/src/platform/linux.rs
+++ b/rust/libs/desktop-notifications/src/platform/linux.rs
@@ -1,0 +1,236 @@
+use anyhow::{Context as _, Result};
+use futures::StreamExt as _;
+use std::collections::HashMap;
+use url::Url;
+
+pub(crate) async fn show(
+    app_id: &str,
+    title: &str,
+    body: &str,
+    _open_url: Option<&Url>, // TODO: Clickable notifications are not implemented on Linux.
+) -> Result<()> {
+    let connection = zbus::Connection::session()
+        .await
+        .context("Failed to connect to session bus")?;
+
+    show_at(&connection, app_id, title, body).await?;
+
+    Ok(())
+}
+
+/// Shows a notification via the [`org.freedesktop.Notifications`] D-Bus interface.
+///
+/// Resolves once the notification is closed: the D-Bus connection must stay
+/// open for as long as the notification is showing, otherwise it doesn't get
+/// displayed reliably on all desktops.
+///
+/// [`org.freedesktop.Notifications`]: https://specifications.freedesktop.org/notification-spec/latest/protocol.html
+async fn show_at(
+    connection: &zbus::Connection,
+    app_name: &str,
+    summary: &str,
+    body: &str,
+) -> Result<()> {
+    let proxy = zbus::Proxy::new(
+        connection,
+        "org.freedesktop.Notifications",
+        "/org/freedesktop/Notifications",
+        "org.freedesktop.Notifications",
+    )
+    .await
+    .context("Failed to create proxy")?;
+
+    // Subscribe before `Notify` so we cannot miss the close signal.
+    let mut closed = proxy
+        .receive_signal("NotificationClosed")
+        .await
+        .context("Failed to subscribe to `NotificationClosed`")?;
+
+    let id: u32 = proxy
+        .call(
+            "Notify",
+            &(
+                app_name,
+                0_u32, // We are not replacing an existing notification.
+                "",    // No icon.
+                summary,
+                body,
+                Vec::<&str>::new(),                            // No actions.
+                HashMap::<&str, zbus::zvariant::Value>::new(), // No hints.
+                -1_i32, // Let the server pick an expiry timeout.
+            ),
+        )
+        .await
+        .context("Failed to call `Notify`")?;
+
+    while let Some(message) = closed.next().await {
+        let (closed_id, _reason): (u32, u32) = message
+            .body()
+            .deserialize()
+            .context("Failed to deserialize `NotificationClosed`")?;
+
+        if closed_id == id {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::BufRead as _;
+    use std::time::Duration;
+
+    const NOTIFICATION_ID: u32 = 42;
+
+    #[tokio::test]
+    async fn shows_notification_end_to_end() {
+        let daemon = DbusDaemon::start();
+
+        let (received_tx, mut received_rx) = futures::channel::mpsc::unbounded();
+        let server = zbus::connection::Builder::address(daemon.address.as_str())
+            .unwrap()
+            .name("org.freedesktop.Notifications")
+            .unwrap()
+            .serve_at(
+                "/org/freedesktop/Notifications",
+                MockNotifications { received_tx },
+            )
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        let client = zbus::connection::Builder::address(daemon.address.as_str())
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+
+        let task =
+            tokio::spawn(
+                async move { show_at(&client, "Firezone", "Test title", "Test body").await },
+            );
+
+        // The daemon must receive exactly what we sent.
+        let notify = tokio::time::timeout(Duration::from_secs(10), received_rx.next())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(notify.app_name, "Firezone");
+        assert_eq!(notify.replaces_id, 0);
+        assert_eq!(notify.app_icon, "");
+        assert_eq!(notify.summary, "Test title");
+        assert_eq!(notify.body, "Test body");
+        assert!(notify.actions.is_empty());
+        assert_eq!(notify.num_hints, 0);
+        assert_eq!(notify.expire_timeout, -1);
+
+        // Closing some other notification must not resolve ours.
+        emit_notification_closed(&server, NOTIFICATION_ID + 1).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(!task.is_finished());
+
+        // Closing ours must.
+        emit_notification_closed(&server, NOTIFICATION_ID).await;
+        tokio::time::timeout(Duration::from_secs(10), task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+    }
+
+    async fn emit_notification_closed(connection: &zbus::Connection, id: u32) {
+        connection
+            .emit_signal(
+                None::<zbus::names::BusName>,
+                "/org/freedesktop/Notifications",
+                "org.freedesktop.Notifications",
+                "NotificationClosed",
+                &(id, 1_u32),
+            )
+            .await
+            .unwrap();
+    }
+
+    struct MockNotifications {
+        received_tx: futures::channel::mpsc::UnboundedSender<ReceivedNotify>,
+    }
+
+    #[zbus::interface(name = "org.freedesktop.Notifications")]
+    impl MockNotifications {
+        fn notify(
+            &self,
+            app_name: String,
+            replaces_id: u32,
+            app_icon: String,
+            summary: String,
+            body: String,
+            actions: Vec<String>,
+            hints: HashMap<String, zbus::zvariant::OwnedValue>,
+            expire_timeout: i32,
+        ) -> u32 {
+            self.received_tx
+                .unbounded_send(ReceivedNotify {
+                    app_name,
+                    replaces_id,
+                    app_icon,
+                    summary,
+                    body,
+                    actions,
+                    num_hints: hints.len(),
+                    expire_timeout,
+                })
+                .unwrap();
+
+            NOTIFICATION_ID
+        }
+    }
+
+    #[derive(Debug)]
+    struct ReceivedNotify {
+        app_name: String,
+        replaces_id: u32,
+        app_icon: String,
+        summary: String,
+        body: String,
+        actions: Vec<String>,
+        num_hints: usize,
+        expire_timeout: i32,
+    }
+
+    /// A private session bus, killed on drop.
+    struct DbusDaemon {
+        process: std::process::Child,
+        address: String,
+    }
+
+    impl DbusDaemon {
+        fn start() -> Self {
+            let mut process = std::process::Command::new("dbus-daemon")
+                .args(["--session", "--nofork", "--print-address"])
+                .stdout(std::process::Stdio::piped())
+                .spawn()
+                .expect("`dbus-daemon` must be installed to run this test");
+
+            let stdout = process.stdout.take().unwrap();
+            let mut address = String::new();
+            std::io::BufReader::new(stdout)
+                .read_line(&mut address)
+                .unwrap();
+
+            Self {
+                process,
+                address: address.trim().to_owned(),
+            }
+        }
+    }
+
+    impl Drop for DbusDaemon {
+        fn drop(&mut self) {
+            let _ = self.process.kill();
+            let _ = self.process.wait();
+        }
+    }
+}

--- a/rust/libs/desktop-notifications/src/platform/linux.rs
+++ b/rust/libs/desktop-notifications/src/platform/linux.rs
@@ -7,22 +7,34 @@ pub(crate) async fn show(
     app_id: &str,
     title: &str,
     body: &str,
-    _open_url: Option<&Url>, // TODO: Clickable notifications are not implemented on Linux.
+    open_url: Option<&Url>,
 ) -> Result<()> {
     let connection = zbus::Connection::session()
         .await
         .context("Failed to connect to session bus")?;
 
-    show_at(&connection, app_id, title, body).await?;
+    show_at(
+        &connection,
+        app_id,
+        title,
+        body,
+        open_url,
+        open_with_xdg_open,
+    )
+    .await?;
 
     Ok(())
 }
 
 /// Shows a notification via the [`org.freedesktop.Notifications`] D-Bus interface.
 ///
+/// A clickable notification carries the special `default` action, which
+/// servers invoke when the user clicks the notification itself; we then hand
+/// the URL to `open`.
+///
 /// Resolves once the notification is closed: the D-Bus connection must stay
 /// open for as long as the notification is showing, otherwise it doesn't get
-/// displayed reliably on all desktops.
+/// displayed reliably on all desktops (and we would miss the click).
 ///
 /// [`org.freedesktop.Notifications`]: https://specifications.freedesktop.org/notification-spec/latest/protocol.html
 async fn show_at(
@@ -30,6 +42,8 @@ async fn show_at(
     app_name: &str,
     summary: &str,
     body: &str,
+    open_url: Option<&Url>,
+    open: impl Fn(&Url),
 ) -> Result<()> {
     let proxy = zbus::Proxy::new(
         connection,
@@ -40,11 +54,21 @@ async fn show_at(
     .await
     .context("Failed to create proxy")?;
 
-    // Subscribe before `Notify` so we cannot miss the close signal.
-    let mut closed = proxy
+    // Subscribe before `Notify` so we cannot miss any signal.
+    let closed = proxy
         .receive_signal("NotificationClosed")
         .await
         .context("Failed to subscribe to `NotificationClosed`")?;
+    let invoked = proxy
+        .receive_signal("ActionInvoked")
+        .await
+        .context("Failed to subscribe to `ActionInvoked`")?;
+    let mut signals = futures::stream::select(closed, invoked);
+
+    let actions = match open_url {
+        Some(_) => vec!["default", "Open"],
+        None => Vec::new(),
+    };
 
     let id: u32 = proxy
         .call(
@@ -55,7 +79,7 @@ async fn show_at(
                 "",    // No icon.
                 summary,
                 body,
-                Vec::<&str>::new(),                            // No actions.
+                actions,
                 HashMap::<&str, zbus::zvariant::Value>::new(), // No hints.
                 -1_i32, // Let the server pick an expiry timeout.
             ),
@@ -63,18 +87,55 @@ async fn show_at(
         .await
         .context("Failed to call `Notify`")?;
 
-    while let Some(message) = closed.next().await {
-        let (closed_id, _reason): (u32, u32) = message
-            .body()
-            .deserialize()
-            .context("Failed to deserialize `NotificationClosed`")?;
+    while let Some(message) = signals.next().await {
+        match message.header().member().map(|member| member.as_str()) {
+            Some("NotificationClosed") => {
+                let (closed_id, _reason): (u32, u32) = message
+                    .body()
+                    .deserialize()
+                    .context("Failed to deserialize `NotificationClosed`")?;
 
-        if closed_id == id {
-            break;
+                if closed_id == id {
+                    break;
+                }
+            }
+            Some("ActionInvoked") => {
+                let (invoked_id, action): (u32, String) = message
+                    .body()
+                    .deserialize()
+                    .context("Failed to deserialize `ActionInvoked`")?;
+
+                if invoked_id == id
+                    && action == "default"
+                    && let Some(url) = open_url
+                {
+                    open(url);
+                }
+            }
+            _ => {}
         }
     }
 
     Ok(())
+}
+
+/// Opens `url` with the user's preferred application.
+///
+/// `xdg-open` is part of `xdg-utils`, which every desktop Linux
+/// installation ships.
+fn open_with_xdg_open(url: &Url) {
+    match std::process::Command::new("xdg-open")
+        .arg(url.as_str())
+        .spawn()
+    {
+        Ok(mut child) => {
+            // Reap the child to not leave a zombie process behind.
+            std::thread::spawn(move || {
+                let _ = child.wait();
+            });
+        }
+        Err(e) => tracing::debug!("Failed to spawn `xdg-open`: {e}"),
+    }
 }
 
 #[cfg(test)]
@@ -108,10 +169,16 @@ mod tests {
             .await
             .unwrap();
 
-        let task =
-            tokio::spawn(
-                async move { show_at(&client, "Firezone", "Test title", "Test body").await },
-            );
+        // Part 1: a plain notification, no URL.
+        let task = tokio::spawn({
+            let client = client.clone();
+            async move {
+                show_at(&client, "Firezone", "Test title", "Test body", None, |_| {
+                    panic!("Nothing to open for a plain notification")
+                })
+                .await
+            }
+        });
 
         // The daemon must receive exactly what we sent.
         let notify = tokio::time::timeout(Duration::from_secs(10), received_rx.next())
@@ -139,6 +206,52 @@ mod tests {
             .unwrap()
             .unwrap()
             .unwrap();
+
+        // Part 2: a clickable notification.
+        let url = Url::parse("https://www.firezone.dev/dl?arch=x86_64&os=linux").unwrap();
+        let (opened_tx, mut opened_rx) = futures::channel::mpsc::unbounded();
+        let task = tokio::spawn({
+            let client = client.clone();
+            let url = url.clone();
+            async move {
+                show_at(
+                    &client,
+                    "Firezone",
+                    "Update title",
+                    "Update body",
+                    Some(&url),
+                    move |url| opened_tx.unbounded_send(url.clone()).unwrap(),
+                )
+                .await
+            }
+        });
+
+        // The `default` action makes the notification clickable.
+        let notify = tokio::time::timeout(Duration::from_secs(10), received_rx.next())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(notify.actions, vec!["default", "Open"]);
+
+        // Clicks on other notifications must be ignored.
+        emit_action_invoked(&server, NOTIFICATION_ID + 1).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(opened_rx.try_recv().is_err(), "URL must not be opened yet");
+
+        // A click on ours must open the URL.
+        emit_action_invoked(&server, NOTIFICATION_ID).await;
+        let opened = tokio::time::timeout(Duration::from_secs(10), opened_rx.next())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(opened, url);
+
+        emit_notification_closed(&server, NOTIFICATION_ID).await;
+        tokio::time::timeout(Duration::from_secs(10), task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
     }
 
     async fn emit_notification_closed(connection: &zbus::Connection, id: u32) {
@@ -149,6 +262,19 @@ mod tests {
                 "org.freedesktop.Notifications",
                 "NotificationClosed",
                 &(id, 1_u32),
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn emit_action_invoked(connection: &zbus::Connection, id: u32) {
+        connection
+            .emit_signal(
+                None::<zbus::names::BusName>,
+                "/org/freedesktop/Notifications",
+                "org.freedesktop.Notifications",
+                "ActionInvoked",
+                &(id, "default"),
             )
             .await
             .unwrap();

--- a/rust/libs/desktop-notifications/src/platform/macos.rs
+++ b/rust/libs/desktop-notifications/src/platform/macos.rs
@@ -1,0 +1,14 @@
+use anyhow::Result;
+use url::Url;
+
+#[expect(clippy::unused_async, reason = "Signature must match other platforms.")]
+pub(crate) async fn show(
+    _app_id: &str,
+    _title: &str,
+    _body: &str,
+    _open_url: Option<&Url>,
+) -> Result<()> {
+    tracing::warn!("Notifications are not implemented on macOS");
+
+    Ok(())
+}

--- a/rust/libs/desktop-notifications/src/platform/windows.rs
+++ b/rust/libs/desktop-notifications/src/platform/windows.rs
@@ -1,0 +1,105 @@
+use anyhow::{Context as _, Result};
+use url::Url;
+use windows::{
+    Data::Xml::Dom::XmlDocument,
+    UI::Notifications::{ToastNotification, ToastNotificationManager},
+    core::HSTRING,
+};
+
+#[expect(clippy::unused_async, reason = "Signature must match other platforms.")]
+pub(crate) async fn show(
+    app_id: &str,
+    title: &str,
+    body: &str,
+    open_url: Option<&Url>,
+) -> Result<()> {
+    let toast_xml = toast_xml(title, body, open_url);
+
+    let xml = XmlDocument::new()?;
+    xml.LoadXml(&HSTRING::from(&toast_xml))
+        .context("Failed to load toast XML")?;
+    let toast =
+        ToastNotification::CreateToastNotification(&xml).context("Failed to create toast")?;
+    ToastNotificationManager::CreateToastNotifierWithId(&HSTRING::from(app_id))
+        .context("Failed to create toast notifier")?
+        .Show(&toast)
+        .context("Failed to show toast")?;
+
+    Ok(())
+}
+
+/// Renders the [toast content XML] for a notification.
+///
+/// A clickable toast declares `activationType="protocol"`, so the shell opens
+/// the URL itself. Unlike an in-process activation callback, that also works
+/// after the toast has moved into the notification center. Such a toast also
+/// uses `duration="long"` to stay on screen for 25 seconds instead of the
+/// default ~6, giving the user more time to actually click it.
+///
+/// [toast content XML]: https://learn.microsoft.com/en-us/uwp/schemas/tiles/toastschema/element-toast
+fn toast_xml(title: &str, body: &str, open_url: Option<&Url>) -> String {
+    let toast_attributes = match open_url {
+        Some(url) => format!(
+            r#" duration="long" activationType="protocol" launch="{}""#,
+            xml_escape(url.as_str())
+        ),
+        None => String::new(),
+    };
+
+    format!(
+        r#"<toast{toast_attributes}>
+    <visual>
+        <binding template="ToastGeneric">
+            <text id="1">{title}</text>
+            <text id="2">{body}</text>
+        </binding>
+    </visual>
+</toast>"#,
+        title = xml_escape(title),
+        body = xml_escape(body),
+    )
+}
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// AppUserModelID of Windows PowerShell, which is registered on every
+    /// Windows installation, so toasts under it are accepted even where our
+    /// own identity isn't registered (e.g. in CI).
+    const POWERSHELL_APP_ID: &str =
+        "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe";
+
+    #[tokio::test]
+    async fn shows_toasts_end_to_end() {
+        // A plain notification; XML-hostile characters must survive
+        // `XmlDocument::LoadXml`, i.e. Windows' own parser.
+        show(
+            POWERSHELL_APP_ID,
+            "Firezone <connected> & \"ready\"",
+            "Resource 'R&D' says <hello>",
+            None,
+        )
+        .await
+        .unwrap();
+
+        // A clickable notification, with a URL that needs escaping.
+        let url = Url::parse("https://www.firezone.dev/dl?arch=x86_64&os=windows").unwrap();
+        show(
+            POWERSHELL_APP_ID,
+            "Firezone 1.99.0 available for download",
+            "Click here to download the new version",
+            Some(&url),
+        )
+        .await
+        .unwrap();
+    }
+}


### PR DESCRIPTION
The update notification was near-unusable on Windows. The toast used the "reminder" scenario without any buttons, which Windows [silently ignores](https://learn.microsoft.com/en-us/uwp/schemas/tiles/toastschema/element-toast), so it showed for only ~6 seconds instead of staying on screen. Clicking it only worked while it was on screen because activation relies on the in-process `Activated` callback, which Windows does not deliver for toasts clicked in the notification center unless a COM activator is registered. On Linux, clicking never did anything at all, and the download URL always pointed at the `.deb`, even on RPM-based distributions that cannot install it. On top of that, the last-notified version was persisted to disk before the toast was even shown, so each user got exactly one notification per release, ever.

Notifications now live in a new `desktop-notifications` crate with a single `show` function for plain and clickable notifications alike, taking the application identity, a title, a body and an optional URL to open on click. On Windows, the crate builds the [toast content XML](https://learn.microsoft.com/en-us/uwp/schemas/tiles/toastschema/element-toast) itself and a clickable toast uses protocol activation with a long duration, so the shell opens the download URL, also from the notification center. On Linux, the crate calls the [`org.freedesktop.Notifications`](https://specifications.freedesktop.org/notification-spec/latest/protocol.html) D-Bus interface directly via `zbus`, holds the connection open until the notification is closed (dropping it early makes notifications unreliable on some desktops), and advertises the spec's `default` action so that clicking the notification opens the URL via `xdg-open`.

The last-notified version only lives in memory now, so users are re-notified about a pending update once per GUI session, and the `latest_version_seen.txt` state file is deleted on startup. The download URL now requests the package format matching the distribution, detected via `os-release`. This also replaces the `tauri-winrt-notification` and `notify-rust` dependencies, removing their never-compiled platform backends from the lockfile and therefore from SBOMs and dependency audits.

Related: firezone/website#411