### PR TITLE
fix(portal): serve HTTP behind a TLS-terminating proxy

### DIFF
--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -256,8 +256,11 @@ defmodule Portal.Config.Definitions do
   defconfig(:phoenix_listen_address, Types.IP, default: "0.0.0.0")
 
   @doc """
-  Internal HTTP port for the public endpoint. Requests other than readiness
-  checks are redirected to HTTPS. Leave unset to disable the listener.
+  Internal HTTP port for the public endpoint. Leave unset to disable the listener.
+
+  Requests other than readiness checks are redirected to HTTPS while
+  `PHOENIX_HTTPS_PUBLIC_PORT` is set. Without it this listener serves the
+  requests, which is what a reverse proxy that terminates TLS connects to.
   """
   defconfig(:phoenix_http_public_port, :integer,
     default: nil,
@@ -270,7 +273,8 @@ defmodule Portal.Config.Definitions do
   )
 
   @doc """
-  Internal HTTPS port for the public endpoint. Leave unset to disable the listener.
+  Internal HTTPS port for the public endpoint. Leave unset to disable the
+  listener and let a reverse proxy in front of Firezone terminate TLS.
   """
   defconfig(:phoenix_https_public_port, :integer,
     default: nil,
@@ -353,6 +357,15 @@ defmodule Portal.Config.Definitions do
   This is used to determine the correct IP address of the client when the
   application is behind a reverse proxy by skipping a trusted proxy IP
   from a list of possible source IPs.
+
+  The public endpoint keeps the `X-Forwarded-*` headers only on requests that
+  arrive from one of these addresses. Every other request has them removed and
+  its client IP address read from the connection itself.
+
+  Your proxy must append the client address to `X-Forwarded-For` rather than
+  pass on what the client sent. Also list your own private ranges in
+  `PHOENIX_PRIVATE_CLIENTS` when your clients have private addresses, because
+  private addresses in the header are read as further proxy hops.
   """
   defconfig(:phoenix_external_trusted_proxies, {:json_array, {:one_of, [Types.IP, Types.CIDR]}},
     default: []

--- a/elixir/lib/portal/endpoint.ex
+++ b/elixir/lib/portal/endpoint.ex
@@ -5,17 +5,47 @@ defmodule Portal.Endpoint do
 
   use Phoenix.Endpoint, otp_app: :portal
 
+  @forwarded_headers ~w(x-forwarded-for x-forwarded-host x-forwarded-port x-forwarded-proto)
+  @geo_headers ~w(x-azure-geo-country x-geo-location-region x-geo-location-city)
+  @proxy_headers @forwarded_headers ++ @geo_headers
+  @rewrite_on Plug.RewriteOn.init([:x_forwarded_host, :x_forwarded_port, :x_forwarded_proto])
+  @real_ip_opts [
+    headers: ["x-forwarded-for"],
+    parsers: %{"x-forwarded-for" => Portal.RemoteIp.XForwardedForParser},
+    proxies: {__MODULE__, :external_trusted_proxies, []},
+    clients: {__MODULE__, :clients, []}
+  ]
+  @remote_ip RemoteIp.init(@real_ip_opts)
+  @ssl_opts Plug.SSL.init([])
+
   plug Portal.Health
-  plug :drop_forwarded_headers
-  plug Plug.SSL
+  plug :apply_forwarded_headers
+  plug :redirect_to_https
   plug :dispatch
 
-  def drop_forwarded_headers(%Plug.Conn{} = conn, _opts) do
-    Enum.reduce(
-      ~w(x-forwarded-for x-forwarded-host x-forwarded-port x-forwarded-proto),
-      conn,
-      &Plug.Conn.delete_req_header(&2, &1)
-    )
+  # Clients reach this listener directly, so the headers they send are only
+  # trustworthy when the request itself comes from a declared reverse proxy.
+  # The geo headers decide the location that policy conditions match on, so
+  # they are dropped with the rest. Everything behind this endpoint reads the
+  # connection and does not look at these headers again.
+  def apply_forwarded_headers(%Plug.Conn{} = conn, _opts) do
+    if from_trusted_proxy?(conn) do
+      conn
+      |> Plug.RewriteOn.call(@rewrite_on)
+      |> RemoteIp.call(@remote_ip)
+    else
+      Enum.reduce(@proxy_headers, conn, &Plug.Conn.delete_req_header(&2, &1))
+    end
+  end
+
+  # Without a TLS listener something in front terminates TLS, and redirecting
+  # would send the request back to it in a loop.
+  def redirect_to_https(%Plug.Conn{} = conn, _opts) do
+    if terminates_tls?() do
+      Plug.SSL.call(conn, @ssl_opts)
+    else
+      conn
+    end
   end
 
   def dispatch(%Plug.Conn{} = conn, _opts) do
@@ -42,6 +72,26 @@ defmodule Portal.Endpoint do
     end
   end
 
+  @doc """
+  Options for resolving the client IP address from WebSocket connect headers.
+
+  Sockets get their headers before this endpoint can rewrite the connection, so
+  they resolve the address themselves and fall back to the peer address.
+  """
+  def real_ip_opts do
+    @real_ip_opts
+  end
+
+  def external_trusted_proxies do
+    Portal.Config.fetch_env!(:portal, :external_trusted_proxies)
+    |> Enum.map(&to_string/1)
+  end
+
+  def clients do
+    Portal.Config.fetch_env!(:portal, :private_clients)
+    |> Enum.map(&to_string/1)
+  end
+
   defp forward(conn, endpoint) do
     conn
     |> endpoint.call(endpoint.init([]))
@@ -66,5 +116,27 @@ defmodule Portal.Endpoint do
     else
       _unconfigured -> nil
     end
+  end
+
+  defp from_trusted_proxy?(%Plug.Conn{remote_ip: peer}) do
+    peer = %Postgrex.INET{address: peer}
+
+    Portal.Config.fetch_env!(:portal, :external_trusted_proxies)
+    |> Enum.any?(&Portal.Types.CIDR.contains?(as_block(&1), peer))
+  end
+
+  # A bare address carries no netmask, and CIDR.range/1 would then read an IPv6
+  # address as a /32 block.
+  defp as_block(%Postgrex.INET{netmask: nil} = inet) do
+    %{inet | netmask: Portal.Types.CIDR.max_netmask(inet)}
+  end
+
+  defp as_block(%Postgrex.INET{} = inet) do
+    inet
+  end
+
+  defp terminates_tls? do
+    Portal.Config.fetch_env!(:portal, __MODULE__)
+    |> Keyword.has_key?(:https)
   end
 end

--- a/elixir/lib/portal_api/endpoint.ex
+++ b/elixir/lib/portal_api/endpoint.ex
@@ -8,7 +8,6 @@ defmodule PortalAPI.Endpoint do
     plug Phoenix.Ecto.SQL.Sandbox
   end
 
-  plug Plug.RewriteOn, [:x_forwarded_host, :x_forwarded_port, :x_forwarded_proto]
   plug Plug.MethodOverride
   plug :put_hsts_header
   plug Plug.Head
@@ -16,12 +15,6 @@ defmodule PortalAPI.Endpoint do
   if code_reloading? do
     plug Phoenix.CodeReloader
   end
-
-  plug RemoteIp,
-    headers: ["x-forwarded-for"],
-    parsers: %{"x-forwarded-for" => Portal.RemoteIp.XForwardedForParser},
-    proxies: {__MODULE__, :external_trusted_proxies, []},
-    clients: {__MODULE__, :clients, []}
 
   plug Portal.Plugs.CountryCodeBlocklist
 
@@ -127,25 +120,6 @@ defmodule PortalAPI.Endpoint do
     else
       conn
     end
-  end
-
-  def real_ip_opts do
-    [
-      headers: ["x-forwarded-for"],
-      parsers: %{"x-forwarded-for" => Portal.RemoteIp.XForwardedForParser},
-      proxies: {__MODULE__, :external_trusted_proxies, []},
-      clients: {__MODULE__, :clients, []}
-    ]
-  end
-
-  def external_trusted_proxies do
-    Portal.Config.fetch_env!(:portal, :external_trusted_proxies)
-    |> Enum.map(&to_string/1)
-  end
-
-  def clients do
-    Portal.Config.fetch_env!(:portal, :private_clients)
-    |> Enum.map(&to_string/1)
   end
 
   defp redirect_to_canonical_host(%Plug.Conn{host: host} = conn, %URI{host: host}), do: conn

--- a/elixir/lib/portal_api/sockets.ex
+++ b/elixir/lib/portal_api/sockets.ex
@@ -96,7 +96,7 @@ defmodule PortalAPI.Sockets do
   defp real_ip(x_headers, peer_data) do
     real_ip =
       if is_list(x_headers) and x_headers != [] do
-        RemoteIp.from(x_headers, PortalAPI.Endpoint.real_ip_opts())
+        RemoteIp.from(x_headers, Portal.Endpoint.real_ip_opts())
       end
 
     real_ip || peer_data.address

--- a/elixir/lib/portal_api/sockets/rate_limit.ex
+++ b/elixir/lib/portal_api/sockets/rate_limit.ex
@@ -46,7 +46,7 @@ defmodule PortalAPI.Sockets.RateLimit do
 
   defp extract_ip(%{x_headers: x_headers, peer_data: peer_data})
        when is_list(x_headers) and x_headers != [] do
-    RemoteIp.from(x_headers, PortalAPI.Endpoint.real_ip_opts()) || peer_data.address
+    RemoteIp.from(x_headers, Portal.Endpoint.real_ip_opts()) || peer_data.address
   end
 
   defp extract_ip(%{peer_data: peer_data}), do: peer_data.address

--- a/elixir/lib/portal_web/authentication.ex
+++ b/elixir/lib/portal_web/authentication.ex
@@ -10,7 +10,7 @@ defmodule PortalWeb.Authentication do
 
     real_ip =
       if is_list(x_headers) and x_headers != [] do
-        RemoteIp.from(x_headers, PortalWeb.Endpoint.real_ip_opts())
+        RemoteIp.from(x_headers, Portal.Endpoint.real_ip_opts())
       end
 
     real_ip || peer_data.address

--- a/elixir/lib/portal_web/endpoint.ex
+++ b/elixir/lib/portal_web/endpoint.ex
@@ -25,18 +25,11 @@ defmodule PortalWeb.Endpoint do
     plug PortalWeb.Plugs.AllowEctoSandbox
   end
 
-  plug Plug.RewriteOn, [:x_forwarded_host, :x_forwarded_port, :x_forwarded_proto]
   plug Plug.MethodOverride
 
   # Security Headers
   plug PortalWeb.Plugs.PutSTSHeader
   plug PortalWeb.Plugs.PutSecurityHeaders
-
-  plug RemoteIp,
-    headers: ["x-forwarded-for"],
-    parsers: %{"x-forwarded-for" => Portal.RemoteIp.XForwardedForParser},
-    proxies: {__MODULE__, :external_trusted_proxies, []},
-    clients: {__MODULE__, :clients, []}
 
   plug Portal.Plugs.CountryCodeBlocklist
 
@@ -89,25 +82,6 @@ defmodule PortalWeb.Endpoint do
     ],
     longpoll: false,
     drainer: []
-
-  def real_ip_opts do
-    [
-      headers: ["x-forwarded-for"],
-      parsers: %{"x-forwarded-for" => Portal.RemoteIp.XForwardedForParser},
-      proxies: {__MODULE__, :external_trusted_proxies, []},
-      clients: {__MODULE__, :clients, []}
-    ]
-  end
-
-  def external_trusted_proxies do
-    Portal.Config.fetch_env!(:portal, :external_trusted_proxies)
-    |> Enum.map(&to_string/1)
-  end
-
-  def clients do
-    Portal.Config.fetch_env!(:portal, :private_clients)
-    |> Enum.map(&to_string/1)
-  end
 
   def cookie_signing_salt do
     Portal.Config.fetch_env!(:portal, :cookie_signing_salt)

--- a/elixir/test/portal/endpoint_test.exs
+++ b/elixir/test/portal/endpoint_test.exs
@@ -14,41 +14,129 @@ defmodule Portal.EndpointTest do
     Portal.Config.put_env_override(:portal, :mtls_external_url, "https://mtls.firezone.test/")
   end
 
-  test "redirects public HTTP requests to HTTPS" do
-    conn = Endpoint.call(conn(:get, "http://api.firezone.test/client?foo=bar"), [])
+  describe "when this endpoint terminates TLS" do
+    setup do
+      Portal.Config.put_env_override(:portal, Endpoint, https: [port: 443])
+    end
 
-    assert conn.status == 301
-    assert get_resp_header(conn, "location") == ["https://api.firezone.test/client?foo=bar"]
+    test "redirects public HTTP requests to HTTPS" do
+      conn = Endpoint.call(conn(:get, "http://api.firezone.test/client?foo=bar"), [])
+
+      assert conn.status == 301
+      assert get_resp_header(conn, "location") == ["https://api.firezone.test/client?foo=bar"]
+    end
+
+    test "preserves the method when redirecting a non-GET request" do
+      conn = Endpoint.call(conn(:post, "http://flow-api.firezone.test/ingestion/flow_logs"), [])
+
+      assert conn.status == 307
+
+      assert get_resp_header(conn, "location") == [
+               "https://flow-api.firezone.test/ingestion/flow_logs"
+             ]
+    end
+
+    test "does not trust forwarded headers from the public listener" do
+      conn =
+        :get
+        |> conn("http://api.firezone.test/client")
+        |> put_req_header("x-forwarded-host", "mtls.firezone.test")
+        |> put_req_header("x-forwarded-proto", "https")
+        |> Endpoint.call([])
+
+      assert conn.status == 301
+      assert get_resp_header(conn, "location") == ["https://api.firezone.test/client"]
+      assert get_req_header(conn, "x-forwarded-host") == []
+      assert get_req_header(conn, "x-forwarded-proto") == []
+    end
+
+    test "serves readiness checks without redirecting" do
+      conn = Endpoint.call(conn(:get, "http://api.firezone.test/readyz"), [])
+
+      assert conn.status in [200, 503]
+      assert get_resp_header(conn, "location") == []
+    end
   end
 
-  test "preserves the method when redirecting a non-GET request" do
-    conn = Endpoint.call(conn(:post, "http://flow-api.firezone.test/ingestion/flow_logs"), [])
+  describe "when a reverse proxy terminates TLS" do
+    test "serves plain HTTP requests instead of redirecting" do
+      conn = Endpoint.call(conn(:get, "http://api.firezone.test/client"), [])
 
-    assert conn.status == 307
-    assert get_resp_header(conn, "location") == [
-             "https://flow-api.firezone.test/ingestion/flow_logs"
-           ]
-  end
+      assert conn.private.phoenix_endpoint == PortalAPI.Endpoint
+    end
 
-  test "does not trust forwarded headers from the public listener" do
-    conn =
-      :get
-      |> conn("http://api.firezone.test/client")
-      |> put_req_header("x-forwarded-host", "mtls.firezone.test")
-      |> put_req_header("x-forwarded-proto", "https")
-      |> Endpoint.call([])
+    test "drops forwarded and geo headers while no proxy is trusted" do
+      conn =
+        :get
+        |> conn("http://unknown.firezone.test/")
+        |> put_req_header("x-forwarded-for", "1.2.3.4")
+        |> put_req_header("x-forwarded-host", "app.firezone.test")
+        |> put_req_header("x-azure-geo-country", "US")
+        |> put_req_header("x-geo-location-region", "US")
+        |> Endpoint.call([])
 
-    assert conn.status == 301
-    assert get_resp_header(conn, "location") == ["https://api.firezone.test/client"]
-    assert get_req_header(conn, "x-forwarded-host") == []
-    assert get_req_header(conn, "x-forwarded-proto") == []
-  end
+      assert conn.status == 404
+      assert conn.remote_ip == {127, 0, 0, 1}
+      assert get_req_header(conn, "x-forwarded-for") == []
+      assert get_req_header(conn, "x-forwarded-host") == []
+      assert get_req_header(conn, "x-azure-geo-country") == []
+      assert get_req_header(conn, "x-geo-location-region") == []
+    end
 
-  test "serves readiness checks without redirecting" do
-    conn = Endpoint.call(conn(:get, "http://api.firezone.test/readyz"), [])
+    test "takes the client, host and scheme from a trusted proxy" do
+      trust_proxy({127, 0, 0, 1})
 
-    assert conn.status in [200, 503]
-    assert get_resp_header(conn, "location") == []
+      conn =
+        :get
+        |> conn("http://portal.internal/not-found")
+        |> put_req_header("x-forwarded-for", "1.2.3.4")
+        |> put_req_header("x-forwarded-host", "app.firezone.test")
+        |> put_req_header("x-forwarded-proto", "https")
+        |> Endpoint.call([])
+
+      assert conn.private.phoenix_endpoint == PortalWeb.Endpoint
+      assert conn.scheme == :https
+      assert conn.remote_ip == {1, 2, 3, 4}
+    end
+
+    test "ignores an address the client prepended before the proxy appended its own" do
+      trust_proxy({127, 0, 0, 1})
+
+      conn =
+        :get
+        |> conn("http://unknown.firezone.test/")
+        |> put_req_header("x-forwarded-for", "6.6.6.6, 203.0.113.5")
+        |> Endpoint.call([])
+
+      assert conn.remote_ip == {203, 0, 113, 5}
+    end
+
+    test "skips further proxy hops on private addresses" do
+      trust_proxy({127, 0, 0, 1})
+
+      conn =
+        :get
+        |> conn("http://unknown.firezone.test/")
+        |> put_req_header("x-forwarded-for", "6.6.6.6, 203.0.113.5, 10.0.0.1")
+        |> Endpoint.call([])
+
+      assert conn.remote_ip == {203, 0, 113, 5}
+    end
+
+    test "ignores forwarded headers on a request that skipped the proxy" do
+      trust_proxy({10, 0, 0, 1})
+
+      conn =
+        :get
+        |> conn("http://unknown.firezone.test/")
+        |> put_req_header("x-forwarded-for", "6.6.6.6")
+        |> put_req_header("x-forwarded-host", "app.firezone.test")
+        |> Endpoint.call([])
+
+      assert conn.status == 404
+      assert conn.remote_ip == {127, 0, 0, 1}
+      assert get_req_header(conn, "x-forwarded-for") == []
+    end
   end
 
   test "dispatches the web hostname to the web endpoint" do
@@ -83,5 +171,11 @@ defmodule Portal.EndpointTest do
 
     assert conn.status == 404
     assert conn.private.phoenix_endpoint == Endpoint
+  end
+
+  defp trust_proxy(address) do
+    Portal.Config.put_env_override(:portal, :external_trusted_proxies, [
+      %Postgrex.INET{address: address, netmask: 32}
+    ])
   end
 end

--- a/elixir/test/portal/telemetry/otel_bandit_test.exs
+++ b/elixir/test/portal/telemetry/otel_bandit_test.exs
@@ -44,7 +44,9 @@ defmodule Portal.Telemetry.OtelBanditTest do
 
       ids = [:bandit, :request] |> :telemetry.list_handlers() |> Enum.map(& &1.id)
 
-      assert log == ""
+      # capture_log/1 collects the whole node, so match the report :telemetry
+      # writes when it drops a handler rather than assert on an empty string.
+      refute log =~ "has been detached"
       assert {OtelBandit, :otel_bandit} in ids
     end
   end

--- a/elixir/test/portal_api/plugs/request_log_test.exs
+++ b/elixir/test/portal_api/plugs/request_log_test.exs
@@ -65,12 +65,12 @@ defmodule PortalAPI.Plugs.RequestLogTest do
       assert Repo.aggregate(APIRequestLog, :count) == 2
     end
 
-    test "records the RemoteIp-resolved client address, not the peer", %{actor: actor} do
+    test "records the client address resolved by the public endpoint", %{actor: actor} do
       conn =
         build_conn()
         |> authorize_conn(actor)
-        |> put_req_header("x-forwarded-for", "203.0.113.5")
         |> put_req_header("content-type", "application/json")
+        |> Map.put(:remote_ip, {203, 0, 113, 5})
         |> get(~p"/account")
 
       assert json_response(conn, 200)


### PR DESCRIPTION
Firezone used to run behind a proxy that held the TLS certificate and passed the client details along in `X-Forwarded-*` headers. Phoenix holds the certificate itself now, so the client is simply the other end of the socket.

#14671 finished that move, but it also removed the option to put your own proxy in front, which self-hosted installs rely on. With `https://` external URLs nothing listened at all, and with `http://` URLs every link and cookie became plain HTTP.

The public endpoint now decides once whether a proxy sits in front of it, and nothing behind it asks again. It redirects to HTTPS only while it holds a certificate itself, and it trusts the forwarded headers only on requests that arrive from an address in `PHOENIX_EXTERNAL_TRUSTED_PROXIES`. Every other request has them removed, including the geolocation headers that policy conditions match on.

To run behind a proxy, keep the external URLs on `https://` and set `PHOENIX_HTTP_PUBLIC_PORT` plus `PHOENIX_EXTERNAL_TRUSTED_PROXIES`. Your proxy must append to `X-Forwarded-For` rather than pass on what the client sent, and clients with private addresses need their ranges in `PHOENIX_PRIVATE_CLIENTS`.

Related: #14671
