### PR TITLE
ci: publish the iOS IPA on the apple-client release

### DIFF
--- a/.github/actions/create-sentry-release/action.yml
+++ b/.github/actions/create-sentry-release/action.yml
@@ -1,20 +1,16 @@
 ---
 name: "Create Sentry release"
-description: "Creates a Sentry release for projects from a particular Git tag"
+description: "Creates a Sentry release for a project from a particular Git tag"
 inputs:
+  project:
+    description: "The Sentry project, which is also the release name prefix"
+    required: true
+    # e.g. "gateway", "gui-client", "apple-client", ...
   component:
-    description: "The component to create a release for"
-    required: true
-    # e.g. "gateway", "gui-client", "headless-client", ...
-  tag_prefix:
-    description: "The release name prefix that precedes the version"
+    description: "The component to create a release for. Defaults to `project`."
     required: false
-    # Defaults to `component`. Set it when one release ships several
-    # components, e.g. `apple-client-*` ships `macos-client` and `ios-client`.
-  projects:
-    description: "The Sentry projects to create a release for"
-    required: true
-    # Must be space-separated.
+    # Set it when one project ships several components, e.g. `apple-client`
+    # ships `macos-client` and `ios-client`.
   sentry_token:
     description: "The authentication token to use with sentry."
     required: true
@@ -26,9 +22,9 @@ runs:
       id: version
       env:
         release_name: ${{ github.event.release.name }}
-        tag_prefix: ${{ inputs.tag_prefix || inputs.component }}
+        project: ${{ inputs.project }}
       run: |
-        version=${release_name#"$tag_prefix-"}
+        version=${release_name#"$project-"}
         echo "version=$version" >> $GITHUB_OUTPUT
       shell: bash
 
@@ -37,6 +33,6 @@ runs:
         SENTRY_AUTH_TOKEN: ${{ inputs.sentry_token }}
         SENTRY_ORG: firezone-inc
       with:
-        version: ${{ inputs.component }}@${{ steps.version.outputs.version }}
-        projects: ${{ inputs.projects }}
+        version: ${{ inputs.component || inputs.project }}@${{ steps.version.outputs.version }}
+        projects: ${{ inputs.project }}
         set_commits: auto

--- a/.github/actions/create-sentry-release/action.yml
+++ b/.github/actions/create-sentry-release/action.yml
@@ -6,6 +6,11 @@ inputs:
     description: "The component to create a release for"
     required: true
     # e.g. "gateway", "gui-client", "headless-client", ...
+  tag_prefix:
+    description: "The release name prefix that precedes the version"
+    required: false
+    # Defaults to `component`. Set it when one release ships several
+    # components, e.g. `apple-client-*` ships `macos-client` and `ios-client`.
   projects:
     description: "The Sentry projects to create a release for"
     required: true
@@ -19,9 +24,11 @@ runs:
   steps:
     - name: Extract semantic version from release name
       id: version
+      env:
+        release_name: ${{ github.event.release.name }}
+        tag_prefix: ${{ inputs.tag_prefix || inputs.component }}
       run: |
-        version=${{ github.event.release.name }}
-        version=${version#${{ inputs.component }}-}
+        version=${release_name#"$tag_prefix-"}
         echo "version=$version" >> $GITHUB_OUTPUT
       shell: bash
 

--- a/.github/release-drafter-apple-client.yml
+++ b/.github/release-drafter-apple-client.yml
@@ -1,4 +1,4 @@
-tag-prefix: "macos-client-"
+tag-prefix: "apple-client-"
 template: >
   README: HAVE YOU SENT THE CLIENTS FOR REVIEW AND HAVE THEY BEEN ACCEPTED?
   DO NOT PUBLISH THIS RELEASE UNTIL THAT IS DONE.

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -11,13 +11,13 @@ jobs:
       contents: write # release-drafter needs to create/update releases
     env:
       # mark:next-apple-version
-      RELEASE_NAME: macos-client-1.5.20
+      RELEASE_NAME: apple-client-1.5.20
     steps:
       - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
         id: update-release-draft
         with:
-          config-name: release-drafter-macos-client.yml
+          config-name: release-drafter-apple-client.yml
           tag: ${{ env.RELEASE_NAME}}
           version: ${{ env.RELEASE_NAME}}
           name: ${{ env.RELEASE_NAME}}
@@ -90,8 +90,11 @@ jobs:
             rust-targets: aarch64-apple-ios
             build-script: scripts/build/ios-appstore.sh
             upload-script: scripts/upload/app-store-connect.sh
-            artifact-file: "Firezone.ipa"
+            # mark:next-apple-version
+            artifact-file: "firezone-ios-client-1.5.20.ipa"
             platform: iOS
+            # mark:next-apple-version
+            release-name: apple-client-1.5.20
 
           - job_name: build-macos-appstore
             rust-targets: aarch64-apple-darwin x86_64-apple-darwin
@@ -109,7 +112,7 @@ jobs:
             # mark:next-apple-version
             pkg-artifact-file: "firezone-macos-client-1.5.20.pkg"
             # mark:next-apple-version
-            release-name: macos-client-1.5.20
+            release-name: apple-client-1.5.20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -181,6 +184,14 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           RELEASE_NAME: "${{ matrix.release-name }}"
           PLATFORM: "${{ matrix.platform }}"
+      # The App Store IPA is also attached to the release so admins can verify the exact binary we shipped.
+      - name: Upload .ipa to the GitHub release
+        run: scripts/upload/github-release.sh
+        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && matrix.job_name == 'build-ios' }}"
+        env:
+          ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.artifact-file }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          RELEASE_NAME: "${{ matrix.release-name }}"
       - name: Setup sentry CLI
         if: "${{ github.event_name == 'workflow_dispatch' }}"
         uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2.0.0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -166,24 +166,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - tag_prefix: gateway
-            component: gateway
-          - tag_prefix: gui-client
-            component: gui-client
-          - tag_prefix: headless-client
-            component: headless-client
-          - tag_prefix: apple-client
-            component: apple-client
-          - tag_prefix: android-client
-            component: android-client
+        component:
+          - gateway
+          - gui-client
+          - headless-client
+          - apple-client
+          - android-client
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.RELEASE_PR_BOT_GITHUB_TOKEN }}
       - uses: ./.github/actions/setup-gpg
         id: setup-gpg
-        if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.tag_prefix) }}
+        if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.component) }}
         with:
           key: ${{ secrets.RELEASE_PR_BOT_GPG_KEY }}
           email: github-bot@firezone.dev
@@ -220,13 +215,13 @@ jobs:
 
             echo "$env_name=$checksum" >> "$GITHUB_ENV"
           done
-      - if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.tag_prefix) }}
+      - if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.component) }}
         run: |
           set -x
 
           # Extract version from release name
           version=${{ inputs.release_name || github.event.release.name }}
-          version=${version#${{ matrix.tag_prefix }}-}
+          version=${version#${{ matrix.component }}-}
 
           # Configure git
           git config --local user.email "github-bot@firezone.dev"
@@ -249,19 +244,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - tag_prefix: gateway
-            component: gateway
-          - tag_prefix: gui-client
-            component: gui-client
-          - tag_prefix: headless-client
-            component: headless-client
-          - tag_prefix: apple-client
-            component: apple-client
-          - tag_prefix: android-client
-            component: android-client
+        component:
+          - gateway
+          - gui-client
+          - headless-client
+          - apple-client
+          - android-client
     steps:
-      - if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.tag_prefix) }}
+      - if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.component) }}
         env:
           # repository_dispatch on firezone/website requires this token to
           # have Contents: write there.
@@ -270,7 +260,7 @@ jobs:
         run: |
           set -xeuo pipefail
 
-          version=${release_name#${{ matrix.tag_prefix }}-}
+          version=${release_name#${{ matrix.component }}-}
 
           gh api \
             --method POST \
@@ -282,36 +272,29 @@ jobs:
             --field "client_payload[version]=$version"
 
   create-sentry-release:
-    name: create_${{ matrix.component }}_sentry_release
+    name: create_${{ matrix.component || matrix.project }}_sentry_release
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        # The `apple-client` release ships two components, each reporting its own release name to Sentry.
         include:
-          - component: gateway
-            projects: gateway
-          - component: gui-client
-            projects: gui-client
-          - component: headless-client
-            projects: headless-client
-          - component: macos-client
-            tag_prefix: apple-client
-            projects: apple-client
-          - component: ios-client
-            tag_prefix: apple-client
-            projects: apple-client
-          - component: android-client
-            projects: android-client
+          - project: gateway
+          - project: gui-client
+          - project: headless-client
+          - project: android-client
+          # The `apple-client` release ships two components, each reporting its own release name to Sentry.
+          - project: apple-client
+            component: macos-client
+          - project: apple-client
+            component: ios-client
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - uses: ./.github/actions/create-sentry-release
-        if: ${{ startsWith(github.event.release.name, matrix.tag_prefix || matrix.component) }}
+        if: ${{ startsWith(github.event.release.name, matrix.project) }}
         with:
+          project: ${{ matrix.project }}
           component: ${{ matrix.component }}
-          tag_prefix: ${{ matrix.tag_prefix }}
-          projects: ${{ matrix.projects }}
           sentry_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
   promote-deb-packages:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -167,14 +167,13 @@ jobs:
     strategy:
       matrix:
         include:
-          # TODO: This hack is needed because the macOS client isn't tagged as `apple-client`.
           - tag_prefix: gateway
             component: gateway
           - tag_prefix: gui-client
             component: gui-client
           - tag_prefix: headless-client
             component: headless-client
-          - tag_prefix: macos-client
+          - tag_prefix: apple-client
             component: apple-client
           - tag_prefix: android-client
             component: android-client
@@ -251,14 +250,13 @@ jobs:
     strategy:
       matrix:
         include:
-          # TODO: This hack is needed because the macOS client isn't tagged as `apple-client`.
           - tag_prefix: gateway
             component: gateway
           - tag_prefix: gui-client
             component: gui-client
           - tag_prefix: headless-client
             component: headless-client
-          - tag_prefix: macos-client
+          - tag_prefix: apple-client
             component: apple-client
           - tag_prefix: android-client
             component: android-client
@@ -288,7 +286,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        # TODO: This hack is needed because the macOS client isn't tagged as `apple-client`.
+        # The `apple-client` release ships two components, each reporting its own release name to Sentry.
         include:
           - component: gateway
             projects: gateway
@@ -297,6 +295,10 @@ jobs:
           - component: headless-client
             projects: headless-client
           - component: macos-client
+            tag_prefix: apple-client
+            projects: apple-client
+          - component: ios-client
+            tag_prefix: apple-client
             projects: apple-client
           - component: android-client
             projects: android-client
@@ -305,9 +307,10 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/create-sentry-release
-        if: ${{ startsWith(github.event.release.name, matrix.component) }}
+        if: ${{ startsWith(github.event.release.name, matrix.tag_prefix || matrix.component) }}
         with:
           component: ${{ matrix.component }}
+          tag_prefix: ${{ matrix.tag_prefix }}
           projects: ${{ matrix.projects }}
           sentry_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
 

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -107,13 +107,13 @@ function update_version_variables() {
 #
 # Instructions:
 # 1. Run the `Swift` workflow from `main`. This will push iOS and macOS app
-#    store builds to AppStore Connect and upload a new standalone DMG to the
-#    drafted release.
+#    store builds to AppStore Connect and upload the iOS IPA along with the
+#    macOS standalone DMG and PKG to the drafted `apple-client` release.
 # 2. Sign in to AppStore Connect and create new iOS and macOS releases and
 #    submit them for review. Ensure the "automatically publish release" is
 #    DISABLED.
 # 3. Once *both* are approved, publish them in the app stores.
-# 4. Publish the macOS standalone drafted release on GitHub.
+# 4. Publish the drafted `apple-client` release on GitHub.
 # 5. Bump current_apple_client_version / next_apple_client_version at the top
 #    of this script (the release pipeline does this automatically via
 #    `update_version_variables`).


### PR DESCRIPTION
MDMs that manage iOS offer the ability to install / manage the client via an IPA package. For example, here is Intune:

<img width="845" height="396" alt="Screenshot 2026-08-15 at 4 00 08 PM" src="https://github.com/user-attachments/assets/d77d34e0-fd5c-486f-a0d9-84c4374c61da" />

To support this we expose the ipa as a downloadable artifact on the `apple-client` release.