### PR TITLE
fix(portal): harden Content-Security-Policy

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -420,7 +420,12 @@ config :portal, PortalWeb.Plugs.PutSecurityHeaders,
     "default-src 'self' https://firezone.statuspage.io",
     "img-src 'self' data: https://www.gravatar.com https://firezone.statuspage.io",
     "style-src 'self'",
-    "script-src 'self' 'nonce-${nonce}'"
+    "script-src 'self' 'nonce-${nonce}'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    # Client deep link: some browsers check form-action across post-submit redirects.
+    "form-action 'self' firezone-fd0020211111:",
+    "frame-ancestors 'none'"
   ]
 
 config :portal, api_url_override: "ws://localhost:13001/"

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -222,7 +222,11 @@ config :portal, PortalWeb.Plugs.PutSecurityHeaders,
     "default-src 'self' https://firezone.statuspage.io",
     "img-src 'self' data: https://www.gravatar.com https://www.firezone.dev https://firezone.statuspage.io",
     "style-src 'self'",
-    "script-src 'self' 'nonce-${nonce}' https://cdn.tailwindcss.com/"
+    "script-src 'self' 'nonce-${nonce}' https://cdn.tailwindcss.com/",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self' firezone-fd0020211111:",
+    "frame-ancestors 'none'"
   ],
   live_reload_frame_csp_policy: [
     "default-src 'self' https://firezone.statuspage.io",
@@ -230,7 +234,11 @@ config :portal, PortalWeb.Plugs.PutSecurityHeaders,
     "style-src 'self' 'unsafe-inline'",
     "script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com/",
     "connect-src 'self' ws: wss:",
-    "frame-src 'self'"
+    "frame-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
   ]
 
 # Note: on Linux you may need to add `--add-host=host.docker.internal:host-gateway`

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -289,7 +289,11 @@ config :portal, PortalWeb.Plugs.PutSecurityHeaders,
     "default-src 'self' https://firezone.statuspage.io",
     "img-src 'self' data: https://www.gravatar.com https://firezone.statuspage.io",
     "style-src 'self'",
-    "script-src 'self' 'nonce-${nonce}'"
+    "script-src 'self' 'nonce-${nonce}'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self' firezone-fd0020211111:",
+    "frame-ancestors 'none'"
   ]
 
 config :portal, :constant_execution_time, 1

--- a/elixir/lib/portal_ops/router.ex
+++ b/elixir/lib/portal_ops/router.ex
@@ -9,6 +9,9 @@ defmodule PortalOps.Router do
          "img-src 'self' data:; " <>
          "font-src 'self' data:; " <>
          "connect-src 'self' ws: wss:; " <>
+         "object-src 'none'; " <>
+         "base-uri 'self'; " <>
+         "form-action 'self'; " <>
          "frame-ancestors 'none'"
 
   @secure_browser_headers PortalWeb.Plugs.PutSecurityHeaders.headers(@csp)


### PR DESCRIPTION
The portal's Content-Security-Policy listed `default-src`, `img-src`, `style-src` and `script-src`. Three of the directives it left out do not fall back to `default-src`, so nothing covered them at all.

This adds them. `base-uri` stops an injected `<base>` tag from repointing every relative script URL somewhere else. `form-action` stops an injected form from posting elsewhere. `frame-ancestors` now carries the anti-framing rule that only the older `X-Frame-Options` header carried before. `object-src 'none'` was already inherited from `default-src`, and is now written out.

`form-action` also allows the client deep link scheme. Signing in from a desktop or mobile client can start with a form post and end in a redirect to that handler, and some browsers check `form-action` against each redirect in the chain.

The ops dashboard policy gets the same three additions.

Related: firezone/website#436
