### PR TITLE
fix(portal): treat provider throttling as transient

### DIFF
--- a/elixir/lib/portal/entra/error_handler.ex
+++ b/elixir/lib/portal/entra/error_handler.ex
@@ -12,6 +12,12 @@ defmodule Portal.Entra.ErrorHandler do
 
   @non_disabling_steps [:batch_upsert_identities, :batch_upsert_memberships]
 
+  # Req has already retried these before the response reaches us, so an
+  # exhausted throttle means the provider is busy, not that the directory is
+  # misconfigured. Disabling on one would make the admin re-verify to recover
+  # from rate limiting.
+  @throttled_statuses [408, 429]
+
   def handle(%Entra.SyncError{error: error, step: step}, directory_id) do
     type = classify(error, step)
     message = format(error)
@@ -31,17 +37,26 @@ defmodule Portal.Entra.ErrorHandler do
 
   # Classification
 
-  defp classify(%Req.Response{status: status} = _resp) when status >= 400 and status < 500 do
+  defp classify(%Req.Response{status: status}) when status in @throttled_statuses,
+    do: :transient
+
+  defp classify(%Req.Response{status: status}) when status >= 400 and status < 500 do
     :client_error
   end
 
   defp classify(%Req.Response{}), do: :transient
+
+  defp classify({:batch_all_failed, status, _body}) when status in @throttled_statuses,
+    do: :transient
 
   defp classify({:batch_all_failed, status, _body}) when status >= 400 and status < 500 do
     :client_error
   end
 
   defp classify({:batch_all_failed, _status, _body}), do: :transient
+
+  defp classify({:batch_request_failed, status, _body}) when status in @throttled_statuses,
+    do: :transient
 
   defp classify({:batch_request_failed, status, _body}) when status >= 400 and status < 500 do
     :client_error

--- a/elixir/lib/portal/google/error_handler.ex
+++ b/elixir/lib/portal/google/error_handler.ex
@@ -12,6 +12,12 @@ defmodule Portal.Google.ErrorHandler do
 
   @non_disabling_steps [:batch_upsert_identities, :batch_upsert_memberships]
 
+  # Req has already retried these before the response reaches us, so an
+  # exhausted throttle means the provider is busy, not that the directory is
+  # misconfigured. Disabling on one would make the admin re-verify to recover
+  # from rate limiting.
+  @throttled_statuses [408, 429]
+
   def handle(%Google.SyncError{error: error, step: step}, directory_id) do
     type = classify(error, step)
     message = format(error)
@@ -30,6 +36,9 @@ defmodule Portal.Google.ErrorHandler do
   defp classify(error, _step), do: classify(error)
 
   # Classification
+
+  defp classify(%Req.Response{status: status}) when status in @throttled_statuses,
+    do: :transient
 
   defp classify(%Req.Response{status: status}) when status >= 400 and status < 500 do
     :client_error

--- a/elixir/lib/portal/okta/error_handler.ex
+++ b/elixir/lib/portal/okta/error_handler.ex
@@ -12,6 +12,12 @@ defmodule Portal.Okta.ErrorHandler do
 
   @non_disabling_steps [:batch_upsert_identities, :batch_upsert_memberships]
 
+  # Req has already retried these before the response reaches us, so an
+  # exhausted throttle means the provider is busy, not that the directory is
+  # misconfigured. Disabling on one would make the admin re-verify to recover
+  # from rate limiting.
+  @throttled_statuses [408, 429]
+
   def handle(%Okta.SyncError{error: error, step: step}, directory_id) do
     type = classify(error, step)
     message = format(error)
@@ -30,6 +36,9 @@ defmodule Portal.Okta.ErrorHandler do
   defp classify(error, _step), do: classify(error)
 
   # Classification
+
+  defp classify(%Req.Response{status: status}) when status in @throttled_statuses,
+    do: :transient
 
   defp classify(%Req.Response{status: status}) when status >= 400 and status < 500 do
     :client_error

--- a/elixir/test/portal/directory_sync/throttle_classification_test.exs
+++ b/elixir/test/portal/directory_sync/throttle_classification_test.exs
@@ -1,0 +1,135 @@
+defmodule Portal.DirectorySync.ThrottleClassificationTest do
+  use Portal.DataCase, async: true
+
+  import Portal.EntraDirectoryFixtures
+  import Portal.GoogleDirectoryFixtures
+  import Portal.OktaDirectoryFixtures
+
+  @throttled [408, 429]
+
+  describe "Entra" do
+    test "keeps the directory enabled when the provider throttles" do
+      for status <- @throttled do
+        directory = entra_directory_fixture()
+
+        Portal.Entra.ErrorHandler.handle(
+          Portal.Entra.SyncError.exception(
+            directory_id: directory.id,
+            step: :list_users,
+            error: %Req.Response{status: status, body: ""}
+          ),
+          directory.id
+        )
+
+        directory = Repo.get!(Portal.Entra.Directory, directory.id)
+        refute directory.is_disabled
+        assert directory.errored_at
+      end
+    end
+
+    test "keeps the directory enabled when a throttled batch fails" do
+      for tag <- [:batch_all_failed, :batch_request_failed], status <- @throttled do
+        directory = entra_directory_fixture()
+
+        Portal.Entra.ErrorHandler.handle(
+          Portal.Entra.SyncError.exception(
+            directory_id: directory.id,
+            step: :list_users,
+            error: {tag, status, ""}
+          ),
+          directory.id
+        )
+
+        directory = Repo.get!(Portal.Entra.Directory, directory.id)
+        refute directory.is_disabled
+      end
+    end
+
+    test "still disables the directory when access is denied" do
+      directory = entra_directory_fixture()
+
+      Portal.Entra.ErrorHandler.handle(
+        Portal.Entra.SyncError.exception(
+          directory_id: directory.id,
+          step: :list_users,
+          error: %Req.Response{status: 403, body: ""}
+        ),
+        directory.id
+      )
+
+      assert Repo.get!(Portal.Entra.Directory, directory.id).is_disabled
+    end
+  end
+
+  describe "Google" do
+    test "keeps the directory enabled when the provider throttles" do
+      for status <- @throttled do
+        directory = google_directory_fixture()
+
+        Portal.Google.ErrorHandler.handle(
+          Portal.Google.SyncError.exception(
+            directory_id: directory.id,
+            step: :list_users,
+            error: %Req.Response{status: status, body: ""}
+          ),
+          directory.id
+        )
+
+        directory = Repo.get!(Portal.Google.Directory, directory.id)
+        refute directory.is_disabled
+        assert directory.errored_at
+      end
+    end
+
+    test "still disables the directory when access is denied" do
+      directory = google_directory_fixture()
+
+      Portal.Google.ErrorHandler.handle(
+        Portal.Google.SyncError.exception(
+          directory_id: directory.id,
+          step: :list_users,
+          error: %Req.Response{status: 403, body: ""}
+        ),
+        directory.id
+      )
+
+      assert Repo.get!(Portal.Google.Directory, directory.id).is_disabled
+    end
+  end
+
+  describe "Okta" do
+    test "keeps the directory enabled when the provider throttles" do
+      for status <- @throttled do
+        directory = okta_directory_fixture()
+
+        Portal.Okta.ErrorHandler.handle(
+          Portal.Okta.SyncError.exception(
+            directory_id: directory.id,
+            step: :list_users,
+            error: %Req.Response{status: status, body: ""}
+          ),
+          directory.id
+        )
+
+        directory = Repo.get!(Portal.Okta.Directory, directory.id)
+        refute directory.is_disabled
+        assert directory.errored_at
+      end
+    end
+
+    test "still disables the directory when access is denied" do
+      directory = okta_directory_fixture()
+
+      Portal.Okta.ErrorHandler.handle(
+        Portal.Okta.SyncError.exception(
+          directory_id: directory.id,
+          step: :list_users,
+          error: %Req.Response{status: 403, body: ""}
+        ),
+        directory.id
+      )
+
+      assert Repo.get!(Portal.Okta.Directory, directory.id).is_disabled
+    end
+  end
+end


### PR DESCRIPTION
When a directory provider rate limits us, Req retries the request a few times and then hands back the last response it got. If every attempt was throttled, that last response is a 429. The directory sync error handlers treated any 4xx as the customer's fault, so they disabled the directory, marked it unverified, and emailed the admin to go re-verify it. Nothing was actually wrong with the setup, and the busier the tenant the more likely it was to happen.

Throttling now counts as a temporary problem, like a timeout or a 500. The directory keeps running and retries on the next scheduled sync. If the provider is still throttling us a day later, the existing 24 hour rule disables it as before.

Log sink deliveries already worked this way. This brings directory sync in line.

Related: #14488
