### PR TITLE
fix(gui-client): drop existing session before connecting

### DIFF
--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -610,7 +610,11 @@ impl<'a> Handler<'a> {
                 is_internet_resource_active,
             } => {
                 if !self.session.is_none() {
-                    tracing::debug!(session = ?self.session, "Connecting despite existing session");
+                    tracing::debug!(session = ?self.session, "Dropping existing session before connecting");
+
+                    // Release the TUN device before we create a new one:
+                    // attaching to a device that is still in use is not reliable.
+                    self.session = Session::None;
                 }
 
                 let result = self.try_connect(token.clone(), is_internet_resource_active);


### PR DESCRIPTION
Connecting over an existing session created the new TUN device while the old one was still alive. Releasing the old session first makes the TUN lifecycle sequential, so the device name is never contended between the outgoing and the incoming session.