### PR TITLE
fix(portal): validate OIDC issuer and nonce

### DIFF
--- a/elixir/lib/openid_connect.ex
+++ b/elixir/lib/openid_connect.ex
@@ -435,21 +435,29 @@ defmodule OpenIDConnect do
     end
   end
 
-  defp issuer_matches?(issuer, issuer, _claims), do: true
+  defp issuer_matches?(issuer, expected_issuer, claims) do
+    cond do
+      is_binary(expected_issuer) and String.contains?(expected_issuer, "{tenantid}") ->
+        tenant_issuer_matches?(issuer, expected_issuer, claims)
 
-  # Google documents this legacy issuer as equivalent to the issuer in its
-  # discovery document.
-  defp issuer_matches?("accounts.google.com", "https://accounts.google.com", _claims), do: true
+      # Google documents this legacy issuer as equivalent to the issuer in its
+      # discovery document.
+      issuer == "accounts.google.com" and expected_issuer == "https://accounts.google.com" ->
+        true
+
+      true ->
+        issuer === expected_issuer
+    end
+  end
 
   # Microsoft Entra's tenant-independent discovery documents publish an issuer
   # template. The signed `tid` claim must fill that template exactly.
-  defp issuer_matches?(issuer, expected_issuer, %{"tid" => tenant_id})
-       when is_binary(expected_issuer) and is_binary(tenant_id) do
-    String.contains?(expected_issuer, "{tenantid}") and
-      issuer == String.replace(expected_issuer, "{tenantid}", tenant_id)
+  defp tenant_issuer_matches?(issuer, expected_issuer, %{"tid" => tenant_id})
+       when is_binary(tenant_id) do
+    issuer == String.replace(expected_issuer, "{tenantid}", tenant_id)
   end
 
-  defp issuer_matches?(_issuer, _expected_issuer, _claims), do: false
+  defp tenant_issuer_matches?(_issuer, _expected_issuer, _claims), do: false
 
   defp verify_nonce_claim(_claims, nil), do: :ok
 

--- a/elixir/lib/openid_connect.ex
+++ b/elixir/lib/openid_connect.ex
@@ -237,8 +237,7 @@ defmodule OpenIDConnect do
       verify_with_retry(
         config,
         jwt,
-        token_alg,
-        token_kid,
+        {token_alg, token_kid},
         discovery_document_uri,
         req_opts,
         opts
@@ -246,13 +245,13 @@ defmodule OpenIDConnect do
     end
   end
 
-  defp verify_with_retry(config, jwt, token_alg, token_kid, uri, req_opts, opts) do
+  defp verify_with_retry(config, jwt, {token_alg, _token_kid} = token_header, uri, req_opts, opts) do
     # Snapshot pre-call so we only retry when JWKS was cached (cold cache = already fresh).
     pre_cached = Cache.peek(uri)
 
     case do_verify(config, jwt, token_alg, uri, req_opts, opts) do
       {:error, {:invalid_jwt, "verification failed"}} = error ->
-        retry_verify(config, jwt, token_alg, token_kid, uri, req_opts, opts, pre_cached, error)
+        retry_verify(config, jwt, token_header, uri, req_opts, opts, pre_cached, error)
 
       result ->
         result
@@ -262,7 +261,16 @@ defmodule OpenIDConnect do
   # Refresh out-of-band so a failed refetch (provider unreachable) leaves the old
   # cached JWKS intact for legitimate cached-key-signed tokens. `allow_refresh?`
   # enforces a per-URI cooldown to throttle DoS via unknown-kid spam.
-  defp retry_verify(config, jwt, token_alg, token_kid, uri, req_opts, opts, pre_cached, error) do
+  defp retry_verify(
+         config,
+         jwt,
+         {token_alg, token_kid},
+         uri,
+         req_opts,
+         opts,
+         pre_cached,
+         error
+       ) do
     with true <- should_refresh_jwks?(token_kid, pre_cached),
          true <- Cache.allow_refresh?(uri),
          {:ok, _fresh} <- Document.refresh_document(uri, req_opts) do

--- a/elixir/lib/openid_connect.ex
+++ b/elixir/lib/openid_connect.ex
@@ -224,27 +224,35 @@ defmodule OpenIDConnect do
   @doc """
   Verifies the validity of the JSON Web Token (JWT)
 
-  This verification will assert the token's encryption against the provider's
-  JSON Web Key (JWK)
+  This verification validates the token signature and claims against the
+  provider's discovery document and JSON Web Key (JWK).
   """
-  @spec verify(config(), jwt :: String.t()) ::
+  @spec verify(config(), jwt :: String.t(), opts :: keyword()) ::
           {:ok, claims :: map()} | {:error, term()}
-  def verify(config, jwt) do
+  def verify(config, jwt, opts \\ []) do
     discovery_document_uri = config.discovery_document_uri
     req_opts = Map.get(config, :req_opts, [])
 
     with {:ok, token_alg, token_kid} <- peek_token_header(jwt) do
-      verify_with_retry(config, jwt, token_alg, token_kid, discovery_document_uri, req_opts)
+      verify_with_retry(
+        config,
+        jwt,
+        token_alg,
+        token_kid,
+        discovery_document_uri,
+        req_opts,
+        opts
+      )
     end
   end
 
-  defp verify_with_retry(config, jwt, token_alg, token_kid, uri, req_opts) do
+  defp verify_with_retry(config, jwt, token_alg, token_kid, uri, req_opts, opts) do
     # Snapshot pre-call so we only retry when JWKS was cached (cold cache = already fresh).
     pre_cached = Cache.peek(uri)
 
-    case do_verify(config, jwt, token_alg, uri, req_opts) do
+    case do_verify(config, jwt, token_alg, uri, req_opts, opts) do
       {:error, {:invalid_jwt, "verification failed"}} = error ->
-        retry_verify(config, jwt, token_alg, token_kid, uri, req_opts, pre_cached, error)
+        retry_verify(config, jwt, token_alg, token_kid, uri, req_opts, opts, pre_cached, error)
 
       result ->
         result
@@ -254,11 +262,11 @@ defmodule OpenIDConnect do
   # Refresh out-of-band so a failed refetch (provider unreachable) leaves the old
   # cached JWKS intact for legitimate cached-key-signed tokens. `allow_refresh?`
   # enforces a per-URI cooldown to throttle DoS via unknown-kid spam.
-  defp retry_verify(config, jwt, token_alg, token_kid, uri, req_opts, pre_cached, error) do
+  defp retry_verify(config, jwt, token_alg, token_kid, uri, req_opts, opts, pre_cached, error) do
     with true <- should_refresh_jwks?(token_kid, pre_cached),
          true <- Cache.allow_refresh?(uri),
          {:ok, _fresh} <- Document.refresh_document(uri, req_opts) do
-      do_verify(config, jwt, token_alg, uri, req_opts)
+      do_verify(config, jwt, token_alg, uri, req_opts, opts)
     else
       _ -> error
     end
@@ -308,11 +316,11 @@ defmodule OpenIDConnect do
     end
   end
 
-  defp do_verify(config, jwt, token_alg, discovery_document_uri, req_opts) do
+  defp do_verify(config, jwt, token_alg, discovery_document_uri, req_opts, opts) do
     with {:ok, document} <- Document.fetch_document(discovery_document_uri, req_opts),
          {true, claims, _jwk} <- verify_signature(document.jwks, token_alg, jwt),
          {:ok, unverified_claims} <- JSON.decode(claims),
-         {:ok, verified_claims} <- verify_claims(unverified_claims, config) do
+         {:ok, verified_claims} <- verify_claims(unverified_claims, config, document, opts) do
       {:ok, verified_claims}
     else
       {:error, {:unexpected_end, _position}} ->
@@ -360,12 +368,14 @@ defmodule OpenIDConnect do
   defp verify_signature(%JOSE.JWK{} = jwk, token_alg, jwt),
     do: JOSE.JWS.verify_strict(jwk, [token_alg], jwt)
 
-  defp verify_claims(claims, config) do
+  defp verify_claims(claims, config, document, opts) do
     leeway = Map.get(config, :leeway, 30)
     client_id = Map.fetch!(config, :client_id)
 
     with :ok <- verify_exp_claim(claims, leeway),
-         :ok <- verify_aud_claim(claims, client_id) do
+         :ok <- verify_aud_claim(claims, client_id),
+         :ok <- verify_iss_claim(claims, document.issuer),
+         :ok <- verify_nonce_claim(claims, Keyword.get(opts, :nonce)) do
       {:ok, claims}
     end
   end
@@ -401,6 +411,58 @@ defmodule OpenIDConnect do
 
   defp audience_matches?(aud, expected_aud) when is_list(aud), do: Enum.member?(aud, expected_aud)
   defp audience_matches?(aud, expected_aud), do: aud === expected_aud
+
+  defp verify_iss_claim(claims, expected_issuer) do
+    case Map.fetch(claims, "iss") do
+      {:ok, issuer} when is_binary(issuer) ->
+        if issuer_matches?(issuer, expected_issuer, claims),
+          do: :ok,
+          else: {:error, "iss", "token was issued by another provider"}
+
+      {:ok, _issuer} ->
+        {:error, "iss", "is invalid"}
+
+      :error ->
+        {:error, "iss", "missing"}
+    end
+  end
+
+  defp issuer_matches?(issuer, issuer, _claims), do: true
+
+  # Google documents this legacy issuer as equivalent to the issuer in its
+  # discovery document.
+  defp issuer_matches?("accounts.google.com", "https://accounts.google.com", _claims), do: true
+
+  # Microsoft Entra's tenant-independent discovery documents publish an issuer
+  # template. The signed `tid` claim must fill that template exactly.
+  defp issuer_matches?(issuer, expected_issuer, %{"tid" => tenant_id})
+       when is_binary(expected_issuer) and is_binary(tenant_id) do
+    String.contains?(expected_issuer, "{tenantid}") and
+      issuer == String.replace(expected_issuer, "{tenantid}", tenant_id)
+  end
+
+  defp issuer_matches?(_issuer, _expected_issuer, _claims), do: false
+
+  defp verify_nonce_claim(_claims, nil), do: :ok
+
+  defp verify_nonce_claim(claims, expected_nonce) when is_binary(expected_nonce) do
+    case Map.fetch(claims, "nonce") do
+      {:ok, nonce} when is_binary(nonce) ->
+        if secure_match?(nonce, expected_nonce),
+          do: :ok,
+          else: {:error, "nonce", "does not match the authorization request"}
+
+      {:ok, _nonce} ->
+        {:error, "nonce", "is invalid"}
+
+      :error ->
+        {:error, "nonce", "missing"}
+    end
+  end
+
+  defp secure_match?(left, right) do
+    byte_size(left) == byte_size(right) and Plug.Crypto.secure_compare(left, right)
+  end
 
   @doc "Fetches the userinfo claims for `access_token` from the provider's userinfo endpoint."
   def fetch_userinfo(config, access_token) do

--- a/elixir/lib/openid_connect/document.ex
+++ b/elixir/lib/openid_connect/document.ex
@@ -8,6 +8,7 @@ defmodule OpenIDConnect.Document do
   alias OpenIDConnect.Document.Cache
 
   defstruct raw: nil,
+            issuer: nil,
             authorization_endpoint: nil,
             end_session_endpoint: nil,
             token_endpoint: nil,
@@ -188,11 +189,12 @@ defmodule OpenIDConnect.Document do
   end
 
   defp build_document(document_json) do
-    required_keys = ["jwks_uri", "authorization_endpoint", "token_endpoint"]
+    required_keys = ["issuer", "jwks_uri", "authorization_endpoint", "token_endpoint"]
 
-    if Enum.all?(required_keys, &Map.has_key?(document_json, &1)) do
+    if Enum.all?(required_keys, &valid_required_value?(document_json, &1)) do
       document = %__MODULE__{
         raw: document_json,
+        issuer: Map.fetch!(document_json, "issuer"),
         authorization_endpoint: Map.fetch!(document_json, "authorization_endpoint"),
         end_session_endpoint: Map.get(document_json, "end_session_endpoint"),
         token_endpoint: Map.fetch!(document_json, "token_endpoint"),
@@ -214,6 +216,13 @@ defmodule OpenIDConnect.Document do
       {:ok, document}
     else
       {:error, :invalid_document}
+    end
+  end
+
+  defp valid_required_value?(document, key) do
+    case Map.fetch(document, key) do
+      {:ok, value} when is_binary(value) -> String.trim(value) != ""
+      _ -> false
     end
   end
 

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -182,7 +182,7 @@ defmodule PortalWeb.OIDCController do
     with :ok <- validate_context(provider, context_type),
          :ok <- ensure_client_sign_in_allowed(account, context_type),
          {:ok, tokens} <- PortalWeb.OIDC.exchange_code(provider, code, verifier),
-         {:ok, claims} <- PortalWeb.OIDC.verify_token(provider, tokens["id_token"]),
+         {:ok, claims} <- PortalWeb.OIDC.verify_token(provider, tokens["id_token"], verifier),
          userinfo = fetch_userinfo(provider, tokens["access_token"]),
          {:ok, identity_result} <- resolve_identity(account, provider, claims, userinfo) do
       finish_resolved_identity(auth_context, identity_result, tokens)

--- a/elixir/lib/portal_web/oidc.ex
+++ b/elixir/lib/portal_web/oidc.ex
@@ -113,8 +113,21 @@ defmodule PortalWeb.OIDC do
       additional_params = Keyword.get(opts, :additional_params, %{})
 
       oidc_params =
-        %{state: state, code_challenge_method: :S256, code_challenge: challenge}
-        |> Map.merge(additional_params)
+        additional_params
+        |> Map.drop([
+          :state,
+          "state",
+          :nonce,
+          "nonce",
+          :code_challenge_method,
+          "code_challenge_method",
+          :code_challenge,
+          "code_challenge"
+        ])
+        |> Map.put(:state, state)
+        |> Map.put(:nonce, nonce(verifier))
+        |> Map.put(:code_challenge_method, :S256)
+        |> Map.put(:code_challenge, challenge)
 
       case OpenIDConnect.authorization_uri(config, callback_url(provider), oidc_params) do
         {:ok, uri} -> {:ok, uri, state, verifier}
@@ -175,9 +188,9 @@ defmodule PortalWeb.OIDC do
   Verifies ID token and returns claims.
   Returns {:ok, claims} or {:error, reason}.
   """
-  def verify_token(provider, id_token) do
+  def verify_token(provider, id_token, verifier) do
     with {:ok, config} <- config_for_provider(provider) do
-      OpenIDConnect.verify(config, id_token)
+      OpenIDConnect.verify(config, id_token, nonce: nonce(verifier))
     end
   end
 
@@ -208,6 +221,10 @@ defmodule PortalWeb.OIDC do
   """
   def verify_token_with_config(config, id_token) do
     OpenIDConnect.verify(config, id_token)
+  end
+
+  def verify_token_with_config(config, id_token, verifier) do
+    OpenIDConnect.verify(config, id_token, nonce: nonce(verifier))
   end
 
   @doc """
@@ -351,6 +368,7 @@ defmodule PortalWeb.OIDC do
 
     oidc_params = %{
       state: state_token,
+      nonce: nonce(verifier),
       code_challenge_method: :S256,
       code_challenge: challenge,
       prompt: "login"
@@ -432,9 +450,15 @@ defmodule PortalWeb.OIDC do
   """
   def verify_callback(config, code, verifier) do
     with {:ok, tokens} <- exchange_code_with_config(config, code, verifier),
-         {:ok, claims} <- verify_token_with_config(config, tokens["id_token"]) do
+         {:ok, claims} <- verify_token_with_config(config, tokens["id_token"], verifier) do
       {:ok, claims, fetch_userinfo_with_config(config, tokens["access_token"])}
     end
+  end
+
+  @doc false
+  def nonce(verifier) when is_binary(verifier) do
+    :crypto.hash(:sha256, "oidc-nonce:" <> verifier)
+    |> Base.url_encode64(padding: false)
   end
 
   @doc """
@@ -461,6 +485,9 @@ defmodule PortalWeb.OIDC do
        }}
     else
       nil -> {:error, {:invalid_entra_id_token, :missing_id_token}}
+      {:error, {:invalid_jwt, reason}} ->
+        {:error, {:invalid_entra_id_token, {:invalid_jwt, reason}}}
+
       error -> error
     end
   end

--- a/elixir/test/openid_connect/document_test.exs
+++ b/elixir/test/openid_connect/document_test.exs
@@ -15,6 +15,7 @@ defmodule OpenIDConnect.DocumentTest do
 
       assert %OpenIDConnect.Document{
                authorization_endpoint: "https://common.auth0.com/authorize",
+               issuer: "https://common.auth0.com/",
                claims_supported: [
                  "aud",
                  "auth_time",
@@ -169,6 +170,12 @@ defmodule OpenIDConnect.DocumentTest do
       end)
 
       uri = "http://#{test_name}/.well-known/discovery-document.json"
+
+      assert fetch_document(uri, req_test_options(test_name)) == {:error, :invalid_document}
+    end
+
+    test "rejects a discovery document without a valid issuer" do
+      {test_name, uri} = start_fixture("google", %{"issuer" => nil})
 
       assert fetch_document(uri, req_test_options(test_name)) == {:error, :invalid_document}
     end

--- a/elixir/test/openid_connect_test.exs
+++ b/elixir/test/openid_connect_test.exs
@@ -638,6 +638,36 @@ defmodule OpenIDConnectTest do
                 {:invalid_jwt, "invalid iss claim: token was issued by another provider"}}
     end
 
+    test "rejects a literal Microsoft tenant issuer template" do
+      {config, jwk} = verification_fixture("azure")
+
+      claims =
+        config
+        |> valid_claims("https://login.microsoftonline.com/{tenantid}/v2.0")
+        |> Map.put("tid", "12345678-1234-1234-1234-123456789012")
+
+      token = sign_token(jwk, claims)
+
+      assert verify(config, token) ==
+               {:error,
+                {:invalid_jwt, "invalid iss claim: token was issued by another provider"}}
+    end
+
+    test "accepts an exact concrete issuer when the token also contains tid" do
+      tenant_id = "12345678-1234-1234-1234-123456789012"
+      issuer = "https://login.microsoftonline.com/#{tenant_id}/v2.0"
+      {config, jwk} = verification_fixture("azure", %{"issuer" => issuer})
+
+      claims =
+        config
+        |> valid_claims(issuer)
+        |> Map.put("tid", tenant_id)
+
+      token = sign_token(jwk, claims)
+
+      assert verify(config, token) == {:ok, claims}
+    end
+
     test "validates a nonce when one is expected" do
       {config, jwk} = verification_fixture("vault")
       claims = valid_claims(config) |> Map.put("nonce", "expected-nonce")
@@ -1272,11 +1302,14 @@ defmodule OpenIDConnectTest do
     OpenIDConnect.Fixtures.send_response(conn, status, %{"keys" => [pubkey]}, headers)
   end
 
-  defp verification_fixture(provider) do
+  defp verification_fixture(provider, overrides \\ %{}) do
     {raw_jwk, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
     jwk = JOSE.JWK.from(raw_jwk)
     {_, public_jwk} = JOSE.JWK.to_public_map(jwk)
-    {test_name, uri} = start_fixture(provider, %{"jwks" => public_jwk})
+
+    {test_name, uri} =
+      start_fixture(provider, Map.put(overrides, "jwks", public_jwk))
+
     config = %{@config | discovery_document_uri: uri, req_opts: req_test_options(test_name)}
     {config, jwk}
   end

--- a/elixir/test/openid_connect_test.exs
+++ b/elixir/test/openid_connect_test.exs
@@ -4,6 +4,7 @@ defmodule OpenIDConnectTest do
   import OpenIDConnect
 
   @redirect_uri "https://localhost/redirect_uri"
+  @vault_issuer "http://0.0.0.0:8200/v1/identity/oidc/provider/default"
 
   @config %{
     discovery_document_uri: nil,
@@ -568,7 +569,8 @@ defmodule OpenIDConnectTest do
       claims = %{
         "email" => "brian@example.com",
         "exp" => DateTime.utc_now() |> DateTime.add(10, :second) |> DateTime.to_unix(),
-        "aud" => config.client_id
+        "aud" => config.client_id,
+        "iss" => @vault_issuer
       }
 
       {_alg, token} =
@@ -577,6 +579,88 @@ defmodule OpenIDConnectTest do
         |> JOSE.JWS.compact()
 
       assert verify(config, token) == {:ok, claims}
+    end
+
+    test "rejects a token without an issuer" do
+      {config, jwk} = verification_fixture("vault")
+      claims = valid_claims(config) |> Map.delete("iss")
+      token = sign_token(jwk, claims)
+
+      assert verify(config, token) == {:error, {:invalid_jwt, "invalid iss claim: missing"}}
+    end
+
+    test "rejects a token issued by a different provider" do
+      {config, jwk} = verification_fixture("vault")
+      claims = valid_claims(config, "https://attacker.example.com")
+      token = sign_token(jwk, claims)
+
+      assert verify(config, token) ==
+               {:error,
+                {:invalid_jwt, "invalid iss claim: token was issued by another provider"}}
+    end
+
+    test "accepts Google's documented legacy issuer" do
+      {config, jwk} = verification_fixture("google")
+      claims = valid_claims(config, "accounts.google.com")
+      token = sign_token(jwk, claims)
+
+      assert verify(config, token) == {:ok, claims}
+    end
+
+    test "accepts a Microsoft tenant issuer matching the discovery document template" do
+      {config, jwk} = verification_fixture("azure")
+      tenant_id = "12345678-1234-1234-1234-123456789012"
+
+      claims =
+        config
+        |> valid_claims("https://login.microsoftonline.com/#{tenant_id}/v2.0")
+        |> Map.put("tid", tenant_id)
+
+      token = sign_token(jwk, claims)
+
+      assert verify(config, token) == {:ok, claims}
+    end
+
+    test "rejects a Microsoft issuer that does not match its signed tenant ID" do
+      {config, jwk} = verification_fixture("azure")
+
+      claims =
+        config
+        |> valid_claims(
+          "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0"
+        )
+        |> Map.put("tid", "87654321-4321-4321-4321-210987654321")
+
+      token = sign_token(jwk, claims)
+
+      assert verify(config, token) ==
+               {:error,
+                {:invalid_jwt, "invalid iss claim: token was issued by another provider"}}
+    end
+
+    test "validates a nonce when one is expected" do
+      {config, jwk} = verification_fixture("vault")
+      claims = valid_claims(config) |> Map.put("nonce", "expected-nonce")
+      token = sign_token(jwk, claims)
+
+      assert verify(config, token, nonce: "expected-nonce") == {:ok, claims}
+    end
+
+    test "rejects a missing or mismatched nonce when one is expected" do
+      {config, jwk} = verification_fixture("vault")
+
+      missing_nonce_token = sign_token(jwk, valid_claims(config))
+
+      assert verify(config, missing_nonce_token, nonce: "expected-nonce") ==
+               {:error, {:invalid_jwt, "invalid nonce claim: missing"}}
+
+      mismatched_claims = valid_claims(config) |> Map.put("nonce", "attacker-nonce")
+      mismatched_nonce_token = sign_token(jwk, mismatched_claims)
+
+      assert verify(config, mismatched_nonce_token, nonce: "expected-nonce") ==
+               {:error,
+                {:invalid_jwt,
+                 "invalid nonce claim: does not match the authorization request"}}
     end
 
     test "returns claims when aud claim is a list containing client_id" do
@@ -590,7 +674,8 @@ defmodule OpenIDConnectTest do
       claims = %{
         "email" => "brian@example.com",
         "exp" => DateTime.utc_now() |> DateTime.add(10, :second) |> DateTime.to_unix(),
-        "aud" => ["other-app", config.client_id, "another-app"]
+        "aud" => ["other-app", config.client_id, "another-app"],
+        "iss" => @vault_issuer
       }
 
       {_alg, token} =
@@ -618,7 +703,8 @@ defmodule OpenIDConnectTest do
       claims = %{
         "email" => "brian@example.com",
         "exp" => DateTime.utc_now() |> DateTime.add(10, :second) |> DateTime.to_unix(),
-        "aud" => config.client_id
+        "aud" => config.client_id,
+        "iss" => @vault_issuer
       }
 
       {_alg, token} =
@@ -631,7 +717,8 @@ defmodule OpenIDConnectTest do
       claims = %{
         "email" => "brian@example.com",
         "exp" => DateTime.utc_now() |> DateTime.add(-10, :second) |> DateTime.to_unix(),
-        "aud" => config.client_id
+        "aud" => config.client_id,
+        "iss" => @vault_issuer
       }
 
       {_alg, token} =
@@ -660,7 +747,8 @@ defmodule OpenIDConnectTest do
       claims = %{
         "email" => "brian@example.com",
         "exp" => DateTime.utc_now() |> DateTime.add(10, :second) |> DateTime.to_unix(),
-        "aud" => config.client_id
+        "aud" => config.client_id,
+        "iss" => @vault_issuer
       }
 
       {_alg, token} =
@@ -820,7 +908,8 @@ defmodule OpenIDConnectTest do
       claims = %{
         "email" => "brian@example.com",
         "exp" => DateTime.utc_now() |> DateTime.add(10, :second) |> DateTime.to_unix(),
-        "aud" => config.client_id
+        "aud" => config.client_id,
+        "iss" => @vault_issuer
       }
 
       {_alg, token} =
@@ -938,7 +1027,8 @@ defmodule OpenIDConnectTest do
       legit_claims = %{
         "email" => "brian@example.com",
         "exp" => DateTime.utc_now() |> DateTime.add(10, :second) |> DateTime.to_unix(),
-        "aud" => config.client_id
+        "aud" => config.client_id,
+        "iss" => @vault_issuer
       }
 
       {_alg, legit_token} =
@@ -1180,5 +1270,32 @@ defmodule OpenIDConnectTest do
     pubkey = if :counters.get(calls, 1) == 1, do: first, else: subsequent
     # Wrap in `keys` so JOSE.JWK.from/1 produces a jwk_set, matching real JWKS endpoints.
     OpenIDConnect.Fixtures.send_response(conn, status, %{"keys" => [pubkey]}, headers)
+  end
+
+  defp verification_fixture(provider) do
+    {raw_jwk, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
+    jwk = JOSE.JWK.from(raw_jwk)
+    {_, public_jwk} = JOSE.JWK.to_public_map(jwk)
+    {test_name, uri} = start_fixture(provider, %{"jwks" => public_jwk})
+    config = %{@config | discovery_document_uri: uri, req_opts: req_test_options(test_name)}
+    {config, jwk}
+  end
+
+  defp valid_claims(config, issuer \\ @vault_issuer) do
+    %{
+      "aud" => config.client_id,
+      "exp" => DateTime.utc_now() |> DateTime.add(10, :second) |> DateTime.to_unix(),
+      "iss" => issuer,
+      "sub" => "test-subject"
+    }
+  end
+
+  defp sign_token(jwk, claims) do
+    {_alg, token} =
+      jwk
+      |> JOSE.JWS.sign(JSON.encode!(claims), %{"alg" => "RS256"})
+      |> JOSE.JWS.compact()
+
+    token
   end
 end

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -57,6 +57,7 @@ defmodule PortalWeb.OIDCControllerTest do
 
       assert redirected_to(conn) =~ "/authorize"
       assert oidc_cookie_from_response(conn) != nil
+      assert_oidc_nonce_bound(conn)
     end
 
     test "accepts account slug instead of id", %{conn: conn} do
@@ -1320,6 +1321,16 @@ defmodule PortalWeb.OIDCControllerTest do
       assert_portal_sign_in_success(ctx)
     end
 
+    test "rejects an ID token whose nonce is not bound to the sign-in session", ctx do
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
+      setup_successful_auth(ctx, actor, nonce: "attacker-nonce")
+
+      conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
+
+      assert redirected_to(conn) == "/#{ctx.account.slug}/sign_in"
+      assert flash(conn, :error) == "Unable to verify your identity token. Please try signing in again."
+    end
+
     test "recreated user with a new idp_id overwrites their identity in place", ctx do
       actor = admin_actor_fixture(account: ctx.account, email: unique_email())
 
@@ -1528,7 +1539,8 @@ defmodule PortalWeb.OIDCControllerTest do
           "sub" => "admin-user-123",
           "name" => actor.name,
           "aud" => ctx.provider.client_id,
-          "exp" => token_exp()
+          "exp" => token_exp(),
+          "nonce" => PortalWeb.OIDC.nonce("test-verifier")
         })
 
       expect_token_exchange(id_token)
@@ -2579,7 +2591,8 @@ defmodule PortalWeb.OIDCControllerTest do
           "sub" => "nonexistent-user-123",
           "name" => "Test User",
           "aud" => ctx.provider.client_id,
-          "exp" => token_exp()
+          "exp" => token_exp(),
+          "nonce" => PortalWeb.OIDC.nonce("test-verifier")
         })
 
       expect_token_exchange(id_token)
@@ -2607,7 +2620,8 @@ defmodule PortalWeb.OIDCControllerTest do
           "sub" => "user-without-email-123",
           "name" => "User Without Email",
           "aud" => ctx.provider.client_id,
-          "exp" => token_exp()
+          "exp" => token_exp(),
+          "nonce" => PortalWeb.OIDC.nonce("test-verifier")
         })
 
       expect_token_exchange(id_token)
@@ -2638,7 +2652,6 @@ defmodule PortalWeb.OIDCControllerTest do
     # Format: {field_name, claim_name, limit}
     for {field, claim, limit} <- [
           {"email", "email", 160},
-          {"issuer", "iss", 2048},
           {"idp_id", "sub", 255},
           {"name", "name", 255},
           {"given_name", "given_name", 255},
@@ -2675,7 +2688,8 @@ defmodule PortalWeb.OIDCControllerTest do
                 "sub" => "admin-user-123",
                 "name" => actor.name,
                 "aud" => ctx.provider.client_id,
-                "exp" => token_exp()
+                "exp" => token_exp(),
+                "nonce" => PortalWeb.OIDC.nonce("test-verifier")
               },
               overrides
             )
@@ -2740,6 +2754,7 @@ defmodule PortalWeb.OIDCControllerTest do
       redirect_url = redirected_to(conn)
       assert redirect_url =~ "#{mock_endpoint}/authorize"
       assert redirect_url =~ "prompt=select_account"
+      assert_oidc_nonce_bound(conn)
     end
   end
 
@@ -2769,6 +2784,7 @@ defmodule PortalWeb.OIDCControllerTest do
       redirect_url = redirected_to(conn)
       assert redirect_url =~ "#{mock_endpoint}/authorize"
       assert redirect_url =~ "prompt=select_account"
+      assert_oidc_nonce_bound(conn)
     end
   end
 
@@ -2797,6 +2813,7 @@ defmodule PortalWeb.OIDCControllerTest do
       redirect_url = redirected_to(conn)
       assert redirect_url =~ "#{mock_endpoint}/authorize"
       assert redirect_url =~ "prompt=select_account"
+      assert_oidc_nonce_bound(conn)
     end
   end
 
@@ -3529,6 +3546,10 @@ defmodule PortalWeb.OIDCControllerTest do
   end
 
   defp set_entra_claims_response(claims) do
+    Mocks.OIDC.set_discovery_document_overrides(%{
+      "issuer" => "https://login.microsoftonline.com/{tenantid}/v2.0"
+    })
+
     claims
     |> Mocks.OIDC.sign_openid_connect_token()
     |> set_entra_id_token_response()
@@ -3592,7 +3613,8 @@ defmodule PortalWeb.OIDCControllerTest do
         "email" => email,
         "sub" => sub,
         "aud" => provider.client_id,
-        "exp" => token_exp()
+        "exp" => token_exp(),
+        "nonce" => Keyword.get(opts, :nonce, PortalWeb.OIDC.nonce("test-verifier"))
       }
       |> maybe_add_email_verified(opts)
       |> maybe_add_claim("name", opts, actor.name)
@@ -3629,6 +3651,13 @@ defmodule PortalWeb.OIDCControllerTest do
       "id_token" => id_token,
       "token_type" => "Bearer"
     })
+  end
+
+  defp assert_oidc_nonce_bound(conn) do
+    params = conn |> redirected_to() |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+    cookie = oidc_cookie_from_response(conn)
+
+    assert params["nonce"] == PortalWeb.OIDC.nonce(cookie.verifier)
   end
 
   # Sets up the userinfo endpoint mock response.

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -401,7 +401,7 @@ defmodule PortalWeb.OIDCControllerTest do
       assert {:ok, %{ok: false, error: error}} =
                entra_verification_result_from_redirect(redirected_to(conn))
 
-      assert error =~ "Unable to verify your identity token"
+      assert error =~ "Unable to verify the Microsoft Entra tenant"
     end
 
     test "rejects an Entra identity proof whose ID token audience does not match", %{conn: conn} do
@@ -417,7 +417,7 @@ defmodule PortalWeb.OIDCControllerTest do
       assert {:ok, %{ok: false, error: error}} =
                entra_verification_result_from_redirect(redirected_to(conn))
 
-      assert error =~ "Unable to verify your identity token"
+      assert error =~ "Unable to verify the Microsoft Entra tenant"
     end
 
     test "rejects an Entra identity proof whose ID token signature is invalid", %{conn: conn} do
@@ -440,7 +440,7 @@ defmodule PortalWeb.OIDCControllerTest do
       assert {:ok, %{ok: false, error: error}} =
                entra_verification_result_from_redirect(redirected_to(conn))
 
-      assert error =~ "Unable to verify your identity token"
+      assert error =~ "Unable to verify the Microsoft Entra tenant"
     end
 
     test "does not exchange the authorization code when an Entra identity-proof callback is replayed",

--- a/elixir/test/portal_web/oidc_test.exs
+++ b/elixir/test/portal_web/oidc_test.exs
@@ -63,6 +63,62 @@ defmodule PortalWeb.OIDCTest do
     end
   end
 
+  describe "OIDC verification URI" do
+    test "binds Google, Okta, and generic OIDC verification requests to the PKCE verifier",
+         %{config: config} do
+      config = Map.new(config)
+
+      for type <- ["google", "okta", "oidc"] do
+        assert {:ok, url} =
+                 OIDC.build_verification_uri(type, config, "verification-verifier", "signed-state")
+
+        params = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+
+        assert params["nonce"] == OIDC.nonce("verification-verifier")
+      end
+    end
+  end
+
+  describe "authorization URI" do
+    test "does not allow additional parameters to override state, nonce, or PKCE", %{
+      config: config,
+      provider: provider
+    } do
+      Portal.Config.put_env_override(:portal, Entra.AuthProvider, config)
+
+      additional_params = %{
+        "state" => "attacker-state",
+        "nonce" => "attacker-nonce",
+        "code_challenge_method" => "plain",
+        "code_challenge" => "attacker-challenge"
+      }
+
+      assert {:ok, url, "trusted-state", verifier} =
+               OIDC.authorization_uri(provider,
+                 state: "trusted-state",
+                 additional_params: additional_params
+               )
+
+      query_params = url |> URI.parse() |> Map.fetch!(:query) |> URI.query_decoder() |> Enum.to_list()
+
+      assert Enum.filter(query_params, &match?({"state", _value}, &1)) == [
+               {"state", "trusted-state"}
+             ]
+
+      assert Enum.filter(query_params, &match?({"nonce", _value}, &1)) == [
+               {"nonce", OIDC.nonce(verifier)}
+             ]
+
+      assert Enum.filter(query_params, &match?({"code_challenge_method", _value}, &1)) == [
+               {"code_challenge_method", "S256"}
+             ]
+
+      assert Enum.filter(query_params, &match?({"code_challenge", _value}, &1)) == [
+               {"code_challenge", pkce_challenge(verifier)}
+             ]
+    end
+  end
+
   describe "Entra tenant-proof authorization URI" do
     @tenant_id "12345678-1234-1234-1234-123456789012"
 

--- a/elixir/test/support/mocks/oidc.ex
+++ b/elixir/test/support/mocks/oidc.ex
@@ -162,12 +162,20 @@ defmodule PortalWeb.Mocks.OIDC do
   end
 
   @doc """
+  Overrides fields in the discovery document returned by the mock provider.
+  """
+  def set_discovery_document_overrides(overrides) do
+    Process.put(:oidc_mock_discovery_document_overrides, overrides)
+  end
+
+  @doc """
   Clears any custom token or userinfo responses.
   """
   def clear_custom_responses do
     Process.delete(:oidc_mock_token_response)
     Process.delete(:oidc_mock_userinfo_response)
     Process.delete(:oidc_mock_jwks_response)
+    Process.delete(:oidc_mock_discovery_document_overrides)
   end
 
   defp handle_request(conn, test_pid, endpoint) do
@@ -177,7 +185,12 @@ defmodule PortalWeb.Mocks.OIDC do
     # Match paths by suffix to support per-test unique endpoints (e.g., /024530/.well-known/openid-configuration)
     cond do
       String.ends_with?(conn.request_path, "/.well-known/openid-configuration") ->
-        Req.Test.json(conn, discovery_document(endpoint))
+        overrides = get_from_test_process(test_pid, :oidc_mock_discovery_document_overrides) || %{}
+
+        endpoint
+        |> discovery_document()
+        |> Map.merge(overrides)
+        |> then(&Req.Test.json(conn, &1))
 
       String.ends_with?(conn.request_path, "/.well-known/jwks.json") ->
         jwks = get_from_test_process(test_pid, :oidc_mock_jwks_response) || jwks()
@@ -223,11 +236,18 @@ defmodule PortalWeb.Mocks.OIDC do
 
           nil ->
             # Default response
+            verifier = conn.body_params["code_verifier"]
+
+            claims =
+              endpoint
+              |> default_claims()
+              |> Map.put("nonce", PortalWeb.OIDC.nonce(verifier))
+
             Req.Test.json(conn, %{
               "access_token" => "test_access_token",
               "token_type" => "Bearer",
               "expires_in" => 3600,
-              "id_token" => sign_openid_connect_token(default_claims(endpoint))
+              "id_token" => sign_openid_connect_token(claims)
             })
         end
     end
@@ -361,8 +381,11 @@ defmodule PortalWeb.Mocks.OIDC do
     }
   end
 
-  # Use static base endpoint for tests that create their own stubs
-  def default_claims, do: default_claims(@mock_endpoint_base)
+  def default_claims do
+    mock_endpoint()
+    |> default_claims()
+    |> Map.put("nonce", PortalWeb.OIDC.nonce("test-verifier"))
+  end
 
   def default_claims(port) when is_integer(port), do: default_claims("http://localhost:#{port}")
 


### PR DESCRIPTION
## Summary

- require and retain the issuer from OIDC discovery, then validate each ID token issuer against it
- bind Google, Okta, and generic OIDC authorization requests and callbacks with a nonce derived from the server-held PKCE verifier
- preserve the documented Google legacy issuer and Microsoft tenant-independent issuer-template behavior
- prevent additional authorization parameters from overriding state, nonce, or PKCE parameters

## Dependency

This is intentionally stacked on #14658 because the shared verifier must support the Microsoft Entra tenant-independent discovery issuer introduced and exercised by that PR. It can be retargeted to main after #14658 merges.

## References

- https://developers.google.com/identity/openid-connect/openid-connect#validatinganidtoken
- https://learn.microsoft.com/en-us/entra/identity-platform/access-tokens#validate-the-issuer

## Testing

- mix test
- 4,610 tests passed (6 doctests, 4,604 tests)