### PR TITLE
feat(portal): terminate public TLS in Phoenix

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -377,6 +377,25 @@ config :portal, PortalWeb.Endpoint,
     signing_salt: "t01wa0K4lUd7mKa0HAtZdE+jFOPDDejX"
   ]
 
+###############################
+##### Public Endpoint #########
+###############################
+
+config :portal, Portal.Endpoint,
+  adapter: Bandit.PhoenixAdapter,
+  url: [
+    scheme: "https",
+    host: "localhost",
+    port: 443,
+    path: nil
+  ],
+  render_errors: [
+    formats: [json: PortalAPI.ErrorView],
+    layout: false
+  ],
+  pubsub_server: Portal.PubSub,
+  secret_key_base: "5OVYJ83AcoQcPmdKNksuBhJFBhjHD1uUa9mDOHV/6EIdBQ6pXksIhkVeWIzFk5SD"
+
 config :portal,
   api_external_url: "http://localhost:13001"
 

--- a/elixir/config/prod.exs
+++ b/elixir/config/prod.exs
@@ -17,6 +17,7 @@ config :portal, PortalWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json",
   server: true
 
+config :portal, Portal.Endpoint, server: true
 config :portal, PortalAPI.Endpoint, server: true
 config :portal, PortalOps.Endpoint, server: true
 

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -354,6 +354,66 @@ if config_env() == :prod do
     repo: Portal.Repo
 
   ###############################
+  ##### Public Endpoint #########
+  ###############################
+
+  public_http =
+    case env_var_to_config(:phoenix_http_public_port) do
+      nil ->
+        []
+
+      port ->
+        [
+          http: [
+            ip: env_var_to_config!(:phoenix_listen_address).address,
+            port: port,
+            http_1_options: env_var_to_config!(:phoenix_http_protocol_options)
+          ]
+        ]
+    end
+
+  public_https =
+    case env_var_to_config(:phoenix_https_public_port) do
+      nil ->
+        []
+
+      port ->
+        sni_hosts = env_var_to_config!(:phoenix_https_sni_hosts)
+
+        if sni_hosts == %{} do
+          raise "PHOENIX_HTTPS_SNI_HOSTS must be set when PHOENIX_HTTPS_PUBLIC_PORT is set"
+        end
+
+        [
+          https: [
+            ip: env_var_to_config!(:phoenix_listen_address).address,
+            port: port,
+            http_1_options: env_var_to_config!(:phoenix_http_protocol_options),
+            thousand_island_options: [
+              transport_options: [
+                sni_fun:
+                  Portal.TLS.sni_fun(
+                    sni_hosts,
+                    env_var_to_config(:mtls_external_url)
+                  )
+              ]
+            ]
+          ]
+        ]
+    end
+
+  web_external_url = env_var_to_config!(:web_external_url)
+  web_external_url_host = URI.parse(web_external_url).host
+
+  config :portal,
+         Portal.Endpoint,
+         public_http ++ public_https ++
+           [
+             url: [scheme: "https", host: web_external_url_host, port: 443],
+             secret_key_base: env_var_to_config!(:secret_key_base)
+           ]
+
+  ###############################
   ##### PortalWeb Endpoint ######
   ###############################
 
@@ -365,29 +425,41 @@ if config_env() == :prod do
       path: web_external_url_path
     } = URI.parse(web_external_url)
 
-    config :portal, PortalWeb.Endpoint,
-      http: [
-        ip: env_var_to_config!(:phoenix_listen_address).address,
-        port: env_var_to_config!(:phoenix_http_web_port),
-        http_1_options: env_var_to_config!(:phoenix_http_protocol_options)
-      ],
-      url: [
-        scheme: web_external_url_scheme,
-        host: web_external_url_host,
-        port: web_external_url_port,
-        path: web_external_url_path
-      ],
-      secret_key_base: env_var_to_config!(:secret_key_base),
-      check_origin:
+    web_listener =
+      if env_var_to_config!(:phoenix_legacy_listeners_enabled) do
         [
-          "#{web_external_url_scheme}://#{web_external_url_host}:#{web_external_url_port}",
-          "#{web_external_url_scheme}://*.#{web_external_url_host}:#{web_external_url_port}",
-          "#{web_external_url_scheme}://#{web_external_url_host}",
-          "#{web_external_url_scheme}://*.#{web_external_url_host}"
-        ] ++ env_var_to_config!(:websocket_additional_origins),
-      live_view: [
-        signing_salt: env_var_to_config!(:live_view_signing_salt)
-      ]
+          http: [
+            ip: env_var_to_config!(:phoenix_listen_address).address,
+            port: env_var_to_config!(:phoenix_http_web_port),
+            http_1_options: env_var_to_config!(:phoenix_http_protocol_options)
+          ]
+        ]
+      else
+        []
+      end
+
+    config :portal,
+           PortalWeb.Endpoint,
+           web_listener ++
+             [
+               url: [
+                 scheme: web_external_url_scheme,
+                 host: web_external_url_host,
+                 port: web_external_url_port,
+                 path: web_external_url_path
+               ],
+               secret_key_base: env_var_to_config!(:secret_key_base),
+               check_origin:
+                 [
+                   "#{web_external_url_scheme}://#{web_external_url_host}:#{web_external_url_port}",
+                   "#{web_external_url_scheme}://*.#{web_external_url_host}:#{web_external_url_port}",
+                   "#{web_external_url_scheme}://#{web_external_url_host}",
+                   "#{web_external_url_scheme}://*.#{web_external_url_host}"
+                 ] ++ env_var_to_config!(:websocket_additional_origins),
+               live_view: [
+                 signing_salt: env_var_to_config!(:live_view_signing_salt)
+               ]
+             ]
 
     config :portal, PortalWeb.RateLimit,
       refill_rate: env_var_to_config!(:web_refill_rate),
@@ -408,19 +480,31 @@ if config_env() == :prod do
       path: api_external_url_path
     } = URI.parse(api_external_url)
 
-    config :portal, PortalAPI.Endpoint,
-      http: [
-        ip: env_var_to_config!(:phoenix_listen_address).address,
-        port: env_var_to_config!(:phoenix_http_api_port),
-        http_1_options: env_var_to_config!(:phoenix_http_protocol_options)
-      ],
-      url: [
-        scheme: api_external_url_scheme,
-        host: api_external_url_host,
-        port: api_external_url_port,
-        path: api_external_url_path
-      ],
-      secret_key_base: env_var_to_config!(:secret_key_base)
+    api_listener =
+      if env_var_to_config!(:phoenix_legacy_listeners_enabled) do
+        [
+          http: [
+            ip: env_var_to_config!(:phoenix_listen_address).address,
+            port: env_var_to_config!(:phoenix_http_api_port),
+            http_1_options: env_var_to_config!(:phoenix_http_protocol_options)
+          ]
+        ]
+      else
+        []
+      end
+
+    config :portal,
+           PortalAPI.Endpoint,
+           api_listener ++
+             [
+               url: [
+                 scheme: api_external_url_scheme,
+                 host: api_external_url_host,
+                 port: api_external_url_port,
+                 path: api_external_url_path
+               ],
+               secret_key_base: env_var_to_config!(:secret_key_base)
+             ]
 
     config :portal, PortalAPI.RateLimit,
       refill_rate: env_var_to_config!(:api_refill_rate),

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -60,7 +60,10 @@ defmodule Portal.Application do
       # before transports are force-terminated.
       {PortalWeb.Endpoint, shutdown: 40_000},
       {PortalAPI.Endpoint, shutdown: 40_000},
-      {PortalOps.Endpoint, shutdown: 40_000}
+      {PortalOps.Endpoint, shutdown: 40_000},
+      # The public listener stops first during reverse-order shutdown, before
+      # the endpoints it dispatches into begin draining.
+      {Portal.Endpoint, shutdown: 40_000}
     ]
 
     # Child order is chosen to make reverse-order shutdown graceful:

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -143,14 +143,12 @@ defmodule Portal.Config.Definitions do
   The external URL clients use to connect with a device certificate, for
   example `https://mtls.firezone.dev/`.
 
-  The load balancer terminates mutual TLS on this host and passes the client
-  certificate up as base64-encoded DER in the `x-client-cert` header. It must
-  strip any inbound `x-client-cert` on this host before setting it, so that a
-  client cannot supply its own, and it must not forward a client-supplied
-  `x-forwarded-host`, which is what the request host is derived from.
+  The public Phoenix endpoint requests a client certificate during the TLS
+  handshake on this host. The application validates the presented certificate
+  against the account's configured trust anchors.
 
   When this is not set, certificate-based device trust is disabled and the
-  header is ignored.
+  peer certificate is ignored.
   """
 
   defconfig(:mtls_external_url, :string,
@@ -253,6 +251,50 @@ defmodule Portal.Config.Definitions do
   defconfig(:phoenix_secure_cookies, :boolean, default: true)
 
   defconfig(:phoenix_listen_address, Types.IP, default: "0.0.0.0")
+
+  @doc """
+  Internal HTTP port for the public endpoint. Requests other than readiness
+  checks are redirected to HTTPS. Leave unset to disable the listener.
+  """
+  defconfig(:phoenix_http_public_port, :integer,
+    default: nil,
+    changeset: fn changeset, key ->
+      Ecto.Changeset.validate_number(changeset, key,
+        greater_than: 0,
+        less_than_or_equal_to: 65_535
+      )
+    end
+  )
+
+  @doc """
+  Internal HTTPS port for the public endpoint. Leave unset to disable the listener.
+  """
+  defconfig(:phoenix_https_public_port, :integer,
+    default: nil,
+    changeset: fn changeset, key ->
+      Ecto.Changeset.validate_number(changeset, key,
+        greater_than: 0,
+        less_than_or_equal_to: 65_535
+      )
+    end
+  )
+
+  @doc """
+  JSON object mapping public hostnames to their TLS certificate and key files.
+
+  Each value must contain `certfile` and `keyfile` paths. The hostname from
+  `MTLS_EXTERNAL_URL` additionally requires a client certificate during the
+  TLS handshake.
+  """
+  defconfig(:phoenix_https_sni_hosts, :map, default: %{})
+
+  @doc """
+  Whether the separate web and API HTTP listeners are enabled.
+
+  Keep this enabled while deploying behind a reverse proxy. It can be disabled
+  once the public Phoenix endpoint receives traffic directly.
+  """
+  defconfig(:phoenix_legacy_listeners_enabled, :boolean, default: true)
 
   @doc """
   Internal port to listen on for the Phoenix server for the `web` application.

--- a/elixir/lib/portal/endpoint.ex
+++ b/elixir/lib/portal/endpoint.ex
@@ -6,8 +6,17 @@ defmodule Portal.Endpoint do
   use Phoenix.Endpoint, otp_app: :portal
 
   plug Portal.Health
+  plug :drop_forwarded_headers
   plug Plug.SSL
   plug :dispatch
+
+  def drop_forwarded_headers(%Plug.Conn{} = conn, _opts) do
+    Enum.reduce(
+      ~w(x-forwarded-for x-forwarded-host x-forwarded-port x-forwarded-proto),
+      conn,
+      &Plug.Conn.delete_req_header(&2, &1)
+    )
+  end
 
   def dispatch(%Plug.Conn{} = conn, _opts) do
     host = String.downcase(conn.host)

--- a/elixir/lib/portal/endpoint.ex
+++ b/elixir/lib/portal/endpoint.ex
@@ -1,0 +1,61 @@
+defmodule Portal.Endpoint do
+  @moduledoc """
+  Public HTTP and HTTPS ingress for the web and API endpoints.
+  """
+
+  use Phoenix.Endpoint, otp_app: :portal
+
+  plug Portal.Health
+  plug Plug.SSL
+  plug :dispatch
+
+  def dispatch(%Plug.Conn{} = conn, _opts) do
+    host = String.downcase(conn.host)
+    web_host = configured_host(:web_external_url)
+    mtls_host = configured_host(:mtls_external_url)
+
+    cond do
+      host == web_host ->
+        forward(conn, PortalWeb.Endpoint)
+
+      host == mtls_host and not websocket_upgrade?(conn) ->
+        conn
+        |> Plug.Conn.send_resp(:not_found, "Not Found")
+        |> Plug.Conn.halt()
+
+      host in api_hosts() ->
+        forward(conn, PortalAPI.Endpoint)
+
+      true ->
+        conn
+        |> Plug.Conn.send_resp(:not_found, "Not Found")
+        |> Plug.Conn.halt()
+    end
+  end
+
+  defp forward(conn, endpoint) do
+    conn
+    |> endpoint.call(endpoint.init([]))
+    |> Plug.Conn.halt()
+  end
+
+  defp websocket_upgrade?(conn) do
+    Plug.Conn.get_req_header(conn, "upgrade")
+    |> Enum.any?(&(String.downcase(&1) == "websocket"))
+  end
+
+  defp api_hosts do
+    [:api_external_url, :rest_api_url, :flow_logs_api_url, :mtls_external_url]
+    |> Enum.map(&configured_host/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp configured_host(key) do
+    with url when is_binary(url) <- Portal.Config.get_env(:portal, key),
+         %URI{host: host} when is_binary(host) <- URI.parse(url) do
+      String.downcase(host)
+    else
+      _unconfigured -> nil
+    end
+  end
+end

--- a/elixir/lib/portal/tls.ex
+++ b/elixir/lib/portal/tls.ex
@@ -1,0 +1,47 @@
+defmodule Portal.TLS do
+  @moduledoc false
+
+  def sni_fun(hosts, mtls_external_url) when is_map(hosts) do
+    mtls_host = external_host(mtls_external_url)
+
+    hosts =
+      Map.new(hosts, fn
+        {host, %{"certfile" => certfile, "keyfile" => keyfile}}
+        when is_binary(host) and is_binary(certfile) and is_binary(keyfile) ->
+          options = [certfile: String.to_charlist(certfile), keyfile: String.to_charlist(keyfile)]
+          host = String.downcase(host)
+          {host, maybe_require_client_certificate(options, host, mtls_host)}
+
+        {host, options} ->
+          raise ArgumentError,
+                "invalid TLS configuration for #{inspect(host)}: #{inspect(options)}"
+      end)
+
+    fn hostname -> Map.get(hosts, hostname |> to_string() |> String.downcase(), :unrecognized) end
+  end
+
+  def verify_client_certificate(_certificate, _event, state), do: {:valid, state}
+
+  defp maybe_require_client_certificate(options, host, host) do
+    # TLS proves possession of the private key here. The socket authenticates
+    # the leaf against the account-specific trust anchors after connecting.
+    options ++
+      [
+        verify: :verify_peer,
+        fail_if_no_peer_cert: true,
+        certificate_authorities: false,
+        cacerts: [],
+        verify_fun: {&__MODULE__.verify_client_certificate/3, nil}
+      ]
+  end
+
+  defp maybe_require_client_certificate(options, _host, _mtls_host), do: options
+
+  defp external_host(url) when is_binary(url) do
+    case URI.parse(url).host do
+      host when is_binary(host) -> String.downcase(host)
+      nil -> nil
+    end
+  end
+  defp external_host(_url), do: nil
+end

--- a/elixir/lib/portal_api/client/device_trust.ex
+++ b/elixir/lib/portal_api/client/device_trust.ex
@@ -3,17 +3,9 @@ defmodule PortalAPI.Client.DeviceTrust do
   Device attestation from the client certificate presented at connect.
 
   Clients holding an MDM-provisioned certificate connect over mutual TLS to
-  the dedicated `mtls_external_url` host. The load balancer
-  terminates the handshake, so TLS has already proven the client holds the
-  certificate's private key, and passes the leaf up as base64-encoded DER in
-  the `x-client-cert` header.
-
-  The header is honored only when the request host matches that URL, so a
-  forged `x-client-cert` on the plain API host is ignored. That holds as long
-  as the load balancer overwrites the header on the mutual-TLS host from the
-  real handshake rather than passing through whatever the client sent, and
-  does not forward a client-supplied `x-forwarded-host`, which is where
-  `Plug.RewriteOn` takes the request host from.
+  the dedicated `mtls_external_url` host. Phoenix terminates the handshake, so
+  TLS has already proven the client holds the certificate's private key. Bandit
+  exposes the leaf certificate as part of the connection's peer data.
 
   A certificate is trusted when it allows TLS client authentication, permits
   digital signatures (Key Usage absent or including `digitalSignature`), is
@@ -40,13 +32,10 @@ defmodule PortalAPI.Client.DeviceTrust do
   alias __MODULE__.Database
   require Logger
 
-  # Mirrors the trust anchor upload bound. Bandit rejects any header over
-  # 10_000 bytes on the wire first, so a certificate large enough to reach
-  # this bound never gets here.
+  # Mirrors the trust anchor upload bound and caps synthetic peer data before
+  # certificate decoding.
   @max_cert_bytes 16_384
   @max_chain_depth 4
-  @certificate_header "x-client-cert"
-
   # Matches the varchar(255) device columns: the bulk session flush bypasses
   # changeset validation, so an oversized value would abort the whole batch.
   # This bound only protects the columns; garbage screening is the
@@ -163,8 +152,7 @@ defmodule PortalAPI.Client.DeviceTrust do
   end
 
   @doc """
-  Attests the connecting device from the certificate the load balancer passed
-  up.
+  Attests the connecting device from the TLS peer certificate.
 
   `{:error, :not_attestation_host}` means the connect did not arrive on the
   mutual-TLS host, or no such host is configured, so there was nothing to
@@ -230,11 +218,14 @@ defmodule PortalAPI.Client.DeviceTrust do
     end
   end
 
-  defp presented_certificate(connect_info) do
-    with {:ok, encoded} <- fetch_certificate_header(connect_info) do
-      decode_certificate(encoded)
-    end
-  end
+  defp presented_certificate(%{peer_data: %{ssl_cert: der}})
+       when is_binary(der) and byte_size(der) > 0 and byte_size(der) <= @max_cert_bytes,
+       do: {:ok, der}
+
+  defp presented_certificate(%{peer_data: %{ssl_cert: der}}) when is_binary(der),
+    do: {:error, :invalid_certificate}
+
+  defp presented_certificate(_connect_info), do: {:error, :no_certificate_presented}
 
   defp attestation_host do
     with url when is_binary(url) <- Portal.Config.get_env(:portal, :mtls_external_url),
@@ -254,24 +245,6 @@ defmodule PortalAPI.Client.DeviceTrust do
   end
 
   defp validate_host(_connect_info, _attestation_host), do: {:error, :not_attestation_host}
-
-  # The load balancer sets the header to an empty value when the handshake
-  # carried no client certificate.
-  defp fetch_certificate_header(%{x_headers: x_headers}) when is_list(x_headers) do
-    case List.keyfind(x_headers, @certificate_header, 0) do
-      {@certificate_header, encoded} when is_binary(encoded) and encoded != "" -> {:ok, encoded}
-      _other -> {:error, :no_certificate_presented}
-    end
-  end
-
-  defp fetch_certificate_header(_connect_info), do: {:error, :no_certificate_presented}
-
-  defp decode_certificate(encoded) do
-    case decode_base64(encoded, @max_cert_bytes) do
-      {:ok, der} -> {:ok, der}
-      :error -> {:error, :invalid_certificate}
-    end
-  end
 
   defp decode_leaf(der) do
     case X509.decode_der_certificate(der, :otp) do
@@ -472,20 +445,6 @@ defmodule PortalAPI.Client.DeviceTrust do
       {:error, :malformed_cert_serial}
     end
   end
-
-  # Bound the encoded input before decoding: base64 is 4 characters per 3 bytes.
-  defp decode_base64(value, max_decoded_bytes)
-       when is_binary(value) and byte_size(value) <= div(max_decoded_bytes + 2, 3) * 4 do
-    case Base.decode64(value) do
-      {:ok, decoded} when decoded != "" and byte_size(decoded) <= max_decoded_bytes ->
-        {:ok, decoded}
-
-      _other ->
-        :error
-    end
-  end
-
-  defp decode_base64(_value, _max_decoded_bytes), do: :error
 
   defp within_validity_window?(leaf) do
     now = DateTime.utc_now()

--- a/elixir/test/portal/endpoint_test.exs
+++ b/elixir/test/portal/endpoint_test.exs
@@ -30,6 +30,20 @@ defmodule Portal.EndpointTest do
            ]
   end
 
+  test "does not trust forwarded headers from the public listener" do
+    conn =
+      :get
+      |> conn("http://api.firezone.test/client")
+      |> put_req_header("x-forwarded-host", "mtls.firezone.test")
+      |> put_req_header("x-forwarded-proto", "https")
+      |> Endpoint.call([])
+
+    assert conn.status == 301
+    assert get_resp_header(conn, "location") == ["https://api.firezone.test/client"]
+    assert get_req_header(conn, "x-forwarded-host") == []
+    assert get_req_header(conn, "x-forwarded-proto") == []
+  end
+
   test "serves readiness checks without redirecting" do
     conn = Endpoint.call(conn(:get, "http://api.firezone.test/readyz"), [])
 

--- a/elixir/test/portal/endpoint_test.exs
+++ b/elixir/test/portal/endpoint_test.exs
@@ -1,0 +1,73 @@
+defmodule Portal.EndpointTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Conn
+  import Plug.Test
+
+  alias Portal.Endpoint
+
+  setup do
+    Portal.Config.put_env_override(:portal, :web_external_url, "https://app.firezone.test/")
+    Portal.Config.put_env_override(:portal, :api_external_url, "https://api.firezone.test/")
+    Portal.Config.put_env_override(:portal, :rest_api_url, "https://rest-api.firezone.test/")
+    Portal.Config.put_env_override(:portal, :flow_logs_api_url, "https://flow-api.firezone.test/")
+    Portal.Config.put_env_override(:portal, :mtls_external_url, "https://mtls.firezone.test/")
+  end
+
+  test "redirects public HTTP requests to HTTPS" do
+    conn = Endpoint.call(conn(:get, "http://api.firezone.test/client?foo=bar"), [])
+
+    assert conn.status == 301
+    assert get_resp_header(conn, "location") == ["https://api.firezone.test/client?foo=bar"]
+  end
+
+  test "preserves the method when redirecting a non-GET request" do
+    conn = Endpoint.call(conn(:post, "http://flow-api.firezone.test/ingestion/flow_logs"), [])
+
+    assert conn.status == 307
+    assert get_resp_header(conn, "location") == [
+             "https://flow-api.firezone.test/ingestion/flow_logs"
+           ]
+  end
+
+  test "serves readiness checks without redirecting" do
+    conn = Endpoint.call(conn(:get, "http://api.firezone.test/readyz"), [])
+
+    assert conn.status in [200, 503]
+    assert get_resp_header(conn, "location") == []
+  end
+
+  test "dispatches the web hostname to the web endpoint" do
+    conn = Endpoint.call(conn(:get, "https://app.firezone.test/not-found"), [])
+
+    assert conn.private.phoenix_endpoint == PortalWeb.Endpoint
+  end
+
+  test "dispatches every API hostname to the API endpoint" do
+    for host <- ~w(api.firezone.test rest-api.firezone.test flow-api.firezone.test) do
+      conn = Endpoint.call(conn(:get, "https://#{host}/not-found"), [])
+      assert conn.private.phoenix_endpoint == PortalAPI.Endpoint
+    end
+  end
+
+  test "only exposes WebSocket requests on the mutual-TLS hostname" do
+    rejected = Endpoint.call(conn(:get, "https://mtls.firezone.test/not-found"), [])
+    assert rejected.status == 404
+    assert rejected.private.phoenix_endpoint == Endpoint
+
+    forwarded =
+      :get
+      |> conn("https://mtls.firezone.test/not-found")
+      |> put_req_header("upgrade", "websocket")
+      |> Endpoint.call([])
+
+    assert forwarded.private.phoenix_endpoint == PortalAPI.Endpoint
+  end
+
+  test "rejects unknown hostnames" do
+    conn = Endpoint.call(conn(:get, "https://unknown.firezone.test/"), [])
+
+    assert conn.status == 404
+    assert conn.private.phoenix_endpoint == Endpoint
+  end
+end

--- a/elixir/test/portal/tls_test.exs
+++ b/elixir/test/portal/tls_test.exs
@@ -1,0 +1,144 @@
+defmodule Portal.TLSTest do
+  use ExUnit.Case, async: true
+
+  import Portal.DeviceTrustFixtures
+
+  alias Portal.TLS
+
+  defmodule PeerCertificatePlug do
+    import Plug.Conn
+
+    def init(opts), do: opts
+
+    def call(conn, _opts) do
+      peer_data = get_peer_data(conn)
+      send_resp(conn, :ok, if(peer_data.ssl_cert, do: "present", else: "absent"))
+    end
+  end
+
+  test "selects certificates by SNI hostname" do
+    sni_fun =
+      TLS.sni_fun(
+        %{
+          "api.firezone.test" => %{
+            "certfile" => "/certs/api.crt",
+            "keyfile" => "/certs/api.key"
+          }
+        },
+        nil
+      )
+
+    assert sni_fun.(~c"API.FIREZONE.TEST") == [
+             certfile: ~c"/certs/api.crt",
+             keyfile: ~c"/certs/api.key"
+           ]
+
+    assert sni_fun.(~c"unknown.firezone.test") == :unrecognized
+  end
+
+  test "requires but defers validation of the mutual-TLS client certificate" do
+    sni_fun =
+      TLS.sni_fun(
+        %{
+          "mtls.firezone.test" => %{
+            "certfile" => "/certs/mtls.crt",
+            "keyfile" => "/certs/mtls.key"
+          }
+        },
+        "https://mtls.firezone.test/"
+      )
+
+    options = sni_fun.(~c"mtls.firezone.test")
+
+    assert options[:verify] == :verify_peer
+    assert options[:fail_if_no_peer_cert]
+    assert options[:certificate_authorities] == false
+    assert options[:cacerts] == []
+
+    {verify_fun, state} = options[:verify_fun]
+    assert verify_fun.(:certificate, {:bad_cert, :unknown_ca}, state) == {:valid, state}
+  end
+
+  test "rejects malformed host configurations" do
+    assert_raise ArgumentError, fn ->
+      TLS.sni_fun(%{"api.firezone.test" => %{"certfile" => "/certs/api.crt"}}, nil)
+    end
+  end
+
+  test "Bandit exposes the certificate required by the mutual-TLS SNI host" do
+    {certfile, keyfile} = write_certificate_files()
+
+    sni_fun =
+      TLS.sni_fun(
+        %{
+          "api.firezone.test" => %{"certfile" => certfile, "keyfile" => keyfile},
+          "mtls.firezone.test" => %{"certfile" => certfile, "keyfile" => keyfile}
+        },
+        "https://mtls.firezone.test/"
+      )
+
+    server =
+      start_supervised!({Bandit,
+       plug: PeerCertificatePlug,
+       scheme: :https,
+       port: 0,
+       startup_log: false,
+       thousand_island_options: [transport_options: [sni_fun: sni_fun]]})
+
+    {:ok, {_address, port}} = ThousandIsland.listener_info(server)
+
+    assert {:ok, socket} = connect(port, "api.firezone.test", [])
+    assert request(socket, "api.firezone.test") =~ "absent"
+
+    assert_client_certificate_required(connect(port, "mtls.firezone.test", []))
+
+    assert {:ok, socket} =
+             connect(port, "mtls.firezone.test", certfile: certfile, keyfile: keyfile)
+
+    assert request(socket, "mtls.firezone.test") =~ "present"
+  end
+
+  defp connect(port, host, options) do
+    options =
+      [
+        active: false,
+        mode: :binary,
+        verify: :verify_none,
+        server_name_indication: String.to_charlist(host)
+      ] ++ options
+
+    :ssl.connect(~c"127.0.0.1", port, options, 5_000)
+  end
+
+  defp request(socket, host) do
+    :ok = :ssl.send(socket, ["GET / HTTP/1.1\r\nHost: ", host, "\r\nConnection: close\r\n\r\n"])
+    {:ok, response} = :ssl.recv(socket, 0, 5_000)
+    response
+  end
+
+  defp assert_client_certificate_required({:error, _reason}), do: :ok
+
+  defp assert_client_certificate_required({:ok, socket}) do
+    _result = :ssl.send(socket, "GET / HTTP/1.1\r\nHost: mtls.firezone.test\r\n\r\n")
+    assert {:error, _reason} = :ssl.recv(socket, 0, 5_000)
+  end
+
+  defp write_certificate_files do
+    pki = pki()
+    directory = Path.join(System.tmp_dir!(), "portal-tls-#{System.unique_integer([:positive])}")
+    certfile = Path.join(directory, "cert.pem")
+    keyfile = Path.join(directory, "key.pem")
+
+    File.mkdir_p!(directory)
+    File.write!(certfile, Portal.Crypto.X509.pem_encode(pki.ca_der))
+
+    File.write!(
+      keyfile,
+      :public_key.pem_encode([:public_key.pem_entry_encode(:ECPrivateKey, pki.ca.key)])
+    )
+
+    on_exit(fn -> File.rm_rf!(directory) end)
+
+    {certfile, keyfile}
+  end
+end

--- a/elixir/test/portal_api/client/device_trust_test.exs
+++ b/elixir/test/portal_api/client/device_trust_test.exs
@@ -496,30 +496,18 @@ defmodule PortalAPI.Client.DeviceTrustTest do
       assert DeviceTrust.attest(connect_info, subject) == {:error, :not_attestation_host}
     end
 
-    test "rejects a connect without the header", %{subject: subject} do
-      assert DeviceTrust.attest(connect_info_with_header(nil), subject) ==
+    test "rejects a connect without a peer certificate", %{subject: subject} do
+      assert DeviceTrust.attest(connect_info_with_cert(nil), subject) ==
                {:error, :no_certificate_presented}
     end
 
-    test "rejects an empty header", %{subject: subject} do
-      assert DeviceTrust.attest(connect_info_with_header(""), subject) ==
-               {:error, :no_certificate_presented}
-    end
-
-    test "rejects a header that is not a certificate", %{subject: subject} do
-      assert DeviceTrust.attest(connect_info_with_header("not base64!"), subject) ==
-               {:error, :invalid_certificate}
-
-      encoded = Base.encode64("not a certificate")
-
-      assert DeviceTrust.attest(connect_info_with_header(encoded), subject) ==
+    test "rejects peer data that is not a certificate", %{subject: subject} do
+      assert DeviceTrust.attest(connect_info_with_cert("not a certificate"), subject) ==
                {:error, :invalid_certificate}
     end
 
-    test "rejects an oversized certificate without decoding it", %{subject: subject} do
-      encoded = Base.encode64(:crypto.strong_rand_bytes(64_000))
-
-      assert DeviceTrust.attest(connect_info_with_header(encoded), subject) ==
+    test "rejects an oversized peer certificate", %{subject: subject} do
+      assert DeviceTrust.attest(connect_info_with_cert(:crypto.strong_rand_bytes(64_000)), subject) ==
                {:error, :invalid_certificate}
     end
   end
@@ -691,14 +679,16 @@ defmodule PortalAPI.Client.DeviceTrustTest do
   end
 
   defp connect_info(der, opts \\ []) do
-    connect_info_with_header(Base.encode64(der), opts)
+    connect_info_with_cert(der, opts)
   end
 
-  defp connect_info_with_header(value, opts \\ []) do
+  defp connect_info_with_cert(value, opts \\ []) do
     host = Keyword.get(opts, :host, @attestation_host)
-    headers = if is_nil(value), do: [], else: [{"x-client-cert", value}]
 
-    %{uri: %URI{scheme: "https", host: host, port: 443, path: "/"}, x_headers: headers}
+    %{
+      uri: %URI{scheme: "https", host: host, port: 443, path: "/"},
+      peer_data: %{ssl_cert: value}
+    }
   end
 
   defp otp(profile) do

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -533,7 +533,7 @@ defmodule PortalAPI.Client.SocketTest do
         build_connect_info(
           token: token,
           host: "mtls.firezone.test",
-          client_cert: client_cert_header(pki, :untrusted)
+          client_cert: client_cert(pki, :untrusted)
         )
 
       assert capture_log(fn ->
@@ -561,7 +561,7 @@ defmodule PortalAPI.Client.SocketTest do
         build_connect_info(
           token: token,
           host: "api.firezone.test",
-          client_cert: client_cert_header(pki, :rsa)
+          client_cert: client_cert(pki, :rsa)
         )
 
       assert {:ok, socket} = connect(Socket, connect_attrs([]), connect_info: connect_info)
@@ -1223,7 +1223,7 @@ defmodule PortalAPI.Client.SocketTest do
     build_connect_info(
       token: token,
       host: "mtls.firezone.test",
-      client_cert: client_cert_header(pki, :rsa)
+      client_cert: client_cert(pki, :rsa)
     )
   end
 end

--- a/elixir/test/support/channel_case.ex
+++ b/elixir/test/support/channel_case.ex
@@ -43,7 +43,7 @@ defmodule PortalAPI.ChannelCase do
     * `:user_agent` - User agent string (default: "iOS/12.7 connlib/1.3.0")
     * `:x_headers` - Custom x_headers that REPLACE the default geo headers
     * `:host` - Request host, as `connect_info.uri` carries it
-    * `:client_cert` - Base64 DER for the `x-client-cert` header
+    * `:client_cert` - DER-encoded TLS peer certificate
   """
   def build_connect_info(opts \\ []) do
     ip = Keyword.get(opts, :ip, unique_ip())
@@ -61,16 +61,13 @@ defmodule PortalAPI.ChannelCase do
         @geo_headers
       end
 
-    base_headers = [{"x-forwarded-for", :inet.ntoa(ip) |> to_string()} | geo_headers]
-
     x_headers =
-      base_headers
+      [{"x-forwarded-for", :inet.ntoa(ip) |> to_string()} | geo_headers]
       |> prepend_header(token && {"x-authorization", "Bearer #{token}"})
-      |> prepend_header(client_cert && {"x-client-cert", client_cert})
 
     %{
       user_agent: user_agent,
-      peer_data: %{address: ip},
+      peer_data: %{address: ip, ssl_cert: client_cert},
       x_headers: x_headers,
       uri: %URI{scheme: "https", host: host, port: 443, path: "/"},
       trace_context_headers: []

--- a/elixir/test/support/fixtures/device_trust_fixtures.ex
+++ b/elixir/test/support/fixtures/device_trust_fixtures.ex
@@ -165,12 +165,9 @@ defmodule Portal.DeviceTrustFixtures do
   end
 
   @doc """
-  Returns the `x-client-cert` header value the load balancer sends for the
-  named leaf profile.
+  Returns the DER-encoded client certificate for the named leaf profile.
   """
-  def client_cert_header(pki, name) do
-    pki |> leaf(name) |> Base.encode64()
-  end
+  def client_cert(pki, name), do: leaf(pki, name)
 
   @doc """
   Mints a standalone CA certificate under the given common name, for tests that


### PR DESCRIPTION
Add an opt-in public Phoenix ingress that selects on-disk certificates by SNI, dispatches web and API hosts, and redirects HTTP to HTTPS.

The mTLS listener obtains the client certificate directly from Bandit peer data, removing the trusted proxy header. Existing listeners remain enabled by default so this image can deploy before the infrastructure cutover.

Rollout order: deploy this PR before applying firezone/infra#831 in each environment.

Related: firezone/infra#831