### PR TITLE
chore(portal): collapse redundant devices indexes

### DIFF
--- a/elixir/lib/portal/device.ex
+++ b/elixir/lib/portal/device.ex
@@ -215,8 +215,8 @@ defmodule Portal.Device do
         |> unique_constraint(:last_attested_mdm_device_id,
           name: :devices_account_id_actor_id_last_attested_mdm_device_id_index
         )
-        |> unique_constraint(:last_attested_cert_fingerprint,
-          name: :devices_account_id_actor_id_last_attested_cert_fingerprint_index
+        |> unique_constraint(:last_attested_cert_serial,
+          name: :devices_account_id_cert_issuer_serial_actor_id_index
         )
 
       :gateway ->

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -417,9 +417,9 @@ defmodule PortalAPI.Client.Socket do
 
       case find_by_mdm_device_id(actor_id, mdm_device_id, subject) do
         nil ->
-          case find_by_cert_fingerprint(actor_id, proof.last_attested_cert_fingerprint, subject) do
+          case find_by_cert_identity(actor_id, proof, subject) do
             nil -> nil
-            client -> {client, :cert_fingerprint}
+            client -> {client, :cert_identity}
           end
 
         client ->
@@ -444,15 +444,17 @@ defmodule PortalAPI.Client.Socket do
       |> Safe.one()
     end
 
-    # The fingerprint rather than the certificate serial: a serial is unique
+    # Issuer and serial together, never the serial alone: a serial is unique
     # only per issuing CA (RFC 5280 4.1.2.2), and an account may trust several
     # anchors, so matching on it would let a certificate from one CA resolve to
-    # a device enrolled under another. A SHA-256 of the DER cannot collide.
-    defp find_by_cert_fingerprint(actor_id, fingerprint, subject) do
+    # a device enrolled under another. The pair is what a revocation list names
+    # a certificate by, so it is also what a revoked device is found by.
+    defp find_by_cert_identity(actor_id, proof, subject) do
       from(d in Device,
         where: d.actor_id == ^actor_id,
         where: d.type == :client,
-        where: d.last_attested_cert_fingerprint == ^fingerprint
+        where: d.last_attested_cert_issuer == ^proof.last_attested_cert_issuer,
+        where: d.last_attested_cert_serial == ^proof.last_attested_cert_serial
       )
       |> Safe.scoped(subject)
       |> Safe.one()
@@ -498,10 +500,10 @@ defmodule PortalAPI.Client.Socket do
     # the one the row was written by, so an identifier appearing or disappearing
     # is a profile that changed what it emits, and the row follows.
     #
-    # A certificate reached by its fingerprint is the same certificate. Its
-    # identifiers cannot have changed, so anything but an exact match means we
-    # read the same bytes differently than we did before. That is a bug in the
-    # reading, and the connect is refused rather than letting a worse read
+    # A certificate reached by its issuer and serial is the same certificate.
+    # Its identifiers cannot have changed, so anything but an exact match means
+    # we read the same bytes differently than we did before. That is a bug in
+    # the reading, and the connect is refused rather than letting a worse read
     # rewrite the row. Fixing the reading is what repairs those rows.
     defp contradicted_attested_ids(client, cert_identifiers, matched_on) do
       Enum.filter(@attested_id_fields, fn field ->
@@ -512,7 +514,7 @@ defmodule PortalAPI.Client.Socket do
       end)
     end
 
-    defp contradicts?(row_value, cert_value, :cert_fingerprint), do: row_value != cert_value
+    defp contradicts?(row_value, cert_value, :cert_identity), do: row_value != cert_value
     defp contradicts?(nil, _cert_value, :mdm_device_id), do: false
     defp contradicts?(_row_value, nil, :mdm_device_id), do: false
     defp contradicts?(row_value, cert_value, :mdm_device_id), do: row_value != cert_value

--- a/elixir/lib/portal_api/sockets/latest_session.ex
+++ b/elixir/lib/portal_api/sockets/latest_session.ex
@@ -170,12 +170,17 @@ defmodule PortalAPI.Sockets.LatestSession do
 
     @attested_identifier_fields ~w[last_attested_device_serial last_attested_device_uuid last_attested_mdm_device_id]a
 
-    # The MDM device id and the pinned certificate fingerprint are the
-    # identifiers a flush can collide on, since they are the ones carrying
-    # unique indexes. A hardware serial or UUID shared across rows is normal: a
-    # device whose MDM record changed enrolls as a new row and keeps the
-    # hardware it reports.
-    @attested_unique_fields ~w[last_attested_mdm_device_id last_attested_cert_fingerprint]a
+    # The MDM device id and the pinned certificate are the identities a flush
+    # can collide on, since they are the ones carrying unique indexes. The
+    # certificate takes both of its columns: issuer and serial identify a
+    # certificate only together. A hardware serial or UUID shared across rows is
+    # normal: a device whose MDM record changed enrolls as a new row and keeps
+    # the hardware it reports.
+    @attested_unique_keys [
+      [:last_attested_mdm_device_id],
+      [:last_attested_cert_issuer, :last_attested_cert_serial]
+    ]
+    @attested_unique_fields Enum.concat(@attested_unique_keys)
     @attested_fields @attested_identifier_fields ++
                        ~w[last_attested_cert_serial last_attested_cert_fingerprint
                           last_attested_cert_issuer last_attested_at]a
@@ -184,7 +189,8 @@ defmodule PortalAPI.Sockets.LatestSession do
       actor_id: Ecto.UUID,
       device_id: Ecto.UUID,
       last_attested_mdm_device_id: :string,
-      last_attested_cert_fingerprint: :string
+      last_attested_cert_issuer: :binary,
+      last_attested_cert_serial: :string
     }
 
     @token_schemas %{
@@ -446,14 +452,16 @@ defmodule PortalAPI.Sockets.LatestSession do
     # attested update entirely, since the snapshot is all-or-nothing.
     defp dedupe_proposed_attested_identities(rows) do
       losers =
-        for field <- @attested_unique_fields,
+        for fields <- @attested_unique_keys,
             {_key, contenders} <-
               rows
-              |> Enum.filter(&(not is_nil(Map.fetch!(&1, field)) and not is_nil(&1.actor_id)))
-              |> Enum.group_by(&{&1.account_id, &1.actor_id, Map.fetch!(&1, field)}),
+              |> Enum.filter(&claims_attested_identity?(&1, fields))
+              |> Enum.group_by(fn row ->
+                {row.account_id, row.actor_id, Enum.map(fields, &Map.fetch!(row, &1))}
+              end),
             loser <- contenders |> sort_freshest_proof_first() |> tl(),
             uniq: true do
-          %{device_id: loser.device_id, field: field}
+          %{device_id: loser.device_id, fields: fields}
         end
 
       loser_ids = MapSet.new(losers, & &1.device_id)
@@ -462,7 +470,7 @@ defmodule PortalAPI.Sockets.LatestSession do
         Logger.warning(
           "Skipping attested identity during flush: another device in the same batch claims this identifier",
           device_id: loser.device_id,
-          field: loser.field
+          fields: inspect(loser.fields)
         )
       end
 
@@ -489,8 +497,7 @@ defmodule PortalAPI.Sockets.LatestSession do
     defp strip_conflicting_attested_identities(rows) do
       probe_rows =
         for row <- rows,
-            not is_nil(row.actor_id),
-            Enum.any?(@attested_unique_fields, &(not is_nil(Map.fetch!(row, &1)))) do
+            Enum.any?(@attested_unique_keys, &claims_attested_identity?(row, &1)) do
           Map.take(row, [:account_id, :actor_id, :device_id | @attested_unique_fields])
         end
 
@@ -504,7 +511,8 @@ defmodule PortalAPI.Sockets.LatestSession do
             where:
               d.type == :client and
                 (d.last_attested_mdm_device_id == v.last_attested_mdm_device_id or
-                   d.last_attested_cert_fingerprint == v.last_attested_cert_fingerprint),
+                   (d.last_attested_cert_issuer == v.last_attested_cert_issuer and
+                      d.last_attested_cert_serial == v.last_attested_cert_serial)),
             select: %{device_id: v.device_id, conflicting_id: d.id}
           )
           |> probe()
@@ -519,6 +527,12 @@ defmodule PortalAPI.Sockets.LatestSession do
       end
 
       strip_attested_fields(rows, MapSet.new(conflicts, & &1.device_id))
+    end
+
+    # A key with any column missing claims nothing: the partial unique index
+    # skips those rows, so they cannot collide.
+    defp claims_attested_identity?(row, fields) do
+      not is_nil(row.actor_id) and Enum.all?(fields, &(not is_nil(Map.fetch!(row, &1))))
     end
 
     defp strip_attested_fields(rows, device_ids) do

--- a/elixir/priv/repo/migrations/20260811000000_collapse_redundant_device_indexes.exs
+++ b/elixir/priv/repo/migrations/20260811000000_collapse_redundant_device_indexes.exs
@@ -1,0 +1,268 @@
+defmodule Portal.Repo.Migrations.CollapseRedundantDeviceIndexes do
+  @moduledoc """
+  Folds five `devices` indexes into two.
+
+  Four of the fourteen indexes on `devices` only existed because a wider index
+  that already covered their columns was predicated on something the query
+  could not be proven to satisfy:
+
+    * `(account_id, actor_id)` and `(account_id, site_id)` duplicate the leading
+      columns of the two firezone_id unique indexes. They survived because those
+      indexes were predicated on `type`, while the `ON DELETE CASCADE` from
+      `actors` and `sites` emits `WHERE $1 = account_id AND $2 = actor_id` with
+      no `type` qual, which Postgres cannot match against a `type` predicate.
+      The check constraints make `actor_id IS NOT NULL` equivalent to
+      `type = 'client'` (and site to gateway), so repredicating on the column
+      covers the same rows and admits the cascade, since `actor_id = $2` proves
+      `actor_id IS NOT NULL`.
+
+    * `(account_id, id, type)` exists only as the target of the
+      `static_device_pool_members` foreign key, and `(account_id, type)` only to
+      list an account's devices of one type. A foreign key matches a unique
+      index by column set rather than column order, so reordering to
+      `(account_id, type, id)` keeps the key valid and leaves `(account_id,
+      type)` as a usable prefix. Point lookups keep using the primary key.
+
+    * `(account_id, actor_id, last_attested_cert_fingerprint)` is replaced by
+      `(account_id, last_attested_cert_issuer, last_attested_cert_serial,
+      actor_id)`. Issuer and serial together identify a certificate (RFC 5280
+      4.1.2.2), so the per-actor uniqueness is unchanged, and the leading
+      `(account_id, issuer, serial)` is the shape a revocation list is matched
+      by. Its name also fits in 63 characters, where the fingerprint index name
+      was truncated and so never matched the `unique_constraint/3` naming it.
+
+  Every build and drop is concurrent, so writes to `devices` (client connects)
+  are never blocked. The foreign key is rebuilt `NOT VALID` and validated
+  separately to keep its lock on `devices` catalog-only; for the seconds between
+  the drop and the re-add, a pool member could reference a gateway.
+  """
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  def up do
+    create_if_not_exists(
+      unique_index(:devices, [:account_id, :actor_id, :firezone_id],
+        where: "actor_id IS NOT NULL",
+        name: :devices_account_id_actor_id_firezone_id_tmp_index,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:devices, [:account_id, :actor_id, :firezone_id],
+        name: :devices_account_id_actor_id_firezone_id_index,
+        concurrently: true
+      )
+    )
+
+    execute("""
+    ALTER INDEX devices_account_id_actor_id_firezone_id_tmp_index
+    RENAME TO devices_account_id_actor_id_firezone_id_index
+    """)
+
+    drop_if_exists(
+      index(:devices, [:account_id, :actor_id],
+        name: :devices_account_id_actor_id_index,
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      unique_index(:devices, [:account_id, :site_id, :firezone_id],
+        where: "site_id IS NOT NULL",
+        name: :devices_account_id_site_id_firezone_id_tmp_index,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:devices, [:account_id, :site_id, :firezone_id],
+        name: :devices_account_id_site_id_firezone_id_index,
+        concurrently: true
+      )
+    )
+
+    execute("""
+    ALTER INDEX devices_account_id_site_id_firezone_id_tmp_index
+    RENAME TO devices_account_id_site_id_firezone_id_index
+    """)
+
+    drop_if_exists(
+      index(:devices, [:account_id, :site_id],
+        name: :devices_account_id_site_id_index,
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      unique_index(:devices, [:account_id, :type, :id],
+        name: :devices_account_id_type_id_index,
+        concurrently: true
+      )
+    )
+
+    execute("""
+    ALTER TABLE static_device_pool_members
+    DROP CONSTRAINT IF EXISTS static_device_pool_members_device_id_device_type_fkey
+    """)
+
+    drop_if_exists(
+      index(:devices, [:account_id, :id, :type],
+        name: :devices_account_id_id_type_index,
+        concurrently: true
+      )
+    )
+
+    execute("""
+    ALTER TABLE static_device_pool_members
+    ADD CONSTRAINT static_device_pool_members_device_id_device_type_fkey
+    FOREIGN KEY (account_id, device_id, device_type)
+    REFERENCES devices(account_id, id, type)
+    ON DELETE CASCADE
+    NOT VALID
+    """)
+
+    execute("""
+    ALTER TABLE static_device_pool_members
+    VALIDATE CONSTRAINT static_device_pool_members_device_id_device_type_fkey
+    """)
+
+    drop_if_exists(
+      index(:devices, [:account_id, :type],
+        name: :devices_account_id_type_index,
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      unique_index(
+        :devices,
+        [:account_id, :last_attested_cert_issuer, :last_attested_cert_serial, :actor_id],
+        where: "last_attested_cert_issuer IS NOT NULL AND last_attested_cert_serial IS NOT NULL",
+        name: :devices_account_id_cert_issuer_serial_actor_id_index,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:devices, [:account_id, :actor_id, :last_attested_cert_fingerprint],
+        name: :devices_account_id_actor_id_last_attested_cert_fingerprint_inde,
+        concurrently: true
+      )
+    )
+  end
+
+  def down do
+    create_if_not_exists(
+      unique_index(:devices, [:account_id, :actor_id, :last_attested_cert_fingerprint],
+        where: "last_attested_cert_fingerprint IS NOT NULL",
+        name: :devices_account_id_actor_id_last_attested_cert_fingerprint_inde,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:devices, [:account_id, :last_attested_cert_issuer, :last_attested_cert_serial],
+        name: :devices_account_id_cert_issuer_serial_actor_id_index,
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:devices, [:account_id, :type],
+        name: :devices_account_id_type_index,
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      unique_index(:devices, [:account_id, :id, :type],
+        name: :devices_account_id_id_type_index,
+        concurrently: true
+      )
+    )
+
+    execute("""
+    ALTER TABLE static_device_pool_members
+    DROP CONSTRAINT IF EXISTS static_device_pool_members_device_id_device_type_fkey
+    """)
+
+    drop_if_exists(
+      index(:devices, [:account_id, :type, :id],
+        name: :devices_account_id_type_id_index,
+        concurrently: true
+      )
+    )
+
+    execute("""
+    ALTER TABLE static_device_pool_members
+    ADD CONSTRAINT static_device_pool_members_device_id_device_type_fkey
+    FOREIGN KEY (account_id, device_id, device_type)
+    REFERENCES devices(account_id, id, type)
+    ON DELETE CASCADE
+    NOT VALID
+    """)
+
+    execute("""
+    ALTER TABLE static_device_pool_members
+    VALIDATE CONSTRAINT static_device_pool_members_device_id_device_type_fkey
+    """)
+
+    create_if_not_exists(
+      index(:devices, [:account_id, :site_id],
+        where: "site_id IS NOT NULL",
+        name: :devices_account_id_site_id_index,
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      unique_index(:devices, [:account_id, :site_id, :firezone_id],
+        where: "type = 'gateway'",
+        name: :devices_account_id_site_id_firezone_id_tmp_index,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:devices, [:account_id, :site_id, :firezone_id],
+        name: :devices_account_id_site_id_firezone_id_index,
+        concurrently: true
+      )
+    )
+
+    execute("""
+    ALTER INDEX devices_account_id_site_id_firezone_id_tmp_index
+    RENAME TO devices_account_id_site_id_firezone_id_index
+    """)
+
+    create_if_not_exists(
+      index(:devices, [:account_id, :actor_id],
+        where: "actor_id IS NOT NULL",
+        name: :devices_account_id_actor_id_index,
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      unique_index(:devices, [:account_id, :actor_id, :firezone_id],
+        where: "type = 'client'",
+        name: :devices_account_id_actor_id_firezone_id_tmp_index,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:devices, [:account_id, :actor_id, :firezone_id],
+        name: :devices_account_id_actor_id_firezone_id_index,
+        concurrently: true
+      )
+    )
+
+    execute("""
+    ALTER INDEX devices_account_id_actor_id_firezone_id_tmp_index
+    RENAME TO devices_account_id_actor_id_firezone_id_index
+    """)
+  end
+end

--- a/elixir/test/portal/queue/callbacks_test.exs
+++ b/elixir/test/portal/queue/callbacks_test.exs
@@ -373,6 +373,66 @@ defmodule Portal.Queue.CallbacksTest do
       assert_receive {:confirm_session_durability, ^ref_b}
     end
 
+    test "a same-batch certificate collision needs both the issuer and the serial" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      client_a = client_fixture(account: account, actor: actor)
+      client_b = client_fixture(account: account, actor: actor)
+      client_c = client_fixture(account: account, actor: actor)
+
+      :ok = PG.register(client_a.id)
+      :ok = PG.register(client_b.id)
+      :ok = PG.register(client_c.id)
+
+      older = DateTime.add(DateTime.utc_now(), -60, :second)
+      newer = DateTime.utc_now()
+
+      entry = fn client, serial, fingerprint, attested_at ->
+        token = client_token_fixture(account: account, actor: actor)
+
+        {%{
+           session_ref: make_ref(),
+           account_id: account.id,
+           device_id: client.id,
+           actor_id: actor.id,
+           last_attested_cert_issuer: <<"issuer-der">>,
+           last_attested_cert_serial: serial,
+           last_attested_cert_fingerprint: fingerprint,
+           last_attested_at: attested_at,
+           client_token_id: token.id,
+           public_key: generate_public_key(),
+           user_agent: "test-client/1.0",
+           remote_ip: {100, 64, 0, 1},
+           version: "1.3.0",
+           inserted_at: attested_at
+         }, %{subject: %{"actor_id" => actor.id}, timestamp: attested_at}}
+      end
+
+      on_flush = Keyword.fetch!(PortalAPI.Client.Socket.client_session_queue_opts(), :on_flush)
+
+      # A and B name the same certificate under one issuer, so only the
+      # freshest keeps its snapshot. C shares the issuer but not the serial,
+      # which names a different certificate and collides with neither.
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert 3 =
+                   on_flush.([
+                     entry.(client_a, "S1", "fp-a", older),
+                     entry.(client_b, "S1", "fp-b", newer),
+                     entry.(client_c, "S2", "fp-c", newer)
+                   ])
+        end)
+
+      assert log =~ "another device in the same batch claims this identifier"
+
+      assert is_nil(Repo.get_by!(Device, id: client_a.id, account_id: account.id).last_attested_at)
+      assert Repo.get_by!(Device, id: client_b.id, account_id: account.id).last_attested_cert_serial ==
+               "S1"
+
+      assert Repo.get_by!(Device, id: client_c.id, account_id: account.id).last_attested_cert_serial ==
+               "S2"
+    end
+
     test "skips an attested identity another device row already holds" do
       account = account_fixture()
       actor = actor_fixture(account: account)

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -849,6 +849,8 @@ defmodule PortalAPI.Client.SocketTest do
           actor: actor,
           last_attested_device_serial: "SN-MOSYLE",
           last_attested_cert_fingerprint: "fp-mosyle",
+          last_attested_cert_serial: "4A2F008C",
+          last_attested_cert_issuer: <<"issuer-der">>,
           firezone_id: nil
         )
 
@@ -878,6 +880,8 @@ defmodule PortalAPI.Client.SocketTest do
           actor: actor,
           last_attested_device_serial: "SN-RENEW",
           last_attested_cert_fingerprint: "fp-old",
+          last_attested_cert_serial: "OLDSERIAL",
+          last_attested_cert_issuer: <<"issuer-der">>,
           firezone_id: nil
         )
 
@@ -914,6 +918,8 @@ defmodule PortalAPI.Client.SocketTest do
           account: account,
           actor: actor,
           last_attested_cert_fingerprint: "fp-shared",
+          last_attested_cert_serial: "AA",
+          last_attested_cert_issuer: <<"issuer-der">>,
           firezone_id: nil
         )
 
@@ -1005,6 +1011,8 @@ defmodule PortalAPI.Client.SocketTest do
         actor: actor,
         last_attested_mdm_device_id: "mdm-was",
         last_attested_cert_fingerprint: "fp-shared",
+        last_attested_cert_serial: "AA",
+        last_attested_cert_issuer: <<"issuer-der">>,
         firezone_id: nil
       )
 
@@ -1037,6 +1045,8 @@ defmodule PortalAPI.Client.SocketTest do
         actor: actor,
         last_attested_mdm_device_id: "mdm-known",
         last_attested_cert_fingerprint: "fp-lossy",
+        last_attested_cert_serial: "CC",
+        last_attested_cert_issuer: <<"issuer-der">>,
         firezone_id: nil
       )
 
@@ -1069,6 +1079,8 @@ defmodule PortalAPI.Client.SocketTest do
         account: account,
         actor: actor,
         last_attested_cert_fingerprint: "fp-repair",
+        last_attested_cert_serial: "BB",
+        last_attested_cert_issuer: <<"issuer-der">>,
         firezone_id: nil
       )
 


### PR DESCRIPTION
Collapses / reorders a few of the `devices` indexes to reduce bloat.
