### PR TITLE
fix(portal): add authentication settings docs link

### DIFF
--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -607,12 +607,15 @@ defmodule PortalWeb.Settings.Authentication do
             <h2 class="text-xs font-semibold text-heading">Identity Providers</h2>
             <span class="text-xs text-subtle tabular-nums">{length(@providers)}</span>
           </div>
-          <.link
-            patch={~p"/#{@account}/settings/authentication/new"}
-            class="flex items-center gap-1 px-2.5 py-1 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
-          >
-            <.icon name="ri-add-line" class="w-3 h-3" /> Add
-          </.link>
+          <div class="flex items-center gap-2">
+            <.docs_action path="/authenticate" />
+            <.link
+              patch={~p"/#{@account}/settings/authentication/new"}
+              class="flex items-center gap-1 px-2.5 py-1 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
+            >
+              <.icon name="ri-add-line" class="w-3 h-3" /> Add
+            </.link>
+          </div>
         </div>
 
         <div class="flex-1 overflow-auto">

--- a/elixir/test/portal_web/live/settings/authentication_test.exs
+++ b/elixir/test/portal_web/live/settings/authentication_test.exs
@@ -129,6 +129,19 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       assert Floki.text(add_button) =~ "Add"
     end
 
+    test "renders authentication documentation link", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/authentication")
+
+      assert html =~ "https://www.firezone.dev/kb/authenticate?utm_source=product#"
+    end
+
     test "renders make default option for providers", %{
       account: account,
       actor: actor,


### PR DESCRIPTION
## Summary
- Add the authentication documentation link to the settings header
- Add a rendering test for the docs URL

## Tests
- mix test test/portal_web/live/settings/authentication_test.exs (184 passed)