### PR TITLE
fix(portal): scope user-triggered sync jobs by account

### DIFF
--- a/elixir/lib/portal/datadog/scheduler.ex
+++ b/elixir/lib/portal/datadog/scheduler.ex
@@ -29,7 +29,7 @@ defmodule Portal.Datadog.Scheduler do
         |> Safe.unscoped()
         |> Safe.stream()
         |> Stream.each(fn sink ->
-          args = %{log_sink_id: sink.id}
+          args = %{account_id: sink.account_id, log_sink_id: sink.id}
           {:ok, _job} = Portal.Datadog.Sync.new(args) |> Oban.insert()
         end)
         |> Stream.run()

--- a/elixir/lib/portal/datadog/sync.ex
+++ b/elixir/lib/portal/datadog/sync.ex
@@ -18,10 +18,11 @@ defmodule Portal.Datadog.Sync do
   require Logger
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"log_sink_id" => log_sink_id}}) do
-    case Delivery.get_sink(Datadog.LogSink, log_sink_id) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id, "log_sink_id" => log_sink_id}}) do
+    case Delivery.get_sink(Datadog.LogSink, account_id, log_sink_id) do
       nil ->
         Logger.info("Datadog log sink not found, disabled, or account ineligible, skipping",
+          account_id: account_id,
           datadog_log_sink_id: log_sink_id
         )
 

--- a/elixir/lib/portal/elastic/scheduler.ex
+++ b/elixir/lib/portal/elastic/scheduler.ex
@@ -29,7 +29,7 @@ defmodule Portal.Elastic.Scheduler do
         |> Safe.unscoped()
         |> Safe.stream()
         |> Stream.each(fn sink ->
-          args = %{log_sink_id: sink.id}
+          args = %{account_id: sink.account_id, log_sink_id: sink.id}
           {:ok, _job} = Portal.Elastic.Sync.new(args) |> Oban.insert()
         end)
         |> Stream.run()

--- a/elixir/lib/portal/elastic/sync.ex
+++ b/elixir/lib/portal/elastic/sync.ex
@@ -18,10 +18,11 @@ defmodule Portal.Elastic.Sync do
   require Logger
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"log_sink_id" => log_sink_id}}) do
-    case Delivery.get_sink(Elastic.LogSink, log_sink_id) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id, "log_sink_id" => log_sink_id}}) do
+    case Delivery.get_sink(Elastic.LogSink, account_id, log_sink_id) do
       nil ->
         Logger.info("Elastic log sink not found, disabled, or account ineligible, skipping",
+          account_id: account_id,
           elastic_log_sink_id: log_sink_id
         )
 

--- a/elixir/lib/portal/entra/scheduler.ex
+++ b/elixir/lib/portal/entra/scheduler.ex
@@ -30,7 +30,7 @@ defmodule Portal.Entra.Scheduler do
         |> Safe.unscoped()
         |> Safe.stream()
         |> Stream.each(fn directory ->
-          args = %{directory_id: directory.id}
+          args = %{account_id: directory.account_id, directory_id: directory.id}
           {:ok, _job} = Portal.Entra.Sync.new(args) |> Oban.insert()
         end)
         |> Stream.run()

--- a/elixir/lib/portal/entra/sync.ex
+++ b/elixir/lib/portal/entra/sync.ex
@@ -16,15 +16,17 @@ defmodule Portal.Entra.Sync do
   require Logger
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"directory_id" => directory_id}}) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id, "directory_id" => directory_id}}) do
     Logger.info("Starting Entra directory sync",
+      account_id: account_id,
       entra_directory_id: directory_id,
       timestamp: DateTime.utc_now()
     )
 
-    case Database.get_directory(directory_id) do
+    case Database.get_directory(account_id, directory_id) do
       nil ->
         Logger.info("Entra directory not found, disabled, or account disabled, skipping",
+          account_id: account_id,
           entra_directory_id: directory_id
         )
 
@@ -35,6 +37,8 @@ defmodule Portal.Entra.Sync do
 
     :ok
   end
+
+  def perform(_), do: :ok
 
   defp update(directory, attrs) do
     changeset =
@@ -776,10 +780,11 @@ defmodule Portal.Entra.Sync do
     import Ecto.Query
     alias Portal.Safe
 
-    def get_directory(id) do
+    def get_directory(account_id, id) do
       from(d in Entra.Directory,
         join: a in Portal.Account,
         on: a.id == d.account_id,
+        where: d.account_id == ^account_id,
         where: d.id == ^id,
         where: d.is_disabled == false,
         where: a.is_disabled == false

--- a/elixir/lib/portal/google/scheduler.ex
+++ b/elixir/lib/portal/google/scheduler.ex
@@ -30,7 +30,7 @@ defmodule Portal.Google.Scheduler do
         |> Safe.unscoped()
         |> Safe.stream()
         |> Stream.each(fn directory ->
-          args = %{directory_id: directory.id}
+          args = %{account_id: directory.account_id, directory_id: directory.id}
           {:ok, _job} = Portal.Google.Sync.new(args) |> Oban.insert()
         end)
         |> Stream.run()

--- a/elixir/lib/portal/google/sync.ex
+++ b/elixir/lib/portal/google/sync.ex
@@ -31,15 +31,17 @@ defmodule Portal.Google.Sync do
   @db_batch_size 500
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"directory_id" => directory_id}}) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id, "directory_id" => directory_id}}) do
     Logger.info("Starting Google directory sync",
+      account_id: account_id,
       google_directory_id: directory_id,
       timestamp: DateTime.utc_now()
     )
 
-    case Database.get_directory(directory_id) do
+    case Database.get_directory(account_id, directory_id) do
       nil ->
         Logger.info("Google directory not found, disabled, or account disabled, skipping",
+          account_id: account_id,
           google_directory_id: directory_id
         )
 
@@ -50,6 +52,8 @@ defmodule Portal.Google.Sync do
 
     :ok
   end
+
+  def perform(_), do: :ok
 
   defp update(directory, attrs) do
     changeset =
@@ -1035,10 +1039,11 @@ defmodule Portal.Google.Sync do
 
     @issuer "https://accounts.google.com"
 
-    def get_directory(id) do
+    def get_directory(account_id, id) do
       from(d in Google.Directory,
         join: a in Portal.Account,
         on: a.id == d.account_id,
+        where: d.account_id == ^account_id,
         where: d.id == ^id,
         where: d.is_disabled == false,
         where: a.is_disabled == false

--- a/elixir/lib/portal/http/scheduler.ex
+++ b/elixir/lib/portal/http/scheduler.ex
@@ -29,7 +29,7 @@ defmodule Portal.HTTP.Scheduler do
         |> Safe.unscoped()
         |> Safe.stream()
         |> Stream.each(fn sink ->
-          args = %{log_sink_id: sink.id}
+          args = %{account_id: sink.account_id, log_sink_id: sink.id}
           {:ok, _job} = Portal.HTTP.Sync.new(args) |> Oban.insert()
         end)
         |> Stream.run()

--- a/elixir/lib/portal/http/sync.ex
+++ b/elixir/lib/portal/http/sync.ex
@@ -18,10 +18,11 @@ defmodule Portal.HTTP.Sync do
   require Logger
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"log_sink_id" => log_sink_id}}) do
-    case Delivery.get_sink(HTTP.LogSink, log_sink_id) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id, "log_sink_id" => log_sink_id}}) do
+    case Delivery.get_sink(HTTP.LogSink, account_id, log_sink_id) do
       nil ->
         Logger.info("HTTP log sink not found, disabled, or account ineligible, skipping",
+          account_id: account_id,
           http_log_sink_id: log_sink_id
         )
 

--- a/elixir/lib/portal/log_sinks/delivery.ex
+++ b/elixir/lib/portal/log_sinks/delivery.ex
@@ -28,8 +28,8 @@ defmodule Portal.LogSinks.Delivery do
   # Bounds one run; the next scheduler tick resumes from the cursor.
   @max_batches_per_stream 20
 
-  def get_sink(schema, id) do
-    Database.get_sink(schema, id)
+  def get_sink(schema, account_id, id) do
+    Database.get_sink(schema, account_id, id)
   end
 
   def sync(sink, adapter) do
@@ -498,10 +498,11 @@ defmodule Portal.LogSinks.Delivery do
       flow: {Portal.FlowLog, :inserted_at}
     }
 
-    def get_sink(schema, id) do
+    def get_sink(schema, account_id, id) do
       from(s in schema,
         join: a in Portal.Account,
         on: a.id == s.account_id,
+        where: s.account_id == ^account_id,
         where: s.id == ^id,
         where: s.is_disabled == false,
         where: a.is_disabled == false,

--- a/elixir/lib/portal/new_relic/scheduler.ex
+++ b/elixir/lib/portal/new_relic/scheduler.ex
@@ -29,7 +29,7 @@ defmodule Portal.NewRelic.Scheduler do
         |> Safe.unscoped()
         |> Safe.stream()
         |> Stream.each(fn sink ->
-          args = %{log_sink_id: sink.id}
+          args = %{account_id: sink.account_id, log_sink_id: sink.id}
           {:ok, _job} = Portal.NewRelic.Sync.new(args) |> Oban.insert()
         end)
         |> Stream.run()

--- a/elixir/lib/portal/new_relic/sync.ex
+++ b/elixir/lib/portal/new_relic/sync.ex
@@ -18,10 +18,11 @@ defmodule Portal.NewRelic.Sync do
   require Logger
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"log_sink_id" => log_sink_id}}) do
-    case Delivery.get_sink(NewRelic.LogSink, log_sink_id) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id, "log_sink_id" => log_sink_id}}) do
+    case Delivery.get_sink(NewRelic.LogSink, account_id, log_sink_id) do
       nil ->
         Logger.info("New Relic log sink not found, disabled, or account ineligible, skipping",
+          account_id: account_id,
           newrelic_log_sink_id: log_sink_id
         )
 

--- a/elixir/lib/portal/okta/scheduler.ex
+++ b/elixir/lib/portal/okta/scheduler.ex
@@ -29,7 +29,7 @@ defmodule Portal.Okta.Scheduler do
         |> Safe.unscoped()
         |> Safe.stream()
         |> Stream.each(fn directory ->
-          args = %{directory_id: directory.id}
+          args = %{account_id: directory.account_id, directory_id: directory.id}
           {:ok, _job} = Portal.Okta.Sync.new(args) |> Oban.insert()
         end)
         |> Stream.run()

--- a/elixir/lib/portal/okta/sync.ex
+++ b/elixir/lib/portal/okta/sync.ex
@@ -26,15 +26,17 @@ defmodule Portal.Okta.Sync do
   ]
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"directory_id" => directory_id}}) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id, "directory_id" => directory_id}}) do
     Logger.info("Starting Okta directory sync",
+      account_id: account_id,
       okta_directory_id: directory_id,
       timestamp: DateTime.utc_now()
     )
 
-    case Database.get_directory(directory_id) do
+    case Database.get_directory(account_id, directory_id) do
       nil ->
         Logger.info("Okta directory not found, disabled, or account disabled, skipping",
+          account_id: account_id,
           okta_directory_id: directory_id
         )
 
@@ -634,10 +636,11 @@ defmodule Portal.Okta.Sync do
     import Ecto.Query
     alias Portal.Safe
 
-    def get_directory(id) do
+    def get_directory(account_id, id) do
       from(d in Okta.Directory,
         join: a in Portal.Account,
         on: a.id == d.account_id,
+        where: d.account_id == ^account_id,
         where: d.id == ^id,
         where: d.is_disabled == false,
         where: a.is_disabled == false

--- a/elixir/lib/portal/qradar/scheduler.ex
+++ b/elixir/lib/portal/qradar/scheduler.ex
@@ -29,7 +29,7 @@ defmodule Portal.QRadar.Scheduler do
         |> Safe.unscoped()
         |> Safe.stream()
         |> Stream.each(fn sink ->
-          args = %{log_sink_id: sink.id}
+          args = %{account_id: sink.account_id, log_sink_id: sink.id}
           {:ok, _job} = Portal.QRadar.Sync.new(args) |> Oban.insert()
         end)
         |> Stream.run()

--- a/elixir/lib/portal/qradar/sync.ex
+++ b/elixir/lib/portal/qradar/sync.ex
@@ -18,10 +18,11 @@ defmodule Portal.QRadar.Sync do
   require Logger
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"log_sink_id" => log_sink_id}}) do
-    case Delivery.get_sink(QRadar.LogSink, log_sink_id) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id, "log_sink_id" => log_sink_id}}) do
+    case Delivery.get_sink(QRadar.LogSink, account_id, log_sink_id) do
       nil ->
         Logger.info("QRadar log sink not found, disabled, or account ineligible, skipping",
+          account_id: account_id,
           qradar_log_sink_id: log_sink_id
         )
 

--- a/elixir/lib/portal/s3/scheduler.ex
+++ b/elixir/lib/portal/s3/scheduler.ex
@@ -29,7 +29,7 @@ defmodule Portal.S3.Scheduler do
         |> Safe.unscoped()
         |> Safe.stream()
         |> Stream.each(fn sink ->
-          args = %{log_sink_id: sink.id}
+          args = %{account_id: sink.account_id, log_sink_id: sink.id}
           {:ok, _job} = Portal.S3.Sync.new(args) |> Oban.insert()
         end)
         |> Stream.run()

--- a/elixir/lib/portal/s3/sync.ex
+++ b/elixir/lib/portal/s3/sync.ex
@@ -18,10 +18,11 @@ defmodule Portal.S3.Sync do
   require Logger
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"log_sink_id" => log_sink_id}}) do
-    case Delivery.get_sink(S3.LogSink, log_sink_id) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id, "log_sink_id" => log_sink_id}}) do
+    case Delivery.get_sink(S3.LogSink, account_id, log_sink_id) do
       nil ->
         Logger.info("Amazon S3 log sink not found, disabled, or account ineligible, skipping",
+          account_id: account_id,
           s3_log_sink_id: log_sink_id
         )
 

--- a/elixir/lib/portal/safe.ex
+++ b/elixir/lib/portal/safe.ex
@@ -375,6 +375,10 @@ defmodule Portal.Safe do
   Inserts multiple entries for the given schema.
   The queryable field in Scoped/Unscoped is ignored for this operation.
 
+  Scoped inserts stamp the subject's `account_id` on every entry and refuse an
+  entry that names another account. Entries that span accounts, and the query
+  form of `entries`, require `unscoped/0`.
+
   ## Examples
       Safe.unscoped() |> Safe.insert_all(Actor, entries, on_conflict: :nothing)
       Safe.scoped(subject) |> Safe.insert_all(Actor, entries)
@@ -391,19 +395,16 @@ defmodule Portal.Safe do
   def insert_all(%Scoped{subject: subject}, schema_or_source, entries, opts) do
     schema = if is_atom(schema_or_source), do: schema_or_source, else: schema_or_source.__struct__
 
-    case permit(:insert_all, schema, subject) do
-      :ok ->
-        {:ok, result} =
-          Repo.transact(fn ->
-            emit_subject_message(subject)
+    with :ok <- permit(:insert_all, schema, subject),
+         {:ok, entries} <- scope_entries(entries, subject.account.id) do
+      {:ok, result} =
+        Repo.transact(fn ->
+          emit_subject_message(subject)
 
-            {:ok, Repo.insert_all(schema_or_source, entries, opts)}
-          end)
+          {:ok, Repo.insert_all(schema_or_source, entries, opts)}
+        end)
 
-        result
-
-      {:error, :unauthorized} ->
-        {:error, :unauthorized}
+      result
     end
   end
 
@@ -526,7 +527,13 @@ defmodule Portal.Safe do
 
   @spec update_all(Scoped.t(), Keyword.t()) ::
           {non_neg_integer(), nil | [term()]} | {:error, :unauthorized}
-  def update_all(%Scoped{subject: subject, queryable: queryable}, updates) do
+  def update_all(
+        %Scoped{
+          subject: %Subject{account: %{id: account_id}} = subject,
+          queryable: queryable
+        },
+        updates
+      ) do
     schema = get_schema_module(queryable)
 
     case permit(:update_all, schema, subject) do
@@ -535,7 +542,9 @@ defmodule Portal.Safe do
           Repo.transact(fn ->
             emit_subject_message(subject)
 
-            {:ok, Repo.update_all(queryable, updates)}
+            filtered_query = apply_account_filter(queryable, schema, account_id)
+
+            {:ok, Repo.update_all(filtered_query, updates)}
           end)
 
         result
@@ -705,6 +714,40 @@ defmodule Portal.Safe do
   defp apply_account_filter(queryable, _schema, account_id) do
     # For all other schemas, filter by account_id
     where(queryable, account_id: ^account_id)
+  end
+
+  # Bulk inserts get the same treatment `insert/1` gives a changeset: the
+  # subject's account is stamped on, and an entry naming another account is
+  # refused. Cross-account inserts must say so with `unscoped/0`.
+  defp scope_entries(entries, account_id) when is_list(entries) do
+    Enum.reduce_while(entries, {:ok, []}, fn entry, {:ok, scoped} ->
+      case scope_entry(entry, account_id) do
+        {:ok, entry} -> {:cont, {:ok, [entry | scoped]}}
+        {:error, :unauthorized} -> {:halt, {:error, :unauthorized}}
+      end
+    end)
+    |> case do
+      {:ok, scoped} -> {:ok, Enum.reverse(scoped)}
+      {:error, :unauthorized} -> {:error, :unauthorized}
+    end
+  end
+
+  defp scope_entries(_query, _account_id), do: {:error, :unauthorized}
+
+  defp scope_entry(entry, account_id) when is_map(entry) do
+    case Map.fetch(entry, :account_id) do
+      {:ok, ^account_id} -> {:ok, entry}
+      {:ok, _other} -> {:error, :unauthorized}
+      :error -> {:ok, Map.put(entry, :account_id, account_id)}
+    end
+  end
+
+  defp scope_entry(entry, account_id) when is_list(entry) do
+    case Keyword.fetch(entry, :account_id) do
+      {:ok, ^account_id} -> {:ok, entry}
+      {:ok, _other} -> {:error, :unauthorized}
+      :error -> {:ok, Keyword.put(entry, :account_id, account_id)}
+    end
   end
 
   defp apply_schema_changeset(changeset, schema) do

--- a/elixir/lib/portal/sentinel/scheduler.ex
+++ b/elixir/lib/portal/sentinel/scheduler.ex
@@ -29,7 +29,7 @@ defmodule Portal.Sentinel.Scheduler do
         |> Safe.unscoped()
         |> Safe.stream()
         |> Stream.each(fn sink ->
-          args = %{log_sink_id: sink.id}
+          args = %{account_id: sink.account_id, log_sink_id: sink.id}
           {:ok, _job} = Portal.Sentinel.Sync.new(args) |> Oban.insert()
         end)
         |> Stream.run()

--- a/elixir/lib/portal/sentinel/sync.ex
+++ b/elixir/lib/portal/sentinel/sync.ex
@@ -19,10 +19,11 @@ defmodule Portal.Sentinel.Sync do
   require Logger
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"log_sink_id" => log_sink_id}}) do
-    case Delivery.get_sink(Sentinel.LogSink, log_sink_id) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id, "log_sink_id" => log_sink_id}}) do
+    case Delivery.get_sink(Sentinel.LogSink, account_id, log_sink_id) do
       nil ->
         Logger.info("Sentinel log sink not found, disabled, or account ineligible, skipping",
+          account_id: account_id,
           sentinel_log_sink_id: log_sink_id
         )
 

--- a/elixir/lib/portal/splunk/scheduler.ex
+++ b/elixir/lib/portal/splunk/scheduler.ex
@@ -29,7 +29,7 @@ defmodule Portal.Splunk.Scheduler do
         |> Safe.unscoped()
         |> Safe.stream()
         |> Stream.each(fn sink ->
-          args = %{log_sink_id: sink.id}
+          args = %{account_id: sink.account_id, log_sink_id: sink.id}
           {:ok, _job} = Portal.Splunk.Sync.new(args) |> Oban.insert()
         end)
         |> Stream.run()

--- a/elixir/lib/portal/splunk/sync.ex
+++ b/elixir/lib/portal/splunk/sync.ex
@@ -18,10 +18,11 @@ defmodule Portal.Splunk.Sync do
   require Logger
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"log_sink_id" => log_sink_id}}) do
-    case Delivery.get_sink(Splunk.LogSink, log_sink_id) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id, "log_sink_id" => log_sink_id}}) do
+    case Delivery.get_sink(Splunk.LogSink, account_id, log_sink_id) do
       nil ->
         Logger.info("Splunk log sink not found, disabled, or account ineligible, skipping",
+          account_id: account_id,
           splunk_log_sink_id: log_sink_id
         )
 

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -290,27 +290,31 @@ defmodule PortalWeb.Settings.DirectorySync do
     end
   end
 
-  def handle_event("sync_directory", %{"id" => id, "type" => type}, socket) do
-    sync_module =
-      case type do
-        "entra" -> Portal.Entra.Sync
-        "google" -> Portal.Google.Sync
-        "okta" -> Portal.Okta.Sync
-        _ -> raise "Unsupported directory type for sync: #{type}"
+  def handle_event("sync_directory", %{"id" => id}, socket) do
+    directory = socket.assigns.directories |> Enum.find(fn d -> d.id == id end)
+
+    if is_nil(directory) do
+      {:noreply, put_flash(socket, :error, "Failed to queue directory sync.")}
+    else
+      args = %{"account_id" => directory.account_id, "directory_id" => directory.id}
+
+      case Oban.insert(sync_module(directory).new(args)) do
+        {:ok, _job} ->
+          socket =
+            socket
+            |> init()
+            |> put_flash(:success, "Directory sync has been queued successfully.")
+
+          {:noreply, socket}
+
+        {:error, reason} ->
+          Logger.info("Failed to enqueue directory sync job",
+            id: directory.id,
+            reason: inspect(reason)
+          )
+
+          {:noreply, put_flash(socket, :error, "Failed to queue directory sync.")}
       end
-
-    case Oban.insert(sync_module.new(%{"directory_id" => id})) do
-      {:ok, _job} ->
-        socket =
-          socket
-          |> init()
-          |> put_flash(:success, "Directory sync has been queued successfully.")
-
-        {:noreply, socket}
-
-      {:error, reason} ->
-        Logger.info("Failed to enqueue #{type} sync job", id: id, reason: inspect(reason))
-        {:noreply, put_flash(socket, :error, "Failed to queue directory sync.")}
     end
   end
 
@@ -928,7 +932,6 @@ defmodule PortalWeb.Settings.DirectorySync do
               type="button"
               phx-click="sync_directory"
               phx-value-id={@directory.id}
-              phx-value-type={@type}
               disabled={@directory.is_disabled or @directory.has_active_job}
               class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-raised transition-colors text-body disabled:opacity-50 disabled:cursor-not-allowed"
             >
@@ -1972,6 +1975,10 @@ defmodule PortalWeb.Settings.DirectorySync do
 
     {String.trim(key), clean_value}
   end
+
+  defp sync_module(%Entra.Directory{}), do: Entra.Sync
+  defp sync_module(%Google.Directory{}), do: Google.Sync
+  defp sync_module(%Okta.Directory{}), do: Okta.Sync
 
   defmodule Database do
     alias Portal.{Entra, Google, Okta, Safe}

--- a/elixir/lib/portal_web/live/settings/log_sinks.ex
+++ b/elixir/lib/portal_web/live/settings/log_sinks.ex
@@ -244,7 +244,9 @@ defmodule PortalWeb.Settings.LogSinks do
          )}
 
       true ->
-        case Oban.insert(sync_module(sink).new(%{"log_sink_id" => sink.id})) do
+        args = %{"account_id" => sink.account_id, "log_sink_id" => sink.id}
+
+        case Oban.insert(sync_module(sink).new(args)) do
           {:ok, _job} ->
             {:noreply,
              socket

--- a/elixir/test/portal/datadog/sync_test.exs
+++ b/elixir/test/portal/datadog/sync_test.exs
@@ -99,6 +99,17 @@ defmodule Portal.Datadog.SyncTest do
       assert sink.errored_at
       assert sink.error_message == "Datadog returned HTTP 429: Too many requests"
     end
+
+    test "skips sink belonging to another account", %{account: account} do
+      sink = datadog_log_sink_fixture(account: account, enabled_streams: [:session])
+      session_log_fixture(account: account)
+      other_account = account_fixture(features: %{log_sinks: true})
+
+      assert :ok = perform_job(Datadog.Sync, %{account_id: other_account.id, log_sink_id: sink.id})
+
+      refute_receive {:intake, _conn, _events}
+      assert Repo.all(LogSinkCursor) == []
+    end
   end
 
   describe "Scheduler" do
@@ -110,7 +121,7 @@ defmodule Portal.Datadog.SyncTest do
 
       assert {:ok, :scheduled} = perform_job(Datadog.Scheduler, %{})
 
-      assert_enqueued(worker: Datadog.Sync, args: %{log_sink_id: sink.id})
+      assert_enqueued(worker: Datadog.Sync, args: %{account_id: sink.account_id, log_sink_id: sink.id})
       refute_enqueued(worker: Datadog.Sync, args: %{log_sink_id: disabled_sink.id})
       refute_enqueued(worker: Datadog.Sync, args: %{log_sink_id: feature_off_sink.id})
     end

--- a/elixir/test/portal/datadog/sync_test.exs
+++ b/elixir/test/portal/datadog/sync_test.exs
@@ -32,11 +32,11 @@ defmodule Portal.Datadog.SyncTest do
           enabled_streams: [:session],
           tags: "env:prod,team:secops"
         )
-      assert :ok = perform_job(Datadog.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Datadog.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       log = session_log_fixture(account: account)
 
-      assert :ok = perform_job(Datadog.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Datadog.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:intake, conn, [event]}
       assert conn.request_path == "/api/v2/logs"
@@ -64,7 +64,7 @@ defmodule Portal.Datadog.SyncTest do
 
     test "a 403 disables the sink immediately", %{account: account} do
       sink = datadog_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Datadog.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Datadog.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(Datadog.APIClient, fn conn ->
@@ -73,7 +73,7 @@ defmodule Portal.Datadog.SyncTest do
         |> Req.Test.json(%{"errors" => [%{"detail" => "Invalid API key"}]})
       end)
 
-      assert :ok = perform_job(Datadog.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Datadog.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       assert sink.is_disabled
@@ -83,7 +83,7 @@ defmodule Portal.Datadog.SyncTest do
 
     test "a 429 is transient", %{account: account} do
       sink = datadog_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Datadog.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Datadog.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(Datadog.APIClient, fn conn ->
@@ -92,7 +92,7 @@ defmodule Portal.Datadog.SyncTest do
         |> Req.Test.json(%{"errors" => ["Too many requests"]})
       end)
 
-      assert :ok = perform_job(Datadog.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Datadog.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       refute sink.is_disabled

--- a/elixir/test/portal/elastic/sync_test.exs
+++ b/elixir/test/portal/elastic/sync_test.exs
@@ -372,6 +372,17 @@ defmodule Portal.Elastic.SyncTest do
       assert sink.error_message ==
                "Elasticsearch returned HTTP 401: unable to authenticate user"
     end
+
+    test "skips sink belonging to another account", %{account: account} do
+      sink = elastic_log_sink_fixture(account: account, enabled_streams: [:session])
+      session_log_fixture(account: account)
+      other_account = account_fixture(features: %{log_sinks: true})
+
+      assert :ok = perform_job(Elastic.Sync, %{account_id: other_account.id, log_sink_id: sink.id})
+
+      refute_receive {:bulk, _conn, _lines}
+      assert Repo.all(LogSinkCursor) == []
+    end
   end
 
   describe "Scheduler" do
@@ -383,7 +394,7 @@ defmodule Portal.Elastic.SyncTest do
 
       assert {:ok, :scheduled} = perform_job(Elastic.Scheduler, %{})
 
-      assert_enqueued(worker: Elastic.Sync, args: %{log_sink_id: sink.id})
+      assert_enqueued(worker: Elastic.Sync, args: %{account_id: sink.account_id, log_sink_id: sink.id})
       refute_enqueued(worker: Elastic.Sync, args: %{log_sink_id: disabled_sink.id})
       refute_enqueued(worker: Elastic.Sync, args: %{log_sink_id: feature_off_sink.id})
     end

--- a/elixir/test/portal/elastic/sync_test.exs
+++ b/elixir/test/portal/elastic/sync_test.exs
@@ -55,11 +55,11 @@ defmodule Portal.Elastic.SyncTest do
       sink = elastic_log_sink_fixture(account: account, enabled_streams: [:session])
 
       # An idle run has nothing to deliver and makes no destination calls.
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       refute_receive {:put, _path, _body}
 
       session_log_fixture(account: account)
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:put, "/_index_template/firezone-logs-firezone-default", template}
       assert template["index_patterns"] == ["logs-firezone-default"]
@@ -91,11 +91,11 @@ defmodule Portal.Elastic.SyncTest do
 
     test "bulk-creates documents with log_id as _id", %{account: account} do
       sink = elastic_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       log = session_log_fixture(account: account)
 
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:bulk, conn, [action, document]}
       assert conn.request_path == "/_bulk"
@@ -114,7 +114,7 @@ defmodule Portal.Elastic.SyncTest do
 
     test "flow start and end events get distinct document ids", %{account: account} do
       sink = elastic_log_sink_fixture(account: account, enabled_streams: [:flow])
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       flow =
         flow_log_fixture(
@@ -127,7 +127,7 @@ defmodule Portal.Elastic.SyncTest do
           tx_bytes: nil
         )
 
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       assert_receive {:bulk, _conn, [start_action, _start_doc]}
       assert start_action["create"]["_id"] == flow.log_id <> "-s"
 
@@ -158,7 +158,7 @@ defmodule Portal.Elastic.SyncTest do
       )
       |> Repo.update_all([])
 
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       assert_receive {:bulk, _conn, [end_action, end_doc]}
       assert end_action["create"]["_id"] == flow.log_id <> "-e"
       assert end_doc["firezone"]["log_id"] == flow.log_id <> "-e"
@@ -166,7 +166,7 @@ defmodule Portal.Elastic.SyncTest do
 
     test "version conflicts count as delivered", %{account: account} do
       sink = elastic_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       log = session_log_fixture(account: account)
 
       Req.Test.stub(Elastic.APIClient, fn conn ->
@@ -184,7 +184,7 @@ defmodule Portal.Elastic.SyncTest do
         })
       end)
 
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       cursor = get_cursor(sink, :session, :live)
       assert cursor.cursor == log.seq
@@ -196,7 +196,7 @@ defmodule Portal.Elastic.SyncTest do
       account: account
     } do
       sink = elastic_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(Elastic.APIClient, fn conn ->
@@ -214,7 +214,7 @@ defmodule Portal.Elastic.SyncTest do
         })
       end)
 
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       cursor = get_cursor(sink, :session, :live)
       assert cursor.synced_count == 0
@@ -228,7 +228,7 @@ defmodule Portal.Elastic.SyncTest do
       account: account
     } do
       sink = elastic_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       fine = session_log_fixture(account: account, actor_email: "fine@example.com")
       poison = session_log_fixture(account: account, actor_email: "poison@example.com")
@@ -237,7 +237,7 @@ defmodule Portal.Elastic.SyncTest do
 
       log_output =
         ExUnit.CaptureLog.capture_log([level: :error], fn ->
-          assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+          assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 
       assert log_output =~ "Log sink event cannot be delivered, halting stream"
@@ -268,13 +268,13 @@ defmodule Portal.Elastic.SyncTest do
           last_rollover_at: DateTime.utc_now()
         )
 
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account, actor_email: "poison@example.com")
 
       stub_with_poison(self(), "document_parsing_exception")
 
       ExUnit.CaptureLog.capture_log(fn ->
-        assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+        assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       end)
 
       refute_receive {:rollover, _path}
@@ -282,14 +282,14 @@ defmodule Portal.Elastic.SyncTest do
 
     test "a non-mapping rejection is a customer-facing transient error", %{account: account} do
       sink = elastic_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       poison = session_log_fixture(account: account, actor_email: "poison@example.com")
 
       stub_with_poison(self(), "cluster_block_exception")
 
       log_output =
         ExUnit.CaptureLog.capture_log([level: :error], fn ->
-          assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+          assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 
       refute log_output =~ "cannot be delivered"
@@ -311,7 +311,7 @@ defmodule Portal.Elastic.SyncTest do
       account: account
     } do
       sink = elastic_log_sink_fixture(account: account, enabled_streams: [:session, :flow])
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       session_log_fixture(account: account)
       flow_log_fixture(account: account, domain: "example.com")
@@ -345,7 +345,7 @@ defmodule Portal.Elastic.SyncTest do
       end)
 
       ExUnit.CaptureLog.capture_log(fn ->
-        assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+        assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       end)
 
       assert_receive {:rollover, _path}
@@ -354,7 +354,7 @@ defmodule Portal.Elastic.SyncTest do
 
     test "a 401 disables the sink immediately", %{account: account} do
       sink = elastic_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(Elastic.APIClient, fn conn ->
@@ -363,7 +363,7 @@ defmodule Portal.Elastic.SyncTest do
         |> Req.Test.json(%{"error" => %{"reason" => "unable to authenticate user"}})
       end)
 
-      assert :ok = perform_job(Elastic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       assert sink.is_disabled

--- a/elixir/test/portal/entra/scheduler_test.exs
+++ b/elixir/test/portal/entra/scheduler_test.exs
@@ -115,7 +115,7 @@ defmodule Portal.Entra.SchedulerTest do
       # Verify job structure
       assert job.worker == "Portal.Entra.Sync"
       assert job.queue == "entra_sync"
-      assert job.args == %{"directory_id" => directory.id}
+      assert job.args == %{"account_id" => directory.account_id, "directory_id" => directory.id}
     end
 
     test "schedules multiple jobs for multiple accounts" do

--- a/elixir/test/portal/entra/sync_test.exs
+++ b/elixir/test/portal/entra/sync_test.exs
@@ -130,7 +130,7 @@ defmodule Portal.Entra.SyncTest do
       end)
 
       # Perform sync
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # Verify identities created (3 total: 1 direct user + 2 group members)
       identities = Repo.all(ExternalIdentity)
@@ -216,7 +216,7 @@ defmodule Portal.Entra.SyncTest do
       end)
 
       # Perform sync
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # Verify identities created (2 users)
       identities = Repo.all(ExternalIdentity)
@@ -361,7 +361,7 @@ defmodule Portal.Entra.SyncTest do
         end
       end)
 
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       identities = Repo.all(ExternalIdentity)
       identity_emails = Enum.map(identities, & &1.email) |> Enum.sort()
@@ -396,7 +396,7 @@ defmodule Portal.Entra.SyncTest do
         }
       ])
 
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       disabled_identity =
         Repo.get_by!(ExternalIdentity,
@@ -427,7 +427,7 @@ defmodule Portal.Entra.SyncTest do
         }
       ])
 
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       identities = Repo.all(ExternalIdentity)
       assert Enum.map(identities, & &1.email) == ["active@example.com"]
@@ -441,9 +441,20 @@ defmodule Portal.Entra.SyncTest do
       non_existent_id = Ecto.UUID.generate()
 
       # Should not raise an error
-      assert :ok = perform_job(Sync, %{directory_id: non_existent_id})
+      assert :ok = perform_job(Sync, %{account_id: Ecto.UUID.generate(), directory_id: non_existent_id})
 
       # No data should be created
+      assert Repo.all(ExternalIdentity) == []
+      assert Repo.all(Group) == []
+    end
+
+    test "skips directory belonging to another account" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = entra_directory_fixture(account: account)
+      other_account = account_fixture(features: %{idp_sync: true})
+
+      assert :ok = perform_job(Sync, %{account_id: other_account.id, directory_id: directory.id})
+
       assert Repo.all(ExternalIdentity) == []
       assert Repo.all(Group) == []
     end
@@ -453,7 +464,7 @@ defmodule Portal.Entra.SyncTest do
       directory = entra_directory_fixture(account: account, is_disabled: true)
 
       # Should not perform sync
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # No data should be created
       assert Repo.all(ExternalIdentity) == []
@@ -471,7 +482,7 @@ defmodule Portal.Entra.SyncTest do
       directory = entra_directory_fixture(account: account)
 
       # Should not perform sync
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # No data should be created
       assert Repo.all(ExternalIdentity) == []
@@ -550,7 +561,7 @@ defmodule Portal.Entra.SyncTest do
       end)
 
       # Perform sync
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # Old identity should be deleted
       refute Repo.get_by(ExternalIdentity, id: old_identity.id)
@@ -601,7 +612,7 @@ defmodule Portal.Entra.SyncTest do
       end)
 
       # Perform sync
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # Old group should be deleted
       refute Repo.get_by(Group, id: old_group.id)
@@ -659,7 +670,7 @@ defmodule Portal.Entra.SyncTest do
       end)
 
       # Perform sync
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # Only the user identity should be created
       identities = Repo.all(ExternalIdentity)
@@ -732,7 +743,7 @@ defmodule Portal.Entra.SyncTest do
       end)
 
       # Perform sync
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # Identity should use userPrincipalName as email
       identities = Repo.all(ExternalIdentity)
@@ -815,7 +826,7 @@ defmodule Portal.Entra.SyncTest do
       end)
 
       # Perform sync
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # Only the successful user should be synced
       identities = Repo.all(ExternalIdentity)
@@ -850,7 +861,7 @@ defmodule Portal.Entra.SyncTest do
       end)
 
       # Perform sync
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # Error state should be cleared
       updated_directory = Repo.get(Portal.Entra.Directory, directory.id)
@@ -898,7 +909,7 @@ defmodule Portal.Entra.SyncTest do
 
       # Should raise SyncError
       assert_raise Portal.Entra.SyncError, fn ->
-        perform_job(Sync, %{directory_id: directory.id})
+        perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
       end
     end
 
@@ -941,7 +952,7 @@ defmodule Portal.Entra.SyncTest do
 
       # Should raise SyncError
       assert_raise Portal.Entra.SyncError, fn ->
-        perform_job(Sync, %{directory_id: directory.id})
+        perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
       end
     end
 
@@ -967,7 +978,7 @@ defmodule Portal.Entra.SyncTest do
 
       # Should raise SyncError
       assert_raise Portal.Entra.SyncError, fn ->
-        perform_job(Sync, %{directory_id: directory.id})
+        perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
       end
     end
 
@@ -1092,7 +1103,7 @@ defmodule Portal.Entra.SyncTest do
       end)
 
       # Perform sync
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # Verify both service principals were looked up
       lookups = receive_all_messages(:service_principal_lookup)
@@ -1224,7 +1235,7 @@ defmodule Portal.Entra.SyncTest do
       end)
 
       # Perform sync
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # Verify BOTH groups were created
       groups = Repo.all(Group)
@@ -1333,7 +1344,7 @@ defmodule Portal.Entra.SyncTest do
       end)
 
       # Perform sync
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # Verify user from auth provider was synced
       identities = Repo.all(ExternalIdentity)
@@ -1391,7 +1402,7 @@ defmodule Portal.Entra.SyncTest do
       end)
 
       # Perform sync - should complete successfully with no data
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # No identities should be created
       assert Repo.all(ExternalIdentity) == []
@@ -1430,7 +1441,7 @@ defmodule Portal.Entra.SyncTest do
       # Should raise SyncError with appropriate step
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :fetch_directory_sync_service_principal
@@ -1511,7 +1522,7 @@ defmodule Portal.Entra.SyncTest do
       end)
 
       # Should complete successfully even though auth provider app is not found
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # User should be synced from directory sync app
       identities = Repo.all(ExternalIdentity)
@@ -1533,7 +1544,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :get_access_token
@@ -1549,7 +1560,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :get_access_token
@@ -1581,7 +1592,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :fetch_directory_sync_service_principal
@@ -1623,7 +1634,7 @@ defmodule Portal.Entra.SyncTest do
         end
       end)
 
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
       assert Repo.all(ExternalIdentity) == []
     end
 
@@ -1663,7 +1674,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :stream_app_role_assignments
@@ -1705,7 +1716,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :process_assignment
@@ -1748,7 +1759,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :process_assignment
@@ -1791,7 +1802,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :process_assignment
@@ -1845,7 +1856,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :batch_get_users
@@ -1898,7 +1909,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :stream_group_transitive_members
@@ -1925,7 +1936,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :stream_groups
@@ -1957,7 +1968,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :stream_group_transitive_members
@@ -1982,7 +1993,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :process_group
@@ -2043,7 +2054,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :process_group_member
@@ -2108,7 +2119,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :process_user
@@ -2177,7 +2188,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :process_user
@@ -2226,7 +2237,7 @@ defmodule Portal.Entra.SyncTest do
         end
       end)
 
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       assert Repo.get_by!(Portal.Policy, account_id: account.id, id: policy.id).group_id ==
                group.id
@@ -2308,7 +2319,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :batch_upsert_memberships
@@ -2389,7 +2400,7 @@ defmodule Portal.Entra.SyncTest do
 
       error =
         assert_raise Portal.Entra.SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :batch_upsert_identities

--- a/elixir/test/portal/google/scheduler_test.exs
+++ b/elixir/test/portal/google/scheduler_test.exs
@@ -115,7 +115,7 @@ defmodule Portal.Google.SchedulerTest do
       # Verify job structure
       assert job.worker == "Portal.Google.Sync"
       assert job.queue == "google_sync"
-      assert job.args == %{"directory_id" => directory.id}
+      assert job.args == %{"account_id" => directory.account_id, "directory_id" => directory.id}
     end
 
     test "schedules multiple jobs for multiple accounts" do

--- a/elixir/test/portal/google/sync_test.exs
+++ b/elixir/test/portal/google/sync_test.exs
@@ -125,6 +125,24 @@ defmodule Portal.Google.SyncTest do
       assert log =~ fake_directory_id
     end
 
+    test "logs and returns :ok when directory belongs to another account" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account)
+      other_account = account_fixture()
+
+      log =
+        capture_log(fn ->
+          assert :ok =
+                   perform_job(Sync, %{
+                     "account_id" => other_account.id,
+                     "directory_id" => directory.id
+                   })
+        end)
+
+      assert log =~ "Google directory not found, disabled, or account disabled, skipping"
+      assert log =~ directory.id
+    end
+
     test "logs and returns :ok when directory is disabled" do
       account = account_fixture()
       directory = google_directory_fixture(account: account, is_disabled: true)

--- a/elixir/test/portal/google/sync_test.exs
+++ b/elixir/test/portal/google/sync_test.exs
@@ -118,7 +118,7 @@ defmodule Portal.Google.SyncTest do
 
       log =
         capture_log(fn ->
-          assert :ok = perform_job(Sync, %{"directory_id" => fake_directory_id})
+          assert :ok = perform_job(Sync, %{"account_id" => Ecto.UUID.generate(), "directory_id" => fake_directory_id})
         end)
 
       assert log =~ "Google directory not found, disabled, or account disabled, skipping"
@@ -131,7 +131,7 @@ defmodule Portal.Google.SyncTest do
 
       log =
         capture_log(fn ->
-          assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+          assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
         end)
 
       assert log =~ "Google directory not found, disabled, or account disabled, skipping"
@@ -150,7 +150,7 @@ defmodule Portal.Google.SyncTest do
 
       log =
         capture_log(fn ->
-          assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+          assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
         end)
 
       assert log =~ "Google directory not found, disabled, or account disabled, skipping"
@@ -216,7 +216,7 @@ defmodule Portal.Google.SyncTest do
         })
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       # Verify directory was updated with synced_at
       updated_directory = Repo.get!(Portal.Google.Directory, directory.id)
@@ -279,7 +279,7 @@ defmodule Portal.Google.SyncTest do
         respond_with_batch_users(conn, [%{"id" => "user1", "primaryEmail" => "user1@example.com"}])
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       identities = Repo.all(Portal.ExternalIdentity)
       assert Enum.map(identities, & &1.idp_id) == ["user1"]
@@ -297,7 +297,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/get_access_token/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -318,7 +318,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/at stream_groups: HTTP 500/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -344,7 +344,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/at stream_org_units: HTTP 403/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -381,7 +381,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/member missing 'id' field/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -424,7 +424,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/user .* missing 'primaryEmail' field/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -447,7 +447,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/group missing 'id' field/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -470,7 +470,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/group .* missing 'name' field/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -498,7 +498,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/org_unit missing 'orgUnitId' field/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -526,7 +526,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/org_unit .* missing 'name' field/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -554,7 +554,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/org_unit .* missing 'orgUnitPath' field/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -580,7 +580,7 @@ defmodule Portal.Google.SyncTest do
 
       # No group members, no org unit members, no get_user calls
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       updated_directory = Repo.get!(Portal.Google.Directory, directory.id)
       assert updated_directory.synced_at != nil
@@ -651,7 +651,7 @@ defmodule Portal.Google.SyncTest do
         ])
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       # Verify old identity was deleted
       refute Repo.get_by(Portal.ExternalIdentity, id: old_identity.id)
@@ -741,7 +741,7 @@ defmodule Portal.Google.SyncTest do
         ])
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       identities = Repo.all(Portal.ExternalIdentity)
       assert Enum.map(identities, & &1.email) == ["active@example.com"]
@@ -783,7 +783,7 @@ defmodule Portal.Google.SyncTest do
         ]
       )
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       suspended_identity =
         Repo.get_by!(Portal.ExternalIdentity,
@@ -813,7 +813,7 @@ defmodule Portal.Google.SyncTest do
         ]
       )
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       identities = Repo.all(Portal.ExternalIdentity)
       assert Enum.map(identities, & &1.email) == ["active@example.com"]
@@ -879,7 +879,7 @@ defmodule Portal.Google.SyncTest do
         })
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       assert Repo.all(Portal.ExternalIdentity) == []
       assert Repo.all(Portal.Membership) == []
@@ -933,7 +933,7 @@ defmodule Portal.Google.SyncTest do
         Req.Test.json(conn, %{"organizationUnits" => []})
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       # Verify the legacy key was used by checking the JWT assertion
       assert_receive {:token_request, body}
@@ -1002,7 +1002,7 @@ defmodule Portal.Google.SyncTest do
         ])
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       # Verify both users were synced
       identities = Repo.all(Portal.ExternalIdentity)
@@ -1079,7 +1079,7 @@ defmodule Portal.Google.SyncTest do
         Req.Test.json(conn, %{"members" => []})
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       # Verify group1 (seed) and group2 (discovered via BFS) both exist as portal groups
       groups = Repo.all(Portal.Group) |> Enum.sort_by(& &1.idp_id)
@@ -1140,7 +1140,7 @@ defmodule Portal.Google.SyncTest do
         |> Plug.Conn.send_resp(200, body)
       end)
 
-      assert_raise SyncError, fn -> perform_job(Sync, %{"directory_id" => directory.id}) end
+      assert_raise SyncError, fn -> perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id}) end
 
       assert Repo.get_by(Portal.ExternalIdentity, id: identity.id, account_id: account.id)
     end
@@ -1210,7 +1210,7 @@ defmodule Portal.Google.SyncTest do
         flunk("unexpected extra request to #{conn.request_path}")
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       identities = Repo.all(Portal.ExternalIdentity)
       assert Enum.map(identities, & &1.idp_id) |> Enum.sort() == ["user1", "user2"]
@@ -1262,7 +1262,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise Portal.Google.SyncError, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
 
       assert Repo.get_by(Portal.ExternalIdentity, id: identity.id, account_id: account.id)
@@ -1320,7 +1320,7 @@ defmodule Portal.Google.SyncTest do
         ])
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       identities = Repo.all(Portal.ExternalIdentity)
       assert Enum.map(identities, & &1.idp_id) == ["user1"]
@@ -1431,7 +1431,7 @@ defmodule Portal.Google.SyncTest do
         ])
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       # All three portal groups were created
       groups = Repo.all(Portal.Group) |> Enum.sort_by(& &1.idp_id)
@@ -1531,7 +1531,7 @@ defmodule Portal.Google.SyncTest do
 
       # No get_group("group1") call — it's already in visited, BFS skips it
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       groups = Repo.all(Portal.Group) |> Enum.sort_by(& &1.idp_id)
       assert Enum.map(groups, & &1.idp_id) == ["group1", "group2"]
@@ -1591,7 +1591,7 @@ defmodule Portal.Google.SyncTest do
 
       # No group2 members call — it was skipped
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       # Only group1 exists; deleted_group was silently skipped
       groups = Repo.all(Portal.Group)
@@ -1644,7 +1644,7 @@ defmodule Portal.Google.SyncTest do
 
       # No members call for external_group — it was skipped
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       # Only group1 exists; external_group was silently skipped
       groups = Repo.all(Portal.Group)
@@ -1731,7 +1731,7 @@ defmodule Portal.Google.SyncTest do
         Req.Test.json(conn, %{"members" => []})
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       groups = Repo.all(Portal.Group) |> Enum.sort_by(& &1.idp_id)
       assert length(groups) == 2
@@ -1777,7 +1777,7 @@ defmodule Portal.Google.SyncTest do
         Req.Test.json(conn, %{"organizationUnits" => []})
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       # Stale group was not synced this run — delete_unsynced removes it
       refute Repo.get_by(Portal.Group, id: existing_group.id)
@@ -1817,7 +1817,7 @@ defmodule Portal.Google.SyncTest do
 
       # No org units API call expected (orgunit_sync_enabled: false)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       # Stale org unit was not synced this run — delete_unsynced removes it
       refute Repo.get_by(Portal.Group, id: existing_ou.id)
@@ -1863,7 +1863,7 @@ defmodule Portal.Google.SyncTest do
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       # Both are stale — delete_unsynced removes them
       refute Repo.get_by(Portal.Group, id: existing_group.id)
@@ -1908,7 +1908,7 @@ defmodule Portal.Google.SyncTest do
         Req.Test.json(conn, %{"organizationUnits" => []})
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       # Non-matching group is stale — delete_unsynced removes it
       refute Repo.get_by(Portal.Group, id: non_matching_group.id)
@@ -1945,7 +1945,7 @@ defmodule Portal.Google.SyncTest do
 
       # No get_user calls — no members
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
 
       # Verify org unit was created
       groups = Repo.all(Portal.Group)
@@ -1968,7 +1968,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/get_access_token/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -1981,7 +1981,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/get_access_token/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -1998,7 +1998,7 @@ defmodule Portal.Google.SyncTest do
       )
 
       assert_raise SyncError, ~r/service account key is not configured/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -2037,7 +2037,7 @@ defmodule Portal.Google.SyncTest do
 
       log =
         capture_log(fn ->
-          assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+          assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
         end)
 
       assert log =~ "Reconnected 1 orphaned policies after sync"
@@ -2073,7 +2073,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/discovered group 'group2' missing 'name' field/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -2106,7 +2106,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/discovered group missing 'id' field/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -2141,7 +2141,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/get_group/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -2170,7 +2170,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/at stream_group_members: HTTP 403/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -2205,7 +2205,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/at batch_get_users: HTTP 500/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -2246,7 +2246,7 @@ defmodule Portal.Google.SyncTest do
         ])
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       assert Repo.aggregate(Portal.Group, :count, :id) == 1
       assert Repo.aggregate(Portal.Membership, :count, :id) == 1
     end
@@ -2278,7 +2278,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/at stream_org_unit_members: HTTP 403/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -2309,7 +2309,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       assert_raise SyncError, ~r/user missing 'id' field in org unit ou1/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
+        perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       end
     end
 
@@ -2345,7 +2345,7 @@ defmodule Portal.Google.SyncTest do
         })
       end)
 
-      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert :ok = perform_job(Sync, %{"account_id" => directory.account_id, "directory_id" => directory.id})
       assert Repo.aggregate(Portal.ExternalIdentity, :count, :id) == 1
       assert Repo.aggregate(Portal.Membership, :count, :id) == 1
     end

--- a/elixir/test/portal/http/sync_test.exs
+++ b/elixir/test/portal/http/sync_test.exs
@@ -25,12 +25,12 @@ defmodule Portal.HTTP.SyncTest do
   describe "perform/1" do
     test "delivers a JSON array of events with the bearer token", %{account: account} do
       sink = http_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(HTTP.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(HTTP.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       refute_receive {:post, _conn, _events}
 
       log = session_log_fixture(account: account)
 
-      assert :ok = perform_job(HTTP.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(HTTP.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:post, conn, [event]}
       assert conn.request_path == "/ingest"
@@ -50,10 +50,10 @@ defmodule Portal.HTTP.SyncTest do
       sink =
         http_log_sink_fixture(account: account, bearer_token: nil, enabled_streams: [:session])
 
-      assert :ok = perform_job(HTTP.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(HTTP.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
-      assert :ok = perform_job(HTTP.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(HTTP.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:post, conn, [_event]}
       assert Plug.Conn.get_req_header(conn, "authorization") == []
@@ -63,11 +63,11 @@ defmodule Portal.HTTP.SyncTest do
       sink =
         http_log_sink_fixture(account: account, batch_max_events: 2, enabled_streams: [:session])
 
-      assert :ok = perform_job(HTTP.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(HTTP.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       logs = for _ <- 1..5, do: session_log_fixture(account: account)
 
-      assert :ok = perform_job(HTTP.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(HTTP.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       batches =
         for _ <- 1..3 do
@@ -89,7 +89,7 @@ defmodule Portal.HTTP.SyncTest do
       sink =
         http_log_sink_fixture(account: account, batch_max_events: 1, enabled_streams: [:flow])
 
-      assert :ok = perform_job(HTTP.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(HTTP.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       flow1 =
         flow_log_fixture(
@@ -108,7 +108,7 @@ defmodule Portal.HTTP.SyncTest do
 
       flow2 = flow_log_fixture(account: account)
 
-      assert :ok = perform_job(HTTP.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(HTTP.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:post, _conn, [start1, end1]}
       assert start1["log_id"] == flow1.log_id <> "-s"
@@ -143,14 +143,14 @@ defmodule Portal.HTTP.SyncTest do
 
     test "a 401 disables the sink immediately with the response excerpt", %{account: account} do
       sink = http_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(HTTP.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(HTTP.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(HTTP.APIClient, fn conn ->
         Plug.Conn.send_resp(conn, 401, "invalid token")
       end)
 
-      assert :ok = perform_job(HTTP.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(HTTP.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       assert sink.is_disabled
@@ -160,14 +160,14 @@ defmodule Portal.HTTP.SyncTest do
 
     test "a 429 is transient", %{account: account} do
       sink = http_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(HTTP.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(HTTP.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(HTTP.APIClient, fn conn ->
         Plug.Conn.send_resp(conn, 429, "slow down")
       end)
 
-      assert :ok = perform_job(HTTP.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(HTTP.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       cursor = get_cursor(sink, :session, :live)
       assert cursor.synced_count == 0

--- a/elixir/test/portal/http/sync_test.exs
+++ b/elixir/test/portal/http/sync_test.exs
@@ -177,6 +177,17 @@ defmodule Portal.HTTP.SyncTest do
       assert sink.errored_at
       assert sink.error_message == "The endpoint returned HTTP 429: slow down"
     end
+
+    test "skips sink belonging to another account", %{account: account} do
+      sink = http_log_sink_fixture(account: account, enabled_streams: [:session])
+      session_log_fixture(account: account)
+      other_account = account_fixture(features: %{log_sinks: true})
+
+      assert :ok = perform_job(HTTP.Sync, %{account_id: other_account.id, log_sink_id: sink.id})
+
+      refute_receive {:post, _conn, _events}
+      assert Repo.all(LogSinkCursor) == []
+    end
   end
 
   describe "Scheduler" do
@@ -188,7 +199,7 @@ defmodule Portal.HTTP.SyncTest do
 
       assert {:ok, :scheduled} = perform_job(HTTP.Scheduler, %{})
 
-      assert_enqueued(worker: HTTP.Sync, args: %{log_sink_id: sink.id})
+      assert_enqueued(worker: HTTP.Sync, args: %{account_id: sink.account_id, log_sink_id: sink.id})
       refute_enqueued(worker: HTTP.Sync, args: %{log_sink_id: disabled_sink.id})
       refute_enqueued(worker: HTTP.Sync, args: %{log_sink_id: feature_off_sink.id})
     end

--- a/elixir/test/portal/new_relic/sync_test.exs
+++ b/elixir/test/portal/new_relic/sync_test.exs
@@ -124,6 +124,17 @@ defmodule Portal.NewRelic.SyncTest do
       refute sink.is_disabled
       assert sink.errored_at
     end
+
+    test "skips sink belonging to another account", %{account: account} do
+      sink = newrelic_log_sink_fixture(account: account, enabled_streams: [:session])
+      session_log_fixture(account: account)
+      other_account = account_fixture(features: %{log_sinks: true})
+
+      assert :ok = perform_job(NewRelic.Sync, %{account_id: other_account.id, log_sink_id: sink.id})
+
+      refute_receive {:intake, _conn, _events}
+      assert Repo.all(LogSinkCursor) == []
+    end
   end
 
   describe "Scheduler" do
@@ -135,7 +146,7 @@ defmodule Portal.NewRelic.SyncTest do
 
       assert {:ok, :scheduled} = perform_job(NewRelic.Scheduler, %{})
 
-      assert_enqueued(worker: NewRelic.Sync, args: %{log_sink_id: sink.id})
+      assert_enqueued(worker: NewRelic.Sync, args: %{account_id: sink.account_id, log_sink_id: sink.id})
       refute_enqueued(worker: NewRelic.Sync, args: %{log_sink_id: disabled_sink.id})
       refute_enqueued(worker: NewRelic.Sync, args: %{log_sink_id: feature_off_sink.id})
     end

--- a/elixir/test/portal/new_relic/sync_test.exs
+++ b/elixir/test/portal/new_relic/sync_test.exs
@@ -27,11 +27,11 @@ defmodule Portal.NewRelic.SyncTest do
   describe "perform/1" do
     test "delivers the detailed payload format", %{account: account} do
       sink = newrelic_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(NewRelic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(NewRelic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       log = session_log_fixture(account: account)
 
-      assert :ok = perform_job(NewRelic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(NewRelic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:intake, conn, [%{"logs" => [event]}]}
       assert conn.request_path == "/log/v1"
@@ -64,9 +64,9 @@ defmodule Portal.NewRelic.SyncTest do
           enabled_streams: [:session]
         )
 
-      assert :ok = perform_job(NewRelic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(NewRelic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
-      assert :ok = perform_job(NewRelic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(NewRelic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:intake, conn, _payload}
       assert conn.host == "log-api.eu.newrelic.com"
@@ -80,9 +80,9 @@ defmodule Portal.NewRelic.SyncTest do
           enabled_streams: [:session]
         )
 
-      assert :ok = perform_job(NewRelic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(NewRelic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
-      assert :ok = perform_job(NewRelic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(NewRelic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:intake, conn, _payload}
       assert conn.host == "log-api.jp.nr-data.net"
@@ -90,7 +90,7 @@ defmodule Portal.NewRelic.SyncTest do
 
     test "a 403 disables the sink immediately", %{account: account} do
       sink = newrelic_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(NewRelic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(NewRelic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(NewRelic.APIClient, fn conn ->
@@ -99,7 +99,7 @@ defmodule Portal.NewRelic.SyncTest do
         |> Req.Test.json(%{"message" => "Invalid license key"})
       end)
 
-      assert :ok = perform_job(NewRelic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(NewRelic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       assert sink.is_disabled
@@ -109,7 +109,7 @@ defmodule Portal.NewRelic.SyncTest do
 
     test "a 429 is transient", %{account: account} do
       sink = newrelic_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(NewRelic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(NewRelic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(NewRelic.APIClient, fn conn ->
@@ -118,7 +118,7 @@ defmodule Portal.NewRelic.SyncTest do
         |> Req.Test.json(%{"message" => "Too many requests"})
       end)
 
-      assert :ok = perform_job(NewRelic.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(NewRelic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       refute sink.is_disabled

--- a/elixir/test/portal/okta/sync_test.exs
+++ b/elixir/test/portal/okta/sync_test.exs
@@ -466,6 +466,17 @@ defmodule Portal.Okta.SyncTest do
       assert Repo.all(Group) == []
     end
 
+    test "skips directory belonging to another account" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = okta_directory_fixture(account: account)
+      other_account = account_fixture(features: %{idp_sync: true})
+
+      assert :ok = perform_job(Sync, %{account_id: other_account.id, directory_id: directory.id})
+
+      assert Repo.all(ExternalIdentity) == []
+      assert Repo.all(Group) == []
+    end
+
     test "returns :ok for jobs without a directory_id arg" do
       assert :ok = Sync.perform(%Oban.Job{args: %{"foo" => "bar"}})
     end

--- a/elixir/test/portal/okta/sync_test.exs
+++ b/elixir/test/portal/okta/sync_test.exs
@@ -124,7 +124,7 @@ defmodule Portal.Okta.SyncTest do
         end
       end)
 
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # Verify identity was created
       identities = Repo.all(ExternalIdentity)
@@ -260,7 +260,7 @@ defmodule Portal.Okta.SyncTest do
 
       log =
         capture_log(fn ->
-          assert :ok = perform_job(Sync, %{directory_id: directory.id})
+          assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end)
 
       identities = Repo.all(ExternalIdentity)
@@ -309,7 +309,7 @@ defmodule Portal.Okta.SyncTest do
         }
       ])
 
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       suspended_identity =
         Repo.get_by!(ExternalIdentity,
@@ -340,7 +340,7 @@ defmodule Portal.Okta.SyncTest do
         }
       ])
 
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       identities = Repo.all(ExternalIdentity)
       assert Enum.map(identities, & &1.email) == ["active@example.com"]
@@ -450,7 +450,7 @@ defmodule Portal.Okta.SyncTest do
         end
       end)
 
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       assert Repo.get_by!(Portal.Policy, account_id: account.id, id: policy.id).group_id ==
                group.id
@@ -459,7 +459,7 @@ defmodule Portal.Okta.SyncTest do
     test "handles missing directory gracefully" do
       non_existent_id = Ecto.UUID.generate()
 
-      assert :ok = perform_job(Sync, %{directory_id: non_existent_id})
+      assert :ok = perform_job(Sync, %{account_id: Ecto.UUID.generate(), directory_id: non_existent_id})
 
       # No data should be created
       assert Repo.all(ExternalIdentity) == []
@@ -480,7 +480,7 @@ defmodule Portal.Okta.SyncTest do
           is_disabled: true
         )
 
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # No data should be created
       assert Repo.all(ExternalIdentity) == []
@@ -548,7 +548,7 @@ defmodule Portal.Okta.SyncTest do
 
       # Should raise SyncError with appropriate message
       assert_raise SyncError, ~r/missing 'email' field/, fn ->
-        perform_job(Sync, %{directory_id: directory.id})
+        perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
       end
     end
 
@@ -613,7 +613,7 @@ defmodule Portal.Okta.SyncTest do
 
       # Should raise SyncError with appropriate message
       assert_raise SyncError, ~r/missing 'email' field/, fn ->
-        perform_job(Sync, %{directory_id: directory.id})
+        perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
       end
     end
 
@@ -674,7 +674,7 @@ defmodule Portal.Okta.SyncTest do
 
       error =
         assert_raise SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :batch_upsert_identities
@@ -760,7 +760,7 @@ defmodule Portal.Okta.SyncTest do
 
       error =
         assert_raise SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :batch_upsert_memberships
@@ -784,7 +784,7 @@ defmodule Portal.Okta.SyncTest do
       end)
 
       assert_raise SyncError, ~r/get_access_token/, fn ->
-        perform_job(Sync, %{directory_id: directory.id})
+        perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
       end
     end
 
@@ -821,7 +821,7 @@ defmodule Portal.Okta.SyncTest do
       end)
 
       assert_raise SyncError, ~r/scopes: missing.*okta\.users\.read/, fn ->
-        perform_job(Sync, %{directory_id: directory.id})
+        perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
       end
     end
 
@@ -855,7 +855,7 @@ defmodule Portal.Okta.SyncTest do
       assert_raise SyncError,
                    ~r/missing okta\.apps\.read, okta\.users\.read, okta\.groups\.read/,
                    fn ->
-                     perform_job(Sync, %{directory_id: directory.id})
+                     perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
                    end
     end
 
@@ -892,7 +892,7 @@ defmodule Portal.Okta.SyncTest do
       end)
 
       assert_raise SyncError, ~r/list_apps/, fn ->
-        perform_job(Sync, %{directory_id: directory.id})
+        perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
       end
     end
 
@@ -935,7 +935,7 @@ defmodule Portal.Okta.SyncTest do
         end
       end)
 
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # Error state should be cleared
       updated_directory = Repo.get(Portal.Okta.Directory, directory.id)
@@ -983,7 +983,7 @@ defmodule Portal.Okta.SyncTest do
 
       error =
         assert_raise SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :stream_app_users
@@ -1024,7 +1024,7 @@ defmodule Portal.Okta.SyncTest do
 
       error =
         assert_raise SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :stream_app_users
@@ -1071,7 +1071,7 @@ defmodule Portal.Okta.SyncTest do
 
       error =
         assert_raise SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :stream_app_groups
@@ -1115,7 +1115,7 @@ defmodule Portal.Okta.SyncTest do
 
       error =
         assert_raise SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :stream_app_groups
@@ -1221,7 +1221,7 @@ defmodule Portal.Okta.SyncTest do
 
       log =
         capture_log(fn ->
-          assert :ok = perform_job(Sync, %{directory_id: directory.id})
+          assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end)
 
       memberships = Repo.all(Membership)
@@ -1283,7 +1283,7 @@ defmodule Portal.Okta.SyncTest do
 
       error =
         assert_raise SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       assert error.step == :stream_group_members
@@ -1350,7 +1350,7 @@ defmodule Portal.Okta.SyncTest do
       # Capture the raised exception
       exception =
         assert_raise SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       # Simulate Oban telemetry error handling
@@ -1411,7 +1411,7 @@ defmodule Portal.Okta.SyncTest do
       # Capture the raised exception
       exception =
         assert_raise SyncError, fn ->
-          perform_job(Sync, %{directory_id: directory.id})
+          perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
         end
 
       # Simulate Oban telemetry error handling
@@ -1512,7 +1512,7 @@ defmodule Portal.Okta.SyncTest do
 
       # Should raise SyncError due to circuit breaker
       assert_raise SyncError, ~r/would delete all identities/, fn ->
-        perform_job(Sync, %{directory_id: directory.id})
+        perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
       end
 
       # Verify no identities were deleted
@@ -1622,7 +1622,7 @@ defmodule Portal.Okta.SyncTest do
 
       # Should raise SyncError due to circuit breaker on groups
       assert_raise SyncError, ~r/would delete all groups/, fn ->
-        perform_job(Sync, %{directory_id: directory.id})
+        perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
       end
 
       # Verify no groups were deleted
@@ -1719,7 +1719,7 @@ defmodule Portal.Okta.SyncTest do
       end)
 
       # Should succeed - deletion is below threshold
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
 
       # Verify 2 identities were deleted
       identity_count =
@@ -1772,7 +1772,7 @@ defmodule Portal.Okta.SyncTest do
       end)
 
       # Should succeed even though nothing is returned (first sync)
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      assert :ok = perform_job(Sync, %{account_id: directory.account_id, directory_id: directory.id})
     end
   end
 

--- a/elixir/test/portal/qradar/sync_test.exs
+++ b/elixir/test/portal/qradar/sync_test.exs
@@ -157,6 +157,17 @@ defmodule Portal.QRadar.SyncTest do
       assert sink.errored_at
       assert sink.error_message == "IBM QRadar returned HTTP 503"
     end
+
+    test "skips sink belonging to another account", %{account: account} do
+      sink = qradar_log_sink_fixture(account: account, enabled_streams: [:session])
+      session_log_fixture(account: account)
+      other_account = account_fixture(features: %{log_sinks: true})
+
+      assert :ok = perform_job(QRadar.Sync, %{account_id: other_account.id, log_sink_id: sink.id})
+
+      refute_receive {:receiver, _conn, _body}
+      assert Repo.all(LogSinkCursor) == []
+    end
   end
 
   describe "Scheduler" do
@@ -168,7 +179,7 @@ defmodule Portal.QRadar.SyncTest do
 
       assert {:ok, :scheduled} = perform_job(QRadar.Scheduler, %{})
 
-      assert_enqueued(worker: QRadar.Sync, args: %{log_sink_id: sink.id})
+      assert_enqueued(worker: QRadar.Sync, args: %{account_id: sink.account_id, log_sink_id: sink.id})
       refute_enqueued(worker: QRadar.Sync, args: %{log_sink_id: disabled_sink.id})
       refute_enqueued(worker: QRadar.Sync, args: %{log_sink_id: feature_off_sink.id})
     end

--- a/elixir/test/portal/qradar/sync_test.exs
+++ b/elixir/test/portal/qradar/sync_test.exs
@@ -31,13 +31,13 @@ defmodule Portal.QRadar.SyncTest do
           auth_header: "Bearer test-shared-secret"
         )
 
-      assert :ok = perform_job(QRadar.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(QRadar.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       refute_receive {:receiver, _conn, _body}
 
       log = session_log_fixture(account: account)
 
-      assert :ok = perform_job(QRadar.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(QRadar.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:receiver, conn, body}
       assert conn.method == "POST"
@@ -64,12 +64,12 @@ defmodule Portal.QRadar.SyncTest do
       account: account
     } do
       sink = qradar_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(QRadar.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(QRadar.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       session_log_fixture(account: account)
       session_log_fixture(account: account)
 
-      assert :ok = perform_job(QRadar.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(QRadar.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:receiver, conn, body}
       assert Plug.Conn.get_req_header(conn, "authorization") == []
@@ -85,14 +85,14 @@ defmodule Portal.QRadar.SyncTest do
 
     test "a 403 disables the sink immediately with an actionable message", %{account: account} do
       sink = qradar_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(QRadar.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(QRadar.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(QRadar.APIClient, fn conn ->
         Plug.Conn.send_resp(conn, 403, "Forbidden")
       end)
 
-      assert :ok = perform_job(QRadar.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(QRadar.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       assert sink.is_disabled
@@ -103,7 +103,7 @@ defmodule Portal.QRadar.SyncTest do
 
     test "a redirect disables the sink and points at the listen port", %{account: account} do
       sink = qradar_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(QRadar.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(QRadar.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(QRadar.APIClient, fn conn ->
@@ -112,7 +112,7 @@ defmodule Portal.QRadar.SyncTest do
         |> Plug.Conn.send_resp(301, "")
       end)
 
-      assert :ok = perform_job(QRadar.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(QRadar.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       assert sink.is_disabled
@@ -123,14 +123,14 @@ defmodule Portal.QRadar.SyncTest do
 
     test "a 429 is transient", %{account: account} do
       sink = qradar_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(QRadar.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(QRadar.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(QRadar.APIClient, fn conn ->
         Plug.Conn.send_resp(conn, 429, "")
       end)
 
-      assert :ok = perform_job(QRadar.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(QRadar.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       cursor = get_cursor(sink, :session, :live)
       assert cursor.synced_count == 0
@@ -143,14 +143,14 @@ defmodule Portal.QRadar.SyncTest do
 
     test "a 503 is transient", %{account: account} do
       sink = qradar_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(QRadar.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(QRadar.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(QRadar.APIClient, fn conn ->
         Plug.Conn.send_resp(conn, 503, "")
       end)
 
-      assert :ok = perform_job(QRadar.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(QRadar.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       refute sink.is_disabled

--- a/elixir/test/portal/s3/sync_test.exs
+++ b/elixir/test/portal/s3/sync_test.exs
@@ -264,6 +264,17 @@ defmodule Portal.S3.SyncTest do
       assert sink.disabled_reason == "Sync error"
       assert sink.error_message == "Amazon S3 returned HTTP 403 (AccessDenied): Access Denied"
     end
+
+    test "skips sink belonging to another account", %{account: account} do
+      sink = s3_log_sink_fixture(account: account, enabled_streams: [:session])
+      session_log_fixture(account: account)
+      other_account = account_fixture(features: %{log_sinks: true})
+
+      assert :ok = perform_job(S3.Sync, %{account_id: other_account.id, log_sink_id: sink.id})
+
+      refute_receive {:put_object, _conn, _body}
+      assert Repo.all(LogSinkCursor) == []
+    end
   end
 
   describe "Scheduler" do
@@ -275,7 +286,7 @@ defmodule Portal.S3.SyncTest do
 
       assert {:ok, :scheduled} = perform_job(S3.Scheduler, %{})
 
-      assert_enqueued(worker: S3.Sync, args: %{log_sink_id: sink.id})
+      assert_enqueued(worker: S3.Sync, args: %{account_id: sink.account_id, log_sink_id: sink.id})
       refute_enqueued(worker: S3.Sync, args: %{log_sink_id: disabled_sink.id})
       refute_enqueued(worker: S3.Sync, args: %{log_sink_id: feature_off_sink.id})
     end

--- a/elixir/test/portal/s3/sync_test.exs
+++ b/elixir/test/portal/s3/sync_test.exs
@@ -74,11 +74,11 @@ defmodule Portal.S3.SyncTest do
           key_prefix: "firezone/logs"
         )
 
-      assert :ok = perform_job(S3.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(S3.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       log = session_log_fixture(account: account)
 
-      assert :ok = perform_job(S3.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(S3.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:sts, _probe_conn, probe_params}
       assert probe_params["RoleArn"] == sink.role_arn
@@ -127,7 +127,7 @@ defmodule Portal.S3.SyncTest do
 
     test "redelivery after a transient failure reuses the same object key", %{account: account} do
       sink = s3_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(S3.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(S3.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       test_pid = self()
@@ -146,7 +146,7 @@ defmodule Portal.S3.SyncTest do
         end
       end)
 
-      assert :ok = perform_job(S3.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(S3.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       assert_receive {:put_object_key, first_key}
 
       sink_after_failure = reload_sink(sink)
@@ -164,7 +164,7 @@ defmodule Portal.S3.SyncTest do
         end
       end)
 
-      assert :ok = perform_job(S3.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(S3.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       assert_receive {:put_object_key, second_key}
 
       assert first_key == second_key
@@ -173,7 +173,7 @@ defmodule Portal.S3.SyncTest do
 
     test "a role that ignores the external id disables the sink", %{account: account} do
       sink = s3_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(S3.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(S3.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(S3.APIClient, fn conn ->
@@ -181,7 +181,7 @@ defmodule Portal.S3.SyncTest do
         Plug.Conn.resp(conn, 200, @sts_response)
       end)
 
-      assert :ok = perform_job(S3.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(S3.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       assert sink.is_disabled
@@ -191,14 +191,14 @@ defmodule Portal.S3.SyncTest do
 
     test "an STS AccessDenied disables the sink with an actionable message", %{account: account} do
       sink = s3_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(S3.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(S3.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(S3.APIClient, fn conn ->
         Plug.Conn.resp(conn, 403, @sts_access_denied)
       end)
 
-      assert :ok = perform_job(S3.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(S3.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       assert sink.is_disabled
@@ -212,7 +212,7 @@ defmodule Portal.S3.SyncTest do
       account: account
     } do
       sink = s3_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(S3.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(S3.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(S3.APIClient, fn conn ->
@@ -230,7 +230,7 @@ defmodule Portal.S3.SyncTest do
         end
       end)
 
-      assert :ok = perform_job(S3.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(S3.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       assert sink.is_disabled
@@ -240,7 +240,7 @@ defmodule Portal.S3.SyncTest do
 
     test "a 403 from S3 disables the sink immediately", %{account: account} do
       sink = s3_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(S3.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(S3.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(S3.APIClient, fn conn ->
@@ -257,7 +257,7 @@ defmodule Portal.S3.SyncTest do
         end
       end)
 
-      assert :ok = perform_job(S3.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(S3.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       assert sink.is_disabled

--- a/elixir/test/portal/safe_test.exs
+++ b/elixir/test/portal/safe_test.exs
@@ -2,6 +2,7 @@ defmodule Portal.SafeTest do
   use Portal.DataCase, async: true
   import Ecto.Query
   import Portal.AccountFixtures
+  import Portal.SubjectFixtures
   alias Portal.Safe
   alias Portal.Account
 
@@ -209,5 +210,85 @@ defmodule Portal.SafeTest do
       assert Safe.permit(:read, __MODULE__, :account_admin_user) == {:error, :unauthorized}
       assert Safe.permit(:delete, Portal.ChangeLog, :service_account) == {:error, :unauthorized}
     end
+  end
+
+  describe "scoped bulk writes" do
+    setup do
+      account = account_fixture()
+      other_account = account_fixture()
+
+      %{
+        account: account,
+        other_account: other_account,
+        subject: admin_subject_fixture(account: account)
+      }
+    end
+
+    test "insert_all stamps the subject's account on entries that omit it", %{
+      account: account,
+      subject: subject
+    } do
+      assert {1, nil} =
+               Safe.scoped(subject)
+               |> Safe.insert_all(Portal.Group, [group_entry("Stamped")])
+
+      assert [group] = Repo.all(Portal.Group)
+      assert group.account_id == account.id
+      assert group.name == "Stamped"
+    end
+
+    test "insert_all refuses entries naming another account", %{
+      other_account: other_account,
+      subject: subject
+    } do
+      entries = [group_entry("Mine"), group_entry("Theirs", other_account.id)]
+
+      assert {:error, :unauthorized} =
+               Safe.scoped(subject) |> Safe.insert_all(Portal.Group, entries)
+
+      assert Repo.all(Portal.Group) == []
+    end
+
+    test "insert_all refuses the query form", %{subject: subject} do
+      query = from(g in Portal.Group, select: %{})
+
+      assert {:error, :unauthorized} =
+               Safe.scoped(subject) |> Safe.insert_all(Portal.Group, query)
+    end
+
+    test "update_all only touches rows in the subject's account", %{
+      account: account,
+      other_account: other_account,
+      subject: subject
+    } do
+      Safe.unscoped()
+      |> Safe.insert_all(Portal.Group, [
+        group_entry("Mine", account.id),
+        group_entry("Theirs", other_account.id)
+      ])
+
+      assert {1, nil} =
+               from(g in Portal.Group)
+               |> Safe.scoped(subject)
+               |> Safe.update_all(set: [name: "Renamed"])
+
+      assert Repo.get_by!(Portal.Group, account_id: account.id).name == "Renamed"
+      assert Repo.get_by!(Portal.Group, account_id: other_account.id).name == "Theirs"
+    end
+  end
+
+  defp group_entry(name, account_id \\ nil) do
+    now = DateTime.utc_now()
+
+    entry = %{
+      id: Ecto.UUID.generate(),
+      name: name,
+      type: :static,
+      entity_type: :group,
+      inserted_at: now,
+      updated_at: now
+    }
+
+    if account_id, do: Map.put(entry, :account_id, account_id), else: entry
   end
 end

--- a/elixir/test/portal/sentinel/sync_test.exs
+++ b/elixir/test/portal/sentinel/sync_test.exs
@@ -233,6 +233,17 @@ defmodule Portal.Sentinel.SyncTest do
       assert sink.errored_at
       assert sink.error_message == "Azure Monitor returned HTTP 429: Rate limit exceeded"
     end
+
+    test "skips sink belonging to another account", %{account: account} do
+      sink = sentinel_log_sink_fixture(account: account, enabled_streams: [:session])
+      session_log_fixture(account: account)
+      other_account = account_fixture(features: %{log_sinks: true})
+
+      assert :ok = perform_job(Sentinel.Sync, %{account_id: other_account.id, log_sink_id: sink.id})
+
+      refute_receive {:ingest, _conn, _events}
+      assert Repo.all(LogSinkCursor) == []
+    end
   end
 
   describe "Scheduler" do
@@ -244,7 +255,7 @@ defmodule Portal.Sentinel.SyncTest do
 
       assert {:ok, :scheduled} = perform_job(Sentinel.Scheduler, %{})
 
-      assert_enqueued(worker: Sentinel.Sync, args: %{log_sink_id: sink.id})
+      assert_enqueued(worker: Sentinel.Sync, args: %{account_id: sink.account_id, log_sink_id: sink.id})
       refute_enqueued(worker: Sentinel.Sync, args: %{log_sink_id: disabled_sink.id})
       refute_enqueued(worker: Sentinel.Sync, args: %{log_sink_id: feature_off_sink.id})
     end

--- a/elixir/test/portal/sentinel/sync_test.exs
+++ b/elixir/test/portal/sentinel/sync_test.exs
@@ -40,13 +40,13 @@ defmodule Portal.Sentinel.SyncTest do
       account: account
     } do
       sink = sentinel_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Sentinel.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       refute_receive {:token, _conn, _params}
 
       log = session_log_fixture(account: account)
 
-      assert :ok = perform_job(Sentinel.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:token, token_conn, token_params}
       assert token_conn.request_path == "/#{sink.tenant_id}/oauth2/v2.0/token"
@@ -78,7 +78,7 @@ defmodule Portal.Sentinel.SyncTest do
 
     test "a token error for a missing service principal disables the sink", %{account: account} do
       sink = sentinel_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Sentinel.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(Sentinel.APIClient, fn conn ->
@@ -92,7 +92,7 @@ defmodule Portal.Sentinel.SyncTest do
         })
       end)
 
-      assert :ok = perform_job(Sentinel.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       assert sink.is_disabled
@@ -103,7 +103,7 @@ defmodule Portal.Sentinel.SyncTest do
 
     test "a 403 is transient while the role propagates and names it", %{account: account} do
       sink = sentinel_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Sentinel.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       stub_ingest_status(403, %{
@@ -113,7 +113,7 @@ defmodule Portal.Sentinel.SyncTest do
         }
       })
 
-      assert :ok = perform_job(Sentinel.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       refute sink.is_disabled
@@ -136,9 +136,9 @@ defmodule Portal.Sentinel.SyncTest do
       end)
 
       sink = sentinel_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Sentinel.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
-      assert :ok = perform_job(Sentinel.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:token, _conn, params}
       assert params["client_assertion"] == "mi-federation-assertion"
@@ -154,7 +154,7 @@ defmodule Portal.Sentinel.SyncTest do
 
     test "an invalid stream 400 is a customer-facing transient error", %{account: account} do
       sink = sentinel_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Sentinel.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       log = session_log_fixture(account: account)
 
       stub_ingest_status(400, %{
@@ -166,7 +166,7 @@ defmodule Portal.Sentinel.SyncTest do
 
       log_output =
         ExUnit.CaptureLog.capture_log([level: :error], fn ->
-          assert :ok = perform_job(Sentinel.Sync, %{log_sink_id: sink.id})
+          assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 
       refute log_output =~ "cannot be delivered"
@@ -187,7 +187,7 @@ defmodule Portal.Sentinel.SyncTest do
       account: account
     } do
       sink = sentinel_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Sentinel.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       log = session_log_fixture(account: account)
 
       stub_ingest_status(400, %{
@@ -199,7 +199,7 @@ defmodule Portal.Sentinel.SyncTest do
 
       log_output =
         ExUnit.CaptureLog.capture_log([level: :error], fn ->
-          assert :ok = perform_job(Sentinel.Sync, %{log_sink_id: sink.id})
+          assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 
       assert log_output =~ "Log sink event cannot be delivered, halting stream"
@@ -216,14 +216,14 @@ defmodule Portal.Sentinel.SyncTest do
 
     test "a 429 is transient", %{account: account} do
       sink = sentinel_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Sentinel.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       stub_ingest_status(429, %{
         "error" => %{"code" => "TooManyRequests", "message" => "Rate limit exceeded"}
       })
 
-      assert :ok = perform_job(Sentinel.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       cursor = get_cursor(sink, :session, :live)
       assert cursor.synced_count == 0

--- a/elixir/test/portal/splunk/sync_test.exs
+++ b/elixir/test/portal/splunk/sync_test.exs
@@ -658,7 +658,7 @@ defmodule Portal.Splunk.SyncTest do
 
       assert {:ok, :scheduled} = perform_job(Splunk.Scheduler, %{})
 
-      assert_enqueued(worker: Splunk.Sync, args: %{log_sink_id: sink.id})
+      assert_enqueued(worker: Splunk.Sync, args: %{account_id: sink.account_id, log_sink_id: sink.id})
       refute_enqueued(worker: Splunk.Sync, args: %{log_sink_id: disabled_sink.id})
       refute_enqueued(worker: Splunk.Sync, args: %{log_sink_id: feature_off_sink.id})
     end

--- a/elixir/test/portal/splunk/sync_test.exs
+++ b/elixir/test/portal/splunk/sync_test.exs
@@ -33,7 +33,7 @@ defmodule Portal.Splunk.SyncTest do
       sink = splunk_log_sink_fixture(account: account)
       session_log_fixture(account: account)
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       refute_receive {:hec, _conn, _events}
       refute get_cursor(sink, :session, :live)
@@ -43,12 +43,12 @@ defmodule Portal.Splunk.SyncTest do
       session_log_fixture(account: account)
       sink = splunk_log_sink_fixture(account: account)
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       refute_receive {:hec, _conn, _events}
 
       log = session_log_fixture(account: account)
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:hec, conn, [event]}
       assert conn.request_path == "/services/collector/event"
@@ -69,14 +69,14 @@ defmodule Portal.Splunk.SyncTest do
 
     test "delivers every enabled stream with its own sourcetype", %{account: account} do
       sink = splunk_log_sink_fixture(account: account)
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       change_log_fixture(account: account)
       session_log_fixture(account: account)
       api_request_log_fixture(account: account)
       flow_log_fixture(account: account)
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sourcetypes =
         for _batch <- 1..4 do
@@ -100,7 +100,7 @@ defmodule Portal.Splunk.SyncTest do
           enabled_streams: [:session]
         )
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:hec, _conn, events}
       assert length(events) == 3
@@ -134,7 +134,7 @@ defmodule Portal.Splunk.SyncTest do
           enabled_streams: [:session]
         )
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:hec, _conn, events}
       assert length(events) == 2
@@ -146,7 +146,7 @@ defmodule Portal.Splunk.SyncTest do
       from(l in Portal.SessionLog, where: l.account_id == ^account.id)
       |> Repo.update_all(set: [timestamp: old])
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:hec, _conn, events}
       assert length(events) == 2
@@ -182,7 +182,7 @@ defmodule Portal.Splunk.SyncTest do
 
     test "closing a delivered flow sends only the end event", %{account: account} do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:flow])
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       flow =
         flow_log_fixture(
@@ -195,7 +195,7 @@ defmodule Portal.Splunk.SyncTest do
           tx_bytes: nil
         )
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:hec, _conn, [start_event]}
       assert start_event["event"]["log_id"] == flow.log_id <> "-s"
@@ -208,7 +208,7 @@ defmodule Portal.Splunk.SyncTest do
       flow_end = DateTime.utc_now()
       close_flow(account, flow_end)
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       # start_seq sits at or below this sink's frontier, so the start is known
       # to be delivered and only the end event ships: no duplicates.
@@ -223,7 +223,7 @@ defmodule Portal.Splunk.SyncTest do
 
     test "a flow that closes before delivery sends both events", %{account: account} do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:flow])
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       flow =
         flow_log_fixture(
@@ -240,7 +240,7 @@ defmodule Portal.Splunk.SyncTest do
       # the sink's frontier, so the start must be synthesized.
       close_flow(account, DateTime.utc_now())
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:hec, _conn, [start_event, end_event]}
       assert start_event["event"]["log_id"] == flow.log_id <> "-s"
@@ -259,7 +259,7 @@ defmodule Portal.Splunk.SyncTest do
           enabled_streams: [:flow]
         )
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:hec, _conn, [start_event, end_event]}
       assert start_event["event"]["log_id"] == flow.log_id <> "-s"
@@ -278,13 +278,13 @@ defmodule Portal.Splunk.SyncTest do
 
     test "splits deliveries that exceed the HEC request size limit", %{account: account} do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       blob = String.duplicate("x", 400_000)
       session_log_fixture(account: account, subject: %{"blob" => blob})
       session_log_fixture(account: account, subject: %{"blob" => blob})
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:hec, _conn, [_event_a]}
       assert_receive {:hec, _conn, [_event_b]}
@@ -295,7 +295,7 @@ defmodule Portal.Splunk.SyncTest do
 
     test "bisects a rejected batch until events deliver individually", %{account: account} do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       for _ <- 1..4 do
         session_log_fixture(account: account)
@@ -317,7 +317,7 @@ defmodule Portal.Splunk.SyncTest do
         end
       end)
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       for _ <- 1..4 do
         assert_receive {:hec_single, _event}
@@ -334,7 +334,7 @@ defmodule Portal.Splunk.SyncTest do
       account: account
     } do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       log =
         session_log_fixture(
@@ -350,7 +350,7 @@ defmodule Portal.Splunk.SyncTest do
 
       log_output =
         ExUnit.CaptureLog.capture_log([level: :error], fn ->
-          assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+          assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 
       assert log_output =~ "Log sink event cannot be delivered, halting stream"
@@ -370,7 +370,7 @@ defmodule Portal.Splunk.SyncTest do
       account: account
     } do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       session_log_fixture(account: account, actor_email: "fine@example.com")
       poison = session_log_fixture(account: account, actor_email: "poison@example.com")
@@ -394,7 +394,7 @@ defmodule Portal.Splunk.SyncTest do
 
       log_output =
         ExUnit.CaptureLog.capture_log([level: :error], fn ->
-          assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+          assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 
       assert log_output =~ "Log sink event cannot be delivered, halting stream"
@@ -414,7 +414,7 @@ defmodule Portal.Splunk.SyncTest do
 
     test "round timestamps render in fixed sec.ms notation", %{account: account} do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       # 1752480000.0 JSON-encodes as 1.75248e9, which HEC rejects with
       # "Error in handling indexed fields (code 15)".
@@ -423,7 +423,7 @@ defmodule Portal.Splunk.SyncTest do
         timestamp: DateTime.from_unix!(1_752_480_000_000_000, :microsecond)
       )
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       assert_receive {:hec, _conn, [event]}
       assert event["time"] == "1752480000.000"
@@ -431,7 +431,7 @@ defmodule Portal.Splunk.SyncTest do
 
     test "an indexed-fields rejection parks the stream and pages us", %{account: account} do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       poison = session_log_fixture(account: account, actor_email: "poison@example.com")
 
@@ -449,7 +449,7 @@ defmodule Portal.Splunk.SyncTest do
 
       log_output =
         ExUnit.CaptureLog.capture_log(fn ->
-          assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+          assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 
       assert log_output =~ "Log sink event cannot be delivered, halting stream"
@@ -466,7 +466,7 @@ defmodule Portal.Splunk.SyncTest do
 
     test "capacity warnings on successful deliveries are still successes", %{account: account} do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       log = session_log_fixture(account: account)
 
       Req.Test.stub(Splunk.APIClient, fn conn ->
@@ -476,7 +476,7 @@ defmodule Portal.Splunk.SyncTest do
         })
       end)
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       cursor = get_cursor(sink, :session, :live)
       assert cursor.cursor == log.seq
@@ -490,7 +490,7 @@ defmodule Portal.Splunk.SyncTest do
       account: account
     } do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(Splunk.APIClient, fn conn ->
@@ -501,7 +501,7 @@ defmodule Portal.Splunk.SyncTest do
 
       log_output =
         ExUnit.CaptureLog.capture_log([level: :error], fn ->
-          assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+          assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 
       assert log_output =~ "Log sink event cannot be delivered, halting stream"
@@ -518,7 +518,7 @@ defmodule Portal.Splunk.SyncTest do
 
     test "a redirect disables the sink with a pointed error", %{account: account} do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(Splunk.APIClient, fn conn ->
@@ -530,7 +530,7 @@ defmodule Portal.Splunk.SyncTest do
         |> Plug.Conn.send_resp(303, "")
       end)
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       cursor = get_cursor(sink, :session, :live)
       assert cursor.synced_count == 0
@@ -542,7 +542,7 @@ defmodule Portal.Splunk.SyncTest do
 
     test "a 4xx response disables the sink immediately", %{account: account} do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(Splunk.APIClient, fn conn ->
@@ -551,7 +551,7 @@ defmodule Portal.Splunk.SyncTest do
         |> Req.Test.json(%{"text" => "Invalid token", "code" => 4})
       end)
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       assert sink.is_disabled
@@ -565,7 +565,7 @@ defmodule Portal.Splunk.SyncTest do
 
     test "transient errors disable the sink only after 24 hours", %{account: account} do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(Splunk.APIClient, fn conn ->
@@ -574,7 +574,7 @@ defmodule Portal.Splunk.SyncTest do
         |> Req.Test.json(%{"text" => "Server is busy", "code" => 9})
       end)
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       refute sink.is_disabled
@@ -588,7 +588,7 @@ defmodule Portal.Splunk.SyncTest do
         |> Ecto.Changeset.change(errored_at: stale_errored_at)
         |> Repo.update()
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       assert sink.is_disabled
@@ -597,14 +597,14 @@ defmodule Portal.Splunk.SyncTest do
 
     test "transport errors are transient", %{account: account} do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
       session_log_fixture(account: account)
 
       Req.Test.stub(Splunk.APIClient, fn conn ->
         Req.Test.transport_error(conn, :econnrefused)
       end)
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       refute sink.is_disabled
@@ -621,7 +621,7 @@ defmodule Portal.Splunk.SyncTest do
           error_message: "Splunk HEC returned HTTP 503: Server is busy"
         )
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
 
       sink = reload_sink(sink)
       refute sink.errored_at
@@ -631,8 +631,18 @@ defmodule Portal.Splunk.SyncTest do
     test "skips sinks that are disabled or missing", %{account: account} do
       sink = splunk_log_sink_fixture(account: account, is_disabled: true)
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: Ecto.UUID.generate()})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
+      assert :ok = perform_job(Splunk.Sync, %{account_id: account.id, log_sink_id: Ecto.UUID.generate()})
+
+      refute_receive {:hec, _conn, _events}
+      assert Repo.all(LogSinkCursor) == []
+    end
+
+    test "skips sink belonging to another account", %{account: account} do
+      sink = splunk_log_sink_fixture(account: account)
+      other_account = account_fixture(features: %{log_sinks: true})
+
+      assert :ok = perform_job(Splunk.Sync, %{account_id: other_account.id, log_sink_id: sink.id})
 
       refute_receive {:hec, _conn, _events}
       assert Repo.all(LogSinkCursor) == []

--- a/elixir/test/portal_web/live/settings/directory_sync_test.exs
+++ b/elixir/test/portal_web/live/settings/directory_sync_test.exs
@@ -1,5 +1,6 @@
 defmodule PortalWeb.Settings.DirectorySyncTest do
   use PortalWeb.ConnCase, async: true
+  use Oban.Testing, repo: Portal.Repo
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
@@ -144,12 +145,35 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
       assert html =~ "Directory enabled successfully."
       assert html =~ "Active"
 
-      html = render_click(lv, "sync_directory", %{"id" => directory.id, "type" => "google"})
+      html = render_click(lv, "sync_directory", %{"id" => directory.id})
       assert html =~ "Directory sync has been queued successfully."
+
+      assert_enqueued(
+        worker: Portal.Google.Sync,
+        args: %{account_id: account.id, directory_id: directory.id}
+      )
 
       html = render_click(lv, "delete_directory", %{"id" => directory.id})
       assert html =~ "Directory deleted successfully."
       refute html =~ "Ops Google"
+    end
+
+    test "sync rejects directories from other accounts", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      other_directory = google_directory_fixture(name: "Other Account Google")
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/directory_sync")
+
+      html = render_click(lv, "sync_directory", %{"id" => other_directory.id})
+
+      assert html =~ "Failed to queue directory sync."
+      refute_enqueued(worker: Portal.Google.Sync)
     end
 
     test "closes the actions menu when navigating to edit", %{

--- a/elixir/test/portal_web/live/settings/log_sinks_test.exs
+++ b/elixir/test/portal_web/live/settings/log_sinks_test.exs
@@ -1039,7 +1039,7 @@ defmodule PortalWeb.Settings.LogSinksTest do
       |> element("button[phx-click='sync_sink'][phx-value-id='#{sink.id}']")
       |> render_click()
 
-      assert_enqueued(worker: Splunk.Sync, args: %{log_sink_id: sink.id})
+      assert_enqueued(worker: Splunk.Sync, args: %{account_id: sink.account_id, log_sink_id: sink.id})
     end
 
     test "deliver now rejects sinks from other accounts", %{


### PR DESCRIPTION
The "Sync Now" button on the Directory Sync settings page took the directory id straight from the browser and put it in a background job. Nothing checked that the directory belonged to the admin's own account, and the worker looked the row up by id alone, so an admin who knew another account's directory id could start a sync in that account.

Sync jobs now carry the account id next to the row id, and the workers resolve the row by both. That way the check holds even if a future caller forgets it. The settings pages pick the row out of the account-scoped list they already loaded before queueing anything.

Log sink deliveries were not exposed, because that page already resolved the sink from the account-scoped list, but they get the same treatment so the rule is the same everywhere.

Jobs queued in the minute before this ships have no account id and are skipped. The schedulers queue them again on the next tick.
