### PR TITLE
feat(portal): identify attributed website users

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -259,6 +259,12 @@ config :portal, Portal.Okta.AuthProvider,
 # 15 minutes in milliseconds
 config :portal, Portal.Okta.APIClient, req_opts: [receive_timeout: 900_000]
 
+config :portal, Portal.Analytics.PostHog,
+  enabled: false,
+  endpoint: "https://e.firezone.dev/i/v0/e/",
+  project_api_key: "phc_ubuPhiqqjMdedpmbWpG2Ak3axqv5eMVhFDNBaXl9UZK",
+  req_opts: [receive_timeout: 5_000, retry: :transient]
+
 config :portal, Portal.Splunk.APIClient, req_opts: []
 
 config :portal, Portal.Datadog.APIClient, req_opts: []

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -262,7 +262,7 @@ config :portal, Portal.Okta.APIClient, req_opts: [receive_timeout: 900_000]
 config :portal, Portal.Analytics.PostHog,
   enabled: false,
   endpoint: "https://e.firezone.dev/i/v0/e/",
-  project_api_key: "phc_ubuPhiqqjMdedpmbWpG2Ak3axqv5eMVhFDNBaXl9UZK",
+  project_api_key: nil,
   req_opts: [receive_timeout: 5_000, retry: :transient]
 
 config :portal, Portal.Splunk.APIClient, req_opts: []

--- a/elixir/config/prod.exs
+++ b/elixir/config/prod.exs
@@ -16,6 +16,8 @@ config :portal, Portal.Entra.AuthProvider,
 config :portal, PortalWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json"
 
+config :portal, Portal.Analytics.PostHog, enabled: true
+
 config :portal, Portal.Endpoint, server: true
 config :portal, PortalOps.Endpoint, server: true
 

--- a/elixir/config/prod.exs
+++ b/elixir/config/prod.exs
@@ -16,8 +16,6 @@ config :portal, Portal.Entra.AuthProvider,
 config :portal, PortalWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json"
 
-config :portal, Portal.Analytics.PostHog, enabled: true
-
 config :portal, Portal.Endpoint, server: true
 config :portal, PortalOps.Endpoint, server: true
 

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -623,6 +623,12 @@ if config_env() == :prod do
   config :portal, Portal.Telemetry,
     metrics_reporter: env_var_to_config!(:telemetry_metrics_reporter)
 
+  posthog_project_api_key = env_var_to_config(:posthog_project_api_key)
+
+  config :portal, Portal.Analytics.PostHog,
+    enabled: not is_nil(posthog_project_api_key),
+    project_api_key: posthog_project_api_key
+
   if telemetry_metrics_reporter = env_var_to_config!(:telemetry_metrics_reporter) do
     config :portal,
            telemetry_metrics_reporter,

--- a/elixir/lib/portal/analytics/post_hog.ex
+++ b/elixir/lib/portal/analytics/post_hog.ex
@@ -1,0 +1,109 @@
+defmodule Portal.Analytics.PostHog do
+  @moduledoc """
+  Sends consented website attribution events to PostHog without affecting auth flows.
+  """
+
+  require Logger
+
+  @type attribution :: map()
+
+  @spec capture_portal_landing(attribution(), String.t()) :: :ok
+  def capture_portal_landing(attribution, destination_path) do
+    properties = %{
+      "$insert_id" => insert_id([attribution["distinct_id"], destination_path]),
+      "$process_person_profile" => false,
+      "destination_path" => destination_path,
+      "website_path" => attribution["website_path"],
+      "website_source" => attribution["source"]
+    }
+
+    dispatch("Portal Attribution Received", attribution["distinct_id"], properties)
+  end
+
+  @spec identify_actor(Portal.Actor.t(), Portal.Account.t(), attribution() | nil) :: :ok
+  def identify_actor(_actor, _account, nil), do: :ok
+
+  def identify_actor(actor, account, attribution) do
+    {event, distinct_id, properties} = identify_event(actor, account, attribution)
+    dispatch(event, distinct_id, properties)
+  end
+
+  @doc false
+  def identify_event(actor, account, attribution) do
+    profile_properties =
+      %{
+        "account_id" => account.id,
+        "account_name" => account.name,
+        "account_slug" => account.slug,
+        "actor_type" => actor.type,
+        "email" => actor.email,
+        "name" => actor.name
+      }
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+      |> Map.new()
+
+    properties = %{
+      "$anon_distinct_id" => attribution["distinct_id"],
+      "$insert_id" => insert_id([actor.id, attribution["distinct_id"]]),
+      "$process_person_profile" => true,
+      "$set" => profile_properties,
+      "$set_once" => %{
+        "initial_website_path" => attribution["website_path"],
+        "initial_website_source" => attribution["source"]
+      }
+    }
+
+    {"$identify", actor.id, properties}
+  end
+
+  @doc false
+  @spec capture(String.t(), String.t(), map()) :: :ok | {:error, term()}
+  def capture(event, distinct_id, properties) do
+    config = Portal.Config.fetch_env!(:portal, __MODULE__)
+
+    if Keyword.fetch!(config, :enabled) do
+      body = %{
+        "api_key" => Keyword.fetch!(config, :project_api_key),
+        "event" => event,
+        "properties" => Map.put(properties, "distinct_id", distinct_id)
+      }
+
+      req_opts = [json: body] ++ Keyword.get(config, :req_opts, [])
+
+      case Req.post(Keyword.fetch!(config, :endpoint), req_opts) do
+        {:ok, %Req.Response{status: status}} when status in 200..299 ->
+          :ok
+
+        {:ok, %Req.Response{status: status}} ->
+          {:error, {:http_status, status}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    else
+      :ok
+    end
+  end
+
+  defp dispatch(event, distinct_id, properties) do
+    config = Portal.Config.fetch_env!(:portal, __MODULE__)
+
+    if Keyword.fetch!(config, :enabled) do
+      Task.Supervisor.start_child(Portal.Analytics.TaskSupervisor, fn ->
+        case capture(event, distinct_id, properties) do
+          :ok -> :ok
+          {:error, reason} -> Logger.warning("PostHog event failed", event: event, reason: reason)
+        end
+      end)
+    end
+
+    :ok
+  end
+
+  defp insert_id(parts) do
+    parts
+    |> Enum.join(":")
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.url_encode64(padding: false)
+  end
+end

--- a/elixir/lib/portal/analytics/post_hog.ex
+++ b/elixir/lib/portal/analytics/post_hog.ex
@@ -89,15 +89,20 @@ defmodule Portal.Analytics.PostHog do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
 
     if Keyword.fetch!(config, :enabled) do
-      Task.Supervisor.start_child(Portal.Analytics.TaskSupervisor, fn ->
-        case capture(event, distinct_id, properties) do
-          :ok -> :ok
-          {:error, reason} -> Logger.warning("PostHog event failed", event: event, reason: reason)
-        end
-      end)
+      Task.Supervisor.start_child(
+        Portal.Analytics.TaskSupervisor,
+        fn -> capture_and_log(event, distinct_id, properties) end
+      )
     end
 
     :ok
+  end
+
+  defp capture_and_log(event, distinct_id, properties) do
+    case capture(event, distinct_id, properties) do
+      :ok -> :ok
+      {:error, reason} -> Logger.warning("PostHog event failed", event: event, reason: reason)
+    end
   end
 
   defp insert_id(parts) do

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -44,6 +44,7 @@ defmodule Portal.Application do
       Portal.Repo.Web,
       Portal.Repo.Api,
       Portal.Repo.Poller,
+      {Task.Supervisor, name: Portal.Analytics.TaskSupervisor},
       # Default pg scope for distributed process discovery (used by replication)
       %{id: :pg, start: {:pg, :start_link, []}},
       # Named pg scope for Portal.PG, isolated so a crash here does not affect replication

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -807,6 +807,25 @@ defmodule Portal.Config.Definitions do
   )
 
   @doc """
+  PostHog project API key used to attribute consented website visitors after authentication.
+
+  PostHog analytics are disabled when this is unset or blank.
+  """
+  defconfig(:posthog_project_api_key, :string,
+    default: nil,
+    dump: fn
+      project_api_key when is_binary(project_api_key) ->
+        case String.trim(project_api_key) do
+          "" -> nil
+          project_api_key -> project_api_key
+        end
+
+      project_api_key ->
+        project_api_key
+    end
+  )
+
+  @doc """
   Enable or disable the Firezone telemetry collection.
   """
   defconfig(:instrumentation_client_logs_enabled, :boolean, default: true)

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -792,10 +792,10 @@ defmodule PortalWeb.OIDCController do
 
   # Context: :portal
   # Store session cookie and redirect to portal or redirect_to parameter
-  defp signed_in(conn, :portal, account, _identity, session, _provider, _tokens, params) do
+  defp signed_in(conn, :portal, account, identity, session, _provider, _tokens, params) do
     conn
     |> PortalWeb.Cookie.Session.put(account.id, %PortalWeb.Cookie.Session{session_id: session.id})
-    |> Redirector.portal_signed_in(account, params)
+    |> Redirector.portal_signed_in(account, params, identity.actor)
   end
 
   # Context: :gui_client

--- a/elixir/lib/portal_web/live/sign_up.ex
+++ b/elixir/lib/portal_web/live/sign_up.ex
@@ -79,9 +79,10 @@ defmodule PortalWeb.SignUp do
 
   # ── Mount & params ────────────────────────────────────────────────────────────
 
-  def mount(_params, _session, socket) do
+  def mount(_params, session, socket) do
     user_agent = Phoenix.LiveView.get_connect_info(socket, :user_agent)
     real_ip = PortalWeb.Authentication.real_ip(socket)
+    website_attribution = PortalWeb.WebsiteAttribution.fetch(session)
 
     case socket.assigns.live_action do
       :verify ->
@@ -93,6 +94,7 @@ defmodule PortalWeb.SignUp do
            provider: nil,
            actor: nil,
            error_message: nil,
+           website_attribution: website_attribution,
            user_agent: user_agent,
            real_ip: real_ip
          )}
@@ -109,6 +111,7 @@ defmodule PortalWeb.SignUp do
             account: nil,
             provider: nil,
             actor: nil,
+            website_attribution: website_attribution,
             user_agent: user_agent,
             real_ip: real_ip
           )
@@ -524,7 +527,8 @@ defmodule PortalWeb.SignUp do
         send_verification_email(
           registration.email,
           registration.account.name,
-          registration.actor.name
+          registration.actor.name,
+          socket.assigns.website_attribution
         )
       else
         send_existing_accounts_email(registration.email, existing_accounts)
@@ -594,10 +598,16 @@ defmodule PortalWeb.SignUp do
     )
   end
 
-  @spec send_verification_email(String.t(), String.t(), String.t()) ::
+  @spec send_verification_email(String.t(), String.t(), String.t(), map() | nil) ::
           {:ok, any()} | {:error, any()}
-  defp send_verification_email(email, company_name, actor_name) do
-    payload = %{email: email, company_name: company_name, actor_name: actor_name}
+  defp send_verification_email(email, company_name, actor_name, website_attribution) do
+    payload = %{
+      email: email,
+      company_name: company_name,
+      actor_name: actor_name,
+      website_attribution: website_attribution
+    }
+
     token = Phoenix.Token.sign(PortalWeb.Endpoint, @sign_up_token_salt, payload)
     sign_up_url = url(~p"/verify_sign_up?token=#{token}")
 
@@ -741,7 +751,7 @@ defmodule PortalWeb.SignUp do
            email: email,
            company_name: company_name,
            actor_name: actor_name
-         },
+         } = registration_claims,
          user_agent,
          real_ip
        ) do
@@ -756,14 +766,21 @@ defmodule PortalWeb.SignUp do
           actor: %{name: actor_name}
         }
 
-        handle_registration_result(socket, register_account(registration, user_agent, real_ip))
+        handle_registration_result(
+          socket,
+          register_account(registration, user_agent, real_ip),
+          Map.get(registration_claims, :website_attribution)
+        )
     end
   end
 
   defp handle_registration_result(
          socket,
-         {:ok, %{account: account, provider: provider, actor: actor}}
+         {:ok, %{account: account, provider: provider, actor: actor}},
+         website_attribution
        ) do
+    Portal.Analytics.PostHog.identify_actor(actor, account, website_attribution)
+
     assign(socket,
       step: :account_created,
       account: account,
@@ -772,11 +789,11 @@ defmodule PortalWeb.SignUp do
     )
   end
 
-  defp handle_registration_result(socket, {:error, :stripe_provision}) do
+  defp handle_registration_result(socket, {:error, :stripe_provision}, _website_attribution) do
     sign_up_error(socket, "We encountered a temporary error. Please try again.")
   end
 
-  defp handle_registration_result(socket, {:error, _, _, _}) do
+  defp handle_registration_result(socket, {:error, _, _, _}, _website_attribution) do
     sign_up_error(socket, "We encountered an error creating your account. Please try again.")
   end
 

--- a/elixir/lib/portal_web/router.ex
+++ b/elixir/lib/portal_web/router.ex
@@ -4,6 +4,7 @@ defmodule PortalWeb.Router do
   pipeline :public do
     plug :accepts, ["html", "xml"]
     plug :fetch_session
+    plug PortalWeb.WebsiteAttribution
     plug :protect_from_forgery
     plug :fetch_live_flash
     plug :put_root_layout, html: {PortalWeb.Layouts, :root}

--- a/elixir/lib/portal_web/session/redirector.ex
+++ b/elixir/lib/portal_web/session/redirector.ex
@@ -10,7 +10,9 @@ defmodule PortalWeb.Session.Redirector do
   use PortalWeb, :verified_routes
 
   alias Portal.Authentication
+  alias Portal.Analytics.PostHog
   alias Portal.ClientToken
+  alias PortalWeb.WebsiteAttribution
 
   @doc """
   Sanitizes and validates a redirect_to parameter.
@@ -67,6 +69,9 @@ defmodule PortalWeb.Session.Redirector do
 
   def portal_signed_in(%Plug.Conn{} = conn, %Portal.Account{} = account, params, actor) do
     redirect_to = sanitize_redirect_to(account, params["redirect_to"], actor)
+    {conn, website_attribution} = WebsiteAttribution.pop(conn)
+
+    PostHog.identify_actor(actor, account, website_attribution)
 
     conn
     |> PortalWeb.Cookie.RecentAccounts.prepend(account.id)

--- a/elixir/lib/portal_web/website_attribution.ex
+++ b/elixir/lib/portal_web/website_attribution.ex
@@ -1,0 +1,93 @@
+defmodule PortalWeb.WebsiteAttribution do
+  @moduledoc """
+  Moves consented website attribution from the query string into the portal session.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  alias Portal.Analytics.PostHog
+
+  @distinct_id_param "fz_website_id"
+  @pathname_param "fz_website_path"
+  @session_key "website_attribution"
+  @source "www.firezone.dev"
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(%Plug.Conn{method: "GET"} = conn, _opts) do
+    conn = fetch_query_params(conn)
+
+    if attribution_params_present?(conn.query_params) do
+      conn
+      |> maybe_store_attribution(conn.query_params)
+      |> Phoenix.Controller.redirect(to: clean_request_target(conn))
+      |> halt()
+    else
+      conn
+    end
+  end
+
+  def call(conn, _opts), do: conn
+
+  @spec fetch(map()) :: PostHog.attribution() | nil
+  def fetch(session), do: Map.get(session, @session_key)
+
+  @spec pop(Plug.Conn.t()) :: {Plug.Conn.t(), PostHog.attribution() | nil}
+  def pop(conn) do
+    attribution = get_session(conn, @session_key)
+    {delete_session(conn, @session_key), attribution}
+  end
+
+  defp attribution_params_present?(params) do
+    Map.has_key?(params, @distinct_id_param) or Map.has_key?(params, @pathname_param)
+  end
+
+  defp maybe_store_attribution(conn, params) do
+    with {:ok, distinct_id} <- valid_distinct_id(params[@distinct_id_param]),
+         {:ok, website_path} <- valid_website_path(params[@pathname_param]) do
+      attribution = %{
+        "distinct_id" => distinct_id,
+        "source" => @source,
+        "website_path" => website_path
+      }
+
+      PostHog.capture_portal_landing(attribution, conn.request_path)
+      put_session(conn, @session_key, attribution)
+    else
+      _ -> conn
+    end
+  end
+
+  defp valid_distinct_id(value) when is_binary(value) do
+    case Ecto.UUID.cast(value) do
+      {:ok, distinct_id} -> {:ok, distinct_id}
+      :error -> :error
+    end
+  end
+
+  defp valid_distinct_id(_value), do: :error
+
+  defp valid_website_path("/" <> _rest = path) when byte_size(path) <= 512 do
+    if String.contains?(path, ["?", "#", <<0>>]), do: :error, else: {:ok, path}
+  end
+
+  defp valid_website_path(_value), do: :error
+
+  defp clean_request_target(conn) do
+    query_string =
+      conn.query_string
+      |> URI.query_decoder()
+      |> Enum.reject(fn {key, _value} -> key in [@distinct_id_param, @pathname_param] end)
+      |> URI.encode_query()
+
+    if query_string == "" do
+      conn.request_path
+    else
+      conn.request_path <> "?" <> query_string
+    end
+  end
+end

--- a/elixir/test/portal/analytics/post_hog_test.exs
+++ b/elixir/test/portal/analytics/post_hog_test.exs
@@ -1,0 +1,73 @@
+defmodule Portal.Analytics.PostHogTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Analytics.PostHog
+
+  setup do
+    Portal.Config.put_env_override(:portal, PostHog,
+      enabled: true,
+      endpoint: "https://posthog.test/i/v0/e/",
+      project_api_key: "phc_test",
+      req_opts: [retry: false, plug: {Req.Test, __MODULE__}]
+    )
+
+    :ok
+  end
+
+  test "posts events to the configured capture endpoint" do
+    test_pid = self()
+
+    Req.Test.expect(__MODULE__, fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      send(test_pid, {:posthog_request, conn, JSON.decode!(body)})
+      Req.Test.json(conn, %{"status" => "ok"})
+    end)
+
+    assert :ok =
+             PostHog.capture("Portal Attribution Received", "anonymous-id", %{
+               "$process_person_profile" => false,
+               "website_path" => "/pricing"
+             })
+
+    assert_receive {:posthog_request, conn, body}
+    assert conn.method == "POST"
+    assert conn.request_path == "/i/v0/e/"
+    assert body["api_key"] == "phc_test"
+    assert body["event"] == "Portal Attribution Received"
+    assert body["properties"]["distinct_id"] == "anonymous-id"
+    assert body["properties"]["website_path"] == "/pricing"
+    assert body["properties"]["$process_person_profile"] == false
+  end
+
+  test "builds an identify event that aliases the website visitor to the actor" do
+    actor = %Portal.Actor{
+      id: "c69036ab-96d0-4534-86b6-f1af9092015c",
+      email: "ada@example.com",
+      name: "Ada Lovelace",
+      type: :account_admin_user
+    }
+
+    account = %Portal.Account{
+      id: "a649f7b5-ef17-45a9-8983-48e02d441e0e",
+      name: "Analytical Engines",
+      slug: "analytical-engines"
+    }
+
+    attribution = %{
+      "distinct_id" => "7d2ed047-64d3-41f9-9a41-ac2c9b92e761",
+      "source" => "www.firezone.dev",
+      "website_path" => "/pricing"
+    }
+
+    actor_id = actor.id
+
+    assert {"$identify", ^actor_id, properties} =
+             PostHog.identify_event(actor, account, attribution)
+
+    assert properties["$anon_distinct_id"] == attribution["distinct_id"]
+    assert properties["$process_person_profile"] == true
+    assert properties["$set"]["email"] == actor.email
+    assert properties["$set"]["account_id"] == account.id
+    assert properties["$set_once"]["initial_website_path"] == "/pricing"
+  end
+end

--- a/elixir/test/portal/config_test.exs
+++ b/elixir/test/portal/config_test.exs
@@ -203,6 +203,22 @@ defmodule Portal.ConfigTest do
              }) == dsn
     end
 
+    test "returns nil for a missing or blank PostHog project API key" do
+      assert env_var_to_config!(Portal.Config.Definitions, :posthog_project_api_key, %{}) == nil
+
+      assert env_var_to_config!(Portal.Config.Definitions, :posthog_project_api_key, %{
+               "POSTHOG_PROJECT_API_KEY" => "  \n"
+             }) == nil
+    end
+
+    test "returns the configured PostHog project API key" do
+      project_api_key = "phc_test"
+
+      assert env_var_to_config!(Portal.Config.Definitions, :posthog_project_api_key, %{
+               "POSTHOG_PROJECT_API_KEY" => project_api_key
+             }) == project_api_key
+    end
+
     test "returns config value" do
       assert env_var_to_config!(Test, :optional_generated) ==
                %Postgrex.INET{address: {1, 1, 1, 1}, netmask: nil}

--- a/elixir/test/portal_web/controllers/home_controller_test.exs
+++ b/elixir/test/portal_web/controllers/home_controller_test.exs
@@ -4,6 +4,42 @@ defmodule PortalWeb.HomeControllerTest do
   import Portal.AccountFixtures
 
   @client_sign_in_types ["client", "gui-client", "headless-client"]
+  @website_distinct_id "7d2ed047-64d3-41f9-9a41-ac2c9b92e761"
+
+  describe "website attribution" do
+    test "stores attribution and redirects sign-up links to a clean URL", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          "/sign_up?fz_website_id=#{@website_distinct_id}&fz_website_path=%2Fpricing"
+        )
+
+      assert redirected_to(conn) == "/sign_up"
+
+      assert get_session(conn, "website_attribution") == %{
+               "distinct_id" => @website_distinct_id,
+               "source" => "www.firezone.dev",
+               "website_path" => "/pricing"
+             }
+    end
+
+    test "preserves unrelated sign-in parameters while removing attribution", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          "/sign_in?as=gui-client&fz_website_id=#{@website_distinct_id}&fz_website_path=%2F"
+        )
+
+      assert redirected_to(conn) == "/sign_in?as=gui-client"
+    end
+
+    test "removes invalid attribution without storing it", %{conn: conn} do
+      conn = get(conn, "/sign_up?fz_website_id=invalid&fz_website_path=%2Fpricing")
+
+      assert redirected_to(conn) == "/sign_up"
+      assert get_session(conn, "website_attribution") == nil
+    end
+  end
 
   describe "home/2" do
     test "redirects to /getting_started when no cookie present", %{conn: conn} do

--- a/elixir/test/portal_web/live/sign_up_test.exs
+++ b/elixir/test/portal_web/live/sign_up_test.exs
@@ -143,6 +143,45 @@ defmodule PortalWeb.SignUpTest do
       assert_email_sent()
     end
 
+    test "carries website attribution in the signed verification token", %{conn: conn} do
+      distinct_id = "7d2ed047-64d3-41f9-9a41-ac2c9b92e761"
+
+      conn =
+        get(
+          conn,
+          "/sign_up?fz_website_id=#{distinct_id}&fz_website_path=%2Fpricing"
+        )
+
+      assert redirected_to(conn) == "/sign_up"
+      {:ok, lv, _html} = live(recycle(conn), ~p"/sign_up")
+
+      lv
+      |> form("form",
+        registration: %{
+          email: "attributed@example.com",
+          phone: "",
+          account: %{name: "Attributed Corp"},
+          actor: %{name: "Attributed User"}
+        }
+      )
+      |> render_submit()
+
+      assert_email_sent(fn email ->
+        [_, token] = Regex.run(~r/verify_sign_up\?token=([^\s]+)/, email.text_body)
+
+        assert {:ok, claims} =
+                 Phoenix.Token.verify(PortalWeb.Endpoint, @sign_up_token_salt, token)
+
+        assert claims.website_attribution == %{
+                 "distinct_id" => distinct_id,
+                 "source" => "www.firezone.dev",
+                 "website_path" => "/pricing"
+               }
+
+        true
+      end)
+    end
+
     test "honeypot submission shows email sent step without sending email", %{conn: conn} do
       {:ok, lv, _html} = live(conn, ~p"/sign_up")
 

--- a/elixir/test/portal_web/session_redirector_test.exs
+++ b/elixir/test/portal_web/session_redirector_test.exs
@@ -1,7 +1,26 @@
 defmodule PortalWeb.Session.RedirectorTest do
-  use ExUnit.Case, async: true
+  use PortalWeb.ConnCase, async: true
 
   alias PortalWeb.Session.Redirector
+
+  describe "portal_signed_in/4" do
+    test "clears website attribution after a successful portal sign-in", %{conn: conn} do
+      account = %Portal.Account{id: Ecto.UUID.generate(), slug: "acme"}
+      actor = %Portal.Actor{id: Ecto.UUID.generate()}
+
+      conn =
+        conn
+        |> put_session("website_attribution", %{
+          "distinct_id" => Ecto.UUID.generate(),
+          "source" => "www.firezone.dev",
+          "website_path" => "/pricing"
+        })
+        |> Redirector.portal_signed_in(account, %{}, actor)
+
+      assert redirected_to(conn) == "/acme/sites"
+      assert get_session(conn, "website_attribution") == nil
+    end
+  end
 
   describe "sanitize_redirect_to/3" do
     setup do


### PR DESCRIPTION
## Summary

- validate website attribution parameters, persist them in the signed portal session, and redirect to a clean URL
- send anonymous landing events and non-blocking PostHog $identify events after successful portal sign-in or account creation
- carry signup attribution through the signed email verification token
- cover email OTP, userpass, already-authenticated, and OIDC portal sign-in flows
- load POSTHOG_PROJECT_API_KEY through runtime env_var_to_config and disable PostHog when it is unset or blank

## Testing

- mix credo --strict
- mix format --check-formatted on changed Elixir files
- mix test test/portal/config_test.exs test/portal/analytics/post_hog_test.exs test/portal_web/controllers/home_controller_test.exs test/portal_web/live/sign_up_test.exs test/portal_web/session_redirector_test.exs (63 tests)
- git diff --check

## Related

- Website attribution handoff: https://github.com/firezone/website/pull/441
- Production infrastructure configuration: https://github.com/firezone/infra/pull/835

---