### PR TITLE
fix(portal): authorize Entra tenant setup

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -124,6 +124,8 @@ if config_env() == :prod do
   # When ENTRA_OIDC_CLIENT_SECRET is unset, authorization-code redemption
   # authenticates with a token-exchange assertion from the portal's managed
   # identity. The optional secret supports dev and migration environments.
+  # The Entra app registration must set groupMembershipClaims to DirectoryRole
+  # so setup tokens include the signed `wids` claim used for the admin check.
   config :portal, Portal.Entra.AuthProvider,
     client_id: env_var_to_config!(:entra_oidc_client_id),
     client_secret: env_var_to_config!(:entra_oidc_client_secret)
@@ -132,6 +134,9 @@ if config_env() == :prod do
   # authenticates with workload identity federation, minting a token-exchange
   # assertion from the portal's managed identity (Portal.Azure.ManagedIdentity).
   # The optional secret still flows from config.exs for environments that set it.
+  # The app registration must also declare the delegated Microsoft Graph
+  # permissions `openid` and `profile` so the `.default` admin-consent grant
+  # covers the signed user identity proof without a second consent prompt.
   config :portal, Portal.Entra.APIClient,
     client_id: env_var_to_config!(:entra_sync_client_id),
     token_base_url: "https://login.microsoftonline.com",

--- a/elixir/lib/portal/entra/api_client.ex
+++ b/elixir/lib/portal/entra/api_client.ex
@@ -90,6 +90,24 @@ defmodule Portal.Entra.APIClient do
   end
 
   @doc """
+  Lists the effective Entra directory roles for one immutable principal ID.
+  This is used during setup to prove that the user identified by the verified
+  ID token is authorized to grant the application's tenant-wide permissions.
+  """
+  def list_transitive_directory_roles(access_token, principal_id) do
+    query =
+      URI.encode_query(%{
+        "$select" => "id,roleTemplateId"
+      })
+
+    get(
+      "/v1.0/users/#{principal_id}/transitiveMemberOf/microsoft.graph.directoryRole",
+      query,
+      access_token
+    )
+  end
+
+  @doc """
   Streams assigned principals (users and groups) for the service principal.
   This respects group assignment settings in Entra.
   Returns a stream that yields pages of assignments.

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -1283,7 +1283,7 @@ defmodule PortalWeb.OIDCController do
   defp request_pending_verification(nil, _verification_ref), do: {:error, :no_pid}
 
   defp request_pending_verification(lv_pid, verification_ref) do
-    send(lv_pid, {:get_pending_verification, self()})
+    send(lv_pid, {:get_pending_verification, verification_ref, self()})
 
     receive do
       {:pending_verification, %{verification_ref: ^verification_ref} = pending} ->

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -28,19 +28,74 @@ defmodule PortalWeb.OIDCController do
       {:oidc_verification, lv_pid_string} ->
         handle_oidc_verification(conn, code, lv_pid_string)
 
+      {:entra_tenant_proof,
+       verification_type,
+       lv_pid_string,
+       verification_ref,
+       expected_tenant_id,
+       _silent?} ->
+        handle_entra_verification(
+          conn,
+          code,
+          lv_pid_string,
+          verification_ref,
+          verification_type,
+          expected_tenant_id
+        )
+
       _ ->
         handle_authentication_callback(conn, state, code)
     end
   end
 
-  # Handle Entra admin consent callback (returns admin_consent and may include tenant)
-  def callback(conn, %{"state" => state, "admin_consent" => _} = params) do
+  def callback(conn, %{"state" => state, "error" => _error} = params) do
     case parse_callback_state(state) do
-      {:entra_auth_provider, _lv_pid_string} ->
-        redirect(conn, to: ~p"/verification/entra?#{params}")
+      {:entra_auth_provider, lv_pid_string, verification_ref} ->
+        handle_entra_admin_consent_error(conn, params, lv_pid_string, verification_ref)
 
-      {:entra_directory_sync, _lv_pid_string} ->
-        redirect(conn, to: ~p"/verification/entra?#{params}")
+      {:entra_directory_sync, lv_pid_string, verification_ref} ->
+        handle_entra_admin_consent_error(conn, params, lv_pid_string, verification_ref)
+
+      {:entra_tenant_proof,
+       verification_type,
+       lv_pid_string,
+       verification_ref,
+       expected_tenant_id,
+       silent?} ->
+        handle_entra_tenant_proof_error(
+          conn,
+          params,
+          verification_type,
+          lv_pid_string,
+          verification_ref,
+          expected_tenant_id,
+          silent?
+        )
+
+      _ ->
+        handle_error(conn, {:error, :invalid_callback_params})
+    end
+  end
+
+  def callback(conn, %{"state" => state, "admin_consent" => "True"} = params) do
+    case parse_callback_state(state) do
+      {:entra_auth_provider, lv_pid_string, verification_ref} ->
+        handle_entra_admin_consent(
+          conn,
+          params,
+          "entra-auth-provider",
+          lv_pid_string,
+          verification_ref
+        )
+
+      {:entra_directory_sync, lv_pid_string, verification_ref} ->
+        handle_entra_admin_consent(
+          conn,
+          params,
+          "entra-directory-sync",
+          lv_pid_string,
+          verification_ref
+        )
 
       _ ->
         handle_error(conn, {:error, :invalid_callback_params})
@@ -880,6 +935,280 @@ defmodule PortalWeb.OIDCController do
     redirect(conn, to: ~p"/verification/oidc?result=#{token}")
   end
 
+  defp handle_entra_verification(
+         conn,
+         code,
+         lv_pid_string,
+         verification_ref,
+         verification_type,
+         expected_tenant_id
+       ) do
+    verification_result =
+      lv_pid_string
+      |> PortalWeb.OIDC.deserialize_pid()
+      |> request_pending_verification(verification_ref)
+      |> verify_entra_callback(
+        code,
+        expected_tenant_id
+      )
+
+    case verification_result do
+      {:ok, identity} ->
+        result = %{
+          ok: true,
+          type: verification_type,
+          tenant_id: identity.tenant_id,
+          issuer: identity.issuer,
+          principal_id: identity.principal_id,
+          role_ids: identity.role_ids,
+          lv_pid: lv_pid_string,
+          verification_ref: verification_ref
+        }
+
+        redirect_with_entra_verification_result(conn, result)
+
+      {:error, error} ->
+        result = entra_verification_failure(error, lv_pid_string, verification_ref)
+        redirect_with_entra_verification_result(conn, result)
+    end
+  end
+
+  defp verify_entra_callback(
+         {:ok, %{config: config, verifier: verifier}},
+         code,
+         expected_tenant_id
+       ) do
+    case PortalWeb.OIDC.verify_entra_callback(config, code, verifier, expected_tenant_id) do
+      {:ok, identity} ->
+        {:ok, identity}
+
+      {:error, reason} ->
+        maybe_log_verification_error(reason)
+        {:error, verification_error_message(reason)}
+    end
+  end
+
+  defp verify_entra_callback(
+         {:error, reason},
+         _code,
+         _expected_tenant_id
+       ) do
+    {:error, pending_verification_error_message(reason)}
+  end
+
+  defp handle_entra_admin_consent(
+         conn,
+         params,
+         verification_type,
+         lv_pid_string,
+         verification_ref
+       )
+       when verification_type in ["entra-auth-provider", "entra-directory-sync"] do
+    tenant_id = params["tenant"]
+
+    pending_result =
+      lv_pid_string
+      |> PortalWeb.OIDC.deserialize_pid()
+      |> peek_pending_verification(verification_ref)
+
+    case pending_result do
+      {:ok, %{config: config, verifier: verifier}} ->
+        redirect_to_entra_tenant_proof(
+          conn,
+          config,
+          verifier,
+          tenant_id,
+          lv_pid_string,
+          verification_ref,
+          verification_type,
+          true
+        )
+
+      {:error, reason} ->
+        handle_entra_verification_error(
+          conn,
+          pending_verification_error_message(reason),
+          lv_pid_string,
+          verification_ref
+        )
+    end
+  end
+
+  defp redirect_to_entra_tenant_proof(
+         conn,
+         config,
+         verifier,
+         tenant_id,
+         lv_pid_string,
+         verification_ref,
+         verification_type,
+         silent?
+       ) do
+    state_token =
+      PortalWeb.OIDC.sign_verification_state(
+        lv_pid_string,
+        entra_tenant_proof_state_type(verification_type),
+        %{
+          silent: silent?,
+          tenant_id: tenant_id,
+          verification_ref: verification_ref
+        }
+      )
+
+    prompt = if silent?, do: "none", else: nil
+
+    case PortalWeb.OIDC.build_entra_tenant_authorization_uri(
+           config,
+           tenant_id,
+           verifier,
+           state_token,
+           prompt: prompt
+         ) do
+      {:ok, uri} ->
+        redirect(conn, external: uri)
+
+      {:error, reason} ->
+        maybe_log_verification_error(reason)
+
+        handle_entra_verification_error(
+          conn,
+          verification_error_message(reason),
+          lv_pid_string,
+          verification_ref
+        )
+    end
+  end
+
+  defp entra_tenant_proof_state_type("entra-auth-provider"),
+    do: "entra-auth-provider-tenant-proof"
+
+  defp entra_tenant_proof_state_type("entra-directory-sync"),
+    do: "entra-directory-sync-tenant-proof"
+
+  defp handle_entra_tenant_proof_error(
+         conn,
+         params,
+         verification_type,
+         lv_pid_string,
+         verification_ref,
+         tenant_id,
+         true
+       ) do
+    if silent_sso_unavailable?(params) do
+      pending_result =
+        lv_pid_string
+        |> PortalWeb.OIDC.deserialize_pid()
+        |> peek_pending_verification(verification_ref)
+
+      case pending_result do
+        {:ok, %{config: config, verifier: verifier}} ->
+          redirect_to_entra_tenant_proof(
+            conn,
+            config,
+            verifier,
+            tenant_id,
+            lv_pid_string,
+            verification_ref,
+            verification_type,
+            false
+          )
+
+        {:error, reason} ->
+          handle_entra_verification_error(
+            conn,
+            pending_verification_error_message(reason),
+            lv_pid_string,
+            verification_ref
+          )
+      end
+    else
+      handle_entra_verification_error(
+        conn,
+        entra_authorization_error_message(params),
+        lv_pid_string,
+        verification_ref
+      )
+    end
+  end
+
+  defp handle_entra_tenant_proof_error(
+         conn,
+         params,
+         _verification_type,
+         lv_pid_string,
+         verification_ref,
+         _tenant_id,
+         false
+       ) do
+    handle_entra_verification_error(
+      conn,
+      entra_authorization_error_message(params),
+      lv_pid_string,
+      verification_ref
+    )
+  end
+
+  defp silent_sso_unavailable?(%{"error" => error}) do
+    error in ["consent_required", "interaction_required", "login_required"]
+  end
+
+  defp silent_sso_unavailable?(_params), do: false
+
+  defp handle_entra_verification_error(conn, error_message, lv_pid_string, verification_ref) do
+    result =
+      case lv_pid_string
+           |> PortalWeb.OIDC.deserialize_pid()
+           |> request_pending_verification(verification_ref) do
+        {:ok, _pending} ->
+          entra_verification_failure(error_message, lv_pid_string, verification_ref)
+
+        {:error, reason} ->
+          entra_verification_failure(
+            pending_verification_error_message(reason),
+            lv_pid_string,
+            verification_ref
+          )
+      end
+
+    redirect_with_entra_verification_result(conn, result)
+  end
+
+  defp handle_entra_admin_consent_error(conn, params, lv_pid_string, verification_ref) do
+    handle_entra_verification_error(
+      conn,
+      entra_authorization_error_message(params),
+      lv_pid_string,
+      verification_ref
+    )
+  end
+
+  defp entra_authorization_error_message(params) do
+    case params do
+      %{"error_description" => description} when is_binary(description) and description != "" ->
+        description
+
+      %{"error" => error} when is_binary(error) and error != "" ->
+        error
+
+      _ ->
+        "Microsoft Entra authorization failed. Please try again."
+    end
+  end
+
+  defp entra_verification_failure(error, lv_pid_string, verification_ref) do
+    %{
+      ok: false,
+      error: error,
+      lv_pid: lv_pid_string,
+      verification_ref: verification_ref
+    }
+  end
+
+  defp redirect_with_entra_verification_result(conn, result) do
+    token = Phoenix.Token.sign(PortalWeb.Endpoint, "entra-verification-result", result)
+    redirect(conn, to: ~p"/verification/entra?result=#{token}")
+  end
+
   defp verify_oidc_callback(
          {:ok, %{config: config, verifier: verifier} = pending},
          code,
@@ -951,6 +1280,38 @@ defmodule PortalWeb.OIDCController do
     end
   end
 
+  defp request_pending_verification(nil, _verification_ref), do: {:error, :no_pid}
+
+  defp request_pending_verification(lv_pid, verification_ref) do
+    send(lv_pid, {:get_pending_verification, self()})
+
+    receive do
+      {:pending_verification, %{verification_ref: ^verification_ref} = pending} ->
+        {:ok, pending}
+
+      {:pending_verification, _} ->
+        {:error, :not_found}
+    after
+      5_000 -> {:error, :timeout}
+    end
+  end
+
+  defp peek_pending_verification(nil, _verification_ref), do: {:error, :no_pid}
+
+  defp peek_pending_verification(lv_pid, verification_ref) do
+    send(lv_pid, {:peek_pending_verification, self()})
+
+    receive do
+      {:pending_verification, %{verification_ref: ^verification_ref} = pending} ->
+        {:ok, pending}
+
+      {:pending_verification, _} ->
+        {:error, :not_found}
+    after
+      5_000 -> {:error, :timeout}
+    end
+  end
+
   defp pending_verification_error_message(reason)
        when reason in [:no_pid, :not_found, :timeout] do
     "Verification session was not found or has expired. Please retry verification."
@@ -978,6 +1339,14 @@ defmodule PortalWeb.OIDCController do
     "Unable to verify your identity token. Please try again."
   end
 
+  defp verification_error_message({:invalid_entra_id_token, _reason}) do
+    "Unable to verify the Microsoft Entra tenant. Please try again."
+  end
+
+  defp verification_error_message(:invalid_entra_tenant) do
+    "Unable to verify the Microsoft Entra tenant. Please try again."
+  end
+
   defp verification_error_message(:email_not_verified) do
     @unverified_email_error
   end
@@ -989,9 +1358,43 @@ defmodule PortalWeb.OIDCController do
   defp parse_callback_state(state) do
     case PortalWeb.OIDC.verify_verification_state(state) do
       {:ok, %{type: "oidc-auth-provider", lv_pid: lv_pid}} -> {:oidc_verification, lv_pid}
-      {:ok, %{type: "entra-auth-provider", lv_pid: lv_pid}} -> {:entra_auth_provider, lv_pid}
-      {:ok, %{type: "entra-directory-sync", lv_pid: lv_pid}} -> {:entra_directory_sync, lv_pid}
+
+      {:ok,
+       %{type: "entra-auth-provider", lv_pid: lv_pid, verification_ref: verification_ref}}
+      when is_binary(verification_ref) ->
+        {:entra_auth_provider, lv_pid, verification_ref}
+
+      {:ok,
+       %{type: "entra-directory-sync", lv_pid: lv_pid, verification_ref: verification_ref}}
+      when is_binary(verification_ref) ->
+        {:entra_directory_sync, lv_pid, verification_ref}
+
+      {:ok,
+       %{
+         type: "entra-auth-provider-tenant-proof",
+         lv_pid: lv_pid,
+         verification_ref: verification_ref,
+         tenant_id: tenant_id,
+         silent: silent?
+       }}
+      when is_binary(verification_ref) and is_binary(tenant_id) and is_boolean(silent?) ->
+        {:entra_tenant_proof, "entra-auth-provider", lv_pid, verification_ref, tenant_id,
+         silent?}
+
+      {:ok,
+       %{
+         type: "entra-directory-sync-tenant-proof",
+         lv_pid: lv_pid,
+         verification_ref: verification_ref,
+         tenant_id: tenant_id,
+         silent: silent?
+       }}
+      when is_binary(verification_ref) and is_binary(tenant_id) and is_boolean(silent?) ->
+        {:entra_tenant_proof, "entra-directory-sync", lv_pid, verification_ref, tenant_id,
+         silent?}
+
       {:error, _} -> :authentication
+      _ -> :authentication
     end
   end
 

--- a/elixir/lib/portal_web/controllers/verification_controller.ex
+++ b/elixir/lib/portal_web/controllers/verification_controller.ex
@@ -6,6 +6,7 @@ defmodule PortalWeb.VerificationController do
   require Logger
   @verification_ack_timeout 5_000
   @verification_ack_error "Could not confirm verification in settings. Please try again."
+  @entra_admin_required_error "The Microsoft account completing setup must be a tenant-wide Global Administrator or Privileged Role Administrator."
 
   # Render standalone HTML pages with minimal layout (CSS only, no portal chrome)
   plug :put_root_layout, html: {PortalWeb.Layouts, :verification}
@@ -53,27 +54,19 @@ defmodule PortalWeb.VerificationController do
   end
 
   @doc """
-  Handles an Entra verification callback (both auth_provider and directory_sync flows).
-  Reads the LV PID and flow type from the signed state token passed through by OIDCController,
-  extracts tenant_id from params, sends result to LV PID, and renders success or failure.
+  Renders an Entra verification result. Auth-provider results contain a tenant
+  identity verified from an ID token; directory-sync results are accepted only
+  after this controller verifies the tenant's app-only Microsoft Graph grant.
   """
-  def entra(conn, %{"state" => state} = params) do
-    case PortalWeb.OIDC.verify_verification_state(state) do
-      {:ok,
-       %{type: "entra-auth-provider", lv_pid: lv_pid_string, verification_ref: verification_ref}}
-      when is_binary(verification_ref) ->
-        handle_entra_auth_provider(conn, params, lv_pid_string, verification_ref)
-
-      {:ok,
-       %{type: "entra-directory-sync", lv_pid: lv_pid_string, verification_ref: verification_ref}}
-      when is_binary(verification_ref) ->
-        handle_entra_directory_sync(conn, params, lv_pid_string, verification_ref)
-
-      {:ok, _state} ->
-        render(conn, :failure, error: "Invalid or expired verification state. Please try again.")
+  def entra(conn, %{"result" => result_token}) do
+    case Phoenix.Token.verify(PortalWeb.Endpoint, "entra-verification-result", result_token,
+           max_age: 60
+         ) do
+      {:ok, result} ->
+        render_entra_result(conn, result)
 
       {:error, _} ->
-        render(conn, :failure, error: "Invalid or expired verification state. Please try again.")
+        render_invalid_entra_result(conn)
     end
   end
 
@@ -81,57 +74,107 @@ defmodule PortalWeb.VerificationController do
     render(conn, :failure, error: "Invalid verification request. Please try again.")
   end
 
-  defp handle_entra_auth_provider(conn, params, lv_pid_string, verification_ref) do
+  defp render_entra_result(
+         conn,
+         %{
+           ok: true,
+           type: "entra-auth-provider",
+           issuer: issuer,
+           tenant_id: tenant_id,
+           role_ids: role_ids,
+           lv_pid: lv_pid_string,
+           verification_ref: verification_ref
+         }
+       )
+       when is_binary(issuer) and is_binary(tenant_id) and is_list(role_ids) and
+              is_binary(verification_ref) do
     lv_pid = PortalWeb.OIDC.deserialize_pid(lv_pid_string)
 
-    case run_entra_auth_provider_verification(params, lv_pid, verification_ref) do
-      :ok ->
-        render(conn, :success)
-
-      {:error, error_message, notify_lv?} ->
-        if notify_lv? and lv_pid,
-          do: send(lv_pid, {:verification_failed, error_message, verification_ref})
-
-        render(conn, :failure, error: error_message)
-    end
-  end
-
-  defp handle_entra_directory_sync(conn, params, lv_pid_string, verification_ref) do
-    lv_pid = PortalWeb.OIDC.deserialize_pid(lv_pid_string)
-
-    case run_entra_directory_sync_verification(params, lv_pid, verification_ref) do
-      :ok ->
-        render(conn, :success)
-
-      {:error, error_message, notify_lv?} ->
-        if notify_lv? and lv_pid,
-          do: send(lv_pid, {:verification_failed, error_message, verification_ref})
-
-        render(conn, :failure, error: error_message)
-    end
-  end
-
-  defp run_entra_auth_provider_verification(params, lv_pid, verification_ref) do
-    with {:ok, tenant_id} <- extract_tenant_id_for_verification(params),
-         issuer = "https://login.microsoftonline.com/#{tenant_id}/v2.0",
-         :ok <-
-           notify_and_await_ack(
+    if PortalWeb.OIDC.entra_setup_admin?(role_ids) do
+      case notify_and_await_ack(
              lv_pid,
              {:entra_verify_complete, issuer, tenant_id, verification_ref}
            ) do
-      :ok
+        :ok -> render(conn, :success)
+        {:error, _reason} -> render(conn, :failure, error: @verification_ack_error)
+      end
     else
-      {:error, reason} when reason in [:ack_timeout, :no_receiver] ->
-        ack_failure_result()
+      maybe_notify_verification_failure(
+        lv_pid,
+        verification_ref,
+        @entra_admin_required_error,
+        true
+      )
 
-      {:error, {:consent_error, reason}} ->
-        {:error, format_consent_error(reason, params), true}
+      render(conn, :failure, error: @entra_admin_required_error)
     end
   end
 
-  defp run_entra_directory_sync_verification(params, lv_pid, verification_ref) do
-    with {:ok, tenant_id} <- extract_tenant_id_for_verification(params),
-         {:ok, :verified} <- verify_directory_access_for_verification(tenant_id),
+  defp render_entra_result(
+         conn,
+         %{
+           ok: true,
+           type: "entra-directory-sync",
+           tenant_id: tenant_id,
+           principal_id: principal_id,
+           lv_pid: lv_pid_string,
+           verification_ref: verification_ref
+         }
+       )
+       when is_binary(tenant_id) and is_binary(principal_id) and is_binary(verification_ref) do
+    lv_pid = PortalWeb.OIDC.deserialize_pid(lv_pid_string)
+
+    case run_entra_directory_sync_verification(
+           tenant_id,
+           principal_id,
+           lv_pid,
+           verification_ref
+         ) do
+      :ok ->
+        render(conn, :success)
+
+      {:error, error_message, notify_lv?} ->
+        maybe_notify_verification_failure(lv_pid, verification_ref, error_message, notify_lv?)
+        render(conn, :failure, error: error_message)
+    end
+  end
+
+  defp render_entra_result(
+         conn,
+         %{
+           ok: false,
+           error: error,
+           lv_pid: lv_pid_string,
+           verification_ref: verification_ref
+         }
+       )
+       when is_binary(error) and is_binary(verification_ref) do
+    lv_pid = PortalWeb.OIDC.deserialize_pid(lv_pid_string)
+    maybe_notify_verification_failure(lv_pid, verification_ref, error, true)
+    render(conn, :failure, error: error)
+  end
+
+  defp render_entra_result(conn, _result), do: render_invalid_entra_result(conn)
+
+  defp render_invalid_entra_result(conn) do
+    render(conn, :failure, error: "Invalid or expired verification result. Please try again.")
+  end
+
+  defp maybe_notify_verification_failure(lv_pid, verification_ref, error, true)
+       when is_pid(lv_pid) do
+    send(lv_pid, {:verification_failed, error, verification_ref})
+  end
+
+  defp maybe_notify_verification_failure(_lv_pid, _verification_ref, _error, _notify_lv?),
+    do: :ok
+
+  defp run_entra_directory_sync_verification(
+         tenant_id,
+         principal_id,
+         lv_pid,
+         verification_ref
+       ) do
+    with {:ok, :verified} <- verify_directory_access_for_verification(tenant_id, principal_id),
          :ok <-
            notify_and_await_ack(
              lv_pid,
@@ -142,23 +185,13 @@ defmodule PortalWeb.VerificationController do
       {:error, reason} when reason in [:ack_timeout, :no_receiver] ->
         ack_failure_result()
 
-      {:error, {:consent_error, reason}} ->
-        {:error, format_consent_error(reason, params), true}
-
       {:error, {:directory_verification_error, reason}} ->
         {:error, format_entra_verification_error(reason), true}
     end
   end
 
-  defp extract_tenant_id_for_verification(params) do
-    case extract_tenant_id(params) do
-      {:ok, tenant_id} -> {:ok, tenant_id}
-      {:error, reason} -> {:error, {:consent_error, reason}}
-    end
-  end
-
-  defp verify_directory_access_for_verification(tenant_id) do
-    case verify_directory_access(tenant_id) do
+  defp verify_directory_access_for_verification(tenant_id, principal_id) do
+    case verify_directory_access(tenant_id, principal_id) do
       {:ok, :verified} = result -> result
       error -> {:error, {:directory_verification_error, error}}
     end
@@ -166,32 +199,7 @@ defmodule PortalWeb.VerificationController do
 
   defp ack_failure_result, do: {:error, @verification_ack_error, false}
 
-  defp extract_tenant_id(%{"admin_consent" => "True", "tenant" => tenant_id})
-       when is_binary(tenant_id) and tenant_id != "" do
-    {:ok, tenant_id}
-  end
-
-  defp extract_tenant_id(%{"error" => _error, "error_description" => desc})
-       when is_binary(desc) and desc != "" do
-    {:error, desc}
-  end
-
-  defp extract_tenant_id(%{"error" => error}) when is_binary(error) and error != "" do
-    {:error, error}
-  end
-
-  defp extract_tenant_id(%{"admin_consent" => admin_consent})
-       when admin_consent != "True" do
-    {:error, :consent_not_granted}
-  end
-
-  defp extract_tenant_id(_), do: {:error, :missing_tenant}
-
-  defp format_consent_error(:consent_not_granted, _params), do: "Admin consent was not granted"
-  defp format_consent_error(:missing_tenant, _params), do: "Missing tenant information"
-  defp format_consent_error(reason, _params) when is_binary(reason), do: reason
-
-  defp verify_directory_access(tenant_id) do
+  defp verify_directory_access(tenant_id, principal_id) do
     config = Portal.Config.fetch_env!(:portal, Entra.APIClient)
     client_id = config[:client_id]
 
@@ -201,10 +209,24 @@ defmodule PortalWeb.VerificationController do
            Entra.APIClient.get_service_principal(access_token, client_id),
          {:ok, %Req.Response{status: 200, body: %{"value" => _assignments}}} <-
            Entra.APIClient.list_app_role_assignments(access_token, service_principal["id"]),
+         {:ok, %Req.Response{status: 200, body: %{"value" => directory_roles}}} <-
+           Entra.APIClient.list_transitive_directory_roles(access_token, principal_id),
+         :ok <- verify_entra_setup_admin_role(directory_roles),
          :ok <- Entra.APIClient.test_connection(access_token) do
       {:ok, :verified}
     end
   end
+
+  defp verify_entra_setup_admin_role(directory_roles) when is_list(directory_roles) do
+    role_ids = Enum.map(directory_roles, & &1["roleTemplateId"])
+
+    if PortalWeb.OIDC.entra_setup_admin?(role_ids),
+      do: :ok,
+      else: {:error, :entra_setup_admin_required}
+  end
+
+  defp verify_entra_setup_admin_role(_directory_roles),
+    do: {:error, :entra_setup_admin_required}
 
   defp notify_and_await_ack(nil, _msg), do: {:error, :no_receiver}
 
@@ -256,6 +278,9 @@ defmodule PortalWeb.VerificationController do
   defp format_entra_verification_error({:error, %Req.TransportError{}}) do
     "Failed to verify directory access due to a network error."
   end
+
+  defp format_entra_verification_error({:error, :entra_setup_admin_required}),
+    do: @entra_admin_required_error
 
   defp format_entra_verification_error({:error, _reason}) do
     "Failed to verify directory access."

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -192,11 +192,7 @@ defmodule PortalWeb.Settings.Authentication do
       }
 
       socket =
-        if type == "entra" do
-          assign(socket, active_verification: verification, pending_verification: nil)
-        else
-          assign(socket, active_verification: nil, pending_verification: verification)
-        end
+        assign(socket, active_verification: nil, pending_verification: verification)
 
       {:noreply, push_event(socket, "open_url", %{url: uri})}
     else
@@ -373,6 +369,13 @@ defmodule PortalWeb.Settings.Authentication do
 
   def handle_info(%Portal.Changes.Change{old_struct: %Portal.PortalSession{}}, socket) do
     {:noreply, refresh_session_counts(socket)}
+  end
+
+  # Used after Entra admin consent to build the PKCE request without consuming
+  # the verifier before the authorization-code callback.
+  def handle_info({:peek_pending_verification, from}, socket) do
+    send(from, {:pending_verification, socket.assigns[:pending_verification]})
+    {:noreply, socket}
   end
 
   # Sent by VerificationController/OIDCController to fetch config+verifier for code exchange

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -395,6 +395,25 @@ defmodule PortalWeb.Settings.Authentication do
     {:noreply, socket}
   end
 
+  # Entra callbacks include their verification reference so a stale callback
+  # cannot consume a newer pending verifier.
+  def handle_info({:get_pending_verification, verification_ref, from}, socket) do
+    case socket.assigns[:pending_verification] do
+      %{verification_ref: ^verification_ref} = pending_verification ->
+        send(from, {:pending_verification, pending_verification})
+
+        {:noreply,
+         assign(socket,
+           pending_verification: nil,
+           active_verification: pending_verification
+         )}
+
+      _pending_verification ->
+        send(from, {:pending_verification, nil})
+        {:noreply, socket}
+    end
+  end
+
   # Sent directly by the OIDC verification controller after code exchange succeeds
   def handle_info({:oidc_verify_complete, issuer, verification_ref, ack_to}, socket) do
     if active_verification?(socket, verification_ref) do

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -358,6 +358,30 @@ defmodule PortalWeb.Settings.DirectorySync do
     start_verification(socket)
   end
 
+  # Used after Entra admin consent to build the PKCE request without consuming
+  # the verifier before the authorization-code callback.
+  def handle_info({:peek_pending_verification, from}, socket) do
+    send(from, {:pending_verification, socket.assigns[:pending_verification]})
+    {:noreply, socket}
+  end
+
+  # Sent by OIDCController to consume and activate the Entra verification session.
+  def handle_info({:get_pending_verification, from}, socket) do
+    pending_verification = socket.assigns[:pending_verification]
+    send(from, {:pending_verification, pending_verification})
+
+    socket =
+      case pending_verification do
+        nil ->
+          assign(socket, pending_verification: nil)
+
+        pending_verification ->
+          assign(socket, pending_verification: nil, active_verification: pending_verification)
+      end
+
+    {:noreply, socket}
+  end
+
   # Sent directly by the Entra directory_sync verification controller
   def handle_info({:entra_directory_sync_complete, tenant_id, verification_ref, ack_to}, socket) do
     if active_verification?(socket, verification_ref) do
@@ -434,7 +458,7 @@ defmodule PortalWeb.Settings.DirectorySync do
   end
 
   defp clear_verification_state(socket) do
-    assign(socket, active_verification: nil)
+    assign(socket, active_verification: nil, pending_verification: nil)
   end
 
   defp format_verification_error_reason(reason) when is_binary(reason), do: reason
@@ -1713,6 +1737,7 @@ defmodule PortalWeb.Settings.DirectorySync do
 
   defp start_verification(%{assigns: %{type: "entra"}} = socket) do
     with {:ok, %{config: config}} <- PortalWeb.OIDC.setup_verification("entra_directory_sync", []),
+         verifier = :crypto.strong_rand_bytes(32) |> Base.url_encode64(padding: false),
          verification_ref = Ecto.UUID.generate(),
          lv_pid_string = self() |> :erlang.pid_to_list() |> to_string(),
          state_token <-
@@ -1725,10 +1750,18 @@ defmodule PortalWeb.Settings.DirectorySync do
            PortalWeb.OIDC.build_verification_uri(
              "entra_directory_sync",
              config,
-             "",
+             verifier,
              state_token
            ) do
-      socket = assign(socket, active_verification: %{verification_ref: verification_ref})
+      verification = %{
+        config: config,
+        verifier: verifier,
+        verification_ref: verification_ref
+      }
+
+      socket =
+        assign(socket, active_verification: nil, pending_verification: verification)
+
       {:noreply, push_event(socket, "open_url", %{url: uri})}
     else
       {:error, reason} ->

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -382,6 +382,25 @@ defmodule PortalWeb.Settings.DirectorySync do
     {:noreply, socket}
   end
 
+  # Entra callbacks include their verification reference so a stale callback
+  # cannot consume a newer pending verifier.
+  def handle_info({:get_pending_verification, verification_ref, from}, socket) do
+    case socket.assigns[:pending_verification] do
+      %{verification_ref: ^verification_ref} = pending_verification ->
+        send(from, {:pending_verification, pending_verification})
+
+        {:noreply,
+         assign(socket,
+           pending_verification: nil,
+           active_verification: pending_verification
+         )}
+
+      _pending_verification ->
+        send(from, {:pending_verification, nil})
+        {:noreply, socket}
+    end
+  end
+
   # Sent directly by the Entra directory_sync verification controller
   def handle_info({:entra_directory_sync_complete, tenant_id, verification_ref, ack_to}, socket) do
     if active_verification?(socket, verification_ref) do

--- a/elixir/lib/portal_web/oidc.ex
+++ b/elixir/lib/portal_web/oidc.ex
@@ -11,6 +11,16 @@ defmodule PortalWeb.OIDC do
   require Logger
 
   @client_assertion_type "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+  @entra_organizations_discovery_document_uri "https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration"
+  @entra_organizations_admin_consent_endpoint "https://login.microsoftonline.com/organizations/v2.0/adminconsent"
+  @entra_issuer_prefix "https://login.microsoftonline.com/"
+  @entra_issuer_suffix "/v2.0"
+  @entra_setup_admin_role_template_ids MapSet.new([
+                                         # Global Administrator
+                                         "62e90394-69f5-4237-9190-012177145e10",
+                                         # Privileged Role Administrator
+                                         "e8611ab8-c189-46e8-94e1-60213ab1f814"
+                                       ])
 
   # Workaround for an OTP `ssl` bug: the TLS 1.3 client aborts the handshake
   # against servers that send their middlebox-compatibility ChangeCipherSpec
@@ -177,14 +187,18 @@ defmodule PortalWeb.OIDC do
   Returns {:ok, tokens} or {:error, reason}.
   """
   def exchange_code_with_config(config, code, verifier) do
-    params = %{
-      grant_type: "authorization_code",
-      code: code,
-      code_verifier: verifier,
-      redirect_uri: callback_url()
-    }
+    with {:ok, credential} <- verification_client_credential(config) do
+      params =
+        %{
+          grant_type: "authorization_code",
+          code: code,
+          code_verifier: verifier,
+          redirect_uri: callback_url()
+        }
+        |> Map.merge(credential)
 
-    OpenIDConnect.fetch_tokens(config, params)
+      OpenIDConnect.fetch_tokens(config, params)
+    end
   end
 
   @doc """
@@ -252,8 +266,8 @@ defmodule PortalWeb.OIDC do
 
   Provider types:
   - "google", "okta", "oidc" — OIDC authorization code + PKCE flow
-  - "entra" — Entra auth_provider admin consent flow
-  - "entra_directory_sync" — Entra directory_sync admin consent flow
+  - "entra" — Entra auth_provider admin consent + silent authorization code/PKCE proof
+  - "entra_directory_sync" — Entra directory_sync admin consent + user-bound PKCE proof
 
   Options:
   - :okta_domain - Required for Okta providers
@@ -261,8 +275,20 @@ defmodule PortalWeb.OIDC do
   - :client_secret - Required for Okta and generic OIDC providers
   - :discovery_document_uri - Required for generic OIDC providers
   """
+  def setup_verification("entra", opts) do
+    config =
+      Portal.Config.fetch_env!(:portal, Portal.Entra.AuthProvider)
+      |> Keyword.merge(opts)
+      |> entra_verification_config("openid email profile", "openid email profile")
+
+    {:ok, %{config: config}}
+  end
+
   def setup_verification("entra_directory_sync", _opts) do
-    config = Portal.Config.fetch_env!(:portal, Portal.Entra.APIClient) |> Enum.into(%{})
+    config =
+      Portal.Config.fetch_env!(:portal, Portal.Entra.APIClient)
+      |> entra_verification_config("openid profile", "https://graph.microsoft.com/.default")
+
     {:ok, %{config: config}}
   end
 
@@ -311,8 +337,10 @@ defmodule PortalWeb.OIDC do
   end
 
   @doc """
-  Builds the IdP URI for the verification flow. For OIDC types this is an
-  authorization URI with PKCE; for Entra types it is an admin consent URI.
+  Builds the IdP URI for the verification flow. Google, Okta, and generic OIDC
+  start an authorization code flow with PKCE. Entra starts with tenant-wide
+  admin consent. Both Entra flows follow it with a tenant-specific PKCE identity
+  proof that binds the setup to the signed-in user's immutable tenant and object IDs.
   The state_token (from sign_verification_state/2) is passed through the IdP unchanged.
   Accepts types: "google", "okta", "oidc", "entra", "entra_directory_sync".
   Returns {:ok, uri} or {:error, reason}.
@@ -335,22 +363,62 @@ defmodule PortalWeb.OIDC do
     end
   end
 
-  def build_verification_uri("entra", config, _verifier, state_token) do
-    build_entra_adminconsent_uri(config, state_token, "openid email profile")
-  end
+  def build_verification_uri(type, config, _verifier, state_token)
+      when type in ["entra", "entra_directory_sync"] do
+    params = %{
+      client_id: config[:client_id],
+      redirect_uri: callback_url(),
+      scope: config[:admin_consent_scope],
+      state: state_token
+    }
 
-  def build_verification_uri("entra_directory_sync", config, _verifier, state_token) do
-    build_entra_adminconsent_uri(
-      config,
-      state_token,
-      "https://graph.microsoft.com/.default"
-    )
+    {:ok, @entra_organizations_admin_consent_endpoint <> "?" <> URI.encode_query(params)}
   end
 
   def build_verification_uri(type, _config, _verifier, _state_token) do
     Logger.error("Unknown verification type", type: type)
     {:error, :unknown_verification_type}
   end
+
+  @doc """
+  Builds a tenant-specific Entra authorization-code request after admin consent.
+  The initial request is silent so the Microsoft session created by admin consent
+  can be reused without showing a second account picker. Set `prompt: nil` for the
+  interactive fallback when Entra reports that silent SSO is unavailable.
+  """
+  def build_entra_tenant_authorization_uri(
+        config,
+        tenant_id,
+        verifier,
+        state_token,
+        opts \\ []
+      ) do
+    with {:ok, tenant_id} <- Ecto.UUID.cast(tenant_id) do
+      challenge = :crypto.hash(:sha256, verifier) |> Base.url_encode64(padding: false)
+
+      params = %{
+        client_id: config[:client_id],
+        redirect_uri: callback_url(),
+        response_type: "code",
+        response_mode: "query",
+        scope: config[:scope],
+        state: state_token,
+        nonce: entra_verification_nonce(verifier),
+        code_challenge_method: "S256",
+        code_challenge: challenge
+      }
+      |> maybe_put_prompt(Keyword.get(opts, :prompt, "none"))
+
+      {:ok,
+       @entra_issuer_prefix <>
+         tenant_id <> "/oauth2/v2.0/authorize?" <> URI.encode_query(params)}
+    else
+      _ -> {:error, :invalid_entra_tenant}
+    end
+  end
+
+  defp maybe_put_prompt(params, nil), do: params
+  defp maybe_put_prompt(params, prompt), do: Map.put(params, :prompt, prompt)
 
   @doc """
   Returns the OIDC callback URL. Public so controllers can use it without
@@ -366,6 +434,63 @@ defmodule PortalWeb.OIDC do
     with {:ok, tokens} <- exchange_code_with_config(config, code, verifier),
          {:ok, claims} <- verify_token_with_config(config, tokens["id_token"]) do
       {:ok, claims, fetch_userinfo_with_config(config, tokens["access_token"])}
+    end
+  end
+
+  @doc """
+  Exchanges an Entra verification authorization code and returns the user identity
+  from the cryptographically verified ID token after requiring it to match the
+  tenant selected by the preceding admin-consent callback.
+  """
+  def verify_entra_callback(config, code, verifier, expected_tenant_id) do
+    with {:ok, expected_tenant_id} <- normalize_entra_tenant_id(expected_tenant_id),
+         {:ok, tokens} <- exchange_code_with_config(config, code, verifier),
+         id_token when is_binary(id_token) <- tokens["id_token"],
+         {:ok, claims} <- verify_token_with_config(config, id_token),
+         {:ok, tenant_id, issuer} <- verify_entra_tenant_claims(claims),
+         {:ok, principal_id, role_ids} <- verify_entra_principal_claims(claims),
+         :ok <- verify_entra_tenant_match(tenant_id, expected_tenant_id),
+         :ok <- verify_entra_signing_key(config, id_token, issuer),
+         :ok <- verify_entra_nonce(claims, verifier) do
+      {:ok,
+       %{
+         tenant_id: tenant_id,
+         issuer: issuer,
+         principal_id: principal_id,
+         role_ids: role_ids
+       }}
+    else
+      nil -> {:error, {:invalid_entra_id_token, :missing_id_token}}
+      error -> error
+    end
+  end
+
+  @doc """
+  Validates and normalizes a Microsoft Entra tenant ID as a UUID.
+  """
+  def normalize_entra_tenant_id(tenant_id) do
+    case Ecto.UUID.cast(tenant_id) do
+      {:ok, tenant_id} -> {:ok, tenant_id}
+      :error -> {:error, :invalid_entra_tenant}
+    end
+  end
+
+  @doc """
+  Returns whether the verified Entra identity has a tenant-wide role authorized
+  to approve Firezone's setup. Role IDs must come from a signature-verified token.
+  """
+  def entra_setup_admin?(role_ids) when is_list(role_ids) do
+    Enum.any?(role_ids, &MapSet.member?(@entra_setup_admin_role_template_ids, &1))
+  end
+
+  def entra_setup_admin?(_role_ids), do: false
+
+  defp verify_entra_tenant_match(tenant_id, expected_tenant_id) do
+    if byte_size(tenant_id) == byte_size(expected_tenant_id) and
+         Plug.Crypto.secure_compare(tenant_id, expected_tenant_id) do
+      :ok
+    else
+      {:error, {:invalid_entra_id_token, :tenant_mismatch}}
     end
   end
 
@@ -399,7 +524,7 @@ defmodule PortalWeb.OIDC do
 
   defp callback_url(_provider), do: callback_url()
 
-  # TODO: This can be refactored to reduce duplication with config_for_provider/1
+  # This can be refactored to reduce duplication with config_for_provider/1.
 
   defp verification_config_for_type("google", opts) do
     Application.fetch_env!(:portal, Portal.Google.AuthProvider)
@@ -427,15 +552,119 @@ defmodule PortalWeb.OIDC do
     |> Enum.into(%{redirect_uri: callback_url()})
   end
 
-  defp build_entra_adminconsent_uri(config, state, scope) do
-    params = %{
-      client_id: config[:client_id] || config["client_id"],
-      state: state,
+  defp entra_verification_config(config, scope, admin_consent_scope) do
+    config
+    |> Keyword.put(:discovery_document_uri, @entra_organizations_discovery_document_uri)
+    |> Keyword.put(:response_type, "code")
+    |> Keyword.put(:scope, scope)
+    |> Keyword.put(:admin_consent_scope, admin_consent_scope)
+    |> Enum.into(%{
       redirect_uri: callback_url(),
-      scope: scope
-    }
-
-    {:ok,
-     "https://login.microsoftonline.com/organizations/v2.0/adminconsent?#{URI.encode_query(params)}"}
+      req_opts: @discovery_req_opts,
+      verification_client_auth: :entra
+    })
   end
+
+  defp verification_client_credential(%{verification_client_auth: :entra} = config) do
+    case config[:client_secret] do
+      secret when is_binary(secret) and secret != "" -> {:ok, %{}}
+      _ -> federated_credential()
+    end
+  end
+
+  defp verification_client_credential(_config), do: {:ok, %{}}
+
+  defp verify_entra_signing_key(config, id_token, issuer) do
+    req_opts = Map.get(config, :req_opts, [])
+
+    with {:ok, document} <-
+           OpenIDConnect.Document.fetch_document(config.discovery_document_uri, req_opts),
+         {:ok, algorithm, key_id} <- token_signing_key(id_token),
+         true <- algorithm in List.wrap(document.raw["id_token_signing_alg_values_supported"]),
+         {_modules, %{"keys" => signing_keys}} <- JOSE.JWK.to_map(document.jwks),
+         true <-
+           Enum.any?(signing_keys, fn signing_key ->
+             signing_key["kid"] == key_id and
+               entra_signing_key_issuer_matches?(signing_key["issuer"], issuer) and
+               valid_signature?(signing_key, algorithm, id_token)
+           end) do
+      :ok
+    else
+      _ -> {:error, {:invalid_entra_id_token, :invalid_signing_key}}
+    end
+  end
+
+  defp token_signing_key(id_token) do
+    with protected when is_binary(protected) <- JOSE.JWS.peek_protected(id_token),
+         {:ok, %{"alg" => algorithm, "kid" => key_id}} <- JSON.decode(protected),
+         true <- is_binary(algorithm) and is_binary(key_id) do
+      {:ok, algorithm, key_id}
+    else
+      _ -> {:error, :invalid_token_header}
+    end
+  rescue
+    _ -> {:error, :invalid_token_header}
+  end
+
+  defp entra_signing_key_issuer_matches?(key_issuer, issuer) when is_binary(key_issuer) do
+    key_issuer == issuer or
+      key_issuer == @entra_issuer_prefix <> "{tenantid}" <> @entra_issuer_suffix
+  end
+
+  defp entra_signing_key_issuer_matches?(_key_issuer, _issuer), do: false
+
+  defp valid_signature?(signing_key, algorithm, id_token) do
+    case signing_key |> JOSE.JWK.from() |> JOSE.JWS.verify_strict([algorithm], id_token) do
+      {true, _claims, _jws} -> true
+      _ -> false
+    end
+  rescue
+    _ -> false
+  end
+
+  defp verify_entra_nonce(%{"nonce" => nonce}, verifier) when is_binary(nonce) do
+    expected_nonce = entra_verification_nonce(verifier)
+
+    if byte_size(nonce) == byte_size(expected_nonce) and
+         Plug.Crypto.secure_compare(nonce, expected_nonce) do
+      :ok
+    else
+      {:error, {:invalid_entra_id_token, :invalid_nonce}}
+    end
+  end
+
+  defp verify_entra_nonce(_claims, _verifier),
+    do: {:error, {:invalid_entra_id_token, :missing_nonce}}
+
+  defp entra_verification_nonce(verifier) do
+    :crypto.hash(:sha256, "entra-verification-nonce:" <> verifier)
+    |> Base.url_encode64(padding: false)
+  end
+
+  defp verify_entra_tenant_claims(%{"tid" => tenant_id, "iss" => issuer})
+       when is_binary(tenant_id) and is_binary(issuer) do
+    with {:ok, normalized_tenant_id} <- Ecto.UUID.cast(tenant_id),
+         expected_issuer = @entra_issuer_prefix <> normalized_tenant_id <> @entra_issuer_suffix,
+         true <- issuer == expected_issuer do
+      {:ok, normalized_tenant_id, expected_issuer}
+    else
+      _ -> {:error, {:invalid_entra_id_token, :invalid_tenant}}
+    end
+  end
+
+  defp verify_entra_tenant_claims(_claims),
+    do: {:error, {:invalid_entra_id_token, :missing_tenant}}
+
+  defp verify_entra_principal_claims(%{"oid" => principal_id} = claims)
+       when is_binary(principal_id) do
+    with {:ok, principal_id} <- Ecto.UUID.cast(principal_id),
+         role_ids when is_list(role_ids) <- Map.get(claims, "wids", []) do
+      {:ok, principal_id, role_ids}
+    else
+      _ -> {:error, {:invalid_entra_id_token, :invalid_principal}}
+    end
+  end
+
+  defp verify_entra_principal_claims(_claims),
+    do: {:error, {:invalid_entra_id_token, :missing_principal}}
 end

--- a/elixir/test/portal/entra/api_client_test.exs
+++ b/elixir/test/portal/entra/api_client_test.exs
@@ -166,6 +166,41 @@ defmodule Portal.Entra.APIClientTest do
     end
   end
 
+  describe "list_transitive_directory_roles/2" do
+    test "fetches the effective directory roles for a verified principal" do
+      test_pid = self()
+      principal_id = "87654321-4321-4321-4321-210987654321"
+
+      Req.Test.expect(APIClient, fn conn ->
+        assert conn.method == "GET"
+
+        assert conn.request_path ==
+                 "/v1.0/users/#{principal_id}/transitiveMemberOf/microsoft.graph.directoryRole"
+
+        conn = Plug.Conn.fetch_query_params(conn)
+        send(test_pid, {:directory_roles_request, conn.query_params})
+
+        Req.Test.json(conn, %{
+          "value" => [
+            %{
+              "id" => "tenant-role-id",
+              "roleTemplateId" => "62e90394-69f5-4237-9190-012177145e10"
+            }
+          ]
+        })
+      end)
+
+      assert {:ok, %Req.Response{status: 200, body: body}} =
+               APIClient.list_transitive_directory_roles(@test_access_token, principal_id)
+
+      assert [%{"roleTemplateId" => "62e90394-69f5-4237-9190-012177145e10"}] =
+               body["value"]
+
+      assert_receive {:directory_roles_request, query_params}
+      assert query_params["$select"] == "id,roleTemplateId"
+    end
+  end
+
   describe "stream_app_role_assignments/2" do
     test "streams a single page of app role assignments" do
       test_pid = self()

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -382,6 +382,121 @@ defmodule PortalWeb.OIDCControllerTest do
       assert error =~ "Unable to verify the Microsoft Entra tenant"
     end
 
+    test "rejects an Entra identity proof whose ID token audience is missing", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-auth-provider", verification_ref)
+
+      conn = complete_entra_admin_consent(conn, state)
+
+      "entra-client-id"
+      |> entra_claims()
+      |> Map.delete("aud")
+      |> set_entra_claims_response()
+
+      conn = complete_entra_tenant_proof(conn)
+
+      assert {:ok, %{ok: false, error: error}} =
+               entra_verification_result_from_redirect(redirected_to(conn))
+
+      assert error =~ "Unable to verify your identity token"
+    end
+
+    test "rejects an Entra identity proof whose ID token audience does not match", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-auth-provider", verification_ref)
+
+      conn = complete_entra_admin_consent(conn, state)
+      set_entra_claims_response(entra_claims("other-client-id"))
+      conn = complete_entra_tenant_proof(conn)
+
+      assert {:ok, %{ok: false, error: error}} =
+               entra_verification_result_from_redirect(redirected_to(conn))
+
+      assert error =~ "Unable to verify your identity token"
+    end
+
+    test "rejects an Entra identity proof whose ID token signature is invalid", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-auth-provider", verification_ref)
+
+      conn = complete_entra_admin_consent(conn, state)
+
+      id_token =
+        "entra-client-id"
+        |> entra_claims()
+        |> Mocks.OIDC.sign_openid_connect_token()
+        |> invalidate_jwt_signature()
+
+      set_entra_id_token_response(id_token)
+      conn = complete_entra_tenant_proof(conn)
+
+      assert {:ok, %{ok: false, error: error}} =
+               entra_verification_result_from_redirect(redirected_to(conn))
+
+      assert error =~ "Unable to verify your identity token"
+    end
+
+    test "does not exchange the authorization code when an Entra identity-proof callback is replayed",
+         %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-auth-provider", verification_ref)
+
+      consent_conn = complete_entra_admin_consent(conn, state)
+      tenant_proof_state = callback_state_from_redirect(consent_conn)
+      set_entra_token_response("entra-client-id")
+
+      first_conn = complete_entra_tenant_proof(consent_conn)
+      assert {:ok, %{ok: true}} = entra_verification_result_from_redirect(redirected_to(first_conn))
+      flush_oidc_requests()
+
+      replayed_conn =
+        get(recycle(first_conn), ~p"/auth/oidc/callback", %{
+          "state" => tenant_proof_state,
+          "code" => "replayed-code"
+        })
+
+      assert {:ok, %{ok: false, error: error}} =
+               entra_verification_result_from_redirect(redirected_to(replayed_conn))
+
+      assert error =~ "Verification session was not found or has expired"
+      refute_received {:oidc_request, _path, _conn}
+    end
+
+    test "does not consume a newer pending verification when a stale Entra callback arrives", %{
+      conn: conn
+    } do
+      stale_ref = Ecto.UUID.generate()
+      current_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-client-id")
+      lv_pid = pending_verification_process(config, current_ref)
+
+      state = entra_tenant_proof_state(lv_pid, "entra-auth-provider", stale_ref)
+      flush_oidc_requests()
+
+      conn =
+        get(recycle(conn), ~p"/auth/oidc/callback", %{
+          "state" => state,
+          "code" => "stale-code"
+        })
+
+      assert {:ok, %{ok: false, error: error, verification_ref: ^stale_ref}} =
+               entra_verification_result_from_redirect(redirected_to(conn))
+
+      assert error =~ "Verification session was not found or has expired"
+      refute_received {:oidc_request, _path, _conn}
+
+      send(lv_pid, {:peek_pending_verification, self()})
+      assert_receive {:pending_verification, %{verification_ref: ^current_ref}}
+    end
+
     test "returns a signed failure when the admin denies consent", %{conn: conn} do
       verification_ref = Ecto.UUID.generate()
       config = entra_verification_config("entra-client-id")
@@ -3374,6 +3489,17 @@ defmodule PortalWeb.OIDCControllerTest do
       {:get_pending_verification, from} ->
         send(from, {:pending_verification, pending})
         pending_verification_loop(nil)
+
+      {:get_pending_verification, verification_ref, from} ->
+        case pending do
+          %{verification_ref: ^verification_ref} ->
+            send(from, {:pending_verification, pending})
+            pending_verification_loop(nil)
+
+          _pending ->
+            send(from, {:pending_verification, nil})
+            pending_verification_loop(pending)
+        end
     end
   end
 
@@ -3385,24 +3511,62 @@ defmodule PortalWeb.OIDCControllerTest do
     })
   end
 
-  defp set_entra_token_response(client_id, claim_overrides \\ %{}) do
-    claims =
-      Mocks.OIDC.default_claims()
-      |> Map.merge(%{
-        "aud" => client_id,
-        "iss" => "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0",
-        "nonce" => entra_nonce("test-verifier"),
-        "oid" => "87654321-4321-4321-4321-210987654321",
-        "wids" => ["62e90394-69f5-4237-9190-012177145e10"],
-        "tid" => "12345678-1234-1234-1234-123456789012"
-      })
-      |> Map.merge(claim_overrides)
+  defp entra_tenant_proof_state(lv_pid, type, verification_ref) do
+    lv_pid_string = lv_pid |> :erlang.pid_to_list() |> to_string()
 
+    PortalWeb.OIDC.sign_verification_state(lv_pid_string, "#{type}-tenant-proof", %{
+      verification_ref: verification_ref,
+      tenant_id: @tenant_id,
+      silent: true
+    })
+  end
+
+  defp set_entra_token_response(client_id, claim_overrides \\ %{}) do
+    client_id
+    |> entra_claims()
+    |> Map.merge(claim_overrides)
+    |> set_entra_claims_response()
+  end
+
+  defp set_entra_claims_response(claims) do
+    claims
+    |> Mocks.OIDC.sign_openid_connect_token()
+    |> set_entra_id_token_response()
+  end
+
+  defp set_entra_id_token_response(id_token) do
     Mocks.OIDC.set_token_response(%{
       "access_token" => "test-access-token",
       "token_type" => "Bearer",
-      "id_token" => Mocks.OIDC.sign_openid_connect_token(claims)
+      "id_token" => id_token
     })
+  end
+
+  defp entra_claims(client_id) do
+    Mocks.OIDC.default_claims()
+    |> Map.merge(%{
+      "aud" => client_id,
+      "iss" => "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0",
+      "nonce" => entra_nonce("test-verifier"),
+      "oid" => "87654321-4321-4321-4321-210987654321",
+      "wids" => ["62e90394-69f5-4237-9190-012177145e10"],
+      "tid" => "12345678-1234-1234-1234-123456789012"
+    })
+  end
+
+  defp invalidate_jwt_signature(id_token) do
+    [header, payload, signature] = String.split(id_token, ".")
+    replacement = if String.starts_with?(signature, "A"), do: "B", else: "A"
+    invalid_signature = replacement <> String.slice(signature, 1..-1//1)
+    Enum.join([header, payload, invalid_signature], ".")
+  end
+
+  defp flush_oidc_requests do
+    receive do
+      {:oidc_request, _path, _conn} -> flush_oidc_requests()
+    after
+      0 -> :ok
+    end
   end
 
   defp entra_nonce(verifier) do

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -214,65 +214,300 @@ defmodule PortalWeb.OIDCControllerTest do
     end
   end
 
-  describe "callback/2 with Entra admin consent params" do
-    test "redirects with error when state format is invalid", %{conn: conn} do
-      params = %{
-        "state" => "invalid-format",
-        "admin_consent" => "True",
-        "tenant" => "test-tenant-id"
-      }
+  describe "callback/2 with Entra verification state" do
+    @tenant_id "12345678-1234-1234-1234-123456789012"
+    @tenant_issuer "https://login.microsoftonline.com/#{@tenant_id}/v2.0"
+    @principal_id "87654321-4321-4321-4321-210987654321"
 
-      conn = get(conn, ~p"/auth/oidc/callback", params)
+    test "derives the auth-provider tenant from a verified ID token", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-auth-provider", verification_ref)
+
+      conn = complete_entra_admin_consent(conn, state)
+      assert_tenant_proof_redirect(conn, "openid email profile", "none")
+
+      set_entra_token_response("entra-client-id")
+      conn = complete_entra_tenant_proof(conn)
+
+      assert {:ok,
+              %{
+                ok: true,
+                type: "entra-auth-provider",
+                tenant_id: @tenant_id,
+                issuer: @tenant_issuer,
+                verification_ref: ^verification_ref
+              }} = entra_verification_result_from_redirect(redirected_to(conn))
+    end
+
+    test "binds directory sync to a user identity from a verified ID token", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-sync-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-directory-sync", verification_ref)
+
+      conn = complete_entra_admin_consent(conn, state)
+      assert_tenant_proof_redirect(conn, "openid profile", "none")
+
+      set_entra_token_response("entra-sync-client-id")
+      conn = complete_entra_tenant_proof(conn)
+
+      assert {:ok,
+              %{
+                ok: true,
+                type: "entra-directory-sync",
+                tenant_id: @tenant_id,
+                principal_id: @principal_id,
+                verification_ref: ^verification_ref
+              }} = entra_verification_result_from_redirect(redirected_to(conn))
+    end
+
+    test "rejects a malformed directory-sync callback tenant", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-sync-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-directory-sync", verification_ref)
+
+      conn =
+        complete_entra_admin_consent(conn, state, %{
+          "tenant" => "attacker-controlled-tenant"
+        })
+
+      assert {:ok, %{ok: false, error: error, verification_ref: ^verification_ref}} =
+               entra_verification_result_from_redirect(redirected_to(conn))
+
+      assert error =~ "Unable to verify the Microsoft Entra tenant"
+    end
+
+    test "rejects a token for a tenant other than the admin-consent callback tenant", %{
+      conn: conn
+    } do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-auth-provider", verification_ref)
+      other_tenant_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+      conn = complete_entra_admin_consent(conn, state, %{"tenant" => other_tenant_id})
+      assert URI.parse(redirected_to(conn)).path =~ other_tenant_id
+
+      set_entra_token_response("entra-client-id")
+      conn = complete_entra_tenant_proof(conn)
+
+      assert {:ok, %{ok: false, error: error}} =
+               entra_verification_result_from_redirect(redirected_to(conn))
+
+      assert error =~ "Unable to verify the Microsoft Entra tenant"
+    end
+
+    test "rejects a malformed admin-consent callback tenant", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-auth-provider", verification_ref)
+
+      conn =
+        complete_entra_admin_consent(conn, state, %{
+          "tenant" => "attacker-controlled-tenant"
+        })
+
+      assert {:ok, %{ok: false, error: error, verification_ref: ^verification_ref}} =
+               entra_verification_result_from_redirect(redirected_to(conn))
+
+      assert error =~ "Unable to verify the Microsoft Entra tenant"
+    end
+
+    test "rejects a signed ID token whose issuer does not match tid", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-auth-provider", verification_ref)
+
+      conn = complete_entra_admin_consent(conn, state)
+
+      set_entra_token_response("entra-client-id", %{
+        "iss" => "https://login.microsoftonline.com/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/v2.0"
+      })
+
+      conn = complete_entra_tenant_proof(conn)
+
+      assert {:ok, %{ok: false, error: error}} =
+               entra_verification_result_from_redirect(redirected_to(conn))
+
+      assert error =~ "Unable to verify the Microsoft Entra tenant"
+    end
+
+    test "rejects a token signed by a key scoped to another tenant", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-auth-provider", verification_ref)
+
+      conn = complete_entra_admin_consent(conn, state)
+
+      Mocks.OIDC.set_jwks_response(
+        Map.put(
+          Mocks.OIDC.jwks(),
+          "issuer",
+          "https://login.microsoftonline.com/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/v2.0"
+        )
+      )
+
+      set_entra_token_response("entra-client-id")
+
+      conn = complete_entra_tenant_proof(conn)
+
+      assert {:ok, %{ok: false, error: error}} =
+               entra_verification_result_from_redirect(redirected_to(conn))
+
+      assert error =~ "Unable to verify the Microsoft Entra tenant"
+    end
+
+    test "rejects a token whose nonce is not bound to the verification session", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-auth-provider", verification_ref)
+
+      conn = complete_entra_admin_consent(conn, state)
+
+      set_entra_token_response("entra-client-id", %{"nonce" => "wrong-nonce"})
+
+      conn = complete_entra_tenant_proof(conn)
+
+      assert {:ok, %{ok: false, error: error}} =
+               entra_verification_result_from_redirect(redirected_to(conn))
+
+      assert error =~ "Unable to verify the Microsoft Entra tenant"
+    end
+
+    test "returns a signed failure when the admin denies consent", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-auth-provider", verification_ref)
+
+      conn =
+        get(conn, ~p"/auth/oidc/callback", %{
+          "state" => state,
+          "error" => "access_denied",
+          "error_description" => "The user denied consent"
+        })
+
+      assert {:ok,
+              %{
+                ok: false,
+                error: "The user denied consent",
+                verification_ref: ^verification_ref
+              }} = entra_verification_result_from_redirect(redirected_to(conn))
+    end
+
+    test "falls back to an interactive tenant proof when silent SSO is unavailable", %{
+      conn: conn
+    } do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-auth-provider", verification_ref)
+
+      conn = complete_entra_admin_consent(conn, state)
+      silent_state = callback_state_from_redirect(conn)
+
+      conn =
+        get(recycle(conn), ~p"/auth/oidc/callback", %{
+          "state" => silent_state,
+          "error" => "interaction_required",
+          "error_description" => "Silent SSO was unavailable"
+        })
+
+      assert_tenant_proof_redirect(conn, "openid email profile", nil)
+
+      set_entra_token_response("entra-client-id")
+      conn = complete_entra_tenant_proof(conn)
+
+      assert {:ok, %{ok: true, verification_ref: ^verification_ref}} =
+               entra_verification_result_from_redirect(redirected_to(conn))
+    end
+
+    test "directory sync falls back to an interactive identity proof when OIDC consent is required",
+         %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-sync-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-directory-sync", verification_ref)
+
+      conn = complete_entra_admin_consent(conn, state)
+      silent_state = callback_state_from_redirect(conn)
+
+      conn =
+        get(recycle(conn), ~p"/auth/oidc/callback", %{
+          "state" => silent_state,
+          "error" => "consent_required",
+          "error_description" => "The user has not consented to sign in"
+        })
+
+      assert_tenant_proof_redirect(conn, "openid profile", nil)
+    end
+
+    test "rejects an Entra ID token without an immutable user object ID", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-auth-provider", verification_ref)
+
+      conn = complete_entra_admin_consent(conn, state)
+      set_entra_token_response("entra-client-id", %{"oid" => nil})
+      conn = complete_entra_tenant_proof(conn)
+
+      assert {:ok, %{ok: false, error: error}} =
+               entra_verification_result_from_redirect(redirected_to(conn))
+
+      assert error =~ "Unable to verify the Microsoft Entra tenant"
+    end
+
+    test "returns a signed failure when the interactive tenant proof is denied", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      config = entra_verification_config("entra-client-id")
+      lv_pid = pending_verification_process(config, verification_ref)
+      state = entra_verification_state(lv_pid, "entra-auth-provider", verification_ref)
+
+      conn = complete_entra_admin_consent(conn, state)
+      silent_state = callback_state_from_redirect(conn)
+
+      conn =
+        get(recycle(conn), ~p"/auth/oidc/callback", %{
+          "state" => silent_state,
+          "error" => "interaction_required"
+        })
+
+      interactive_state = callback_state_from_redirect(conn)
+
+      conn =
+        get(recycle(conn), ~p"/auth/oidc/callback", %{
+          "state" => interactive_state,
+          "error" => "access_denied",
+          "error_description" => "The user denied sign in"
+        })
+
+      assert {:ok,
+              %{
+                ok: false,
+                error: "The user denied sign in",
+                verification_ref: ^verification_ref
+              }} = entra_verification_result_from_redirect(redirected_to(conn))
+    end
+
+    test "rejects an admin-consent response without signed state", %{conn: conn} do
+      conn =
+        get(conn, ~p"/auth/oidc/callback", %{
+          "state" => "attacker-controlled-state",
+          "admin_consent" => "True",
+          "tenant" => @tenant_id
+        })
 
       assert redirected_to(conn) == "/sign_in"
       assert flash(conn, :error) == "Invalid sign-in request. Please try again."
-    end
-
-    test "redirects to /verification/entra for entra-auth-provider state", %{conn: conn} do
-      lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      state = PortalWeb.OIDC.sign_verification_state(lv_pid_string, "entra-auth-provider")
-
-      params = %{
-        "state" => state,
-        "admin_consent" => "True",
-        "tenant" => "test-tenant-id"
-      }
-
-      conn = get(conn, ~p"/auth/oidc/callback", params)
-
-      assert redirected_to(conn) =~ "/verification/entra"
-    end
-
-    test "redirects to /verification/entra for entra-directory-sync state", %{conn: conn} do
-      lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      state = PortalWeb.OIDC.sign_verification_state(lv_pid_string, "entra-directory-sync")
-
-      params = %{
-        "state" => state,
-        "admin_consent" => "True",
-        "tenant" => "test-tenant-id"
-      }
-
-      conn = get(conn, ~p"/auth/oidc/callback", params)
-
-      assert redirected_to(conn) =~ "/verification/entra"
-    end
-
-    test "redirects to /verification/entra when admin_consent callback omits tenant", %{
-      conn: conn
-    } do
-      lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      state = PortalWeb.OIDC.sign_verification_state(lv_pid_string, "entra-auth-provider")
-
-      params = %{
-        "state" => state,
-        "admin_consent" => "False",
-        "error" => "access_denied"
-      }
-
-      conn = get(conn, ~p"/auth/oidc/callback", params)
-
-      assert redirected_to(conn) =~ "/verification/entra"
     end
   end
 
@@ -3038,6 +3273,141 @@ defmodule PortalWeb.OIDCControllerTest do
     Phoenix.Token.verify(PortalWeb.Endpoint, "oidc-verification-result", result_token,
       max_age: 60
     )
+  end
+
+  defp entra_verification_result_from_redirect(redirect_url) do
+    result_token =
+      redirect_url
+      |> URI.parse()
+      |> Map.fetch!(:query)
+      |> URI.decode_query()
+      |> Map.fetch!("result")
+
+    Phoenix.Token.verify(PortalWeb.Endpoint, "entra-verification-result", result_token,
+      max_age: 60
+    )
+  end
+
+  defp assert_tenant_proof_redirect(conn, expected_scope, expected_prompt) do
+    uri = conn |> redirected_to() |> URI.parse()
+    params = URI.decode_query(uri.query)
+
+    assert uri.host == "login.microsoftonline.com"
+    assert uri.path == "/#{@tenant_id}/oauth2/v2.0/authorize"
+    assert params["scope"] == expected_scope
+    assert params["response_type"] == "code"
+    assert params["code_challenge_method"] == "S256"
+    assert params["prompt"] == expected_prompt
+    assert is_binary(params["state"])
+    refute params["state"] == ""
+  end
+
+  defp complete_entra_admin_consent(conn, state, extra_params \\ %{}) do
+    params =
+      %{
+        "state" => state,
+        "admin_consent" => "True",
+        "tenant" => @tenant_id
+      }
+      |> Map.merge(extra_params)
+
+    get(recycle(conn), ~p"/auth/oidc/callback", params)
+  end
+
+  defp complete_entra_tenant_proof(conn, extra_params \\ %{}) do
+    params =
+      %{
+        "state" => callback_state_from_redirect(conn),
+        "code" => "test-code"
+      }
+      |> Map.merge(extra_params)
+
+    get(recycle(conn), ~p"/auth/oidc/callback", params)
+  end
+
+  defp callback_state_from_redirect(conn) do
+    conn
+    |> redirected_to()
+    |> URI.parse()
+    |> Map.fetch!(:query)
+    |> URI.decode_query()
+    |> Map.fetch!("state")
+  end
+
+  defp entra_verification_config(client_id) do
+    {scope, admin_consent_scope} =
+      if client_id == "entra-sync-client-id" do
+        {"openid profile", "https://graph.microsoft.com/.default"}
+      else
+        {"openid email profile", "openid email profile"}
+      end
+
+    %{
+      admin_consent_scope: admin_consent_scope,
+      client_id: client_id,
+      client_secret: "test-secret",
+      discovery_document_uri: Mocks.OIDC.discovery_document_uri(),
+      redirect_uri: PortalWeb.OIDC.callback_url(),
+      response_type: "code",
+      scope: scope,
+      verification_client_auth: :entra,
+      req_opts: [retry: false, plug: {Req.Test, PortalWeb.OIDC}]
+    }
+  end
+
+  defp pending_verification_process(config, verification_ref) do
+    pending = %{
+      config: config,
+      verifier: "test-verifier",
+      verification_ref: verification_ref
+    }
+
+    spawn(fn -> pending_verification_loop(pending) end)
+  end
+
+  defp pending_verification_loop(pending) do
+    receive do
+      {:peek_pending_verification, from} ->
+        send(from, {:pending_verification, pending})
+        pending_verification_loop(pending)
+
+      {:get_pending_verification, from} ->
+        send(from, {:pending_verification, pending})
+        pending_verification_loop(nil)
+    end
+  end
+
+  defp entra_verification_state(lv_pid, type, verification_ref) do
+    lv_pid_string = lv_pid |> :erlang.pid_to_list() |> to_string()
+
+    PortalWeb.OIDC.sign_verification_state(lv_pid_string, type, %{
+      verification_ref: verification_ref
+    })
+  end
+
+  defp set_entra_token_response(client_id, claim_overrides \\ %{}) do
+    claims =
+      Mocks.OIDC.default_claims()
+      |> Map.merge(%{
+        "aud" => client_id,
+        "iss" => "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0",
+        "nonce" => entra_nonce("test-verifier"),
+        "oid" => "87654321-4321-4321-4321-210987654321",
+        "wids" => ["62e90394-69f5-4237-9190-012177145e10"],
+        "tid" => "12345678-1234-1234-1234-123456789012"
+      })
+      |> Map.merge(claim_overrides)
+
+    Mocks.OIDC.set_token_response(%{
+      "access_token" => "test-access-token",
+      "token_type" => "Bearer",
+      "id_token" => Mocks.OIDC.sign_openid_connect_token(claims)
+    })
+  end
+
+  defp entra_nonce(verifier) do
+    :crypto.hash(:sha256, "entra-verification-nonce:" <> verifier)
+    |> Base.url_encode64(padding: false)
   end
 
   # Sets up mocks for a successful authentication flow.

--- a/elixir/test/portal_web/controllers/verification_controller_test.exs
+++ b/elixir/test/portal_web/controllers/verification_controller_test.exs
@@ -240,6 +240,45 @@ defmodule PortalWeb.VerificationControllerTest do
       refute_received {:entra_directory_sync_complete, _tenant_id, _verification_ref, _ack_to}
     end
 
+    test "looks up directory roles using the principal ID from the signed result", %{conn: conn} do
+      principal_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+      stub_directory_access()
+      lv_pid = verification_ack_process()
+
+      conn =
+        get(conn, ~p"/verification/entra", %{
+          "result" => directory_result_token(lv_pid, Ecto.UUID.generate(), principal_id)
+        })
+
+      assert conn.resp_body =~ "Verification Successful"
+
+      assert "/v1.0/users/#{principal_id}/transitiveMemberOf/microsoft.graph.directoryRole" in
+               drain_entra_api_request_paths()
+    end
+
+    test "probes required Graph endpoints after verifying the signed principal ID", %{conn: conn} do
+      stub_directory_access()
+      lv_pid = verification_ack_process()
+
+      conn = get(conn, ~p"/verification/entra", %{"result" => directory_result_token(lv_pid)})
+
+      assert conn.resp_body =~ "Verification Successful"
+      paths = drain_entra_api_request_paths()
+
+      role_path =
+        "/v1.0/users/#{@principal_id}/transitiveMemberOf/microsoft.graph.directoryRole"
+
+      role_index = Enum.find_index(paths, &(&1 == role_path))
+      users_index = Enum.find_index(paths, &(&1 == "/v1.0/users"))
+      groups_index = Enum.find_index(paths, &(&1 == "/v1.0/groups"))
+
+      assert is_integer(role_index)
+      assert is_integer(users_index)
+      assert is_integer(groups_index)
+      assert role_index < users_index
+      assert users_index < groups_index
+    end
+
     test "renders an Entra API 401 error", %{conn: conn} do
       Req.Test.stub(Portal.Entra.APIClient, fn req_conn ->
         req_conn
@@ -324,7 +363,11 @@ defmodule PortalWeb.VerificationControllerTest do
   defp stub_directory_access(
          directory_roles \\ [%{"roleTemplateId" => @global_administrator_role_id}]
        ) do
+    test_pid = self()
+
     Req.Test.stub(Portal.Entra.APIClient, fn req_conn ->
+      send(test_pid, {:entra_api_request, req_conn.request_path})
+
       cond do
         req_conn.method == "POST" ->
           Req.Test.json(req_conn, %{"access_token" => "test-token"})
@@ -350,16 +393,37 @@ defmodule PortalWeb.VerificationControllerTest do
     end)
   end
 
-  defp directory_result_token(lv_pid, verification_ref \\ Ecto.UUID.generate()) do
+  defp directory_result_token(
+         lv_pid,
+         verification_ref \\ Ecto.UUID.generate(),
+         principal_id \\ @principal_id
+       ) do
     sign_entra_result(%{
       ok: true,
       type: "entra-directory-sync",
       issuer: @issuer,
       tenant_id: @tenant_id,
-      principal_id: @principal_id,
+      principal_id: principal_id,
       lv_pid: serialize_pid(lv_pid),
       verification_ref: verification_ref
     })
+  end
+
+  defp verification_ack_process do
+    spawn(fn ->
+      receive do
+        {:entra_directory_sync_complete, _tenant_id, _verification_ref, {from, ref}} ->
+          send(from, {:verification_ack, ref})
+      end
+    end)
+  end
+
+  defp drain_entra_api_request_paths(paths \\ []) do
+    receive do
+      {:entra_api_request, path} -> drain_entra_api_request_paths([path | paths])
+    after
+      0 -> Enum.reverse(paths)
+    end
   end
 
   defp serialize_pid(pid), do: pid |> :erlang.pid_to_list() |> to_string()

--- a/elixir/test/portal_web/controllers/verification_controller_test.exs
+++ b/elixir/test/portal_web/controllers/verification_controller_test.exs
@@ -1,23 +1,10 @@
 defmodule PortalWeb.VerificationControllerTest do
   use PortalWeb.ConnCase, async: true
 
-  alias PortalWeb.Mocks
-
-  setup do
-    Mocks.OIDC.stub_discovery_document()
-    :ok
-  end
-
-  defp sign_entra_state(lv_pid_string, type) do
-    verification_ref = Ecto.UUID.generate()
-
-    state =
-      PortalWeb.OIDC.sign_verification_state(lv_pid_string, type, %{
-        verification_ref: verification_ref
-      })
-
-    {state, verification_ref}
-  end
+  @tenant_id "12345678-1234-1234-1234-123456789012"
+  @issuer "https://login.microsoftonline.com/#{@tenant_id}/v2.0"
+  @principal_id "87654321-4321-4321-4321-210987654321"
+  @global_administrator_role_id "62e90394-69f5-4237-9190-012177145e10"
 
   describe "oidc/2" do
     test "with valid success result token, sends message to LV and renders success", %{
@@ -85,9 +72,7 @@ defmodule PortalWeb.VerificationControllerTest do
       refute_received {:oidc_verify_complete, _issuer, _verification_ref, _ack_to}
     end
 
-    test "with success result token missing verification_ref, renders failure without sending message", %{
-      conn: conn
-    } do
+    test "with success result token missing verification_ref, renders failure", %{conn: conn} do
       lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
       token = sign_oidc_result(%{ok: true, issuer: "https://example.com", lv_pid: lv_pid_string})
 
@@ -99,24 +84,19 @@ defmodule PortalWeb.VerificationControllerTest do
       refute_received {:oidc_verify_complete, _issuer, _verification_ref, _ack_to}
     end
 
-    test "with invalid result token, renders failure", %{conn: conn} do
+    test "with invalid or missing result token, renders failure", %{conn: conn} do
       conn = get(conn, ~p"/verification/oidc", %{"result" => "invalid-token"})
-
       assert conn.status == 200
-      assert conn.resp_body =~ "Verification Failed"
       assert conn.resp_body =~ "Invalid or expired"
-    end
 
-    test "with missing result param, renders failure", %{conn: conn} do
-      conn = get(conn, ~p"/verification/oidc", %{})
-
+      conn = get(recycle(conn), ~p"/verification/oidc", %{})
       assert conn.status == 200
       assert conn.resp_body =~ "Verification Failed"
     end
   end
 
-  describe "entra/2 (entra-auth-provider / auth_provider flow)" do
-    test "with signed state and admin_consent=True, sends message and renders success", %{
+  describe "entra/2 for auth providers" do
+    test "uses the tenant identity from the signed result and ignores callback tenant params", %{
       conn: conn
     } do
       parent = self()
@@ -125,235 +105,142 @@ defmodule PortalWeb.VerificationControllerTest do
         spawn(fn ->
           receive do
             {:entra_verify_complete, issuer, tenant_id, verification_ref, {from, ref}} ->
-              send(
-                parent,
-                {:entra_verify_complete_received, issuer, tenant_id, verification_ref}
-              )
-
+              send(parent, {:entra_verify_complete_received, issuer, tenant_id, verification_ref})
               send(from, {:verification_ack, ref})
           end
         end)
 
-      lv_pid_string = lv_pid |> :erlang.pid_to_list() |> to_string()
-      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-auth-provider")
+      verification_ref = Ecto.UUID.generate()
 
-      params = %{
-        "state" => state,
-        "admin_consent" => "True",
-        "tenant" => "my-tenant-id"
-      }
+      token =
+        sign_entra_result(%{
+          ok: true,
+          type: "entra-auth-provider",
+          issuer: @issuer,
+          tenant_id: @tenant_id,
+          role_ids: [@global_administrator_role_id],
+          lv_pid: serialize_pid(lv_pid),
+          verification_ref: verification_ref
+        })
 
-      conn = get(conn, ~p"/verification/entra", params)
+      conn =
+        get(conn, ~p"/verification/entra", %{
+          "result" => token,
+          "tenant" => "attacker-controlled-tenant",
+          "admin_consent" => "True"
+        })
 
       assert conn.status == 200
       assert conn.resp_body =~ "Verification Successful"
-
-      assert_received {:entra_verify_complete_received,
-                       "https://login.microsoftonline.com/my-tenant-id/v2.0", "my-tenant-id",
-                       ^verification_ref}
+      assert_received {:entra_verify_complete_received, @issuer, @tenant_id, ^verification_ref}
     end
 
-    test "with invalid state, renders failure", %{conn: conn} do
-      params = %{
-        "state" => "not-a-signed-token",
-        "admin_consent" => "True",
-        "tenant" => "my-tenant-id"
-      }
+    test "rejects a signed-in tenant user who is not an authorized administrator", %{
+      conn: conn
+    } do
+      verification_ref = Ecto.UUID.generate()
 
-      conn = get(conn, ~p"/verification/entra", params)
+      token =
+        sign_entra_result(%{
+          ok: true,
+          type: "entra-auth-provider",
+          issuer: @issuer,
+          tenant_id: @tenant_id,
+          role_ids: [],
+          lv_pid: serialize_pid(self()),
+          verification_ref: verification_ref
+        })
 
-      assert conn.status == 200
-      assert conn.resp_body =~ "Verification Failed"
-      assert conn.resp_body =~ "Invalid or expired"
-    end
+      conn = get(conn, ~p"/verification/entra", %{"result" => token})
 
-    test "with signed state missing verification_ref, renders failure", %{conn: conn} do
-      lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      state = PortalWeb.OIDC.sign_verification_state(lv_pid_string, "entra-auth-provider")
-
-      params = %{
-        "state" => state,
-        "admin_consent" => "True",
-        "tenant" => "my-tenant-id"
-      }
-
-      conn = get(conn, ~p"/verification/entra", params)
-
-      assert conn.status == 200
-      assert conn.resp_body =~ "Verification Failed"
-      assert conn.resp_body =~ "Invalid or expired"
+      assert conn.resp_body =~ "Global Administrator or Privileged Role Administrator"
+      assert_received {:verification_failed, message, ^verification_ref}
+      assert message =~ "Global Administrator or Privileged Role Administrator"
       refute_received {:entra_verify_complete, _issuer, _tenant_id, _verification_ref, _ack_to}
     end
 
-    test "with consent denied (error params), sends failure and renders failure", %{conn: conn} do
-      lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-auth-provider")
+    test "renders a signed authorization failure and notifies the active verification", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
 
-      params = %{
-        "state" => state,
-        "admin_consent" => "False",
-        "error" => "access_denied",
-        "error_description" => "The user denied consent"
-      }
+      token =
+        sign_entra_result(%{
+          ok: false,
+          error: "The user denied consent",
+          lv_pid: serialize_pid(self()),
+          verification_ref: verification_ref
+        })
 
-      conn = get(conn, ~p"/verification/entra", params)
+      conn = get(conn, ~p"/verification/entra", %{"result" => token})
 
       assert conn.status == 200
-      assert conn.resp_body =~ "Verification Failed"
       assert conn.resp_body =~ "The user denied consent"
-      refute conn.resp_body =~ "window.close()"
       assert_received {:verification_failed, "The user denied consent", ^verification_ref}
     end
 
-    test "with admin_consent=False and no error params, sends failure and renders failure", %{
-      conn: conn
-    } do
-      lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-auth-provider")
+    test "rejects a result missing its verification reference", %{conn: conn} do
+      token =
+        sign_entra_result(%{
+          ok: true,
+          type: "entra-auth-provider",
+          issuer: @issuer,
+          tenant_id: @tenant_id,
+          lv_pid: serialize_pid(self())
+        })
 
-      params = %{"state" => state, "admin_consent" => "False"}
-
-      conn = get(conn, ~p"/verification/entra", params)
-
-      assert conn.status == 200
-      assert conn.resp_body =~ "Verification Failed"
-      assert conn.resp_body =~ "Admin consent was not granted"
-      assert_received {:verification_failed, "Admin consent was not granted", ^verification_ref}
-    end
-
-    test "with missing admin_consent param, sends failure and renders failure", %{conn: conn} do
-      lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-auth-provider")
-
-      params = %{"state" => state, "tenant" => "some-tenant"}
-
-      conn = get(conn, ~p"/verification/entra", params)
+      conn = get(conn, ~p"/verification/entra", %{"result" => token})
 
       assert conn.status == 200
-      assert conn.resp_body =~ "Verification Failed"
-      assert conn.resp_body =~ "Missing tenant information"
-      assert_received {:verification_failed, "Missing tenant information", ^verification_ref}
-    end
-
-    # Microsoft always sends error_description alongside error in practice, but it is
-    # technically optional per the OAuth 2.0 spec, so we handle the fallback defensively.
-    test "with error code but no error_description, sends failure and renders failure", %{
-      conn: conn
-    } do
-      lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-auth-provider")
-
-      params = %{
-        "state" => state,
-        "admin_consent" => "True",
-        "error" => "access_denied"
-      }
-
-      conn = get(conn, ~p"/verification/entra", params)
-
-      assert conn.status == 200
-      assert conn.resp_body =~ "Verification Failed"
-      assert conn.resp_body =~ "access_denied"
-      assert_received {:verification_failed, "access_denied", ^verification_ref}
+      assert conn.resp_body =~ "Invalid or expired verification result"
+      refute_received {:entra_verify_complete, _issuer, _tenant_id, _verification_ref, _ack_to}
     end
   end
 
-  describe "entra/2 (entra-directory-sync / directory_sync flow)" do
-    test "with invalid state, renders failure", %{conn: conn} do
-      params = %{
-        "state" => "not-a-signed-token",
-        "admin_consent" => "True",
-        "tenant" => "my-tenant-id"
-      }
-
-      conn = get(conn, ~p"/verification/entra", params)
-
-      assert conn.status == 200
-      assert conn.resp_body =~ "Verification Failed"
-      assert conn.resp_body =~ "Invalid or expired"
-    end
-
-    test "with consent denied (error params), sends failure and renders failure", %{conn: conn} do
-      lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-directory-sync")
-
-      params = %{
-        "state" => state,
-        "admin_consent" => "False",
-        "error" => "access_denied",
-        "error_description" => "The user denied consent"
-      }
-
-      conn = get(conn, ~p"/verification/entra", params)
-
-      assert conn.status == 200
-      assert conn.resp_body =~ "Verification Failed"
-      assert_received {:verification_failed, "The user denied consent", ^verification_ref}
-    end
-
-    test "with successful Entra API verification, sends message and renders success", %{
-      conn: conn
-    } do
+  describe "entra/2 for directory sync" do
+    test "verifies app-only Graph access before returning the signed tenant", %{conn: conn} do
       parent = self()
 
       lv_pid =
         spawn(fn ->
           receive do
             {:entra_directory_sync_complete, tenant_id, verification_ref, {from, ref}} ->
-              send(
-                parent,
-                {:entra_directory_sync_complete_received, tenant_id, verification_ref}
-              )
-
+              send(parent, {:entra_directory_sync_complete_received, tenant_id, verification_ref})
               send(from, {:verification_ack, ref})
           end
         end)
 
-      lv_pid_string = lv_pid |> :erlang.pid_to_list() |> to_string()
-      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-directory-sync")
+      stub_directory_access()
+      verification_ref = Ecto.UUID.generate()
+      token = directory_result_token(lv_pid, verification_ref)
 
-      Req.Test.stub(Portal.Entra.APIClient, fn req_conn ->
-        cond do
-          req_conn.method == "POST" ->
-            Req.Test.json(req_conn, %{"access_token" => "test-token"})
-
-          String.contains?(req_conn.request_path, "appRoleAssignedTo") ->
-            Req.Test.json(req_conn, %{"value" => []})
-
-          String.contains?(req_conn.request_path, "servicePrincipals") ->
-            Req.Test.json(req_conn, %{"value" => [%{"id" => "sp-id"}]})
-
-          String.contains?(req_conn.request_path, "/users") ->
-            Req.Test.json(req_conn, %{"value" => [%{"id" => "user-1"}]})
-
-          String.contains?(req_conn.request_path, "/groups") ->
-            Req.Test.json(req_conn, %{"value" => [%{"id" => "group-1"}]})
-
-          true ->
-            Req.Test.json(req_conn, %{"error" => "not mocked"})
-        end
-      end)
-
-      params = %{
-        "state" => state,
-        "admin_consent" => "True",
-        "tenant" => "my-tenant-id"
-      }
-
-      conn = get(conn, ~p"/verification/entra", params)
+      conn = get(conn, ~p"/verification/entra", %{"result" => token})
 
       assert conn.status == 200
       assert conn.resp_body =~ "Verification Successful"
-      assert_received {:entra_directory_sync_complete_received, "my-tenant-id",
+
+      assert_received {:entra_directory_sync_complete_received, @tenant_id,
                        ^verification_ref}
     end
 
-    test "with Entra API 401 error (nested message body), sends failure and renders failure", %{
+    test "rejects a non-admin user even when the directory app already has tenant access", %{
       conn: conn
     } do
-      # Sign an invalid pid string to cover the deserialize_pid rescue branch
-      {state, _verification_ref} = sign_entra_state("not-a-valid-pid", "entra-directory-sync")
+      verification_ref = Ecto.UUID.generate()
 
+      stub_directory_access([])
+
+      conn =
+        get(conn, ~p"/verification/entra", %{
+          "result" => directory_result_token(self(), verification_ref)
+        })
+
+      assert conn.resp_body =~ "Global Administrator or Privileged Role Administrator"
+      assert_received {:verification_failed, message, ^verification_ref}
+      assert message =~ "Global Administrator or Privileged Role Administrator"
+
+      refute_received {:entra_directory_sync_complete, _tenant_id, _verification_ref, _ack_to}
+    end
+
+    test "renders an Entra API 401 error", %{conn: conn} do
       Req.Test.stub(Portal.Entra.APIClient, fn req_conn ->
         req_conn
         |> Plug.Conn.put_resp_content_type("application/json")
@@ -363,25 +250,14 @@ defmodule PortalWeb.VerificationControllerTest do
         )
       end)
 
-      params = %{
-        "state" => state,
-        "admin_consent" => "True",
-        "tenant" => "my-tenant-id"
-      }
+      conn = get(conn, ~p"/verification/entra", %{"result" => directory_result_token(self())})
 
-      conn = get(conn, ~p"/verification/entra", params)
-
-      assert conn.status == 200
-      assert conn.resp_body =~ "Verification Failed"
       assert conn.resp_body =~ "Unauthorized"
       assert conn.resp_body =~ "Invalid credentials"
     end
 
-    test "with Entra API 403 error (binary error body), sends failure and renders failure", %{
-      conn: conn
-    } do
-      lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-directory-sync")
+    test "renders an Entra API 403 error", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
 
       Req.Test.stub(Portal.Entra.APIClient, fn req_conn ->
         req_conn
@@ -389,99 +265,110 @@ defmodule PortalWeb.VerificationControllerTest do
         |> Plug.Conn.send_resp(403, JSON.encode!(%{"error" => "Access to resource forbidden"}))
       end)
 
-      params = %{
-        "state" => state,
-        "admin_consent" => "True",
-        "tenant" => "my-tenant-id"
-      }
+      conn =
+        get(conn, ~p"/verification/entra", %{
+          "result" => directory_result_token(self(), verification_ref)
+        })
 
-      conn = get(conn, ~p"/verification/entra", params)
-
-      assert conn.status == 200
-      assert conn.resp_body =~ "Verification Failed"
       assert conn.resp_body =~ "Access denied"
       assert conn.resp_body =~ "Access to resource forbidden"
       assert_received {:verification_failed, message, ^verification_ref}
       assert message =~ "Access denied"
     end
 
-    test "with Entra API 4xx error (empty body), sends failure and renders failure", %{
-      conn: conn
-    } do
-      lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-directory-sync")
-
+    test "renders an Entra API error with an empty body", %{conn: conn} do
       Req.Test.stub(Portal.Entra.APIClient, fn req_conn ->
         req_conn
         |> Plug.Conn.put_resp_content_type("application/json")
         |> Plug.Conn.send_resp(404, JSON.encode!(%{}))
       end)
 
-      params = %{
-        "state" => state,
-        "admin_consent" => "True",
-        "tenant" => "my-tenant-id"
-      }
+      conn = get(conn, ~p"/verification/entra", %{"result" => directory_result_token(self())})
 
-      conn = get(conn, ~p"/verification/entra", params)
-
-      assert conn.status == 200
-      assert conn.resp_body =~ "Verification Failed"
       assert conn.resp_body =~ "Verification failed (HTTP 404)"
-      assert_received {:verification_failed, message, ^verification_ref}
-      assert message =~ "Verification failed (HTTP 404)"
     end
 
-    test "with Entra API transport error, sends failure and renders failure", %{conn: conn} do
-      lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-directory-sync")
-
+    test "renders an Entra API transport error", %{conn: conn} do
       Req.Test.stub(Portal.Entra.APIClient, fn req_conn ->
         Req.Test.transport_error(req_conn, :econnrefused)
       end)
 
-      params = %{
-        "state" => state,
-        "admin_consent" => "True",
-        "tenant" => "my-tenant-id"
-      }
+      conn = get(conn, ~p"/verification/entra", %{"result" => directory_result_token(self())})
 
-      conn = get(conn, ~p"/verification/entra", params)
-
-      assert conn.status == 200
-      assert conn.resp_body =~ "Verification Failed"
       assert conn.resp_body =~ "Failed to verify directory access"
-      assert_received {:verification_failed, message, ^verification_ref}
-      assert message =~ "Failed to verify directory access"
     end
   end
 
-  describe "entra/2 with invalid state" do
-    test "renders failure for unsigned/unknown state", %{conn: conn} do
+  describe "entra/2 with an invalid result" do
+    test "rejects raw admin-consent callback parameters", %{conn: conn} do
       conn =
         get(conn, ~p"/verification/entra", %{
-          "state" => "unknown-state",
+          "state" => "attacker-controlled-state",
           "admin_consent" => "True",
-          "tenant" => "my-tenant-id"
+          "tenant" => "attacker-controlled-tenant"
         })
 
       assert conn.status == 200
-      assert conn.resp_body =~ "Verification Failed"
+      assert conn.resp_body =~ "Invalid verification request"
     end
 
-    test "renders failure when no state param", %{conn: conn} do
-      conn = get(conn, ~p"/verification/entra", %{})
+    test "rejects invalid or missing result tokens", %{conn: conn} do
+      conn = get(conn, ~p"/verification/entra", %{"result" => "invalid-token"})
+      assert conn.resp_body =~ "Invalid or expired verification result"
 
-      assert conn.status == 200
-      assert conn.resp_body =~ "Verification Failed"
+      conn = get(recycle(conn), ~p"/verification/entra", %{})
+      assert conn.resp_body =~ "Invalid verification request"
     end
   end
 
-  # ============================================================================
-  # Helper Functions
-  # ============================================================================
+  defp stub_directory_access(
+         directory_roles \\ [%{"roleTemplateId" => @global_administrator_role_id}]
+       ) do
+    Req.Test.stub(Portal.Entra.APIClient, fn req_conn ->
+      cond do
+        req_conn.method == "POST" ->
+          Req.Test.json(req_conn, %{"access_token" => "test-token"})
+
+        String.contains?(req_conn.request_path, "appRoleAssignedTo") ->
+          Req.Test.json(req_conn, %{"value" => []})
+
+        String.contains?(req_conn.request_path, "transitiveMemberOf") ->
+          Req.Test.json(req_conn, %{"value" => directory_roles})
+
+        String.contains?(req_conn.request_path, "servicePrincipals") ->
+          Req.Test.json(req_conn, %{"value" => [%{"id" => "sp-id"}]})
+
+        String.contains?(req_conn.request_path, "/users") ->
+          Req.Test.json(req_conn, %{"value" => [%{"id" => "user-1"}]})
+
+        String.contains?(req_conn.request_path, "/groups") ->
+          Req.Test.json(req_conn, %{"value" => [%{"id" => "group-1"}]})
+
+        true ->
+          Req.Test.json(req_conn, %{"error" => "not mocked"})
+      end
+    end)
+  end
+
+  defp directory_result_token(lv_pid, verification_ref \\ Ecto.UUID.generate()) do
+    sign_entra_result(%{
+      ok: true,
+      type: "entra-directory-sync",
+      issuer: @issuer,
+      tenant_id: @tenant_id,
+      principal_id: @principal_id,
+      lv_pid: serialize_pid(lv_pid),
+      verification_ref: verification_ref
+    })
+  end
+
+  defp serialize_pid(pid), do: pid |> :erlang.pid_to_list() |> to_string()
 
   defp sign_oidc_result(result) do
     Phoenix.Token.sign(PortalWeb.Endpoint, "oidc-verification-result", result)
+  end
+
+  defp sign_entra_result(result) do
+    Phoenix.Token.sign(PortalWeb.Endpoint, "entra-verification-result", result)
   end
 end

--- a/elixir/test/portal_web/live/settings/authentication_test.exs
+++ b/elixir/test/portal_web/live/settings/authentication_test.exs
@@ -2734,6 +2734,35 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       assert_receive {:pending_verification, %{verification_ref: ^verification_ref}}
     end
 
+    test "does not consume an Entra verifier for a stale callback reference", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/authentication/entra/new")
+
+      lv
+      |> form("#auth-provider-form", %{auth_provider: %{name: "Test Entra"}})
+      |> render_change()
+
+      lv |> element("#verify-button") |> render_click()
+      assert_push_event(lv, "open_url", %{url: url})
+
+      %{"state" => state} = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+
+      assert {:ok, %{verification_ref: verification_ref}} =
+               PortalWeb.OIDC.verify_verification_state(state)
+
+      send(lv.pid, {:get_pending_verification, Ecto.UUID.generate(), self()})
+      assert_receive {:pending_verification, nil}
+
+      send(lv.pid, {:peek_pending_verification, self()})
+      assert_receive {:pending_verification, %{verification_ref: ^verification_ref}}
+    end
+
     test "accepts only the active entra verification completion", %{
       account: account,
       actor: actor,

--- a/elixir/test/portal_web/live/settings/authentication_test.exs
+++ b/elixir/test/portal_web/live/settings/authentication_test.exs
@@ -77,6 +77,10 @@ defmodule PortalWeb.Settings.AuthenticationTest do
     assert {:ok, %{verification_ref: verification_ref}} =
              PortalWeb.OIDC.verify_verification_state(state)
 
+    send(lv.pid, {:get_pending_verification, self()})
+
+    assert_receive {:pending_verification, %{verification_ref: ^verification_ref}}
+
     verification_ref
   end
 
@@ -2699,6 +2703,35 @@ defmodule PortalWeb.Settings.AuthenticationTest do
 
       html = render(lv)
       assert html =~ "Verified"
+    end
+
+    test "peeks at an Entra verifier without consuming it before the code callback", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/authentication/entra/new")
+
+      lv
+      |> form("#auth-provider-form", %{auth_provider: %{name: "Test Entra"}})
+      |> render_change()
+
+      lv |> element("#verify-button") |> render_click()
+      assert_push_event(lv, "open_url", %{url: url})
+
+      %{"state" => state} = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+
+      assert {:ok, %{verification_ref: verification_ref}} =
+               PortalWeb.OIDC.verify_verification_state(state)
+
+      send(lv.pid, {:peek_pending_verification, self()})
+      assert_receive {:pending_verification, %{verification_ref: ^verification_ref}}
+
+      send(lv.pid, {:get_pending_verification, self()})
+      assert_receive {:pending_verification, %{verification_ref: ^verification_ref}}
     end
 
     test "accepts only the active entra verification completion", %{

--- a/elixir/test/portal_web/live/settings/directory_sync_test.exs
+++ b/elixir/test/portal_web/live/settings/directory_sync_test.exs
@@ -373,6 +373,31 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
       assert_patch(lv, ~p"/#{account}/settings/directory_sync")
     end
 
+    test "does not consume an Entra directory verifier for a stale callback reference", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/directory_sync/entra/new")
+
+      lv |> element("button[phx-click='start_verification']") |> render_click()
+      assert_push_event(lv, "open_url", %{url: url})
+
+      %{"state" => state} = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+
+      assert {:ok, %{verification_ref: verification_ref}} =
+               PortalWeb.OIDC.verify_verification_state(state)
+
+      send(lv.pid, {:get_pending_verification, Ecto.UUID.generate(), self()})
+      assert_receive {:pending_verification, nil}
+
+      send(lv.pid, {:peek_pending_verification, self()})
+      assert_receive {:pending_verification, %{verification_ref: ^verification_ref}}
+    end
+
     test "accepts only the active entra directory verification completion", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_web/live/settings/directory_sync_test.exs
+++ b/elixir/test/portal_web/live/settings/directory_sync_test.exs
@@ -42,6 +42,10 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
     assert {:ok, %{verification_ref: verification_ref}} =
              PortalWeb.OIDC.verify_verification_state(state)
 
+    send(lv.pid, {:get_pending_verification, self()})
+
+    assert_receive {:pending_verification, %{verification_ref: ^verification_ref}}
+
     verification_ref
   end
 

--- a/elixir/test/portal_web/oidc_test.exs
+++ b/elixir/test/portal_web/oidc_test.exs
@@ -23,6 +23,128 @@ defmodule PortalWeb.OIDCTest do
     %{config: config, provider: provider}
   end
 
+  describe "Entra admin-consent URI" do
+    test "starts auth-provider verification with organization-wide admin consent" do
+      verifier = "auth-provider-verifier"
+      state = "signed-state"
+
+      assert {:ok, %{config: config}} = OIDC.setup_verification("entra", [])
+      assert {:ok, url} = OIDC.build_verification_uri("entra", config, verifier, state)
+
+      uri = URI.parse(url)
+      params = URI.decode_query(uri.query)
+
+      assert uri.path == "/organizations/v2.0/adminconsent"
+      assert params["scope"] == "openid email profile"
+      assert params["state"] == state
+      refute Map.has_key?(params, "prompt")
+      refute Map.has_key?(params, "response_type")
+    end
+
+    test "requests the directory-sync application's static Graph permissions" do
+      verifier = "directory-sync-verifier"
+
+      assert {:ok, %{config: config}} = OIDC.setup_verification("entra_directory_sync", [])
+
+      assert {:ok, url} =
+               OIDC.build_verification_uri(
+                 "entra_directory_sync",
+                 config,
+                 verifier,
+                 "signed-state"
+               )
+
+      uri = URI.parse(url)
+      params = URI.decode_query(uri.query)
+
+      assert uri.path == "/organizations/v2.0/adminconsent"
+      assert params["client_id"] == "test_client_id"
+      assert params["scope"] == "https://graph.microsoft.com/.default"
+    end
+  end
+
+  describe "Entra tenant-proof authorization URI" do
+    @tenant_id "12345678-1234-1234-1234-123456789012"
+
+    test "silently proves the auth-provider tenant with authorization code and PKCE" do
+      verifier = "auth-provider-verifier"
+
+      assert {:ok, %{config: config}} = OIDC.setup_verification("entra", [])
+
+      assert {:ok, url} =
+               OIDC.build_entra_tenant_authorization_uri(
+                 config,
+                 @tenant_id,
+                 verifier,
+                 "signed-state"
+               )
+
+      uri = URI.parse(url)
+      params = URI.decode_query(uri.query)
+
+      assert uri.path == "/#{@tenant_id}/oauth2/v2.0/authorize"
+      assert params["client_id"] == "test_auth_provider_client_id"
+      assert params["scope"] == "openid email profile"
+      assert params["state"] == "signed-state"
+      assert params["response_type"] == "code"
+      assert params["response_mode"] == "query"
+      assert params["prompt"] == "none"
+      assert params["nonce"] == entra_nonce(verifier)
+      assert params["code_challenge_method"] == "S256"
+      assert params["code_challenge"] == pkce_challenge(verifier)
+    end
+
+    test "proves the directory-sync user with only OIDC identity scopes" do
+      verifier = "directory-sync-verifier"
+
+      assert {:ok, %{config: config}} = OIDC.setup_verification("entra_directory_sync", [])
+
+      assert {:ok, url} =
+               OIDC.build_entra_tenant_authorization_uri(
+                 config,
+                 @tenant_id,
+                 verifier,
+                 "signed-state"
+               )
+
+      params = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+
+      assert params["client_id"] == "test_client_id"
+      assert params["scope"] == "openid profile"
+      refute params["scope"] =~ ".default"
+      refute params["scope"] =~ "Directory.Read"
+    end
+
+    test "allows an interactive fallback without forcing another account choice" do
+      assert {:ok, %{config: config}} = OIDC.setup_verification("entra", [])
+
+      assert {:ok, url} =
+               OIDC.build_entra_tenant_authorization_uri(
+                 config,
+                 @tenant_id,
+                 "auth-provider-verifier",
+                 "signed-state",
+                 prompt: nil
+               )
+
+      params = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+
+      refute Map.has_key?(params, "prompt")
+    end
+
+    test "rejects a tenant that was not a validated GUID" do
+      assert {:ok, %{config: config}} = OIDC.setup_verification("entra", [])
+
+      assert {:error, :invalid_entra_tenant} =
+               OIDC.build_entra_tenant_authorization_uri(
+                 config,
+                 "attacker-controlled-tenant",
+                 "auth-provider-verifier",
+                 "signed-state"
+               )
+    end
+  end
+
   describe "exchange_code/3 for Entra" do
     test "uses a configured client secret", %{config: config, provider: provider} do
       Portal.Config.put_env_override(
@@ -84,5 +206,47 @@ defmodule PortalWeb.OIDCTest do
       assert conn.body_params["client_assertion_type"] == @client_assertion_type
       refute conn.body_params["client_secret"]
     end
+  end
+
+  describe "exchange_code_with_config/3 for Entra verification" do
+    test "uses a managed-identity assertion when the verification client has no secret", %{
+      config: config
+    } do
+      config =
+        config
+        |> Keyword.put(:client_secret, nil)
+        |> Enum.into(%{verification_client_auth: :entra})
+
+      Req.Test.expect(Portal.Azure.ManagedIdentity, fn conn ->
+        Req.Test.json(conn, %{
+          "access_token" => "managed-identity-assertion",
+          "expires_on" => System.system_time(:second) + 3600
+        })
+      end)
+
+      assert {:ok, _tokens} =
+               OIDC.exchange_code_with_config(config, "code", "verification-verifier")
+
+      assert_receive {:oidc_request, discovery_path, _conn}
+      assert String.ends_with?(discovery_path, "/.well-known/openid-configuration")
+
+      assert_receive {:oidc_request, jwks_path, _conn}
+      assert String.ends_with?(jwks_path, "/.well-known/jwks.json")
+
+      assert_receive {:oidc_request, token_path, conn}
+      assert String.ends_with?(token_path, "/oauth/token")
+      assert conn.body_params["code_verifier"] == "verification-verifier"
+      assert conn.body_params["client_assertion"] == "managed-identity-assertion"
+      assert conn.body_params["client_assertion_type"] == @client_assertion_type
+    end
+  end
+
+  defp pkce_challenge(verifier) do
+    :crypto.hash(:sha256, verifier) |> Base.url_encode64(padding: false)
+  end
+
+  defp entra_nonce(verifier) do
+    :crypto.hash(:sha256, "entra-verification-nonce:" <> verifier)
+    |> Base.url_encode64(padding: false)
   end
 end

--- a/elixir/test/support/mocks/oidc.ex
+++ b/elixir/test/support/mocks/oidc.ex
@@ -155,11 +155,19 @@ defmodule PortalWeb.Mocks.OIDC do
   end
 
   @doc """
+  Overrides the JWKS returned by the mock provider for the current test.
+  """
+  def set_jwks_response(jwks) do
+    Process.put(:oidc_mock_jwks_response, jwks)
+  end
+
+  @doc """
   Clears any custom token or userinfo responses.
   """
   def clear_custom_responses do
     Process.delete(:oidc_mock_token_response)
     Process.delete(:oidc_mock_userinfo_response)
+    Process.delete(:oidc_mock_jwks_response)
   end
 
   defp handle_request(conn, test_pid, endpoint) do
@@ -172,7 +180,8 @@ defmodule PortalWeb.Mocks.OIDC do
         Req.Test.json(conn, discovery_document(endpoint))
 
       String.ends_with?(conn.request_path, "/.well-known/jwks.json") ->
-        Req.Test.json(conn, %{"keys" => [jwks()]})
+        jwks = get_from_test_process(test_pid, :oidc_mock_jwks_response) || jwks()
+        Req.Test.json(conn, %{"keys" => [jwks]})
 
       String.ends_with?(conn.request_path, "/oauth/token") ->
         handle_token_request(conn, test_pid, endpoint)
@@ -388,7 +397,10 @@ defmodule PortalWeb.Mocks.OIDC do
     {_alg, token} =
       jwks()
       |> JOSE.JWK.from()
-      |> JOSE.JWS.sign(JSON.encode!(claims), %{"alg" => "RS256"})
+      |> JOSE.JWS.sign(JSON.encode!(claims), %{
+        "alg" => "RS256",
+        "kid" => jwks()["kid"]
+      })
       |> JOSE.JWS.compact()
 
     token
@@ -406,6 +418,7 @@ defmodule PortalWeb.Mocks.OIDC do
       "e" => "AQAB",
       "kid" => "example@firezone.dev",
       "kty" => "RSA",
+      "issuer" => "https://login.microsoftonline.com/{tenantid}/v2.0",
       "n" =>
         "qlKll8no4lPYXNSuTTnacpFHiXwPOv_htCYvIXmiR7CWhiiOHQqj7KWXIW7TGxyoLVIyeRM4mwv" <>
           "kLI-UgsSMYdEKTT0j7Ydjrr0zCunPu5Gxr2yOmcRaszAzGxJL5DwpA0V40RqMlm5OuwdqS4To" <>


### PR DESCRIPTION
The Microsoft Entra admin-consent callback contains an unsigned tenant query parameter and cannot be used as proof that the current user controls that tenant. This change treats that callback as untrusted and adds a signed, user-bound verification step before associating an Entra tenant with a Firezone account.

- Follow Entra admin consent with a tenant-specific OIDC authorization-code and PKCE flow.
- Validate the ID-token signature, audience, issuer, tenant, nonce, signing-key issuer, and immutable user object ID.
- Require a tenant-wide Global Administrator or Privileged Role Administrator to complete auth-provider setup using the signed wids claim.
- For directory sync, bind the verified user object ID to an app-only Graph lookup of effective directory roles, then verify the granted app roles and required Graph endpoints.
- Attempt the identity proof silently using the existing Microsoft session, with an interactive fallback only when Entra requires it.
- Keep pending verification state bound to a short-lived reference and consume it before code exchange.

Rollout requirements:

- The Entra authentication app registration must set groupMembershipClaims to DirectoryRole.
- The Entra directory-sync app registration must declare the delegated Microsoft Graph openid and profile permissions in addition to its existing application permissions. Re-granting admin consent lets the identity-proof leg complete without a second consent prompt.

Testing:

- mix format --check-formatted
- mix test: 4,600 passed (6 doctests and 4,594 tests)
- Manually verified Entra authentication-provider and directory-sync setup in dev.

---