### PR TITLE
refactor(gui-client): drop tauri-winrt-notification

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2486,7 +2486,6 @@ dependencies = [
  "tauri-runtime",
  "tauri-specta",
  "tauri-utils",
- "tauri-winrt-notification",
  "telemetry",
  "tempfile",
  "thiserror 2.0.19",

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -92,7 +92,6 @@ mimalloc = { workspace = true }
 [target.'cfg(target_os = "windows")'.dependencies]
 admx-macro = { workspace = true }
 mimalloc = { workspace = true }
-tauri-winrt-notification = "0.7.2"
 windows-native-keyring-store = { workspace = true }
 windows-security = { workspace = true }
 windows-service = { workspace = true }

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -81,11 +81,7 @@ pub trait GuiIntegration {
 
     fn set_tray_icon(&mut self, icon: system_tray::Icon);
     fn set_tray_menu(&mut self, app_state: system_tray::AppState);
-    fn show_notification(
-        &self,
-        title: impl Into<String>,
-        body: impl Into<String>,
-    ) -> Result<NotificationHandle>;
+    fn show_notification(&self, title: impl Into<String>, body: impl Into<String>) -> Result<()>;
 
     /// Shows a notification about a new release, opening `download_url` on click where the platform supports it.
     fn show_update_notification(&self, title: impl Into<String>, download_url: Url) -> Result<()>;
@@ -102,10 +98,6 @@ pub trait GuiIntegration {
         settings: AdvancedSettings,
     ) -> Result<()>;
     fn show_about_page(&self) -> Result<()>;
-}
-
-pub struct NotificationHandle {
-    pub on_click: futures::channel::oneshot::Receiver<()>,
 }
 
 #[derive(strum::Display)]
@@ -654,7 +646,7 @@ impl<I: GuiIntegration> Controller<I> {
         gui::set_autostart(self.general_settings.start_on_login.is_some_and(|v| v)).await?;
 
         self.notify_settings_changed()?;
-        let _ = self.integration.show_notification("Settings saved", "")?;
+        self.integration.show_notification("Settings saved", "")?;
 
         Ok(())
     }
@@ -688,7 +680,7 @@ impl<I: GuiIntegration> Controller<I> {
                 self.sign_out().await?;
                 if is_authentication_error {
                     tracing::info!(?error_msg, "Auth error");
-                    let _ = self.integration.show_notification(
+                    self.integration.show_notification(
                         "Firezone disconnected",
                         "To access resources, sign in again.",
                     )?;
@@ -705,7 +697,7 @@ impl<I: GuiIntegration> Controller<I> {
 
                 // If this is the first time we receive resources, show the notification that we are connected.
                 if let &Status::WaitingForTunnel = &self.status {
-                    let _ = self.integration.show_notification(
+                    self.integration.show_notification(
                         "Firezone connected",
                         "You are now signed in and able to access resources.",
                     )?;
@@ -726,7 +718,7 @@ impl<I: GuiIntegration> Controller<I> {
                 tracing::info!("Tunnel service exited gracefully");
                 self.integration
                     .set_tray_icon(system_tray::icon_terminating());
-                let _ = self.integration.show_notification(
+                self.integration.show_notification(
                     "Firezone disconnected",
                     "The Firezone Tunnel service was shut down, quitting GUI process.",
                 )?;
@@ -750,12 +742,11 @@ impl<I: GuiIntegration> Controller<I> {
                 self.notify_settings_changed()?;
                 self.refresh_ui_state();
 
-                let _ = self.integration.show_notification("Settings saved", "")?;
+                self.integration.show_notification("Settings saved", "")?;
             }
             service::ServerMsg::AdvancedSettingsApplied(Err(err)) => {
                 tracing::error!("Tunnel service failed to save advanced settings: {err}");
-                let _ = self
-                    .integration
+                self.integration
                     .show_notification("Failed to save settings", &err)?;
             }
             service::ServerMsg::GatewayVersionMismatch { resource_id } => {
@@ -1501,7 +1492,7 @@ mod tests {
         opened_urls: Vec<String>,
         tray_icons: Vec<system_tray::Icon>,
         tray_states: Vec<system_tray::AppState>,
-        notifications: Vec<(String, String, futures::channel::oneshot::Sender<()>)>,
+        notifications: Vec<(String, String)>,
         update_notifications: Vec<(String, Url)>,
         window_visibilities: Vec<bool>,
         shown_overview_page: Vec<SessionViewModel>,
@@ -1511,9 +1502,7 @@ mod tests {
 
     impl MockIntegration {
         fn nth_notification(&self, idx: usize) -> Option<(String, String)> {
-            let (title, body, _) = self.notifications.get(idx)?;
-
-            Some((title.clone(), body.clone()))
+            self.notifications.get(idx).cloned()
         }
     }
 
@@ -1563,14 +1552,10 @@ mod tests {
             &self,
             title: impl Into<String>,
             body: impl Into<String>,
-        ) -> Result<NotificationHandle> {
-            let (tx, rx) = futures::channel::oneshot::channel();
+        ) -> Result<()> {
+            self.lock().notifications.push((title.into(), body.into()));
 
-            self.lock()
-                .notifications
-                .push((title.into(), body.into(), tx));
-
-            Ok(NotificationHandle { on_click: rx })
+            Ok(())
         }
 
         fn show_update_notification(

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -4,7 +4,7 @@
 //! The real macOS Client is in `swift/apple`
 
 use crate::{
-    controller::{Controller, ControllerRequest, Failure, GuiIntegration, NotificationHandle},
+    controller::{Controller, ControllerRequest, Failure, GuiIntegration},
     deep_link,
     ipc::{self, ClientRead, ClientWrite, SocketId},
     launch_lock::{self, FirstInstance, LaunchLock},
@@ -158,11 +158,7 @@ impl GuiIntegration for TauriIntegration {
         self.tray.update(app_state)
     }
 
-    fn show_notification(
-        &self,
-        title: impl Into<String>,
-        body: impl Into<String>,
-    ) -> Result<NotificationHandle> {
+    fn show_notification(&self, title: impl Into<String>, body: impl Into<String>) -> Result<()> {
         os::show_notification(title.into(), body.into())
     }
 

--- a/rust/gui-client/src-tauri/src/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_linux.rs
@@ -1,7 +1,5 @@
 use anyhow::{Context as _, Result};
 
-use crate::controller::NotificationHandle;
-
 pub async fn set_autostart(enabled: bool) -> Result<()> {
     let dir = dirs::config_local_dir()
         .context("Can't compute `config_local_dir`")?
@@ -36,9 +34,7 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
     clippy::unnecessary_wraps,
     reason = "Signature must match other platforms."
 )]
-pub(crate) fn show_notification(title: String, body: String) -> Result<NotificationHandle> {
-    let (_, rx) = futures::channel::oneshot::channel();
-
+pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
     tokio::spawn(async move {
         let notification = match notify_rust::Notification::new()
             .summary(&title)
@@ -58,7 +54,7 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<Notificat
         notification.wait_for_action_async(|_| {}).await;
     });
 
-    Ok(NotificationHandle { on_click: rx })
+    Ok(())
 }
 
 /// Show a notification about a new release
@@ -66,7 +62,7 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<Notificat
 /// Clickable notifications don't work on Linux yet, so the notification only
 /// announces the release and the user downloads it via the tray menu.
 pub(crate) fn show_update_notification(title: String, _download_url: url::Url) -> Result<()> {
-    let _ = show_notification(title, String::new())?;
+    show_notification(title, String::new())?;
 
     Ok(())
 }

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -1,8 +1,6 @@
 //! This file is a stub only to do Tauri UI dev natively on a Mac.
 use anyhow::Result;
 
-use crate::controller::NotificationHandle;
-
 pub async fn set_autostart(_enabled: bool) -> Result<()> {
     tracing::warn!("set_autostart is not implemented on macOS; skipping");
 
@@ -13,12 +11,10 @@ pub async fn set_autostart(_enabled: bool) -> Result<()> {
     clippy::unnecessary_wraps,
     reason = "Signature must match other platforms."
 )]
-pub(crate) fn show_notification(_title: String, _body: String) -> Result<NotificationHandle> {
+pub(crate) fn show_notification(_title: String, _body: String) -> Result<()> {
     tracing::warn!("show_notification is not implemented on macOS; skipping");
 
-    let (_tx, on_click) = futures::channel::oneshot::channel();
-
-    Ok(NotificationHandle { on_click })
+    Ok(())
 }
 
 #[expect(

--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -1,9 +1,12 @@
 use anyhow::{Context, Result};
 use std::env;
+use windows::{
+    Data::Xml::Dom::XmlDocument,
+    UI::Notifications::{ToastNotification, ToastNotificationManager},
+    core::HSTRING,
+};
 use winreg::RegKey;
 use winreg::enums::*;
-
-use crate::controller::NotificationHandle;
 
 pub async fn set_autostart(enabled: bool) -> Result<()> {
     // Get path to the current executable
@@ -41,57 +44,34 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
 }
 
 /// Show a notification in the bottom right of the screen
-///
-/// Known issue: If the notification times out and goes into the notification center
-/// (the little thing that pops up when you click the bell icon), then we may not get the
-/// click signal.
-///
-/// I've seen this reported by people using Powershell, C#, etc., so I think it might
-/// be a Windows bug?
-/// - <https://superuser.com/questions/1488763/windows-10-notifications-not-activating-the-associated-app-when-clicking-on-it>
-/// - <https://stackoverflow.com/questions/65835196/windows-toast-notification-com-not-working>
-/// - <https://answers.microsoft.com/en-us/windows/forum/all/notifications-not-activating-the-associated-app/7a3b31b0-3a20-4426-9c88-c6e3f2ac62c6>
-///
-/// Firefox doesn't have this problem. Maybe they're using a different API.
-pub(crate) fn show_notification(title: String, body: String) -> Result<NotificationHandle> {
-    let (tx, rx) = futures::channel::oneshot::channel();
+pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
+    let toast_xml = format!(
+        r#"<toast>
+    <visual>
+        <binding template="ToastGeneric">
+            <text id="1">{title}</text>
+            <text id="2">{body}</text>
+        </binding>
+    </visual>
+</toast>"#,
+        title = xml_escape(&title),
+        body = xml_escape(&body),
+    );
 
-    // For some reason `on_activated` is FnMut
-    let mut tx = Some(tx);
-
-    tauri_winrt_notification::Toast::new(&app_id())
-        .title(&title)
-        .text1(&body)
-        .scenario(tauri_winrt_notification::Scenario::Reminder)
-        .on_activated(move |_| {
-            let Some(tx) = tx.take() else { return Ok(()) };
-
-            let _ = tx.send(());
-
-            Ok(())
-        })
-        .show()
-        .context("Failed to show notification")?;
+    show_toast(&toast_xml).context("Failed to show notification")?;
 
     tracing::debug!(%title, %body, "Showing notification");
 
-    Ok(NotificationHandle { on_click: rx })
+    Ok(())
 }
 
 /// Show a notification about a new release that opens `download_url` when activated
 ///
 /// The toast declares `activationType="protocol"`, so the shell opens the URL
-/// itself. Unlike the in-process activation callback used by
-/// [`show_notification`], this also works after the toast has moved into the
-/// notification center. `duration="long"` keeps the toast on screen for 25
-/// seconds instead of the default ~6.
+/// itself. Unlike an in-process activation callback, this also works after the
+/// toast has moved into the notification center. `duration="long"` keeps the
+/// toast on screen for 25 seconds instead of the default ~6.
 pub(crate) fn show_update_notification(title: String, download_url: url::Url) -> Result<()> {
-    use windows::{
-        Data::Xml::Dom::XmlDocument,
-        UI::Notifications::{ToastNotification, ToastNotificationManager},
-        core::HSTRING,
-    };
-
     let toast_xml = format!(
         r#"<toast duration="long" activationType="protocol" launch="{url}">
     <visual>
@@ -105,8 +85,19 @@ pub(crate) fn show_update_notification(title: String, download_url: url::Url) ->
         title = xml_escape(&title),
     );
 
+    show_toast(&toast_xml).context("Failed to show update notification")?;
+
+    tracing::debug!(%title, %download_url, "Showing update notification");
+
+    Ok(())
+}
+
+/// Displays a toast notification from the given [toast content XML].
+///
+/// [toast content XML]: https://learn.microsoft.com/en-us/uwp/schemas/tiles/toastschema/element-toast
+fn show_toast(toast_xml: &str) -> Result<()> {
     let xml = XmlDocument::new()?;
-    xml.LoadXml(&HSTRING::from(&toast_xml))
+    xml.LoadXml(&HSTRING::from(toast_xml))
         .context("Failed to load toast XML")?;
     let toast =
         ToastNotification::CreateToastNotification(&xml).context("Failed to create toast")?;
@@ -114,8 +105,6 @@ pub(crate) fn show_update_notification(title: String, download_url: url::Url) ->
         .context("Failed to create toast notifier")?
         .Show(&toast)
         .context("Failed to show toast")?;
-
-    tracing::debug!(%title, %download_url, "Showing update notification");
 
     Ok(())
 }

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -34,7 +34,7 @@ pub mod settings;
 ///
 /// Note: under the sparse MSIX identity this is *not* the
 /// AppUserModelId Windows uses to label notifications; that is derived
-/// from [`PACKAGE_FAMILY_NAME`] in `gui::os::show_notification`. It is
+/// from [`PACKAGE_FAMILY_NAME`] in `gui::os::app_id`. It is
 /// still used as the toast AUMID for un-packaged dev builds, which have
 /// no package identity.
 pub const BUNDLE_ID: &str = "dev.firezone.client";
@@ -52,7 +52,7 @@ pub const FIREZONE_CLIENT_GROUP: &str = "firezone-client";
 /// `register-sparse.exe` to stage / provision / deprovision the
 /// package against the AppX deployment service, and to derive the
 /// package AUMID (`<PACKAGE_FAMILY_NAME>!Firezone`) that Windows uses to
-/// label toast notifications (see `gui::os::show_notification`).
+/// label toast notifications (see `gui::os::app_id`).
 pub const PACKAGE_FAMILY_NAME: &str = env!("FIREZONE_PACKAGE_FAMILY_NAME");
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
The only value `tauri-winrt-notification` provided over building the [toast content XML](https://learn.microsoft.com/en-us/uwp/schemas/tiles/toastschema/element-toast) ourselves was its `on_activated` callback, and nothing consumes the click signal of generic notifications. Windows toasts are now built directly via the `windows` crate and the `NotificationHandle` plumbing is gone, so `show_notification` becomes fire-and-forget on all platforms. The crate still appears in the lockfile as `notify-rust`'s Windows backend, but since `notify-rust` is a Linux-only dependency it is never compiled.