### PR TITLE
refactor(gui-client): drop notify-rust

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2457,7 +2457,6 @@ dependencies = [
  "mimalloc",
  "native-dialog",
  "nix 0.31.3",
- "notify-rust",
  "opentelemetry",
  "output_vt100",
  "parking_lot",
@@ -2504,6 +2503,7 @@ dependencies = [
  "windows-security",
  "windows-service",
  "winreg 0.56.0",
+ "zbus",
  "zip",
 ]
 
@@ -4551,20 +4551,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mac-notification-sys"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
-dependencies = [
- "cc",
- "log",
- "objc2",
- "objc2-foundation",
- "time",
- "uuid",
-]
-
-[[package]]
 name = "macaddr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4879,20 +4865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "notify-rust"
-version = "4.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
-dependencies = [
- "futures-lite",
- "log",
- "mac-notification-sys",
- "serde",
- "tauri-winrt-notification",
- "zbus",
 ]
 
 [[package]]
@@ -7874,17 +7846,6 @@ dependencies = [
  "embed-resource",
  "indexmap 2.14.0",
  "toml 0.8.22",
-]
-
-[[package]]
-name = "tauri-winrt-notification"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
-dependencies = [
- "thiserror 2.0.19",
- "windows",
- "windows-version",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -155,7 +155,6 @@ netlink-packet-core = "0.8.1"
 netlink-packet-route = "0.29.0"
 network-types = { version = "0.2.0", default-features = false }
 nix = "0.31.3"
-notify-rust = "4.17.0"
 nu-ansi-term = "0.50.3"
 once_cell = "1.21.4"
 opentelemetry = "0.32.0"

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -82,9 +82,9 @@ ksni = { workspace = true } # Tray icon for Linux.
 libc = { workspace = true }
 mimalloc = { workspace = true }
 nix = { workspace = true, features = ["user"] }
-notify-rust = { workspace = true }
 sd-notify = { workspace = true }
 tracing-journald = { workspace = true }
+zbus = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mimalloc = { workspace = true }

--- a/rust/gui-client/src-tauri/src/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_linux.rs
@@ -1,4 +1,6 @@
 use anyhow::{Context as _, Result};
+use futures::StreamExt as _;
+use std::collections::HashMap;
 
 pub async fn set_autostart(enabled: bool) -> Result<()> {
     let dir = dirs::config_local_dir()
@@ -36,22 +38,9 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
 )]
 pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
     tokio::spawn(async move {
-        let notification = match notify_rust::Notification::new()
-            .summary(&title)
-            .body(&body)
-            .show_async()
-            .await
-        {
-            Ok(n) => n,
-            Err(e) => {
-                tracing::debug!(%title, "Failed to show notification: {e}");
-                return;
-            }
-        };
-
-        tracing::debug!(%title, %body, "Showing notification");
-
-        notification.wait_for_action_async(|_| {}).await;
+        if let Err(e) = notify(&title, &body).await {
+            tracing::debug!(%title, "Failed to show notification: {e:#}");
+        }
     });
 
     Ok(())
@@ -63,6 +52,65 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
 /// announces the release and the user downloads it via the tray menu.
 pub(crate) fn show_update_notification(title: String, _download_url: url::Url) -> Result<()> {
     show_notification(title, String::new())?;
+
+    Ok(())
+}
+
+/// Shows a notification via the [`org.freedesktop.Notifications`] D-Bus interface.
+///
+/// Resolves once the notification is closed: the D-Bus connection must stay
+/// open for as long as the notification is showing, otherwise it doesn't get
+/// displayed reliably on all desktops.
+///
+/// [`org.freedesktop.Notifications`]: https://specifications.freedesktop.org/notification-spec/latest/protocol.html
+async fn notify(summary: &str, body: &str) -> Result<()> {
+    let connection = zbus::Connection::session()
+        .await
+        .context("Failed to connect to session bus")?;
+    let proxy = zbus::Proxy::new(
+        &connection,
+        "org.freedesktop.Notifications",
+        "/org/freedesktop/Notifications",
+        "org.freedesktop.Notifications",
+    )
+    .await
+    .context("Failed to create proxy")?;
+
+    // Subscribe before `Notify` so we cannot miss the close signal.
+    let mut closed = proxy
+        .receive_signal("NotificationClosed")
+        .await
+        .context("Failed to subscribe to `NotificationClosed`")?;
+
+    let id: u32 = proxy
+        .call(
+            "Notify",
+            &(
+                "Firezone",
+                0_u32, // We are not replacing an existing notification.
+                "",    // No icon.
+                summary,
+                body,
+                Vec::<&str>::new(),                            // No actions.
+                HashMap::<&str, zbus::zvariant::Value>::new(), // No hints.
+                -1_i32, // Let the server pick an expiry timeout.
+            ),
+        )
+        .await
+        .context("Failed to call `Notify`")?;
+
+    tracing::debug!(%summary, %body, "Showing notification");
+
+    while let Some(message) = closed.next().await {
+        let (closed_id, _reason): (u32, u32) = message
+            .body()
+            .deserialize()
+            .context("Failed to deserialize `NotificationClosed`")?;
+
+        if closed_id == id {
+            break;
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Notifications on Linux boil down to a single `Notify` call on the [`org.freedesktop.Notifications`](https://specifications.freedesktop.org/notification-spec/latest/protocol.html) D-Bus interface, and `zbus` is already in our dependency tree, so call it directly instead of through `notify-rust`. This removes `notify-rust` and, with it, the never-compiled Windows and macOS notification backends (`tauri-winrt-notification`, `mac-notification-sys`) from the lockfile, keeping dead platform backends out of SBOMs and dependency audits.

The D-Bus connection stays open until the `NotificationClosed` signal arrives for our notification, because dropping the connection early makes notifications unreliable on some desktops. I verified the call against a mock `org.freedesktop.Notifications` daemon on a private bus: the arguments arrive with the expected signature and the close-signal wait resolves.