### PR TITLE
fix(linux): attach exclusively to the TUN device

### DIFF
--- a/rust/libs/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/linux.rs
@@ -747,6 +747,34 @@ impl Tun {
     }
 }
 
+/// Attaches to the TUN device via `TUNSETIFF`, retrying `EBUSY` for a short window.
+///
+/// A previous session's device releases its FD asynchronously: the worker threads
+/// exit only after the session state is dropped. A device that stays busy beyond
+/// the retry window is held by another process and we must not share it.
+fn attach(fd: RawFd) -> Result<()> {
+    const ATTACH_RETRIES: u32 = 25;
+    const ATTACH_RETRY_DELAY: Duration = Duration::from_millis(20);
+
+    let mut request =
+        ioctl::Request::<ioctl::SetTunFlagsPayload>::new(TunDeviceManager::IFACE_NAME);
+    let mut attempt = 0;
+
+    loop {
+        // Safety: The file descriptor is valid.
+        match unsafe { ioctl::exec(fd, TUNSETIFF, &mut request) } {
+            Ok(()) => break,
+            Err(e) if e.raw_os_error() == Some(libc::EBUSY) && attempt < ATTACH_RETRIES => {
+                attempt += 1;
+                std::thread::sleep(ATTACH_RETRY_DELAY);
+            }
+            Err(e) => return Err(anyhow::Error::new(e)),
+        }
+    }
+
+    Ok(())
+}
+
 fn open_tun() -> Result<tun::linux::TunFd<Arc<OwnedFd>>> {
     let fd = match unsafe { open(TUN_FILE.as_ptr() as _, O_RDWR) } {
         -1 => {
@@ -758,14 +786,7 @@ fn open_tun() -> Result<tun::linux::TunFd<Arc<OwnedFd>>> {
         fd => fd,
     };
 
-    unsafe {
-        ioctl::exec(
-            fd,
-            TUNSETIFF,
-            &mut ioctl::Request::<ioctl::SetTunFlagsPayload>::new(TunDeviceManager::IFACE_NAME),
-        )
-        .context("Failed to set flags on TUN device")?;
-    }
+    attach(fd).context("Failed to set flags on TUN device")?;
 
     // A successful `TUNSETOFFLOAD` is the kernel promising it handles these offloads on both the
     // read (GRO) and write (GSO) side, so we use it directly as the capability probe rather than

--- a/rust/libs/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/linux.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use std::{collections::BTreeSet, path::Path};
 use std::{
     collections::HashMap,
-    os::fd::{FromRawFd as _, OwnedFd},
+    os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd},
 };
 use std::{
     collections::HashSet,
@@ -783,16 +783,19 @@ fn open_tun() -> Result<tun::linux::TunFd<Arc<OwnedFd>>> {
             return Err(anyhow::Error::new(get_last_error()))
                 .with_context(|| format!("Failed to open '{file}'"));
         }
-        fd => fd,
+        fd => {
+            // Safety: We just opened the FD.
+            unsafe { OwnedFd::from_raw_fd(fd) }
+        }
     };
 
-    attach(fd).context("Failed to set flags on TUN device")?;
+    attach(fd.as_raw_fd()).context("Failed to set flags on TUN device")?;
 
     // A successful `TUNSETOFFLOAD` is the kernel promising it handles these offloads on both the
     // read (GRO) and write (GSO) side, so we use it directly as the capability probe rather than
     // gating on a kernel version. It fails on kernels without UDP segmentation offload (added in
     // Linux 6.2), where we run without offloads and exchange plain packets.
-    let offloads = try_enable_offloads(fd);
+    let offloads = try_enable_offloads(fd.as_raw_fd());
 
     if !offloads {
         tracing::info!(
@@ -800,10 +803,7 @@ fn open_tun() -> Result<tun::linux::TunFd<Arc<OwnedFd>>> {
         );
     }
 
-    set_non_blocking(fd).context("Failed to make TUN device non-blocking")?;
-
-    // Safety: We are not closing the FD.
-    let fd = unsafe { OwnedFd::from_raw_fd(fd) };
+    set_non_blocking(fd.as_raw_fd()).context("Failed to make TUN device non-blocking")?;
 
     Ok(tun::linux::TunFd::new(Arc::new(fd), offloads))
 }

--- a/rust/libs/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/linux.rs
@@ -747,34 +747,6 @@ impl Tun {
     }
 }
 
-/// Attaches to the TUN device via `TUNSETIFF`, retrying `EBUSY` for a short window.
-///
-/// A previous session's device releases its FD asynchronously: the worker threads
-/// exit only after the session state is dropped. A device that stays busy beyond
-/// the retry window is held by another process and we must not share it.
-fn attach(fd: RawFd) -> Result<()> {
-    const ATTACH_RETRIES: u32 = 25;
-    const ATTACH_RETRY_DELAY: Duration = Duration::from_millis(20);
-
-    let mut request =
-        ioctl::Request::<ioctl::SetTunFlagsPayload>::new(TunDeviceManager::IFACE_NAME);
-    let mut attempt = 0;
-
-    loop {
-        // Safety: The file descriptor is valid.
-        match unsafe { ioctl::exec(fd, TUNSETIFF, &mut request) } {
-            Ok(()) => break,
-            Err(e) if e.raw_os_error() == Some(libc::EBUSY) && attempt < ATTACH_RETRIES => {
-                attempt += 1;
-                std::thread::sleep(ATTACH_RETRY_DELAY);
-            }
-            Err(e) => return Err(anyhow::Error::new(e)),
-        }
-    }
-
-    Ok(())
-}
-
 fn open_tun() -> Result<tun::linux::TunFd<Arc<OwnedFd>>> {
     let fd = match unsafe { open(TUN_FILE.as_ptr() as _, O_RDWR) } {
         -1 => {
@@ -789,7 +761,14 @@ fn open_tun() -> Result<tun::linux::TunFd<Arc<OwnedFd>>> {
         }
     };
 
-    attach(fd.as_raw_fd()).context("Failed to set flags on TUN device")?;
+    unsafe {
+        ioctl::exec(
+            fd.as_raw_fd(),
+            TUNSETIFF,
+            &mut ioctl::Request::<ioctl::SetTunFlagsPayload>::new(TunDeviceManager::IFACE_NAME),
+        )
+        .context("Failed to set flags on TUN device")?;
+    }
 
     // A successful `TUNSETOFFLOAD` is the kernel promising it handles these offloads on both the
     // read (GRO) and write (GSO) side, so we use it directly as the capability probe rather than

--- a/rust/libs/bin-shared/tests/foreign_tun_device.rs
+++ b/rust/libs/bin-shared/tests/foreign_tun_device.rs
@@ -22,7 +22,7 @@ async fn refuses_tun_device_held_by_another_process() {
 
     // A multi-queue device, as created by older versions.
     {
-        let _foreign_device = create_foreign_device(libc::IFF_MULTI_QUEUE);
+        let _foreign_device = create_foreign_device(libc::IFF_MULTI_QUEUE | libc::IFF_VNET_HDR);
 
         assert_make_tun_fails(&mut tun_device_manager);
     }

--- a/rust/libs/bin-shared/tests/foreign_tun_device.rs
+++ b/rust/libs/bin-shared/tests/foreign_tun_device.rs
@@ -1,0 +1,67 @@
+#![cfg(target_os = "linux")]
+#![allow(clippy::unwrap_used)]
+
+use bin_shared::TunDeviceManager;
+use std::os::fd::{FromRawFd as _, OwnedFd};
+
+const TUNSETIFF: libc::c_ulong = 0x4004_54ca;
+
+#[repr(C)]
+struct IfReq {
+    name: [u8; libc::IF_NAMESIZE],
+    flags: libc::c_short,
+    _padding: [u8; 22],
+}
+
+/// Attaching to a TUN device that another process still holds must fail
+/// instead of exchanging packets on a shared device.
+#[tokio::test] // Needs a runtime.
+#[ignore = "Needs admin / sudo"]
+async fn refuses_tun_device_held_by_another_process() {
+    let mut tun_device_manager = TunDeviceManager::new(1280).unwrap();
+
+    // A multi-queue device, as created by older versions.
+    {
+        let _foreign_device = create_foreign_device(libc::IFF_MULTI_QUEUE);
+
+        assert_make_tun_fails(&mut tun_device_manager);
+    }
+
+    // A single-queue device.
+    {
+        let _foreign_device = create_foreign_device(0);
+
+        assert_make_tun_fails(&mut tun_device_manager);
+    }
+}
+
+fn assert_make_tun_fails(tun_device_manager: &mut TunDeviceManager) {
+    let error = match tun_device_manager.make_tun() {
+        Ok(_) => panic!("Expected `make_tun` to fail"),
+        Err(e) => e,
+    };
+
+    assert!(
+        format!("{error:#}").contains("Failed to set flags on TUN device"),
+        "{error:#}"
+    );
+}
+
+fn create_foreign_device(extra_flags: libc::c_int) -> OwnedFd {
+    let fd = unsafe { libc::open(c"/dev/net/tun".as_ptr(), libc::O_RDWR) };
+    assert!(fd >= 0, "{}", std::io::Error::last_os_error());
+
+    let name = TunDeviceManager::IFACE_NAME.as_bytes();
+    let mut request = IfReq {
+        name: [0; libc::IF_NAMESIZE],
+        flags: (libc::IFF_TUN | libc::IFF_NO_PI | extra_flags) as libc::c_short,
+        _padding: [0; 22],
+    };
+    request.name[..name.len()].copy_from_slice(name);
+
+    let ret = unsafe { libc::ioctl(fd, TUNSETIFF as _, &mut request) };
+    assert!(ret >= 0, "{}", std::io::Error::last_os_error());
+
+    // Safety: We just opened the FD.
+    unsafe { OwnedFd::from_raw_fd(fd) }
+}

--- a/rust/libs/connlib/tun/src/ioctl.rs
+++ b/rust/libs/connlib/tun/src/ioctl.rs
@@ -35,11 +35,11 @@ impl Request<SetTunFlagsPayload> {
 
         Self {
             name,
+            // Deliberately not `IFF_MULTI_QUEUE`: we only ever open a single queue,
+            // and attaching to a device that another process still holds must fail
+            // instead of splitting traffic between two processes.
             payload: SetTunFlagsPayload {
-                flags: (libc::IFF_TUN
-                    | libc::IFF_NO_PI
-                    | libc::IFF_MULTI_QUEUE
-                    | libc::IFF_VNET_HDR) as _,
+                flags: (libc::IFF_TUN | libc::IFF_NO_PI | libc::IFF_VNET_HDR) as _,
             },
         }
     }


### PR DESCRIPTION
With `IFF_MULTI_QUEUE`, attaching to a `tun-firezone` device that another process still holds silently adds a second queue: the kernel then splits traffic between both processes and keeps the existing device flags, which corrupts every packet when the flag sets differ across versions. This is the root cause of the packet corruption reported by 1.6.0 gateways running next to an older gateway in the same network namespace. We only ever open a single queue, so request the device without `IFF_MULTI_QUEUE`; attaching to a held device now fails at startup instead, and a restarting supervisor converges once the other process exits.

Related: #14633
Related: #14634