### PR TITLE
fix(portal): standardize device trust timestamps

### DIFF
--- a/elixir/lib/portal_web/live/settings/device_trust/index.ex
+++ b/elixir/lib/portal_web/live/settings/device_trust/index.ex
@@ -452,7 +452,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
       </td>
       <td class="px-6 py-3 w-36">
         <span class="text-sm text-body">
-          {PortalWeb.Format.short_date(@trust_anchor.inserted_at)}
+          <.relative_datetime datetime={@trust_anchor.inserted_at} />
         </span>
       </td>
     </tr>
@@ -545,12 +545,26 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
               label == "Error" && "text-danger",
               label != "Error" && "text-heading"
             ]}>
-              {value}
+              <.detail_value value={value} />
             </dd>
           </div>
         </dl>
       </div>
     </div>
+    """
+  end
+
+  attr :value, :any, required: true
+
+  defp detail_value(%{value: %DateTime{}} = assigns) do
+    ~H"""
+    <.relative_datetime datetime={@value} />
+    """
+  end
+
+  defp detail_value(assigns) do
+    ~H"""
+    {@value}
     """
   end
 
@@ -612,7 +626,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
             <div>
               <dt class="text-[10px] text-subtle mb-0.5">Created</dt>
               <dd class="text-xs text-body">
-                {PortalWeb.Format.short_date(@trust_anchor.inserted_at)}
+                <.relative_datetime datetime={@trust_anchor.inserted_at} />
               </dd>
             </div>
             <div>
@@ -704,7 +718,9 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
               <dl class="space-y-2">
                 <div :for={{label, value} <- certificate_detail_rows(detail)}>
                   <dt class="text-[10px] text-subtle mb-0.5">{label}</dt>
-                  <dd class="text-xs text-heading font-mono break-all">{value}</dd>
+                  <dd class="text-xs text-heading font-mono break-all">
+                    <.detail_value value={value} />
+                  </dd>
                 </div>
               </dl>
             </div>
@@ -1279,9 +1295,9 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
       {"Revoked certificates", to_string(revoked_count)},
       {"List addresses", format_urls(endpoint.crl_urls)},
       {"Responder addresses", format_urls(endpoint.ocsp_urls)},
-      {"Failing since", format_datetime(endpoint.errored_at)},
+      {"Failing since", endpoint.errored_at},
       {"Stopped because", endpoint.is_disabled && endpoint.disabled_reason},
-      {"First seen", format_datetime(endpoint.inserted_at)}
+      {"First seen", endpoint.inserted_at}
     ]
     |> drop_blanks()
   end
@@ -1291,9 +1307,9 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
       []
     else
       [
-        {"Last fetched", format_datetime(endpoint.crl_fetched_at) || "Never"},
-        {"Published", format_datetime(endpoint.crl_this_update)},
-        {"Expires", format_datetime(endpoint.crl_next_update)},
+        {"Last fetched", endpoint.crl_fetched_at || "Never"},
+        {"Published", endpoint.crl_this_update},
+        {"Expires", endpoint.crl_next_update},
         {"CRL number", endpoint.crl_number && to_string(endpoint.crl_number)},
         {"Error", endpoint.crl_error}
       ]
@@ -1303,9 +1319,9 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
 
   defp delta_rows(endpoint) do
     [
-      {"Last fetched", format_datetime(endpoint.delta_fetched_at)},
-      {"Published", format_datetime(endpoint.delta_this_update)},
-      {"Expires", format_datetime(endpoint.delta_next_update)},
+      {"Last fetched", endpoint.delta_fetched_at},
+      {"Published", endpoint.delta_this_update},
+      {"Expires", endpoint.delta_next_update},
       {"Delta number", endpoint.delta_number && to_string(endpoint.delta_number)},
       {"Error", endpoint.delta_error}
     ]
@@ -1317,7 +1333,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
       []
     else
       [
-        {"Last checked", format_datetime(endpoint.ocsp_checked_at) || "Never"},
+        {"Last checked", endpoint.ocsp_checked_at || "Never"},
         {"Error", endpoint.ocsp_error}
       ]
       |> drop_blanks()
@@ -1326,9 +1342,6 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
 
   defp format_urls([]), do: nil
   defp format_urls(urls), do: Enum.join(urls, "\n")
-
-  defp format_datetime(nil), do: nil
-  defp format_datetime(datetime), do: PortalWeb.Format.short_datetime(datetime)
 
   defp drop_blanks(rows) do
     Enum.reject(rows, fn {_label, value} -> value in [nil, "", false] end)
@@ -1377,8 +1390,8 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
       {"Issuer", Map.get(detail, :issuer_name)},
       {"Serial Number", detail |> Map.get(:serial_number) |> format_serial()},
       {"Version", detail |> Map.get(:version) |> format_version()},
-      {"Valid From", detail |> Map.get(:not_before) |> format_date()},
-      {"Expires", detail |> Map.get(:not_after) |> format_date()},
+      {"Valid From", Map.get(detail, :not_before)},
+      {"Expires", Map.get(detail, :not_after)},
       {"Public Key",
        format_public_key(Map.get(detail, :public_key_algorithm), Map.get(detail, :public_key_size))},
       {"Signature Algorithm", Map.get(detail, :signature_algorithm)},
@@ -1412,9 +1425,6 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
 
   defp format_version(nil), do: nil
   defp format_version(version), do: version |> Atom.to_string() |> String.trim_leading("v")
-
-  defp format_date(nil), do: nil
-  defp format_date(datetime), do: PortalWeb.Format.short_date(datetime)
 
   defp format_public_key(nil, _key_size), do: nil
   defp format_public_key(algorithm, nil), do: algorithm

--- a/elixir/test/portal_web/live/settings/device_trust/index_test.exs
+++ b/elixir/test/portal_web/live/settings/device_trust/index_test.exs
@@ -39,6 +39,17 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
     lv |> element("tr[phx-click='toggle_revocation_endpoint']") |> render_click()
   end
 
+  defp timestamp_popovers(html) do
+    html
+    |> Floki.parse_fragment!()
+    |> Floki.find("[role='tooltip']")
+    |> Enum.map(&(Floki.text(&1) |> String.trim()))
+  end
+
+  defp assert_timestamp_popover(popovers, datetime) do
+    assert DateTime.to_iso8601(datetime) in popovers
+  end
+
   defp revocation_fixture(account, issuer, serial) do
     Repo.insert!(%Portal.CrlRevocation{
       account_id: account.id,
@@ -112,6 +123,36 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       assert html =~ "Corporate Issuing CA"
       assert html =~ "1 certificate"
     end
+
+    test "shows created timestamps with their raw values in popovers", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      inserted_at = ~U[2026-01-02 03:04:05.123456Z]
+
+      trust_anchor =
+        trust_anchor_fixture(account: account, name: "Corporate Issuing CA")
+        |> Ecto.Changeset.change(inserted_at: inserted_at)
+        |> Repo.update!()
+
+      conn = authorize_conn(conn, actor)
+
+      {:ok, _lv, index_html} =
+        conn
+        |> live(~p"/#{account}/settings/device_trust")
+
+      assert timestamp_popovers(index_html) == [DateTime.to_iso8601(inserted_at)]
+
+      {:ok, _lv, show_html} =
+        conn
+        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
+
+      assert timestamp_popovers(show_html) == [
+               DateTime.to_iso8601(inserted_at),
+               DateTime.to_iso8601(inserted_at)
+             ]
+    end
   end
 
   describe "show panel" do
@@ -181,6 +222,11 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       assert html =~ "http://crl.test.invalid/ec-ca.crl"
       assert html =~ "http://ocsp.test.invalid"
       assert html =~ "http://ca.test.invalid/root.cer"
+
+      {:ok, certificate} = X509.decode_der_certificate(sample_ec_ca_der())
+      popovers = timestamp_popovers(html)
+      assert_timestamp_popover(popovers, X509.not_before(certificate))
+      assert_timestamp_popover(popovers, X509.not_after(certificate))
 
       assert [download_link] =
                html
@@ -290,6 +336,41 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       assert expand_first_endpoint(lv) =~ "unsupported_url_scheme"
     end
 
+    test "shows revocation timestamps with their raw values in popovers", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      trust_anchor: trust_anchor,
+      issuer: issuer
+    } do
+      timestamps = %{
+        inserted_at: ~U[2026-01-02 03:04:05.100001Z],
+        errored_at: ~U[2026-01-03 03:04:05.100002Z],
+        crl_fetched_at: ~U[2026-01-04 03:04:05.100003Z],
+        crl_this_update: ~U[2026-01-05 03:04:05Z],
+        crl_next_update: ~U[2026-01-06 03:04:05Z],
+        delta_fetched_at: ~U[2026-01-07 03:04:05.100004Z],
+        delta_this_update: ~U[2026-01-08 03:04:05Z],
+        delta_next_update: ~U[2026-01-09 03:04:05Z],
+        ocsp_checked_at: ~U[2026-01-10 03:04:05.100005Z]
+      }
+
+      endpoint_fixture(account, issuer)
+      |> Ecto.Changeset.change(Map.put(timestamps, :ocsp_urls, ["http://ocsp.test.invalid"]))
+      |> Repo.update!()
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
+
+      open_revocation_tab(lv)
+      popovers = lv |> expand_first_endpoint() |> timestamp_popovers()
+
+      Enum.each(timestamps, fn {_field, datetime} ->
+        assert_timestamp_popover(popovers, datetime)
+      end)
+    end
 
     test "shows OCSP state for a CA that publishes no fetchable list", %{
       conn: conn,


### PR DESCRIPTION
## Summary

- render trust anchor creation timestamps with the shared relative datetime popover
- preserve typed timestamps in certificate and revocation detail rows so all displayed values expose the raw ISO timestamp
- add regression coverage for trust anchor, certificate, CRL, delta CRL, and OCSP timestamps

## Testing

- `mix test test/portal_web/live/settings` (334 tests)