### PR TITLE
test(fuzz): anchor roam reset window at portal reconnect

### DIFF
--- a/rust/tests/fuzz/expected-coverage/tunnel-proto.json
+++ b/rust/tests/fuzz/expected-coverage/tunnel-proto.json
@@ -1,4 +1,4 @@
 {
-  "covered": 30123,
+  "covered": 30122,
   "total": 35976
 }

--- a/rust/tests/fuzz/expected-coverage/tunnel-proto.json
+++ b/rust/tests/fuzz/expected-coverage/tunnel-proto.json
@@ -1,4 +1,4 @@
 {
-  "covered": 30122,
-  "total": 35975
+  "covered": 30123,
+  "total": 35976
 }

--- a/rust/tests/fuzz/src/reference.rs
+++ b/rust/tests/fuzz/src/reference.rs
@@ -336,7 +336,7 @@ impl ReferenceState {
                 ip6,
                 nat_ip4,
                 dead_window,
-                portal_window: _,
+                portal_window,
             } => {
                 // With ICE-less connections, a roam re-keys in place and keeps
                 // the connection alive, so we only reset when the portal hands
@@ -354,7 +354,9 @@ impl ReferenceState {
                 // When roaming, we are not connected to any resource and wait for the next packet to re-establish a connection.
                 client.exec_mut(|client| {
                     if !all_iceless {
-                        client.reset_connections(now + *dead_window);
+                        // Reconnecting needs the portal, so recovery can only
+                        // start once the portal connection is back.
+                        client.reset_connections(now + *dead_window + *portal_window);
                     }
                     client.readd_all_resources();
                 });


### PR DESCRIPTION
After a roam under classic ICE, the reference model recorded the connection reset at the end of the dead-socket window. Reconnecting needs the portal though, which only comes back after the portal window, so the model's loss tolerance expired slightly before the client could have finished reconnecting and fuzzing found sequences where the first packet after the roam fell just outside it. Anchoring the reset at the portal reconnect matches when recovery can actually begin.