### PR TITLE
fix(portal): clarify Google verification scope

### DIFF
--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -1494,13 +1494,22 @@ defmodule PortalWeb.Settings.Authentication do
           <.flash :if={@verification_error} kind={:error} class="mb-3">
             {@verification_error}
           </.flash>
+          <.flash
+            :if={@type == "google"}
+            id="google-verification-scope-warning"
+            kind={:warning}
+            class="mb-3"
+          >
+            Google verification confirms that the sign-in flow works. It does not verify
+            Google Workspace administrator privileges or ownership of a Workspace domain.
+          </.flash>
           <div class="rounded border border-border overflow-hidden">
             <div class="flex items-center justify-between px-4 py-3">
               <p class="text-sm text-body">
                 {verification_help_text(@form, @type)}
               </p>
               <div class="ml-4 shrink-0">
-                <.verification_status_badge id="verify-button" form={@form} />
+                <.verification_status_badge id="verify-button" form={@form} type={@type} />
               </div>
             </div>
             <div
@@ -1528,6 +1537,14 @@ defmodule PortalWeb.Settings.Authentication do
     """
   end
 
+  defp verification_help_text(form, "google") do
+    if verified?(form) do
+      "The Google sign-in flow has been successfully verified."
+    else
+      "Sign in with your Google account to verify the sign-in flow."
+    end
+  end
+
   defp verification_help_text(form, type) do
     if verified?(form) do
       "This provider has been successfully verified."
@@ -1542,7 +1559,8 @@ defmodule PortalWeb.Settings.Authentication do
       :if={verified?(@form)}
       class="flex items-center gap-1.5 text-xs font-medium text-success bg-success-light px-2.5 py-1 rounded"
     >
-      <.icon name="ri-checkbox-circle-line" class="w-3.5 h-3.5" /> Verified
+      <.icon name="ri-checkbox-circle-line" class="w-3.5 h-3.5" />
+      {if @type == "google", do: "Verified sign-in", else: "Verified"}
     </div>
     <.button
       :if={not verified?(@form) and ready_to_verify?(@form)}

--- a/elixir/test/portal_web/live/settings/authentication_test.exs
+++ b/elixir/test/portal_web/live/settings/authentication_test.exs
@@ -445,6 +445,11 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       assert html =~ "Clients will be <strong>signed out</strong>"
       assert html =~ "after this and forced to re-authenticate."
       assert html =~ "Verify Now"
+      assert html =~ "Sign in with your Google account to verify the sign-in flow."
+      assert html =~ "Google verification confirms that the sign-in flow works."
+      assert html =~ "does not verify"
+      assert html =~ "Google Workspace administrator privileges"
+      assert html =~ "ownership of a Workspace domain"
     end
 
     test "validates portal_session_lifetime_secs minimum", %{
@@ -821,6 +826,10 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       assert html =~ "Edit Test Google"
       assert html =~ "Verification"
       assert html =~ "Verified"
+      assert html =~ "Verified sign-in"
+      assert html =~ "The Google sign-in flow has been successfully verified."
+      assert html =~ "Google verification confirms that the sign-in flow works."
+      assert html =~ "ownership of a Workspace domain"
     end
 
     test "shows reset verification button when verified", %{


### PR DESCRIPTION
## Summary

- label Google provider verification as sign-in verification
- show a warning that the flow does not verify Google Workspace administrator privileges or Workspace domain ownership
- cover both new and already-verified Google provider states

## Rationale

The current flow proves successful Google authentication with Firezone. It does not request Workspace administration scopes or establish domain ownership, so the UI should not imply that stronger trust boundary.

## Testing

- mix test
- 4,586 tests passed (6 doctests, 4,580 tests)