### PR TITLE
ci: add Windows Client integration test

### DIFF
--- a/.github/actions/setup-wsl/action.yml
+++ b/.github/actions/setup-wsl/action.yml
@@ -12,6 +12,18 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Configure WSL
+      shell: pwsh
+      # WSL2 shuts the VM down once it has been idle for a while, taking the
+      # Docker daemon and every container with it. Steps that do not talk to
+      # WSL2, such as the one running the Client, are idle time as far as WSL2
+      # is concerned. The configuration is read when the VM starts, so this has
+      # to happen before anything else uses `wsl`.
+      run: |
+        @"
+        [wsl2]
+        vmIdleTimeout=-1
+        "@ | Set-Content -Path (Join-Path $env:USERPROFILE ".wslconfig") -Encoding ascii
     - name: Update WSL
       shell: pwsh
       # The runner image ships the inbox WSL, whose kernel predates the
@@ -182,10 +194,7 @@ runs:
     - name: Start the Docker daemon
       shell: pwsh
       # An imported distribution has no init system, so the daemon is started
-      # directly. Running it as a detached session also keeps the VM alive:
-      # WSL2 terminates the VM roughly a minute after the last `wsl.exe`
-      # session exits, taking the daemon and every container with it. The
-      # runner reaps the process at the end of the job.
+      # directly. The runner reaps the process at the end of the job.
       run: Start-Process wsl -ArgumentList "-u", "root", "--", "dockerd" -WindowStyle Hidden
     - name: Wait for the Docker daemon
       shell: wsl-bash {0}
@@ -195,3 +204,10 @@ runs:
           sleep 2
         done
         docker info
+    - name: Keep the distribution running
+      shell: pwsh
+      # A distribution terminates once its last `wsl.exe` session exits, which
+      # takes the Docker daemon and every container with it. This session
+      # bridges the steps that do not talk to WSL2 themselves, such as the one
+      # running the Client.
+      run: Start-Process wsl -ArgumentList "-u", "root", "--", "sleep", "infinity" -WindowStyle Hidden

--- a/.github/actions/setup-wsl/action.yml
+++ b/.github/actions/setup-wsl/action.yml
@@ -1,0 +1,197 @@
+name: "Setup WSL2"
+description: "Installs a WSL2 distribution with a Docker daemon inside and reports the VM's network address"
+
+outputs:
+  ip:
+    description: "The eth0 address of the WSL2 VM, reachable from the Windows host"
+    value: ${{ steps.ip.outputs.ip }}
+  host-ip:
+    description: "The Windows host's address on the WSL2 NAT network, i.e. the VM's default gateway"
+    value: ${{ steps.ip.outputs.host-ip }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Update WSL
+      shell: pwsh
+      # The runner image ships the inbox WSL, whose kernel predates the
+      # nftables support the Gateway's firewall rules need. `--update`
+      # replaces it with the current release. It reaches out to Microsoft's
+      # servers, so it gets a couple of attempts.
+      run: |
+        foreach ($attempt in 1..3) {
+          wsl --update
+          if ($LASTEXITCODE -eq 0) {
+            break
+          }
+
+          Start-Sleep -Seconds 5
+        }
+
+        # Doubles as the assertion that the update took: the inbox WSL does
+        # not know `--version`.
+        wsl --version
+    - name: Install Ubuntu 24.04
+      shell: pwsh
+      # The runner image ships the inbox WSL, which has no `wsl --install`, so
+      # the distribution is imported from Canonical's rootfs image instead.
+      # The download is pinned to a dated release and verified against the
+      # digest Canonical publishes next to it.
+      env:
+        ROOTFS_URL: https://cloud-images.ubuntu.com/wsl/releases/24.04/20240423/ubuntu-noble-wsl-amd64-24.04lts.rootfs.tar.gz
+        ROOTFS_SHA256: 2a790896740b14d637dbdc583cce1ba081ac53b9e9cdb46dc09a2f73abbd9934
+      run: |
+        $rootfs = Join-Path $env:RUNNER_TEMP "ubuntu-24.04.rootfs.tar.gz"
+        curl.exe --fail --location --show-error --silent --output $rootfs $env:ROOTFS_URL
+
+        $digest = (Get-FileHash -Algorithm SHA256 $rootfs).Hash.ToLower()
+        if ($digest -ne $env:ROOTFS_SHA256) {
+          throw "Rootfs digest is $digest, expected $env:ROOTFS_SHA256"
+        }
+
+        # `--import` writes into an existing directory rather than creating
+        # the path itself.
+        $target = Join-Path $env:RUNNER_TEMP "wsl\Ubuntu-24.04"
+        New-Item -ItemType Directory -Force -Path $target | Out-Null
+        wsl --import Ubuntu-24.04 $target $rootfs --version 2
+        wsl --set-default Ubuntu-24.04
+
+        # An imported distribution defaults to root, which is the user every
+        # step below runs as. This also asserts the import worked.
+        wsl -u root -- true
+    - name: Register the `wsl-bash` shell
+      shell: pwsh
+      # Puts `wsl-bash.cmd` on PATH so that steps can select it with
+      # `shell: wsl-bash {0}`; the runner resolves the shell against PATH.
+      run: Add-Content -Path $env:GITHUB_PATH -Value $env:GITHUB_ACTION_PATH
+    - name: Prepare the distribution
+      shell: wsl-bash {0}
+      run: |
+        set -xe
+
+        apt-get update
+        apt-get install -y curl zstd iptables nftables python3
+
+        # Docker must program its firewall rules through the legacy iptables
+        # backend from the very first daemon start: rules it writes through the
+        # nftables backend (e.g. the FORWARD drop policy) are not cleaned up by
+        # a backend switch and silently drop container traffic afterwards.
+        update-alternatives --set iptables /usr/sbin/iptables-legacy
+        update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+    - name: Determine the WSL2 address
+      id: ip
+      shell: pwsh
+      run: |
+        function Get-WslCidr {
+          $out = (wsl -u root -- ip -4 -o addr show dev eth0) -join "`n"
+          if ($out -notmatch "inet\s+(\d+\.\d+\.\d+\.\d+)/(\d+)") {
+            throw "Could not determine the WSL2 address from: $out"
+          }
+          @{ Ip = $Matches[1]; Prefix = [int]$Matches[2] }
+        }
+
+        function Get-NatGateway([string]$ip, [int]$prefix) {
+          $bytes = ([System.Net.IPAddress]::Parse($ip)).GetAddressBytes()
+          [Array]::Reverse($bytes)
+          $addr = [BitConverter]::ToUInt32($bytes, 0)
+          # 4294967295 = 0xFFFFFFFF; a hex literal would parse as Int32 -1.
+          $mask = [uint32]((4294967295 -shl (32 - $prefix)) -band 4294967295)
+          $gwBytes = [BitConverter]::GetBytes([uint32](($addr -band $mask) + 1))
+          [Array]::Reverse($gwBytes)
+          ([System.Net.IPAddress]::new($gwBytes)).ToString()
+        }
+
+        for ($attempt = 0; ; $attempt++) {
+          $cidr = Get-WslCidr
+          $ip = $cidr.Ip
+
+          # The host-side `vEthernet (WSL)` adapter is sometimes missing or
+          # loses its address on the hosted runners, leaving the host without
+          # a route into the NAT subnet:
+          # <https://github.com/microsoft/WSL/issues/8111>. Restore the NAT
+          # gateway address if only that is missing.
+          $gw = Get-NatGateway $ip $cidr.Prefix
+          $adapter = Get-NetAdapter | Where-Object { $_.Name -like "*WSL*" -and $_.Status -eq "Up" }
+          if ($adapter) {
+            $hasGw = Get-NetIPAddress -InterfaceIndex $adapter.ifIndex -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+              Where-Object IPAddress -eq $gw
+            if (-not $hasGw) {
+              Write-Host "Assigning $gw to '$($adapter.Name)'"
+              New-NetIPAddress -InterfaceIndex $adapter.ifIndex -IPAddress $gw -PrefixLength $cidr.Prefix | Out-Null
+            }
+
+            # ICMP alone does not prove TCP works, HNS may even answer the
+            # pings on the VM's behalf, so probe a listener inside the VM. It
+            # runs as a background job because WSL kills backgrounded
+            # processes as soon as their `wsl.exe` session exits.
+            $listener = Start-Job -ScriptBlock { wsl -u root -- python3 -m http.server 18081 --bind 0.0.0.0 }
+
+            $tcpOk = $false
+            foreach ($_try in 1..10) {
+              try {
+                Invoke-WebRequest "http://${ip}:18081/" -UseBasicParsing -TimeoutSec 2 | Out-Null
+                $tcpOk = $true
+                break
+              }
+              catch {
+                Start-Sleep -Seconds 1
+              }
+            }
+
+            # Tearing the probe down is best-effort: it has already served its
+            # purpose, so nothing here should be able to fail the step. That
+            # includes pkill's exit code, which would otherwise leak into it.
+            wsl -u root -- pkill -f http.server
+            $LASTEXITCODE = 0
+            Stop-Job $listener -ErrorAction SilentlyContinue
+            Remove-Job $listener -Force -ErrorAction SilentlyContinue
+            if ($tcpOk) {
+              break
+            }
+
+            Write-Host "The WSL2 VM ($ip) does not accept TCP from the host"
+          }
+          else {
+            Write-Host "No host-side WSL network adapter found"
+          }
+
+          if ($attempt -ge 5) {
+            Get-NetAdapter | Format-Table -AutoSize | Out-String | Write-Host
+            Get-NetIPAddress -AddressFamily IPv4 | Format-Table InterfaceAlias, IPAddress, PrefixLength | Out-String | Write-Host
+            Get-NetRoute -AddressFamily IPv4 | Format-Table DestinationPrefix, NextHop, InterfaceAlias, RouteMetric | Out-String | Write-Host
+            throw "No usable WSL2 network after $attempt reboots"
+          }
+
+          Write-Host "Rebooting WSL2"
+          wsl --shutdown
+          Restart-Service hns -ErrorAction SilentlyContinue
+        }
+
+        "ip=$ip" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+        "host-ip=$(Get-NatGateway $ip $cidr.Prefix)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    - name: Install Docker
+      shell: wsl-bash {0}
+      run: |
+        set -xe
+
+        nft flush ruleset
+
+        # Only installs; the daemon is started below. The installer's own
+        # attempt to enable the service is expected to warn and be ignored.
+        curl -fsSL https://get.docker.com | sh
+    - name: Start the Docker daemon
+      shell: pwsh
+      # An imported distribution has no init system, so the daemon is started
+      # directly. Running it as a detached session also keeps the VM alive:
+      # WSL2 terminates the VM roughly a minute after the last `wsl.exe`
+      # session exits, taking the daemon and every container with it. The
+      # runner reaps the process at the end of the job.
+      run: Start-Process wsl -ArgumentList "-u", "root", "--", "dockerd" -WindowStyle Hidden
+    - name: Wait for the Docker daemon
+      shell: wsl-bash {0}
+      run: |
+        for _ in $(seq 30); do
+          docker info > /dev/null 2>&1 && break
+          sleep 2
+        done
+        docker info

--- a/.github/actions/setup-wsl/wsl-bash.cmd
+++ b/.github/actions/setup-wsl/wsl-bash.cmd
@@ -1,0 +1,10 @@
+@echo off
+:: Runs a step's script inside WSL as root, so that steps can use
+:: `shell: wsl-bash {0}`. The script is handed over as an environment variable
+:: rather than as an argument, both because `WSLENV`'s `/p` flag translates the
+:: Windows path the runner passes into the WSL one, and because an argument
+:: does not survive `wsl.exe`. The runner writes the file with CRLF line
+:: endings, which bash would otherwise read as part of each command.
+set "WSL_BASH_SCRIPT=%~1"
+set "WSLENV=WSL_BASH_SCRIPT/p"
+wsl.exe -u root -- bash -c "sed -i 's/\r$//' \"$WSL_BASH_SCRIPT\"; exec bash -euo pipefail \"$WSL_BASH_SCRIPT\""

--- a/.github/workflows/_collect_images.yml
+++ b/.github/workflows/_collect_images.yml
@@ -104,6 +104,10 @@ jobs:
         # archive so the downstream test-matrix jobs load them via `docker load`
         # instead of each running `docker build` + `apk add` against the Alpine
         # CDN, which was a recurring source of flaky failures.
+        #
+        # Without the guard, an empty `build_services` would build every
+        # buildable service of the compose project.
+        if: inputs.build_services != ''
         run: retry docker compose build ${{ inputs.build_services }}
       - name: Save pulled images as a single archive
         run: |

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -161,6 +161,12 @@ jobs:
       - name: Package binary
         shell: bash
         run: cp target/${{ matrix.target }}/${{ inputs.profile }}/${{ matrix.package }}.exe "$ARTIFACT_PATH"
+      - name: Upload binary for downstream jobs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.package }}-${{ matrix.target }}-${{ inputs.profile }}
+          path: rust/target/${{ matrix.target }}/${{ inputs.profile }}/${{ matrix.package }}.exe
+          if-no-files-found: error
       - uses: ./.github/actions/setup-azure-sign-tool
         if: ${{ inputs.profile == 'release' }}
         with:

--- a/.github/workflows/_windows_integration_tests.yml
+++ b/.github/workflows/_windows_integration_tests.yml
@@ -1,0 +1,257 @@
+name: Windows Integration Tests
+run-name: Triggered from ${{ github.event_name }} by ${{ github.actor }}
+on:
+  workflow_call:
+    inputs:
+      id:
+        description: "Unique identifier for this invocation. Used to namespace the artifact holding the pre-pulled images so that concurrent invocations within the same run don't collide."
+        required: true
+        type: string
+      profile:
+        description: "The Rust profile the data plane components were built with. Selects the binary cache entry of the headless Client."
+        required: false
+        type: string
+        default: "debug"
+      portal_image:
+        required: false
+        type: string
+        default: "ghcr.io/firezone/portal"
+      portal_tag:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+      elixir_image:
+        required: false
+        type: string
+        default: "ghcr.io/firezone/elixir"
+      elixir_tag:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+      relay_image:
+        required: false
+        type: string
+        default: "ghcr.io/firezone/debug/relay"
+      relay_tag:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+      gateway_image:
+        required: false
+        type: string
+        default: "ghcr.io/firezone/debug/gateway"
+      gateway_tag:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+      http_test_server_image:
+        required: false
+        type: string
+        default: "ghcr.io/firezone/debug/http-test-server"
+      http_test_server_tag:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+
+jobs:
+  collect-images:
+    uses: ./.github/workflows/_collect_images.yml
+    permissions:
+      contents: read
+    with:
+      id: ${{ inputs.id }}
+      # Only the services used by scripts/compose/windows-client-test.yml. The
+      # `*-router` images are not needed because the Windows host and the WSL2
+      # VM already provide two separate network stacks.
+      pull_services: "postgres portal elixir relay-1 gateway download.httpbin"
+      build_services: ""
+      portal_image: ${{ inputs.portal_image }}
+      portal_tag: ${{ inputs.portal_tag }}
+      elixir_image: ${{ inputs.elixir_image }}
+      elixir_tag: ${{ inputs.elixir_tag }}
+      relay_image: ${{ inputs.relay_image }}
+      relay_tag: ${{ inputs.relay_tag }}
+      gateway_image: ${{ inputs.gateway_image }}
+      gateway_tag: ${{ inputs.gateway_tag }}
+      http_test_server_image: ${{ inputs.http_test_server_image }}
+      http_test_server_tag: ${{ inputs.http_test_server_tag }}
+
+  integration-tests:
+    name: ${{ matrix.test.script }}
+    runs-on: windows-2022
+    needs: collect-images
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: ${{ github.event_name == 'merge_group' }}
+      matrix:
+        test:
+          # Runs scripts/tests/windows-<script>.ps1.
+          - script: download
+    env:
+      # Interpolated into `run:` scripts via `${{ env.COMPOSE_ARGS }}` because
+      # `wsl.exe` does not forward Windows environment variables into the
+      # `wsl-bash` steps. The `.env` file is loaded explicitly because the
+      # project directory of this compose file is not the repository root.
+      COMPOSE_ARGS: "--env-file .env -p windows-integration-tests -f scripts/compose/windows-client-test.yml"
+      CLIENT_BINARY: rust/target/x86_64-pc-windows-msvc/${{ inputs.profile }}/firezone-headless-client.exe
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # Built and uploaded by the `data-plane` workflow, which this job
+      # depends on.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: firezone-headless-client-x86_64-pc-windows-msvc-${{ inputs.profile }}
+          path: rust/target/x86_64-pc-windows-msvc/${{ inputs.profile }}
+      - uses: ./.github/actions/setup-wsl
+        id: wsl
+      - name: Write the compose env file
+        shell: bash
+        # Compose reads these from the environment, which does not reach the
+        # project inside WSL2: `wsl.exe` does not forward Windows environment
+        # variables into the VM. They are passed as environment rather than
+        # interpolated into the script so that a value cannot end a quote and
+        # run as shell.
+        env:
+          PORTAL_IMAGE: ${{ inputs.portal_image }}
+          PORTAL_TAG: ${{ inputs.portal_tag }}
+          ELIXIR_IMAGE: ${{ inputs.elixir_image }}
+          ELIXIR_TAG: ${{ inputs.elixir_tag }}
+          RELAY_IMAGE: ${{ inputs.relay_image }}
+          RELAY_TAG: ${{ inputs.relay_tag }}
+          GATEWAY_IMAGE: ${{ inputs.gateway_image }}
+          GATEWAY_TAG: ${{ inputs.gateway_tag }}
+          HTTP_TEST_SERVER_IMAGE: ${{ inputs.http_test_server_image }}
+          HTTP_TEST_SERVER_TAG: ${{ inputs.http_test_server_tag }}
+          RELAY_PUBLIC_IP4_ADDR: ${{ steps.wsl.outputs.ip }}
+        run: |
+          for var in PORTAL_IMAGE PORTAL_TAG ELIXIR_IMAGE ELIXIR_TAG \
+            RELAY_IMAGE RELAY_TAG GATEWAY_IMAGE GATEWAY_TAG \
+            HTTP_TEST_SERVER_IMAGE HTTP_TEST_SERVER_TAG RELAY_PUBLIC_IP4_ADDR; do
+            printf '%s=%s\n' "$var" "${!var}"
+          done > .env
+      - name: Route the Client to the gateway's network
+        run: |
+          # The gateway offers its container address as ICE candidate. Without
+          # a route it is unreachable from the Windows host, leaving only
+          # paths that depend on the docker NAT keeping a conntrack entry
+          # alive, which breaks as soon as a flow idles.
+          route add 192.168.223.0 mask 255.255.255.0 ${{ steps.wsl.outputs.ip }} | Out-Null
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: images-${{ inputs.id }}
+      - name: Load images into the WSL2 Docker daemon
+        shell: wsl-bash {0}
+        run: zstd -dc --long=30 images.tar.zst | docker load
+      - name: Seed the database
+        shell: wsl-bash {0}
+        run: docker compose ${{ env.COMPOSE_ARGS }} run --rm --pull never elixir /bin/sh -c 'mix ecto.migrate && mix ecto.seed'
+      - name: Start the Linux half of the topology
+        shell: wsl-bash {0}
+        run: docker compose ${{ env.COMPOSE_ARGS }} up -d --wait --pull never portal relay gateway httpbin
+      - name: Let the gateway's network talk to the Client
+        shell: wsl-bash {0}
+        run: |
+          set -xe
+
+          # Docker only forwards traffic from outside the VM to a container
+          # for published ports; DOCKER-USER is the supported hook to widen
+          # that. Masquerading towards the Client on top of it would hide the
+          # gateway behind the VM's address again and defeat the route added
+          # on the Windows side, so skip it for that destination. Docker
+          # prepends its own masquerade rule whenever it creates a network,
+          # hence this runs once the topology is up.
+          iptables -I DOCKER-USER -d 192.168.223.0/24 -j ACCEPT
+          iptables -I DOCKER-USER -s 192.168.223.0/24 -j ACCEPT
+          iptables -t nat -I POSTROUTING -s 192.168.223.0/24 -d ${{ steps.wsl.outputs.host-ip }} -j ACCEPT
+      - name: Verify the portal is reachable from the host
+        run: |
+          # The Client can only work if the WSL2 VM accepts traffic from the
+          # host, so fail here rather than midway through the test.
+          $ip = "${{ steps.wsl.outputs.ip }}"
+          $probe = Test-NetConnection $ip -Port 8081 -WarningAction SilentlyContinue
+          if (-not $probe.TcpTestSucceeded) {
+            throw "The portal (${ip}:8081) is not reachable from the host"
+          }
+      - name: Allow the Client through the Windows firewall
+        run: |
+          $binary = (Resolve-Path $env:CLIENT_BINARY).Path
+          New-NetFirewallRule -DisplayName "firezone-headless-client" -Direction Inbound -Program $binary -Action Allow | Out-Null
+      - name: "Integration test: ${{ matrix.test.script }}"
+        env:
+          # Same seeded token and ID as client-1 in docker-compose.yml.
+          FIREZONE_TOKEN: "n.SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkN2RhN2QxY2QtMTExYy00NGE3LWI1YWMtNDAyN2I5ZDIzMGU1bQAAACtBaUl5XzZwQmstV0xlUkFQenprQ0ZYTnFJWktXQnMyRGR3XzJ2Z0lRdkZnbgYAR_ywiZQBYgABUYA.PLNlzyqMSgZlbQb1QX5EzZgYNuY9oeOddP0qDkTwtGg"
+          FIREZONE_ID: d24e46a4f96d4859bd8f7ff40100493b06b28ebfae3f8dcb0503bbe3131bfbcd
+          FIREZONE_API_URL: ws://${{ steps.wsl.outputs.ip }}:8081
+          # The test reaches the CIDR resource by IP; NRPT would intercept the
+          # runner's own DNS and can cut it off from GitHub.
+          FIREZONE_DNS_CONTROL: disabled
+          RUST_LOG: debug
+        # The Client runs for the duration of this step: the runner kills the
+        # processes a step spawned once it ends, so it cannot be started in a
+        # step of its own.
+        run: |
+          New-Item -ItemType Directory -Path windows-client-logs -Force | Out-Null
+
+          $client = Start-Process -FilePath (Resolve-Path $env:CLIENT_BINARY).Path -NoNewWindow -PassThru `
+            -RedirectStandardOutput windows-client-logs\client-stdout.log `
+            -RedirectStandardError windows-client-logs\client-stderr.log
+
+          try {
+            # Wait for the Client to route the seeded CIDR resource into the
+            # tunnel, i.e. until it has applied the configuration the portal
+            # sent it. The Linux Client's healthcheck waits for the tunnel
+            # interface, but on Windows the interface exists before its
+            # routes do. Connecting to the gateway happens on demand, i.e.
+            # when the test sends its first packet towards the resource.
+            $deadline = (Get-Date).AddSeconds(60)
+            while (-not (Get-NetRoute -DestinationPrefix "10.20.0.0/16" -ErrorAction SilentlyContinue)) {
+              if ((Get-Date) -ge $deadline) {
+                throw "Client did not route the resource into the tunnel within 60 seconds"
+              }
+              if ($client.HasExited) {
+                throw "Client exited prematurely with code $($client.ExitCode)"
+              }
+
+              Start-Sleep -Seconds 1
+            }
+
+            Start-Sleep -Seconds 3 # Let everything settle for a bit
+
+            ./scripts/tests/windows-${{ matrix.test.script }}.ps1
+          }
+          finally {
+            if (-not $client.HasExited) {
+              Stop-Process -Id $client.Id -Force
+              $client.WaitForExit()
+            }
+          }
+      - name: Ensure the Client emitted no errors
+        if: "!cancelled()"
+        run: |
+          # Nothing to assert if the job failed before the Client ever ran;
+          # erroring out here would only bury the actual failure.
+          if (-not (Test-Path windows-client-logs)) {
+            return
+          }
+
+          $logErrors = Select-String -Path windows-client-logs\*.log -Pattern " ERROR " -ErrorAction SilentlyContinue
+          if ($logErrors) {
+            $logErrors | ForEach-Object { Write-Host $_.Line }
+            throw "Client emitted ERROR logs"
+          }
+      - name: Show Client logs
+        if: "!cancelled()"
+        run: Get-Content windows-client-logs\*.log -ErrorAction SilentlyContinue
+      - uses: ./.github/actions/show-compose-logs
+        if: "!cancelled()"
+        with:
+          compose-args: ${{ env.COMPOSE_ARGS }}
+          services: relay gateway portal postgres
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: "!success()"
+        with:
+          overwrite: true
+          name: windows-client-logs-${{ matrix.test.script }}
+          path: windows-client-logs/

--- a/.github/workflows/_windows_integration_tests.yml
+++ b/.github/workflows/_windows_integration_tests.yml
@@ -194,6 +194,34 @@ jobs:
         run: |
           New-Item -ItemType Directory -Path windows-client-logs -Force | Out-Null
 
+          # TEMPORARY: samples the host's view of the WSL2 VM alongside the
+          # Client, to tell apart the VM becoming unreachable from the Client
+          # mis-routing its own traffic once the tunnel is up.
+          $probe = Start-Job -ArgumentList "${{ steps.wsl.outputs.ip }}" -ScriptBlock {
+            param($ip)
+
+            while ($true) {
+              $tcp = $false
+              try {
+                $client = [System.Net.Sockets.TcpClient]::new()
+                $tcp = $client.ConnectAsync($ip, 8081).Wait(1000)
+              }
+              catch { }
+              finally { $client.Dispose() }
+
+              $adapter = (Get-NetIPAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+                Where-Object InterfaceAlias -like "*WSL*" |
+                ForEach-Object { "$($_.InterfaceAlias)=$($_.IPAddress)/$($_.PrefixLength)" }) -join " "
+              $route = (Get-NetRoute -DestinationPrefix "$ip/32" -ErrorAction SilentlyContinue |
+                ForEach-Object { "if$($_.InterfaceIndex)->$($_.NextHop)" }) -join " "
+              $ping = Test-Connection $ip -Count 1 -Quiet -ErrorAction SilentlyContinue
+
+              "$((Get-Date).ToString('HH:mm:ss.fff')) tcp8081=$tcp icmp=$ping route=[$route] adapter=[$adapter]"
+
+              Start-Sleep -Milliseconds 500
+            }
+          }
+
           $client = Start-Process -FilePath (Resolve-Path $env:CLIENT_BINARY).Path -NoNewWindow -PassThru `
             -RedirectStandardOutput windows-client-logs\client-stdout.log `
             -RedirectStandardError windows-client-logs\client-stderr.log
@@ -226,6 +254,12 @@ jobs:
               Stop-Process -Id $client.Id -Force
               $client.WaitForExit()
             }
+
+            Write-Host "::group::Host view of the WSL2 VM"
+            Stop-Job $probe -ErrorAction SilentlyContinue
+            Receive-Job $probe -ErrorAction SilentlyContinue | ForEach-Object { Write-Host $_ }
+            Remove-Job $probe -Force -ErrorAction SilentlyContinue
+            Write-Host "::endgroup::"
           }
       - name: Ensure the Client emitted no errors
         if: "!cancelled()"

--- a/.github/workflows/_windows_integration_tests.yml
+++ b/.github/workflows/_windows_integration_tests.yml
@@ -260,6 +260,12 @@ jobs:
             Receive-Job $probe -ErrorAction SilentlyContinue | ForEach-Object { Write-Host $_ }
             Remove-Job $probe -Force -ErrorAction SilentlyContinue
             Write-Host "::endgroup::"
+
+            # TEMPORARY: tells apart the distribution having been restarted
+            # from the Docker daemon alone having been restarted.
+            Write-Host "::group::WSL2 VM state"
+            wsl -u root -- bash -c 'uptime; ps -o pid,etimes,comm -p 1; ps -o pid,etimes,args -C dockerd; docker ps -a --format "{{.Names}} {{.Status}}"; journalctl --no-pager -n 40 -u docker.service; dmesg | tail -n 20; true'
+            Write-Host "::endgroup::"
           }
       - name: Ensure the Client emitted no errors
         if: "!cancelled()"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
         data-plane,
         integration-tests,
         compatibility-tests,
+        windows-integration-tests,
         nix,
       ]
     if: always()
@@ -421,6 +422,19 @@ jobs:
       id: integration
       gateway_image: ${{ needs.data-plane.outputs.gateway_image }}
       client_image: ${{ needs.data-plane.outputs.client_image }}
+      relay_image: ${{ needs.data-plane.outputs.relay_image }}
+      http_test_server_image: ${{ needs.data-plane.outputs.http_test_server_image }}
+
+  windows-integration-tests:
+    uses: ./.github/workflows/_windows_integration_tests.yml
+    needs: [control-plane, data-plane]
+    secrets: inherit
+    permissions:
+      contents: read
+    with:
+      id: windows-integration-tests
+      profile: ${{ inputs.profile || 'debug' }}
+      gateway_image: ${{ needs.data-plane.outputs.gateway_image }}
       relay_image: ${{ needs.data-plane.outputs.relay_image }}
       http_test_server_image: ${{ needs.data-plane.outputs.http_test_server_image }}
 

--- a/scripts/compose/portal.yml
+++ b/scripts/compose/portal.yml
@@ -12,7 +12,16 @@ services:
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD:-postgres}
       POSTGRES_DB: ${DATABASE_NAME:-firezone_dev}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
+      # `pg_isready` reports ready as soon as the server accepts connections,
+      # which includes the entrypoint's temporary init server: that one only
+      # listens on the Unix socket and runs before `POSTGRES_DB` is created.
+      # Connecting to the database over TCP only succeeds once the final
+      # server serves it.
+      test:
+        [
+          "CMD-SHELL",
+          "PGPASSWORD=$${POSTGRES_PASSWORD} psql -h 127.0.0.1 -U $${POSTGRES_USER} -d $${POSTGRES_DB} -c 'SELECT 1'",
+        ]
       start_period: 20s
       interval: 30s
       retries: 5

--- a/scripts/compose/windows-client-test.yml
+++ b/scripts/compose/windows-client-test.yml
@@ -1,0 +1,160 @@
+# Compose project for the Windows Client integration test.
+#
+# The Linux half of the test topology (portal, relay, gateway and an HTTP test
+# server acting as a CIDR resource) runs inside WSL2 on a Windows CI runner
+# while the headless Client under test runs natively on the Windows host.
+#
+# The relay uses host networking so that its ICE candidates point at the WSL2
+# VM's eth0 address, which is reachable from the Windows host (UDP included;
+# WSL2's localhost forwarding only handles TCP). The Client reaches the portal
+# through the published API port and the gateway through the relay.
+#
+# The gateway keeps its own network namespace: it installs policy routing
+# rules for the whole namespace it runs in, which in a shared host namespace
+# take precedence over the routing of the VM itself and black-hole every
+# forwarded packet. Its own namespace also connects it to the resource network
+# directly, the same way the Linux integration tests wire it up.
+#
+# See .github/workflows/_windows_integration_tests.yml and
+# scripts/tests/windows-download.ps1 for the Windows half.
+
+services:
+  postgres:
+    extends:
+      file: portal.yml
+      service: postgres
+    networks:
+      - app-internal
+
+  portal:
+    extends:
+      file: portal.yml
+      service: common
+    image: ${PORTAL_IMAGE:-ghcr.io/firezone/portal}:${PORTAL_TAG:-main}
+    hostname: portal.cluster.local
+    ports:
+      - 8081:8081/tcp
+    environment:
+      WEB_EXTERNAL_URL: http://localhost:8080/
+      API_EXTERNAL_URL: http://localhost:8081/
+      PHOENIX_HTTP_WEB_PORT: "8080"
+      PHOENIX_HTTP_API_PORT: "8081"
+      PHOENIX_SECURE_COOKIES: "false"
+      ERLANG_CLUSTER_ADAPTER: "Elixir.Cluster.Strategy.Epmd"
+      ERLANG_CLUSTER_ADAPTER_CONFIG: '{"hosts":["portal@portal.cluster.local"]}'
+      RELEASE_HOSTNAME: "portal.cluster.local"
+      RELEASE_NAME: "portal"
+      LOG_LEVEL: "debug"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f localhost:8080/readyz"]
+      interval: 1s
+      retries: 30
+      timeout: 1s
+    depends_on:
+      postgres:
+        condition: "service_healthy"
+    networks:
+      - app-internal
+
+  elixir:
+    extends:
+      file: portal.yml
+      service: common
+    image: ${ELIXIR_IMAGE:-ghcr.io/firezone/elixir}:${ELIXIR_TAG:-main}
+    hostname: elixir
+    environment:
+      WEB_EXTERNAL_URL: http://localhost:8080/
+      API_EXTERNAL_URL: http://localhost:8081/
+      RELEASE_HOSTNAME: "mix.cluster.local"
+      RELEASE_NAME: "mix"
+      # Higher log level not to make seeds output too verbose
+      LOG_LEVEL: "info"
+      # Mix env should be set to prod to use secrets declared above,
+      # otherwise seeds will generate invalid tokens
+      MIX_ENV: "prod"
+    depends_on:
+      postgres:
+        condition: "service_healthy"
+    networks:
+      - app-internal
+
+  relay:
+    image: ${RELAY_IMAGE:-ghcr.io/firezone/debug/relay}:${RELAY_TAG:-main}
+    init: true
+    network_mode: host
+    environment:
+      # Same seeded token as the relay in scripts/compose/relay.yml.
+      FIREZONE_TOKEN: ".SFMyNTY.g2gDaAN3A25pbG0AAAAkZTgyZmNkYzEtMDU3YS00MDE1LWI5MGItM2IxOGYwZjI4MDUzbQAAADhDMTROR0E4N0VKUlIwM0c0UVBSMDdBOUM2Rzc4NFRTU1RIU0Y0VEk1VDBHRDhENkwwVlJHPT09PW4GAOb7sImUAWIAAVGA.e_k2YXxBOSmqVSu5RRscjZJBkZ7OAGzkpr5X2ge1MNo"
+      FIREZONE_API_URL: ws://127.0.0.1:8081
+      PUBLIC_IP4_ADDR: ${RELAY_PUBLIC_IP4_ADDR:?set to the WSL2 eth0 address}
+      # Binding the sockets to that address as well makes the relay reply from
+      # it no matter which interface a peer arrives on. A wildcard bind picks
+      # the reply address by route, so the gateway (reaching the relay across
+      # the docker bridge) would see the replies come from the bridge address
+      # instead of the address it sent to and discard them.
+      BIND_IP4_ADDR: ${RELAY_PUBLIC_IP4_ADDR}
+      # The default 0.0.0.0:8080 would clash with the gateway in the shared
+      # host network namespace.
+      HEALTH_CHECK_ADDR: 127.0.0.1:8091
+      RUST_LOG: ${RUST_LOG:-debug}
+      RUST_BACKTRACE: 1
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://127.0.0.1:8091/readyz"]
+      start_period: 10s
+      interval: 1s
+      retries: 30
+      timeout: 5s
+    depends_on:
+      portal:
+        condition: "service_healthy"
+
+  gateway:
+    image: ${GATEWAY_IMAGE:-ghcr.io/firezone/debug/gateway}:${GATEWAY_TAG:-main}
+    init: true
+    privileged: true
+    devices:
+      - "/dev/net/tun:/dev/net/tun"
+    environment:
+      # Same seeded token and ID as the gateway in docker-compose.yml.
+      FIREZONE_TOKEN: ".SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkMjI3NDU2MGItZTk3Yi00NWU0LThiMzQtNjc5Yzc2MTdlOThkbQAAADhPMDJMN1VTMkozVklOT01QUjlKNklMODhRSVFQNlVPOEFRVk82VTVJUEwwVkpDMjJKR0gwPT09PW4GAAH8sImUAWIAAVGA.tAm2O9FcyF67VAF3rZdwQpeADrYOIs3S2l2K51G26OM"
+      FIREZONE_ID: c9cc2a8a01f9d3d6b2c26719965709196ae2c79214a837e28f0a751af1e2f2ca
+      FIREZONE_API_URL: ws://portal:8081
+      RUST_LOG: ${RUST_LOG:-debug}
+      RUST_BACKTRACE: 1
+    healthcheck:
+      test: ["CMD-SHELL", "ip link | grep tun-firezone"]
+      interval: 1s
+      retries: 30
+      timeout: 1s
+    depends_on:
+      portal:
+        condition: "service_healthy"
+    networks:
+      - app-internal
+      - resources
+
+  httpbin:
+    image: ${HTTP_TEST_SERVER_IMAGE:-ghcr.io/firezone/debug/http-test-server}:${HTTP_TEST_SERVER_TAG:-main}
+    environment:
+      PORT: 80
+    networks:
+      resources:
+        # Covered by the seeded `10.20.0.0/16` CIDR resource.
+        ipv4_address: 10.20.0.100
+
+networks:
+  app-internal:
+    ipam:
+      config:
+        # Outside `172.16.0.0/12`, so it cannot collide with the WSL2 NAT
+        # subnet.
+        - subnet: 192.168.223.0/24
+  resources:
+    ipam:
+      config:
+        # WSL2 picks its NAT subnet from `172.16.0.0/12` on every boot, so the
+        # resource the Client routes into the tunnel has to live elsewhere.
+        - subnet: 10.20.0.0/24
+
+volumes:
+  postgres-data:

--- a/scripts/tests/windows-download.ps1
+++ b/scripts/tests/windows-download.ps1
@@ -1,0 +1,31 @@
+# Mirror of `download.sh` for the Windows headless Client: fetch a
+# deterministic 10 MB payload from the HTTP test server behind the seeded
+# CIDR resource (`10.20.0.0/16`) and verify its checksum.
+#
+# Expects the Linux half of the topology
+# (scripts/compose/windows-client-test.yml) to be up inside WSL2 and the
+# Client to be connected already; see
+# .github/workflows/_windows_integration_tests.yml.
+
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $false
+
+# Abort only if the transfer stalls (speed stays below 100 KiB/s for 10s)
+# rather than on a fixed deadline: a slow-but-progressing download on a busy
+# runner is fine, a hung tunnel is not. The connect timeout is more generous
+# than in `download.sh` because this first packet also sets up the connection
+# to the gateway.
+curl.exe --fail --connect-timeout 30 --speed-limit 102400 --speed-time 10 --output download.file "http://10.20.0.100/bytes?num=10000000"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Download through the tunnel failed"
+    exit 1
+}
+
+$knownChecksum = "f5e02aa71e67f41d79023a128ca35bad86cf7b6656967bfe0884b3a3c4325eaf"
+$computedChecksum = (Get-FileHash -Algorithm SHA256 download.file).Hash.ToLower()
+if ($computedChecksum -ne $knownChecksum) {
+    Write-Error "Checksum of downloaded file does not match: $computedChecksum"
+    exit 1
+}
+
+Write-Host "Download through the tunnel succeeded"


### PR DESCRIPTION
The docker-compose based integration tests only exercise the Linux IO path of connlib.

This adds a `windows-integration-tests` job that exercises the Windows IO path of the headless Client end-to-end: the Client runs natively on a Windows runner while the portal, relay, gateway and a CIDR resource run in Docker inside WSL2. The relay uses host networking so that its ICE candidates are reachable from the Windows host, and the test downloads a file from the resource through the tunnel, mirroring `download.sh`.