### PR TITLE
fix(portal): build sign-in redirects from decoded params

### DIFF
--- a/elixir/lib/portal_web/authentication.ex
+++ b/elixir/lib/portal_web/authentication.ex
@@ -1,6 +1,10 @@
 defmodule PortalWeb.Authentication do
   use PortalWeb, :verified_routes
 
+  @sign_in_params ["as", "state", "nonce", "redirect_to"]
+
+  @analytics_params ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"]
+
   @doc """
   Returns the real IP address of the client.
   """
@@ -21,11 +25,16 @@ defmodule PortalWeb.Authentication do
   """
   def take_sign_in_params(nil), do: %{}
 
-  def take_sign_in_params(params) do
-    params
-    |> Map.take(["as", "state", "nonce", "redirect_to"])
-    |> Map.reject(fn {_key, value} -> value in ["", nil] end)
-  end
+  def take_sign_in_params(params), do: take_non_empty(params, @sign_in_params)
+
+  @doc """
+  Returns the sign in parameters plus the campaign parameters that should survive a
+  redirect into the sign in flow.
+  """
+  def take_sign_in_redirect_params(nil), do: %{}
+
+  def take_sign_in_redirect_params(params),
+    do: take_non_empty(params, @sign_in_params ++ @analytics_params)
 
   @doc """
   Returns true when the params represent a client sign-in flow.
@@ -34,4 +43,10 @@ defmodule PortalWeb.Authentication do
     do: true
 
   def client_sign_in?(_params), do: false
+
+  defp take_non_empty(params, keys) do
+    params
+    |> Map.take(keys)
+    |> Map.reject(fn {_key, value} -> value in ["", nil] end)
+  end
 end

--- a/elixir/lib/portal_web/controllers/account_landing_controller.ex
+++ b/elixir/lib/portal_web/controllers/account_landing_controller.ex
@@ -2,14 +2,9 @@ defmodule PortalWeb.AccountLandingController do
   use PortalWeb, :controller
 
   @spec redirect_to_sign_in(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def redirect_to_sign_in(conn, %{"account_id_or_slug" => account_id_or_slug}) do
-    path =
-      if conn.query_string != "" do
-        ~p"/#{account_id_or_slug}/sign_in" <> "?" <> conn.query_string
-      else
-        ~p"/#{account_id_or_slug}/sign_in"
-      end
+  def redirect_to_sign_in(conn, %{"account_id_or_slug" => account_id_or_slug} = params) do
+    sign_in_params = PortalWeb.Authentication.take_sign_in_params(params)
 
-    redirect(conn, to: path)
+    redirect(conn, to: ~p"/#{account_id_or_slug}/sign_in?#{sign_in_params}")
   end
 end

--- a/elixir/lib/portal_web/controllers/account_landing_controller.ex
+++ b/elixir/lib/portal_web/controllers/account_landing_controller.ex
@@ -3,8 +3,8 @@ defmodule PortalWeb.AccountLandingController do
 
   @spec redirect_to_sign_in(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def redirect_to_sign_in(conn, %{"account_id_or_slug" => account_id_or_slug} = params) do
-    sign_in_params = PortalWeb.Authentication.take_sign_in_params(params)
+    redirect_params = PortalWeb.Authentication.take_sign_in_redirect_params(params)
 
-    redirect(conn, to: ~p"/#{account_id_or_slug}/sign_in?#{sign_in_params}")
+    redirect(conn, to: ~p"/#{account_id_or_slug}/sign_in?#{redirect_params}")
   end
 end

--- a/elixir/lib/portal_web/plugs/auto_redirect_default_provider.ex
+++ b/elixir/lib/portal_web/plugs/auto_redirect_default_provider.ex
@@ -32,10 +32,10 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProvider do
       when as in ["client", "gui-client", "headless-client"] do
     with %Account{} = account <- Database.get_account_by_id_or_slug(account_id_or_slug),
          provider when is_struct(provider) <- Database.get_default_provider_for_account(account) do
-      sign_in_params = PortalWeb.Authentication.take_sign_in_params(conn.params)
+      redirect_params = PortalWeb.Authentication.take_sign_in_redirect_params(conn.params)
 
       conn
-      |> redirect(to: redirect_path(account, provider, sign_in_params))
+      |> redirect(to: redirect_path(account, provider, redirect_params))
       |> halt()
     else
       _ -> conn

--- a/elixir/lib/portal_web/plugs/auto_redirect_default_provider.ex
+++ b/elixir/lib/portal_web/plugs/auto_redirect_default_provider.ex
@@ -32,18 +32,10 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProvider do
       when as in ["client", "gui-client", "headless-client"] do
     with %Account{} = account <- Database.get_account_by_id_or_slug(account_id_or_slug),
          provider when is_struct(provider) <- Database.get_default_provider_for_account(account) do
-      redirect_path = redirect_path(account, provider)
-
-      # Append original query params
-      full_redirect_path =
-        if conn.query_string != "" do
-          redirect_path <> "?" <> conn.query_string
-        else
-          redirect_path
-        end
+      sign_in_params = PortalWeb.Authentication.take_sign_in_params(conn.params)
 
       conn
-      |> redirect(to: full_redirect_path)
+      |> redirect(to: redirect_path(account, provider, sign_in_params))
       |> halt()
     else
       _ -> conn
@@ -54,20 +46,20 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProvider do
     conn
   end
 
-  defp redirect_path(account, %OIDC.AuthProvider{} = provider) do
-    ~p"/#{account}/sign_in/oidc/#{provider}"
+  defp redirect_path(account, %OIDC.AuthProvider{} = provider, params) do
+    ~p"/#{account}/sign_in/oidc/#{provider}?#{params}"
   end
 
-  defp redirect_path(account, %Google.AuthProvider{} = provider) do
-    ~p"/#{account}/sign_in/google/#{provider}"
+  defp redirect_path(account, %Google.AuthProvider{} = provider, params) do
+    ~p"/#{account}/sign_in/google/#{provider}?#{params}"
   end
 
-  defp redirect_path(account, %Entra.AuthProvider{} = provider) do
-    ~p"/#{account}/sign_in/entra/#{provider}"
+  defp redirect_path(account, %Entra.AuthProvider{} = provider, params) do
+    ~p"/#{account}/sign_in/entra/#{provider}?#{params}"
   end
 
-  defp redirect_path(account, %Okta.AuthProvider{} = provider) do
-    ~p"/#{account}/sign_in/okta/#{provider}"
+  defp redirect_path(account, %Okta.AuthProvider{} = provider, params) do
+    ~p"/#{account}/sign_in/okta/#{provider}?#{params}"
   end
 
   defmodule Database do

--- a/elixir/test/portal_web/controllers/account_landing_controller_test.exs
+++ b/elixir/test/portal_web/controllers/account_landing_controller_test.exs
@@ -12,12 +12,38 @@ defmodule PortalWeb.AccountLandingControllerTest do
     test "redirects client sign-in with slug to /:account/sign_in and preserves all sign-in params",
          %{conn: conn} do
       for client <- @client_sign_in_types do
-        params = "as=#{client}&state=abc&nonce=xyz&redirect_to=%2Fsites"
+        params = %{
+          "as" => client,
+          "state" => "abc",
+          "nonce" => "xyz",
+          "redirect_to" => "/sites"
+        }
 
-        conn = get(conn, "/some-account?#{params}")
+        conn = get(conn, ~p"/some-account?#{params}")
 
-        assert redirected_to(conn) == "/some-account/sign_in?#{params}"
+        assert redirected_to(conn) == ~p"/some-account/sign_in?#{params}"
       end
+    end
+
+    test "drops query params that are not part of the sign-in flow", %{conn: conn} do
+      conn = get(conn, ~p"/some-account?#{%{"as" => "client", "utm_source" => "email"}}")
+
+      assert redirected_to(conn) == ~p"/some-account/sign_in?#{%{"as" => "client"}}"
+    end
+
+    test "redirects without raising when a scanner sends an unsafe query string", %{conn: conn} do
+      conn = get(conn, "/some-account?fccc%27\\%22%3E%3Csvg/onload=alert(/xss/)%3E")
+
+      assert redirected_to(conn) == "/some-account/sign_in"
+    end
+
+    test "escapes sign-in params taken from the query string", %{conn: conn} do
+      conn = get(conn, ~p"/some-account?#{%{"redirect_to" => "/sites\\\"><svg/onload=alert(1)>"}}")
+
+      redirect_path = redirected_to(conn)
+
+      assert redirect_path == ~p"/some-account/sign_in?#{%{"redirect_to" => "/sites\\\"><svg/onload=alert(1)>"}}"
+      refute redirect_path =~ "<svg"
     end
   end
 end

--- a/elixir/test/portal_web/controllers/account_landing_controller_test.exs
+++ b/elixir/test/portal_web/controllers/account_landing_controller_test.exs
@@ -25,10 +25,27 @@ defmodule PortalWeb.AccountLandingControllerTest do
       end
     end
 
-    test "drops query params that are not part of the sign-in flow", %{conn: conn} do
-      conn = get(conn, ~p"/some-account?#{%{"as" => "client", "utm_source" => "email"}}")
+    test "preserves campaign params", %{conn: conn} do
+      params = %{
+        "utm_source" => "email",
+        "utm_medium" => "newsletter",
+        "utm_campaign" => "spring",
+        "utm_term" => "vpn",
+        "utm_content" => "cta"
+      }
 
-      assert redirected_to(conn) == ~p"/some-account/sign_in?#{%{"as" => "client"}}"
+      conn = get(conn, ~p"/some-account?#{params}")
+
+      assert redirected_to(conn) == ~p"/some-account/sign_in?#{params}"
+    end
+
+    test "drops query params that are neither sign-in nor campaign params", %{conn: conn} do
+      params = %{"as" => "client", "utm_source" => "email", "gclid" => "abc123"}
+
+      conn = get(conn, ~p"/some-account?#{params}")
+
+      assert redirected_to(conn) ==
+               ~p"/some-account/sign_in?#{%{"as" => "client", "utm_source" => "email"}}"
     end
 
     test "redirects without raising when a scanner sends an unsafe query string", %{conn: conn} do

--- a/elixir/test/portal_web/plugs/auto_redirect_default_provider_test.exs
+++ b/elixir/test/portal_web/plugs/auto_redirect_default_provider_test.exs
@@ -22,9 +22,12 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProviderTest do
 
         conn =
           conn
-          |> Map.put(:params, %{"as" => as_value, "account_id_or_slug" => account.slug})
+          |> Map.put(:params, %{
+            "as" => as_value,
+            "account_id_or_slug" => account.slug,
+            "state" => "test-state"
+          })
           |> Map.put(:path_info, [account.slug, "sign_in"])
-          |> Map.put(:query_string, "as=#{as_value}&state=test-state")
           |> AutoRedirectDefaultProvider.call([])
 
         assert conn.halted
@@ -45,7 +48,6 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProviderTest do
           conn
           |> Map.put(:params, %{"as" => as_value, "account_id_or_slug" => account.slug})
           |> Map.put(:path_info, [account.slug, "sign_in"])
-          |> Map.put(:query_string, "as=#{as_value}")
           |> AutoRedirectDefaultProvider.call([])
 
         assert conn.halted
@@ -64,7 +66,6 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProviderTest do
           conn
           |> Map.put(:params, %{"as" => as_value, "account_id_or_slug" => account.slug})
           |> Map.put(:path_info, [account.slug, "sign_in"])
-          |> Map.put(:query_string, "as=#{as_value}")
           |> AutoRedirectDefaultProvider.call([])
 
         assert conn.halted
@@ -83,7 +84,6 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProviderTest do
           conn
           |> Map.put(:params, %{"as" => as_value, "account_id_or_slug" => account.slug})
           |> Map.put(:path_info, [account.slug, "sign_in"])
-          |> Map.put(:query_string, "as=#{as_value}")
           |> AutoRedirectDefaultProvider.call([])
 
         assert conn.halted
@@ -165,23 +165,48 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProviderTest do
       refute conn.halted
     end
 
-    test "redirects without query string when query_string is empty", %{
-      conn: conn,
-      account: account
-    } do
+    test "forwards only sign-in params to the provider", %{conn: conn, account: account} do
       provider = oidc_provider_fixture(account: account, is_default: true)
 
       conn =
         conn
-        |> Map.put(:params, %{"as" => "client", "account_id_or_slug" => account.slug})
+        |> Map.put(:params, %{
+          "as" => "client",
+          "account_id_or_slug" => account.slug,
+          "state" => "test-state",
+          "utm_source" => "email"
+        })
         |> Map.put(:path_info, [account.slug, "sign_in"])
-        |> Map.put(:query_string, "")
         |> AutoRedirectDefaultProvider.call([])
 
       assert conn.halted
       location = redirected_to(conn)
+
       assert location =~ "/sign_in/oidc/#{provider.id}"
-      refute location =~ "?"
+      assert location =~ "as=client"
+      assert location =~ "state=test-state"
+      refute location =~ "utm_source"
+    end
+
+    test "escapes sign-in params sent by a scanner", %{conn: conn, account: account} do
+      provider = oidc_provider_fixture(account: account, is_default: true)
+
+      conn =
+        conn
+        |> Map.put(:params, %{
+          "as" => "client",
+          "account_id_or_slug" => account.slug,
+          "redirect_to" => "/sites\\\"><svg/onload=alert(1)>"
+        })
+        |> Map.put(:path_info, [account.slug, "sign_in"])
+        |> Map.put(:query_string, "as=client&redirect_to=/sites\\\"><svg/onload=alert(1)>")
+        |> AutoRedirectDefaultProvider.call([])
+
+      assert conn.halted
+      location = redirected_to(conn)
+
+      assert location =~ "/sign_in/oidc/#{provider.id}"
+      refute location =~ "<svg"
     end
 
     test "looks up account by ID when account_id_or_slug is a UUID", %{

--- a/elixir/test/portal_web/plugs/auto_redirect_default_provider_test.exs
+++ b/elixir/test/portal_web/plugs/auto_redirect_default_provider_test.exs
@@ -165,7 +165,7 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProviderTest do
       refute conn.halted
     end
 
-    test "forwards only sign-in params to the provider", %{conn: conn, account: account} do
+    test "forwards sign-in and campaign params to the provider", %{conn: conn, account: account} do
       provider = oidc_provider_fixture(account: account, is_default: true)
 
       conn =
@@ -174,7 +174,8 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProviderTest do
           "as" => "client",
           "account_id_or_slug" => account.slug,
           "state" => "test-state",
-          "utm_source" => "email"
+          "utm_source" => "email",
+          "gclid" => "should-not-survive"
         })
         |> Map.put(:path_info, [account.slug, "sign_in"])
         |> AutoRedirectDefaultProvider.call([])
@@ -185,7 +186,8 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProviderTest do
       assert location =~ "/sign_in/oidc/#{provider.id}"
       assert location =~ "as=client"
       assert location =~ "state=test-state"
-      refute location =~ "utm_source"
+      assert location =~ "utm_source=email"
+      refute location =~ "should-not-survive"
     end
 
     test "escapes sign-in params sent by a scanner", %{conn: conn, account: account} do


### PR DESCRIPTION
XSS scanners hit `/:account` on staging with a query string like `?fccc%27\%22%3E%3Csvg/onload=alert(/xss/)%3E` and the portal answered with a 500:

```
** (ArgumentError) unsafe characters detected for local redirect in URL
    (phoenix 1.8.10) Phoenix.Controller.validate_local_url/1
    PortalWeb.AccountLandingController.action/2
```

This is not scanner noise in the log. The controller built the redirect target by gluing the raw query string onto the path, so whatever the client sent went straight into `redirect(to: ...)`. Phoenix refuses to redirect to a URL with unsafe characters in it, and that refusal is the only reason the payload went nowhere. The 500 was Phoenix catching a bug for us.

Both places that did this, the account landing controller and the default provider plug, now build the query string from the decoded params instead. They forward the four params the sign-in flow needs, `as`, `state`, `nonce` and `redirect_to`, plus the five standard UTM fields so campaign attribution still survives the hop from a marketing link to the sign-in page. Anything else in the query string is dropped.

Related: #14701
