### PR TITLE
refactor(portal): clean up unused endpoint logic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,6 @@ x-portal-urls: &portal-urls
   WEB_EXTERNAL_URL: http://localhost:8080/
   API_EXTERNAL_URL: http://localhost:8081/
 
-x-phoenix-config: &phoenix-config
-  PHOENIX_HTTP_WEB_PORT: "8080"
-  PHOENIX_HTTP_API_PORT: "8081"
-  PHOENIX_SECURE_COOKIES: "false"
-
 x-health-check: &health-check
   interval: 1s
   retries: 15
@@ -40,7 +35,8 @@ services:
       - 8080:8080/tcp
       - 8081:8081/tcp
     environment:
-      <<: [*portal-urls, *erlang-cluster, *phoenix-config]
+      <<: [*portal-urls, *erlang-cluster]
+      PHOENIX_SECURE_COOKIES: "false"
       RELEASE_HOSTNAME: "portal.cluster.local"
       RELEASE_NAME: "portal"
       LOG_LEVEL: "debug"

--- a/elixir/config/prod.exs
+++ b/elixir/config/prod.exs
@@ -14,11 +14,9 @@ config :portal, Portal.Entra.AuthProvider,
     "https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration"
 
 config :portal, PortalWeb.Endpoint,
-  cache_static_manifest: "priv/static/cache_manifest.json",
-  server: true
+  cache_static_manifest: "priv/static/cache_manifest.json"
 
 config :portal, Portal.Endpoint, server: true
-config :portal, PortalAPI.Endpoint, server: true
 config :portal, PortalOps.Endpoint, server: true
 
 config :portal, Portal.Billing,

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -435,12 +435,15 @@ if config_env() == :prod do
       path: web_external_url_path
     } = URI.parse(web_external_url)
 
+    # Plain HTTP URLs are used by the local Docker Compose environment. HTTPS
+    # deployments are served exclusively through Portal.Endpoint, which owns
+    # TLS and dispatches requests by hostname.
     web_listener =
-      if env_var_to_config!(:phoenix_legacy_listeners_enabled) do
+      if web_external_url_scheme == "http" do
         [
           http: [
             ip: env_var_to_config!(:phoenix_listen_address).address,
-            port: env_var_to_config!(:phoenix_http_web_port),
+            port: web_external_url_port,
             http_1_options: env_var_to_config!(:phoenix_http_protocol_options)
           ]
         ]
@@ -452,6 +455,7 @@ if config_env() == :prod do
            PortalWeb.Endpoint,
            web_listener ++
              [
+               server: web_external_url_scheme == "http",
                url: [
                  scheme: web_external_url_scheme,
                  host: web_external_url_host,
@@ -491,11 +495,11 @@ if config_env() == :prod do
     } = URI.parse(api_external_url)
 
     api_listener =
-      if env_var_to_config!(:phoenix_legacy_listeners_enabled) do
+      if api_external_url_scheme == "http" do
         [
           http: [
             ip: env_var_to_config!(:phoenix_listen_address).address,
-            port: env_var_to_config!(:phoenix_http_api_port),
+            port: api_external_url_port,
             http_1_options: env_var_to_config!(:phoenix_http_protocol_options)
           ]
         ]
@@ -507,6 +511,7 @@ if config_env() == :prod do
            PortalAPI.Endpoint,
            api_listener ++
              [
+               server: api_external_url_scheme == "http",
                url: [
                  scheme: api_external_url_scheme,
                  host: api_external_url_host,

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -97,7 +97,8 @@ defmodule Portal.Config.Definitions do
   @doc """
   The external URL the UI will be accessible at.
 
-  If this field is not set or set to `nil`, the server for `api` and `web` apps will not start.
+  Plain HTTP URLs are served directly by the Web endpoint for local development.
+  HTTPS URLs are served by the public endpoint and dispatched by hostname.
   """
   defconfig(:web_external_url, :string,
     default: nil,
@@ -111,7 +112,8 @@ defmodule Portal.Config.Definitions do
   @doc """
   The external URL the API will be accessible at.
 
-  If this field is not set or set to `nil`, the server for `api` and `web` apps will not start.
+  Plain HTTP URLs are served directly by the API endpoint for local development.
+  HTTPS URLs are served by the public endpoint and dispatched by hostname.
   """
 
   defconfig(:api_external_url, :string,
@@ -288,40 +290,6 @@ defmodule Portal.Config.Definitions do
   TLS handshake.
   """
   defconfig(:phoenix_https_sni_hosts, :map, default: %{})
-
-  @doc """
-  Whether the separate web and API HTTP listeners are enabled.
-
-  Keep this enabled while deploying behind a reverse proxy. It can be disabled
-  once the public Phoenix endpoint receives traffic directly.
-  """
-  defconfig(:phoenix_legacy_listeners_enabled, :boolean, default: true)
-
-  @doc """
-  Internal port to listen on for the Phoenix server for the `web` application.
-  """
-  defconfig(:phoenix_http_web_port, :integer,
-    default: 13_000,
-    changeset: fn changeset, key ->
-      Ecto.Changeset.validate_number(changeset, key,
-        greater_than: 0,
-        less_than_or_equal_to: 65_535
-      )
-    end
-  )
-
-  @doc """
-  Internal port to listen on for the Phoenix server for the `api` application.
-  """
-  defconfig(:phoenix_http_api_port, :integer,
-    default: 13_001,
-    changeset: fn changeset, key ->
-      Ecto.Changeset.validate_number(changeset, key,
-        greater_than: 0,
-        less_than_or_equal_to: 65_535
-      )
-    end
-  )
 
   @doc """
   Internal port to listen on for the Phoenix server for the `ops` application.

--- a/elixir/test/portal/config_test.exs
+++ b/elixir/test/portal/config_test.exs
@@ -172,7 +172,8 @@ defmodule Portal.ConfigTest do
 
       The external URL the UI will be accessible at.
 
-      If this field is not set or set to `nil`, the server for `api` and `web` apps will not start.
+      Plain HTTP URLs are served directly by the Web endpoint for local development.
+      HTTPS URLs are served by the public endpoint and dispatched by hostname.
 
       """
 


### PR DESCRIPTION
## Summary

- serve HTTPS deployments exclusively through the public TLS/SNI endpoint
- retain direct Web and API listeners only for plain-HTTP local environments, deriving their ports from the external URLs
- remove the rollout-only legacy listener flag and redundant Web/API port settings
- simplify Docker Compose while preserving its existing HTTP endpoints

PortalWeb.Endpoint and PortalAPI.Endpoint remain logical Phoenix endpoints for their socket and pipeline responsibilities; they no longer bind production HTTPS listeners. Development continues to serve the Web endpoint at https://localhost:13443.

## Testing

- mix test test/portal/config/definition_test.exs test/portal/config_test.exs test/portal/endpoint_test.exs test/portal_api/endpoint_test.exs test/portal_api/redirect_to_rest_api_url_test.exs
- MIX_ENV=prod mix compile --warnings-as-errors
- mix format --check-formatted
- mix credo --strict
- parsed docker-compose.yml with Ruby YAML