### PR TITLE
fix(portal): relevel Bandit socket errors and TLS alerts

### DIFF
--- a/elixir/lib/portal/logger_filters.ex
+++ b/elixir/lib/portal/logger_filters.ex
@@ -1,6 +1,29 @@
 defmodule Portal.LoggerFilters do
   @moduledoc false
 
+  # :einval means Bandit asked a socket for peer data after the client already hung up.
+  @client_socket_errors [
+    :closed,
+    :econnaborted,
+    :econnreset,
+    :einval,
+    :enotconn,
+    :epipe,
+    :etimedout
+  ]
+
+  # Only post-handshake alerts land here, Thousand Island exits with :shutdown during a handshake.
+  @client_tls_alerts [
+    :bad_record_mac,
+    :close_notify,
+    :decode_error,
+    :decrypt_error,
+    :illegal_parameter,
+    :record_overflow,
+    :unexpected_message,
+    :user_canceled
+  ]
+
   def relevel_expected_client_errors(%{level: :error} = event, _extra) do
     if expected_client_error?(event) do
       %{event | level: :info}
@@ -20,42 +43,26 @@ defmodule Portal.LoggerFilters do
               reason: reason
             }}
        }) do
-    expected_thousand_island_error?(reason)
+    expected_reason?(reason)
   end
 
-  defp expected_client_error?(%{
-         meta: %{domain: domain, crash_reason: {reason, _stacktrace}}
-       })
+  defp expected_client_error?(%{meta: %{domain: domain, crash_reason: crash_reason}})
        when is_list(domain) do
-    :bandit in domain and expected_bandit_error?(reason)
+    :bandit in domain and expected_reason?(crash_reason)
   end
 
   defp expected_client_error?(_event), do: false
 
-  defp expected_thousand_island_error?(
-         {%Bandit.TransportError{
-            message: "Unable to obtain conn_data",
-            error: :einval
-          }, _stacktrace}
-       ),
-       do: true
+  defp expected_reason?({:tls_alert, {alert, _description}}), do: alert in @client_tls_alerts
 
-  defp expected_thousand_island_error?(reason) when reason in [:econnaborted, :econnreset],
-    do: true
+  defp expected_reason?({reason, stacktrace}) when is_list(stacktrace),
+    do: expected_reason?(reason)
 
-  defp expected_thousand_island_error?({:tls_alert, {:user_canceled, _description}}),
-    do: true
+  defp expected_reason?(%Bandit.HTTPError{plug_status: status}), do: client_error_status?(status)
 
-  defp expected_thousand_island_error?(_reason), do: false
+  defp expected_reason?(%Bandit.TransportError{error: error}), do: error in @client_socket_errors
 
-  defp expected_bandit_error?(%Bandit.HTTPError{plug_status: status}),
-    do: client_error_status?(status)
-
-  defp expected_bandit_error?(%Bandit.TransportError{error: reason})
-       when reason in [:closed, :econnaborted, :econnreset],
-       do: true
-
-  defp expected_bandit_error?(_reason), do: false
+  defp expected_reason?(reason), do: reason in @client_socket_errors
 
   defp client_error_status?(status) do
     Plug.Conn.Status.code(status) in 400..499

--- a/elixir/test/portal/logger_filters_test.exs
+++ b/elixir/test/portal/logger_filters_test.exs
@@ -17,20 +17,29 @@ defmodule Portal.LoggerFiltersTest do
     end
 
     test "relevels peer-aborted Thousand Island connections to info" do
-      for reason <- [:econnaborted, :econnreset] do
+      for reason <- [:closed, :econnaborted, :econnreset, :einval, :enotconn, :epipe, :etimedout] do
         event = thousand_island_termination_event(reason)
 
         assert %{level: :info} = LoggerFilters.relevel_expected_client_errors(event, nil)
       end
     end
 
-    test "relevels a client-canceled TLS connection to info" do
-      event =
-        thousand_island_termination_event(
-          {:tls_alert, {:user_canceled, ~c"TLS server: client canceled"}}
-        )
+    test "relevels client TLS alerts to info" do
+      for alert <- [
+            :bad_record_mac,
+            :close_notify,
+            :decode_error,
+            :decrypt_error,
+            :illegal_parameter,
+            :record_overflow,
+            :unexpected_message,
+            :user_canceled
+          ] do
+        event =
+          thousand_island_termination_event({:tls_alert, {alert, ~c"TLS server: #{alert}"}})
 
-      assert %{level: :info} = LoggerFilters.relevel_expected_client_errors(event, nil)
+        assert %{level: :info} = LoggerFilters.relevel_expected_client_errors(event, nil)
+      end
     end
 
     test "relevels Bandit HTTP 4xx errors to info" do
@@ -42,7 +51,16 @@ defmodule Portal.LoggerFiltersTest do
     end
 
     test "relevels Bandit client closures to info" do
-      event = bandit_event(%Bandit.TransportError{message: "closed", error: :closed})
+      for error <- [:closed, :econnaborted, :econnreset, :einval, :enotconn, :epipe, :etimedout] do
+        event = bandit_event(%Bandit.TransportError{message: "socket gone", error: error})
+
+        assert %{level: :info} = LoggerFilters.relevel_expected_client_errors(event, nil)
+      end
+    end
+
+    test "relevels a closed socket lookup reported by Bandit to info" do
+      event =
+        bandit_event(%Bandit.TransportError{message: "Unable to obtain conn_data", error: :einval})
 
       assert %{level: :info} = LoggerFilters.relevel_expected_client_errors(event, nil)
     end
@@ -56,12 +74,23 @@ defmodule Portal.LoggerFiltersTest do
     end
 
     test "leaves other TLS alerts at error" do
-      event =
+      for alert <- [:handshake_failure, :internal_error, :unrecognized_name] do
+        event = thousand_island_termination_event({:tls_alert, {alert, ~c"TLS server: #{alert}"}})
+
+        assert LoggerFilters.relevel_expected_client_errors(event, nil) == :ignore
+      end
+    end
+
+    test "leaves application crashes inside a connection at error" do
+      call_timeout =
         thousand_island_termination_event(
-          {:tls_alert, {:handshake_failure, ~c"TLS server: handshake failure"}}
+          {:timeout, {GenServer, :call, [Portal.Repo, :checkout, 5000]}}
         )
 
-      assert LoggerFilters.relevel_expected_client_errors(event, nil) == :ignore
+      badmatch = thousand_island_termination_event({{:badmatch, [:oops]}, []})
+
+      assert LoggerFilters.relevel_expected_client_errors(call_timeout, nil) == :ignore
+      assert LoggerFilters.relevel_expected_client_errors(badmatch, nil) == :ignore
     end
 
     test "leaves telemetry handler failures at error" do


### PR DESCRIPTION
Scanners and probes keep knocking on the staging portal. #14672 moved most of the log events they cause from error down to info, but it missed one. When a client hangs up in the middle of a request, Bandit asks the socket for the peer address, gets `:einval` back, and reports that at error level. Only the Thousand Island copy of that event was covered, not the one Bandit logs itself.

Both reporting paths now share one list of client-side failures, so the same underlying problem gets the same level no matter which layer logs it. The list also grew to include the other socket errors that mean the peer went away, and the TLS alerts a client can send after the handshake finishes. That last part matters now that the portal terminates public TLS itself.

Server problems still log at error: HTTP 5xx, socket errors we do not expect, TLS handshake failures, and any application crash inside a connection process.

Related: #14672
Related: #14667
