### PR TITLE
fix(linux): verify TUN device flags after TUNSETIFF

### DIFF
--- a/rust/libs/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/linux.rs
@@ -41,6 +41,7 @@ use tun::ioctl;
 
 const TUNSETIFF: libc::c_ulong = 0x4004_54ca;
 const TUNSETOFFLOAD: libc::c_ulong = 0x4004_54d0;
+const TUNGETIFF: libc::c_ulong = 0x8004_54d2;
 
 const TUN_F_CSUM: libc::c_uint = 0x01;
 const TUN_F_TSO4: libc::c_uint = 0x02;
@@ -790,6 +791,8 @@ fn open_tun() -> Result<tun::linux::TunFd<Arc<OwnedFd>>> {
         .context("Failed to set flags on TUN device")?;
     }
 
+    verify_flags(fd).context("Failed to verify TUN device flags")?;
+
     // A successful `TUNSETOFFLOAD` is the kernel promising it handles these offloads on both the
     // read (GRO) and write (GSO) side, so we use it directly as the capability probe rather than
     // gating on a kernel version. It fails on kernels without UDP segmentation offload (added in
@@ -808,6 +811,34 @@ fn open_tun() -> Result<tun::linux::TunFd<Arc<OwnedFd>>> {
     let fd = unsafe { OwnedFd::from_raw_fd(fd) };
 
     Ok(tun::linux::TunFd::new(Arc::new(fd), offloads))
+}
+
+/// Verifies that the TUN device carries the flags we requested via `TUNSETIFF`.
+///
+/// `TUNSETIFF` against an existing multi-queue device whose other queues are still attached
+/// (e.g. held by another process on the same host) attaches us as an additional queue and leaves
+/// the device's flags untouched, so they may silently differ from the ones we requested.
+/// A missing `IFF_VNET_HDR` in particular makes both sides misinterpret every packet:
+/// we would parse the leading bytes of each read as a `virtio_net_hdr` and the kernel would
+/// reject or misparse our writes.
+fn verify_flags(fd: RawFd) -> Result<()> {
+    let mut request = ioctl::Request::<ioctl::GetTunFlagsPayload>::new();
+
+    // Safety: The file descriptor is valid.
+    unsafe {
+        ioctl::exec(fd, TUNGETIFF, &mut request).context("TUNGETIFF failed")?;
+    }
+
+    let flags = request.flags();
+
+    anyhow::ensure!(
+        flags & ioctl::TUN_FLAGS == ioctl::TUN_FLAGS,
+        "TUN device '{}' is missing required flags (expected {:#06x}, got {flags:#06x}); is it attached to another process?",
+        TunDeviceManager::IFACE_NAME,
+        ioctl::TUN_FLAGS,
+    );
+
+    Ok(())
 }
 
 /// Enables checksum and segmentation offloads on the TUN device, returning whether the kernel

--- a/rust/libs/bin-shared/tests/foreign_tun_device.rs
+++ b/rust/libs/bin-shared/tests/foreign_tun_device.rs
@@ -1,0 +1,52 @@
+#![cfg(target_os = "linux")]
+#![allow(clippy::unwrap_used)]
+
+use bin_shared::TunDeviceManager;
+use std::os::fd::{FromRawFd as _, OwnedFd};
+
+const TUNSETIFF: libc::c_ulong = 0x4004_54ca;
+
+#[repr(C)]
+struct IfReq {
+    name: [u8; libc::IF_NAMESIZE],
+    flags: libc::c_short,
+    _padding: [u8; 22],
+}
+
+/// Attaching to a TUN device that another process created with different flags
+/// must fail instead of exchanging packets in a format the kernel does not use.
+#[tokio::test] // Needs a runtime.
+#[ignore = "Needs admin / sudo"]
+async fn refuses_foreign_tun_device_without_vnet_hdr() {
+    let _foreign_device = create_device_without_vnet_hdr();
+
+    let mut tun_device_manager = TunDeviceManager::new(1280).unwrap();
+    let error = match tun_device_manager.make_tun() {
+        Ok(_) => panic!("Expected `make_tun` to fail"),
+        Err(e) => e,
+    };
+
+    assert!(
+        format!("{error:#}").contains("missing required flags"),
+        "{error:#}"
+    );
+}
+
+fn create_device_without_vnet_hdr() -> OwnedFd {
+    let fd = unsafe { libc::open(c"/dev/net/tun".as_ptr(), libc::O_RDWR) };
+    assert!(fd >= 0, "{}", std::io::Error::last_os_error());
+
+    let name = TunDeviceManager::IFACE_NAME.as_bytes();
+    let mut request = IfReq {
+        name: [0; libc::IF_NAMESIZE],
+        flags: (libc::IFF_TUN | libc::IFF_NO_PI | libc::IFF_MULTI_QUEUE) as libc::c_short,
+        _padding: [0; 22],
+    };
+    request.name[..name.len()].copy_from_slice(name);
+
+    let ret = unsafe { libc::ioctl(fd, TUNSETIFF as _, &mut request) };
+    assert!(ret >= 0, "{}", std::io::Error::last_os_error());
+
+    // Safety: We just opened the FD.
+    unsafe { OwnedFd::from_raw_fd(fd) }
+}

--- a/rust/libs/connlib/tun/src/ioctl.rs
+++ b/rust/libs/connlib/tun/src/ioctl.rs
@@ -24,6 +24,11 @@ pub struct Request<P> {
     payload: P,
 }
 
+/// The flags we request for our TUN device.
+#[cfg(target_os = "linux")]
+pub const TUN_FLAGS: std::ffi::c_short =
+    (libc::IFF_TUN | libc::IFF_NO_PI | libc::IFF_MULTI_QUEUE | libc::IFF_VNET_HDR) as _;
+
 #[cfg(target_os = "linux")]
 impl Request<SetTunFlagsPayload> {
     pub fn new(name: &str) -> Self {
@@ -35,13 +40,29 @@ impl Request<SetTunFlagsPayload> {
 
         Self {
             name,
-            payload: SetTunFlagsPayload {
-                flags: (libc::IFF_TUN
-                    | libc::IFF_NO_PI
-                    | libc::IFF_MULTI_QUEUE
-                    | libc::IFF_VNET_HDR) as _,
-            },
+            payload: SetTunFlagsPayload { flags: TUN_FLAGS },
         }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Request<GetTunFlagsPayload> {
+    pub fn new() -> Self {
+        Self {
+            name: [0u8; libc::IF_NAMESIZE],
+            payload: GetTunFlagsPayload::default(),
+        }
+    }
+
+    pub fn flags(&self) -> std::ffi::c_short {
+        self.payload.flags
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Default for Request<GetTunFlagsPayload> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -71,6 +92,16 @@ impl Default for Request<GetInterfaceNamePayload> {
 #[repr(C)]
 pub struct SetTunFlagsPayload {
     flags: std::ffi::c_short,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+#[repr(C)]
+pub struct GetTunFlagsPayload {
+    flags: std::ffi::c_short,
+    // `TUNGETIFF` copies a full `struct ifreq` (40 bytes) back to userspace;
+    // pad the payload to the size of the `ifreq` union so the write stays in bounds.
+    _padding: [u8; 22],
 }
 
 #[derive(Default)]


### PR DESCRIPTION
`TUNSETIFF` on an existing multi-queue TUN device whose other queues are still attached (for example an old gateway process during an upgrade overlap, or a second gateway sharing the host network namespace) attaches the caller as an additional queue and leaves the device's flags untouched. A gateway can therefore end up on a device without `IFF_VNET_HDR` while assuming it is set: it then misparses the leading bytes of every TUN read as a `virtio_net_hdr` and the kernel rejects its writes with `EINVAL`. This is the root cause of the burst of `tun::linux` errors reported against gateway 1.6.0 (see [GATEWAY-5CJ](https://firezone-inc.sentry.io/issues/GATEWAY-5CJ)), and the mirror image of it, a 1.5.2 gateway attaching to a 1.6.0 device, shows up as [GATEWAY-5CH](https://firezone-inc.sentry.io/issues/GATEWAY-5CH). Reading the flags back via `TUNGETIFF` and refusing to run turns silent traffic corruption into a clear startup error that resolves itself once the other process releases the device.

Fixes GATEWAY-5CP
Fixes GATEWAY-5CJ
Fixes GATEWAY-5CF
Fixes GATEWAY-5CG
Fixes GATEWAY-5CK