### PR TITLE
fix(portal): relevel expected Bandit client errors

### DIFF
--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -3,6 +3,8 @@ defmodule Portal.Application do
 
   require Logger
 
+  @expected_client_error_filter :portal_relevel_expected_client_errors
+
   @impl true
   def start(_type, _args) do
     configure_logger()
@@ -28,6 +30,7 @@ defmodule Portal.Application do
     # Remove the Sentry logger handler before Sentry.Supervisor terminates
     # to avoid noproc errors during shutdown
     _ = :logger.remove_handler(:sentry)
+    _ = :logger.remove_primary_filter(@expected_client_error_filter)
     :ok
   end
 
@@ -81,6 +84,17 @@ defmodule Portal.Application do
   end
 
   defp configure_logger do
+    # Bandit and Thousand Island report some routine client disconnects, timeouts,
+    # and malformed requests as errors. Relevel those known client-side events to
+    # info before they reach stdout (and Azure) or the Sentry handler.
+    case :logger.add_primary_filter(
+           @expected_client_error_filter,
+           {&Portal.LoggerFilters.relevel_expected_client_errors/2, nil}
+         ) do
+      :ok -> :ok
+      {:error, {:already_exist, @expected_client_error_filter}} -> :ok
+    end
+
     # Attach Oban to the logger
     Oban.Telemetry.attach_default_logger(encode: false, level: log_level())
 

--- a/elixir/lib/portal/logger_filters.ex
+++ b/elixir/lib/portal/logger_filters.ex
@@ -1,0 +1,65 @@
+defmodule Portal.LoggerFilters do
+  @moduledoc false
+
+  def relevel_expected_client_errors(%{level: :error} = event, _extra) do
+    if expected_client_error?(event) do
+      %{event | level: :info}
+    else
+      :ignore
+    end
+  end
+
+  def relevel_expected_client_errors(_event, _extra), do: :ignore
+
+  defp expected_client_error?(%{
+         msg:
+           {:report,
+            %{
+              label: {:gen_server, :terminate},
+              process_label: {:thousand_island, :connection, _connection},
+              reason: reason
+            }}
+       }) do
+    expected_thousand_island_error?(reason)
+  end
+
+  defp expected_client_error?(%{
+         meta: %{domain: domain, crash_reason: {reason, _stacktrace}}
+       })
+       when is_list(domain) do
+    :bandit in domain and expected_bandit_error?(reason)
+  end
+
+  defp expected_client_error?(_event), do: false
+
+  defp expected_thousand_island_error?(
+         {%Bandit.TransportError{
+            message: "Unable to obtain conn_data",
+            error: :einval
+          }, _stacktrace}
+       ),
+       do: true
+
+  defp expected_thousand_island_error?(reason) when reason in [:econnaborted, :econnreset],
+    do: true
+
+  defp expected_thousand_island_error?({:tls_alert, {:user_canceled, _description}}),
+    do: true
+
+  defp expected_thousand_island_error?(_reason), do: false
+
+  defp expected_bandit_error?(%Bandit.HTTPError{plug_status: status}),
+    do: client_error_status?(status)
+
+  defp expected_bandit_error?(%Bandit.TransportError{error: reason})
+       when reason in [:closed, :econnaborted, :econnreset],
+       do: true
+
+  defp expected_bandit_error?(_reason), do: false
+
+  defp client_error_status?(status) do
+    Plug.Conn.Status.code(status) in 400..499
+  rescue
+    FunctionClauseError -> false
+  end
+end

--- a/elixir/test/portal/logger_filters_test.exs
+++ b/elixir/test/portal/logger_filters_test.exs
@@ -1,0 +1,114 @@
+defmodule Portal.LoggerFiltersTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.LoggerFilters
+
+  describe "relevel_expected_client_errors/2" do
+    test "relevels a closed conn_data lookup to info" do
+      event =
+        thousand_island_termination_event(
+          {%Bandit.TransportError{
+             message: "Unable to obtain conn_data",
+             error: :einval
+           }, []}
+        )
+
+      assert %{level: :info} = LoggerFilters.relevel_expected_client_errors(event, nil)
+    end
+
+    test "relevels peer-aborted Thousand Island connections to info" do
+      for reason <- [:econnaborted, :econnreset] do
+        event = thousand_island_termination_event(reason)
+
+        assert %{level: :info} = LoggerFilters.relevel_expected_client_errors(event, nil)
+      end
+    end
+
+    test "relevels a client-canceled TLS connection to info" do
+      event =
+        thousand_island_termination_event(
+          {:tls_alert, {:user_canceled, ~c"TLS server: client canceled"}}
+        )
+
+      assert %{level: :info} = LoggerFilters.relevel_expected_client_errors(event, nil)
+    end
+
+    test "relevels Bandit HTTP 4xx errors to info" do
+      for status <- [:bad_request, :request_timeout, 431] do
+        event = bandit_event(%Bandit.HTTPError{message: "client error", plug_status: status})
+
+        assert %{level: :info} = LoggerFilters.relevel_expected_client_errors(event, nil)
+      end
+    end
+
+    test "relevels Bandit client closures to info" do
+      event = bandit_event(%Bandit.TransportError{message: "closed", error: :closed})
+
+      assert %{level: :info} = LoggerFilters.relevel_expected_client_errors(event, nil)
+    end
+
+    test "leaves server-side Bandit errors at error" do
+      http_error = bandit_event(%Bandit.HTTPError{message: "server error", plug_status: 500})
+      transport_error = bandit_event(%Bandit.TransportError{message: "socket error", error: :eio})
+
+      assert LoggerFilters.relevel_expected_client_errors(http_error, nil) == :ignore
+      assert LoggerFilters.relevel_expected_client_errors(transport_error, nil) == :ignore
+    end
+
+    test "leaves other TLS alerts at error" do
+      event =
+        thousand_island_termination_event(
+          {:tls_alert, {:handshake_failure, ~c"TLS server: handshake failure"}}
+        )
+
+      assert LoggerFilters.relevel_expected_client_errors(event, nil) == :ignore
+    end
+
+    test "leaves telemetry handler failures at error" do
+      event = %{
+        level: :error,
+        msg:
+          {:report,
+           %{
+             handler_id: {OpentelemetryBandit, :otel_bandit},
+             reason: %Bandit.TransportError{
+               message: "Unable to obtain peer_data",
+               error: :einval
+             }
+           }},
+        meta: %{domain: [:telemetry]}
+      }
+
+      assert LoggerFilters.relevel_expected_client_errors(event, nil) == :ignore
+    end
+
+    test "leaves unrelated logger events at error" do
+      event = %{level: :error, msg: {:string, "an application error"}, meta: %{}}
+
+      assert LoggerFilters.relevel_expected_client_errors(event, nil) == :ignore
+    end
+  end
+
+  defp thousand_island_termination_event(reason) do
+    %{
+      level: :error,
+      msg:
+        {:report,
+         %{
+           label: {:gen_server, :terminate},
+           process_label:
+             {:thousand_island, :connection, {Bandit.DelegatingHandler, {{127, 0, 0, 1}, 443}}},
+           reason: reason
+         }},
+      meta: %{domain: [:otp]}
+    }
+  end
+
+  defp bandit_event(reason) do
+    %{
+      level: :error,
+      msg: {:string, Exception.message(reason)},
+      meta: %{domain: [:elixir, :bandit], crash_reason: {reason, []}}
+    }
+  end
+end


### PR DESCRIPTION
This relevels known client-originated Bandit and Thousand Island failures from error to info using an OTP primary Logger filter. The events remain available in Azure logs, but no longer trip AppLevel=error monitors or the Sentry warning threshold.

The filter covers:

- closed conn_data lookups returning einval
- econnaborted and econnreset connection terminations
- Bandit HTTP 4xx protocol errors, including request timeouts and malformed scanner traffic
- TLS user_canceled alerts

Server-side Bandit HTTP 5xx errors, other transport and TLS failures, telemetry handler failures, and unrelated application errors remain at error level.

The sampled production Azure export contained 62 events. This change relevels 60 of them while leaving the two OpenTelemetry handler failures untouched.

## Testing

- mix test test/portal/logger_filters_test.exs test/portal/application_test.exs (12 tests passed)
- manually verified the Logger pipeline emits client HTTP 400, econnaborted, and TLS user_canceled events at info while preserving HTTP 500 and TLS handshake_failure events at error

---