### PR TITLE
fix(apple): stop the state poller from cycling the tunnel

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -193,12 +193,7 @@ public enum IPCClient {
     message: ProviderMessage,
     cycleStartIfStopped: Bool = true
   ) async throws -> Data? {
-    let isCycleStart: Bool
-    if cycleStartIfStopped {
-      isCycleStart = try await maybeCycleStart(session)
-    } else {
-      isCycleStart = false
-    }
+    let isCycleStart = cycleStartIfStopped ? try await maybeCycleStart(session) : false
 
     defer {
       if isCycleStart { session.stopTunnel() }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -59,7 +59,13 @@ public enum IPCClient {
   ) async throws -> StatePollResponse {
     let message = ProviderMessage.pollUpdates(StatePollRequest(stateHash: currentHash))
 
-    guard let data = try await sendProviderMessage(session: session, message: message) else {
+    guard
+      let data = try await sendProviderMessage(
+        session: session,
+        message: message,
+        cycleStartIfStopped: false
+      )
+    else {
       throw Error.noIPCData
     }
 
@@ -177,11 +183,22 @@ public enum IPCClient {
     }
   }
 
+  /// Sends `message` to the provider, waking a stopped tunnel first if asked to.
+  ///
+  /// Polling opts out: cycle-starting from the poll loop would wake the extension
+  /// without a tunnel behind it, and the stop that follows churns the VPN status,
+  /// which starts the loop over again.
   private static func sendProviderMessage(
     session: any TunnelSessionProtocol,
     message: ProviderMessage,
+    cycleStartIfStopped: Bool = true
   ) async throws -> Data? {
-    let isCycleStart = try await maybeCycleStart(session)
+    let isCycleStart: Bool
+    if cycleStartIfStopped {
+      isCycleStart = try await maybeCycleStart(session)
+    } else {
+      isCycleStart = false
+    }
 
     defer {
       if isCycleStart { session.stopTunnel() }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -617,6 +617,11 @@ public final class Store: ObservableObject {
           didReload = false
         } catch is CancellationError {
           break
+        } catch IPCClient.Error.noIPCData {
+          // The extension can go away underneath a connected session, and it answers
+          // nothing while it does. The status change that follows stops the poller, so
+          // there is nothing to act on here.
+          Log.debug("Tunnel did not answer the state poll")
         } catch let error as NSError {
           // https://developer.apple.com/documentation/networkextension/nevpnerror-swift.struct/code
           if error.domain == "NEVPNErrorDomain" && error.code == 1 {

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/IPCClientTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/IPCClientTests.swift
@@ -81,6 +81,18 @@ struct IPCClientTests {
     #expect(request.stateHash == previousHash)
   }
 
+  @Test("Polling never starts a stopped tunnel")
+  func pollUpdatesDoesNotCycleStart() async {
+    for status in [NEVPNStatus.disconnected, .disconnecting, .invalid] {
+      let session = RecordingTunnelSession(status: status)
+
+      _ = try? await IPCClient.pollUpdates(session: session, currentHash: Data())
+
+      #expect(session.startTunnelCallCount == 0)
+      #expect(session.stopTunnelCallCount == 0)
+    }
+  }
+
   @Test("A running tunnel is left alone")
   func drainDoesNotCycleRunningTunnel() async throws {
     for status in [NEVPNStatus.connected, .connecting, .reasserting] {


### PR DESCRIPTION
The app sends the tunnel messages even while it is disconnected, to drain flow logs or to check the log folder size. These wake the extension, and unless the app starts and stops the tunnel around them, they leave orphaned `utun` interfaces behind. The start is brief, but macOS calls the tunnel connected while it lasts, and that is enough for the state poller to begin. A second later, when the poller sent its first message, the tunnel was stopped again, so the message started it once more, got nothing back because there was no tunnel behind it, and stopped it again, once per second.

Polling now never starts the tunnel. One-off messages still start and stop it as they did.

Fixes #14674
