### PR TITLE
fix(portal): add readiness check to ops endpoint

### DIFF
--- a/elixir/lib/portal_ops/endpoint.ex
+++ b/elixir/lib/portal_ops/endpoint.ex
@@ -1,6 +1,9 @@
 defmodule PortalOps.Endpoint do
   use Phoenix.Endpoint, otp_app: :portal
 
+  # Health checks - early in pipeline for fast, unauthenticated responses
+  plug Portal.Health
+
   # The ops endpoint is always served over plain HTTP, so this must be false.
   # NOTE: Plug.Session does not resolve MFA tuples for the `secure` option —
   # it passes the value directly to put_resp_cookie/4, where any non-false/nil

--- a/elixir/test/portal_ops/endpoint_test.exs
+++ b/elixir/test/portal_ops/endpoint_test.exs
@@ -10,6 +10,15 @@ defmodule PortalOps.EndpointTest do
     put_req_header(conn, "authorization", "Basic #{encoded}")
   end
 
+  test "GET /readyz returns 200 without credentials" do
+    conn =
+      conn(:get, "/readyz")
+      |> PortalOps.Endpoint.call([])
+
+    assert conn.status == 200
+    assert JSON.decode!(conn.resp_body)["status"] == "ready"
+  end
+
   describe "LiveDashboard routes" do
     test "GET /dashboard returns 401 without credentials" do
       conn =


### PR DESCRIPTION
Adds the shared `Portal.Health` plug to `PortalOps.Endpoint`, matching the web and API endpoints.

This provides an unauthenticated `/readyz` endpoint for the internal Caddy blue/green proxy to health-check the ops listeners on ports 8087 and 8088. The ops dashboard remains protected by basic authentication and served over plain HTTP.

Tested with:

```
mix format --check-formatted lib/portal_ops/endpoint.ex test/portal_ops/endpoint_test.exs
mix test test/portal_ops/endpoint_test.exs
```