### PR TITLE
test(portal): require async test cases

### DIFF
--- a/elixir/.credo.exs
+++ b/elixir/.credo.exs
@@ -40,6 +40,7 @@
       # them here, so they can be loaded by Credo before running the analysis.
       #
       requires: [
+        ".credo/check/warning/async_false_in_test.ex",
         ".credo/check/warning/unsafe_repo_usage.ex",
         ".credo/check/warning/safe_calls_outside_database_module.ex",
         ".credo/check/warning/missing_database_alias.ex",
@@ -163,6 +164,7 @@
           {Credo.Check.Warning.UnsafeExec, []},
 
           # Custom Checks
+          {Credo.Check.Warning.AsyncFalseInTest, []},
           {Credo.Check.Warning.ActionFallbackUsage, []},
           {Credo.Check.Warning.MissingChangesetFunction, []},
           {Credo.Check.Warning.SafeCallsOutsideDatabaseModule, []},

--- a/elixir/.credo/README.md
+++ b/elixir/.credo/README.md
@@ -4,6 +4,11 @@ This directory contains custom Credo checks specific to the Firezone codebase.
 
 ## Available Checks
 
+### Warning.AsyncFalseInTest
+
+Prevents test case modules from using `async: false`. Tests must isolate mutable
+state and run asynchronously.
+
 ### Warning.MissingChangesetFunction
 
 Ensures that Ecto schema modules define a `changeset/1` function that accepts an `Ecto.Changeset`.

--- a/elixir/.credo/check/warning/async_false_in_test.ex
+++ b/elixir/.credo/check/warning/async_false_in_test.ex
@@ -1,0 +1,62 @@
+defmodule Credo.Check.Warning.AsyncFalseInTest do
+  use Credo.Check,
+    base_priority: :high,
+    category: :warning,
+    run_on_all: true,
+    explanations: [
+      check: """
+      Test modules must not opt out of asynchronous execution with `async: false`.
+
+      Run the test module asynchronously and isolate mutable state with unique
+      process names, process-scoped configuration, and per-test resources.
+      """,
+      params: []
+    ]
+
+  @impl true
+  def run_on_all_source_files(exec, _source_files, params) do
+    exec
+    |> Execution.working_dir()
+    |> Credo.Sources.find_in_dir(["test/**/*.{ex,exs}"], [])
+    |> Enum.each(fn filename ->
+      source_file = filename |> File.read!() |> SourceFile.parse(filename)
+      run_on_source_file(exec, source_file, params)
+    end)
+  end
+
+  @doc false
+  def run(source_file, params \\ []) do
+    if test_file?(source_file.filename) do
+      issue_meta = IssueMeta.for(source_file, params)
+      Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta), [])
+    else
+      []
+    end
+  end
+
+  defp traverse({:use, meta, [_case_module, options]} = ast, issues, issue_meta)
+       when is_list(options) do
+    if Keyword.get(options, :async) == false do
+      issue =
+        format_issue(
+          issue_meta,
+          message:
+            "Test modules must run asynchronously. Replace `async: false` with `async: true` and isolate shared state.",
+          trigger: "async: false",
+          line_no: meta[:line]
+        )
+
+      {ast, [issue | issues]}
+    else
+      {ast, issues}
+    end
+  end
+
+  defp traverse(ast, issues, _issue_meta), do: {ast, issues}
+
+  defp test_file?(filename) do
+    filename
+    |> String.replace("\\", "/")
+    |> String.match?(~r{(^|/)test/.*\.(ex|exs)$})
+  end
+end

--- a/elixir/lib/portal/azure/managed_identity.ex
+++ b/elixir/lib/portal/azure/managed_identity.ex
@@ -43,14 +43,16 @@ defmodule Portal.Azure.ManagedIdentity do
   error.
   """
   def access_token!(resource) when is_binary(resource) do
-    case Portal.TokenCache.fetch(@token_cache, resource, fn -> fetch_token(resource) end) do
+    config = Portal.Config.fetch_env!(:portal, __MODULE__)
+    token_cache = Keyword.get(config, :token_cache, @token_cache)
+
+    case Portal.TokenCache.fetch(token_cache, resource, fn -> fetch_token(resource, config) end) do
       {:ok, token} -> token
       {:error, exception} -> raise exception
     end
   end
 
-  defp fetch_token(resource) do
-    config = Portal.Config.fetch_env!(:portal, __MODULE__)
+  defp fetch_token(resource, config) do
     req_opts =
       (config[:req_opts] || [])
       |> Keyword.put(:allow_private_ips, true)

--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -57,7 +57,7 @@ defmodule Portal.Google.APIClient do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
     cache_key = workspace_cache_key(impersonation_email, {:service_account_key, key})
 
-    TokenCache.fetch(@token_cache, cache_key, fn ->
+    TokenCache.fetch(token_cache(config), cache_key, fn ->
       fetch_key_access_token(impersonation_email, key, config)
     end)
   end
@@ -68,7 +68,7 @@ defmodule Portal.Google.APIClient do
        workload_identity_config.audience}
 
     with {:ok, federated_token} <-
-           TokenCache.fetch(@token_cache, federated_cache_key, fn ->
+           TokenCache.fetch(token_cache(config), federated_cache_key, fn ->
              fetch_federated_token(workload_identity_config, config)
            end) do
       cache_key =
@@ -77,7 +77,7 @@ defmodule Portal.Google.APIClient do
           {:federated, workload_identity_config}
         )
 
-      TokenCache.fetch(@token_cache, cache_key, fn ->
+      TokenCache.fetch(token_cache(config), cache_key, fn ->
         fetch_federated_access_token(
           impersonation_email,
           workload_identity_config.service_account_email,
@@ -87,6 +87,8 @@ defmodule Portal.Google.APIClient do
       end)
     end
   end
+
+  defp token_cache(config), do: Keyword.get(config, :token_cache, @token_cache)
 
   defp fetch_federated_token(workload_identity_config, config) do
     with {:ok, azure_token} <-

--- a/elixir/test/credo/check/warning/async_false_in_test_test.exs
+++ b/elixir/test/credo/check/warning/async_false_in_test_test.exs
@@ -1,0 +1,77 @@
+defmodule Credo.Check.Warning.AsyncFalseInTestTest do
+  use ExUnit.Case, async: true
+
+  alias Credo.Check.Warning.AsyncFalseInTest
+
+  setup_all do
+    Application.ensure_all_started(:credo)
+    :ok
+  end
+
+  test "reports async: false in an ExUnit case" do
+    issues =
+      """
+      defmodule Portal.ExampleTest do
+        use ExUnit.Case, async: false
+      end
+      """
+      |> issues()
+
+    assert [%{trigger: "async: false", line_no: 2}] = issues
+  end
+
+  test "reports async: false in a custom case template" do
+    issues =
+      """
+      defmodule PortalWeb.ExampleTest do
+        use PortalWeb.ConnCase,
+          async: false
+      end
+      """
+      |> issues()
+
+    assert [%{trigger: "async: false", line_no: 2}] = issues
+  end
+
+  test "allows async: true" do
+    issues =
+      """
+      defmodule Portal.ExampleTest do
+        use ExUnit.Case, async: true
+      end
+      """
+      |> issues()
+
+    assert issues == []
+  end
+
+  test "ignores unrelated async options" do
+    issues =
+      """
+      defmodule Portal.ExampleTest do
+        def request, do: run(async: false)
+      end
+      """
+      |> issues()
+
+    assert issues == []
+  end
+
+  test "ignores non-test files" do
+    issues =
+      """
+      defmodule Portal.Example do
+        use ExUnit.Case, async: false
+      end
+      """
+      |> issues("lib/portal/example.ex")
+
+    assert issues == []
+  end
+
+  defp issues(source, filename \\ "test/portal/example_test.exs") do
+    source
+    |> Credo.SourceFile.parse(filename)
+    |> AsyncFalseInTest.run()
+  end
+end

--- a/elixir/test/portal/azure/managed_identity_test.exs
+++ b/elixir/test/portal/azure/managed_identity_test.exs
@@ -1,5 +1,5 @@
 defmodule Portal.Azure.ManagedIdentityTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias Portal.Azure.ManagedIdentity
   alias Portal.TokenCache
@@ -50,7 +50,7 @@ defmodule Portal.Azure.ManagedIdentityTest do
 
   describe "access token cache" do
     setup do
-      server = start_supervised!({TokenCache, name: Portal.Azure.TokenCache})
+      server = start_token_cache()
 
       # Establish stub ownership before allowing the server process to use it
       Req.Test.stub(ManagedIdentity, fn conn ->
@@ -156,4 +156,10 @@ defmodule Portal.Azure.ManagedIdentityTest do
     end
   end
 
+  defp start_token_cache do
+    name = :"azure_token_cache_#{System.unique_integer([:positive])}"
+    server = start_supervised!({TokenCache, name: name})
+    Portal.Config.put_env_override(:portal, ManagedIdentity, token_cache: server)
+    server
+  end
 end

--- a/elixir/test/portal/google/api_client_test.exs
+++ b/elixir/test/portal/google/api_client_test.exs
@@ -1,5 +1,5 @@
 defmodule Portal.Google.APIClientTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
   import ExUnit.CaptureLog
 
   alias Portal.Google.APIClient
@@ -57,7 +57,7 @@ defmodule Portal.Google.APIClientTest do
         Req.Test.json(conn, %{"error" => "not mocked"})
       end)
 
-      server = start_supervised!({TokenCache, name: Portal.Google.TokenCache})
+      server = start_token_cache()
       Req.Test.allow(APIClient, self(), server)
       Req.Test.allow(Portal.Azure.ManagedIdentity, self(), server)
 
@@ -145,7 +145,7 @@ defmodule Portal.Google.APIClientTest do
     end
 
     test "caches a service-account-key access token" do
-      server = start_supervised!({TokenCache, name: Portal.Google.TokenCache})
+      server = start_token_cache()
       Req.Test.allow(APIClient, self(), server)
 
       Req.Test.expect(APIClient, fn conn ->
@@ -193,7 +193,7 @@ defmodule Portal.Google.APIClientTest do
         Req.Test.json(conn, %{"error" => "not mocked"})
       end)
 
-      server = start_supervised!({TokenCache, name: Portal.Google.TokenCache})
+      server = start_token_cache()
       Req.Test.allow(APIClient, self(), server)
       Req.Test.allow(Portal.Azure.ManagedIdentity, self(), server)
 
@@ -1472,6 +1472,13 @@ defmodule Portal.Google.APIClientTest do
       workload_identity_audience: @workload_identity_audience,
       service_account_email: @service_account_email
     )
+  end
+
+  defp start_token_cache do
+    name = :"google_token_cache_#{System.unique_integer([:positive])}"
+    server = start_supervised!({TokenCache, name: name})
+    Portal.Config.merge_env_override(:portal, APIClient, token_cache: server)
+    server
   end
 
   defp assert_authorization_header(conn, expected_token) do

--- a/elixir/test/portal/telemetry_toggle_test.exs
+++ b/elixir/test/portal/telemetry_toggle_test.exs
@@ -1,8 +1,7 @@
 defmodule Portal.Telemetry.ToggleTest do
-  # Separated from telemetry_test.exs because enable_metrics/1 and disable_metrics/1
-  # call :telemetry.attach_many/:telemetry.detach, which mutate a global ETS table.
-  # Running these tests alongside async: true tests causes races on handler state.
-  use ExUnit.Case, async: false
+  # Keep the global handler mutations sequential within this module. Telemetry is
+  # disabled in the test environment, and no other test module toggles these IDs.
+  use ExUnit.Case, async: true
 
   setup do
     Portal.Telemetry.disable_metrics(:liveview_events)

--- a/elixir/test/portal_web/rate_limit_test.exs
+++ b/elixir/test/portal_web/rate_limit_test.exs
@@ -1,21 +1,11 @@
 defmodule PortalWeb.RateLimitTest do
-  use PortalWeb.ConnCase, async: false
+  use PortalWeb.ConnCase, async: true
 
   setup do
-    previous_config = Application.get_env(:portal, PortalWeb.RateLimit)
-
-    Application.put_env(:portal, PortalWeb.RateLimit,
+    Portal.Config.put_env_override(:portal, PortalWeb.RateLimit,
       refill_rate: 1,
       capacity: PortalWeb.RateLimit.default_cost()
     )
-
-    on_exit(fn ->
-      if previous_config do
-        Application.put_env(:portal, PortalWeb.RateLimit, previous_config)
-      else
-        Application.delete_env(:portal, PortalWeb.RateLimit)
-      end
-    end)
 
     :ok
   end


### PR DESCRIPTION
## Summary

- add a custom Credo check that rejects async: false in test case declarations
- convert the remaining synchronous test modules to async execution
- isolate token caches and rate-limit configuration with per-test resources and process-scoped overrides

## Validation

- mix test: 4,460 passed
- mix credo --strict
- mix format --check-formatted