### PR TITLE
fix(portal): make log index migration idempotent

### DIFF
--- a/elixir/priv/repo/migrations/20260812000003_add_account_id_to_log_timestamp_indexes.exs
+++ b/elixir/priv/repo/migrations/20260812000003_add_account_id_to_log_timestamp_indexes.exs
@@ -18,21 +18,21 @@ defmodule Portal.Repo.Migrations.AddAccountIdToLogTimestampIndexes do
 
   def up do
     for {table, timestamp} <- @indexes do
-      create(index(table, [timestamp, :account_id], concurrently: true))
+      create_if_not_exists(index(table, [timestamp, :account_id], concurrently: true))
     end
 
     for {table, timestamp} <- @indexes do
-      drop(index(table, [timestamp], concurrently: true))
+      drop_if_exists(index(table, [timestamp], concurrently: true))
     end
   end
 
   def down do
     for {table, timestamp} <- @indexes do
-      create(index(table, [timestamp], concurrently: true))
+      create_if_not_exists(index(table, [timestamp], concurrently: true))
     end
 
     for {table, timestamp} <- @indexes do
-      drop(index(table, [timestamp, :account_id], concurrently: true))
+      drop_if_exists(index(table, [timestamp, :account_id], concurrently: true))
     end
   end
 end


### PR DESCRIPTION
The log timestamp index migration builds and drops indexes concurrently. A concurrent build can fail part way, and the migration could not be retried after that: the plain `CREATE INDEX` hit the half-built index and stopped with "already exists".

It now skips work that is already done, so a retry finishes the job.

One caveat: a failed concurrent build leaves an unusable index behind, and the retry skips it instead of rebuilding it. After a failed run, look for `indisvalid = false` in `pg_index` and reindex anything listed.

Related: #14642
