### PR TITLE
fix(windows): ignore missing routes when removing routes

### DIFF
--- a/rust/libs/bin-shared/src/windows.rs
+++ b/rust/libs/bin-shared/src/windows.rs
@@ -214,6 +214,10 @@ fn delete_all_routing_entries_matching(addr: IpAddr) -> io::Result<()> {
 
         // Safety: The `entry` is initialised.
         if let Err(e) = unsafe { DeleteIpForwardEntry2(entry) }.ok() {
+            if e.code() == error::NOT_FOUND {
+                continue;
+            }
+
             tracing::warn!("Failed to remove routing entry: {}", err_with_src(&e));
             continue;
         };


### PR DESCRIPTION
Deleting a routing entry that is already gone fails with `NOT_FOUND` (0x80070490), which is benign: the entry we wanted to remove no longer exists.