### PR TITLE
fix(portal): optimize log timestamp pagination

### DIFF
--- a/elixir/lib/portal/repo/offset_list.ex
+++ b/elixir/lib/portal/repo/offset_list.ex
@@ -9,6 +9,7 @@ defmodule Portal.Repo.OffsetList do
     {order_by, opts} = Keyword.pop(opts, :order_by, [])
     {paginator_opts, opts} = Keyword.pop(opts, :page, [])
     {limit, opts} = Keyword.pop(opts, :limit)
+    {order_by_nulls, opts} = Keyword.pop(opts, :order_by_nulls, :last)
 
     paginator_opts =
       if limit do
@@ -16,6 +17,8 @@ defmodule Portal.Repo.OffsetList do
       else
         paginator_opts
       end
+
+    paginator_opts = Keyword.put(paginator_opts, :order_by_nulls, order_by_nulls)
 
     with {:ok, paginator_opts} <- OffsetPaginator.init(query_module, order_by, paginator_opts),
          {:ok, queryable} <- Filter.filter(queryable, query_module, filter) do

--- a/elixir/lib/portal/repo/offset_paginator.ex
+++ b/elixir/lib/portal/repo/offset_paginator.ex
@@ -57,6 +57,7 @@ defmodule Portal.Repo.OffsetPaginator do
      %{
        query_module: query_module,
        order_fields: order_fields,
+       order_by_nulls: Keyword.get(opts, :order_by_nulls, :last),
        limit: limit,
        offset: offset
      }}
@@ -69,9 +70,12 @@ defmodule Portal.Repo.OffsetPaginator do
     |> limit_page_size(paginator_opts)
   end
 
-  defp order_by_fields(queryable, %{order_fields: order_fields}) do
+  defp order_by_fields(queryable, %{
+         order_fields: order_fields,
+         order_by_nulls: order_by_nulls
+       }) do
     Enum.reduce(order_fields, queryable, fn
-      {binding, :desc, field}, queryable ->
+      {binding, :desc, field}, queryable when order_by_nulls == :last ->
         order_by(queryable, [{^binding, b}], [{:desc_nulls_last, field(b, ^field)}])
 
       {binding, order, field}, queryable ->

--- a/elixir/lib/portal_web/live/logs/api_request_logs.ex
+++ b/elixir/lib/portal_web/live/logs/api_request_logs.ex
@@ -460,7 +460,7 @@ defmodule PortalWeb.Logs.APIRequestLogs do
       result =
         from(arl in APIRequestLog, as: :api_request_logs)
         |> Safe.scoped(subject)
-        |> Safe.list_offset(__MODULE__, opts)
+        |> Safe.list_offset(__MODULE__, Keyword.put(opts, :order_by_nulls, :natural))
 
       case result do
         {:ok, logs, metadata} -> {:ok, enrich(logs, subject), metadata}

--- a/elixir/lib/portal_web/live/logs/change_logs.ex
+++ b/elixir/lib/portal_web/live/logs/change_logs.ex
@@ -385,7 +385,7 @@ defmodule PortalWeb.Logs.ChangeLogs do
     def list_change_logs(subject, opts \\ []) do
       from(cl in ChangeLog, as: :change_logs)
       |> Safe.scoped(subject)
-      |> Safe.list_offset(__MODULE__, opts)
+      |> Safe.list_offset(__MODULE__, Keyword.put(opts, :order_by_nulls, :natural))
     end
 
     def fetch_change_log(log_id, subject) do

--- a/elixir/lib/portal_web/live/logs/flow_logs.ex
+++ b/elixir/lib/portal_web/live/logs/flow_logs.ex
@@ -1015,7 +1015,7 @@ defmodule PortalWeb.Logs.FlowLogs do
       result =
         query
         |> Safe.scoped(subject)
-        |> Safe.list_offset(__MODULE__, opts)
+        |> Safe.list_offset(__MODULE__, Keyword.put(opts, :order_by_nulls, :natural))
 
       case result do
         {:ok, logs, metadata} -> {:ok, enrich(logs, subject), metadata}

--- a/elixir/lib/portal_web/live/logs/session_logs.ex
+++ b/elixir/lib/portal_web/live/logs/session_logs.ex
@@ -344,7 +344,7 @@ defmodule PortalWeb.Logs.SessionLogs do
     def list_session_logs(subject, opts \\ []) do
       from(sl in SessionLog, as: :session_logs)
       |> Safe.scoped(subject)
-      |> Safe.list_offset(__MODULE__, opts)
+      |> Safe.list_offset(__MODULE__, Keyword.put(opts, :order_by_nulls, :natural))
     end
 
     def fetch_log(log_id, subject) do

--- a/elixir/priv/repo/migrations/20260812000002_add_account_id_to_log_timestamp_indexes.exs
+++ b/elixir/priv/repo/migrations/20260812000002_add_account_id_to_log_timestamp_indexes.exs
@@ -1,0 +1,38 @@
+defmodule Portal.Repo.Migrations.AddAccountIdToLogTimestampIndexes do
+  @moduledoc """
+  Adds `account_id` to the global timestamp indexes used by log retention.
+
+  Keeping the timestamp first preserves global retention scans, while the
+  account id lets account-scoped log listings reject rows in the index before
+  fetching their wide heap tuples.
+  """
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  @indexes [
+    {:session_logs, :timestamp},
+    {:change_logs, :timestamp},
+    {:api_request_logs, :inserted_at}
+  ]
+
+  def up do
+    for {table, timestamp} <- @indexes do
+      create(index(table, [timestamp, :account_id], concurrently: true))
+    end
+
+    for {table, timestamp} <- @indexes do
+      drop(index(table, [timestamp], concurrently: true))
+    end
+  end
+
+  def down do
+    for {table, timestamp} <- @indexes do
+      create(index(table, [timestamp], concurrently: true))
+    end
+
+    for {table, timestamp} <- @indexes do
+      drop(index(table, [timestamp, :account_id], concurrently: true))
+    end
+  end
+end

--- a/elixir/test/portal/repo/offset_paginator_test.exs
+++ b/elixir/test/portal/repo/offset_paginator_test.exs
@@ -1,0 +1,35 @@
+defmodule Portal.Repo.OffsetPaginatorTest do
+  use ExUnit.Case, async: true
+
+  import Ecto.Query
+
+  alias Portal.Repo.OffsetPaginator
+
+  defmodule Query do
+    def cursor_fields, do: [{:accounts, :desc, :inserted_at}]
+  end
+
+  test "descending fields default to nulls last" do
+    sql = paginated_sql([])
+
+    assert sql =~ ~s(ORDER BY a0."inserted_at" DESC NULLS LAST)
+  end
+
+  test "the natural null ordering can be requested explicitly" do
+    sql = paginated_sql(order_by_nulls: :natural)
+
+    assert sql =~ ~s(ORDER BY a0."inserted_at" DESC)
+    refute sql =~ "NULLS LAST"
+  end
+
+  defp paginated_sql(init_opts) do
+    {:ok, opts} = OffsetPaginator.init(Query, [], init_opts)
+
+    query =
+      from(account in Portal.Account, as: :accounts)
+      |> OffsetPaginator.query(opts)
+
+    {sql, _params} = Ecto.Adapters.SQL.to_sql(:all, Portal.Repo, query)
+    sql
+  end
+end


### PR DESCRIPTION
## Summary

- replace the standalone Session, Change, and API Request log timestamp indexes with `(timestamp, account_id)` indexes built concurrently
- preserve timestamp-first global retention scans while rejecting other accounts before wide heap fetches
- let the four log query modules use natural null ordering so their `NOT NULL` sort fields can use forward and backward B-tree scans
- reuse Flow Logs partition primary keys for account-scoped `flow_start` ordering without adding another index

## Context

A production Session Logs request scanned 86,345 rows and touched 62,739 buffers to return 51 rows, taking 2.7 seconds on the replica and contributing to exhaustion of the four-connection Web pool. The paginator emitted `DESC NULLS LAST`, which prevented PostgreSQL from using the existing indexes backward even though the relevant fields are all `NOT NULL`.

## Validation

- migration applied, rolled back, and reapplied locally
- `mix test test/portal/repo/offset_paginator_test.exs test/portal_web/live/logs/change_logs_test.exs test/portal_web/live/logs/flow_logs_test.exs` (48 passed)