### PR TITLE
fix(apple): answer state polls that arrive before the adapter

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -228,8 +228,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         completionHandler?(nil)
       case .pollUpdates(let request):
         guard let adapter else {
+          // The system reports us as connected from the moment `startTunnel` returns, so
+          // the app can poll before there is anything to poll. Answer "nothing changed"
+          // rather than nothing at all, which the app can only read as a broken tunnel.
           Log.warning("Adapter is nil")
-          completionHandler?(nil)
+          let empty = StatePollResponse(stateChange: nil, notifications: [])
+          completionHandler?(try PropertyListEncoder().encode(empty))
           return
         }
 


### PR DESCRIPTION
macOS reports the tunnel as connected as soon as `startTunnel` returns, which is before the extension has built its adapter. A state poll that lands in that gap got no answer at all, and the app reads no answer as a broken tunnel. The extension now answers "nothing has changed" instead.

Related: #14674
Related: #14677
