### PR TITLE
refactor(portal): rename Device Trust, drop flow_logs flag

### DIFF
--- a/elixir/lib/portal/features.ex
+++ b/elixir/lib/portal/features.ex
@@ -5,7 +5,7 @@ defmodule Portal.Features do
   @primary_key false
 
   schema "features" do
-    field :feature, Ecto.Enum, values: [:device_trust, :flow_logs]
+    field :feature, Ecto.Enum, values: [:device_trust]
     field :enabled, :boolean, default: false
   end
 end

--- a/elixir/lib/portal/features.ex
+++ b/elixir/lib/portal/features.ex
@@ -5,7 +5,7 @@ defmodule Portal.Features do
   @primary_key false
 
   schema "features" do
-    field :feature, Ecto.Enum, values: [:trust_anchors, :flow_logs]
+    field :feature, Ecto.Enum, values: [:device_trust, :flow_logs]
     field :enabled, :boolean, default: false
   end
 end

--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -8,7 +8,6 @@ defmodule PortalAPI.Client.Channel.Shared do
     FlowLogToken,
     PG,
     Changes.Change,
-    Features,
     PubSub,
     Presence,
     SchemaHelpers,
@@ -2325,19 +2324,15 @@ defmodule PortalAPI.Client.Channel.Shared do
     }
   end
 
-  # Whether flow logs may be uploaded for a flow this policy authorizes: the
-  # global flow_logs feature flag must be on and the policy must not have opted
-  # out. Stamped into the ingest token so devices know whether to upload and
-  # the ingest endpoint can enforce it. A policy missing from the cache fails
-  # closed to false.
+  # Whether flow logs may be uploaded for a flow this policy authorizes, which
+  # is to say whether the policy has opted out. Stamped into the ingest token
+  # so devices know whether to upload and the ingest endpoint can enforce it. A
+  # policy missing from the cache fails closed to false.
   defp flow_log_uploads_enabled?(cache, policy_id) do
-    case Map.get(cache.policies, Ecto.UUID.dump!(policy_id)) do
-      %Cache.Cacheable.Policy{flow_log_uploads_enabled: true} ->
-        Database.flow_logs_feature_enabled?()
-
-      _ ->
-        false
-    end
+    match?(
+      %Cache.Cacheable.Policy{flow_log_uploads_enabled: true},
+      Map.get(cache.policies, Ecto.UUID.dump!(policy_id))
+    )
   end
 
   # Mints the pair of per-flow ingest tokens for an authorization: one for the
@@ -2609,14 +2604,6 @@ defmodule PortalAPI.Client.Channel.Shared do
 
   defmodule Database do
     import Ecto.Query, only: [from: 2]
-
-    alias Portal.Features
-
-    def flow_logs_feature_enabled? do
-      query = from(f in Features, where: f.feature == :flow_logs and f.enabled == true)
-
-      Portal.Safe.unscoped(query) |> Portal.Safe.exists?()
-    end
 
     def all_compatible_gateways_for_client_and_resource(
           client_version,

--- a/elixir/lib/portal_api/client/device_trust.ex
+++ b/elixir/lib/portal_api/client/device_trust.ex
@@ -571,7 +571,7 @@ defmodule PortalAPI.Client.DeviceTrust do
         # The features table is global per-deployment state with no account_id.
         # credo:disable-for-next-line Credo.Check.Warning.MissingAccountIdInJoin
         join: f in Portal.Features,
-        on: f.feature == :trust_anchors and f.enabled == true,
+        on: f.feature == :device_trust and f.enabled == true,
         select: c.pem
       )
       |> Safe.scoped(subject)

--- a/elixir/lib/portal_web/components/navigation_components.ex
+++ b/elixir/lib/portal_web/components/navigation_components.ex
@@ -7,18 +7,18 @@ defmodule PortalWeb.NavigationComponents do
     import Ecto.Query, only: [from: 2]
     alias Portal.{Features, Safe}
 
-    def trust_anchors_feature_enabled? do
-      query = from(f in Features, where: f.feature == :trust_anchors and f.enabled == true)
+    def device_trust_feature_enabled? do
+      query = from(f in Features, where: f.feature == :device_trust and f.enabled == true)
       Safe.unscoped(query) |> Safe.exists?()
     end
   end
 
   @doc """
-  Returns whether the global `trust_anchors` feature flag is enabled. Callers
+  Returns whether the global `device_trust` feature flag is enabled. Callers
   should compute this once in `mount/3` and pass it to `settings_nav/1` as the
-  `trust_anchors_enabled?` assign, rather than calling this on every render.
+  `device_trust_enabled?` assign, rather than calling this on every render.
   """
-  def trust_anchors_enabled?, do: Database.trust_anchors_feature_enabled?()
+  def device_trust_enabled?, do: Database.device_trust_feature_enabled?()
 
   @doc """
   Renders the top navigation bar.
@@ -410,7 +410,7 @@ defmodule PortalWeb.NavigationComponents do
   """
   attr :account, :any, required: true
   attr :current_path, :string, required: true
-  attr :trust_anchors_enabled?, :boolean, default: false
+  attr :device_trust_enabled?, :boolean, default: false
   slot :actions
 
   def settings_nav(assigns) do
@@ -521,13 +521,13 @@ defmodule PortalWeb.NavigationComponents do
           REST API
         </.settings_tab>
         <.settings_tab
-          :if={@trust_anchors_enabled?}
+          :if={@device_trust_enabled?}
           current_path={@current_path}
-          navigate={~p"/#{@account}/settings/trust_anchors"}
-          tab_path="settings/trust_anchors"
+          navigate={~p"/#{@account}/settings/device_trust"}
+          tab_path="settings/device_trust"
           icon="ri-shield-check-fill"
         >
-          Trust Anchors
+          Device Trust
         </.settings_tab>
       </div>
     </div>

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -29,7 +29,6 @@ defmodule PortalWeb.Groups do
     socket =
       socket
       |> assign(page_title: "Groups", selected_group: nil)
-      |> assign(flow_logs_feature_enabled?: Database.flow_logs_feature_enabled?())
       |> assign_async(:groups_count, fn -> {:ok, %{groups_count: Database.count_groups(subject)}} end)
       |> assign(base_group_assigns(socket))
       |> assign_live_table("groups",
@@ -917,7 +916,6 @@ defmodule PortalWeb.Groups do
         group={@selected_group}
         query_params={@query_params}
         flash={@flash}
-        flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
         panel={@group_panel}
         form_state={@group_form}
         members_state={@group_members}
@@ -1334,12 +1332,6 @@ defmodule PortalWeb.Groups do
     def all do
       index_query()
       |> hydrate_group_query()
-    end
-
-    def flow_logs_feature_enabled? do
-      from(f in Portal.Features, where: f.feature == :flow_logs and f.enabled == true)
-      |> Safe.unscoped()
-      |> Safe.exists?()
     end
 
     defp base_group_query do

--- a/elixir/lib/portal_web/live/groups/components.ex
+++ b/elixir/lib/portal_web/live/groups/components.ex
@@ -13,7 +13,6 @@ defmodule PortalWeb.Groups.Components do
   attr :group, :any, default: nil
   attr :flash, :map, required: true
   attr :query_params, :map, default: %{}
-  attr :flow_logs_feature_enabled?, :boolean, required: true
   attr :panel, :map, required: true
   attr :form_state, :map, required: true
   attr :members_state, :map, required: true
@@ -59,7 +58,6 @@ defmodule PortalWeb.Groups.Components do
         account={@account}
         group={@group}
         flash={@flash}
-        flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
         panel={@panel}
         members_state={@members_state}
         resources_state={@resources_state}
@@ -236,7 +234,6 @@ defmodule PortalWeb.Groups.Components do
   attr :account, :any, required: true
   attr :group, :any, required: true
   attr :flash, :map, required: true
-  attr :flow_logs_feature_enabled?, :boolean, required: true
   attr :panel, :map, required: true
   attr :members_state, :map, required: true
   attr :resources_state, :map, required: true
@@ -278,7 +275,6 @@ defmodule PortalWeb.Groups.Components do
           <.group_resources_tab
             :if={@tab == :resources}
             account={@account}
-            flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
             resources_state={@resources_state}
             conditions_state={@conditions_state}
           />
@@ -495,7 +491,6 @@ defmodule PortalWeb.Groups.Components do
   end
 
   attr :account, :any, required: true
-  attr :flow_logs_feature_enabled?, :boolean, required: true
   attr :resources_state, :map, required: true
   attr :conditions_state, :map, required: true
 
@@ -509,7 +504,6 @@ defmodule PortalWeb.Groups.Components do
     <div class="flex-1 flex flex-col overflow-hidden">
       <.group_grant_resource_form
         :if={@tab_view == :grant_form}
-        flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
         resources_state={@resources_state}
         conditions_state={@conditions_state}
       />
@@ -525,7 +519,6 @@ defmodule PortalWeb.Groups.Components do
     """
   end
 
-  attr :flow_logs_feature_enabled?, :boolean, required: true
   attr :resources_state, :map, required: true
   attr :conditions_state, :map, required: true
 
@@ -759,7 +752,7 @@ defmodule PortalWeb.Groups.Components do
               />
             </div>
           </div>
-          <div :if={@flow_logs_feature_enabled?} class="border-t border-border pt-4">
+          <div class="border-t border-border pt-4">
             <.flow_log_uploads_toggle
               form={@grant_resource_form}
               internet_resource?={Enum.any?(selected_resources, &(&1.type == :internet))}

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -30,7 +30,6 @@ defmodule PortalWeb.Policies do
       socket
       |> assign(stale: false)
       |> assign(page_title: "Policies")
-      |> assign(flow_logs_feature_enabled?: Database.flow_logs_feature_enabled?())
       |> assign_async(:policies_count, fn -> {:ok, %{policies_count: Database.count_policies(subject)}} end)
       |> assign(selected_policy: nil, policy_providers: [])
       |> assign(
@@ -348,7 +347,6 @@ defmodule PortalWeb.Policies do
         policy={@selected_policy}
         providers={@policy_providers}
         subject={@subject}
-        flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
         panel={policy_panel_state(assigns)}
         conditions_state={policy_conditions_state(assigns)}
         confirm_state={policy_confirm_state(assigns)}
@@ -1102,12 +1100,6 @@ defmodule PortalWeb.Policies do
     alias Portal.Actor
     alias Portal.Device
     alias Portal.Authentication
-
-    def flow_logs_feature_enabled? do
-      from(f in Portal.Features, where: f.feature == :flow_logs and f.enabled == true)
-      |> Safe.unscoped()
-      |> Safe.exists?()
-    end
 
     def get_site(id, subject) do
       from(s in Site, as: :sites)

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -154,7 +154,6 @@ defmodule PortalWeb.Policies.Components do
   attr :policy, :any, default: nil
   attr :providers, :list, default: []
   attr :subject, :any, required: true
-  attr :flow_logs_feature_enabled?, :boolean, required: true
   attr :panel, :map, required: true
   attr :conditions_state, :map, required: true
   attr :confirm_state, :map, required: true
@@ -204,7 +203,6 @@ defmodule PortalWeb.Policies.Components do
         account={@account}
         subject={@subject}
         providers={@providers}
-        flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
         panel_form={@panel.panel_form}
         panel_selected_resource={@panel.panel_selected_resource}
         panel_active_conditions={@conditions_state.panel_active_conditions}
@@ -218,7 +216,6 @@ defmodule PortalWeb.Policies.Components do
         account={@account}
         subject={@subject}
         providers={@providers}
-        flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
         panel_form={@panel.panel_form}
         panel_selected_resource={@panel.panel_selected_resource}
         panel_active_conditions={@conditions_state.panel_active_conditions}
@@ -232,7 +229,6 @@ defmodule PortalWeb.Policies.Components do
         account={@account}
         policy={@policy}
         providers={@providers}
-        flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
         tab={@panel.panel_tab}
         confirm_disable_policy={@confirm_state.confirm_disable_policy}
         confirm_delete_policy={@confirm_state.confirm_delete_policy}
@@ -248,7 +244,6 @@ defmodule PortalWeb.Policies.Components do
   attr :account, :any, required: true
   attr :subject, :any, required: true
   attr :providers, :list, default: []
-  attr :flow_logs_feature_enabled?, :boolean, required: true
   attr :panel_form, :any, default: nil
   attr :panel_selected_resource, :any, default: nil
   attr :panel_active_conditions, :list, default: []
@@ -272,7 +267,6 @@ defmodule PortalWeb.Policies.Components do
           mode={@mode}
           subject={@subject}
           providers={@providers}
-          flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
           panel_form={@panel_form}
           panel_selected_resource={@panel_selected_resource}
           panel_active_conditions={@panel_active_conditions}
@@ -304,7 +298,6 @@ defmodule PortalWeb.Policies.Components do
   attr :account, :any, required: true
   attr :subject, :any, required: true
   attr :providers, :list, default: []
-  attr :flow_logs_feature_enabled?, :boolean, required: true
   attr :panel_form, :any, default: nil
   attr :panel_selected_resource, :any, default: nil
   attr :panel_active_conditions, :list, default: []
@@ -320,7 +313,6 @@ defmodule PortalWeb.Policies.Components do
         panel_form={@panel_form}
         panel_selected_resource={@panel_selected_resource}
         subject={@subject}
-        flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
       />
       <.policy_conditions_section
         account={@account}
@@ -355,7 +347,6 @@ defmodule PortalWeb.Policies.Components do
   attr :panel_form, :any, default: nil
   attr :panel_selected_resource, :any, default: nil
   attr :subject, :any, required: true
-  attr :flow_logs_feature_enabled?, :boolean, required: true
 
   def policy_fields(assigns) do
     ~H"""
@@ -366,7 +357,6 @@ defmodule PortalWeb.Policies.Components do
       <.policy_flow_log_uploads_field
         panel_form={@panel_form}
         panel_selected_resource={@panel_selected_resource}
-        flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
       />
     </fieldset>
     """
@@ -491,11 +481,10 @@ defmodule PortalWeb.Policies.Components do
 
   attr :panel_form, :any, default: nil
   attr :panel_selected_resource, :any, default: nil
-  attr :flow_logs_feature_enabled?, :boolean, required: true
 
   def policy_flow_log_uploads_field(assigns) do
     ~H"""
-    <div :if={@flow_logs_feature_enabled?}>
+    <div>
       <.flow_log_uploads_toggle
         form={@panel_form}
         internet_resource?={internet_resource?(@panel_selected_resource)}
@@ -519,7 +508,7 @@ defmodule PortalWeb.Policies.Components do
   @doc """
   The flow-log reporting toggle shared by every form that creates or edits a
   policy. Callers initialize the form with the appropriate resource-specific
-  default and gate the component behind the `flow_logs` feature flag.
+  default.
   """
   attr :form, :any, required: true
   attr :internet_resource?, :boolean, default: false
@@ -745,7 +734,6 @@ defmodule PortalWeb.Policies.Components do
   attr :account, :any, required: true
   attr :policy, :any, required: true
   attr :providers, :list, default: []
-  attr :flow_logs_feature_enabled?, :boolean, required: true
   attr :tab, :atom, default: :overview
   attr :confirm_disable_policy, :boolean, default: false
   attr :confirm_delete_policy, :boolean, default: false
@@ -762,7 +750,6 @@ defmodule PortalWeb.Policies.Components do
         account={@account}
         policy={@policy}
         providers={@providers}
-        flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
         tab={@tab}
         confirm_disable_policy={@confirm_disable_policy}
         confirm_delete_policy={@confirm_delete_policy}
@@ -778,7 +765,6 @@ defmodule PortalWeb.Policies.Components do
   attr :account, :any, required: true
   attr :policy, :any, required: true
   attr :providers, :list, default: []
-  attr :flow_logs_feature_enabled?, :boolean, required: true
   attr :tab, :atom, default: :overview
   attr :confirm_disable_policy, :boolean, default: false
   attr :confirm_delete_policy, :boolean, default: false
@@ -842,7 +828,6 @@ defmodule PortalWeb.Policies.Components do
       </div>
       <.policy_sidebar
         policy={@policy}
-        flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
         confirm_disable_policy={@confirm_disable_policy}
         confirm_delete_policy={@confirm_delete_policy}
       />
@@ -1196,7 +1181,6 @@ defmodule PortalWeb.Policies.Components do
   end
 
   attr :policy, :any, required: true
-  attr :flow_logs_feature_enabled?, :boolean, required: true
   attr :confirm_disable_policy, :boolean, default: false
   attr :confirm_delete_policy, :boolean, default: false
 
@@ -1205,7 +1189,6 @@ defmodule PortalWeb.Policies.Components do
     <div class="w-1/3 shrink-0 overflow-y-auto p-4 space-y-5">
       <.policy_details_section
         policy={@policy}
-        flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
       />
       <div class="border-t border-border"></div>
       <.policy_actions_section
@@ -1219,7 +1202,6 @@ defmodule PortalWeb.Policies.Components do
   end
 
   attr :policy, :any, required: true
-  attr :flow_logs_feature_enabled?, :boolean, required: true
 
   def policy_details_section(assigns) do
     ~H"""
@@ -1240,7 +1222,7 @@ defmodule PortalWeb.Policies.Components do
             <.relative_datetime datetime={@policy.inserted_at} />
           </dd>
         </div>
-        <div :if={@flow_logs_feature_enabled?}>
+        <div>
           <dt class="text-[10px] text-subtle mb-0.5">Flow log reporting</dt>
           <dd class="text-xs text-body">
             {if @policy.flow_log_uploads_enabled, do: "Enabled", else: "Disabled"}

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -41,7 +41,6 @@ defmodule PortalWeb.Resources do
       |> assign(stale: false)
       |> assign(presence_tick: 0)
       |> assign(page_title: "Resources")
-      |> assign(flow_logs_feature_enabled?: Database.flow_logs_feature_enabled?())
       |> assign_async(:resources_count, fn -> {:ok, %{resources_count: Database.count_resources(subject)}} end)
       |> assign(
         selected_resource: nil,
@@ -594,7 +593,6 @@ defmodule PortalWeb.Resources do
           <.resource_details_panel
             account={@account}
             resource={@selected_resource}
-            flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
             pool_member_ids={@selected_resource_pool_member_ids}
             pool_clients={@selected_resource_pool_clients}
             clients_expanded_id={@clients_expanded_id}
@@ -1407,12 +1405,6 @@ defmodule PortalWeb.Resources do
 
     defdelegate get_client(client_id, subject), to: Components.Database
     defdelegate search_clients(search_term, subject, selected_clients), to: Components.Database
-
-    def flow_logs_feature_enabled? do
-      from(f in Portal.Features, where: f.feature == :flow_logs and f.enabled == true)
-      |> Safe.unscoped()
-      |> Safe.exists?()
-    end
 
     def all_sites(subject) do
       from(s in Site, as: :sites)

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -977,7 +977,6 @@ defmodule PortalWeb.Resources.Components do
 
   attr :account, :any, required: true
   attr :resource, :any, required: true
-  attr :flow_logs_feature_enabled?, :boolean, required: true
   attr :pool_member_ids, :list, default: []
   attr :pool_clients, :list, default: []
   attr :clients_expanded_id, :string, default: nil
@@ -1061,7 +1060,6 @@ defmodule PortalWeb.Resources.Components do
             :if={@tab == :groups && @panel_view == :grant_form}
             account={@account}
             resource={@resource}
-            flow_logs_feature_enabled?={@flow_logs_feature_enabled?}
             grant_state={@grant_state}
           />
           <.resource_policy_authorizations_tab
@@ -1436,7 +1434,6 @@ defmodule PortalWeb.Resources.Components do
 
   attr :account, :any, required: true
   attr :resource, :any, required: true
-  attr :flow_logs_feature_enabled?, :boolean, required: true
   attr :grant_state, :map, required: true
 
   def resource_grant_form(assigns) do
@@ -1667,10 +1664,7 @@ defmodule PortalWeb.Resources.Components do
               </div>
             <% end %>
           </div>
-          <div
-            :if={@flow_logs_feature_enabled?}
-            class="border-t border-border pt-4"
-          >
+          <div class="border-t border-border pt-4">
             <.flow_log_uploads_toggle
               form={@grant_form}
               internet_resource?={@resource.type == :internet}

--- a/elixir/lib/portal_web/live/settings/account.ex
+++ b/elixir/lib/portal_web/live/settings/account.ex
@@ -25,7 +25,7 @@ defmodule PortalWeb.Settings.Account do
         users_count: Database.count_users_for_account(subject),
         active_users_count: Database.count_1m_active_users_for_account(subject),
         sites_count: Database.count_groups_for_account(subject),
-        trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?()
+        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?()
       )
 
     {:ok, socket}
@@ -37,7 +37,7 @@ defmodule PortalWeb.Settings.Account do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
+        device_trust_enabled?={@device_trust_enabled?}
       >
         <:actions>
           <.button phx-click="open_edit_account" size="xs">

--- a/elixir/lib/portal_web/live/settings/api_clients/beta.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/beta.ex
@@ -24,7 +24,7 @@ defmodule PortalWeb.Settings.ApiClients.Beta do
           socket,
           page_title: "API Clients",
           requested: Portal.Account.rest_api_access_requested?(socket.assigns.account),
-          trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?()
+          device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?()
         )
 
       {:ok, socket}
@@ -37,7 +37,7 @@ defmodule PortalWeb.Settings.ApiClients.Beta do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
+        device_trust_enabled?={@device_trust_enabled?}
       />
 
       <div class="flex-1 flex flex-col overflow-hidden">

--- a/elixir/lib/portal_web/live/settings/api_clients/index.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/index.ex
@@ -83,7 +83,7 @@ defmodule PortalWeb.Settings.ApiClients.Index do
         |> assign(selected_actor: nil)
         |> assign(form: nil, encoded_token: nil)
         |> assign(pending_confirm: nil, open_actor_actions_id: nil)
-        |> assign(trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?())
+        |> assign(device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?())
 
       {:ok, socket}
     else
@@ -145,7 +145,7 @@ defmodule PortalWeb.Settings.ApiClients.Index do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
+        device_trust_enabled?={@device_trust_enabled?}
       />
 
       <div class="flex-1 flex flex-col overflow-hidden">

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -51,7 +51,7 @@ defmodule PortalWeb.Settings.Authentication do
     socket =
       assign(socket,
         page_title: "Authentication",
-        trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?()
+        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?()
       )
 
     if connected?(socket) do
@@ -598,7 +598,7 @@ defmodule PortalWeb.Settings.Authentication do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
+        device_trust_enabled?={@device_trust_enabled?}
       />
 
       <div class="flex-1 flex flex-col overflow-hidden">

--- a/elixir/lib/portal_web/live/settings/device_trust/index.ex
+++ b/elixir/lib/portal_web/live/settings/device_trust/index.ex
@@ -1,4 +1,4 @@
-defmodule PortalWeb.Settings.TrustAnchors.Index do
+defmodule PortalWeb.Settings.DeviceTrust.Index do
   use PortalWeb, :live_view
 
   import Ecto.Changeset, only: [cast: 3, put_change: 3, add_error: 3, get_field: 3]
@@ -52,19 +52,19 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
   end
 
   def mount(_params, _session, socket) do
-    trust_anchors_enabled? = PortalWeb.NavigationComponents.trust_anchors_enabled?()
+    device_trust_enabled? = PortalWeb.NavigationComponents.device_trust_enabled?()
 
-    if trust_anchors_enabled? do
+    if device_trust_enabled? do
       trust_anchors = Database.list_trust_anchors(socket.assigns.subject)
 
       socket =
         socket
-        |> assign(page_title: "Trust Anchors")
+        |> assign(page_title: "Device Trust")
         |> assign(trust_anchors: trust_anchors)
         |> assign(selected_trust_anchor: nil)
         |> assign(form: nil, input_mode: :paste)
         |> assign(confirm_delete?: false)
-        |> assign(trust_anchors_enabled?: trust_anchors_enabled?)
+        |> assign(device_trust_enabled?: device_trust_enabled?)
         |> allow_upload(:cert_file,
           accept: ~w(.pem .crt .cer .der .txt),
           max_entries: @max_upload_entries,
@@ -130,7 +130,7 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
+        device_trust_enabled?={@device_trust_enabled?}
       />
 
       <div class="flex-1 flex flex-col overflow-hidden">
@@ -143,7 +143,7 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
           </div>
           <div class="flex items-center gap-2">
             <.link
-              patch={~p"/#{@account}/settings/trust_anchors/new"}
+              patch={~p"/#{@account}/settings/device_trust/new"}
               class="flex items-center gap-1 px-2.5 py-1 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
             >
               <.icon name="ri-add-line" class="w-3 h-3" /> Add
@@ -165,7 +165,7 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
                   </p>
                 </div>
                 <.link
-                  patch={~p"/#{@account}/settings/trust_anchors/new"}
+                  patch={~p"/#{@account}/settings/device_trust/new"}
                   class="flex items-center gap-1 px-2.5 py-1 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
                 >
                   <.icon name="ri-add-line" class="w-3 h-3" /> Add a trust anchor
@@ -360,7 +360,7 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
           </div>
           <div class="flex items-center gap-1.5 shrink-0">
             <.link
-              patch={~p"/#{@account}/settings/trust_anchors/#{@trust_anchor.id}/edit"}
+              patch={~p"/#{@account}/settings/device_trust/#{@trust_anchor.id}/edit"}
               class="flex items-center gap-1 px-2.5 py-1 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
             >
               <.icon name="ri-pencil-line" class="w-3.5 h-3.5" /> Edit
@@ -601,7 +601,7 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
   end
 
   def handle_event("close_panel", _params, socket) do
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/settings/trust_anchors")}
+    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/settings/device_trust")}
   end
 
   def handle_event(
@@ -610,7 +610,7 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
         %{assigns: %{live_action: action}} = socket
       )
       when action in [:new, :edit, :show] do
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/settings/trust_anchors")}
+    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/settings/device_trust")}
   end
 
   def handle_event("handle_keydown", _params, socket) do
@@ -619,7 +619,7 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
 
   def handle_event("select_trust_anchor", %{"id" => id}, socket) do
     {:noreply,
-     push_patch(socket, to: ~p"/#{socket.assigns.account}/settings/trust_anchors/#{id}")}
+     push_patch(socket, to: ~p"/#{socket.assigns.account}/settings/device_trust/#{id}")}
   end
 
   def handle_event("cancel_upload", %{"ref" => ref}, socket) do
@@ -650,7 +650,7 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
           socket
           |> assign(trust_anchors: Database.list_trust_anchors(socket.assigns.subject))
           |> put_flash(:success, "Trust anchor created successfully")
-          |> push_patch(to: ~p"/#{socket.assigns.account}/settings/trust_anchors")
+          |> push_patch(to: ~p"/#{socket.assigns.account}/settings/device_trust")
 
         {:noreply, socket}
 
@@ -685,7 +685,7 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
           socket
           |> assign(trust_anchors: Database.list_trust_anchors(socket.assigns.subject))
           |> put_flash(:success, "Trust anchor updated successfully")
-          |> push_patch(to: ~p"/#{socket.assigns.account}/settings/trust_anchors")
+          |> push_patch(to: ~p"/#{socket.assigns.account}/settings/device_trust")
 
         {:noreply, socket}
 
@@ -711,7 +711,7 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
           socket
           |> assign(trust_anchors: Database.list_trust_anchors(socket.assigns.subject))
           |> put_flash(:success, "Trust anchor deleted successfully")
-          |> push_patch(to: ~p"/#{socket.assigns.account}/settings/trust_anchors")
+          |> push_patch(to: ~p"/#{socket.assigns.account}/settings/device_trust")
 
         {:noreply, socket}
 
@@ -731,7 +731,7 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
       socket =
         socket
         |> assign(trust_anchors: Database.list_trust_anchors(socket.assigns.subject))
-        |> push_patch(to: ~p"/#{socket.assigns.account}/settings/trust_anchors")
+        |> push_patch(to: ~p"/#{socket.assigns.account}/settings/device_trust")
 
       {:noreply, socket}
   end

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -47,7 +47,7 @@ defmodule PortalWeb.Settings.DirectorySync do
     socket =
       assign(socket,
         page_title: "Directory Sync",
-        trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?()
+        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?()
       )
 
     if connected?(socket) do
@@ -453,7 +453,7 @@ defmodule PortalWeb.Settings.DirectorySync do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
+        device_trust_enabled?={@device_trust_enabled?}
       />
 
       <%= if Portal.Account.idp_sync_enabled?(@account) do %>

--- a/elixir/lib/portal_web/live/settings/dns.ex
+++ b/elixir/lib/portal_web/live/settings/dns.ex
@@ -10,7 +10,7 @@ defmodule PortalWeb.Settings.DNS do
       socket
       |> assign(page_title: "DNS")
       |> assign(dns_account: account)
-      |> assign(trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?())
+      |> assign(device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?())
 
     {:ok, socket}
   end
@@ -38,7 +38,7 @@ defmodule PortalWeb.Settings.DNS do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
+        device_trust_enabled?={@device_trust_enabled?}
       />
 
       <div class="flex-1 flex flex-col overflow-hidden">

--- a/elixir/lib/portal_web/live/settings/log_sinks.ex
+++ b/elixir/lib/portal_web/live/settings/log_sinks.ex
@@ -73,7 +73,7 @@ defmodule PortalWeb.Settings.LogSinks do
         page_title: "Log Sinks",
         sentinel_setup_tab: "portal",
         s3_setup_tab: "console",
-        trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?()
+        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?()
       )
 
     {:ok, init(socket, new: true)}
@@ -279,7 +279,7 @@ defmodule PortalWeb.Settings.LogSinks do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
+        device_trust_enabled?={@device_trust_enabled?}
       />
 
       <%= if Portal.Account.log_sinks_enabled?(@account) do %>

--- a/elixir/lib/portal_web/live/settings/notifications.ex
+++ b/elixir/lib/portal_web/live/settings/notifications.ex
@@ -7,7 +7,7 @@ defmodule PortalWeb.Settings.Notifications do
       assign(socket,
         page_title: "Notifications",
         form: to_form(build_changeset(socket.assigns.account)),
-        trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?()
+        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?()
       )
 
     {:ok, socket}
@@ -19,7 +19,7 @@ defmodule PortalWeb.Settings.Notifications do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
+        device_trust_enabled?={@device_trust_enabled?}
       />
 
       <div class="flex-1 overflow-y-auto p-6">

--- a/elixir/lib/portal_web/router.ex
+++ b/elixir/lib/portal_web/router.ex
@@ -312,7 +312,7 @@ defmodule PortalWeb.Router do
           live "/edit", DNS, :edit
         end
 
-        scope "/trust_anchors", TrustAnchors do
+        scope "/device_trust", DeviceTrust do
           live "/", Index
           live "/new", Index, :new
           live "/:id/edit", Index, :edit

--- a/elixir/priv/repo/migrations/20260812000000_rename_trust_anchors_feature.exs
+++ b/elixir/priv/repo/migrations/20260812000000_rename_trust_anchors_feature.exs
@@ -1,0 +1,10 @@
+defmodule Portal.Repo.Migrations.RenameTrustAnchorsFeature do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      "UPDATE features SET feature = 'device_trust' WHERE feature = 'trust_anchors'",
+      "UPDATE features SET feature = 'trust_anchors' WHERE feature = 'device_trust'"
+    )
+  end
+end

--- a/elixir/priv/repo/migrations/20260812000001_remove_flow_logs_feature.exs
+++ b/elixir/priv/repo/migrations/20260812000001_remove_flow_logs_feature.exs
@@ -1,0 +1,12 @@
+defmodule Portal.Repo.Migrations.RemoveFlowLogsFeature do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      "DELETE FROM features WHERE feature = 'flow_logs'",
+      # Restores the flag as enabled: flow logs are on for every account now,
+      # so a rollback that reinserted it disabled would turn them all off.
+      "INSERT INTO features (feature, enabled) VALUES ('flow_logs', true)"
+    )
+  end
+end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -950,10 +950,6 @@ defmodule Portal.Repo.Seeds do
       "INSERT INTO features (feature, enabled) VALUES ('device_trust', true) ON CONFLICT (feature) DO UPDATE SET enabled = true"
     )
 
-    Repo.query!(
-      "INSERT INTO features (feature, enabled) VALUES ('flow_logs', true) ON CONFLICT (feature) DO UPDATE SET enabled = true"
-    )
-
     account =
       %Account{}
       |> cast(

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -947,7 +947,7 @@ defmodule Portal.Repo.Seeds do
     :rand.seed(:exsss, {1, 2, 3})
 
     Repo.query!(
-      "INSERT INTO features (feature, enabled) VALUES ('trust_anchors', true) ON CONFLICT (feature) DO UPDATE SET enabled = true"
+      "INSERT INTO features (feature, enabled) VALUES ('device_trust', true) ON CONFLICT (feature) DO UPDATE SET enabled = true"
     )
 
     Repo.query!(

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -20,7 +20,6 @@ defmodule PortalAPI.Client.ChannelTest do
   import Portal.SiteFixtures
   import Portal.SubjectFixtures
   import Portal.TokenFixtures
-  import Portal.FeaturesFixtures
 
   defp join_channel(client, subject, opts \\ []) do
     channel = Keyword.get(opts, :channel, PortalAPI.Client.Channel)
@@ -3451,7 +3450,6 @@ defmodule PortalAPI.Client.ChannelTest do
       subject: subject,
       global_relay: global_relay
     } do
-      enable_feature(:flow_logs)
       resource = resource_fixture(account: account, site: site)
 
       policy_fixture(
@@ -3507,7 +3505,6 @@ defmodule PortalAPI.Client.ChannelTest do
       subject: subject,
       global_relay: global_relay
     } do
-      enable_feature(:flow_logs)
       resource = resource_fixture(account: account, site: site)
 
       policy_fixture(
@@ -3548,34 +3545,6 @@ defmodule PortalAPI.Client.ChannelTest do
 
       assert {:ok, initiator_claims} = Portal.FlowLogToken.verify(initiator_token)
       assert initiator_claims["uploads_enabled"] == false
-    end
-
-    test "ingest tokens carry uploads_enabled=false when the feature is disabled", %{
-      dns_resource: resource,
-      client: client,
-      gateway_token: gateway_token,
-      gateway: gateway,
-      subject: subject,
-      global_relay: global_relay
-    } do
-      # No enable_feature(:flow_logs) — the policy defaults to enabled, but the
-      # global flag is off so the claim must be false.
-      socket = join_channel(client, subject)
-      assert_push "init", _init_payload
-      :ok = Portal.Presence.Relays.connect(global_relay)
-      :ok = PG.register(gateway.id)
-      :ok = connect_gateway_presence(gateway, gateway_token.id)
-
-      push(socket, "create_flow", %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => []
-      })
-
-      assert_receive {:create_authorization, _refs, payload}
-      assert is_binary(payload.flow_logs_ingest_token)
-
-      assert {:ok, claims} = Portal.FlowLogToken.verify(payload.flow_logs_ingest_token)
-      assert claims["uploads_enabled"] == false
     end
 
     test "flow_created sends site_id to clients that support renamed site payloads", %{

--- a/elixir/test/portal_api/client/device_trust_test.exs
+++ b/elixir/test/portal_api/client/device_trust_test.exs
@@ -27,7 +27,7 @@ defmodule PortalAPI.Client.DeviceTrustTest do
       subject: subject,
       pki: pki
     } do
-      enable_feature(:trust_anchors)
+      enable_feature(:device_trust)
       trust_anchor_fixture(account: account, certs: [pki.ca_der])
 
       assert DeviceTrust.attest(connect_info(leaf(pki, :rsa)), subject) ==
@@ -51,7 +51,7 @@ defmodule PortalAPI.Client.DeviceTrustTest do
       pki: pki
     } do
       configure_attestation_host()
-      enable_feature(:trust_anchors)
+      enable_feature(:device_trust)
 
       assert DeviceTrust.attest(connect_info(leaf(pki, :rsa)), subject) ==
                {:error, :no_trust_anchors}
@@ -63,7 +63,7 @@ defmodule PortalAPI.Client.DeviceTrustTest do
       configure_attestation_host()
 
       account = account_fixture()
-      enable_feature(:trust_anchors)
+      enable_feature(:device_trust)
       pki = pki()
       trust_anchor_fixture(account: account, certs: [pki.ca_der])
       subject = subject_fixture(account: account)

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -500,7 +500,7 @@ defmodule PortalAPI.Client.SocketTest do
       Portal.Config.put_env_override(:portal, :mtls_external_url, "https://mtls.firezone.test/")
 
       account = account_fixture()
-      enable_feature(:trust_anchors)
+      enable_feature(:device_trust)
       pki = pki()
       trust_anchor_fixture(account: account, certs: [pki.ca_der])
 

--- a/elixir/test/portal_web/components/navigation_components_test.exs
+++ b/elixir/test/portal_web/components/navigation_components_test.exs
@@ -40,35 +40,35 @@ defmodule PortalWeb.NavigationComponentsTest do
     end
   end
 
-  describe "settings_nav trust anchors tab" do
-    test "hidden when trust_anchors feature is disabled", %{
+  describe "settings_nav device trust tab" do
+    test "hidden when device_trust feature is disabled", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      disable_feature(:trust_anchors)
+      disable_feature(:device_trust)
 
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/account")
 
-      refute html =~ "Trust Anchors"
+      refute html =~ "Device Trust"
     end
 
-    test "shown when trust_anchors feature is enabled", %{
+    test "shown when device_trust feature is enabled", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      enable_feature(:trust_anchors)
+      enable_feature(:device_trust)
 
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/account")
 
-      assert html =~ "Trust Anchors"
+      assert html =~ "Device Trust"
     end
   end
 end

--- a/elixir/test/portal_web/live/groups_test.exs
+++ b/elixir/test/portal_web/live/groups_test.exs
@@ -6,7 +6,6 @@ defmodule PortalWeb.GroupsTest do
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
-  import Portal.FeaturesFixtures
   import Portal.GroupFixtures
   import Portal.MembershipFixtures
   import Portal.PolicyFixtures
@@ -226,7 +225,6 @@ defmodule PortalWeb.GroupsTest do
       account: account,
       actor: actor
     } do
-      enable_feature(:flow_logs)
       group = group_fixture(account: account)
       resource = resource_fixture(account: account)
 
@@ -250,7 +248,6 @@ defmodule PortalWeb.GroupsTest do
 
     test "defaults flow log reporting off when granting access to the Internet Resource",
          %{conn: conn} do
-      enable_feature(:flow_logs)
       account = account_fixture(features: %{internet_resource: true})
       actor = admin_actor_fixture(account: account)
       group = group_fixture(account: account)

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -7,7 +7,6 @@ defmodule PortalWeb.PoliciesTest do
   import Portal.AccountFixtures
   import Portal.ActorFixtures
   import Portal.AuthProviderFixtures
-  import Portal.FeaturesFixtures
   import Portal.GroupFixtures
   import Portal.MembershipFixtures
   import Portal.PolicyAuthorizationFixtures
@@ -215,7 +214,6 @@ defmodule PortalWeb.PoliciesTest do
       account: account,
       actor: actor
     } do
-      enable_feature(:flow_logs)
       group = group_fixture(account: account)
       resource = resource_fixture(account: account)
 
@@ -249,7 +247,6 @@ defmodule PortalWeb.PoliciesTest do
       account: account,
       actor: actor
     } do
-      enable_feature(:flow_logs)
       group = group_fixture(account: account)
       resource = resource_fixture(account: account)
 
@@ -268,21 +265,7 @@ defmodule PortalWeb.PoliciesTest do
       assert policy.flow_log_uploads_enabled == true
     end
 
-    test "does not render the flow log reporting checkbox when the feature is disabled", %{
-      conn: conn,
-      account: account,
-      actor: actor
-    } do
-      {:ok, _lv, html} =
-        conn
-        |> authorize_conn(actor)
-        |> live(~p"/#{account}/policies/new")
-
-      refute html =~ "Flow log reporting"
-    end
-
     test "defaults flow log reporting off for Internet Resource policies", %{conn: conn} do
-      enable_feature(:flow_logs)
       account = account_fixture(features: %{internet_resource: true})
       actor = admin_actor_fixture(account: account)
       group = group_fixture(account: account)
@@ -320,7 +303,6 @@ defmodule PortalWeb.PoliciesTest do
 
     test "allows flow log reporting for Internet Resource policies and shows a volume warning",
          %{conn: conn} do
-      enable_feature(:flow_logs)
       account = account_fixture(features: %{internet_resource: true})
       actor = admin_actor_fixture(account: account)
       group = group_fixture(account: account)
@@ -554,7 +536,6 @@ defmodule PortalWeb.PoliciesTest do
     test "shows flow log reporting checkbox when editing an Internet Resource policy", %{
       conn: conn
     } do
-      enable_feature(:flow_logs)
       account = account_fixture(features: %{internet_resource: true})
       actor = admin_actor_fixture(account: account)
       group = group_fixture(account: account)
@@ -577,7 +558,6 @@ defmodule PortalWeb.PoliciesTest do
       account: account,
       actor: actor
     } do
-      enable_feature(:flow_logs)
       group = group_fixture(account: account)
       resource = resource_fixture(account: account)
       policy = policy_fixture(group: group, resource: resource)

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -9,7 +9,6 @@ defmodule PortalWeb.ResourcesTest do
   import Portal.ActorFixtures
   import Portal.ClientSessionFixtures
   import Portal.DeviceFixtures
-  import Portal.FeaturesFixtures
   import Portal.GroupFixtures
   import Portal.MembershipFixtures
   import Portal.PolicyAuthorizationFixtures
@@ -597,7 +596,6 @@ defmodule PortalWeb.ResourcesTest do
       account: account,
       actor: actor
     } do
-      enable_feature(:flow_logs)
       resource = resource_fixture(account: account)
       group = group_fixture(account: account)
 
@@ -620,7 +618,6 @@ defmodule PortalWeb.ResourcesTest do
     end
 
     test "defaults Internet Resource flow logs off and allows enabling them", %{conn: conn} do
-      enable_feature(:flow_logs)
       account = account_fixture(features: %{internet_resource: true})
       actor = admin_actor_fixture(account: account)
       resource = internet_resource_fixture(account: account)

--- a/elixir/test/portal_web/live/settings/device_trust/index_test.exs
+++ b/elixir/test/portal_web/live/settings/device_trust/index_test.exs
@@ -1,4 +1,4 @@
-defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
+defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
   use PortalWeb.ConnCase, async: true
 
   import Portal.AccountFixtures
@@ -17,13 +17,13 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
   setup do
     account = account_fixture()
     actor = admin_actor_fixture(account: account)
-    enable_feature(:trust_anchors)
+    enable_feature(:device_trust)
     %{account: account, actor: actor}
   end
 
   describe "unauthorized" do
     test "redirects to sign-in when not authenticated", %{conn: conn, account: account} do
-      path = ~p"/#{account}/settings/trust_anchors"
+      path = ~p"/#{account}/settings/device_trust"
 
       assert live(conn, path) ==
                {:error,
@@ -36,17 +36,17 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
   end
 
   describe "index (default action)" do
-    test "redirects to account settings when trust_anchors feature is disabled", %{
+    test "redirects to account settings when device_trust feature is disabled", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      disable_feature(:trust_anchors)
+      disable_feature(:device_trust)
 
       assert {:error, {:live_redirect, %{to: to}}} =
                conn
                |> authorize_conn(actor)
-               |> live(~p"/#{account}/settings/trust_anchors")
+               |> live(~p"/#{account}/settings/device_trust")
 
       assert to == ~p"/#{account}/settings/account"
     end
@@ -59,7 +59,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors")
+        |> live(~p"/#{account}/settings/device_trust")
 
       assert html =~ "Trust Anchors"
       assert html =~ "No trust anchors yet"
@@ -71,7 +71,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors")
+        |> live(~p"/#{account}/settings/device_trust")
 
       assert html =~ "Corporate Issuing CA"
       assert html =~ "1 certificate"
@@ -94,7 +94,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors")
+        |> live(~p"/#{account}/settings/device_trust")
 
       refute html =~ "Company Issuing CA"
 
@@ -103,13 +103,13 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
         |> element("tr[phx-click='select_trust_anchor'][phx-value-id='#{trust_anchor.id}']")
         |> render_click()
 
-      assert_patch(lv, ~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
+      assert_patch(lv, ~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
       assert html =~ "Company Issuing CA"
       assert html =~ "Company Root CA"
       assert html =~ Base.encode16(:crypto.hash(:sha256, sample_cert_der()), case: :lower)
 
       render_click(lv, "close_panel")
-      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
+      assert_patch(lv, ~p"/#{account}/settings/device_trust")
       refute render(lv) =~ "Company Issuing CA"
     end
 
@@ -128,7 +128,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
 
       html = render(lv)
 
@@ -162,10 +162,10 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
 
       render_keydown(lv, "handle_keydown", %{"key" => "Escape"})
-      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
+      assert_patch(lv, ~p"/#{account}/settings/device_trust")
     end
 
     test "Edit button navigates to the edit form", %{conn: conn, account: account, actor: actor} do
@@ -174,15 +174,15 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
 
       lv
       |> element(
-        "a[href='#{~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}/edit"}']"
+        "a[href='#{~p"/#{account}/settings/device_trust/#{trust_anchor.id}/edit"}']"
       )
       |> render_click()
 
-      assert_patch(lv, ~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}/edit")
+      assert_patch(lv, ~p"/#{account}/settings/device_trust/#{trust_anchor.id}/edit")
       assert render(lv) =~ "Edit Trust Anchor"
     end
   end
@@ -192,29 +192,29 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/new")
+        |> live(~p"/#{account}/settings/device_trust/new")
 
       assert html =~ "New Trust Anchor"
 
       render_click(lv, "close_panel")
-      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
+      assert_patch(lv, ~p"/#{account}/settings/device_trust")
     end
 
     test "closes creation panel on escape", %{conn: conn, account: account, actor: actor} do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/new")
+        |> live(~p"/#{account}/settings/device_trust/new")
 
       render_keydown(lv, "handle_keydown", %{"key" => "Escape"})
-      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
+      assert_patch(lv, ~p"/#{account}/settings/device_trust")
     end
 
     test "validates required fields", %{conn: conn, account: account, actor: actor} do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/new")
+        |> live(~p"/#{account}/settings/device_trust/new")
 
       html =
         lv
@@ -236,7 +236,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/new")
+        |> live(~p"/#{account}/settings/device_trust/new")
 
       html =
         lv
@@ -266,7 +266,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/new")
+        |> live(~p"/#{account}/settings/device_trust/new")
 
       html =
         lv
@@ -285,7 +285,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/new")
+        |> live(~p"/#{account}/settings/device_trust/new")
 
       html =
         lv
@@ -305,7 +305,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/new")
+        |> live(~p"/#{account}/settings/device_trust/new")
 
       html =
         lv
@@ -321,7 +321,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/new")
+        |> live(~p"/#{account}/settings/device_trust/new")
 
       html =
         lv
@@ -331,7 +331,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
         |> render_submit()
 
       assert html =~ "Trust anchor created successfully"
-      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
+      assert_patch(lv, ~p"/#{account}/settings/device_trust")
       assert render(lv) =~ "Pasted CA"
 
       assert trust_anchor = Repo.get_by(TrustAnchor, account_id: account.id, name: "Pasted CA")
@@ -347,7 +347,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/new")
+        |> live(~p"/#{account}/settings/device_trust/new")
 
       html =
         lv
@@ -376,7 +376,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/new")
+        |> live(~p"/#{account}/settings/device_trust/new")
 
       html =
         lv
@@ -393,7 +393,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/new")
+        |> live(~p"/#{account}/settings/device_trust/new")
 
       render_change(lv, "validate_new", %{
         "trust_anchor" => %{"name" => "Uploaded CA", "input_mode" => "upload"}
@@ -416,7 +416,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
         })
 
       assert html =~ "Trust anchor created successfully"
-      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
+      assert_patch(lv, ~p"/#{account}/settings/device_trust")
       assert render(lv) =~ "Uploaded CA"
 
       assert trust_anchor = Repo.get_by(TrustAnchor, account_id: account.id, name: "Uploaded CA")
@@ -432,7 +432,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/new")
+        |> live(~p"/#{account}/settings/device_trust/new")
 
       render_change(lv, "validate_new", %{
         "trust_anchor" => %{"name" => "Multi-file CA", "input_mode" => "upload"}
@@ -462,7 +462,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
         })
 
       assert html =~ "Trust anchor created successfully"
-      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
+      assert_patch(lv, ~p"/#{account}/settings/device_trust")
       assert render(lv) =~ "Multi-file CA"
 
       assert trust_anchor =
@@ -481,7 +481,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/new")
+        |> live(~p"/#{account}/settings/device_trust/new")
 
       render_change(lv, "validate_new", %{
         "trust_anchor" => %{"name" => "No File CA", "input_mode" => "upload"}
@@ -505,7 +505,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}/edit")
+        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}/edit")
 
       assert html =~ "Edit Trust Anchor"
       assert html =~ "Editable CA"
@@ -520,7 +520,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       assert der == sample_cert_der()
 
       render_click(lv, "close_panel")
-      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
+      assert_patch(lv, ~p"/#{account}/settings/device_trust")
     end
 
     test "updates trust anchor on submit", %{conn: conn, account: account, actor: actor} do
@@ -529,7 +529,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}/edit")
+        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}/edit")
 
       html =
         lv
@@ -539,7 +539,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
         |> render_submit()
 
       assert html =~ "Trust anchor updated successfully"
-      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
+      assert_patch(lv, ~p"/#{account}/settings/device_trust")
       assert render(lv) =~ "New Name"
 
       assert updated = Repo.get_by(TrustAnchor, account_id: account.id, id: trust_anchor.id)
@@ -558,14 +558,14 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
 
       render_click(lv, "confirm_delete_trust_anchor")
       assert render(lv) =~ "Delete this trust anchor?"
 
       render_click(lv, "delete_trust_anchor")
 
-      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
+      assert_patch(lv, ~p"/#{account}/settings/device_trust")
       refute render(lv) =~ "Deletable CA"
       refute Repo.get_by(TrustAnchor, account_id: account.id, id: trust_anchor.id)
     end
@@ -580,7 +580,7 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
 
       Repo.delete!(trust_anchor)
 


### PR DESCRIPTION
Two clean-ups to the global feature flags.

The settings page for uploading CA certificates was called "Trust Anchors". Trust anchors are only one part of what that page is for, so the section is now called "Device Trust". The tab lives at `/settings/device_trust` and the flag is `device_trust`. Inside the page nothing is renamed. The list, the panels, and the buttons still talk about trust anchors, because that is still what an admin adds there. The database tables keep their names too.

Flow logs are on for every account, so the `flow_logs` flag no longer decided anything. It is gone, along with the checks that read it. The per-policy flow log reporting toggle is unchanged and is now always shown.
