### PR TITLE
feat(gui-client): make notifications clickable on Linux

### DIFF
--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -169,13 +169,11 @@ impl GuiIntegration for TauriIntegration {
         title: impl Into<String>,
         download_url: url::Url,
     ) -> Result<()> {
-        // Clickable notifications only work on Windows.
-        #[cfg(target_os = "windows")]
-        let body = "Click here to download the new version";
-        #[cfg(not(target_os = "windows"))]
-        let body = "";
-
-        spawn_notification(title.into(), body.to_owned(), Some(download_url));
+        spawn_notification(
+            title.into(),
+            "Click here to download the new version".to_owned(),
+            Some(download_url),
+        );
 
         Ok(())
     }

--- a/rust/libs/desktop-notifications/Cargo.toml
+++ b/rust/libs/desktop-notifications/Cargo.toml
@@ -11,6 +11,7 @@ url = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 futures = { workspace = true }
+tracing = { workspace = true }
 zbus = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/rust/libs/desktop-notifications/src/lib.rs
+++ b/rust/libs/desktop-notifications/src/lib.rs
@@ -44,8 +44,7 @@ impl Notifier {
 
     /// Shows a notification.
     ///
-    /// Activating the notification opens `open_url`; only Windows supports
-    /// this, other platforms ignore it.
+    /// Clicking the notification opens `open_url` (ignored on macOS).
     ///
     /// Resolves once the notification has been handled: on Windows right
     /// after hand-off to the toast platform, on Linux once the notification

--- a/rust/libs/desktop-notifications/src/platform/linux.rs
+++ b/rust/libs/desktop-notifications/src/platform/linux.rs
@@ -7,22 +7,34 @@ pub(crate) async fn show(
     app_id: &str,
     title: &str,
     body: &str,
-    _open_url: Option<&Url>, // TODO: Clickable notifications are not implemented on Linux.
+    open_url: Option<&Url>,
 ) -> Result<()> {
     let connection = zbus::Connection::session()
         .await
         .context("Failed to connect to session bus")?;
 
-    show_at(&connection, app_id, title, body).await?;
+    show_at(
+        &connection,
+        app_id,
+        title,
+        body,
+        open_url,
+        open_with_xdg_open,
+    )
+    .await?;
 
     Ok(())
 }
 
 /// Shows a notification via the [`org.freedesktop.Notifications`] D-Bus interface.
 ///
+/// A clickable notification carries the special `default` action, which
+/// servers invoke when the user clicks the notification itself; we then hand
+/// the URL to `open`.
+///
 /// Resolves once the notification is closed: the D-Bus connection must stay
 /// open for as long as the notification is showing, otherwise it doesn't get
-/// displayed reliably on all desktops.
+/// displayed reliably on all desktops (and we would miss the click).
 ///
 /// [`org.freedesktop.Notifications`]: https://specifications.freedesktop.org/notification-spec/latest/protocol.html
 async fn show_at(
@@ -30,6 +42,8 @@ async fn show_at(
     app_name: &str,
     summary: &str,
     body: &str,
+    open_url: Option<&Url>,
+    open: impl Fn(&Url),
 ) -> Result<()> {
     let proxy = zbus::Proxy::new(
         connection,
@@ -40,11 +54,21 @@ async fn show_at(
     .await
     .context("Failed to create proxy")?;
 
-    // Subscribe before `Notify` so we cannot miss the close signal.
-    let mut closed = proxy
+    // Subscribe before `Notify` so we cannot miss any signal.
+    let closed = proxy
         .receive_signal("NotificationClosed")
         .await
         .context("Failed to subscribe to `NotificationClosed`")?;
+    let invoked = proxy
+        .receive_signal("ActionInvoked")
+        .await
+        .context("Failed to subscribe to `ActionInvoked`")?;
+    let mut signals = futures::stream::select(closed, invoked);
+
+    let actions = match open_url {
+        Some(_) => vec!["default", "Open"],
+        None => Vec::new(),
+    };
 
     let id: u32 = proxy
         .call(
@@ -55,7 +79,7 @@ async fn show_at(
                 "",    // No icon.
                 summary,
                 body,
-                Vec::<&str>::new(),                            // No actions.
+                actions,
                 HashMap::<&str, zbus::zvariant::Value>::new(), // No hints.
                 -1_i32, // Let the server pick an expiry timeout.
             ),
@@ -63,18 +87,55 @@ async fn show_at(
         .await
         .context("Failed to call `Notify`")?;
 
-    while let Some(message) = closed.next().await {
-        let (closed_id, _reason): (u32, u32) = message
-            .body()
-            .deserialize()
-            .context("Failed to deserialize `NotificationClosed`")?;
+    while let Some(message) = signals.next().await {
+        match message.header().member().map(|member| member.as_str()) {
+            Some("NotificationClosed") => {
+                let (closed_id, _reason): (u32, u32) = message
+                    .body()
+                    .deserialize()
+                    .context("Failed to deserialize `NotificationClosed`")?;
 
-        if closed_id == id {
-            break;
+                if closed_id == id {
+                    break;
+                }
+            }
+            Some("ActionInvoked") => {
+                let (invoked_id, action): (u32, String) = message
+                    .body()
+                    .deserialize()
+                    .context("Failed to deserialize `ActionInvoked`")?;
+
+                if invoked_id == id
+                    && action == "default"
+                    && let Some(url) = open_url
+                {
+                    open(url);
+                }
+            }
+            _ => {}
         }
     }
 
     Ok(())
+}
+
+/// Opens `url` with the user's preferred application.
+///
+/// `xdg-open` is part of `xdg-utils`, which every desktop Linux
+/// installation ships.
+fn open_with_xdg_open(url: &Url) {
+    match std::process::Command::new("xdg-open")
+        .arg(url.as_str())
+        .spawn()
+    {
+        Ok(mut child) => {
+            // Reap the child to not leave a zombie process behind.
+            std::thread::spawn(move || {
+                let _ = child.wait();
+            });
+        }
+        Err(e) => tracing::debug!("Failed to spawn `xdg-open`: {e}"),
+    }
 }
 
 #[cfg(test)]
@@ -108,10 +169,16 @@ mod tests {
             .await
             .unwrap();
 
-        let task =
-            tokio::spawn(
-                async move { show_at(&client, "Firezone", "Test title", "Test body").await },
-            );
+        // Part 1: a plain notification, no URL.
+        let task = tokio::spawn({
+            let client = client.clone();
+            async move {
+                show_at(&client, "Firezone", "Test title", "Test body", None, |_| {
+                    panic!("Nothing to open for a plain notification")
+                })
+                .await
+            }
+        });
 
         // The daemon must receive exactly what we sent.
         let notify = tokio::time::timeout(Duration::from_secs(10), received_rx.next())
@@ -139,6 +206,52 @@ mod tests {
             .unwrap()
             .unwrap()
             .unwrap();
+
+        // Part 2: a clickable notification.
+        let url = Url::parse("https://www.firezone.dev/dl?arch=x86_64&os=linux").unwrap();
+        let (opened_tx, mut opened_rx) = futures::channel::mpsc::unbounded();
+        let task = tokio::spawn({
+            let client = client.clone();
+            let url = url.clone();
+            async move {
+                show_at(
+                    &client,
+                    "Firezone",
+                    "Update title",
+                    "Update body",
+                    Some(&url),
+                    move |url| opened_tx.unbounded_send(url.clone()).unwrap(),
+                )
+                .await
+            }
+        });
+
+        // The `default` action makes the notification clickable.
+        let notify = tokio::time::timeout(Duration::from_secs(10), received_rx.next())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(notify.actions, vec!["default", "Open"]);
+
+        // Clicks on other notifications must be ignored.
+        emit_action_invoked(&server, NOTIFICATION_ID + 1).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(opened_rx.try_recv().is_err(), "URL must not be opened yet");
+
+        // A click on ours must open the URL.
+        emit_action_invoked(&server, NOTIFICATION_ID).await;
+        let opened = tokio::time::timeout(Duration::from_secs(10), opened_rx.next())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(opened, url);
+
+        emit_notification_closed(&server, NOTIFICATION_ID).await;
+        tokio::time::timeout(Duration::from_secs(10), task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
     }
 
     async fn emit_notification_closed(connection: &zbus::Connection, id: u32) {
@@ -149,6 +262,19 @@ mod tests {
                 "org.freedesktop.Notifications",
                 "NotificationClosed",
                 &(id, 1_u32),
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn emit_action_invoked(connection: &zbus::Connection, id: u32) {
+        connection
+            .emit_signal(
+                None::<zbus::names::BusName>,
+                "/org/freedesktop/Notifications",
+                "org.freedesktop.Notifications",
+                "ActionInvoked",
+                &(id, "default"),
             )
             .await
             .unwrap();


### PR DESCRIPTION
Clicking a notification that carries a URL now opens it in the browser on Linux, so the update notification works the same as on Windows. The notification declares the [notification spec](https://specifications.freedesktop.org/notification-spec/latest/protocol.html)'s special `default` action, which servers invoke when the user clicks the notification itself, and the URL is opened with `xdg-open` when the `ActionInvoked` signal arrives on the D-Bus connection we already hold open while the notification is showing.

With clicks working on both desktop platforms, the update notification uses the same body text everywhere. The end-to-end test now also covers the click: the mock daemon asserts the advertised actions, ignores clicks on other notifications, and verifies that invoking the `default` action opens the exact URL.