### PR TITLE
fix(portal): open Google directory verification

### DIFF
--- a/elixir/assets/js/hooks.js
+++ b/elixir/assets/js/hooks.js
@@ -184,9 +184,49 @@ Hooks.CopyClipboard = {
 
 Hooks.OpenURL = {
   mounted() {
+    this.pendingWindow = null;
+
+    // Google directory verification performs an API preflight before the URL is
+    // available. Reserve the window during the user gesture so browsers do not
+    // treat the eventual navigation as an unsolicited popup.
+    this.clickHandler = (event) => {
+      if (!event.target.closest?.("[data-open-url-reserve]")) return;
+
+      this.pendingWindow = window.open("about:blank", "_blank");
+
+      if (this.pendingWindow) {
+        this.pendingWindow.opener = null;
+      }
+    };
+
+    this.el.addEventListener("click", this.clickHandler, { capture: true });
+
     this.handleEvent("open_url", ({ url }) => {
-      window.open(url, "_blank", "noopener,noreferrer");
+      const pendingWindow = this.pendingWindow;
+      this.pendingWindow = null;
+
+      if (pendingWindow && !pendingWindow.closed) {
+        pendingWindow.location.replace(url);
+      } else {
+        window.open(url, "_blank", "noopener,noreferrer");
+      }
     });
+
+    this.handleEvent("close_open_url", () => {
+      if (this.pendingWindow && !this.pendingWindow.closed) {
+        this.pendingWindow.close();
+      }
+
+      this.pendingWindow = null;
+    });
+  },
+
+  destroyed() {
+    this.el.removeEventListener("click", this.clickHandler, { capture: true });
+
+    if (this.pendingWindow && !this.pendingWindow.closed) {
+      this.pendingWindow.close();
+    }
   },
 };
 

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -1568,47 +1568,53 @@ defmodule PortalWeb.Settings.DirectorySync do
     # Entra and Google open a new window for user-bound authorization.
     button_attrs =
       if assigns.type in ["entra", "google"] do
-        [icon: "ri-external-link-line", "phx-hook": "OpenURL"]
+        [icon: "ri-external-link-line"]
       else
         []
       end
 
-    assigns = assign(assigns, :button_attrs, button_attrs)
+    assigns =
+      assigns
+      |> assign(:button_attrs, button_attrs)
+      |> assign(:opens_url?, assigns.type in ["entra", "google"])
 
     ~H"""
-    <div
-      :if={verified?(@form)}
-      class="flex items-center text-green-700 bg-green-100 px-4 py-2 rounded-sm"
-    >
-      <.icon name="ri-checkbox-circle-line" class="h-5 w-5 mr-2" />
-      <span class="font-medium">Verified</span>
+    <div id={@id <> "-open-url"} phx-hook={@opens_url? && "OpenURL"}>
+      <div
+        :if={verified?(@form)}
+        class="flex items-center text-green-700 bg-green-100 px-4 py-2 rounded-sm"
+      >
+        <.icon name="ri-checkbox-circle-line" class="h-5 w-5 mr-2" />
+        <span class="font-medium">Verified</span>
+      </div>
+      <.button
+        :if={not verified?(@form) and ready_to_verify?(@form) and not @verifying}
+        type="button"
+        id={@id <> "-verify-button"}
+        style="primary"
+        phx-click="start_verification"
+        data-open-url-reserve={@type == "google"}
+        {@button_attrs}
+      >
+        Verify Now
+      </.button>
+      <.button
+        :if={not verified?(@form) and @verifying}
+        type="button"
+        style="primary"
+        disabled
+      >
+        Verifying...
+      </.button>
+      <.button
+        :if={not verified?(@form) and not ready_to_verify?(@form)}
+        type="button"
+        style="primary"
+        disabled
+      >
+        Verify Now
+      </.button>
     </div>
-    <.button
-      :if={not verified?(@form) and ready_to_verify?(@form) and not @verifying}
-      type="button"
-      id={@id <> "-verify-button"}
-      style="primary"
-      phx-click="start_verification"
-      {@button_attrs}
-    >
-      Verify Now
-    </.button>
-    <.button
-      :if={not verified?(@form) and @verifying}
-      type="button"
-      style="primary"
-      disabled
-    >
-      Verifying...
-    </.button>
-    <.button
-      :if={not verified?(@form) and not ready_to_verify?(@form)}
-      type="button"
-      style="primary"
-      disabled
-    >
-      Verify Now
-    </.button>
     """
   end
 
@@ -1836,7 +1842,13 @@ defmodule PortalWeb.Settings.DirectorySync do
 
       error ->
         msg = parse_google_verification_error(error)
-        {:noreply, assign(socket, verification_error: msg, verifying: false)}
+
+        socket =
+          socket
+          |> assign(verification_error: msg, verifying: false)
+          |> push_event("close_open_url", %{})
+
+        {:noreply, socket}
     end
   end
 

--- a/elixir/test/portal_web/live/settings/directory_sync_test.exs
+++ b/elixir/test/portal_web/live/settings/directory_sync_test.exs
@@ -670,6 +670,7 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
 
       assert html =~ "Google denied the federated token exchange."
       refute html =~ ":workload_identity_token_exchange"
+      assert_push_event(lv, "close_open_url", %{})
     end
 
     test "generates an okta keypair and closes the panel", %{
@@ -835,6 +836,59 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
       html = render_click(lv, "reset_verification")
       assert html =~ "Verify Now"
       refute html =~ "Verification complete"
+    end
+
+    test "keeps the Google authorization hook mounted while edit verification starts", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      configure_google_directory_workload_identity()
+      configure_google_sync_authorization()
+
+      directory =
+        google_directory_fixture(%{
+          account: account,
+          name: "Unverified Google",
+          domain: "example.com",
+          impersonation_email: "sync-admin@example.com",
+          is_verified: false
+        })
+
+      Req.Test.stub(ManagedIdentity, fn req_conn ->
+        Req.Test.json(req_conn, %{"error" => "not mocked"})
+      end)
+
+      Req.Test.stub(APIClient, fn req_conn ->
+        Req.Test.json(req_conn, %{"error" => "not mocked"})
+      end)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/directory_sync/google/#{directory.id}/edit")
+
+      Req.Test.allow(ManagedIdentity, self(), lv.pid)
+      Req.Test.allow(APIClient, self(), lv.pid)
+      Req.Test.allow(PortalWeb.OIDC, self(), lv.pid)
+
+      expect_google_directory_service_access("C0123", "example.com")
+
+      assert has_element?(lv, "#verify-button-open-url[phx-hook='OpenURL']")
+
+      assert has_element?(
+               lv,
+               "button[phx-click='start_verification'][data-open-url-reserve]"
+             )
+
+      lv
+      |> element("button[phx-click='start_verification']")
+      |> render_click()
+
+      assert_push_event(lv, "open_url", %{url: url})
+      assert URI.parse(url).host == "mock.oidc.test"
+      assert has_element?(lv, "#verify-button-open-url[phx-hook='OpenURL']")
+      assert has_element?(lv, "#verify-button-open-url button[disabled]", "Verifying...")
     end
 
     test "requires reverification after regenerating an okta keypair", %{


### PR DESCRIPTION
## Summary

- keep the `OpenURL` hook mounted while Google directory verification changes the button to its loading state
- reserve the authorization window synchronously from the click gesture so the Google API preflight does not trigger popup blocking
- navigate the reserved window when the OAuth URL is ready and close it when preflight fails
- add regression coverage for Google verification from an existing directory edit form

## Root cause

Google directory verification now performs service-account and Admin SDK preflight requests before generating the OAuth URL. The original hook lived on the Verify Now button, but LiveView replaced that button with Verifying... before the delayed `open_url` event arrived. This destroyed the event listener. The delayed `window.open` could also be rejected as an unsolicited popup.

## Testing

- `mix format --check-formatted`
- 207 focused directory sync and OIDC tests
- `mix assets.build`
- `mix credo --strict`