### PR TITLE
refactor(portal): consolidate feature flag gates

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -337,15 +337,6 @@ config :portal, Portal.Cluster,
   adapter: nil,
   adapter_config: []
 
-config :portal, :enabled_features,
-  idp_sync: true,
-  sign_up: true,
-  policy_conditions: true,
-  rest_api: true,
-  internet_resource: true,
-  log_sinks: true,
-  device_posture: false
-
 config :portal, sign_up_whitelisted_domains: []
 
 config :portal, docker_registry: "ghcr.io/firezone"

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -186,13 +186,6 @@ if config_env() == :prod do
     secondary_adapter: env_var_to_config!(:erlang_cluster_adapter_secondary),
     secondary_adapter_config: env_var_to_config!(:erlang_cluster_adapter_secondary_config)
 
-  config :portal, :enabled_features,
-    idp_sync: env_var_to_config!(:feature_idp_sync_enabled),
-    sign_up: env_var_to_config!(:feature_sign_up_enabled),
-    policy_conditions: env_var_to_config!(:feature_policy_conditions_enabled),
-    rest_api: env_var_to_config!(:feature_rest_api_enabled),
-    internet_resource: env_var_to_config!(:feature_internet_resource_enabled)
-
   config :portal, sign_up_whitelisted_domains: env_var_to_config!(:sign_up_whitelisted_domains)
   config :portal, country_code_blocklist: env_var_to_config!(:country_code_blocklist)
 

--- a/elixir/lib/portal/account.ex
+++ b/elixir/lib/portal/account.ex
@@ -1,7 +1,6 @@
 defmodule Portal.Account do
   use Ecto.Schema
   import Ecto.Changeset
-  alias Portal.Config
 
   @type t :: %__MODULE__{}
 
@@ -135,21 +134,18 @@ defmodule Portal.Account do
   def locked?(%__MODULE__{lock_enabled_at: nil}), do: false
   def locked?(%__MODULE__{}), do: true
 
+  # All plan entitlements except device posture are account-local. Device posture
+  # additionally has a deployment-wide rollout flag in the features table.
   # sobelow_skip ["DOS.BinToAtom"]
-  for feature <- Portal.Accounts.Features.__schema__(:fields), feature != :iceless do
+  for feature <- Portal.Accounts.Features.__schema__(:fields), feature != :device_posture do
     def unquote(:"#{feature}_enabled?")(account) do
-      Config.global_feature_enabled?(unquote(feature)) and
-        account_feature_enabled?(account, unquote(feature))
+      account_feature_enabled?(account, unquote(feature))
     end
   end
 
-  # Unlike the other features, ICE-less is gated per-account only and has no
-  # global `enabled_features` flag, so it can be rolled out to individual
-  # accounts without a release. Keeping the toggle in the portal (rather than a
-  # device-local flag) makes it the single source of truth, so client and
-  # gateway can never disagree on whether to use it.
-  def iceless_enabled?(account) do
-    account_feature_enabled?(account, :iceless)
+  def device_posture_enabled?(account) do
+    Portal.Features.enabled?(:device_posture) and
+      account_feature_enabled?(account, :device_posture)
   end
 
   defp account_feature_enabled?(account, feature) do

--- a/elixir/lib/portal/accounts/features.ex
+++ b/elixir/lib/portal/accounts/features.ex
@@ -10,7 +10,7 @@ defmodule Portal.Accounts.Features do
     field :internet_resource, :boolean
     field :iceless, :boolean
     field :log_sinks, :boolean
-    field :device_posture, :boolean
+    field :device_posture, :boolean, default: nil
   end
 
   def changeset(features \\ %__MODULE__{}, attrs) do

--- a/elixir/lib/portal/accounts/features.ex
+++ b/elixir/lib/portal/accounts/features.ex
@@ -10,7 +10,7 @@ defmodule Portal.Accounts.Features do
     field :internet_resource, :boolean
     field :iceless, :boolean
     field :log_sinks, :boolean
-    field :device_posture, :boolean, default: nil
+    field :device_posture, :boolean
   end
 
   def changeset(features \\ %__MODULE__{}, attrs) do

--- a/elixir/lib/portal/config.ex
+++ b/elixir/lib/portal/config.ex
@@ -80,17 +80,6 @@ defmodule Portal.Config do
     end
   end
 
-  ## Feature flag helpers
-
-  def global_feature_enabled?(feature) do
-    fetch_env!(:portal, :enabled_features)
-    |> Keyword.fetch!(feature)
-  end
-
-  def sign_up_enabled? do
-    global_feature_enabled?(:sign_up)
-  end
-
   ## Test helpers
 
   if Mix.env() != :test do
@@ -203,14 +192,6 @@ defmodule Portal.Config do
         :error ->
           application_env
       end
-    end
-
-    def feature_flag_override(feature, value) do
-      enabled_features =
-        fetch_env!(:portal, :enabled_features)
-        |> Keyword.put(feature, value)
-
-      put_env_override(:enabled_features, enabled_features)
     end
 
     defp pdict_key_function(app, key), do: {app, key}

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -990,19 +990,6 @@ defmodule Portal.Config.Definitions do
   defconfig(:docker_registry, :string, default: "ghcr.io/firezone")
   defconfig(:api_url_override, :string, default: nil)
 
-  ##############################################
-  ## Feature Flags
-  ##
-  ## If feature is disabled globally it won't be available for any account,
-  ## even if account-specific override enables them.
-  ##
-  ##############################################
-
-  @doc """
-  Boolean flag to turn Sign-ups on/off for all accounts.
-  """
-  defconfig(:feature_sign_up_enabled, :boolean, default: true)
-
   @doc """
   List of email domains allowed to signup from. Leave empty to allow signing up from any domain.
   """
@@ -1015,23 +1002,4 @@ defmodule Portal.Config.Definitions do
     end
   )
 
-  @doc """
-  Boolean flag to turn IdP sync on/off for all accounts.
-  """
-  defconfig(:feature_idp_sync_enabled, :boolean, default: true)
-
-  @doc """
-  Boolean flag to turn Policy Conditions functionality on/off for all accounts.
-  """
-  defconfig(:feature_policy_conditions_enabled, :boolean, default: false)
-
-  @doc """
-  Boolean flag to turn API Client UI functionality on/off for all accounts.
-  """
-  defconfig(:feature_rest_api_enabled, :boolean, default: false)
-
-  @doc """
-  Boolean flag to turn Internet Resources functionality on/off for all accounts.
-  """
-  defconfig(:feature_internet_resource_enabled, :boolean, default: false)
 end

--- a/elixir/lib/portal/crl/scheduler.ex
+++ b/elixir/lib/portal/crl/scheduler.ex
@@ -20,7 +20,11 @@ defmodule Portal.Crl.Scheduler do
   def perform(%Oban.Job{}) do
     Logger.debug("Scheduling certificate revocation list refresh jobs")
 
-    Database.queue_sync_jobs()
+    if Portal.Features.enabled?(:device_trust) do
+      Database.queue_sync_jobs()
+    else
+      {:ok, :skipped}
+    end
   end
 
   defmodule Database do
@@ -38,10 +42,6 @@ defmodule Portal.Crl.Scheduler do
         from(e in Portal.RevocationEndpoint,
           join: a in Portal.Account,
           on: a.id == e.account_id,
-          # The features table is global per-deployment state with no account_id.
-          # credo:disable-for-next-line Credo.Check.Warning.MissingAccountIdInJoin
-          join: f in Portal.Features,
-          on: f.feature == :device_trust and f.enabled == true,
           where: e.crl_urls != [],
           where: a.is_disabled == false,
           where: e.is_disabled == false,

--- a/elixir/lib/portal/crl/sync.ex
+++ b/elixir/lib/portal/crl/sync.ex
@@ -31,7 +31,8 @@ defmodule Portal.Crl.Sync do
           "distribution_point" => distribution_point
         }
       }) do
-    with {:ok, issuer} <- Base.decode64(encoded_issuer),
+    with true <- Portal.Features.enabled?(:device_trust),
+         {:ok, issuer} <- Base.decode64(encoded_issuer),
          endpoint when not is_nil(endpoint) <-
            Database.fetch_endpoint(account_id, issuer, distribution_point) do
       refresh(endpoint)
@@ -380,15 +381,8 @@ defmodule Portal.Crl.Sync do
 
     @remove_from_crl "removeFromCRL"
 
-    # Gated on the feature flag as well, so a job already queued when the flag is
-    # turned off does nothing rather than recording a failure against an
-    # endpoint whose anchors it can no longer see.
     def fetch_endpoint(account_id, issuer, distribution_point) do
       from(e in Portal.RevocationEndpoint,
-        # The features table is global per-deployment state with no account_id.
-        # credo:disable-for-next-line Credo.Check.Warning.MissingAccountIdInJoin
-        join: f in Portal.Features,
-        on: f.feature == :device_trust and f.enabled == true,
         where: e.account_id == ^account_id,
         where: e.issuer == ^issuer,
         where: e.distribution_point == ^distribution_point
@@ -399,10 +393,6 @@ defmodule Portal.Crl.Sync do
 
     def anchor_ders(account_id) do
       from(c in Portal.TrustAnchorCertificate,
-        # The features table is global per-deployment state with no account_id.
-        # credo:disable-for-next-line Credo.Check.Warning.MissingAccountIdInJoin
-        join: f in Portal.Features,
-        on: f.feature == :device_trust and f.enabled == true,
         where: c.account_id == ^account_id,
         select: c.pem
       )

--- a/elixir/lib/portal/features.ex
+++ b/elixir/lib/portal/features.ex
@@ -2,10 +2,28 @@ defmodule Portal.Features do
   # credo:disable-for-this-file Credo.Check.Warning.MissingChangesetFunction
   use Ecto.Schema
 
+  @features [:device_trust, :device_posture]
+  @type feature :: :device_trust | :device_posture
+
   @primary_key false
 
   schema "features" do
-    field :feature, Ecto.Enum, values: [:device_trust]
+    field :feature, Ecto.Enum, values: @features
     field :enabled, :boolean, default: false
+  end
+
+  @spec enabled?(feature()) :: boolean()
+  def enabled?(feature) when feature in @features, do: __MODULE__.Database.enabled?(feature)
+
+  defmodule Database do
+    import Ecto.Query
+
+    alias Portal.Safe
+
+    def enabled?(feature) do
+      from(f in Portal.Features, where: f.feature == ^feature and f.enabled == true)
+      |> Safe.unscoped()
+      |> Safe.exists?()
+    end
   end
 end

--- a/elixir/lib/portal/intune/scheduler.ex
+++ b/elixir/lib/portal/intune/scheduler.ex
@@ -3,7 +3,7 @@ defmodule Portal.Intune.Scheduler do
 
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
-    if Portal.Config.global_feature_enabled?(:device_posture) do
+    if Portal.Features.enabled?(:device_posture) do
       __MODULE__.Database.queue_sync_jobs()
     else
       {:ok, :skipped}

--- a/elixir/lib/portal/intune/sync.ex
+++ b/elixir/lib/portal/intune/sync.ex
@@ -26,7 +26,7 @@ defmodule Portal.Intune.Sync do
   def perform(%Oban.Job{
         args: %{"account_id" => account_id, "device_integration_id" => integration_id}
       }) do
-    if Portal.Config.global_feature_enabled?(:device_posture) do
+    if Portal.Features.enabled?(:device_posture) do
       sync(account_id, integration_id)
     else
       :ok

--- a/elixir/lib/portal/mailer/sync_email.ex
+++ b/elixir/lib/portal/mailer/sync_email.ex
@@ -27,7 +27,7 @@ defmodule Portal.Mailer.SyncEmail do
   def device_integration_error_email(integration, recipients) do
     error_email(integration, recipients,
       subject: "Device Integration Error - #{integration.name}",
-      settings_url: url(~p"/#{integration.account}/settings/device_integrations"),
+      settings_url: url(~p"/#{integration.account}/settings/device_posture"),
       noun: "device integration",
       record_label: "Integration",
       details_heading: "Device Integration Details",

--- a/elixir/lib/portal/ocsp/scheduler.ex
+++ b/elixir/lib/portal/ocsp/scheduler.ex
@@ -14,7 +14,11 @@ defmodule Portal.Ocsp.Scheduler do
   def perform(%Oban.Job{}) do
     Logger.debug("Scheduling OCSP refresh jobs")
 
-    Database.queue_sync_jobs()
+    if Portal.Features.enabled?(:device_trust) do
+      Database.queue_sync_jobs()
+    else
+      {:ok, :skipped}
+    end
   end
 
   defmodule Database do
@@ -26,10 +30,6 @@ defmodule Portal.Ocsp.Scheduler do
         from(e in Portal.RevocationEndpoint,
           join: a in Portal.Account,
           on: a.id == e.account_id,
-          # The features table is global per-deployment state with no account_id.
-          # credo:disable-for-next-line Credo.Check.Warning.MissingAccountIdInJoin
-          join: f in Portal.Features,
-          on: f.feature == :device_trust and f.enabled == true,
           where:
             not fragment(
               "EXISTS (SELECT 1 FROM unnest(?) AS u WHERE u LIKE 'http://%' OR u LIKE 'https://%')",

--- a/elixir/lib/portal/ocsp/sync.ex
+++ b/elixir/lib/portal/ocsp/sync.ex
@@ -30,7 +30,8 @@ defmodule Portal.Ocsp.Sync do
           "distribution_point" => distribution_point
         } = args
       }) do
-    with {:ok, issuer} <- Base.decode64(encoded_issuer),
+    with true <- Portal.Features.enabled?(:device_trust),
+         {:ok, issuer} <- Base.decode64(encoded_issuer),
          endpoint when not is_nil(endpoint) <-
            Database.fetch_endpoint(account_id, issuer, distribution_point) do
       refresh(endpoint, Map.get(args, "serial"))
@@ -54,17 +55,19 @@ defmodule Portal.Ocsp.Sync do
   """
   @spec enqueue_check(Ecto.UUID.t(), binary(), String.t()) :: :ok
   def enqueue_check(account_id, issuer, serial) do
-    Database.ocsp_distribution_points(account_id, issuer)
-    |> Enum.each(fn distribution_point ->
-      %{
-        account_id: account_id,
-        issuer: Base.encode64(issuer),
-        distribution_point: distribution_point,
-        serial: serial
-      }
-      |> new(unique: [period: {1, :hour}, states: Oban.Job.states() -- [:discarded]])
-      |> Oban.insert()
-    end)
+    if Portal.Features.enabled?(:device_trust) do
+      Database.ocsp_distribution_points(account_id, issuer)
+      |> Enum.each(fn distribution_point ->
+        %{
+          account_id: account_id,
+          issuer: Base.encode64(issuer),
+          distribution_point: distribution_point,
+          serial: serial
+        }
+        |> new(unique: [period: {1, :hour}, states: Oban.Job.states() -- [:discarded]])
+        |> Oban.insert()
+      end)
+    end
 
     :ok
   end
@@ -271,15 +274,8 @@ defmodule Portal.Ocsp.Sync do
     alias Portal.Revocation.Failure
     alias Portal.Safe
 
-    # Gated on the feature flag as well, so a job already queued when the flag is
-    # turned off does nothing rather than recording a failure against an
-    # endpoint whose anchors it can no longer see.
     def fetch_endpoint(account_id, issuer, distribution_point) do
       from(e in Portal.RevocationEndpoint,
-        # The features table is global per-deployment state with no account_id.
-        # credo:disable-for-next-line Credo.Check.Warning.MissingAccountIdInJoin
-        join: f in Portal.Features,
-        on: f.feature == :device_trust and f.enabled == true,
         where: e.account_id == ^account_id,
         where: e.issuer == ^issuer,
         where: e.distribution_point == ^distribution_point
@@ -304,10 +300,6 @@ defmodule Portal.Ocsp.Sync do
     # so the CA's own certificate has to be on hand to ask about anything.
     def issuer_certificate(endpoint) do
       from(c in Portal.TrustAnchorCertificate,
-        # The features table is global per-deployment state with no account_id.
-        # credo:disable-for-next-line Credo.Check.Warning.MissingAccountIdInJoin
-        join: f in Portal.Features,
-        on: f.feature == :device_trust and f.enabled == true,
         where: c.account_id == ^endpoint.account_id,
         select: c.pem
       )

--- a/elixir/lib/portal_api/client/device_trust.ex
+++ b/elixir/lib/portal_api/client/device_trust.ex
@@ -224,7 +224,12 @@ defmodule PortalAPI.Client.DeviceTrust do
   end
 
   defp fetch_anchors(subject) do
-    case Database.fetch_enabled_anchors(subject) do
+    anchors =
+      if Portal.Features.enabled?(:device_trust),
+        do: Database.fetch_anchors(subject),
+        else: []
+
+    case anchors do
       [] -> {:error, :no_trust_anchors}
       anchors -> {:ok, anchors}
     end
@@ -749,14 +754,6 @@ defmodule PortalAPI.Client.DeviceTrust do
       matched_on: nil
     }
 
-    # One round trip: the join on the global feature-flag row makes the query
-    # return no anchors at all when the flag is off, so the caller's gate
-    # check and verification material come from the same query.
-    # Compared against true rather than taken as truthy: a scoped `exists?`
-    # returns the permission error itself when a read is refused, and an error
-    # tuple reading as "revoked" would lock out every device over something
-    # that is not a revocation at all.
-    #
     # Everything the connect needs to decide about this certificate, in one
     # round trip: whether a list revoked it, whether its issuer publishes a
     # list we can actually fetch, what its responder last said, and which
@@ -872,12 +869,8 @@ defmodule PortalAPI.Client.DeviceTrust do
       end
     end
 
-    def fetch_enabled_anchors(subject) do
+    def fetch_anchors(subject) do
       from(c in Portal.TrustAnchorCertificate,
-        # The features table is global per-deployment state with no account_id.
-        # credo:disable-for-next-line Credo.Check.Warning.MissingAccountIdInJoin
-        join: f in Portal.Features,
-        on: f.feature == :device_trust and f.enabled == true,
         select: %{id: c.id, pem: c.pem}
       )
       |> Safe.scoped(subject)

--- a/elixir/lib/portal_web/components/navigation_components.ex
+++ b/elixir/lib/portal_web/components/navigation_components.ex
@@ -507,8 +507,8 @@ defmodule PortalWeb.NavigationComponents do
         <.settings_tab
           :if={device_posture_enabled?()}
           current_path={@current_path}
-          navigate={~p"/#{@account}/settings/device_integrations"}
-          tab_path="settings/device_integrations"
+          navigate={~p"/#{@account}/settings/device_posture"}
+          tab_path="settings/device_posture"
           icon="ri-shield-star-fill"
         >
           Device Posture

--- a/elixir/lib/portal_web/components/navigation_components.ex
+++ b/elixir/lib/portal_web/components/navigation_components.ex
@@ -3,30 +3,15 @@ defmodule PortalWeb.NavigationComponents do
   use PortalWeb, :verified_routes
   import PortalWeb.CoreComponents
 
-  defmodule Database do
-    import Ecto.Query, only: [from: 2]
-    alias Portal.{Features, Safe}
-
-    def device_trust_feature_enabled? do
-      query = from(f in Features, where: f.feature == :device_trust and f.enabled == true)
-      Safe.unscoped(query) |> Safe.exists?()
-    end
-  end
+  @doc """
+  Returns whether the global `device_trust` rollout flag is enabled.
+  """
+  def device_trust_enabled?, do: Portal.Features.enabled?(:device_trust)
 
   @doc """
-  Returns whether the global `device_trust` feature flag is enabled. Callers
-  should compute this once in `mount/3` and pass it to `settings_nav/1` as the
-  `device_trust_enabled?` assign, rather than calling this on every render.
+  Returns whether the global `device_posture` rollout flag is enabled.
   """
-  def device_trust_enabled?, do: Database.device_trust_feature_enabled?()
-
-  @doc """
-  Whether device posture is enabled globally.
-
-  Unlike `device_trust_enabled?/0` this reads application config rather than the
-  database, so it is cheap enough to call from a template.
-  """
-  def device_posture_enabled?, do: Portal.Config.global_feature_enabled?(:device_posture)
+  def device_posture_enabled?, do: Portal.Features.enabled?(:device_posture)
 
   @doc """
   Renders the top navigation bar.
@@ -419,6 +404,7 @@ defmodule PortalWeb.NavigationComponents do
   attr :account, :any, required: true
   attr :current_path, :string, required: true
   attr :device_trust_enabled?, :boolean, default: false
+  attr :device_posture_enabled?, :boolean, default: false
   slot :actions
 
   def settings_nav(assigns) do
@@ -505,7 +491,7 @@ defmodule PortalWeb.NavigationComponents do
           Directory Sync
         </.settings_tab>
         <.settings_tab
-          :if={device_posture_enabled?()}
+          :if={@device_posture_enabled?}
           current_path={@current_path}
           navigate={~p"/#{@account}/settings/device_posture"}
           tab_path="settings/device_posture"

--- a/elixir/lib/portal_web/live/settings/account.ex
+++ b/elixir/lib/portal_web/live/settings/account.ex
@@ -25,7 +25,8 @@ defmodule PortalWeb.Settings.Account do
         users_count: Database.count_users_for_account(subject),
         active_users_count: Database.count_1m_active_users_for_account(subject),
         sites_count: Database.count_groups_for_account(subject),
-        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?()
+        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?(),
+        device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
       )
 
     {:ok, socket}
@@ -38,6 +39,7 @@ defmodule PortalWeb.Settings.Account do
         account={@account}
         current_path={@current_path}
         device_trust_enabled?={@device_trust_enabled?}
+        device_posture_enabled?={@device_posture_enabled?}
       >
         <:actions>
           <.button phx-click="open_edit_account" size="xs">
@@ -127,6 +129,10 @@ defmodule PortalWeb.Settings.Account do
               enabled={feature_enabled?(@account, :policy_conditions)}
             />
             <.feature_row label="Log Sinks" enabled={feature_enabled?(@account, :log_sinks)} />
+            <.feature_row
+              label="Device Posture"
+              enabled={feature_enabled?(@account, :device_posture)}
+            />
           </div>
 
           <%!-- Actions (pending deletion, self-initiated, not locked) --%>

--- a/elixir/lib/portal_web/live/settings/api_clients/beta.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/beta.ex
@@ -24,7 +24,8 @@ defmodule PortalWeb.Settings.ApiClients.Beta do
           socket,
           page_title: "API Clients",
           requested: Portal.Account.rest_api_access_requested?(socket.assigns.account),
-          device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?()
+          device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?(),
+          device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
         )
 
       {:ok, socket}
@@ -38,6 +39,7 @@ defmodule PortalWeb.Settings.ApiClients.Beta do
         account={@account}
         current_path={@current_path}
         device_trust_enabled?={@device_trust_enabled?}
+        device_posture_enabled?={@device_posture_enabled?}
       />
 
       <div class="flex-1 flex flex-col overflow-hidden">

--- a/elixir/lib/portal_web/live/settings/api_clients/index.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/index.ex
@@ -84,6 +84,7 @@ defmodule PortalWeb.Settings.ApiClients.Index do
         |> assign(form: nil, encoded_token: nil)
         |> assign(pending_confirm: nil, open_actor_actions_id: nil)
         |> assign(device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?())
+        |> assign(device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?())
 
       {:ok, socket}
     else
@@ -146,6 +147,7 @@ defmodule PortalWeb.Settings.ApiClients.Index do
         account={@account}
         current_path={@current_path}
         device_trust_enabled?={@device_trust_enabled?}
+        device_posture_enabled?={@device_posture_enabled?}
       />
 
       <div class="flex-1 flex flex-col overflow-hidden">

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -51,7 +51,8 @@ defmodule PortalWeb.Settings.Authentication do
     socket =
       assign(socket,
         page_title: "Authentication",
-        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?()
+        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?(),
+        device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
       )
 
     if connected?(socket) do
@@ -621,6 +622,7 @@ defmodule PortalWeb.Settings.Authentication do
         account={@account}
         current_path={@current_path}
         device_trust_enabled?={@device_trust_enabled?}
+        device_posture_enabled?={@device_posture_enabled?}
       />
 
       <div class="flex-1 flex flex-col overflow-hidden">

--- a/elixir/lib/portal_web/live/settings/device_posture.ex
+++ b/elixir/lib/portal_web/live/settings/device_posture.ex
@@ -34,6 +34,7 @@ defmodule PortalWeb.Settings.DevicePosture do
      |> assign(
        page_title: "Device Posture",
        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?(),
+       device_posture_enabled?: true,
        verification_error: nil,
        active_verification: nil,
        pending_verification: nil,
@@ -394,6 +395,7 @@ defmodule PortalWeb.Settings.DevicePosture do
         account={@account}
         current_path={@current_path}
         device_trust_enabled?={@device_trust_enabled?}
+        device_posture_enabled?={@device_posture_enabled?}
       />
 
       <%= if Portal.Account.device_posture_enabled?(@account) do %>

--- a/elixir/lib/portal_web/live/settings/device_posture.ex
+++ b/elixir/lib/portal_web/live/settings/device_posture.ex
@@ -1,4 +1,4 @@
-defmodule PortalWeb.Settings.DeviceIntegrations do
+defmodule PortalWeb.Settings.DevicePosture do
   use PortalWeb, :live_view
 
   import Ecto.Changeset
@@ -400,21 +400,21 @@ defmodule PortalWeb.Settings.DeviceIntegrations do
         <div class="flex-1 flex flex-col overflow-hidden">
           <div class="flex items-center justify-between px-6 py-3 border-b border-border shrink-0">
             <div class="flex items-center gap-2">
-              <h2 class="text-xs font-semibold text-heading">Device Integrations</h2>
+              <h2 class="text-xs font-semibold text-heading">Device Posture</h2>
               <span class="text-xs text-subtle tabular-nums">{length(@integrations)}</span>
             </div>
             <.link
               :if={Enum.empty?(@integrations)}
-              patch={~p"/#{@account}/settings/device_integrations/intune/new"}
+              patch={~p"/#{@account}/settings/device_posture/intune/new"}
               class="flex items-center gap-1 px-2.5 py-1 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
             >
-              <.icon name="ri-add-line" class="w-3 h-3" /> Add Device Integration
+              <.icon name="ri-add-line" class="w-3 h-3" /> Add Microsoft Intune
             </.link>
           </div>
 
           <div
             :if={not Enum.empty?(@integrations)}
-            id="device-integration-summary"
+            id="device-posture-summary"
             class="flex flex-wrap items-center gap-2 px-6 py-2.5 border-b border-border shrink-0"
           >
             <.dual_badge type="primary">
@@ -438,12 +438,12 @@ defmodule PortalWeb.Settings.DeviceIntegrations do
           <div class="flex-1 overflow-auto">
             <%= if Enum.empty?(@integrations) do %>
               <div class="flex flex-col items-center justify-center h-full gap-3 text-subtle">
-                <p class="text-sm">No device integrations configured.</p>
+                <p class="text-sm">No device posture provider configured.</p>
                 <.link
-                  patch={~p"/#{@account}/settings/device_integrations/intune/new"}
+                  patch={~p"/#{@account}/settings/device_posture/intune/new"}
                   class="flex items-center gap-1 px-2.5 py-1 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
                 >
-                  <.icon name="ri-add-line" class="w-3 h-3" /> Add a device integration
+                  <.icon name="ri-add-line" class="w-3 h-3" /> Add Microsoft Intune
                 </.link>
               </div>
             <% else %>
@@ -485,7 +485,7 @@ defmodule PortalWeb.Settings.DeviceIntegrations do
       <% end %>
 
       <div
-        id="device-integration-panel"
+        id="device-posture-panel"
         class={[
           "fixed top-14 right-0 bottom-0 z-20 flex flex-col w-full lg:w-3/4 xl:w-1/2",
           "bg-elevated border-l border-border-strong shadow-[-4px_0px_20px_rgba(0,0,0,0.07)]",
@@ -527,7 +527,7 @@ defmodule PortalWeb.Settings.DeviceIntegrations do
             </.button>
             <div class="ml-auto flex items-center gap-2">
               <.button type="button" phx-click="close_panel">Cancel</.button>
-              <.button form="device-integration-form" type="submit" style="primary" disabled={not @form.source.valid?}>
+              <.button form="device-posture-form" type="submit" style="primary" disabled={not @form.source.valid?}>
                 {if @live_action == :new, do: "Create", else: "Save"}
               </.button>
             </div>
@@ -547,7 +547,7 @@ defmodule PortalWeb.Settings.DeviceIntegrations do
     <div class="flex-1 flex flex-col overflow-hidden">
       <div class="flex items-center justify-between px-6 py-3 border-b border-border shrink-0">
         <div class="flex items-center gap-2">
-          <h2 class="text-xs font-semibold text-heading">Device Integrations</h2>
+          <h2 class="text-xs font-semibold text-heading">Device Posture</h2>
         </div>
       </div>
 
@@ -672,7 +672,7 @@ defmodule PortalWeb.Settings.DeviceIntegrations do
             phx-value-id={@integration.id}
           >
             <.link
-              patch={~p"/#{@account}/settings/device_integrations/intune/#{@integration.id}/edit"}
+              patch={~p"/#{@account}/settings/device_posture/intune/#{@integration.id}/edit"}
               class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-raised transition-colors text-body"
             >
               <.icon name="ri-pencil-line" class="w-3.5 h-3.5 shrink-0" /> Edit
@@ -742,7 +742,7 @@ defmodule PortalWeb.Settings.DeviceIntegrations do
     ~H"""
     <.form
       for={@form}
-      id="device-integration-form"
+      id="device-posture-form"
       as={:integration}
       phx-change="validate"
       phx-submit="submit"
@@ -966,7 +966,7 @@ defmodule PortalWeb.Settings.DeviceIntegrations do
   defp account_feature_enabled?(socket),
     do: Portal.Account.device_posture_enabled?(socket.assigns.subject.account)
 
-  defp index_path(socket), do: ~p"/#{socket.assigns.account}/settings/device_integrations"
+  defp index_path(socket), do: ~p"/#{socket.assigns.account}/settings/device_posture"
 
   defmodule Database do
     import Ecto.Query

--- a/elixir/lib/portal_web/live/settings/device_trust/index.ex
+++ b/elixir/lib/portal_web/live/settings/device_trust/index.ex
@@ -144,6 +144,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
         |> assign(revocation: [])
         |> assign(panel_tab: :overview, expanded_endpoint: nil)
         |> assign(device_trust_enabled?: device_trust_enabled?)
+        |> assign(device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?())
         |> allow_upload(:cert_file,
           accept: ~w(.pem .crt .cer .der .txt),
           max_entries: @max_upload_entries,
@@ -214,6 +215,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
         account={@account}
         current_path={@current_path}
         device_trust_enabled?={@device_trust_enabled?}
+        device_posture_enabled?={@device_posture_enabled?}
       />
 
       <div class="flex-1 flex flex-col overflow-hidden">

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -47,7 +47,8 @@ defmodule PortalWeb.Settings.DirectorySync do
     socket =
       assign(socket,
         page_title: "Directory Sync",
-        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?()
+        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?(),
+        device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
       )
 
     if connected?(socket) do
@@ -566,6 +567,7 @@ defmodule PortalWeb.Settings.DirectorySync do
         account={@account}
         current_path={@current_path}
         device_trust_enabled?={@device_trust_enabled?}
+        device_posture_enabled?={@device_posture_enabled?}
       />
 
       <%= if Portal.Account.idp_sync_enabled?(@account) do %>

--- a/elixir/lib/portal_web/live/settings/dns.ex
+++ b/elixir/lib/portal_web/live/settings/dns.ex
@@ -11,6 +11,7 @@ defmodule PortalWeb.Settings.DNS do
       |> assign(page_title: "DNS")
       |> assign(dns_account: account)
       |> assign(device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?())
+      |> assign(device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?())
 
     {:ok, socket}
   end
@@ -39,6 +40,7 @@ defmodule PortalWeb.Settings.DNS do
         account={@account}
         current_path={@current_path}
         device_trust_enabled?={@device_trust_enabled?}
+        device_posture_enabled?={@device_posture_enabled?}
       />
 
       <div class="flex-1 flex flex-col overflow-hidden">

--- a/elixir/lib/portal_web/live/settings/log_sinks.ex
+++ b/elixir/lib/portal_web/live/settings/log_sinks.ex
@@ -73,7 +73,8 @@ defmodule PortalWeb.Settings.LogSinks do
         page_title: "Log Sinks",
         sentinel_setup_tab: "portal",
         s3_setup_tab: "console",
-        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?()
+        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?(),
+        device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
       )
 
     {:ok, init(socket, new: true)}
@@ -282,6 +283,7 @@ defmodule PortalWeb.Settings.LogSinks do
         account={@account}
         current_path={@current_path}
         device_trust_enabled?={@device_trust_enabled?}
+        device_posture_enabled?={@device_posture_enabled?}
       />
 
       <%= if Portal.Account.log_sinks_enabled?(@account) do %>

--- a/elixir/lib/portal_web/live/settings/notifications.ex
+++ b/elixir/lib/portal_web/live/settings/notifications.ex
@@ -7,7 +7,8 @@ defmodule PortalWeb.Settings.Notifications do
       assign(socket,
         page_title: "Notifications",
         form: to_form(build_changeset(socket.assigns.account)),
-        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?()
+        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?(),
+        device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
       )
 
     {:ok, socket}
@@ -20,6 +21,7 @@ defmodule PortalWeb.Settings.Notifications do
         account={@account}
         current_path={@current_path}
         device_trust_enabled?={@device_trust_enabled?}
+        device_posture_enabled?={@device_posture_enabled?}
       />
 
       <div class="flex-1 overflow-y-auto p-6">

--- a/elixir/lib/portal_web/live/sign_up.ex
+++ b/elixir/lib/portal_web/live/sign_up.ex
@@ -1,6 +1,5 @@
 defmodule PortalWeb.SignUp do
   use PortalWeb, {:live_view, layout: {PortalWeb.Layouts, :auth}}
-  alias Portal.Config
   alias __MODULE__.Database
   require Logger
 
@@ -99,8 +98,6 @@ defmodule PortalWeb.SignUp do
          )}
 
       _ ->
-        sign_up_enabled? = Config.sign_up_enabled?()
-
         socket =
           assign(socket,
             page_title: "Sign Up",
@@ -113,8 +110,7 @@ defmodule PortalWeb.SignUp do
             provider: nil,
             actor: nil,
             user_agent: user_agent,
-            real_ip: real_ip,
-            sign_up_enabled?: sign_up_enabled?
+            real_ip: real_ip
           )
 
         {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
@@ -150,9 +146,8 @@ defmodule PortalWeb.SignUp do
     <.flash flash={@flash} kind={:error} />
     <.flash flash={@flash} kind={:info} />
 
-    <.sign_up_disabled :if={!@sign_up_enabled?} />
-    <.sign_up_form :if={@sign_up_enabled? && @step == :fill_form} form={@form} />
-    <.email_sent :if={@sign_up_enabled? && @step == :email_sent} />
+    <.sign_up_form :if={@step == :fill_form} form={@form} />
+    <.email_sent :if={@step == :email_sent} />
     """
   end
 
@@ -395,34 +390,6 @@ defmodule PortalWeb.SignUp do
     """
   end
 
-  defp sign_up_disabled(assigns) do
-    ~H"""
-    <div class="flex items-center gap-3 mb-8">
-      <div class="w-11 h-11 rounded bg-rose-50 dark:bg-rose-950/30 border border-rose-200 dark:border-rose-800 flex items-center justify-center shrink-0">
-        <.icon name="ri-prohibited-line" class="w-5 h-5 text-rose-500" />
-      </div>
-      <div>
-        <h1 class="text-xl font-bold text-heading tracking-tight">
-          Sign-ups are currently disabled
-        </h1>
-        <p class="text-xs text-subtle mt-0.5">
-          Contact us to get access.
-        </p>
-      </div>
-    </div>
-
-    <div class="pt-6 border-t border-border text-center">
-      <p class="text-xs text-subtle leading-relaxed">
-        Please contact
-        <a class={link_style()} href="mailto:sales@firezone.dev?subject=Firezone Sign Up Request">
-          sales@firezone.dev
-        </a>
-        for more information.
-      </p>
-    </div>
-    """
-  end
-
   defp verifying(assigns) do
     ~H"""
     <div class="flex items-center gap-3 mb-8">
@@ -548,8 +515,7 @@ defmodule PortalWeb.SignUp do
     end
   end
 
-  defp apply_registration(socket, %{valid?: true} = changeset)
-       when socket.assigns.sign_up_enabled? do
+  defp apply_registration(socket, %{valid?: true} = changeset) do
     registration = Ecto.Changeset.apply_changes(changeset)
     existing_accounts = Database.find_accounts_by_owner_email(registration.email)
 

--- a/elixir/lib/portal_web/router.ex
+++ b/elixir/lib/portal_web/router.ex
@@ -299,10 +299,10 @@ defmodule PortalWeb.Router do
           live "/:type/:id/edit", DirectorySync, :edit
         end
 
-        scope "/device_integrations" do
-          live "/", DeviceIntegrations
-          live "/intune/new", DeviceIntegrations, :new
-          live "/intune/:id/edit", DeviceIntegrations, :edit
+        scope "/device_posture" do
+          live "/", DevicePosture
+          live "/intune/new", DevicePosture, :new
+          live "/intune/:id/edit", DevicePosture, :edit
         end
 
         # Log Sinks

--- a/elixir/priv/repo/migrations/20260814000000_add_device_posture_feature.exs
+++ b/elixir/priv/repo/migrations/20260814000000_add_device_posture_feature.exs
@@ -1,0 +1,10 @@
+defmodule Portal.Repo.Migrations.AddDevicePostureFeature do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      "INSERT INTO features (feature, enabled) VALUES ('device_posture', false) ON CONFLICT (feature) DO NOTHING",
+      "DELETE FROM features WHERE feature = 'device_posture'"
+    )
+  end
+end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -947,7 +947,11 @@ defmodule Portal.Repo.Seeds do
     :rand.seed(:exsss, {1, 2, 3})
 
     Repo.query!(
-      "INSERT INTO features (feature, enabled) VALUES ('device_trust', true) ON CONFLICT (feature) DO UPDATE SET enabled = true"
+      """
+      INSERT INTO features (feature, enabled)
+      VALUES ('device_trust', true), ('device_posture', true)
+      ON CONFLICT (feature) DO UPDATE SET enabled = true
+      """
     )
 
     account =

--- a/elixir/test/portal/account_test.exs
+++ b/elixir/test/portal/account_test.exs
@@ -3,6 +3,7 @@ defmodule Portal.AccountTest do
 
   import Ecto.Changeset
   import Portal.AccountFixtures
+  import Portal.FeaturesFixtures
 
   alias Portal.Account
 
@@ -78,6 +79,31 @@ defmodule Portal.AccountTest do
     test "returns false when the account has no features" do
       account = %Account{features: nil}
       refute Account.iceless_enabled?(account)
+    end
+  end
+
+  describe "account-local features" do
+    test "log sinks does not require a global rollout flag" do
+      account = %Account{features: %Portal.Accounts.Features{log_sinks: true}}
+      assert Account.log_sinks_enabled?(account)
+    end
+
+    test "device posture requires both the global rollout and account entitlement" do
+      account = %Account{features: %Portal.Accounts.Features{device_posture: true}}
+
+      disable_feature(:device_posture)
+      refute Account.device_posture_enabled?(account)
+
+      enable_feature(:device_posture)
+      assert Account.device_posture_enabled?(account)
+    end
+
+    test "device posture defaults to an unset account entitlement" do
+      enable_feature(:device_posture)
+      account = %Account{features: %Portal.Accounts.Features{}}
+
+      assert account.features.device_posture == nil
+      refute Account.device_posture_enabled?(account)
     end
   end
 

--- a/elixir/test/portal/crl/scheduler_test.exs
+++ b/elixir/test/portal/crl/scheduler_test.exs
@@ -21,7 +21,7 @@ defmodule Portal.Crl.SchedulerTest do
       endpoint_fixture(account, pki.ca_der)
       Portal.Repo.delete_all(Portal.Features)
 
-      assert Scheduler.perform(%Oban.Job{}) == {:ok, :scheduled}
+      assert Scheduler.perform(%Oban.Job{}) == {:ok, :skipped}
 
       assert all_sync_jobs() == []
     end

--- a/elixir/test/portal/features_test.exs
+++ b/elixir/test/portal/features_test.exs
@@ -1,0 +1,15 @@
+defmodule Portal.FeaturesTest do
+  use Portal.DataCase, async: true
+
+  import Portal.FeaturesFixtures
+
+  for feature <- [:device_trust, :device_posture] do
+    test "enabled?/1 reads the #{feature} global rollout flag" do
+      disable_feature(unquote(feature))
+      refute Portal.Features.enabled?(unquote(feature))
+
+      enable_feature(unquote(feature))
+      assert Portal.Features.enabled?(unquote(feature))
+    end
+  end
+end

--- a/elixir/test/portal/mailer/sync_error_email_test.exs
+++ b/elixir/test/portal/mailer/sync_error_email_test.exs
@@ -95,8 +95,8 @@ defmodule Portal.Mailer.SyncErrorEmailTest do
 
       assert email_body.text_body =~ "403 - Forbidden"
       assert email_body.text_body =~ ~r/Tenant ID:\s*#{integration.tenant_id}/
-      assert email_body.text_body =~ "/#{account.slug}/settings/device_integrations"
-      refute email_body.text_body =~ "/#{account.id}/settings/device_integrations"
+      assert email_body.text_body =~ "/#{account.slug}/settings/device_posture"
+      refute email_body.text_body =~ "/#{account.id}/settings/device_posture"
     end
 
     test "email subject includes the integration name", %{integration: integration} do

--- a/elixir/test/portal/workers/sync_error_notification_test.exs
+++ b/elixir/test/portal/workers/sync_error_notification_test.exs
@@ -249,7 +249,7 @@ defmodule Portal.Workers.SyncErrorNotificationTest do
       assert email.subject == "Device Integration Error - #{integration.name}"
       assert {"", admin.email} in email.bcc
       assert email.text_body =~ "device integration has encountered an unrecoverable error"
-      assert email.text_body =~ "settings/device_integrations"
+      assert email.text_body =~ "settings/device_posture"
       assert email.text_body =~ integration.tenant_id
       assert email.text_body =~ "DeviceManagementManagedDevices.Read.All"
     end

--- a/elixir/test/portal_web/live/settings/account_test.exs
+++ b/elixir/test/portal_web/live/settings/account_test.exs
@@ -105,6 +105,8 @@ defmodule PortalWeb.Settings.AccountTest do
         |> live(~p"/#{account}/settings/account")
 
       assert html =~ "Plan Features"
+      assert html =~ "Device Posture"
+      refute html =~ "ICE-less"
     end
 
     test "renders usage section", %{conn: conn, account: account, actor: actor} do

--- a/elixir/test/portal_web/live/settings/device_integrations_test.exs
+++ b/elixir/test/portal_web/live/settings/device_integrations_test.exs
@@ -57,11 +57,12 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       refute html =~ "settings/device_integrations"
     end
 
-    test "shows the settings tab when the global flag is on", %{
-      conn: conn,
-      account: account,
-      actor: actor
+    test "shows the settings tab when the global flag is on even without the account feature", %{
+      conn: conn
     } do
+      account = Portal.AccountFixtures.account_fixture(features: %{device_posture: false})
+      actor = Portal.ActorFixtures.admin_actor_fixture(account: account)
+
       {:ok, _lv, html} =
         conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/directory_sync")
 
@@ -91,6 +92,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
 
       assert html =~ "Upgrade to Unlock"
       assert html =~ "Inventory Your Managed Devices"
+      assert html =~ "settings/device_integrations"
       refute html =~ "Add Device Integration"
 
       # The slide-over cannot be opened from the splash.
@@ -130,6 +132,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
     assert html =~ "No device integrations configured."
     assert html =~ "Add a device integration"
     refute html =~ "Devices synced"
+    refute html =~ "Upgrade to Unlock"
   end
 
   test "summarises synced devices by compliance state", %{

--- a/elixir/test/portal_web/live/settings/device_posture_test.exs
+++ b/elixir/test/portal_web/live/settings/device_posture_test.exs
@@ -1,4 +1,4 @@
-defmodule PortalWeb.Settings.DeviceIntegrationsTest do
+defmodule PortalWeb.Settings.DevicePostureTest do
   use PortalWeb.ConnCase, async: true
   use Oban.Testing, repo: Portal.Repo
 
@@ -54,7 +54,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       {:ok, _lv, html} =
         conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/directory_sync")
 
-      refute html =~ "settings/device_integrations"
+      refute html =~ "settings/device_posture"
     end
 
     test "shows the settings tab when the global flag is on even without the account feature", %{
@@ -66,7 +66,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       {:ok, _lv, html} =
         conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/directory_sync")
 
-      assert html =~ "settings/device_integrations"
+      assert html =~ "settings/device_posture"
       assert html =~ "Device Posture"
     end
 
@@ -78,7 +78,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       enable_device_posture(false)
 
       assert {:error, {:live_redirect, %{to: to}}} =
-               conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_integrations")
+               conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_posture")
 
       assert to =~ "/settings/account"
     end
@@ -88,16 +88,16 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       actor = Portal.ActorFixtures.admin_actor_fixture(account: account)
 
       {:ok, lv, html} =
-        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_integrations")
+        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_posture")
 
       assert html =~ "Upgrade to Unlock"
       assert html =~ "Inventory Your Managed Devices"
-      assert html =~ "settings/device_integrations"
-      refute html =~ "Add Device Integration"
+      assert html =~ "settings/device_posture"
+      refute html =~ "Add Microsoft Intune"
 
       # The slide-over cannot be opened from the splash.
       assert lv
-             |> render_patch(~p"/#{account}/settings/device_integrations/intune/new")
+             |> render_patch(~p"/#{account}/settings/device_posture/intune/new")
              |> Kernel.=~("Upgrade to Unlock")
     end
 
@@ -109,7 +109,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       integration = intune_integration_fixture(account: account)
 
       {:ok, lv, _html} =
-        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_integrations")
+        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_posture")
 
       enable_device_posture(false)
 
@@ -126,11 +126,11 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
     {:ok, _lv, html} =
       conn
       |> authorize_conn(actor)
-      |> live(~p"/#{account}/settings/device_integrations")
+      |> live(~p"/#{account}/settings/device_posture")
 
-    assert html =~ "Device Integrations"
-    assert html =~ "No device integrations configured."
-    assert html =~ "Add a device integration"
+    assert html =~ "Device Posture"
+    assert html =~ "No device posture provider configured."
+    assert html =~ "Add Microsoft Intune"
     refute html =~ "Devices synced"
     refute html =~ "Upgrade to Unlock"
   end
@@ -151,9 +151,9 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
     {:ok, lv, _html} =
       conn
       |> authorize_conn(actor)
-      |> live(~p"/#{account}/settings/device_integrations")
+      |> live(~p"/#{account}/settings/device_posture")
 
-    summary = lv |> element("#device-integration-summary") |> render()
+    summary = lv |> element("#device-posture-summary") |> render()
 
     assert summary =~ "Devices synced"
     assert summary =~ ~r/5.*Devices synced/s
@@ -170,7 +170,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
     {:ok, lv, _html} =
       conn
       |> authorize_conn(actor)
-      |> live(~p"/#{account}/settings/device_integrations/intune/new")
+      |> live(~p"/#{account}/settings/device_posture/intune/new")
 
     assert has_element?(
              lv,
@@ -202,10 +202,10 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
     assert render(lv) =~ "tenant-123"
 
     lv
-    |> form("#device-integration-form", integration: %{name: "Corporate Intune"})
+    |> form("#device-posture-form", integration: %{name: "Corporate Intune"})
     |> render_submit()
 
-    assert_patch(lv, ~p"/#{account}/settings/device_integrations")
+    assert_patch(lv, ~p"/#{account}/settings/device_posture")
 
     integration = Portal.Repo.get_by!(Portal.Intune.Integration, account_id: account.id)
     assert integration.name == "Corporate Intune"
@@ -222,7 +222,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       integration = intune_integration_fixture(account: account)
 
       {:ok, lv, _html} =
-        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_integrations")
+        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_posture")
 
       render_click(lv, "sync", %{"id" => integration.id})
 
@@ -242,7 +242,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       other_integration = intune_integration_fixture(account: other_account)
 
       {:ok, lv, _html} =
-        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_integrations")
+        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_posture")
 
       render_click(lv, "sync", %{"id" => other_integration.id})
 
@@ -265,7 +265,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       integration = intune_integration_fixture(account: account)
 
       {:ok, lv, _html} =
-        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_integrations")
+        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_posture")
 
       enable_device_posture(false)
 
@@ -301,7 +301,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       integration: integration
     } do
       {:ok, lv, _html} =
-        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_integrations")
+        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_posture")
 
       assert render_click(lv, "toggle", %{"id" => integration.id}) =~
                "must be verified before enabling"
@@ -320,7 +320,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       |> Portal.Repo.update!()
 
       {:ok, lv, _html} =
-        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_integrations")
+        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_posture")
 
       render_click(lv, "toggle", %{"id" => integration.id})
 
@@ -342,7 +342,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       integration = intune_integration_fixture(account: account)
 
       {:ok, lv, _html} =
-        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_integrations")
+        conn |> authorize_conn(actor) |> live(~p"/#{account}/settings/device_posture")
 
       # The socket keeps the account it mounted with, so the downgrade is only
       # visible to a write path that re-reads it.
@@ -363,7 +363,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_integrations/intune/new")
+        |> live(~p"/#{account}/settings/device_posture/intune/new")
 
       lv |> element("#intune-admin-consent-button") |> render_click()
       assert_push_event(lv, "open_url", %{url: url})
@@ -371,7 +371,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       state = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query() |> Map.fetch!("state")
       {:ok, %{verification_ref: ref}} = PortalWeb.OIDC.verify_verification_state(state)
 
-      render_patch(lv, ~p"/#{account}/settings/device_integrations")
+      render_patch(lv, ~p"/#{account}/settings/device_posture")
 
       # The callback consumes the pending verifier only if it outlived the panel.
       send(lv.pid, {:get_pending_verification, self()})
@@ -381,7 +381,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       send(lv.pid, {:intune_device_integration_complete, "tenant-123", ref, {self(), ack_ref}})
       assert_receive {:verification_ack, ^ack_ref}
 
-      assert render(lv) =~ "Device Integrations"
+      assert render(lv) =~ "Device Posture"
     end
   end
 
@@ -401,7 +401,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_integrations/intune/#{integration.id}/edit")
+        |> live(~p"/#{account}/settings/device_posture/intune/#{integration.id}/edit")
 
       %{integration: integration, lv: lv}
     end
@@ -413,7 +413,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       reverify(lv, "tenant-123")
 
       lv
-      |> form("#device-integration-form", integration: %{name: integration.name})
+      |> form("#device-posture-form", integration: %{name: integration.name})
       |> render_submit()
 
       integration = reload(integration)
@@ -432,7 +432,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       reverify(lv, integration.tenant_id)
 
       lv
-      |> form("#device-integration-form", integration: %{name: integration.name})
+      |> form("#device-posture-form", integration: %{name: integration.name})
       |> render_submit()
 
       assert_enqueued(
@@ -461,12 +461,12 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
     {:ok, lv, _html} =
       conn
       |> authorize_conn(actor)
-      |> live(~p"/#{account}/settings/device_integrations/intune/#{integration.id}/edit")
+      |> live(~p"/#{account}/settings/device_posture/intune/#{integration.id}/edit")
 
     reverify(lv, "tenant-123")
 
     lv
-    |> form("#device-integration-form", integration: %{name: integration.name})
+    |> form("#device-posture-form", integration: %{name: integration.name})
     |> render_submit()
 
     integration = reload(integration)
@@ -486,7 +486,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_integrations/intune/#{integration.id}/edit")
+        |> live(~p"/#{account}/settings/device_posture/intune/#{integration.id}/edit")
 
       lv |> element("button[phx-click=reset_verification]") |> render_click()
       lv |> element("#intune-admin-consent-button") |> render_click()
@@ -504,7 +504,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       assert_receive {:verification_ack, ^ack_ref}
 
       lv
-      |> form("#device-integration-form", integration: %{name: integration.name})
+      |> form("#device-posture-form", integration: %{name: integration.name})
       |> render_submit()
 
       assert reload(integration).tenant_id == "new-tenant"
@@ -528,10 +528,10 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_integrations/intune/#{integration.id}/edit")
+        |> live(~p"/#{account}/settings/device_posture/intune/#{integration.id}/edit")
 
       lv
-      |> form("#device-integration-form", integration: %{name: "Renamed"})
+      |> form("#device-posture-form", integration: %{name: "Renamed"})
       |> render_submit()
 
       assert reload(integration).name == "Renamed"
@@ -547,7 +547,7 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
     {:ok, lv, _html} =
       conn
       |> authorize_conn(actor)
-      |> live(~p"/#{account}/settings/device_integrations/intune/new")
+      |> live(~p"/#{account}/settings/device_posture/intune/new")
 
     lv |> element("#intune-admin-consent-button") |> render_click()
     assert_push_event(lv, "open_url", %{url: url})
@@ -572,10 +572,10 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
 
     html =
       lv
-      |> form("#device-integration-form", integration: %{name: "Corporate Intune"})
+      |> form("#device-posture-form", integration: %{name: "Corporate Intune"})
       |> render_submit()
 
-    assert html =~ "device-integration-form"
+    assert html =~ "device-posture-form"
     assert Portal.Repo.aggregate(Portal.DeviceIntegration, :count) == 1
   end
 
@@ -590,8 +590,8 @@ defmodule PortalWeb.Settings.DeviceIntegrationsTest do
              }}} =
              conn
              |> authorize_conn(actor)
-             |> live(~p"/#{account}/settings/device_integrations/intune/new")
+             |> live(~p"/#{account}/settings/device_posture/intune/new")
 
-    assert path == ~p"/#{account}/settings/device_integrations"
+    assert path == ~p"/#{account}/settings/device_posture"
   end
 end

--- a/elixir/test/portal_web/live/sign_up_test.exs
+++ b/elixir/test/portal_web/live/sign_up_test.exs
@@ -19,15 +19,6 @@ defmodule PortalWeb.SignUpTest do
       assert html =~ "Create Account"
     end
 
-    test "shows disabled message when sign-up is disabled", %{conn: conn} do
-      Portal.Config.put_env_override(:portal, :enabled_features, sign_up: false)
-
-      {:ok, _lv, html} = live(conn, ~p"/sign_up")
-
-      assert html =~ "Sign-ups are currently disabled"
-      assert html =~ "sales@firezone.dev"
-      refute html =~ "Create Account"
-    end
   end
 
   describe "fill_form edge cases" do
@@ -171,15 +162,6 @@ defmodule PortalWeb.SignUpTest do
       refute_email_sent()
     end
 
-    test "does not proceed when sign-up is disabled", %{conn: conn} do
-      Portal.Config.put_env_override(:portal, :enabled_features, sign_up: false)
-
-      {:ok, lv, _html} = live(conn, ~p"/sign_up")
-
-      html = render(lv)
-      assert html =~ "Sign-ups are currently disabled"
-      refute html =~ "Check your email"
-    end
   end
 
   describe "verify action — mount" do

--- a/elixir/test/support/fixtures/intune_fixtures.ex
+++ b/elixir/test/support/fixtures/intune_fixtures.ex
@@ -7,8 +7,9 @@ defmodule Portal.IntuneFixtures do
   The account half is set through `account_fixture(features: ...)`; both must be
   on for the REST API and the settings LiveView to allow anything.
   """
-  def enable_device_posture(enabled? \\ true),
-    do: Portal.Config.put_env_override(:portal, :enabled_features, device_posture: enabled?)
+  def enable_device_posture(enabled? \\ true)
+  def enable_device_posture(true), do: Portal.FeaturesFixtures.enable_feature(:device_posture)
+  def enable_device_posture(false), do: Portal.FeaturesFixtures.disable_feature(:device_posture)
 
   def device_posture_account_fixture(attrs \\ %{}) do
     attrs

--- a/scripts/compose/portal.yml
+++ b/scripts/compose/portal.yml
@@ -32,13 +32,6 @@ services:
       DATABASE_NAME: ${DATABASE_NAME:-firezone_dev}
       DATABASE_USER: ${DATABASE_USER:-postgres}
       DATABASE_PASSWORD: ${DATABASE_PASSWORD:-postgres}
-      # Feature flags
-      FEATURE_POLICY_CONDITIONS_ENABLED: "true"
-      FEATURE_MULTI_SITE_RESOURCES_ENABLED: "true"
-      FEATURE_SELF_HOSTED_RELAYS_ENABLED: "true"
-      FEATURE_IDP_SYNC_ENABLED: "true"
-      FEATURE_REST_API_ENABLED: "true"
-      FEATURE_INTERNET_RESOURCE_ENABLED: "true"
       ## Warning: The token is for the blackhole Postmark server created in a separate isolated account,
       ## that WILL NOT send any actual emails, but you can see and debug them in the Postmark dashboard.
       OUTBOUND_EMAIL_ADAPTER_OPTS: '{"api_key":"7da7d1cd-111c-44a7-b5ac-4027b9d230e5"}'


### PR DESCRIPTION
## Summary

- rename the device posture settings LiveView, file, routes, DOM IDs, and UI copy consistently
- centralize the only global rollout flags, device_trust and device_posture, as database-backed Portal.Features checks
- show the Device Trust and Device Posture settings tabs from those global rollout flags; show the posture page only with the account entitlement and otherwise show the upgrade splash
- keep plan entitlements account-local, add device_posture with a nil default, keep ICE-less hidden from Account settings, and make log_sinks account-local only
- remove the sign_up gate and obsolete FEATURE_* runtime configuration
- apply the same database rollout gates to device trust and device posture schedulers/workers

## Feature flag inventory

- Global DB rollout: device_trust, device_posture
- Account-local entitlements: policy_conditions, idp_sync, rest_api, internet_resource, iceless, log_sinks, device_posture
- Env: FEATURE_ICELESS_ENABLED only seeds the CI/development account-local ICE-less value; it is not read as a runtime gate
- Always enabled: sign_up

## Testing

- mix test — 4,721 passed
- mix compile --warnings-as-errors
- mix format --check-formatted
- mix credo --strict