### PR TITLE
refactor(gui-client): extract desktop-notifications crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1865,6 +1865,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "desktop-notifications"
+version = "0.1.0"
+dependencies = [
+ "anyhow-ext",
+ "futures",
+ "tokio",
+ "tracing",
+ "url",
+ "windows",
+ "zbus",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2452,7 @@ dependencies = [
  "connlib-model",
  "dbus-secret-service-keyring-store",
  "derive_more",
+ "desktop-notifications",
  "dirs",
  "embed-resource",
  "fd-lock",
@@ -2503,7 +2517,6 @@ dependencies = [
  "windows-security",
  "windows-service",
  "winreg 0.56.0",
- "zbus",
  "zip",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2457,7 +2457,6 @@ dependencies = [
  "mimalloc",
  "native-dialog",
  "nix 0.31.3",
- "notify-rust",
  "opentelemetry",
  "output_vt100",
  "parking_lot",
@@ -2504,6 +2503,7 @@ dependencies = [
  "windows-security",
  "windows-service",
  "winreg 0.56.0",
+ "zbus",
  "zip",
 ]
 
@@ -4551,20 +4551,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mac-notification-sys"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
-dependencies = [
- "cc",
- "log",
- "objc2",
- "objc2-foundation",
- "time",
- "uuid",
-]
-
-[[package]]
 name = "macaddr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4879,20 +4865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "notify-rust"
-version = "4.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
-dependencies = [
- "futures-lite",
- "log",
- "mac-notification-sys",
- "serde",
- "tauri-winrt-notification",
- "zbus",
 ]
 
 [[package]]
@@ -7874,17 +7846,6 @@ dependencies = [
  "embed-resource",
  "indexmap 2.14.0",
  "toml 0.8.22",
-]
-
-[[package]]
-name = "tauri-winrt-notification"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
-dependencies = [
- "thiserror 2.0.19",
- "windows",
- "windows-version",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2486,7 +2486,6 @@ dependencies = [
  "tauri-runtime",
  "tauri-specta",
  "tauri-utils",
- "tauri-winrt-notification",
  "telemetry",
  "tempfile",
  "thiserror 2.0.19",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -155,7 +155,6 @@ netlink-packet-core = "0.8.1"
 netlink-packet-route = "0.29.0"
 network-types = { version = "0.2.0", default-features = false }
 nix = "0.31.3"
-notify-rust = "4.17.0"
 nu-ansi-term = "0.50.3"
 once_cell = "1.21.4"
 opentelemetry = "0.32.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "libs/connlib/tun",
     "libs/connlib/tunnel",
     "libs/connlib/tunnel-proto",
+    "libs/desktop-notifications",
     "libs/eventloop-budget",
     "libs/flow-log-spool",
     "libs/flow-log-upload",
@@ -96,6 +97,7 @@ crossbeam-queue = "0.3.12"
 dashmap = "6.2.1"
 dbus-secret-service-keyring-store = { version = "1.0.0", features = ["crypto-rust"] }
 derive_more = { version = "2.1.1", default-features = false }
+desktop-notifications = { path = "libs/desktop-notifications" }
 difference = "2.0.0"
 dirs = "6.0.0"
 divan = "0.1.21"

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 client-shared = { workspace = true }
 connlib-model = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
+desktop-notifications = { workspace = true }
 fd-lock = { workspace = true }
 flow-log-upload = { workspace = true }
 flow-log-writer = { workspace = true }
@@ -84,7 +85,6 @@ mimalloc = { workspace = true }
 nix = { workspace = true, features = ["user"] }
 sd-notify = { workspace = true }
 tracing-journald = { workspace = true }
-zbus = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mimalloc = { workspace = true }
@@ -128,10 +128,6 @@ features = [
     # a new external location.
     "ApplicationModel",
     "Foundation_Collections",
-    # `XmlDocument` and `ToastNotification` / `ToastNotificationManager`
-    # for the protocol-activated update toast.
-    "Data_Xml_Dom",
-    "UI_Notifications",
 ]
 
 [build-dependencies]

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -92,7 +92,6 @@ mimalloc = { workspace = true }
 [target.'cfg(target_os = "windows")'.dependencies]
 admx-macro = { workspace = true }
 mimalloc = { workspace = true }
-tauri-winrt-notification = "0.7.2"
 windows-native-keyring-store = { workspace = true }
 windows-security = { workspace = true }
 windows-service = { workspace = true }

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -82,9 +82,9 @@ ksni = { workspace = true } # Tray icon for Linux.
 libc = { workspace = true }
 mimalloc = { workspace = true }
 nix = { workspace = true, features = ["user"] }
-notify-rust = { workspace = true }
 sd-notify = { workspace = true }
 tracing-journald = { workspace = true }
+zbus = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mimalloc = { workspace = true }

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -81,11 +81,7 @@ pub trait GuiIntegration {
 
     fn set_tray_icon(&mut self, icon: system_tray::Icon);
     fn set_tray_menu(&mut self, app_state: system_tray::AppState);
-    fn show_notification(
-        &self,
-        title: impl Into<String>,
-        body: impl Into<String>,
-    ) -> Result<NotificationHandle>;
+    fn show_notification(&self, title: impl Into<String>, body: impl Into<String>) -> Result<()>;
 
     /// Shows a notification about a new release, opening `download_url` on click where the platform supports it.
     fn show_update_notification(&self, title: impl Into<String>, download_url: Url) -> Result<()>;
@@ -102,10 +98,6 @@ pub trait GuiIntegration {
         settings: AdvancedSettings,
     ) -> Result<()>;
     fn show_about_page(&self) -> Result<()>;
-}
-
-pub struct NotificationHandle {
-    pub on_click: futures::channel::oneshot::Receiver<()>,
 }
 
 #[derive(strum::Display)]
@@ -654,7 +646,7 @@ impl<I: GuiIntegration> Controller<I> {
         gui::set_autostart(self.general_settings.start_on_login.is_some_and(|v| v)).await?;
 
         self.notify_settings_changed()?;
-        let _ = self.integration.show_notification("Settings saved", "")?;
+        self.integration.show_notification("Settings saved", "")?;
 
         Ok(())
     }
@@ -688,7 +680,7 @@ impl<I: GuiIntegration> Controller<I> {
                 self.sign_out().await?;
                 if is_authentication_error {
                     tracing::info!(?error_msg, "Auth error");
-                    let _ = self.integration.show_notification(
+                    self.integration.show_notification(
                         "Firezone disconnected",
                         "To access resources, sign in again.",
                     )?;
@@ -705,7 +697,7 @@ impl<I: GuiIntegration> Controller<I> {
 
                 // If this is the first time we receive resources, show the notification that we are connected.
                 if let &Status::WaitingForTunnel = &self.status {
-                    let _ = self.integration.show_notification(
+                    self.integration.show_notification(
                         "Firezone connected",
                         "You are now signed in and able to access resources.",
                     )?;
@@ -726,7 +718,7 @@ impl<I: GuiIntegration> Controller<I> {
                 tracing::info!("Tunnel service exited gracefully");
                 self.integration
                     .set_tray_icon(system_tray::icon_terminating());
-                let _ = self.integration.show_notification(
+                self.integration.show_notification(
                     "Firezone disconnected",
                     "The Firezone Tunnel service was shut down, quitting GUI process.",
                 )?;
@@ -750,12 +742,11 @@ impl<I: GuiIntegration> Controller<I> {
                 self.notify_settings_changed()?;
                 self.refresh_ui_state();
 
-                let _ = self.integration.show_notification("Settings saved", "")?;
+                self.integration.show_notification("Settings saved", "")?;
             }
             service::ServerMsg::AdvancedSettingsApplied(Err(err)) => {
                 tracing::error!("Tunnel service failed to save advanced settings: {err}");
-                let _ = self
-                    .integration
+                self.integration
                     .show_notification("Failed to save settings", &err)?;
             }
             service::ServerMsg::GatewayVersionMismatch { resource_id } => {
@@ -1501,7 +1492,7 @@ mod tests {
         opened_urls: Vec<String>,
         tray_icons: Vec<system_tray::Icon>,
         tray_states: Vec<system_tray::AppState>,
-        notifications: Vec<(String, String, futures::channel::oneshot::Sender<()>)>,
+        notifications: Vec<(String, String)>,
         update_notifications: Vec<(String, Url)>,
         window_visibilities: Vec<bool>,
         shown_overview_page: Vec<SessionViewModel>,
@@ -1511,9 +1502,7 @@ mod tests {
 
     impl MockIntegration {
         fn nth_notification(&self, idx: usize) -> Option<(String, String)> {
-            let (title, body, _) = self.notifications.get(idx)?;
-
-            Some((title.clone(), body.clone()))
+            self.notifications.get(idx).cloned()
         }
     }
 
@@ -1563,14 +1552,10 @@ mod tests {
             &self,
             title: impl Into<String>,
             body: impl Into<String>,
-        ) -> Result<NotificationHandle> {
-            let (tx, rx) = futures::channel::oneshot::channel();
+        ) -> Result<()> {
+            self.lock().notifications.push((title.into(), body.into()));
 
-            self.lock()
-                .notifications
-                .push((title.into(), body.into(), tx));
-
-            Ok(NotificationHandle { on_click: rx })
+            Ok(())
         }
 
         fn show_update_notification(

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -159,7 +159,9 @@ impl GuiIntegration for TauriIntegration {
     }
 
     fn show_notification(&self, title: impl Into<String>, body: impl Into<String>) -> Result<()> {
-        os::show_notification(title.into(), body.into())
+        spawn_notification(title.into(), body.into(), None);
+
+        Ok(())
     }
 
     fn show_update_notification(
@@ -167,7 +169,15 @@ impl GuiIntegration for TauriIntegration {
         title: impl Into<String>,
         download_url: url::Url,
     ) -> Result<()> {
-        os::show_update_notification(title.into(), download_url)
+        // Clickable notifications only work on Windows.
+        #[cfg(target_os = "windows")]
+        let body = "Click here to download the new version";
+        #[cfg(not(target_os = "windows"))]
+        let body = "";
+
+        spawn_notification(title.into(), body.to_owned(), Some(download_url));
+
+        Ok(())
     }
 
     fn set_window_visible(&self, visible: bool) -> Result<()> {
@@ -230,6 +240,21 @@ pub struct RunConfig {
     pub telemetry_allowed: bool,
     pub quit_after: Option<u64>,
     pub fail_with: Option<Failure>,
+}
+
+/// Shows a notification without blocking the caller.
+///
+/// Notifications are fire-and-forget: failures are only logged because
+/// there is nothing the caller could do about them.
+fn spawn_notification(title: String, body: String, open_url: Option<url::Url>) {
+    let notifier = desktop_notifications::Notifier::new(os::notification_app_id());
+
+    tokio::spawn(async move {
+        match notifier.show(&title, &body, open_url.as_ref()).await {
+            Ok(()) => tracing::debug!(%title, %body, "Showed notification"),
+            Err(e) => tracing::debug!(%title, "Failed to show notification: {e:#}"),
+        }
+    });
 }
 
 /// IPC messages that a newly launched instance may send to an already

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -4,7 +4,7 @@
 //! The real macOS Client is in `swift/apple`
 
 use crate::{
-    controller::{Controller, ControllerRequest, Failure, GuiIntegration, NotificationHandle},
+    controller::{Controller, ControllerRequest, Failure, GuiIntegration},
     deep_link,
     ipc::{self, ClientRead, ClientWrite, SocketId},
     launch_lock::{self, FirstInstance, LaunchLock},
@@ -158,11 +158,7 @@ impl GuiIntegration for TauriIntegration {
         self.tray.update(app_state)
     }
 
-    fn show_notification(
-        &self,
-        title: impl Into<String>,
-        body: impl Into<String>,
-    ) -> Result<NotificationHandle> {
+    fn show_notification(&self, title: impl Into<String>, body: impl Into<String>) -> Result<()> {
         os::show_notification(title.into(), body.into())
     }
 

--- a/rust/gui-client/src-tauri/src/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_linux.rs
@@ -1,7 +1,5 @@
 use anyhow::{Context as _, Result};
 
-use crate::controller::NotificationHandle;
-
 pub async fn set_autostart(enabled: bool) -> Result<()> {
     let dir = dirs::config_local_dir()
         .context("Can't compute `config_local_dir`")?
@@ -36,9 +34,7 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
     clippy::unnecessary_wraps,
     reason = "Signature must match other platforms."
 )]
-pub(crate) fn show_notification(title: String, body: String) -> Result<NotificationHandle> {
-    let (_, rx) = futures::channel::oneshot::channel();
-
+pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
     tokio::spawn(async move {
         let notification = match notify_rust::Notification::new()
             .summary(&title)
@@ -58,7 +54,7 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<Notificat
         notification.wait_for_action_async(|_| {}).await;
     });
 
-    Ok(NotificationHandle { on_click: rx })
+    Ok(())
 }
 
 /// Show a notification about a new release
@@ -66,7 +62,7 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<Notificat
 /// Clickable notifications don't work on Linux yet, so the notification only
 /// announces the release and the user downloads it via the tray menu.
 pub(crate) fn show_update_notification(title: String, _download_url: url::Url) -> Result<()> {
-    let _ = show_notification(title, String::new())?;
+    show_notification(title, String::new())?;
 
     Ok(())
 }

--- a/rust/gui-client/src-tauri/src/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_linux.rs
@@ -1,4 +1,6 @@
 use anyhow::{Context as _, Result};
+use futures::StreamExt as _;
+use std::collections::HashMap;
 
 pub async fn set_autostart(enabled: bool) -> Result<()> {
     let dir = dirs::config_local_dir()
@@ -36,22 +38,9 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
 )]
 pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
     tokio::spawn(async move {
-        let notification = match notify_rust::Notification::new()
-            .summary(&title)
-            .body(&body)
-            .show_async()
-            .await
-        {
-            Ok(n) => n,
-            Err(e) => {
-                tracing::debug!(%title, "Failed to show notification: {e}");
-                return;
-            }
-        };
-
-        tracing::debug!(%title, %body, "Showing notification");
-
-        notification.wait_for_action_async(|_| {}).await;
+        if let Err(e) = notify(&title, &body).await {
+            tracing::debug!(%title, "Failed to show notification: {e:#}");
+        }
     });
 
     Ok(())
@@ -63,6 +52,65 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
 /// announces the release and the user downloads it via the tray menu.
 pub(crate) fn show_update_notification(title: String, _download_url: url::Url) -> Result<()> {
     show_notification(title, String::new())?;
+
+    Ok(())
+}
+
+/// Shows a notification via the [`org.freedesktop.Notifications`] D-Bus interface.
+///
+/// Resolves once the notification is closed: the D-Bus connection must stay
+/// open for as long as the notification is showing, otherwise it doesn't get
+/// displayed reliably on all desktops.
+///
+/// [`org.freedesktop.Notifications`]: https://specifications.freedesktop.org/notification-spec/latest/protocol.html
+async fn notify(summary: &str, body: &str) -> Result<()> {
+    let connection = zbus::Connection::session()
+        .await
+        .context("Failed to connect to session bus")?;
+    let proxy = zbus::Proxy::new(
+        &connection,
+        "org.freedesktop.Notifications",
+        "/org/freedesktop/Notifications",
+        "org.freedesktop.Notifications",
+    )
+    .await
+    .context("Failed to create proxy")?;
+
+    // Subscribe before `Notify` so we cannot miss the close signal.
+    let mut closed = proxy
+        .receive_signal("NotificationClosed")
+        .await
+        .context("Failed to subscribe to `NotificationClosed`")?;
+
+    let id: u32 = proxy
+        .call(
+            "Notify",
+            &(
+                "Firezone",
+                0_u32, // We are not replacing an existing notification.
+                "",    // No icon.
+                summary,
+                body,
+                Vec::<&str>::new(),                            // No actions.
+                HashMap::<&str, zbus::zvariant::Value>::new(), // No hints.
+                -1_i32, // Let the server pick an expiry timeout.
+            ),
+        )
+        .await
+        .context("Failed to call `Notify`")?;
+
+    tracing::debug!(%summary, %body, "Showing notification");
+
+    while let Some(message) = closed.next().await {
+        let (closed_id, _reason): (u32, u32) = message
+            .body()
+            .deserialize()
+            .context("Failed to deserialize `NotificationClosed`")?;
+
+        if closed_id == id {
+            break;
+        }
+    }
 
     Ok(())
 }

--- a/rust/gui-client/src-tauri/src/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_linux.rs
@@ -1,6 +1,4 @@
 use anyhow::{Context as _, Result};
-use futures::StreamExt as _;
-use std::collections::HashMap;
 
 pub async fn set_autostart(enabled: bool) -> Result<()> {
     let dir = dirs::config_local_dir()
@@ -32,85 +30,7 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
     Ok(())
 }
 
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "Signature must match other platforms."
-)]
-pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
-    tokio::spawn(async move {
-        if let Err(e) = notify(&title, &body).await {
-            tracing::debug!(%title, "Failed to show notification: {e:#}");
-        }
-    });
-
-    Ok(())
-}
-
-/// Show a notification about a new release
-///
-/// Clickable notifications don't work on Linux yet, so the notification only
-/// announces the release and the user downloads it via the tray menu.
-pub(crate) fn show_update_notification(title: String, _download_url: url::Url) -> Result<()> {
-    show_notification(title, String::new())?;
-
-    Ok(())
-}
-
-/// Shows a notification via the [`org.freedesktop.Notifications`] D-Bus interface.
-///
-/// Resolves once the notification is closed: the D-Bus connection must stay
-/// open for as long as the notification is showing, otherwise it doesn't get
-/// displayed reliably on all desktops.
-///
-/// [`org.freedesktop.Notifications`]: https://specifications.freedesktop.org/notification-spec/latest/protocol.html
-async fn notify(summary: &str, body: &str) -> Result<()> {
-    let connection = zbus::Connection::session()
-        .await
-        .context("Failed to connect to session bus")?;
-    let proxy = zbus::Proxy::new(
-        &connection,
-        "org.freedesktop.Notifications",
-        "/org/freedesktop/Notifications",
-        "org.freedesktop.Notifications",
-    )
-    .await
-    .context("Failed to create proxy")?;
-
-    // Subscribe before `Notify` so we cannot miss the close signal.
-    let mut closed = proxy
-        .receive_signal("NotificationClosed")
-        .await
-        .context("Failed to subscribe to `NotificationClosed`")?;
-
-    let id: u32 = proxy
-        .call(
-            "Notify",
-            &(
-                "Firezone",
-                0_u32, // We are not replacing an existing notification.
-                "",    // No icon.
-                summary,
-                body,
-                Vec::<&str>::new(),                            // No actions.
-                HashMap::<&str, zbus::zvariant::Value>::new(), // No hints.
-                -1_i32, // Let the server pick an expiry timeout.
-            ),
-        )
-        .await
-        .context("Failed to call `Notify`")?;
-
-    tracing::debug!(%summary, %body, "Showing notification");
-
-    while let Some(message) = closed.next().await {
-        let (closed_id, _reason): (u32, u32) = message
-            .body()
-            .deserialize()
-            .context("Failed to deserialize `NotificationClosed`")?;
-
-        if closed_id == id {
-            break;
-        }
-    }
-
-    Ok(())
+/// The application name that desktops use to group our notifications.
+pub(crate) fn notification_app_id() -> String {
+    "Firezone".to_owned()
 }

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -1,8 +1,6 @@
 //! This file is a stub only to do Tauri UI dev natively on a Mac.
 use anyhow::Result;
 
-use crate::controller::NotificationHandle;
-
 pub async fn set_autostart(_enabled: bool) -> Result<()> {
     tracing::warn!("set_autostart is not implemented on macOS; skipping");
 
@@ -13,12 +11,10 @@ pub async fn set_autostart(_enabled: bool) -> Result<()> {
     clippy::unnecessary_wraps,
     reason = "Signature must match other platforms."
 )]
-pub(crate) fn show_notification(_title: String, _body: String) -> Result<NotificationHandle> {
+pub(crate) fn show_notification(_title: String, _body: String) -> Result<()> {
     tracing::warn!("show_notification is not implemented on macOS; skipping");
 
-    let (_tx, on_click) = futures::channel::oneshot::channel();
-
-    Ok(NotificationHandle { on_click })
+    Ok(())
 }
 
 #[expect(

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -7,22 +7,6 @@ pub async fn set_autostart(_enabled: bool) -> Result<()> {
     Ok(())
 }
 
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "Signature must match other platforms."
-)]
-pub(crate) fn show_notification(_title: String, _body: String) -> Result<()> {
-    tracing::warn!("show_notification is not implemented on macOS; skipping");
-
-    Ok(())
-}
-
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "Signature must match other platforms."
-)]
-pub(crate) fn show_update_notification(_title: String, _download_url: url::Url) -> Result<()> {
-    tracing::warn!("show_update_notification is not implemented on macOS; skipping");
-
-    Ok(())
+pub(crate) fn notification_app_id() -> String {
+    crate::BUNDLE_ID.to_owned()
 }

--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -1,10 +1,5 @@
 use anyhow::{Context, Result};
 use std::env;
-use windows::{
-    Data::Xml::Dom::XmlDocument,
-    UI::Notifications::{ToastNotification, ToastNotificationManager},
-    core::HSTRING,
-};
 use winreg::RegKey;
 use winreg::enums::*;
 
@@ -43,73 +38,7 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
     Ok(())
 }
 
-/// Show a notification in the bottom right of the screen
-pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
-    let toast_xml = format!(
-        r#"<toast>
-    <visual>
-        <binding template="ToastGeneric">
-            <text id="1">{title}</text>
-            <text id="2">{body}</text>
-        </binding>
-    </visual>
-</toast>"#,
-        title = xml_escape(&title),
-        body = xml_escape(&body),
-    );
-
-    show_toast(&toast_xml).context("Failed to show notification")?;
-
-    tracing::debug!(%title, %body, "Showing notification");
-
-    Ok(())
-}
-
-/// Show a notification about a new release that opens `download_url` when activated
-///
-/// The toast declares `activationType="protocol"`, so the shell opens the URL
-/// itself. Unlike an in-process activation callback, this also works after the
-/// toast has moved into the notification center. `duration="long"` keeps the
-/// toast on screen for 25 seconds instead of the default ~6.
-pub(crate) fn show_update_notification(title: String, download_url: url::Url) -> Result<()> {
-    let toast_xml = format!(
-        r#"<toast duration="long" activationType="protocol" launch="{url}">
-    <visual>
-        <binding template="ToastGeneric">
-            <text id="1">{title}</text>
-            <text id="2">Click here to download the new version</text>
-        </binding>
-    </visual>
-</toast>"#,
-        url = xml_escape(download_url.as_str()),
-        title = xml_escape(&title),
-    );
-
-    show_toast(&toast_xml).context("Failed to show update notification")?;
-
-    tracing::debug!(%title, %download_url, "Showing update notification");
-
-    Ok(())
-}
-
-/// Displays a toast notification from the given [toast content XML].
-///
-/// [toast content XML]: https://learn.microsoft.com/en-us/uwp/schemas/tiles/toastschema/element-toast
-fn show_toast(toast_xml: &str) -> Result<()> {
-    let xml = XmlDocument::new()?;
-    xml.LoadXml(&HSTRING::from(toast_xml))
-        .context("Failed to load toast XML")?;
-    let toast =
-        ToastNotification::CreateToastNotification(&xml).context("Failed to create toast")?;
-    ToastNotificationManager::CreateToastNotifierWithId(&HSTRING::from(&app_id()))
-        .context("Failed to create toast notifier")?
-        .Show(&toast)
-        .context("Failed to show toast")?;
-
-    Ok(())
-}
-
-/// The AppUserModelID Windows attributes our toasts to
+/// The AppUserModelID Windows attributes our notifications to
 ///
 /// Windows silently drops a toast whose AUMID doesn't match the calling
 /// process's identity. Packaged builds run under the sparse MSIX identity, so
@@ -119,18 +48,10 @@ fn show_toast(toast_xml: &str) -> Result<()> {
 /// come from the manifest's `VisualElements`. Un-packaged dev builds (no
 /// package identity) fall back to [`crate::BUNDLE_ID`].
 /// <https://github.com/tauri-apps/winrt-notification/issues/17#issuecomment-1988715694>
-fn app_id() -> String {
+pub(crate) fn notification_app_id() -> String {
     if crate::package_identity::has_package_identity() {
         format!("{}!Firezone", crate::PACKAGE_FAMILY_NAME)
     } else {
         crate::BUNDLE_ID.to_owned()
     }
-}
-
-fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
 }

--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -1,9 +1,12 @@
 use anyhow::{Context, Result};
 use std::env;
+use windows::{
+    Data::Xml::Dom::XmlDocument,
+    UI::Notifications::{ToastNotification, ToastNotificationManager},
+    core::HSTRING,
+};
 use winreg::RegKey;
 use winreg::enums::*;
-
-use crate::controller::NotificationHandle;
 
 pub async fn set_autostart(enabled: bool) -> Result<()> {
     // Get path to the current executable
@@ -41,57 +44,34 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
 }
 
 /// Show a notification in the bottom right of the screen
-///
-/// Known issue: If the notification times out and goes into the notification center
-/// (the little thing that pops up when you click the bell icon), then we may not get the
-/// click signal.
-///
-/// I've seen this reported by people using Powershell, C#, etc., so I think it might
-/// be a Windows bug?
-/// - <https://superuser.com/questions/1488763/windows-10-notifications-not-activating-the-associated-app-when-clicking-on-it>
-/// - <https://stackoverflow.com/questions/65835196/windows-toast-notification-com-not-working>
-/// - <https://answers.microsoft.com/en-us/windows/forum/all/notifications-not-activating-the-associated-app/7a3b31b0-3a20-4426-9c88-c6e3f2ac62c6>
-///
-/// Firefox doesn't have this problem. Maybe they're using a different API.
-pub(crate) fn show_notification(title: String, body: String) -> Result<NotificationHandle> {
-    let (tx, rx) = futures::channel::oneshot::channel();
+pub(crate) fn show_notification(title: String, body: String) -> Result<()> {
+    let toast_xml = format!(
+        r#"<toast>
+    <visual>
+        <binding template="ToastGeneric">
+            <text id="1">{title}</text>
+            <text id="2">{body}</text>
+        </binding>
+    </visual>
+</toast>"#,
+        title = xml_escape(&title),
+        body = xml_escape(&body),
+    );
 
-    // For some reason `on_activated` is FnMut
-    let mut tx = Some(tx);
-
-    tauri_winrt_notification::Toast::new(&app_id())
-        .title(&title)
-        .text1(&body)
-        .scenario(tauri_winrt_notification::Scenario::Reminder)
-        .on_activated(move |_| {
-            let Some(tx) = tx.take() else { return Ok(()) };
-
-            let _ = tx.send(());
-
-            Ok(())
-        })
-        .show()
-        .context("Failed to show notification")?;
+    show_toast(&toast_xml).context("Failed to show notification")?;
 
     tracing::debug!(%title, %body, "Showing notification");
 
-    Ok(NotificationHandle { on_click: rx })
+    Ok(())
 }
 
 /// Show a notification about a new release that opens `download_url` when activated
 ///
 /// The toast declares `activationType="protocol"`, so the shell opens the URL
-/// itself. Unlike the in-process activation callback used by
-/// [`show_notification`], this also works after the toast has moved into the
-/// notification center. `duration="long"` keeps the toast on screen for 25
-/// seconds instead of the default ~6.
+/// itself. Unlike an in-process activation callback, this also works after the
+/// toast has moved into the notification center. `duration="long"` keeps the
+/// toast on screen for 25 seconds instead of the default ~6.
 pub(crate) fn show_update_notification(title: String, download_url: url::Url) -> Result<()> {
-    use windows::{
-        Data::Xml::Dom::XmlDocument,
-        UI::Notifications::{ToastNotification, ToastNotificationManager},
-        core::HSTRING,
-    };
-
     let toast_xml = format!(
         r#"<toast duration="long" activationType="protocol" launch="{url}">
     <visual>
@@ -105,8 +85,19 @@ pub(crate) fn show_update_notification(title: String, download_url: url::Url) ->
         title = xml_escape(&title),
     );
 
+    show_toast(&toast_xml).context("Failed to show update notification")?;
+
+    tracing::debug!(%title, %download_url, "Showing update notification");
+
+    Ok(())
+}
+
+/// Displays a toast notification from the given [toast content XML].
+///
+/// [toast content XML]: https://learn.microsoft.com/en-us/uwp/schemas/tiles/toastschema/element-toast
+fn show_toast(toast_xml: &str) -> Result<()> {
     let xml = XmlDocument::new()?;
-    xml.LoadXml(&HSTRING::from(&toast_xml))
+    xml.LoadXml(&HSTRING::from(toast_xml))
         .context("Failed to load toast XML")?;
     let toast =
         ToastNotification::CreateToastNotification(&xml).context("Failed to create toast")?;
@@ -114,8 +105,6 @@ pub(crate) fn show_update_notification(title: String, download_url: url::Url) ->
         .context("Failed to create toast notifier")?
         .Show(&toast)
         .context("Failed to show toast")?;
-
-    tracing::debug!(%title, %download_url, "Showing update notification");
 
     Ok(())
 }

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -34,7 +34,7 @@ pub mod settings;
 ///
 /// Note: under the sparse MSIX identity this is *not* the
 /// AppUserModelId Windows uses to label notifications; that is derived
-/// from [`PACKAGE_FAMILY_NAME`] in `gui::os::show_notification`. It is
+/// from [`PACKAGE_FAMILY_NAME`] in `gui::os::app_id`. It is
 /// still used as the toast AUMID for un-packaged dev builds, which have
 /// no package identity.
 pub const BUNDLE_ID: &str = "dev.firezone.client";
@@ -52,7 +52,7 @@ pub const FIREZONE_CLIENT_GROUP: &str = "firezone-client";
 /// `register-sparse.exe` to stage / provision / deprovision the
 /// package against the AppX deployment service, and to derive the
 /// package AUMID (`<PACKAGE_FAMILY_NAME>!Firezone`) that Windows uses to
-/// label toast notifications (see `gui::os::show_notification`).
+/// label toast notifications (see `gui::os::app_id`).
 pub const PACKAGE_FAMILY_NAME: &str = env!("FIREZONE_PACKAGE_FAMILY_NAME");
 
 #[cfg(target_os = "linux")]

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -34,7 +34,7 @@ pub mod settings;
 ///
 /// Note: under the sparse MSIX identity this is *not* the
 /// AppUserModelId Windows uses to label notifications; that is derived
-/// from [`PACKAGE_FAMILY_NAME`] in `gui::os::app_id`. It is
+/// from [`PACKAGE_FAMILY_NAME`] in `gui::os::notification_app_id`. It is
 /// still used as the toast AUMID for un-packaged dev builds, which have
 /// no package identity.
 pub const BUNDLE_ID: &str = "dev.firezone.client";
@@ -52,7 +52,7 @@ pub const FIREZONE_CLIENT_GROUP: &str = "firezone-client";
 /// `register-sparse.exe` to stage / provision / deprovision the
 /// package against the AppX deployment service, and to derive the
 /// package AUMID (`<PACKAGE_FAMILY_NAME>!Firezone`) that Windows uses to
-/// label toast notifications (see `gui::os::app_id`).
+/// label toast notifications (see `gui::os::notification_app_id`).
 pub const PACKAGE_FAMILY_NAME: &str = env!("FIREZONE_PACKAGE_FAMILY_NAME");
 
 #[cfg(target_os = "linux")]

--- a/rust/libs/desktop-notifications/Cargo.toml
+++ b/rust/libs/desktop-notifications/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "desktop-notifications"
+version = "0.1.0"
+edition = { workspace = true }
+description = "Cross-platform desktop notifications for the Firezone GUI client"
+license = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+url = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+futures = { workspace = true }
+zbus = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+tracing = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies.windows]
+workspace = true
+features = [
+    # `XmlDocument` for building the toast XML
+    "Data_Xml_Dom",
+    # `ToastNotification` / `ToastNotificationManager` for showing toasts
+    "UI_Notifications",
+]
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+
+[lints]
+workspace = true

--- a/rust/libs/desktop-notifications/src/lib.rs
+++ b/rust/libs/desktop-notifications/src/lib.rs
@@ -1,0 +1,59 @@
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+#![cfg_attr(test, allow(clippy::unwrap_in_result))]
+
+//! Cross-platform desktop notifications.
+//!
+//! Notifications are shown natively: as toasts via WinRT on Windows and via
+//! the `org.freedesktop.Notifications` D-Bus interface on Linux. macOS only
+//! has a stub because the production macOS client is a native app; the stub
+//! exists so the Tauri UI can be developed on a Mac.
+
+use anyhow::Result;
+use url::Url;
+
+#[cfg(target_os = "linux")]
+#[path = "platform/linux.rs"]
+mod platform;
+
+#[cfg(target_os = "macos")]
+#[path = "platform/macos.rs"]
+mod platform;
+
+#[cfg(target_os = "windows")]
+#[path = "platform/windows.rs"]
+mod platform;
+
+/// Shows notifications under a fixed application identity.
+#[derive(Clone, Debug)]
+pub struct Notifier {
+    app_id: String,
+}
+
+impl Notifier {
+    /// Creates a notifier for the given application identity.
+    ///
+    /// On Windows, this is the AppUserModelID that toasts are attributed to;
+    /// Windows silently drops toasts whose AUMID doesn't match the calling
+    /// process's identity. On Linux, it is the application name that some
+    /// desktops use to group notifications.
+    pub fn new(app_id: impl Into<String>) -> Self {
+        Self {
+            app_id: app_id.into(),
+        }
+    }
+
+    /// Shows a notification.
+    ///
+    /// Activating the notification opens `open_url`; only Windows supports
+    /// this, other platforms ignore it.
+    ///
+    /// Resolves once the notification has been handled: on Windows right
+    /// after hand-off to the toast platform, on Linux once the notification
+    /// is closed. Callers that don't want to wait for that should spawn the
+    /// future into a task.
+    pub async fn show(&self, title: &str, body: &str, open_url: Option<&Url>) -> Result<()> {
+        platform::show(&self.app_id, title, body, open_url).await?;
+
+        Ok(())
+    }
+}

--- a/rust/libs/desktop-notifications/src/platform/linux.rs
+++ b/rust/libs/desktop-notifications/src/platform/linux.rs
@@ -1,0 +1,236 @@
+use anyhow::{Context as _, Result};
+use futures::StreamExt as _;
+use std::collections::HashMap;
+use url::Url;
+
+pub(crate) async fn show(
+    app_id: &str,
+    title: &str,
+    body: &str,
+    _open_url: Option<&Url>, // TODO: Clickable notifications are not implemented on Linux.
+) -> Result<()> {
+    let connection = zbus::Connection::session()
+        .await
+        .context("Failed to connect to session bus")?;
+
+    show_at(&connection, app_id, title, body).await?;
+
+    Ok(())
+}
+
+/// Shows a notification via the [`org.freedesktop.Notifications`] D-Bus interface.
+///
+/// Resolves once the notification is closed: the D-Bus connection must stay
+/// open for as long as the notification is showing, otherwise it doesn't get
+/// displayed reliably on all desktops.
+///
+/// [`org.freedesktop.Notifications`]: https://specifications.freedesktop.org/notification-spec/latest/protocol.html
+async fn show_at(
+    connection: &zbus::Connection,
+    app_name: &str,
+    summary: &str,
+    body: &str,
+) -> Result<()> {
+    let proxy = zbus::Proxy::new(
+        connection,
+        "org.freedesktop.Notifications",
+        "/org/freedesktop/Notifications",
+        "org.freedesktop.Notifications",
+    )
+    .await
+    .context("Failed to create proxy")?;
+
+    // Subscribe before `Notify` so we cannot miss the close signal.
+    let mut closed = proxy
+        .receive_signal("NotificationClosed")
+        .await
+        .context("Failed to subscribe to `NotificationClosed`")?;
+
+    let id: u32 = proxy
+        .call(
+            "Notify",
+            &(
+                app_name,
+                0_u32, // We are not replacing an existing notification.
+                "",    // No icon.
+                summary,
+                body,
+                Vec::<&str>::new(),                            // No actions.
+                HashMap::<&str, zbus::zvariant::Value>::new(), // No hints.
+                -1_i32, // Let the server pick an expiry timeout.
+            ),
+        )
+        .await
+        .context("Failed to call `Notify`")?;
+
+    while let Some(message) = closed.next().await {
+        let (closed_id, _reason): (u32, u32) = message
+            .body()
+            .deserialize()
+            .context("Failed to deserialize `NotificationClosed`")?;
+
+        if closed_id == id {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::BufRead as _;
+    use std::time::Duration;
+
+    const NOTIFICATION_ID: u32 = 42;
+
+    #[tokio::test]
+    async fn shows_notification_end_to_end() {
+        let daemon = DbusDaemon::start();
+
+        let (received_tx, mut received_rx) = futures::channel::mpsc::unbounded();
+        let server = zbus::connection::Builder::address(daemon.address.as_str())
+            .unwrap()
+            .name("org.freedesktop.Notifications")
+            .unwrap()
+            .serve_at(
+                "/org/freedesktop/Notifications",
+                MockNotifications { received_tx },
+            )
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        let client = zbus::connection::Builder::address(daemon.address.as_str())
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+
+        let task =
+            tokio::spawn(
+                async move { show_at(&client, "Firezone", "Test title", "Test body").await },
+            );
+
+        // The daemon must receive exactly what we sent.
+        let notify = tokio::time::timeout(Duration::from_secs(10), received_rx.next())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(notify.app_name, "Firezone");
+        assert_eq!(notify.replaces_id, 0);
+        assert_eq!(notify.app_icon, "");
+        assert_eq!(notify.summary, "Test title");
+        assert_eq!(notify.body, "Test body");
+        assert!(notify.actions.is_empty());
+        assert_eq!(notify.num_hints, 0);
+        assert_eq!(notify.expire_timeout, -1);
+
+        // Closing some other notification must not resolve ours.
+        emit_notification_closed(&server, NOTIFICATION_ID + 1).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(!task.is_finished());
+
+        // Closing ours must.
+        emit_notification_closed(&server, NOTIFICATION_ID).await;
+        tokio::time::timeout(Duration::from_secs(10), task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+    }
+
+    async fn emit_notification_closed(connection: &zbus::Connection, id: u32) {
+        connection
+            .emit_signal(
+                None::<zbus::names::BusName>,
+                "/org/freedesktop/Notifications",
+                "org.freedesktop.Notifications",
+                "NotificationClosed",
+                &(id, 1_u32),
+            )
+            .await
+            .unwrap();
+    }
+
+    struct MockNotifications {
+        received_tx: futures::channel::mpsc::UnboundedSender<ReceivedNotify>,
+    }
+
+    #[zbus::interface(name = "org.freedesktop.Notifications")]
+    impl MockNotifications {
+        fn notify(
+            &self,
+            app_name: String,
+            replaces_id: u32,
+            app_icon: String,
+            summary: String,
+            body: String,
+            actions: Vec<String>,
+            hints: HashMap<String, zbus::zvariant::OwnedValue>,
+            expire_timeout: i32,
+        ) -> u32 {
+            self.received_tx
+                .unbounded_send(ReceivedNotify {
+                    app_name,
+                    replaces_id,
+                    app_icon,
+                    summary,
+                    body,
+                    actions,
+                    num_hints: hints.len(),
+                    expire_timeout,
+                })
+                .unwrap();
+
+            NOTIFICATION_ID
+        }
+    }
+
+    #[derive(Debug)]
+    struct ReceivedNotify {
+        app_name: String,
+        replaces_id: u32,
+        app_icon: String,
+        summary: String,
+        body: String,
+        actions: Vec<String>,
+        num_hints: usize,
+        expire_timeout: i32,
+    }
+
+    /// A private session bus, killed on drop.
+    struct DbusDaemon {
+        process: std::process::Child,
+        address: String,
+    }
+
+    impl DbusDaemon {
+        fn start() -> Self {
+            let mut process = std::process::Command::new("dbus-daemon")
+                .args(["--session", "--nofork", "--print-address"])
+                .stdout(std::process::Stdio::piped())
+                .spawn()
+                .expect("`dbus-daemon` must be installed to run this test");
+
+            let stdout = process.stdout.take().unwrap();
+            let mut address = String::new();
+            std::io::BufReader::new(stdout)
+                .read_line(&mut address)
+                .unwrap();
+
+            Self {
+                process,
+                address: address.trim().to_owned(),
+            }
+        }
+    }
+
+    impl Drop for DbusDaemon {
+        fn drop(&mut self) {
+            let _ = self.process.kill();
+            let _ = self.process.wait();
+        }
+    }
+}

--- a/rust/libs/desktop-notifications/src/platform/macos.rs
+++ b/rust/libs/desktop-notifications/src/platform/macos.rs
@@ -1,0 +1,14 @@
+use anyhow::Result;
+use url::Url;
+
+#[expect(clippy::unused_async, reason = "Signature must match other platforms.")]
+pub(crate) async fn show(
+    _app_id: &str,
+    _title: &str,
+    _body: &str,
+    _open_url: Option<&Url>,
+) -> Result<()> {
+    tracing::warn!("Notifications are not implemented on macOS");
+
+    Ok(())
+}

--- a/rust/libs/desktop-notifications/src/platform/windows.rs
+++ b/rust/libs/desktop-notifications/src/platform/windows.rs
@@ -1,0 +1,105 @@
+use anyhow::{Context as _, Result};
+use url::Url;
+use windows::{
+    Data::Xml::Dom::XmlDocument,
+    UI::Notifications::{ToastNotification, ToastNotificationManager},
+    core::HSTRING,
+};
+
+#[expect(clippy::unused_async, reason = "Signature must match other platforms.")]
+pub(crate) async fn show(
+    app_id: &str,
+    title: &str,
+    body: &str,
+    open_url: Option<&Url>,
+) -> Result<()> {
+    let toast_xml = toast_xml(title, body, open_url);
+
+    let xml = XmlDocument::new()?;
+    xml.LoadXml(&HSTRING::from(&toast_xml))
+        .context("Failed to load toast XML")?;
+    let toast =
+        ToastNotification::CreateToastNotification(&xml).context("Failed to create toast")?;
+    ToastNotificationManager::CreateToastNotifierWithId(&HSTRING::from(app_id))
+        .context("Failed to create toast notifier")?
+        .Show(&toast)
+        .context("Failed to show toast")?;
+
+    Ok(())
+}
+
+/// Renders the [toast content XML] for a notification.
+///
+/// A clickable toast declares `activationType="protocol"`, so the shell opens
+/// the URL itself. Unlike an in-process activation callback, that also works
+/// after the toast has moved into the notification center. Such a toast also
+/// uses `duration="long"` to stay on screen for 25 seconds instead of the
+/// default ~6, giving the user more time to actually click it.
+///
+/// [toast content XML]: https://learn.microsoft.com/en-us/uwp/schemas/tiles/toastschema/element-toast
+fn toast_xml(title: &str, body: &str, open_url: Option<&Url>) -> String {
+    let toast_attributes = match open_url {
+        Some(url) => format!(
+            r#" duration="long" activationType="protocol" launch="{}""#,
+            xml_escape(url.as_str())
+        ),
+        None => String::new(),
+    };
+
+    format!(
+        r#"<toast{toast_attributes}>
+    <visual>
+        <binding template="ToastGeneric">
+            <text id="1">{title}</text>
+            <text id="2">{body}</text>
+        </binding>
+    </visual>
+</toast>"#,
+        title = xml_escape(title),
+        body = xml_escape(body),
+    )
+}
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// AppUserModelID of Windows PowerShell, which is registered on every
+    /// Windows installation, so toasts under it are accepted even where our
+    /// own identity isn't registered (e.g. in CI).
+    const POWERSHELL_APP_ID: &str =
+        "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe";
+
+    #[tokio::test]
+    async fn shows_toasts_end_to_end() {
+        // A plain notification; XML-hostile characters must survive
+        // `XmlDocument::LoadXml`, i.e. Windows' own parser.
+        show(
+            POWERSHELL_APP_ID,
+            "Firezone <connected> & \"ready\"",
+            "Resource 'R&D' says <hello>",
+            None,
+        )
+        .await
+        .unwrap();
+
+        // A clickable notification, with a URL that needs escaping.
+        let url = Url::parse("https://www.firezone.dev/dl?arch=x86_64&os=windows").unwrap();
+        show(
+            POWERSHELL_APP_ID,
+            "Firezone 1.99.0 available for download",
+            "Click here to download the new version",
+            Some(&url),
+        )
+        .await
+        .unwrap();
+    }
+}


### PR DESCRIPTION
Notification code moves into a new `desktop-notifications` crate with a single public API for both of our notification needs: `Notifier::show(title, body, open_url)`, where activating the notification opens the optional URL (Windows only for now). The gui-client only supplies the application identity (the package AUMID on Windows) and spawns the returned future.

This replaces the `tauri-winrt-notification` and `notify-rust` dependencies: on Windows the crate builds the [toast content XML](https://learn.microsoft.com/en-us/uwp/schemas/tiles/toastschema/element-toast) itself, and on Linux it calls the [`org.freedesktop.Notifications`](https://specifications.freedesktop.org/notification-spec/latest/protocol.html) D-Bus interface directly via `zbus`, keeping the connection open until the notification is closed because dropping it early makes notifications unreliable on some desktops. Dropping those dependencies also removes their never-compiled platform backends from the lockfile and therefore from SBOMs and dependency audits.

The crate has one end-to-end test per platform, both running in CI's `cargo test` matrix: the Linux test spawns a private `dbus-daemon` with a mock notification service and asserts the exact `Notify` arguments plus that `show` only resolves once the notification's own close signal arrives; the Windows test shows real toasts under the PowerShell AUMID, passing XML-hostile titles, bodies and URLs through Windows' own XML parser.