### PR TITLE
feat(portal): count authorized connections by iceless state

### DIFF
--- a/elixir/lib/portal/telemetry.ex
+++ b/elixir/lib/portal/telemetry.ex
@@ -458,6 +458,16 @@ defmodule Portal.Telemetry do
   defp register_application_instruments(meter) do
     :otel_meter.create_counter(
       meter,
+      :"connections.authorized",
+      %{
+        description:
+          "Connections authorized, by ICE-less feature flag state and peer capability",
+        unit: :"1"
+      }
+    )
+
+    :otel_meter.create_counter(
+      meter,
       :"http.server.requests",
       %{description: "Total HTTP requests by route, method, and status", unit: :"1"}
     )
@@ -742,6 +752,47 @@ defmodule Portal.Telemetry do
 
     :otel_counter.add(ctx, meter, :"phoenix.channel.messages", 1, attrs)
     :otel_histogram.record(ctx, meter, :"phoenix.channel.message.duration", duration_ms, attrs)
+    :ok
+  end
+
+  @doc """
+  Records an authorized connection on the `connections.authorized` counter.
+
+  The attributes break the count down by the ICE-less feature flag state and
+  which peers reported the ICE-less capability, so adoption can be tracked as
+  a share of all connections and blockers (flag off vs. incapable peers) can
+  be told apart.
+  """
+  @spec connection_authorized(
+          :client_to_gateway | :client_to_client,
+          boolean(),
+          boolean(),
+          boolean()
+        ) :: :ok
+  def connection_authorized(
+        connection_type,
+        feature_enabled?,
+        initiator_capable?,
+        receiver_capable?
+      ) do
+    capability =
+      case {initiator_capable?, receiver_capable?} do
+        {true, true} -> "both"
+        {true, false} -> "initiator_only"
+        {false, true} -> "receiver_only"
+        {false, false} -> "neither"
+      end
+
+    attrs = %{
+      "connection_type" => to_string(connection_type),
+      "feature_flag" => if(feature_enabled?, do: "enabled", else: "disabled"),
+      "capability" => capability,
+      "iceless" => feature_enabled? and initiator_capable? and receiver_capable?,
+      "node_name" => System.get_env("NODE_NAME", to_string(node()))
+    }
+
+    meter = :opentelemetry_experimental.get_meter()
+    :otel_counter.add(:otel_ctx.get_current(), meter, :"connections.authorized", 1, attrs)
     :ok
   end
 

--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -449,9 +449,18 @@ defmodule PortalAPI.Client.Channel.Shared do
     {policy_authorization, payload} = Map.pop(payload, :policy_authorization)
     {initiator_iceless_capable, payload} = Map.pop(payload, :initiator_iceless_capable, false)
 
+    iceless_enabled = Portal.Account.iceless_enabled?(socket.assigns.subject.account)
+
     use_iceless =
       socket.assigns.iceless_capable == true and initiator_iceless_capable == true and
-        Portal.Account.iceless_enabled?(socket.assigns.subject.account)
+        iceless_enabled
+
+    Portal.Telemetry.connection_authorized(
+      :client_to_client,
+      iceless_enabled,
+      initiator_iceless_capable == true,
+      socket.assigns.iceless_capable == true
+    )
 
     payload = Map.put(payload, :use_iceless, use_iceless)
 

--- a/elixir/lib/portal_api/gateway/channel/shared.ex
+++ b/elixir/lib/portal_api/gateway/channel/shared.ex
@@ -309,9 +309,18 @@ defmodule PortalAPI.Gateway.Channel.Shared do
 
     rid_bytes = Ecto.UUID.dump!(resource.id)
 
+    iceless_enabled = Account.iceless_enabled?(socket.assigns.account)
+
     use_iceless =
       socket.assigns.iceless_capable == true and initiator_iceless_capable == true and
-        Account.iceless_enabled?(socket.assigns.account)
+        iceless_enabled
+
+    Portal.Telemetry.connection_authorized(
+      :client_to_gateway,
+      iceless_enabled,
+      initiator_iceless_capable == true,
+      socket.assigns.iceless_capable == true
+    )
 
     ref =
       encode_ref(socket, {

--- a/elixir/test/portal/telemetry_test.exs
+++ b/elixir/test/portal/telemetry_test.exs
@@ -450,6 +450,23 @@ defmodule Portal.TelemetryTest do
     end
   end
 
+  describe "connection_authorized/4" do
+    test "returns :ok for every feature flag and capability combination" do
+      for connection_type <- [:client_to_gateway, :client_to_client],
+          feature_enabled? <- [true, false],
+          initiator_capable? <- [true, false],
+          receiver_capable? <- [true, false] do
+        assert :ok =
+                 Portal.Telemetry.connection_authorized(
+                   connection_type,
+                   feature_enabled?,
+                   initiator_capable?,
+                   receiver_capable?
+                 )
+      end
+    end
+  end
+
   defp metric_names do
     Enum.map(Portal.Telemetry.metrics(), & &1.name)
   end


### PR DESCRIPTION
The ICE-less rollout needs visibility into what share of authorized connections actually negotiate ICE-less and what blocks the rest. Record a `connections.authorized` OTel counter at both authorization points (client-to-gateway and client-to-client), attributed by feature-flag state and which peers reported the capability, so adoption and its blockers (flag off vs. incapable peers) can be charted separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_018miKZ8YBVED747s5xtszk8)_