### PR TITLE
fix(portal): verify Google directory admins via delegation

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -240,7 +240,7 @@ config :portal, Portal.Google.SyncAuthorization,
   client_id: System.get_env("GOOGLE_SYNC_AUTHZ_CLIENT_ID"),
   client_secret: System.get_env("GOOGLE_SYNC_AUTHZ_CLIENT_SECRET"),
   response_type: "code",
-  scope: "https://www.googleapis.com/auth/admin.directory.customer.readonly",
+  scope: "openid email",
   discovery_document_uri: "https://accounts.google.com/.well-known/openid-configuration"
 
 config :portal, Portal.Okta.AuthProvider,

--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -8,11 +8,12 @@ defmodule Portal.Google.APIClient do
   @access_token_type "urn:ietf:params:oauth:token-type:access_token"
   @jwt_token_type "urn:ietf:params:oauth:token-type:jwt"
   @cloud_platform_scope "https://www.googleapis.com/auth/cloud-platform"
-  @workspace_scope ~w[
-    https://www.googleapis.com/auth/admin.directory.customer.readonly
-    https://www.googleapis.com/auth/admin.directory.orgunit.readonly
-    https://www.googleapis.com/auth/admin.directory.group.readonly
-    https://www.googleapis.com/auth/admin.directory.user.readonly
+  @customer_readonly_scope "https://www.googleapis.com/auth/admin.directory.customer.readonly"
+  @workspace_scope [
+    @customer_readonly_scope,
+    "https://www.googleapis.com/auth/admin.directory.orgunit.readonly",
+    "https://www.googleapis.com/auth/admin.directory.group.readonly",
+    "https://www.googleapis.com/auth/admin.directory.user.readonly"
   ]
                    |> Enum.join(" ")
 
@@ -32,16 +33,31 @@ defmodule Portal.Google.APIClient do
   temporary fallback for federation-stage failures until the key is removed.
   """
   def get_access_token(impersonation_email) do
+    get_delegated_access_token(impersonation_email, @workspace_scope)
+  end
+
+  @doc """
+  Gets a delegated access token limited to reading Workspace customer information.
+
+  This is used to verify that an interactively authenticated Google user can read
+  the customer record without granting Admin SDK scopes to the interactive OAuth
+  client.
+  """
+  def get_customer_access_token(impersonation_email) do
+    get_delegated_access_token(impersonation_email, @customer_readonly_scope)
+  end
+
+  defp get_delegated_access_token(impersonation_email, scope) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
 
     case workload_identity_config(config) do
       {:ok, workload_identity_config} ->
         impersonation_email
-        |> get_federated_access_token(config, workload_identity_config)
-        |> maybe_fallback_to_service_account_key(impersonation_email, config)
+        |> get_federated_access_token(scope, config, workload_identity_config)
+        |> maybe_fallback_to_service_account_key(impersonation_email, scope, config)
 
       :not_configured ->
-        get_access_token_with_configured_key(impersonation_email, config)
+        get_access_token_with_configured_key(impersonation_email, scope, config)
 
       {:error, _reason} = error ->
         error
@@ -55,14 +71,24 @@ defmodule Portal.Google.APIClient do
   """
   def get_access_token(impersonation_email, key) when is_map(key) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
-    cache_key = workspace_cache_key(impersonation_email, {:service_account_key, key})
+
+    get_access_token_with_key(impersonation_email, key, @workspace_scope, config)
+  end
+
+  defp get_access_token_with_key(impersonation_email, key, scope, config) do
+    cache_key = workspace_cache_key(impersonation_email, scope, {:service_account_key, key})
 
     TokenCache.fetch(token_cache(config), cache_key, fn ->
-      fetch_key_access_token(impersonation_email, key, config)
+      fetch_key_access_token(impersonation_email, key, scope, config)
     end)
   end
 
-  defp get_federated_access_token(impersonation_email, config, workload_identity_config) do
+  defp get_federated_access_token(
+         impersonation_email,
+         scope,
+         config,
+         workload_identity_config
+       ) do
     federated_cache_key =
       {:federated_access_token, workload_identity_config.provider,
        workload_identity_config.audience}
@@ -74,6 +100,7 @@ defmodule Portal.Google.APIClient do
       cache_key =
         workspace_cache_key(
           impersonation_email,
+          scope,
           {:federated, workload_identity_config}
         )
 
@@ -82,6 +109,7 @@ defmodule Portal.Google.APIClient do
           impersonation_email,
           workload_identity_config.service_account_email,
           federated_token,
+          scope,
           config
         )
       end)
@@ -105,9 +133,10 @@ defmodule Portal.Google.APIClient do
          impersonation_email,
          service_account_email,
          federated_token,
+         scope,
          config
        ) do
-    claims = claim_set(impersonation_email, service_account_email, config[:token_endpoint])
+    claims = claim_set(impersonation_email, service_account_email, scope, config[:token_endpoint])
 
     with {:ok, signed_jwt} <-
            sign_jwt(claims, service_account_email, federated_token, config) do
@@ -117,13 +146,13 @@ defmodule Portal.Google.APIClient do
     end
   end
 
-  defp fetch_key_access_token(impersonation_email, key, config) do
+  defp fetch_key_access_token(impersonation_email, key, scope, config) do
     jws = %{"alg" => "RS256", "typ" => "JWT"}
     jwk = JOSE.JWK.from_pem(key["private_key"])
 
     claim_set =
       impersonation_email
-      |> claim_set(key["client_email"], config[:token_endpoint])
+      |> claim_set(key["client_email"], scope, config[:token_endpoint])
       |> JSON.encode!()
 
     jwt =
@@ -178,6 +207,7 @@ defmodule Portal.Google.APIClient do
   defp maybe_fallback_to_service_account_key(
          {:error, {stage, _reason}} = error,
          impersonation_email,
+         scope,
          config
        )
        when stage in @federation_failure_stages do
@@ -187,19 +217,25 @@ defmodule Portal.Google.APIClient do
           stage: stage
         )
 
-        get_access_token(impersonation_email, JSON.decode!(key))
+        get_access_token_with_key(impersonation_email, JSON.decode!(key), scope, config)
 
       _ ->
         error
     end
   end
 
-  defp maybe_fallback_to_service_account_key(result, _impersonation_email, _config), do: result
+  defp maybe_fallback_to_service_account_key(
+         result,
+         _impersonation_email,
+         _scope,
+         _config
+       ),
+       do: result
 
-  defp get_access_token_with_configured_key(impersonation_email, config) do
+  defp get_access_token_with_configured_key(impersonation_email, scope, config) do
     case config[:service_account_key] do
       key when is_binary(key) and key != "" ->
-        get_access_token(impersonation_email, JSON.decode!(key))
+        get_access_token_with_key(impersonation_email, JSON.decode!(key), scope, config)
 
       _ ->
         {:error, :service_account_not_configured}
@@ -256,12 +292,12 @@ defmodule Portal.Google.APIClient do
     end
   end
 
-  defp claim_set(impersonation_email, service_account_email, token_endpoint) do
+  defp claim_set(impersonation_email, service_account_email, scope, token_endpoint) do
     unix_timestamp = :os.system_time(:seconds)
 
     %{
       "iss" => service_account_email,
-      "scope" => @workspace_scope,
+      "scope" => scope,
       "aud" => token_endpoint,
       "sub" => impersonation_email,
       "exp" => unix_timestamp + 3600,
@@ -300,18 +336,19 @@ defmodule Portal.Google.APIClient do
   defp access_token_response({:ok, %Req.Response{} = response}), do: {:error, response}
   defp access_token_response({:error, _reason} = error), do: error
 
-  defp workspace_cache_key(impersonation_email, {:federated, config}) do
+  defp workspace_cache_key(impersonation_email, scope, {:federated, config}) do
     {
       :workspace_access_token,
       :federated,
       config.provider,
       config.audience,
       config.service_account_email,
-      impersonation_email
+      impersonation_email,
+      scope
     }
   end
 
-  defp workspace_cache_key(impersonation_email, {:service_account_key, key}) do
+  defp workspace_cache_key(impersonation_email, scope, {:service_account_key, key}) do
     key_id =
       key["private_key_id"] ||
         (:sha256
@@ -319,7 +356,7 @@ defmodule Portal.Google.APIClient do
          |> Base.encode16(case: :lower))
 
     {:workspace_access_token, :service_account_key, key["client_email"], key_id,
-     impersonation_email}
+     impersonation_email, scope}
   end
 
   def get_customer(access_token) do

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -1038,8 +1038,6 @@ defmodule PortalWeb.OIDCController do
     end
   end
 
-  defp google_workspace_identity(_claims), do: {:error, :invalid_google_identity}
-
   defp google_identity_claim(claims, claim) do
     case claims[claim] do
       value when is_binary(value) and value != "" -> {:ok, value}

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -978,7 +978,11 @@ defmodule PortalWeb.OIDCController do
          verification_ref
        ) do
     with {:ok, tokens} <- PortalWeb.OIDC.exchange_code_with_config(config, code, verifier),
-         access_token when is_binary(access_token) <- tokens["access_token"],
+         {:ok, id_token} <- google_id_token(tokens),
+         {:ok, claims} <-
+           PortalWeb.OIDC.verify_token_with_config(config, id_token, verifier),
+         {:ok, identity} <- google_workspace_identity(claims),
+         {:ok, access_token} <- Google.APIClient.get_customer_access_token(identity.email),
          {:ok, %Req.Response{status: 200, body: customer}} <-
            Google.APIClient.get_customer(access_token),
          {:ok, customer_id, domain} <- google_customer_identity(customer),
@@ -991,13 +995,6 @@ defmodule PortalWeb.OIDCController do
         verification_ref: verification_ref
       }
     else
-      nil ->
-        google_directory_sync_failure(
-          :missing_access_token,
-          lv_pid_string,
-          verification_ref
-        )
-
       error ->
         maybe_log_verification_error(error)
         google_directory_sync_failure(error, lv_pid_string, verification_ref)
@@ -1015,6 +1012,39 @@ defmodule PortalWeb.OIDCController do
       lv_pid_string,
       verification_ref
     )
+  end
+
+  defp google_id_token(%{"id_token" => id_token})
+       when is_binary(id_token) and id_token != "",
+       do: {:ok, id_token}
+
+  defp google_id_token(_tokens), do: {:error, :missing_google_id_token}
+
+  defp google_workspace_identity(claims) when is_map(claims) do
+    with true <- claims["email_verified"] == true,
+         {:ok, subject_id} <- google_identity_claim(claims, "sub"),
+         {:ok, email} <- google_identity_claim(claims, "email"),
+         {:ok, hosted_domain} <- google_identity_claim(claims, "hd") do
+      {:ok,
+       %{
+         subject_id: subject_id,
+         email: email,
+         hosted_domain: hosted_domain
+       }}
+    else
+      false -> {:error, :google_email_not_verified}
+      {:error, "hd"} -> {:error, :not_google_workspace_account}
+      {:error, _claim} -> {:error, :invalid_google_identity}
+    end
+  end
+
+  defp google_workspace_identity(_claims), do: {:error, :invalid_google_identity}
+
+  defp google_identity_claim(claims, claim) do
+    case claims[claim] do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _value -> {:error, claim}
+    end
   end
 
   defp google_customer_identity(%{"id" => customer_id, "customerDomain" => domain})
@@ -1102,8 +1132,17 @@ defmodule PortalWeb.OIDCController do
     "The Google account completing verification belongs to a different Workspace than the configured impersonation account."
   end
 
-  defp google_directory_sync_error_message(:missing_access_token),
-    do: "Google did not return an access token. Please try verification again."
+  defp google_directory_sync_error_message(:missing_google_id_token),
+    do: "Google did not return an identity token. Please try verification again."
+
+  defp google_directory_sync_error_message(:google_email_not_verified),
+    do: "Google did not confirm that the signed-in account's email is verified."
+
+  defp google_directory_sync_error_message(:not_google_workspace_account),
+    do: "Please sign in with a managed Google Workspace account."
+
+  defp google_directory_sync_error_message(:invalid_google_identity),
+    do: "Google returned incomplete account identity information. Please try verification again."
 
   defp google_directory_sync_error_message(:invalid_google_customer),
     do: "Google returned invalid Workspace customer information. Please try verification again."

--- a/elixir/lib/portal_web/oidc.ex
+++ b/elixir/lib/portal_web/oidc.ex
@@ -11,7 +11,7 @@ defmodule PortalWeb.OIDC do
   require Logger
 
   @client_assertion_type "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
-  @google_directory_customer_scope "https://www.googleapis.com/auth/admin.directory.customer.readonly"
+  @google_directory_identity_scope "openid email"
   @entra_organizations_discovery_document_uri "https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration"
   @entra_organizations_admin_consent_endpoint "https://login.microsoftonline.com/organizations/v2.0/adminconsent"
   @entra_issuer_prefix "https://login.microsoftonline.com/"
@@ -284,7 +284,7 @@ defmodule PortalWeb.OIDC do
 
   Provider types:
   - "google", "okta", "oidc" — OIDC authorization code + PKCE flow
-  - "google_directory_sync" — OAuth authorization code + PKCE Workspace admin proof
+  - "google_directory_sync" — OIDC code + PKCE identity proof for a Workspace admin probe
   - "entra" — Entra auth_provider admin consent + silent authorization code/PKCE proof
   - "entra_directory_sync" — Entra directory_sync admin consent + user-bound PKCE proof
 
@@ -315,7 +315,7 @@ defmodule PortalWeb.OIDC do
     config =
       Portal.Config.fetch_env!(:portal, Portal.Google.SyncAuthorization)
       |> Keyword.put(:response_type, "code")
-      |> Keyword.put(:scope, @google_directory_customer_scope)
+      |> Keyword.put(:scope, @google_directory_identity_scope)
       |> verification_config([])
 
     {:ok, %{config: config}}
@@ -431,6 +431,7 @@ defmodule PortalWeb.OIDC do
 
     oauth_params = %{
       state: state_token,
+      nonce: nonce(verifier),
       code_challenge_method: :S256,
       code_challenge: challenge,
       prompt: "select_account"

--- a/elixir/test/portal/google/api_client_test.exs
+++ b/elixir/test/portal/google/api_client_test.exs
@@ -144,6 +144,94 @@ defmodule Portal.Google.APIClientTest do
       refute_receive {:sts_request, _sts_params}
     end
 
+    test "uses and caches a customer-read-only token separately from the sync token" do
+      configure_workload_identity()
+      test_pid = self()
+
+      Req.Test.stub(Portal.Azure.ManagedIdentity, fn conn ->
+        Req.Test.json(conn, %{"error" => "not mocked"})
+      end)
+
+      server = start_token_cache()
+      Req.Test.allow(APIClient, self(), server)
+      Req.Test.allow(Portal.Azure.ManagedIdentity, self(), server)
+
+      Req.Test.expect(Portal.Azure.ManagedIdentity, fn conn ->
+        Req.Test.json(conn, %{
+          "access_token" => "azure-managed-identity-token",
+          "expires_on" => Integer.to_string(System.system_time(:second) + 3600)
+        })
+      end)
+
+      Req.Test.expect(APIClient, 5, fn conn ->
+        case conn.request_path do
+          "/v1/token" ->
+            Req.Test.json(conn, %{
+              "access_token" => "federated-google-token",
+              "expires_in" => 3600
+            })
+
+          "/v1/projects/-/serviceAccounts/" <>
+              @service_account_email <> ":signJwt" ->
+            {:ok, body, conn} = Plug.Conn.read_body(conn)
+            %{"payload" => payload} = JSON.decode!(body)
+            claims = JSON.decode!(payload)
+            send(test_pid, {:delegated_claims, claims})
+
+            signed_jwt =
+              if claims["scope"] ==
+                   "https://www.googleapis.com/auth/admin.directory.customer.readonly" do
+                "customer-signed-jwt"
+              else
+                "sync-signed-jwt"
+              end
+
+            Req.Test.json(conn, %{"signedJwt" => signed_jwt})
+
+          "/token" ->
+            {:ok, body, conn} = Plug.Conn.read_body(conn)
+            params = URI.decode_query(body)
+
+            token =
+              case params["assertion"] do
+                "customer-signed-jwt" -> "customer-access-token"
+                "sync-signed-jwt" -> "sync-access-token"
+              end
+
+            Req.Test.json(conn, %{"access_token" => token, "expires_in" => 3600})
+        end
+      end)
+
+      assert {:ok, "sync-access-token"} = APIClient.get_access_token("admin@example.com")
+
+      assert {:ok, "customer-access-token"} =
+               APIClient.get_customer_access_token("admin@example.com")
+
+      assert {:ok, "sync-access-token"} = APIClient.get_access_token("admin@example.com")
+
+      assert {:ok, "customer-access-token"} =
+               APIClient.get_customer_access_token("admin@example.com")
+
+      assert_receive {:delegated_claims, sync_claims}
+      assert sync_claims["sub"] == "admin@example.com"
+
+      assert MapSet.new(String.split(sync_claims["scope"])) ==
+               MapSet.new([
+                 "https://www.googleapis.com/auth/admin.directory.customer.readonly",
+                 "https://www.googleapis.com/auth/admin.directory.orgunit.readonly",
+                 "https://www.googleapis.com/auth/admin.directory.group.readonly",
+                 "https://www.googleapis.com/auth/admin.directory.user.readonly"
+               ])
+
+      assert_receive {:delegated_claims, customer_claims}
+      assert customer_claims["sub"] == "admin@example.com"
+
+      assert customer_claims["scope"] ==
+               "https://www.googleapis.com/auth/admin.directory.customer.readonly"
+
+      refute_receive {:delegated_claims, _claims}
+    end
+
     test "caches a service-account-key access token" do
       server = start_token_cache()
       Req.Test.allow(APIClient, self(), server)

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -977,6 +977,23 @@ defmodule PortalWeb.OIDCControllerTest do
   end
 
   describe "callback/2 with Google directory verification state" do
+    setup do
+      configure_google_directory_workload_identity()
+      test_pid = self()
+
+      Req.Test.stub(Portal.Azure.ManagedIdentity, fn conn ->
+        send(test_pid, {:unexpected_google_managed_identity_request, conn.request_path})
+        Req.Test.json(conn, %{"error" => "not mocked"})
+      end)
+
+      Req.Test.stub(Portal.Google.APIClient, fn conn ->
+        send(test_pid, {:unexpected_google_api_request, conn.request_path})
+        Req.Test.json(conn, %{"error" => "not mocked"})
+      end)
+
+      :ok
+    end
+
     test "binds the authorized Workspace customer to the delegated service-account customer", %{
       conn: conn
     } do
@@ -984,20 +1001,19 @@ defmodule PortalWeb.OIDCControllerTest do
       lv_pid = google_directory_pending_verification_process(verification_ref, "C0123")
       state = google_directory_verification_state(lv_pid, verification_ref)
 
-      Mocks.OIDC.set_token_response(%{"access_token" => "interactive-google-token"})
+      set_google_directory_id_token(%{
+        "email" => "workspace-admin@verified.example.com",
+        "hd" => "verified.example.com"
+      })
 
-      Req.Test.expect(Portal.Google.APIClient, fn req_conn ->
-        assert req_conn.request_path == "/admin/directory/v1/customers/my_customer"
-
-        assert Plug.Conn.get_req_header(req_conn, "authorization") == [
-                 "Bearer interactive-google-token"
-               ]
-
-        Req.Test.json(req_conn, %{
+      expect_google_directory_admin_check(
+        "workspace-admin@verified.example.com",
+        {:ok,
+         %{
           "id" => "C0123",
           "customerDomain" => "verified.example.com"
-        })
-      end)
+         }}
+      )
 
       conn =
         get(conn, ~p"/auth/oidc/callback", %{"state" => state, "code" => "test-code"})
@@ -1019,14 +1035,19 @@ defmodule PortalWeb.OIDCControllerTest do
       lv_pid = google_directory_pending_verification_process(verification_ref, "C-victim")
       state = google_directory_verification_state(lv_pid, verification_ref)
 
-      Mocks.OIDC.set_token_response(%{"access_token" => "attacker-google-token"})
+      set_google_directory_id_token(%{
+        "email" => "attacker@attacker.example.com",
+        "hd" => "attacker.example.com"
+      })
 
-      Req.Test.expect(Portal.Google.APIClient, fn req_conn ->
-        Req.Test.json(req_conn, %{
+      expect_google_directory_admin_check(
+        "attacker@attacker.example.com",
+        {:ok,
+         %{
           "id" => "C-attacker",
           "customerDomain" => "attacker.example.com"
-        })
-      end)
+         }}
+      )
 
       conn =
         get(conn, ~p"/auth/oidc/callback", %{"state" => state, "code" => "test-code"})
@@ -1049,13 +1070,16 @@ defmodule PortalWeb.OIDCControllerTest do
       lv_pid = google_directory_pending_verification_process(verification_ref, "C0123")
       state = google_directory_verification_state(lv_pid, verification_ref)
 
-      Mocks.OIDC.set_token_response(%{"access_token" => "non-admin-google-token"})
+      set_google_directory_id_token(%{
+        "email" => "member@verified.example.com",
+        "hd" => "verified.example.com"
+      })
 
-      Req.Test.expect(Portal.Google.APIClient, fn req_conn ->
-        req_conn
-        |> Plug.Conn.put_status(403)
-        |> Req.Test.json(%{"error" => %{"message" => "Not Authorized to access this resource/api"}})
-      end)
+      expect_google_directory_admin_check(
+        "member@verified.example.com",
+        {:error, 403,
+         %{"error" => %{"message" => "Not Authorized to access this resource/api"}}}
+      )
 
       conn =
         get(conn, ~p"/auth/oidc/callback", %{"state" => state, "code" => "test-code"})
@@ -1067,20 +1091,134 @@ defmodule PortalWeb.OIDCControllerTest do
       assert error =~ "permission to view customer information"
     end
 
+    test "rejects a missing Google ID token before requesting delegated access", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      lv_pid = google_directory_pending_verification_process(verification_ref, "C0123")
+      state = google_directory_verification_state(lv_pid, verification_ref)
+
+      Mocks.OIDC.set_token_response(%{"access_token" => "unused-interactive-token"})
+
+      conn =
+        get(conn, ~p"/auth/oidc/callback", %{"state" => state, "code" => "test-code"})
+
+      assert {:ok, %{ok: false, error: error}} =
+               oidc_verification_result_from_redirect(redirected_to(conn))
+
+      assert error =~ "did not return an identity token"
+      refute_received {:unexpected_google_managed_identity_request, _path}
+      refute_received {:unexpected_google_api_request, _path}
+    end
+
+    test "rejects a Google ID token with an invalid signature before requesting delegated access", %{
+      conn: conn
+    } do
+      verification_ref = Ecto.UUID.generate()
+      lv_pid = google_directory_pending_verification_process(verification_ref, "C0123")
+      state = google_directory_verification_state(lv_pid, verification_ref)
+
+      Mocks.OIDC.set_token_response(%{"id_token" => "not-a-signed-token"})
+
+      conn =
+        get(conn, ~p"/auth/oidc/callback", %{"state" => state, "code" => "test-code"})
+
+      assert {:ok, %{ok: false, error: error}} =
+               oidc_verification_result_from_redirect(redirected_to(conn))
+
+      assert error =~ "Unable to verify your identity token"
+      refute_received {:unexpected_google_managed_identity_request, _path}
+      refute_received {:unexpected_google_api_request, _path}
+    end
+
+    test "rejects a Google ID token for another OAuth client", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      lv_pid = google_directory_pending_verification_process(verification_ref, "C0123")
+      state = google_directory_verification_state(lv_pid, verification_ref)
+
+      set_google_directory_id_token(%{
+        "aud" => "another-google-client",
+        "hd" => "verified.example.com"
+      })
+
+      conn =
+        get(conn, ~p"/auth/oidc/callback", %{"state" => state, "code" => "test-code"})
+
+      assert {:ok, %{ok: false, error: error}} =
+               oidc_verification_result_from_redirect(redirected_to(conn))
+
+      assert error =~ "Unable to verify your identity token"
+      refute_received {:unexpected_google_managed_identity_request, _path}
+      refute_received {:unexpected_google_api_request, _path}
+    end
+
+    test "rejects a Google ID token whose nonce is not bound to the verification", %{conn: conn} do
+      verification_ref = Ecto.UUID.generate()
+      lv_pid = google_directory_pending_verification_process(verification_ref, "C0123")
+      state = google_directory_verification_state(lv_pid, verification_ref)
+
+      set_google_directory_id_token(%{
+        "nonce" => "nonce-from-another-verification",
+        "hd" => "verified.example.com"
+      })
+
+      conn =
+        get(conn, ~p"/auth/oidc/callback", %{"state" => state, "code" => "test-code"})
+
+      assert {:ok, %{ok: false, error: error}} =
+               oidc_verification_result_from_redirect(redirected_to(conn))
+
+      assert error =~ "Unable to verify your identity token"
+      refute_received {:unexpected_google_managed_identity_request, _path}
+      refute_received {:unexpected_google_api_request, _path}
+    end
+
+    test "requires a verified email from a managed Google Workspace account", %{conn: conn} do
+      for {claims, expected_error} <- [
+            {%{"email_verified" => false, "hd" => "verified.example.com"},
+             "email is verified"},
+            {%{"hd" => nil}, "managed Google Workspace account"},
+            {%{"sub" => nil, "hd" => "verified.example.com"},
+             "incomplete account identity information"}
+          ] do
+        verification_ref = Ecto.UUID.generate()
+        lv_pid = google_directory_pending_verification_process(verification_ref, "C0123")
+        state = google_directory_verification_state(lv_pid, verification_ref)
+        set_google_directory_id_token(claims)
+
+        callback_conn =
+          get(recycle(conn), ~p"/auth/oidc/callback", %{
+            "state" => state,
+            "code" => "test-code"
+          })
+
+        assert {:ok, %{ok: false, error: error}} =
+                 oidc_verification_result_from_redirect(redirected_to(callback_conn))
+
+        assert error =~ expected_error
+      end
+
+      refute_received {:unexpected_google_managed_identity_request, _path}
+      refute_received {:unexpected_google_api_request, _path}
+    end
+
     test "does not exchange the authorization code when a Google verification callback is replayed",
          %{conn: conn} do
       verification_ref = Ecto.UUID.generate()
       lv_pid = google_directory_pending_verification_process(verification_ref, "C0123")
       state = google_directory_verification_state(lv_pid, verification_ref)
 
-      Mocks.OIDC.set_token_response(%{"access_token" => "interactive-google-token"})
+      set_google_directory_id_token(%{
+        "email" => "workspace-admin@verified.example.com",
+        "hd" => "verified.example.com"
+      })
 
-      Req.Test.expect(Portal.Google.APIClient, fn req_conn ->
-        Req.Test.json(req_conn, %{
+      expect_google_directory_admin_check(
+        "workspace-admin@verified.example.com",
+        {:ok,
+         %{
           "id" => "C0123",
           "customerDomain" => "verified.example.com"
-        })
-      end)
+         }}
+      )
 
       first_conn =
         get(conn, ~p"/auth/oidc/callback", %{"state" => state, "code" => "test-code"})
@@ -3666,6 +3804,92 @@ defmodule PortalWeb.OIDCControllerTest do
     }
 
     spawn(fn -> pending_verification_loop(pending) end)
+  end
+
+  defp configure_google_directory_workload_identity do
+    Portal.Config.put_env_override(
+      :portal,
+      Portal.Google.APIClient,
+      workload_identity_provider: "google-workload-identity-provider",
+      workload_identity_audience: "google-workload-identity-audience",
+      service_account_email: "directory-sync@example.iam.gserviceaccount.com",
+      service_account_key: nil
+    )
+  end
+
+  defp set_google_directory_id_token(overrides) do
+    claims =
+      Mocks.OIDC.default_claims()
+      |> Map.put("hd", "example.com")
+      |> Map.merge(overrides)
+
+    Mocks.OIDC.set_token_response(%{
+      "id_token" => Mocks.OIDC.sign_openid_connect_token(claims)
+    })
+  end
+
+  defp expect_google_directory_admin_check(email, customer_response) do
+    Req.Test.expect(Portal.Azure.ManagedIdentity, fn conn ->
+      Req.Test.json(conn, %{
+        "access_token" => "azure-managed-identity-token",
+        "expires_on" => Integer.to_string(System.system_time(:second) + 3600)
+      })
+    end)
+
+    Req.Test.expect(Portal.Google.APIClient, 4, fn conn ->
+      case conn.request_path do
+        "/v1/token" ->
+          Req.Test.json(conn, %{
+            "access_token" => "federated-google-token",
+            "expires_in" => 3600
+          })
+
+        "/v1/projects/-/serviceAccounts/" <>
+            "directory-sync@example.iam.gserviceaccount.com:signJwt" ->
+          assert Plug.Conn.get_req_header(conn, "authorization") == [
+                   "Bearer federated-google-token"
+                 ]
+
+          {:ok, body, conn} = Plug.Conn.read_body(conn)
+          %{"payload" => payload} = JSON.decode!(body)
+          claims = JSON.decode!(payload)
+
+          assert claims["sub"] == email
+
+          assert claims["scope"] ==
+                   "https://www.googleapis.com/auth/admin.directory.customer.readonly"
+
+          Req.Test.json(conn, %{"signedJwt" => "customer-read-signed-jwt"})
+
+        "/oauth2.googleapis.com/token" ->
+          flunk("Google token exchange used an unexpected endpoint")
+
+        "/token" ->
+          {:ok, body, conn} = Plug.Conn.read_body(conn)
+          params = URI.decode_query(body)
+          assert params["assertion"] == "customer-read-signed-jwt"
+
+          Req.Test.json(conn, %{
+            "access_token" => "delegated-customer-read-token",
+            "expires_in" => 3600
+          })
+
+        "/admin/directory/v1/customers/my_customer" ->
+          assert Plug.Conn.get_req_header(conn, "authorization") == [
+                   "Bearer delegated-customer-read-token"
+                 ]
+
+          google_customer_test_response(conn, customer_response)
+      end
+    end)
+  end
+
+  defp google_customer_test_response(conn, {:ok, body}), do: Req.Test.json(conn, body)
+
+  defp google_customer_test_response(conn, {:error, status, body}) do
+    conn
+    |> Plug.Conn.put_status(status)
+    |> Req.Test.json(body)
   end
 
   defp google_directory_pending_verification_process(verification_ref, workspace_customer_id) do

--- a/elixir/test/portal_web/live/settings/directory_sync_test.exs
+++ b/elixir/test/portal_web/live/settings/directory_sync_test.exs
@@ -70,7 +70,7 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
       client_id: "google-sync-authz-client-id",
       client_secret: "google-sync-authz-client-secret",
       response_type: "code",
-      scope: "https://www.googleapis.com/auth/admin.directory.customer.readonly",
+      scope: "openid email",
       discovery_document_uri: Mocks.OIDC.discovery_document_uri(),
       req_opts: [retry: false, plug: {Req.Test, PortalWeb.OIDC}]
     )
@@ -387,12 +387,10 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
       assert users_index < groups_index
       assert groups_index < orgunits_index
 
-      assert params["scope"] ==
-               "https://www.googleapis.com/auth/admin.directory.customer.readonly"
+      assert params["scope"] == "openid email"
 
       assert params["prompt"] == "select_account"
       assert params["code_challenge_method"] == "S256"
-      refute Map.has_key?(params, "nonce")
 
       assert {:ok, %{verification_ref: verification_ref}} =
                PortalWeb.OIDC.verify_verification_state(params["state"])
@@ -402,10 +400,13 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
       assert_receive {:pending_verification,
                       %{
                         type: "google_directory_sync",
+                        verifier: verifier,
                         verification_ref: ^verification_ref,
                         workspace_customer_id: "C0123",
                         impersonation_email: "sync-admin@verified.example.com"
                       }}
+
+      assert params["nonce"] == PortalWeb.OIDC.nonce(verifier)
 
       ack_ref = make_ref()
 

--- a/elixir/test/portal_web/oidc_test.exs
+++ b/elixir/test/portal_web/oidc_test.exs
@@ -144,7 +144,7 @@ defmodule PortalWeb.OIDCTest do
   end
 
   describe "Google directory verification URI" do
-    test "requests only Workspace customer read access for Google directory verification" do
+    test "requests only basic identity access for Google directory verification" do
       Portal.Config.put_env_override(:portal, Portal.Google.SyncAuthorization,
         client_id: "google-sync-authz-client-id",
         client_secret: "google-sync-authz-client-secret",
@@ -167,16 +167,15 @@ defmodule PortalWeb.OIDCTest do
       params = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
 
       assert params["client_id"] == "google-sync-authz-client-id"
-      assert params["scope"] ==
-               "https://www.googleapis.com/auth/admin.directory.customer.readonly"
+      assert params["scope"] == "openid email"
 
       assert params["state"] == "signed-state"
       assert params["response_type"] == "code"
       assert params["prompt"] == "select_account"
       assert params["code_challenge_method"] == "S256"
       assert params["code_challenge"] == pkce_challenge("verification-verifier")
-      refute Map.has_key?(params, "nonce")
-      refute params["scope"] =~ "openid"
+      assert params["nonce"] == OIDC.nonce("verification-verifier")
+      refute params["scope"] =~ "admin.directory"
     end
   end
 


### PR DESCRIPTION
## Summary

- request only `openid email` from the dedicated Google directory authorization client
- verify the signed ID token, including audience, issuer, expiry, PKCE-bound nonce, verified email, subject, and hosted-domain claims
- impersonate the exact signed-in email through domain-wide delegation with only `admin.directory.customer.readonly`
- call `customers/my_customer` to enforce the signed-in user permission and compare the returned customer ID with the configured sync customer
- keep customer-read verification tokens isolated from full sync tokens in the cache

## Security properties

A non-admin in the configured Workspace cannot pass the Admin SDK probe. An admin from another Workspace receives a different customer ID and cannot bind that Workspace to the Firezone account. Interactive OAuth credentials are never used to access the Admin SDK.

## Deployment

The existing `GOOGLE_SYNC_AUTHZ_CLIENT_ID` and `GOOGLE_SYNC_AUTHZ_CLIENT_SECRET` remain in use. Its OAuth consent configuration only needs `openid` and `userinfo.email`. The domain-wide delegation grant for the sync service account must retain `admin.directory.customer.readonly` along with the normal sync scopes.

## Tests

- `mix test` — 4,645 passed
- `mix test test/portal_web/controllers/oidc_controller_test.exs` — 154 passed after the Dialyzer fix
- `mix compile --warnings-as-errors` — passed
- `mix dialyzer --format dialyxir` — passed
- `mix credo --strict` — passed with existing TODO suggestions