### PR TITLE
feat(portal): count policy authorizations by iceless status

### DIFF
--- a/elixir/lib/portal/telemetry.ex
+++ b/elixir/lib/portal/telemetry.ex
@@ -41,10 +41,10 @@ defmodule Portal.Telemetry do
         [:phoenix, :channel_handled_in]
       ]
     },
-    connections: %{
-      handler_id: "portal-connection-metrics",
+    authorizations: %{
+      handler_id: "portal-authorization-metrics",
       events: [
-        [:portal, :connection, :authorized]
+        [:portal, :authorization, :granted]
       ]
     }
   }
@@ -314,6 +314,27 @@ defmodule Portal.Telemetry do
       :ok
   end
 
+  @doc """
+  Records that the portal granted a policy authorization to a peer.
+
+  `receiver` is `:gateway` for client-to-gateway authorizations and `:client` for
+  client-to-client device access. The initiator is always the requesting client.
+
+  The three inputs the ICE-less decision is derived from are reported separately, so
+  an authorization that did not go ICE-less can be attributed to the account's
+  feature flag rather than to a peer that never advertised the capability (or the
+  other way around).
+  """
+  @spec authorization_granted(:client | :gateway, keyword()) :: :ok
+  def authorization_granted(receiver, opts) when receiver in [:client, :gateway] do
+    :telemetry.execute([:portal, :authorization, :granted], %{count: 1}, %{
+      receiver: receiver,
+      iceless_feature_enabled: Keyword.fetch!(opts, :iceless_feature_enabled) == true,
+      initiator_iceless_capable: Keyword.fetch!(opts, :initiator_iceless_capable) == true,
+      receiver_iceless_capable: Keyword.fetch!(opts, :receiver_iceless_capable) == true
+    })
+  end
+
   defp register_otel_instruments do
     meter = :opentelemetry_experimental.get_meter()
     node_attrs = %{"node_name" => System.get_env("NODE_NAME", to_string(node()))}
@@ -560,8 +581,11 @@ defmodule Portal.Telemetry do
 
     :otel_meter.create_counter(
       meter,
-      :"portal.connections.authorized",
-      %{description: "Total connections authorized, split by ICE-less eligibility", unit: :"1"}
+      :"portal.authorizations.granted",
+      %{
+        description: "Total policy authorizations granted, split by ICE-less eligibility",
+        unit: :"1"
+      }
     )
 
     :ok
@@ -757,15 +781,11 @@ defmodule Portal.Telemetry do
     :ok
   end
 
-  # `iceless` is the decision the portal handed to the peers; the three inputs it
-  # is derived from are kept as separate attributes so that a connection which
-  # missed out can be attributed to the account's feature flag rather than to a
-  # peer that never reported the capability (or the other way around).
   @doc false
-  @spec handle_connection_metric(list(), map(), map(), map()) :: :ok
-  def handle_connection_metric(
-        [:portal, :connection, :authorized],
-        _measurements,
+  @spec handle_authorization_metric(list(), map(), map(), map()) :: :ok
+  def handle_authorization_metric(
+        [:portal, :authorization, :granted],
+        measurements,
         metadata,
         config
       ) do
@@ -777,8 +797,8 @@ defmodule Portal.Telemetry do
     } = metadata
 
     attrs = %{
-      "connection.receiver" => to_string(receiver),
-      "iceless" => feature_enabled and initiator_capable and receiver_capable,
+      "authorization.receiver" => to_string(receiver),
+      "iceless.used" => feature_enabled and initiator_capable and receiver_capable,
       "iceless.feature_enabled" => feature_enabled,
       "iceless.initiator_capable" => initiator_capable,
       "iceless.receiver_capable" => receiver_capable,
@@ -786,7 +806,15 @@ defmodule Portal.Telemetry do
     }
 
     meter = :opentelemetry_experimental.get_meter()
-    :otel_counter.add(:otel_ctx.get_current(), meter, :"portal.connections.authorized", 1, attrs)
+
+    :otel_counter.add(
+      :otel_ctx.get_current(),
+      meter,
+      :"portal.authorizations.granted",
+      measurements.count,
+      attrs
+    )
+
     :ok
   end
 
@@ -840,7 +868,7 @@ defmodule Portal.Telemetry do
   defp metric_group_handler(:liveview_lifecycle), do: &__MODULE__.handle_liveview_lifecycle_metric/4
   defp metric_group_handler(:liveview_events), do: &__MODULE__.handle_liveview_event_metric/4
   defp metric_group_handler(:channels), do: &__MODULE__.handle_channel_metric/4
-  defp metric_group_handler(:connections), do: &__MODULE__.handle_connection_metric/4
+  defp metric_group_handler(:authorizations), do: &__MODULE__.handle_authorization_metric/4
 
   @doc false
   @spec endpoint_name(Plug.Conn.t()) :: String.t()

--- a/elixir/lib/portal/telemetry.ex
+++ b/elixir/lib/portal/telemetry.ex
@@ -40,6 +40,12 @@ defmodule Portal.Telemetry do
         [:phoenix, :channel_joined],
         [:phoenix, :channel_handled_in]
       ]
+    },
+    connections: %{
+      handler_id: "portal-connection-metrics",
+      events: [
+        [:portal, :connection, :authorized]
+      ]
     }
   }
 
@@ -552,6 +558,12 @@ defmodule Portal.Telemetry do
       %{description: "Channel message handling duration", unit: :ms}
     )
 
+    :otel_meter.create_counter(
+      meter,
+      :"portal.connections.authorized",
+      %{description: "Total connections authorized, split by ICE-less eligibility", unit: :"1"}
+    )
+
     :ok
   rescue
     error ->
@@ -745,6 +757,39 @@ defmodule Portal.Telemetry do
     :ok
   end
 
+  # `iceless` is the decision the portal handed to the peers; the three inputs it
+  # is derived from are kept as separate attributes so that a connection which
+  # missed out can be attributed to the account's feature flag rather than to a
+  # peer that never reported the capability (or the other way around).
+  @doc false
+  @spec handle_connection_metric(list(), map(), map(), map()) :: :ok
+  def handle_connection_metric(
+        [:portal, :connection, :authorized],
+        _measurements,
+        metadata,
+        config
+      ) do
+    %{
+      receiver: receiver,
+      iceless_feature_enabled: feature_enabled,
+      initiator_iceless_capable: initiator_capable,
+      receiver_iceless_capable: receiver_capable
+    } = metadata
+
+    attrs = %{
+      "connection.receiver" => to_string(receiver),
+      "iceless" => feature_enabled and initiator_capable and receiver_capable,
+      "iceless.feature_enabled" => feature_enabled,
+      "iceless.initiator_capable" => initiator_capable,
+      "iceless.receiver_capable" => receiver_capable,
+      "node_name" => config.node_name
+    }
+
+    meter = :opentelemetry_experimental.get_meter()
+    :otel_counter.add(:otel_ctx.get_current(), meter, :"portal.connections.authorized", 1, attrs)
+    :ok
+  end
+
   @spec enable_metrics(atom()) :: :ok | {:error, :already_enabled} | {:error, :unknown_group}
   def enable_metrics(group) do
     case Map.fetch(@metric_groups, group) do
@@ -795,6 +840,7 @@ defmodule Portal.Telemetry do
   defp metric_group_handler(:liveview_lifecycle), do: &__MODULE__.handle_liveview_lifecycle_metric/4
   defp metric_group_handler(:liveview_events), do: &__MODULE__.handle_liveview_event_metric/4
   defp metric_group_handler(:channels), do: &__MODULE__.handle_channel_metric/4
+  defp metric_group_handler(:connections), do: &__MODULE__.handle_connection_metric/4
 
   @doc false
   @spec endpoint_name(Plug.Conn.t()) :: String.t()

--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -449,9 +449,18 @@ defmodule PortalAPI.Client.Channel.Shared do
     {policy_authorization, payload} = Map.pop(payload, :policy_authorization)
     {initiator_iceless_capable, payload} = Map.pop(payload, :initiator_iceless_capable, false)
 
-    use_iceless =
-      socket.assigns.iceless_capable == true and initiator_iceless_capable == true and
-        Portal.Account.iceless_enabled?(socket.assigns.subject.account)
+    iceless_feature_enabled = Portal.Account.iceless_enabled?(socket.assigns.subject.account)
+    initiator_capable = initiator_iceless_capable == true
+    receiver_capable = socket.assigns.iceless_capable == true
+
+    use_iceless = iceless_feature_enabled and initiator_capable and receiver_capable
+
+    :telemetry.execute([:portal, :connection, :authorized], %{count: 1}, %{
+      receiver: :client,
+      iceless_feature_enabled: iceless_feature_enabled,
+      initiator_iceless_capable: initiator_capable,
+      receiver_iceless_capable: receiver_capable
+    })
 
     payload = Map.put(payload, :use_iceless, use_iceless)
 

--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -455,12 +455,11 @@ defmodule PortalAPI.Client.Channel.Shared do
 
     use_iceless = iceless_feature_enabled and initiator_capable and receiver_capable
 
-    :telemetry.execute([:portal, :connection, :authorized], %{count: 1}, %{
-      receiver: :client,
+    Portal.Telemetry.authorization_granted(:client,
       iceless_feature_enabled: iceless_feature_enabled,
       initiator_iceless_capable: initiator_capable,
       receiver_iceless_capable: receiver_capable
-    })
+    )
 
     payload = Map.put(payload, :use_iceless, use_iceless)
 

--- a/elixir/lib/portal_api/gateway/channel/shared.ex
+++ b/elixir/lib/portal_api/gateway/channel/shared.ex
@@ -12,7 +12,8 @@ defmodule PortalAPI.Gateway.Channel.Shared do
     PubSub,
     Resource,
     Presence,
-    SchemaHelpers
+    SchemaHelpers,
+    Telemetry
   }
 
   require Logger
@@ -313,7 +314,7 @@ defmodule PortalAPI.Gateway.Channel.Shared do
       socket.assigns.iceless_capable == true and initiator_iceless_capable == true and
         Account.iceless_enabled?(socket.assigns.account)
 
-    record_connection_authorized(socket, initiator_iceless_capable)
+    record_authorization_granted(socket, initiator_iceless_capable)
 
     ref =
       encode_ref(socket, {
@@ -389,7 +390,7 @@ defmodule PortalAPI.Gateway.Channel.Shared do
           client_ipv6: client_ipv6
         })
 
-        record_connection_authorized(socket, false)
+        record_authorization_granted(socket, false)
 
         cache =
           socket.assigns.cache
@@ -436,7 +437,7 @@ defmodule PortalAPI.Gateway.Channel.Shared do
           expires_at: DateTime.to_unix(authorization_expires_at, :second)
         })
 
-        record_connection_authorized(socket, false)
+        record_authorization_granted(socket, false)
 
         cache =
           socket.assigns.cache
@@ -734,13 +735,12 @@ defmodule PortalAPI.Gateway.Channel.Shared do
 
   # `initiator_iceless_capable` is always false on the deprecated 1.4 paths:
   # those clients predate the capability handshake, so they can never go ICE-less.
-  defp record_connection_authorized(socket, initiator_iceless_capable) do
-    :telemetry.execute([:portal, :connection, :authorized], %{count: 1}, %{
-      receiver: :gateway,
+  defp record_authorization_granted(socket, initiator_iceless_capable) do
+    Telemetry.authorization_granted(:gateway,
       iceless_feature_enabled: Account.iceless_enabled?(socket.assigns.account),
-      initiator_iceless_capable: initiator_iceless_capable == true,
-      receiver_iceless_capable: socket.assigns.iceless_capable == true
-    })
+      initiator_iceless_capable: initiator_iceless_capable,
+      receiver_iceless_capable: socket.assigns.iceless_capable
+    )
   end
 
   defp encode_ref(socket, tuple) do

--- a/elixir/lib/portal_api/gateway/channel/shared.ex
+++ b/elixir/lib/portal_api/gateway/channel/shared.ex
@@ -313,6 +313,8 @@ defmodule PortalAPI.Gateway.Channel.Shared do
       socket.assigns.iceless_capable == true and initiator_iceless_capable == true and
         Account.iceless_enabled?(socket.assigns.account)
 
+    record_connection_authorized(socket, initiator_iceless_capable)
+
     ref =
       encode_ref(socket, {
         channel_pid,
@@ -387,6 +389,8 @@ defmodule PortalAPI.Gateway.Channel.Shared do
           client_ipv6: client_ipv6
         })
 
+        record_connection_authorized(socket, false)
+
         cache =
           socket.assigns.cache
           |> Cache.Gateway.put(
@@ -431,6 +435,8 @@ defmodule PortalAPI.Gateway.Channel.Shared do
           client: client,
           expires_at: DateTime.to_unix(authorization_expires_at, :second)
         })
+
+        record_connection_authorized(socket, false)
 
         cache =
           socket.assigns.cache
@@ -724,6 +730,17 @@ defmodule PortalAPI.Gateway.Channel.Shared do
     Logger.error("Unknown gateway message", message: message, payload: payload)
 
     {:reply, {:error, %{reason: :unknown_message}}, socket}
+  end
+
+  # `initiator_iceless_capable` is always false on the deprecated 1.4 paths:
+  # those clients predate the capability handshake, so they can never go ICE-less.
+  defp record_connection_authorized(socket, initiator_iceless_capable) do
+    :telemetry.execute([:portal, :connection, :authorized], %{count: 1}, %{
+      receiver: :gateway,
+      iceless_feature_enabled: Account.iceless_enabled?(socket.assigns.account),
+      initiator_iceless_capable: initiator_iceless_capable == true,
+      receiver_iceless_capable: socket.assigns.iceless_capable == true
+    })
   end
 
   defp encode_ref(socket, tuple) do

--- a/elixir/test/portal/telemetry_test.exs
+++ b/elixir/test/portal/telemetry_test.exs
@@ -450,6 +450,123 @@ defmodule Portal.TelemetryTest do
     end
   end
 
+  describe "authorization_granted/2" do
+    setup do
+      test_pid = self()
+      handler_id = "test-authorization-granted-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:portal, :authorization, :granted],
+        fn _event, measurements, metadata, _config ->
+          # The handler is attached globally, so other async tests emitting the
+          # same event land in this mailbox too. Tag with the emitting pid so
+          # each test can ignore them.
+          send(test_pid, {:authorization_granted, self(), measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      %{test_pid: test_pid}
+    end
+
+    test "emits the event with a count of one", %{test_pid: test_pid} do
+      assert :ok =
+               Portal.Telemetry.authorization_granted(:gateway,
+                 iceless_feature_enabled: true,
+                 initiator_iceless_capable: true,
+                 receiver_iceless_capable: true
+               )
+
+      assert_receive {:authorization_granted, ^test_pid, measurements, metadata}
+
+      assert measurements == %{count: 1}
+
+      assert metadata == %{
+               receiver: :gateway,
+               iceless_feature_enabled: true,
+               initiator_iceless_capable: true,
+               receiver_iceless_capable: true
+             }
+    end
+
+    test "keeps the three iceless inputs apart", %{test_pid: test_pid} do
+      assert :ok =
+               Portal.Telemetry.authorization_granted(:client,
+                 iceless_feature_enabled: false,
+                 initiator_iceless_capable: true,
+                 receiver_iceless_capable: false
+               )
+
+      assert_receive {:authorization_granted, ^test_pid, _measurements, metadata}
+
+      assert metadata == %{
+               receiver: :client,
+               iceless_feature_enabled: false,
+               initiator_iceless_capable: true,
+               receiver_iceless_capable: false
+             }
+    end
+
+    test "coerces non-boolean inputs so callers can pass assigns as-is", %{test_pid: test_pid} do
+      assert :ok =
+               Portal.Telemetry.authorization_granted(:gateway,
+                 iceless_feature_enabled: nil,
+                 initiator_iceless_capable: "yes",
+                 receiver_iceless_capable: true
+               )
+
+      assert_receive {:authorization_granted, ^test_pid, _measurements, metadata}
+
+      assert metadata.iceless_feature_enabled == false
+      assert metadata.initiator_iceless_capable == false
+      assert metadata.receiver_iceless_capable == true
+    end
+
+    test "raises when an iceless input is missing" do
+      assert_raise KeyError, fn ->
+        Portal.Telemetry.authorization_granted(:gateway,
+          iceless_feature_enabled: true,
+          initiator_iceless_capable: true
+        )
+      end
+    end
+  end
+
+  describe "handle_authorization_metric/4" do
+    test "returns :ok for an ICE-less authorization" do
+      assert :ok =
+               Portal.Telemetry.handle_authorization_metric(
+                 [:portal, :authorization, :granted],
+                 %{count: 1},
+                 %{
+                   receiver: :gateway,
+                   iceless_feature_enabled: true,
+                   initiator_iceless_capable: true,
+                   receiver_iceless_capable: true
+                 },
+                 @config
+               )
+    end
+
+    test "returns :ok when the account feature flag is off" do
+      assert :ok =
+               Portal.Telemetry.handle_authorization_metric(
+                 [:portal, :authorization, :granted],
+                 %{count: 1},
+                 %{
+                   receiver: :client,
+                   iceless_feature_enabled: false,
+                   initiator_iceless_capable: true,
+                   receiver_iceless_capable: true
+                 },
+                 @config
+               )
+    end
+  end
+
   defp metric_names do
     Enum.map(Portal.Telemetry.metrics(), & &1.name)
   end

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -5496,13 +5496,13 @@ defmodule PortalAPI.Client.ChannelTest do
       pool_resource: pool_resource
     } do
       test_pid = self()
-      handler_id = "test-connection-authorized-#{System.unique_integer([:positive])}"
+      handler_id = "test-authorization-granted-#{System.unique_integer([:positive])}"
 
       :telemetry.attach(
         handler_id,
-        [:portal, :connection, :authorized],
+        [:portal, :authorization, :granted],
         fn _event, _measurements, metadata, _config ->
-          send(test_pid, {:connection_authorized, self(), metadata})
+          send(test_pid, {:authorization_granted, self(), metadata})
         end,
         nil
       )
@@ -5535,7 +5535,7 @@ defmodule PortalAPI.Client.ChannelTest do
       # The handler runs in the emitting channel, so match on the target's pid to
       # ignore events from other tests sharing the globally attached handler.
       target_channel_pid = target_socket.channel_pid
-      assert_receive {:connection_authorized, ^target_channel_pid, metadata}
+      assert_receive {:authorization_granted, ^target_channel_pid, metadata}
 
       assert metadata == %{
                receiver: :client,

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -5488,6 +5488,62 @@ defmodule PortalAPI.Client.ChannelTest do
       assert is_integer(target_expires_at)
     end
 
+    test "reports iceless inputs separately via telemetry", %{
+      client: client,
+      subject: subject,
+      target_client: target_client,
+      target_subject: target_subject,
+      pool_resource: pool_resource
+    } do
+      test_pid = self()
+      handler_id = "test-connection-authorized-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:portal, :connection, :authorized],
+        fn _event, _measurements, metadata, _config ->
+          send(test_pid, {:connection_authorized, self(), metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      # Both peers are iceless-capable; the account fixture leaves the feature off.
+      push(initiating_socket, "set_snownet_capabilities", %{"iceless" => true})
+      push(target_socket, "set_snownet_capabilities", %{"iceless" => true})
+
+      # Synchronous call on each channel, so both capability pushes are out of
+      # their mailboxes before the authorization can race them.
+      :sys.get_state(initiating_socket.channel_pid)
+      :sys.get_state(target_socket.channel_pid)
+
+      push(initiating_socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv4" => Portal.Types.INET.to_string(target_client.ipv4)
+      })
+
+      assert_push "client_device_access_authorized", %{use_iceless: false}
+
+      # The handler runs in the emitting channel, so match on the target's pid to
+      # ignore events from other tests sharing the globally attached handler.
+      target_channel_pid = target_socket.channel_pid
+      assert_receive {:connection_authorized, ^target_channel_pid, metadata}
+
+      assert metadata == %{
+               receiver: :client,
+               iceless_feature_enabled: false,
+               initiator_iceless_capable: true,
+               receiver_iceless_capable: true
+             }
+    end
+
     test "sends authorized when target ipv6 is found in presence", %{
       client: client,
       subject: subject,

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -5515,7 +5515,8 @@ defmodule PortalAPI.Client.ChannelTest do
       target_socket = join_channel(target_client, target_subject)
       assert_push "init", _
 
-      # Both peers are iceless-capable; the account fixture leaves the feature off.
+      # The account fixture has the feature on, so both peers advertising the
+      # capability is the case where the connection actually goes ICE-less.
       push(initiating_socket, "set_snownet_capabilities", %{"iceless" => true})
       push(target_socket, "set_snownet_capabilities", %{"iceless" => true})
 
@@ -5529,7 +5530,7 @@ defmodule PortalAPI.Client.ChannelTest do
         "ipv4" => Portal.Types.INET.to_string(target_client.ipv4)
       })
 
-      assert_push "client_device_access_authorized", %{use_iceless: false}
+      assert_push "client_device_access_authorized", %{use_iceless: true}
 
       # The handler runs in the emitting channel, so match on the target's pid to
       # ignore events from other tests sharing the globally attached handler.
@@ -5538,7 +5539,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
       assert metadata == %{
                receiver: :client,
-               iceless_feature_enabled: false,
+               iceless_feature_enabled: true,
                initiator_iceless_capable: true,
                receiver_iceless_capable: true
              }

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -3797,6 +3797,94 @@ defmodule PortalAPI.Gateway.ChannelTest do
       }
     end
 
+    test "create_authorization reports iceless inputs separately via telemetry", %{
+      client: client,
+      account: account,
+      actor: actor,
+      resource: resource,
+      gateway: gateway,
+      site: site,
+      token: token,
+      subject: subject,
+      group: group
+    } do
+      update_account(account, %{features: %{iceless: false}})
+
+      test_pid = self()
+      handler_id = "test-connection-authorized-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:portal, :connection, :authorized],
+        fn _event, _measurements, metadata, _config ->
+          send(test_pid, {:connection_authorized, self(), metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      socket = join_channel(gateway, site, token)
+      assert_push "init", %{relays: _}
+
+      # Both peers are iceless-capable, only the account flag holds them back.
+      push(socket, "set_snownet_capabilities", %{"iceless" => true})
+
+      policy_authorization =
+        policy_authorization_fixture(
+          account: account,
+          actor: actor,
+          client: client,
+          resource: resource,
+          group: group
+        )
+
+      expires_at = DateTime.utc_now() |> DateTime.add(30, :second)
+      preshared_key = "PSK"
+      public_key = Portal.DeviceFixtures.generate_public_key()
+
+      ice_credentials = %{
+        initiator: %{username: "A", password: "B"},
+        receiver: %{username: "C", password: "D"}
+      }
+
+      send(
+        socket.channel_pid,
+        {:create_authorization, {self(), make_ref()},
+         %{
+           client:
+             PortalAPI.Gateway.Views.Client.render(
+               client,
+               public_key,
+               preshared_key,
+               @test_user_agent
+             ),
+           subject: PortalAPI.Gateway.Views.Subject.render(subject),
+           resource: PortalAPI.Gateway.Views.Resource.render(to_cache(resource)),
+           resource_id: to_cache(resource).id,
+           policy_authorization_id: policy_authorization.id,
+           authorization_expires_at: expires_at,
+           ice_credentials: ice_credentials,
+           preshared_key: preshared_key,
+           initiator_iceless_capable: true
+         }}
+      )
+
+      assert_push "authorize_flow", %{use_iceless: false}
+
+      # The handler runs in the emitting channel, so match on its pid to ignore
+      # events from other tests sharing the globally attached handler.
+      gateway_channel_pid = socket.channel_pid
+      assert_receive {:connection_authorized, ^gateway_channel_pid, metadata}
+
+      assert metadata == %{
+               receiver: :gateway,
+               iceless_feature_enabled: false,
+               initiator_iceless_capable: true,
+               receiver_iceless_capable: true
+             }
+    end
+
     test "use_iceless picks up an account flag toggled on after join", %{
       client: client,
       account: account,

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -3811,13 +3811,13 @@ defmodule PortalAPI.Gateway.ChannelTest do
       update_account(account, %{features: %{iceless: false}})
 
       test_pid = self()
-      handler_id = "test-connection-authorized-#{System.unique_integer([:positive])}"
+      handler_id = "test-authorization-granted-#{System.unique_integer([:positive])}"
 
       :telemetry.attach(
         handler_id,
-        [:portal, :connection, :authorized],
+        [:portal, :authorization, :granted],
         fn _event, _measurements, metadata, _config ->
-          send(test_pid, {:connection_authorized, self(), metadata})
+          send(test_pid, {:authorization_granted, self(), metadata})
         end,
         nil
       )
@@ -3875,7 +3875,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       # The handler runs in the emitting channel, so match on its pid to ignore
       # events from other tests sharing the globally attached handler.
       gateway_channel_pid = socket.channel_pid
-      assert_receive {:connection_authorized, ^gateway_channel_pid, metadata}
+      assert_receive {:authorization_granted, ^gateway_channel_pid, metadata}
 
       assert metadata == %{
                receiver: :gateway,


### PR DESCRIPTION
The portal already decides per authorization whether the peers can run ICE-less, but nothing records the outcome, so there is no way to tell how far the rollout has actually got. Emit an OpenTelemetry counter for every policy authorization the portal grants, tagged with the resolved decision and with each of the three inputs it is derived from, so that an authorization which stayed on ICE can be attributed to the account feature flag rather than to a peer that never advertised the capability.

Authorizations granted over the deprecated 1.4 paths are counted as well, so the denominator is every authorization the portal grants rather than only those on the current handshake.