### PR TITLE
fix(portal): keep revocation list inside the panel

### DIFF
--- a/elixir/lib/portal_web/live/settings/device_trust/index.ex
+++ b/elixir/lib/portal_web/live/settings/device_trust/index.ex
@@ -642,13 +642,13 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
             issues, so this fills in the first time a device connects with one.
           </p>
 
-          <table :if={@revocation != []} class="w-full text-xs">
+          <table :if={@revocation != []} class="w-full table-fixed text-xs">
             <thead>
               <tr class="border-b border-border text-subtle">
                 <th class="text-left px-2 py-2 font-medium">Certificate authority</th>
                 <th class="text-left px-2 py-2 font-medium w-20">Checked via</th>
                 <th class="text-left px-2 py-2 font-medium w-24">Status</th>
-                <th class="w-6"></th>
+                <th class="w-10"></th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
The revocation list showed the full CRL address in every row. Those addresses are long, so the table grew wider than the panel and pushed the expand arrow past the right edge of the screen, where nobody could click it.

Rows now stay inside the panel and cut long names and addresses off with an ellipsis. The arrow is visible again, and expanding a row still shows the full address.
