### PR TITLE
fix(portal): preserve verification process node

### DIFF
--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -175,7 +175,7 @@ defmodule PortalWeb.Settings.Authentication do
     with {:ok, %{config: config}} <- PortalWeb.OIDC.setup_verification(type, opts),
          verifier = :crypto.strong_rand_bytes(32) |> Base.url_encode64(padding: false),
          verification_ref = Ecto.UUID.generate(),
-         lv_pid_string = self() |> :erlang.pid_to_list() |> to_string(),
+         lv_pid_string = PortalWeb.OIDC.serialize_pid(self()),
          state_token <-
            PortalWeb.OIDC.sign_verification_state(
              lv_pid_string,

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -1803,7 +1803,7 @@ defmodule PortalWeb.Settings.DirectorySync do
              PortalWeb.OIDC.setup_verification("google_directory_sync", []),
            verifier = :crypto.strong_rand_bytes(32) |> Base.url_encode64(padding: false),
            verification_ref = Ecto.UUID.generate(),
-           lv_pid_string = self() |> :erlang.pid_to_list() |> to_string(),
+           lv_pid_string = PortalWeb.OIDC.serialize_pid(self()),
            state_token <-
              PortalWeb.OIDC.sign_verification_state(
                lv_pid_string,
@@ -1856,7 +1856,7 @@ defmodule PortalWeb.Settings.DirectorySync do
     with {:ok, %{config: config}} <- PortalWeb.OIDC.setup_verification("entra_directory_sync", []),
          verifier = :crypto.strong_rand_bytes(32) |> Base.url_encode64(padding: false),
          verification_ref = Ecto.UUID.generate(),
-         lv_pid_string = self() |> :erlang.pid_to_list() |> to_string(),
+         lv_pid_string = PortalWeb.OIDC.serialize_pid(self()),
          state_token <-
            PortalWeb.OIDC.sign_verification_state(
              lv_pid_string,

--- a/elixir/lib/portal_web/oidc.ex
+++ b/elixir/lib/portal_web/oidc.ex
@@ -358,8 +358,40 @@ defmodule PortalWeb.OIDC do
   def verification_state_type(type) when type in ["google", "okta", "oidc"],
     do: "oidc-auth-provider"
 
+  @serialized_pid_prefix "pid:"
+  # Key-derivation salt; Phoenix.Token derives the actual encryption key from
+  # the endpoint secret_key_base shared by the portal cluster.
+  @serialized_pid_salt "oidc-verification-pid"
+  @serialized_pid_max_age 15 * 60
+
+  @doc """
+  Serializes a PID without losing its originating Erlang node.
+
+  The value is carried only inside signed verification state and result tokens.
+  """
+  def serialize_pid(pid) when is_pid(pid) do
+    encrypted_pid =
+      Phoenix.Token.encrypt(PortalWeb.Endpoint, @serialized_pid_salt, pid)
+
+    @serialized_pid_prefix <> encrypted_pid
+  end
+
   def deserialize_pid(nil), do: nil
 
+  def deserialize_pid(@serialized_pid_prefix <> encrypted_pid) do
+    case Phoenix.Token.decrypt(
+           PortalWeb.Endpoint,
+           @serialized_pid_salt,
+           encrypted_pid,
+           max_age: @serialized_pid_max_age
+         ) do
+      {:ok, pid} when is_pid(pid) -> pid
+      _ -> nil
+    end
+  end
+
+  # Accept verification callbacks created shortly before a deployment. This
+  # legacy representation identifies a PID only on the current Erlang node.
   def deserialize_pid(pid_string) when is_binary(pid_string) do
     pid_string |> String.to_charlist() |> :erlang.list_to_pid()
   rescue

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -3680,7 +3680,7 @@ defmodule PortalWeb.OIDCControllerTest do
   end
 
   defp google_directory_verification_state(lv_pid, verification_ref) do
-    lv_pid_string = lv_pid |> :erlang.pid_to_list() |> to_string()
+    lv_pid_string = PortalWeb.OIDC.serialize_pid(lv_pid)
 
     PortalWeb.OIDC.sign_verification_state(lv_pid_string, "google-directory-sync", %{
       verification_ref: verification_ref
@@ -3711,7 +3711,7 @@ defmodule PortalWeb.OIDCControllerTest do
   end
 
   defp entra_verification_state(lv_pid, type, verification_ref) do
-    lv_pid_string = lv_pid |> :erlang.pid_to_list() |> to_string()
+    lv_pid_string = PortalWeb.OIDC.serialize_pid(lv_pid)
 
     PortalWeb.OIDC.sign_verification_state(lv_pid_string, type, %{
       verification_ref: verification_ref
@@ -3719,7 +3719,7 @@ defmodule PortalWeb.OIDCControllerTest do
   end
 
   defp entra_tenant_proof_state(lv_pid, type, verification_ref) do
-    lv_pid_string = lv_pid |> :erlang.pid_to_list() |> to_string()
+    lv_pid_string = PortalWeb.OIDC.serialize_pid(lv_pid)
 
     PortalWeb.OIDC.sign_verification_state(lv_pid_string, "#{type}-tenant-proof", %{
       verification_ref: verification_ref,

--- a/elixir/test/portal_web/controllers/verification_controller_test.exs
+++ b/elixir/test/portal_web/controllers/verification_controller_test.exs
@@ -487,7 +487,7 @@ defmodule PortalWeb.VerificationControllerTest do
     end
   end
 
-  defp serialize_pid(pid), do: pid |> :erlang.pid_to_list() |> to_string()
+  defp serialize_pid(pid), do: PortalWeb.OIDC.serialize_pid(pid)
 
   defp sign_oidc_result(result) do
     Phoenix.Token.sign(PortalWeb.Endpoint, "oidc-verification-result", result)

--- a/elixir/test/portal_web/live/settings/authentication_test.exs
+++ b/elixir/test/portal_web/live/settings/authentication_test.exs
@@ -74,8 +74,10 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       |> Map.fetch!(:query)
       |> URI.decode_query()
 
-    assert {:ok, %{verification_ref: verification_ref}} =
+    assert {:ok, %{verification_ref: verification_ref, lv_pid: serialized_pid}} =
              PortalWeb.OIDC.verify_verification_state(state)
+
+    assert PortalWeb.OIDC.deserialize_pid(serialized_pid) == lv.pid
 
     send(lv.pid, {:get_pending_verification, self()})
 

--- a/elixir/test/portal_web/live/settings/directory_sync_test.exs
+++ b/elixir/test/portal_web/live/settings/directory_sync_test.exs
@@ -40,8 +40,10 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
       |> Map.fetch!(:query)
       |> URI.decode_query()
 
-    assert {:ok, %{verification_ref: verification_ref}} =
+    assert {:ok, %{verification_ref: verification_ref, lv_pid: serialized_pid}} =
              PortalWeb.OIDC.verify_verification_state(state)
+
+    assert PortalWeb.OIDC.deserialize_pid(serialized_pid) == lv.pid
 
     send(lv.pid, {:get_pending_verification, self()})
 

--- a/elixir/test/portal_web/oidc_test.exs
+++ b/elixir/test/portal_web/oidc_test.exs
@@ -23,6 +23,30 @@ defmodule PortalWeb.OIDCTest do
     %{config: config, provider: provider}
   end
 
+  describe "verification process serialization" do
+    test "round trips the PID with its Erlang node identity" do
+      serialized_pid = OIDC.serialize_pid(self())
+
+      assert String.starts_with?(serialized_pid, "pid:")
+      assert OIDC.deserialize_pid(serialized_pid) == self()
+    end
+
+    test "accepts legacy local PID strings for callbacks already in flight" do
+      legacy_pid = self() |> :erlang.pid_to_list() |> to_string()
+
+      assert OIDC.deserialize_pid(legacy_pid) == self()
+    end
+
+    test "rejects malformed values" do
+      encrypted_term =
+        Phoenix.Token.encrypt(PortalWeb.Endpoint, "oidc-verification-pid", "not-a-pid")
+
+      assert OIDC.deserialize_pid("pid:" <> encrypted_term) == nil
+      assert OIDC.deserialize_pid("pid:not-base64!") == nil
+      assert OIDC.deserialize_pid("not-a-pid") == nil
+    end
+  end
+
   describe "Entra admin-consent URI" do
     test "starts auth-provider verification with organization-wide admin consent" do
       verifier = "auth-provider-verifier"


### PR DESCRIPTION
## Summary

- preserve the originating Erlang node when encoding the LiveView PID into OAuth verification state
- encrypt the node-aware PID value so internal node names are not exposed to browsers or identity providers
- use the node-aware encoding for Google, Okta, generic OIDC, Entra authentication, Entra directory sync, and Google directory sync verification callbacks
- continue accepting legacy local PID strings for callbacks already in flight during deployment
- reject malformed and authenticated non-PID values

## Root cause

Verification state previously stored a PID as text such as `<0.23297.0>`. That representation identifies the process only on the node where it was created. When a callback was routed to another portal node, `list_to_pid/1` interpreted it as a local PID on the callback node and could not retrieve the pending PKCE verification session.

The replacement uses an encrypted Erlang external PID representation. It retains the source node, allowing the callback and result controllers to communicate with the original LiveView across the connected cluster.

Okta directory sync is not changed because its verification is synchronous and has no OAuth callback.

## Testing

- 396 focused OIDC controller, verification controller, authentication LiveView, directory LiveView, and OIDC helper tests
- `mix format --check-formatted`
- `mix credo --strict`
- manual two-node BEAM test confirming the value decodes to the exact remote PID, supports remote signaling, and does not expose the node name