### PR TITLE
fix(portal): keep OTel Bandit handler attached on dead sockets

### DIFF
--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -18,7 +18,7 @@ defmodule Portal.Application do
     :ok = OpentelemetryEcto.setup([:portal, :repo])
     :ok = OpentelemetryEcto.setup([:portal, :repo, :web])
     :ok = OpentelemetryEcto.setup([:portal, :repo, :api])
-    :ok = OpentelemetryBandit.setup()
+    :ok = Portal.Telemetry.OtelBandit.setup()
     :ok = OpentelemetryPhoenix.setup(adapter: :bandit)
     :ok = OpentelemetryOban.setup()
 

--- a/elixir/lib/portal/telemetry/otel_bandit.ex
+++ b/elixir/lib/portal/telemetry/otel_bandit.ex
@@ -1,0 +1,33 @@
+defmodule Portal.Telemetry.OtelBandit do
+  @moduledoc false
+
+  @events [
+    [:bandit, :request, :start],
+    [:bandit, :request, :stop],
+    [:bandit, :request, :exception]
+  ]
+
+  @handler_id {__MODULE__, :otel_bandit}
+
+  def setup do
+    :ok = OpentelemetryBandit.setup()
+
+    %{id: id, config: config} =
+      [:bandit, :request]
+      |> :telemetry.list_handlers()
+      |> Enum.find(&match?({OpentelemetryBandit, _handler_id}, &1.id))
+
+    :ok = :telemetry.detach(id)
+
+    :telemetry.attach_many(@handler_id, @events, &__MODULE__.handle_request/4, config)
+  end
+
+  # A client that hangs up mid-request leaves Bandit unable to read the peer address, which
+  # raises here. Without this rescue :telemetry detaches the handler and the node stops
+  # tracing HTTP requests until it restarts.
+  def handle_request(event, measurements, meta, config) do
+    OpentelemetryBandit.handle_request(event, measurements, meta, config)
+  rescue
+    Bandit.TransportError -> :ok
+  end
+end

--- a/elixir/test/portal/telemetry/otel_bandit_test.exs
+++ b/elixir/test/portal/telemetry/otel_bandit_test.exs
@@ -1,0 +1,78 @@
+defmodule Portal.Telemetry.OtelBanditTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Portal.Telemetry.OtelBandit
+
+  defmodule ClosedSocketAdapter do
+    def get_peer_data(_payload) do
+      raise %Bandit.TransportError{message: "Unable to obtain peer_data", error: :einval}
+    end
+  end
+
+  defmodule BrokenAdapter do
+    def get_peer_data(_payload), do: raise(ArgumentError, "handler bug")
+  end
+
+  setup_all do
+    :ok = OpentelemetryBandit.setup(handler_id: :otel_bandit_test_config)
+    handler_id = {OpentelemetryBandit, :otel_bandit_test_config}
+
+    %{config: config} =
+      [:bandit, :request]
+      |> :telemetry.list_handlers()
+      |> Enum.find(&(&1.id == handler_id))
+
+    :ok = :telemetry.detach(handler_id)
+
+    %{config: config}
+  end
+
+  describe "setup/0" do
+    test "replaces the OpentelemetryBandit handler on the running node" do
+      ids = [:bandit, :request] |> :telemetry.list_handlers() |> Enum.map(& &1.id)
+
+      assert {OtelBandit, :otel_bandit} in ids
+      refute {OpentelemetryBandit, :otel_bandit} in ids
+    end
+
+    test "keeps the handler attached when the client socket is already gone" do
+      meta = %{conn: conn(ClosedSocketAdapter)}
+
+      log = capture_log(fn -> :telemetry.execute([:bandit, :request, :start], %{}, meta) end)
+
+      ids = [:bandit, :request] |> :telemetry.list_handlers() |> Enum.map(& &1.id)
+
+      assert log == ""
+      assert {OtelBandit, :otel_bandit} in ids
+    end
+  end
+
+  describe "handle_request/4" do
+    test "skips the span when the client socket is already gone", %{config: config} do
+      meta = %{conn: conn(ClosedSocketAdapter)}
+
+      assert OtelBandit.handle_request([:bandit, :request, :start], %{}, meta, config) == :ok
+    end
+
+    test "lets other handler failures detach the handler", %{config: config} do
+      meta = %{conn: conn(BrokenAdapter)}
+
+      assert_raise ArgumentError, fn ->
+        OtelBandit.handle_request([:bandit, :request, :start], %{}, meta, config)
+      end
+    end
+  end
+
+  defp conn(adapter) do
+    %Plug.Conn{
+      adapter: {adapter, :payload},
+      host: "app.firezone.dev",
+      method: "GET",
+      port: 443,
+      request_path: "/",
+      scheme: :https
+    }
+  end
+end


### PR DESCRIPTION
After #14676 the only error left on staging from scanners is this one:

```
Handler {OpentelemetryBandit, :otel_bandit} has failed and has been detached.
Reason=%Bandit.TransportError{message: "Unable to obtain peer_data", error: :einval}
```

It looks like the same kind of noise, but it is not. When a client hangs up in the middle of a request, the OpenTelemetry handler asks Bandit for the client address, Bandit cannot read a socket that is already gone, and the handler raises. `:telemetry` then removes that handler from the node. From that moment the portal records no HTTP traces at all until it restarts. One scanner can switch off tracing for a whole node, and demoting the message to info would only hide that.

So this stops the crash instead of hiding it. The portal now attaches a thin wrapper around the OpenTelemetry handler. When the client socket is already gone the wrapper drops the span and the request carries on. Any other failure still crashes the handler and logs at error, because that would be a real bug worth seeing.

Related: #14676
