### PR TITLE
refactor(portal): rename Device Trust back to Trust Anchors

### DIFF
--- a/elixir/lib/portal/crl/scheduler.ex
+++ b/elixir/lib/portal/crl/scheduler.ex
@@ -20,7 +20,7 @@ defmodule Portal.Crl.Scheduler do
   def perform(%Oban.Job{}) do
     Logger.debug("Scheduling certificate revocation list refresh jobs")
 
-    if Portal.Features.enabled?(:device_trust) do
+    if Portal.Features.enabled?(:trust_anchors) do
       Database.queue_sync_jobs()
     else
       {:ok, :skipped}

--- a/elixir/lib/portal/crl/sync.ex
+++ b/elixir/lib/portal/crl/sync.ex
@@ -31,7 +31,7 @@ defmodule Portal.Crl.Sync do
           "distribution_point" => distribution_point
         }
       }) do
-    with true <- Portal.Features.enabled?(:device_trust),
+    with true <- Portal.Features.enabled?(:trust_anchors),
          {:ok, issuer} <- Base.decode64(encoded_issuer),
          endpoint when not is_nil(endpoint) <-
            Database.fetch_endpoint(account_id, issuer, distribution_point) do

--- a/elixir/lib/portal/features.ex
+++ b/elixir/lib/portal/features.ex
@@ -2,8 +2,8 @@ defmodule Portal.Features do
   # credo:disable-for-this-file Credo.Check.Warning.MissingChangesetFunction
   use Ecto.Schema
 
-  @features [:device_trust, :device_posture]
-  @type feature :: :device_trust | :device_posture
+  @features [:trust_anchors, :device_posture]
+  @type feature :: :trust_anchors | :device_posture
 
   @primary_key false
 

--- a/elixir/lib/portal/ocsp/scheduler.ex
+++ b/elixir/lib/portal/ocsp/scheduler.ex
@@ -14,7 +14,7 @@ defmodule Portal.Ocsp.Scheduler do
   def perform(%Oban.Job{}) do
     Logger.debug("Scheduling OCSP refresh jobs")
 
-    if Portal.Features.enabled?(:device_trust) do
+    if Portal.Features.enabled?(:trust_anchors) do
       Database.queue_sync_jobs()
     else
       {:ok, :skipped}

--- a/elixir/lib/portal/ocsp/sync.ex
+++ b/elixir/lib/portal/ocsp/sync.ex
@@ -30,7 +30,7 @@ defmodule Portal.Ocsp.Sync do
           "distribution_point" => distribution_point
         } = args
       }) do
-    with true <- Portal.Features.enabled?(:device_trust),
+    with true <- Portal.Features.enabled?(:trust_anchors),
          {:ok, issuer} <- Base.decode64(encoded_issuer),
          endpoint when not is_nil(endpoint) <-
            Database.fetch_endpoint(account_id, issuer, distribution_point) do
@@ -55,7 +55,7 @@ defmodule Portal.Ocsp.Sync do
   """
   @spec enqueue_check(Ecto.UUID.t(), binary(), String.t()) :: :ok
   def enqueue_check(account_id, issuer, serial) do
-    if Portal.Features.enabled?(:device_trust) do
+    if Portal.Features.enabled?(:trust_anchors) do
       Database.ocsp_distribution_points(account_id, issuer)
       |> Enum.each(fn distribution_point ->
         %{

--- a/elixir/lib/portal_api/client/device_trust.ex
+++ b/elixir/lib/portal_api/client/device_trust.ex
@@ -213,7 +213,7 @@ defmodule PortalAPI.Client.DeviceTrust do
 
   defp fetch_anchors(subject) do
     anchors =
-      if Portal.Features.enabled?(:device_trust),
+      if Portal.Features.enabled?(:trust_anchors),
         do: Database.fetch_anchors(subject),
         else: []
 

--- a/elixir/lib/portal_web/components/navigation_components.ex
+++ b/elixir/lib/portal_web/components/navigation_components.ex
@@ -4,9 +4,9 @@ defmodule PortalWeb.NavigationComponents do
   import PortalWeb.CoreComponents
 
   @doc """
-  Returns whether the global `device_trust` rollout flag is enabled.
+  Returns whether the global `trust_anchors` rollout flag is enabled.
   """
-  def device_trust_enabled?, do: Portal.Features.enabled?(:device_trust)
+  def trust_anchors_enabled?, do: Portal.Features.enabled?(:trust_anchors)
 
   @doc """
   Returns whether the global `device_posture` rollout flag is enabled.
@@ -403,7 +403,7 @@ defmodule PortalWeb.NavigationComponents do
   """
   attr :account, :any, required: true
   attr :current_path, :string, required: true
-  attr :device_trust_enabled?, :boolean, default: false
+  attr :trust_anchors_enabled?, :boolean, default: false
   attr :device_posture_enabled?, :boolean, default: false
   slot :actions
 
@@ -524,13 +524,13 @@ defmodule PortalWeb.NavigationComponents do
           REST API
         </.settings_tab>
         <.settings_tab
-          :if={@device_trust_enabled?}
+          :if={@trust_anchors_enabled?}
           current_path={@current_path}
-          navigate={~p"/#{@account}/settings/device_trust"}
-          tab_path="settings/device_trust"
-          icon="ri-fingerprint-fill"
+          navigate={~p"/#{@account}/settings/trust_anchors"}
+          tab_path="settings/trust_anchors"
+          icon="ri-shield-check-fill"
         >
-          Device Trust
+          Trust Anchors
         </.settings_tab>
       </div>
     </div>

--- a/elixir/lib/portal_web/live/settings/account.ex
+++ b/elixir/lib/portal_web/live/settings/account.ex
@@ -25,7 +25,7 @@ defmodule PortalWeb.Settings.Account do
         users_count: Database.count_users_for_account(subject),
         active_users_count: Database.count_1m_active_users_for_account(subject),
         sites_count: Database.count_groups_for_account(subject),
-        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?(),
+        trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?(),
         device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
       )
 
@@ -38,7 +38,7 @@ defmodule PortalWeb.Settings.Account do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        device_trust_enabled?={@device_trust_enabled?}
+        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       >
         <:actions>

--- a/elixir/lib/portal_web/live/settings/api_clients/beta.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/beta.ex
@@ -24,7 +24,7 @@ defmodule PortalWeb.Settings.ApiClients.Beta do
           socket,
           page_title: "API Clients",
           requested: Portal.Account.rest_api_access_requested?(socket.assigns.account),
-          device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?(),
+          trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?(),
           device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
         )
 
@@ -38,7 +38,7 @@ defmodule PortalWeb.Settings.ApiClients.Beta do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        device_trust_enabled?={@device_trust_enabled?}
+        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 

--- a/elixir/lib/portal_web/live/settings/api_clients/index.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/index.ex
@@ -83,7 +83,7 @@ defmodule PortalWeb.Settings.ApiClients.Index do
         |> assign(selected_actor: nil)
         |> assign(form: nil, encoded_token: nil)
         |> assign(pending_confirm: nil, open_actor_actions_id: nil)
-        |> assign(device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?())
+        |> assign(trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?())
         |> assign(device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?())
 
       {:ok, socket}
@@ -146,7 +146,7 @@ defmodule PortalWeb.Settings.ApiClients.Index do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        device_trust_enabled?={@device_trust_enabled?}
+        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -51,7 +51,7 @@ defmodule PortalWeb.Settings.Authentication do
     socket =
       assign(socket,
         page_title: "Authentication",
-        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?(),
+        trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?(),
         device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
       )
 
@@ -621,7 +621,7 @@ defmodule PortalWeb.Settings.Authentication do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        device_trust_enabled?={@device_trust_enabled?}
+        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 

--- a/elixir/lib/portal_web/live/settings/device_posture.ex
+++ b/elixir/lib/portal_web/live/settings/device_posture.ex
@@ -33,7 +33,7 @@ defmodule PortalWeb.Settings.DevicePosture do
      socket
      |> assign(
        page_title: "Device Posture",
-       device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?(),
+       trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?(),
        device_posture_enabled?: true,
        verification_error: nil,
        active_verification: nil,
@@ -394,7 +394,7 @@ defmodule PortalWeb.Settings.DevicePosture do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        device_trust_enabled?={@device_trust_enabled?}
+        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -47,7 +47,7 @@ defmodule PortalWeb.Settings.DirectorySync do
     socket =
       assign(socket,
         page_title: "Directory Sync",
-        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?(),
+        trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?(),
         device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
       )
 
@@ -566,7 +566,7 @@ defmodule PortalWeb.Settings.DirectorySync do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        device_trust_enabled?={@device_trust_enabled?}
+        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 

--- a/elixir/lib/portal_web/live/settings/dns.ex
+++ b/elixir/lib/portal_web/live/settings/dns.ex
@@ -10,7 +10,7 @@ defmodule PortalWeb.Settings.DNS do
       socket
       |> assign(page_title: "DNS")
       |> assign(dns_account: account)
-      |> assign(device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?())
+      |> assign(trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?())
       |> assign(device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?())
 
     {:ok, socket}
@@ -39,7 +39,7 @@ defmodule PortalWeb.Settings.DNS do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        device_trust_enabled?={@device_trust_enabled?}
+        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 

--- a/elixir/lib/portal_web/live/settings/log_sinks.ex
+++ b/elixir/lib/portal_web/live/settings/log_sinks.ex
@@ -73,7 +73,7 @@ defmodule PortalWeb.Settings.LogSinks do
         page_title: "Log Sinks",
         sentinel_setup_tab: "portal",
         s3_setup_tab: "console",
-        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?(),
+        trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?(),
         device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
       )
 
@@ -282,7 +282,7 @@ defmodule PortalWeb.Settings.LogSinks do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        device_trust_enabled?={@device_trust_enabled?}
+        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 

--- a/elixir/lib/portal_web/live/settings/notifications.ex
+++ b/elixir/lib/portal_web/live/settings/notifications.ex
@@ -7,7 +7,7 @@ defmodule PortalWeb.Settings.Notifications do
       assign(socket,
         page_title: "Notifications",
         form: to_form(build_changeset(socket.assigns.account)),
-        device_trust_enabled?: PortalWeb.NavigationComponents.device_trust_enabled?(),
+        trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?(),
         device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
       )
 
@@ -20,7 +20,7 @@ defmodule PortalWeb.Settings.Notifications do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        device_trust_enabled?={@device_trust_enabled?}
+        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 

--- a/elixir/lib/portal_web/live/settings/trust_anchors/index.ex
+++ b/elixir/lib/portal_web/live/settings/trust_anchors/index.ex
@@ -1,4 +1,4 @@
-defmodule PortalWeb.Settings.DeviceTrust.Index do
+defmodule PortalWeb.Settings.TrustAnchors.Index do
   use PortalWeb, :live_view
 
   import Ecto.Changeset, only: [cast: 3, put_change: 3, add_error: 3, get_field: 3]
@@ -128,14 +128,14 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
   end
 
   def mount(_params, _session, socket) do
-    device_trust_enabled? = PortalWeb.NavigationComponents.device_trust_enabled?()
+    trust_anchors_enabled? = PortalWeb.NavigationComponents.trust_anchors_enabled?()
 
-    if device_trust_enabled? do
+    if trust_anchors_enabled? do
       trust_anchors = Database.list_trust_anchors(socket.assigns.subject)
 
       socket =
         socket
-        |> assign(page_title: "Device Trust")
+        |> assign(page_title: "Trust Anchors")
         |> assign(trust_anchors: trust_anchors)
         |> assign_revocation_health(trust_anchors)
         |> assign(selected_trust_anchor: nil)
@@ -143,7 +143,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
         |> assign(confirm_delete?: false)
         |> assign(revocation: [])
         |> assign(panel_tab: :overview, expanded_endpoint: nil)
-        |> assign(device_trust_enabled?: device_trust_enabled?)
+        |> assign(trust_anchors_enabled?: trust_anchors_enabled?)
         |> assign(device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?())
         |> allow_upload(:cert_file,
           accept: ~w(.pem .crt .cer .der .txt),
@@ -214,7 +214,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        device_trust_enabled?={@device_trust_enabled?}
+        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 
@@ -228,7 +228,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
           </div>
           <div class="flex items-center gap-2">
             <.link
-              patch={~p"/#{@account}/settings/device_trust/new"}
+              patch={~p"/#{@account}/settings/trust_anchors/new"}
               class="flex items-center gap-1 px-2.5 py-1 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
             >
               <.icon name="ri-add-line" class="w-3 h-3" /> Add
@@ -250,7 +250,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
                   </p>
                 </div>
                 <.link
-                  patch={~p"/#{@account}/settings/device_trust/new"}
+                  patch={~p"/#{@account}/settings/trust_anchors/new"}
                   class="flex items-center gap-1 px-2.5 py-1 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
                 >
                   <.icon name="ri-add-line" class="w-3 h-3" /> Add a trust anchor
@@ -591,7 +591,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
           </div>
           <div class="flex items-center gap-1.5 shrink-0">
             <.link
-              patch={~p"/#{@account}/settings/device_trust/#{@trust_anchor.id}/edit"}
+              patch={~p"/#{@account}/settings/trust_anchors/#{@trust_anchor.id}/edit"}
               class="flex items-center gap-1 px-2.5 py-1 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
             >
               <.icon name="ri-pencil-line" class="w-3.5 h-3.5" /> Edit
@@ -922,7 +922,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
   end
 
   def handle_event("close_panel", _params, socket) do
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/settings/device_trust")}
+    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/settings/trust_anchors")}
   end
 
   def handle_event(
@@ -931,7 +931,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
         %{assigns: %{live_action: action}} = socket
       )
       when action in [:new, :edit, :show] do
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/settings/device_trust")}
+    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/settings/trust_anchors")}
   end
 
   def handle_event("handle_keydown", _params, socket) do
@@ -940,7 +940,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
 
   def handle_event("select_trust_anchor", %{"id" => id}, socket) do
     {:noreply,
-     push_patch(socket, to: ~p"/#{socket.assigns.account}/settings/device_trust/#{id}")}
+     push_patch(socket, to: ~p"/#{socket.assigns.account}/settings/trust_anchors/#{id}")}
   end
 
   def handle_event("cancel_upload", %{"ref" => ref}, socket) do
@@ -971,7 +971,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
           socket
           |> assign(trust_anchors: Database.list_trust_anchors(socket.assigns.subject))
           |> put_flash(:success, "Trust anchor created successfully")
-          |> push_patch(to: ~p"/#{socket.assigns.account}/settings/device_trust")
+          |> push_patch(to: ~p"/#{socket.assigns.account}/settings/trust_anchors")
 
         {:noreply, socket}
 
@@ -1010,7 +1010,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
           |> assign(trust_anchors: trust_anchors)
           |> assign_revocation_health(trust_anchors)
           |> put_flash(:success, "Trust anchor updated successfully")
-          |> push_patch(to: ~p"/#{socket.assigns.account}/settings/device_trust")
+          |> push_patch(to: ~p"/#{socket.assigns.account}/settings/trust_anchors")
 
         {:noreply, socket}
 
@@ -1036,7 +1036,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
           socket
           |> assign(trust_anchors: Database.list_trust_anchors(socket.assigns.subject))
           |> put_flash(:success, "Trust anchor deleted successfully")
-          |> push_patch(to: ~p"/#{socket.assigns.account}/settings/device_trust")
+          |> push_patch(to: ~p"/#{socket.assigns.account}/settings/trust_anchors")
 
         {:noreply, socket}
 
@@ -1056,7 +1056,7 @@ defmodule PortalWeb.Settings.DeviceTrust.Index do
       socket =
         socket
         |> assign(trust_anchors: Database.list_trust_anchors(socket.assigns.subject))
-        |> push_patch(to: ~p"/#{socket.assigns.account}/settings/device_trust")
+        |> push_patch(to: ~p"/#{socket.assigns.account}/settings/trust_anchors")
 
       {:noreply, socket}
   end

--- a/elixir/lib/portal_web/router.ex
+++ b/elixir/lib/portal_web/router.ex
@@ -319,7 +319,7 @@ defmodule PortalWeb.Router do
           live "/edit", DNS, :edit
         end
 
-        scope "/device_trust", DeviceTrust do
+        scope "/trust_anchors", TrustAnchors do
           live "/", Index
           live "/new", Index, :new
           live "/:id/edit", Index, :edit

--- a/elixir/priv/repo/migrations/20260817000000_rename_device_trust_feature_to_trust_anchors.exs
+++ b/elixir/priv/repo/migrations/20260817000000_rename_device_trust_feature_to_trust_anchors.exs
@@ -1,0 +1,10 @@
+defmodule Portal.Repo.Migrations.RenameDeviceTrustFeatureToTrustAnchors do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      "UPDATE features SET feature = 'trust_anchors' WHERE feature = 'device_trust'",
+      "UPDATE features SET feature = 'device_trust' WHERE feature = 'trust_anchors'"
+    )
+  end
+end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -949,7 +949,7 @@ defmodule Portal.Repo.Seeds do
     Repo.query!(
       """
       INSERT INTO features (feature, enabled)
-      VALUES ('device_trust', true), ('device_posture', true)
+      VALUES ('trust_anchors', true), ('device_posture', true)
       ON CONFLICT (feature) DO UPDATE SET enabled = true
       """
     )

--- a/elixir/test/portal/crl/scheduler_test.exs
+++ b/elixir/test/portal/crl/scheduler_test.exs
@@ -9,11 +9,11 @@ defmodule Portal.Crl.SchedulerTest do
   alias Portal.Crypto.X509
 
   setup do
-    enable_feature(:device_trust)
+    enable_feature(:trust_anchors)
     %{account: account_fixture(), pki: pki()}
   end
 
-  describe "perform/1 when the device_trust feature is off" do
+  describe "perform/1 when the trust_anchors feature is off" do
     test "nothing is queued, so endpoints are left exactly as they are", %{
       account: account,
       pki: pki

--- a/elixir/test/portal/crl/sync_test.exs
+++ b/elixir/test/portal/crl/sync_test.exs
@@ -17,7 +17,7 @@ defmodule Portal.Crl.SyncTest do
 
   setup do
     account = account_fixture()
-    enable_feature(:device_trust)
+    enable_feature(:trust_anchors)
     pki = pki()
     trust_anchor_fixture(account: account, certs: [pki.ca_der])
 

--- a/elixir/test/portal/features_test.exs
+++ b/elixir/test/portal/features_test.exs
@@ -3,7 +3,7 @@ defmodule Portal.FeaturesTest do
 
   import Portal.FeaturesFixtures
 
-  for feature <- [:device_trust, :device_posture] do
+  for feature <- [:trust_anchors, :device_posture] do
     test "enabled?/1 reads the #{feature} global rollout flag" do
       disable_feature(unquote(feature))
       refute Portal.Features.enabled?(unquote(feature))

--- a/elixir/test/portal/ocsp/sync_test.exs
+++ b/elixir/test/portal/ocsp/sync_test.exs
@@ -14,7 +14,7 @@ defmodule Portal.Ocsp.SyncTest do
 
   setup do
     account = account_fixture()
-    enable_feature(:device_trust)
+    enable_feature(:trust_anchors)
     pki = pki()
     trust_anchor_fixture(account: account, certs: [pki.ca_der])
 

--- a/elixir/test/portal_api/client/device_trust_test.exs
+++ b/elixir/test/portal_api/client/device_trust_test.exs
@@ -28,7 +28,7 @@ defmodule PortalAPI.Client.DeviceTrustTest do
       subject: subject,
       pki: pki
     } do
-      enable_feature(:device_trust)
+      enable_feature(:trust_anchors)
       trust_anchor_fixture(account: account, certs: [pki.ca_der])
 
       assert DeviceTrust.attest(connect_info(leaf(pki, :rsa)), subject) ==
@@ -52,14 +52,14 @@ defmodule PortalAPI.Client.DeviceTrustTest do
       pki: pki
     } do
       configure_attestation_host()
-      enable_feature(:device_trust)
+      enable_feature(:trust_anchors)
 
       assert DeviceTrust.attest(connect_info(leaf(pki, :rsa)), subject) ==
                {:error, :no_trust_anchors}
     end
   end
 
-  describe "attest/2 when the device_trust feature is off" do
+  describe "attest/2 when the trust_anchors feature is off" do
     setup do
       configure_attestation_host()
       start_revocation_endpoint_queue()
@@ -98,7 +98,7 @@ defmodule PortalAPI.Client.DeviceTrustTest do
       start_revocation_endpoint_queue()
 
       account = account_fixture()
-      enable_feature(:device_trust)
+      enable_feature(:trust_anchors)
       pki = pki()
       trust_anchor_fixture(account: account, certs: [pki.ca_der])
       subject = subject_fixture(account: account)

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -500,7 +500,7 @@ defmodule PortalAPI.Client.SocketTest do
       Portal.Config.put_env_override(:portal, :mtls_external_url, "https://mtls.firezone.test/")
 
       account = account_fixture()
-      enable_feature(:device_trust)
+      enable_feature(:trust_anchors)
       pki = pki()
       trust_anchor_fixture(account: account, certs: [pki.ca_der])
 

--- a/elixir/test/portal_web/components/navigation_components_test.exs
+++ b/elixir/test/portal_web/components/navigation_components_test.exs
@@ -40,35 +40,35 @@ defmodule PortalWeb.NavigationComponentsTest do
     end
   end
 
-  describe "settings_nav device trust tab" do
-    test "hidden when device_trust feature is disabled", %{
+  describe "settings_nav trust anchors tab" do
+    test "hidden when trust_anchors feature is disabled", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      disable_feature(:device_trust)
+      disable_feature(:trust_anchors)
 
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/account")
 
-      refute html =~ "Device Trust"
+      refute html =~ "Trust Anchors"
     end
 
-    test "shown when device_trust feature is enabled", %{
+    test "shown when trust_anchors feature is enabled", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      enable_feature(:device_trust)
+      enable_feature(:trust_anchors)
 
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/account")
 
-      assert html =~ "Device Trust"
+      assert html =~ "Trust Anchors"
     end
   end
 end

--- a/elixir/test/portal_web/live/settings/trust_anchors/index_test.exs
+++ b/elixir/test/portal_web/live/settings/trust_anchors/index_test.exs
@@ -1,4 +1,4 @@
-defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
+defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
   use PortalWeb.ConnCase, async: true
 
   import Portal.AccountFixtures
@@ -64,13 +64,13 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
   setup do
     account = account_fixture()
     actor = admin_actor_fixture(account: account)
-    enable_feature(:device_trust)
+    enable_feature(:trust_anchors)
     %{account: account, actor: actor}
   end
 
   describe "unauthorized" do
     test "redirects to sign-in when not authenticated", %{conn: conn, account: account} do
-      path = ~p"/#{account}/settings/device_trust"
+      path = ~p"/#{account}/settings/trust_anchors"
 
       assert live(conn, path) ==
                {:error,
@@ -83,17 +83,17 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
   end
 
   describe "index (default action)" do
-    test "redirects to account settings when device_trust feature is disabled", %{
+    test "redirects to account settings when trust_anchors feature is disabled", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      disable_feature(:device_trust)
+      disable_feature(:trust_anchors)
 
       assert {:error, {:live_redirect, %{to: to}}} =
                conn
                |> authorize_conn(actor)
-               |> live(~p"/#{account}/settings/device_trust")
+               |> live(~p"/#{account}/settings/trust_anchors")
 
       assert to == ~p"/#{account}/settings/account"
     end
@@ -106,7 +106,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust")
+        |> live(~p"/#{account}/settings/trust_anchors")
 
       assert html =~ "Trust Anchors"
       assert html =~ "No trust anchors yet"
@@ -118,7 +118,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust")
+        |> live(~p"/#{account}/settings/trust_anchors")
 
       assert html =~ "Corporate Issuing CA"
       assert html =~ "1 certificate"
@@ -140,13 +140,13 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
 
       {:ok, _lv, index_html} =
         conn
-        |> live(~p"/#{account}/settings/device_trust")
+        |> live(~p"/#{account}/settings/trust_anchors")
 
       assert timestamp_popovers(index_html) == [DateTime.to_iso8601(inserted_at)]
 
       {:ok, _lv, show_html} =
         conn
-        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
 
       assert timestamp_popovers(show_html) == [
                DateTime.to_iso8601(inserted_at),
@@ -171,7 +171,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust")
+        |> live(~p"/#{account}/settings/trust_anchors")
 
       refute html =~ "Company Issuing CA"
 
@@ -180,7 +180,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
         |> element("tr[phx-click='select_trust_anchor'][phx-value-id='#{trust_anchor.id}']")
         |> render_click()
 
-      assert_patch(lv, ~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
+      assert_patch(lv, ~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
       refute html =~ "Company Issuing CA"
 
       html = open_certificates_tab(lv)
@@ -189,7 +189,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       assert html =~ Base.encode16(:crypto.hash(:sha256, sample_cert_der()), case: :lower)
 
       render_click(lv, "close_panel")
-      assert_patch(lv, ~p"/#{account}/settings/device_trust")
+      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
       refute render(lv) =~ "Company Issuing CA"
     end
 
@@ -208,7 +208,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
 
       html = open_certificates_tab(lv)
 
@@ -247,10 +247,10 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
 
       render_keydown(lv, "handle_keydown", %{"key" => "Escape"})
-      assert_patch(lv, ~p"/#{account}/settings/device_trust")
+      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
     end
 
     test "Edit button navigates to the edit form", %{conn: conn, account: account, actor: actor} do
@@ -259,15 +259,15 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
 
       lv
       |> element(
-        "a[href='#{~p"/#{account}/settings/device_trust/#{trust_anchor.id}/edit"}']"
+        "a[href='#{~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}/edit"}']"
       )
       |> render_click()
 
-      assert_patch(lv, ~p"/#{account}/settings/device_trust/#{trust_anchor.id}/edit")
+      assert_patch(lv, ~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}/edit")
       assert render(lv) =~ "Edit Trust Anchor"
     end
   end
@@ -289,7 +289,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
 
       assert open_revocation_tab(lv) =~ "No revocation endpoint known yet"
     end
@@ -307,7 +307,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
 
       assert open_revocation_tab(lv) =~ "CN=EC Trust Anchor CA"
 
@@ -330,7 +330,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
 
       open_revocation_tab(lv)
       assert expand_first_endpoint(lv) =~ "unsupported_url_scheme"
@@ -362,7 +362,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
 
       open_revocation_tab(lv)
       popovers = lv |> expand_first_endpoint() |> timestamp_popovers()
@@ -404,7 +404,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
 
       assert open_revocation_tab(lv) =~ "OCSP"
 
@@ -426,7 +426,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
 
       assert open_revocation_tab(lv) =~ "No revocation endpoint known yet"
     end
@@ -453,7 +453,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust")
+        |> live(~p"/#{account}/settings/trust_anchors")
 
       assert html =~ "ri-error-warning-fill"
       assert html =~ "having trouble reaching"
@@ -476,7 +476,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust")
+        |> live(~p"/#{account}/settings/trust_anchors")
 
       assert html =~ "ri-error-warning-fill"
       assert html =~ "not being checked"
@@ -493,7 +493,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust")
+        |> live(~p"/#{account}/settings/trust_anchors")
 
       refute html =~ "ri-error-warning-fill"
     end
@@ -516,7 +516,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}/edit")
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}/edit")
 
       lv
       |> form("#trust-anchor-edit-form",
@@ -537,29 +537,29 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/new")
+        |> live(~p"/#{account}/settings/trust_anchors/new")
 
       assert html =~ "New Trust Anchor"
 
       render_click(lv, "close_panel")
-      assert_patch(lv, ~p"/#{account}/settings/device_trust")
+      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
     end
 
     test "closes creation panel on escape", %{conn: conn, account: account, actor: actor} do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/new")
+        |> live(~p"/#{account}/settings/trust_anchors/new")
 
       render_keydown(lv, "handle_keydown", %{"key" => "Escape"})
-      assert_patch(lv, ~p"/#{account}/settings/device_trust")
+      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
     end
 
     test "validates required fields", %{conn: conn, account: account, actor: actor} do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/new")
+        |> live(~p"/#{account}/settings/trust_anchors/new")
 
       html =
         lv
@@ -581,7 +581,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/new")
+        |> live(~p"/#{account}/settings/trust_anchors/new")
 
       html =
         lv
@@ -611,7 +611,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/new")
+        |> live(~p"/#{account}/settings/trust_anchors/new")
 
       html =
         lv
@@ -630,7 +630,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/new")
+        |> live(~p"/#{account}/settings/trust_anchors/new")
 
       html =
         lv
@@ -650,7 +650,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/new")
+        |> live(~p"/#{account}/settings/trust_anchors/new")
 
       html =
         lv
@@ -666,7 +666,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/new")
+        |> live(~p"/#{account}/settings/trust_anchors/new")
 
       html =
         lv
@@ -676,7 +676,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
         |> render_submit()
 
       assert html =~ "Trust anchor created successfully"
-      assert_patch(lv, ~p"/#{account}/settings/device_trust")
+      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
       assert render(lv) =~ "Pasted CA"
 
       assert trust_anchor = Repo.get_by(TrustAnchor, account_id: account.id, name: "Pasted CA")
@@ -692,7 +692,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/new")
+        |> live(~p"/#{account}/settings/trust_anchors/new")
 
       html =
         lv
@@ -721,7 +721,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/new")
+        |> live(~p"/#{account}/settings/trust_anchors/new")
 
       html =
         lv
@@ -738,7 +738,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/new")
+        |> live(~p"/#{account}/settings/trust_anchors/new")
 
       render_change(lv, "validate_new", %{
         "trust_anchor" => %{"name" => "Uploaded CA", "input_mode" => "upload"}
@@ -761,7 +761,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
         })
 
       assert html =~ "Trust anchor created successfully"
-      assert_patch(lv, ~p"/#{account}/settings/device_trust")
+      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
       assert render(lv) =~ "Uploaded CA"
 
       assert trust_anchor = Repo.get_by(TrustAnchor, account_id: account.id, name: "Uploaded CA")
@@ -777,7 +777,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/new")
+        |> live(~p"/#{account}/settings/trust_anchors/new")
 
       render_change(lv, "validate_new", %{
         "trust_anchor" => %{"name" => "Multi-file CA", "input_mode" => "upload"}
@@ -807,7 +807,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
         })
 
       assert html =~ "Trust anchor created successfully"
-      assert_patch(lv, ~p"/#{account}/settings/device_trust")
+      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
       assert render(lv) =~ "Multi-file CA"
 
       assert trust_anchor =
@@ -826,7 +826,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/new")
+        |> live(~p"/#{account}/settings/trust_anchors/new")
 
       render_change(lv, "validate_new", %{
         "trust_anchor" => %{"name" => "No File CA", "input_mode" => "upload"}
@@ -850,7 +850,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}/edit")
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}/edit")
 
       assert html =~ "Edit Trust Anchor"
       assert html =~ "Editable CA"
@@ -865,7 +865,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       assert der == sample_cert_der()
 
       render_click(lv, "close_panel")
-      assert_patch(lv, ~p"/#{account}/settings/device_trust")
+      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
     end
 
     test "updates trust anchor on submit", %{conn: conn, account: account, actor: actor} do
@@ -874,7 +874,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}/edit")
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}/edit")
 
       html =
         lv
@@ -884,7 +884,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
         |> render_submit()
 
       assert html =~ "Trust anchor updated successfully"
-      assert_patch(lv, ~p"/#{account}/settings/device_trust")
+      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
       assert render(lv) =~ "New Name"
 
       assert updated = Repo.get_by(TrustAnchor, account_id: account.id, id: trust_anchor.id)
@@ -903,14 +903,14 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
 
       render_click(lv, "confirm_delete_trust_anchor")
       assert render(lv) =~ "Delete this trust anchor?"
 
       render_click(lv, "delete_trust_anchor")
 
-      assert_patch(lv, ~p"/#{account}/settings/device_trust")
+      assert_patch(lv, ~p"/#{account}/settings/trust_anchors")
       refute render(lv) =~ "Deletable CA"
       refute Repo.get_by(TrustAnchor, account_id: account.id, id: trust_anchor.id)
     end
@@ -925,7 +925,7 @@ defmodule PortalWeb.Settings.DeviceTrust.IndexTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/device_trust/#{trust_anchor.id}")
+        |> live(~p"/#{account}/settings/trust_anchors/#{trust_anchor.id}")
 
       Repo.delete!(trust_anchor)
 


### PR DESCRIPTION
The settings page that holds CA certificates was renamed to "Device Trust" a few weeks ago. That name was too broad. The page only stores trust anchors, which validate an upcoming feature, so the tab is called "Trust Anchors" again. It lives at `/settings/trust_anchors`, and the global flag is `trust_anchors` again. A migration renames the row in the `features` table.

Device attestation keeps the "device trust" name. When a client connects and we read its MDM device id, serial, and UUID, that is still device trust and nothing there changed.

Related: #14640
