### PR TITLE
feat(portal): add X.509 authentication provider

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -125,7 +125,7 @@ openssl req -x509 -newkey rsa:2048 -nodes -sha256 -days 365 \
     -keyout priv/cert/selfsigned-key.pem \
     -out priv/cert/selfsigned.pem \
     -subj "/O=Firezone Development/CN=localhost" \
-    -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
+    -addext "subjectAltName=DNS:localhost,DNS:host.docker.internal,IP:127.0.0.1" \
     -addext "basicConstraints=critical,CA:FALSE" \
     -addext "keyUsage=critical,digitalSignature,keyEncipherment" \
     -addext "extendedKeyUsage=critical,serverAuth"

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -43,7 +43,7 @@ Inside the `/elixir` directory run the following commands:
 The web and API endpoints should now be running:
 
 - Web -> https://localhost:13443/
-- API -> ws://localhost:13001/
+- API -> wss://localhost:13001/
 
 ### Stripe integration for local development
 

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -94,6 +94,7 @@ config :portal, Portal.ChangeLogs.Consumer,
     oidc_auth_providers
     email_otp_auth_providers
     userpass_auth_providers
+    x509_auth_providers
     entra_directories
     okta_directories
     google_directories
@@ -160,6 +161,7 @@ config :portal, Portal.Changes.Consumer,
     oidc_auth_providers
     email_otp_auth_providers
     userpass_auth_providers
+    x509_auth_providers
     entra_directories
     okta_directories
     google_directories

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -4,6 +4,8 @@ import Config
 web_port = System.get_env("PHOENIX_WEB_PORT", "13443") |> String.to_integer()
 api_port = System.get_env("PHOENIX_API_PORT", "13001") |> String.to_integer()
 ops_port = System.get_env("PHOENIX_OPS_PORT", "13002") |> String.to_integer()
+certfile_path = System.get_env("CERTFILE_PATH", "priv/cert/selfsigned.pem")
+keyfile_path = System.get_env("KEYFILE_PATH", "priv/cert/selfsigned_key.pem")
 
 # DATABASE_SSL can be "true", "false", or a JSON object with SSL options
 db_ssl =
@@ -198,8 +200,8 @@ config :portal, PortalWeb.Endpoint,
   url: [scheme: "https", host: "localhost", port: web_port],
   https: [
     port: web_port,
-    certfile: System.get_env("CERTFILE_PATH", "priv/cert/selfsigned.pem"),
-    keyfile: System.get_env("KEYFILE_PATH", "priv/cert/selfsigned_key.pem")
+    certfile: certfile_path,
+    keyfile: keyfile_path
   ],
   code_reloader: true,
   debug_errors: true,
@@ -229,7 +231,8 @@ config :portal, PortalWeb.Endpoint,
   server: true
 
 config :portal,
-  api_external_url: "http://localhost:#{api_port}"
+  api_external_url: "https://localhost:#{api_port}",
+  mtls_external_url: "https://localhost:#{api_port}"
 
 config :phoenix_live_reload, :dirs, [File.cwd!()]
 
@@ -257,14 +260,31 @@ config :portal, PortalWeb.Plugs.PutSecurityHeaders,
 
 # Note: on Linux you may need to add `--add-host=host.docker.internal:host-gateway`
 # to the `docker run` command. Works on Docker v20.10 and above.
-config :portal, api_url_override: "ws://host.docker.internal:#{api_port}/"
+config :portal, api_url_override: "wss://host.docker.internal:#{api_port}/"
 
 ###############################
 ##### PortalAPI Endpoint ######
 ###############################
 
 config :portal, PortalAPI.Endpoint,
-  http: [port: api_port],
+  url: [scheme: "https", host: "localhost", port: api_port],
+  https: [
+    port: api_port,
+    certfile: certfile_path,
+    keyfile: keyfile_path,
+    thousand_island_options: [
+      transport_options: [
+        # Request a client certificate when one is available, but retain support
+        # for token-authenticated clients. The application validates a presented
+        # leaf against the account's trust anchors after the WebSocket upgrade.
+        verify: :verify_peer,
+        fail_if_no_peer_cert: false,
+        certificate_authorities: false,
+        cacerts: [],
+        verify_fun: {&Portal.TLS.verify_client_certificate/3, nil}
+      ]
+    ]
+  ],
   debug_errors: true,
   code_reloader: true,
   check_origin: ["//10.0.0.107", "//10.0.2.2", "//127.0.0.1", "//localhost"],

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -3,6 +3,7 @@ import Config
 # Local vars
 web_port = System.get_env("PHOENIX_WEB_PORT", "13443") |> String.to_integer()
 api_port = System.get_env("PHOENIX_API_PORT", "13001") |> String.to_integer()
+mtls_port = System.get_env("PHOENIX_MTLS_PORT", "13003") |> String.to_integer()
 ops_port = System.get_env("PHOENIX_OPS_PORT", "13002") |> String.to_integer()
 certfile_path = System.get_env("CERTFILE_PATH", "priv/cert/selfsigned.pem")
 keyfile_path = System.get_env("KEYFILE_PATH", "priv/cert/selfsigned_key.pem")
@@ -232,7 +233,7 @@ config :portal, PortalWeb.Endpoint,
 
 config :portal,
   api_external_url: "https://localhost:#{api_port}",
-  mtls_external_url: "https://localhost:#{api_port}"
+  mtls_external_url: "https://localhost:#{mtls_port}"
 
 config :phoenix_live_reload, :dirs, [File.cwd!()]
 
@@ -263,6 +264,30 @@ config :portal, PortalWeb.Plugs.PutSecurityHeaders,
 config :portal, api_url_override: "wss://host.docker.internal:#{api_port}/"
 
 ###############################
+##### Public Endpoint #########
+###############################
+
+# Keep mutual TLS on a dedicated listener so the ordinary API endpoint cannot
+# accidentally be treated as the mTLS endpoint during local development.
+config :portal, Portal.Endpoint,
+  url: [scheme: "https", host: "localhost", port: mtls_port],
+  https: [
+    port: mtls_port,
+    certfile: certfile_path,
+    keyfile: keyfile_path,
+    thousand_island_options: [
+      transport_options: [
+        verify: :verify_peer,
+        fail_if_no_peer_cert: true,
+        certificate_authorities: false,
+        cacerts: [],
+        verify_fun: {&Portal.TLS.verify_client_certificate/3, nil}
+      ]
+    ]
+  ],
+  server: true
+
+###############################
 ##### PortalAPI Endpoint ######
 ###############################
 
@@ -271,19 +296,7 @@ config :portal, PortalAPI.Endpoint,
   https: [
     port: api_port,
     certfile: certfile_path,
-    keyfile: keyfile_path,
-    thousand_island_options: [
-      transport_options: [
-        # Request a client certificate when one is available, but retain support
-        # for token-authenticated clients. The application validates a presented
-        # leaf against the account's trust anchors after the WebSocket upgrade.
-        verify: :verify_peer,
-        fail_if_no_peer_cert: false,
-        certificate_authorities: false,
-        cacerts: [],
-        verify_fun: {&Portal.TLS.verify_client_certificate/3, nil}
-      ]
-    ]
+    keyfile: keyfile_path
   ],
   debug_errors: true,
   code_reloader: true,

--- a/elixir/lib/portal/account.ex
+++ b/elixir/lib/portal/account.ex
@@ -68,6 +68,7 @@ defmodule Portal.Account do
     has_many :oidc_auth_providers, Portal.OIDC.AuthProvider
     has_one :email_otp_auth_provider, Portal.EmailOTP.AuthProvider
     has_one :userpass_auth_provider, Portal.Userpass.AuthProvider
+    has_one :x509_auth_provider, Portal.X509.AuthProvider
 
     # Billing limit exceeded flags - set by CheckAccountLimits worker and Stripe event processing
     field :users_limit_exceeded, :boolean, default: false

--- a/elixir/lib/portal/actor.ex
+++ b/elixir/lib/portal/actor.ex
@@ -2,6 +2,7 @@ defmodule Portal.Actor do
   use Ecto.Schema
   import Ecto.Changeset
   import Portal.Changeset
+  alias Portal.Email
 
   @primary_key false
   @foreign_key_type :binary_id
@@ -67,31 +68,6 @@ defmodule Portal.Actor do
     end
   end
 
-  @doc """
-  Normalizes an email address for storage or comparison.
-
-  Whitespace around each component is removed and the domain is lowercased
-  and IDNA-encoded. The local part retains its case; case-insensitive matching
-  is enforced by the `citext` database column.
-  """
-  @spec normalize_email(String.t()) :: {:ok, String.t()} | :error
-  def normalize_email(email) when is_binary(email) do
-    case String.split(email, "@", parts: 2) do
-      [local, domain] ->
-        local = String.trim(local)
-        domain = domain |> String.trim() |> String.downcase()
-
-        case try_encode_domain(domain) do
-          {:ok, punycode_domain} -> {:ok, local <> "@" <> to_string(punycode_domain)}
-          _error -> :error
-        end
-
-      # No @ sign, return as-is (will be caught by validate_email)
-      _ ->
-        {:ok, String.trim(email)}
-    end
-  end
-
   defp validate_type_transition(changeset) do
     old_type = changeset.data.type
     new_type = get_change(changeset, :type)
@@ -120,8 +96,12 @@ defmodule Portal.Actor do
 
   defp normalize_for_compare(nil), do: ""
 
-  defp normalize_for_compare(value) when is_binary(value),
-    do: value |> String.trim() |> String.downcase()
+  defp normalize_for_compare(value) when is_binary(value) do
+    case Email.normalize_for_match(value) do
+      {:ok, email} -> email
+      :error -> value |> String.trim() |> String.downcase()
+    end
+  end
 
   defp normalize_email(changeset, field) do
     update_change(changeset, field, fn
@@ -129,7 +109,7 @@ defmodule Portal.Actor do
         nil
 
       email when is_binary(email) ->
-        case normalize_email(email) do
+        case Email.normalize(email) do
           {:ok, encoded} ->
             encoded
 

--- a/elixir/lib/portal/actor.ex
+++ b/elixir/lib/portal/actor.ex
@@ -67,6 +67,31 @@ defmodule Portal.Actor do
     end
   end
 
+  @doc """
+  Normalizes an email address for storage or comparison.
+
+  Whitespace around each component is removed and the domain is lowercased
+  and IDNA-encoded. The local part retains its case; case-insensitive matching
+  is enforced by the `citext` database column.
+  """
+  @spec normalize_email(String.t()) :: {:ok, String.t()} | :error
+  def normalize_email(email) when is_binary(email) do
+    case String.split(email, "@", parts: 2) do
+      [local, domain] ->
+        local = String.trim(local)
+        domain = domain |> String.trim() |> String.downcase()
+
+        case try_encode_domain(domain) do
+          {:ok, punycode_domain} -> {:ok, local <> "@" <> to_string(punycode_domain)}
+          _error -> :error
+        end
+
+      # No @ sign, return as-is (will be caught by validate_email)
+      _ ->
+        {:ok, String.trim(email)}
+    end
+  end
+
   defp validate_type_transition(changeset) do
     old_type = changeset.data.type
     new_type = get_change(changeset, :type)
@@ -104,7 +129,7 @@ defmodule Portal.Actor do
         nil
 
       email when is_binary(email) ->
-        case encode_email(email) do
+        case normalize_email(email) do
           {:ok, encoded} ->
             encoded
 
@@ -116,22 +141,5 @@ defmodule Portal.Actor do
       other ->
         other
     end)
-  end
-
-  defp encode_email(email) do
-    case String.split(email, "@", parts: 2) do
-      [local, domain] ->
-        local = String.trim(local)
-        domain = String.trim(domain) |> String.downcase()
-
-        case try_encode_domain(domain) do
-          {:ok, punycode_domain} -> {:ok, local <> "@" <> to_string(punycode_domain)}
-          _error -> :error
-        end
-
-      # No @ sign, return as-is (will be caught by validate_email)
-      _ ->
-        {:ok, email}
-    end
   end
 end

--- a/elixir/lib/portal/auth_provider.ex
+++ b/elixir/lib/portal/auth_provider.ex
@@ -12,13 +12,14 @@ defmodule Portal.AuthProvider do
     "entra" => Portal.Entra.AuthProvider,
     "oidc" => Portal.OIDC.AuthProvider,
     "email_otp" => Portal.EmailOTP.AuthProvider,
-    "userpass" => Portal.Userpass.AuthProvider
+    "userpass" => Portal.Userpass.AuthProvider,
+    "x509" => Portal.X509.AuthProvider
   }
 
   schema "auth_providers" do
     belongs_to :account, Portal.Account, primary_key: true
     field :id, :binary_id, primary_key: true
-    field :type, Ecto.Enum, values: ~w[google okta entra oidc email_otp userpass]a
+    field :type, Ecto.Enum, values: ~w[google okta entra oidc email_otp userpass x509]a
 
     has_one :email_otp_auth_provider, Portal.EmailOTP.AuthProvider,
       references: :id,
@@ -49,6 +50,11 @@ defmodule Portal.AuthProvider do
       references: :id,
       foreign_key: :id,
       where: [type: :oidc]
+
+    has_one :x509_auth_provider, Portal.X509.AuthProvider,
+      references: :id,
+      foreign_key: :id,
+      where: [type: :x509]
   end
 
   def module!(type) do
@@ -69,6 +75,10 @@ defmodule Portal.AuthProvider do
     |> validate_required(~w[type]a)
     |> assoc_constraint(:account)
     |> unique_constraint(:id, name: :auth_providers_pkey)
+    |> unique_constraint(:account_id,
+      name: :auth_providers_account_id_x509_index,
+      message: "already has an X.509 authentication provider"
+    )
     |> check_constraint(:type, name: :type_must_be_valid, message: "is not valid")
   end
 end

--- a/elixir/lib/portal/authentication/credential.ex
+++ b/elixir/lib/portal/authentication/credential.ex
@@ -2,12 +2,14 @@ defmodule Portal.Authentication.Credential do
   @moduledoc """
   Represents the authentication credential used to create a Subject.
 
-  The `type` field takes one of three values:
+  The `type` field takes one of four values:
   - `:api_token` - API tokens for api_client actors. `auth_provider_id` is always nil.
   - `:client_token` - Client tokens. `auth_provider_id` is set when the token was
     minted from an interactive sign-in flow (OIDC, Email/OTP, userpass) and nil
     when the token was issued directly by an admin (no sign-in flow).
   - `:portal_session` - Portal sessions for web users. `auth_provider_id` is always set.
+  - `:x509` - Ephemeral credentials authenticated by a client certificate. These
+    have an `auth_provider_id`, but no persisted client token.
   """
 
   @type api_token :: %__MODULE__{type: :api_token, id: Ecto.UUID.t()}
@@ -26,8 +28,18 @@ defmodule Portal.Authentication.Credential do
           auth_provider_id: Ecto.UUID.t()
         }
 
+  @type x509 :: %__MODULE__{
+          type: :x509,
+          id: Ecto.UUID.t(),
+          auth_provider_id: Ecto.UUID.t()
+        }
+
   @type t ::
-          api_token() | non_interactive_client_token() | interactive_client_token() | portal_session()
+          api_token()
+          | non_interactive_client_token()
+          | interactive_client_token()
+          | portal_session()
+          | x509()
 
   @enforce_keys [:type, :id]
   defstruct [:type, :id, :auth_provider_id]

--- a/elixir/lib/portal/billing/event_handler.ex
+++ b/elixir/lib/portal/billing/event_handler.ex
@@ -494,6 +494,7 @@ defmodule Portal.Billing.EventHandler do
 
     # Create email provider
     {:ok, _email_provider} = Database.create_email_provider(account)
+    {:ok, _x509_provider} = Database.create_x509_provider(account)
 
     # Create admin user
     email = metadata["account_admin_email"] || account_email
@@ -663,7 +664,8 @@ defmodule Portal.Billing.EventHandler do
       Account,
       AuthProvider,
       EmailOTP,
-      Safe
+      Safe,
+      X509
     }
 
     def with_customer_lock(customer_id, fun) do
@@ -695,6 +697,42 @@ defmodule Portal.Billing.EventHandler do
       with {:ok, _auth_provider} <- Safe.unscoped(auth_provider) |> Safe.insert(),
            {:ok, email_provider} <- Safe.unscoped(email_otp_provider) |> Safe.insert() do
         {:ok, email_provider}
+      end
+    end
+
+    # OTP 28 dialyzer is stricter about opaque types (MapSet) inside Ecto.Multi
+    @dialyzer {:no_opaque, create_x509_provider: 1}
+    def create_x509_provider(account) do
+      id = Ecto.UUID.generate()
+
+      parent_changeset =
+        cast(
+          %AuthProvider{},
+          %{account_id: account.id, id: id, type: :x509},
+          ~w[id account_id type]a
+        )
+
+      x509_changeset =
+        %X509.AuthProvider{}
+        |> cast(
+          %{
+            id: id,
+            account_id: account.id,
+            name: "X.509",
+            context: :clients_only,
+            is_disabled: true
+          },
+          ~w[id account_id name context is_disabled]a
+        )
+        |> X509.AuthProvider.changeset()
+
+      Ecto.Multi.new()
+      |> Ecto.Multi.insert(:auth_provider, parent_changeset)
+      |> Ecto.Multi.insert(:x509_provider, x509_changeset)
+      |> Safe.transact()
+      |> case do
+        {:ok, %{x509_provider: provider}} -> {:ok, provider}
+        {:error, _step, changeset, _changes} -> {:error, changeset}
       end
     end
 

--- a/elixir/lib/portal/change_logs/consumer.ex
+++ b/elixir/lib/portal/change_logs/consumer.ex
@@ -44,6 +44,7 @@ defmodule Portal.ChangeLogs.Consumer do
     "trust_anchor_certificates" => Portal.TrustAnchorCertificate,
     "trust_anchors" => Portal.TrustAnchor,
     "userpass_auth_providers" => Portal.Userpass.AuthProvider,
+    "x509_auth_providers" => Portal.X509.AuthProvider,
     "splunk_log_sinks" => Portal.Splunk.LogSink,
     "datadog_log_sinks" => Portal.Datadog.LogSink,
     "newrelic_log_sinks" => Portal.NewRelic.LogSink,

--- a/elixir/lib/portal/changes/consumer.ex
+++ b/elixir/lib/portal/changes/consumer.ex
@@ -35,6 +35,7 @@ defmodule Portal.Changes.Consumer do
     "oidc_auth_providers" => Hooks.AuthProviders,
     "email_otp_auth_providers" => Hooks.AuthProviders,
     "userpass_auth_providers" => Hooks.AuthProviders,
+    "x509_auth_providers" => Hooks.X509AuthProviders,
     "entra_directories" => Hooks.Directories,
     "okta_directories" => Hooks.Directories,
     "google_directories" => Hooks.Directories,

--- a/elixir/lib/portal/changes/hooks/x509_auth_providers.ex
+++ b/elixir/lib/portal/changes/hooks/x509_auth_providers.ex
@@ -1,0 +1,37 @@
+defmodule Portal.Changes.Hooks.X509AuthProviders do
+  @behaviour Portal.Changes.Hooks
+  alias Portal.{Changes.Change, PubSub}
+  alias Portal.X509.AuthProvider
+  import Portal.SchemaHelpers
+
+  @impl true
+  def on_insert(lsn, data) do
+    auth_provider = struct_from_params(AuthProvider, data)
+    change = %Change{lsn: lsn, op: :insert, struct: auth_provider}
+
+    PubSub.Changes.broadcast(auth_provider.account_id, :x509_auth_providers, change)
+  end
+
+  @impl true
+  def on_update(lsn, old_data, data) do
+    old_auth_provider = struct_from_params(AuthProvider, old_data)
+    auth_provider = struct_from_params(AuthProvider, data)
+
+    change = %Change{
+      lsn: lsn,
+      op: :update,
+      old_struct: old_auth_provider,
+      struct: auth_provider
+    }
+
+    PubSub.Changes.broadcast(auth_provider.account_id, :x509_auth_providers, change)
+  end
+
+  @impl true
+  def on_delete(lsn, old_data) do
+    auth_provider = struct_from_params(AuthProvider, old_data)
+    change = %Change{lsn: lsn, op: :delete, old_struct: auth_provider}
+
+    PubSub.Changes.broadcast(auth_provider.account_id, :x509_auth_providers, change)
+  end
+end

--- a/elixir/lib/portal/dev/account_population.ex
+++ b/elixir/lib/portal/dev/account_population.ex
@@ -16,6 +16,7 @@ defmodule Portal.Dev.AccountPopulation do
   alias Portal.Repo
   alias Portal.Resource
   alias Portal.Site
+  alias Portal.X509
 
   alias Portal.Authentication.{Context, Credential, Subject}
 
@@ -392,6 +393,7 @@ defmodule Portal.Dev.AccountPopulation do
 
     everyone_group = create_group(account, %{name: "Everyone", type: :managed})
     email_provider = create_email_provider(account)
+    _x509_provider = create_x509_provider(account)
 
     admin_actor =
       create_actor(account, :account_admin_user, "Admin 1", email_for(account.slug, "admin-1"))
@@ -868,6 +870,33 @@ defmodule Portal.Dev.AccountPopulation do
       [:id, :account_id, :name, :context]
     )
     |> EmailOTP.AuthProvider.changeset()
+    |> Repo.insert!()
+  end
+
+  defp create_x509_provider(account) do
+    provider_id = Ecto.UUID.generate()
+
+    %AuthProvider{}
+    |> cast(%{id: provider_id, account_id: account.id, type: :x509}, [
+      :id,
+      :account_id,
+      :type
+    ])
+    |> AuthProvider.changeset()
+    |> Repo.insert!()
+
+    %X509.AuthProvider{}
+    |> cast(
+      %{
+        id: provider_id,
+        account_id: account.id,
+        name: "X.509",
+        context: :clients_only,
+        is_disabled: true
+      },
+      [:id, :account_id, :name, :context, :is_disabled]
+    )
+    |> X509.AuthProvider.changeset()
     |> Repo.insert!()
   end
 

--- a/elixir/lib/portal/email.ex
+++ b/elixir/lib/portal/email.ex
@@ -1,0 +1,38 @@
+defmodule Portal.Email do
+  import Portal.Changeset, only: [try_encode_domain: 1]
+
+  @doc """
+  Normalizes an email address while preserving the local part's case.
+
+  Whitespace around each component is removed and the domain is lowercased
+  and IDNA-encoded. This only normalizes the address; callers that accept user
+  input must still validate it separately.
+  """
+  @spec normalize(String.t()) :: {:ok, String.t()} | :error
+  def normalize(email) when is_binary(email) do
+    case String.split(email, "@", parts: 2) do
+      [local, domain] ->
+        local = String.trim(local)
+        domain = domain |> String.trim() |> String.downcase()
+
+        case try_encode_domain(domain) do
+          {:ok, punycode_domain} -> {:ok, local <> "@" <> to_string(punycode_domain)}
+          _error -> :error
+        end
+
+      _ ->
+        {:ok, String.trim(email)}
+    end
+  end
+
+  @doc """
+  Normalizes an email address for case-insensitive matching.
+  """
+  @spec normalize_for_match(String.t()) :: {:ok, String.t()} | :error
+  def normalize_for_match(email) when is_binary(email) do
+    case normalize(email) do
+      {:ok, email} -> {:ok, String.downcase(email)}
+      :error -> :error
+    end
+  end
+end

--- a/elixir/lib/portal/email_suppression.ex
+++ b/elixir/lib/portal/email_suppression.ex
@@ -1,6 +1,7 @@
 defmodule Portal.EmailSuppression do
   use Ecto.Schema
   import Ecto.Changeset, only: [validate_required: 2, unique_constraint: 2]
+  alias Portal.Email
 
   @primary_key false
   @timestamps_opts [type: :utc_datetime_usec]
@@ -18,8 +19,9 @@ defmodule Portal.EmailSuppression do
   end
 
   def normalize_email(email) when is_binary(email) do
-    email
-    |> String.trim()
-    |> String.downcase()
+    case Email.normalize_for_match(email) do
+      {:ok, email} -> email
+      :error -> email |> String.trim() |> String.downcase()
+    end
   end
 end

--- a/elixir/lib/portal/endpoint.ex
+++ b/elixir/lib/portal/endpoint.ex
@@ -50,17 +50,21 @@ defmodule Portal.Endpoint do
 
   def dispatch(%Plug.Conn{} = conn, _opts) do
     host = String.downcase(conn.host)
+    origin = {host, conn.port}
     web_host = configured_host(:web_external_url)
-    mtls_host = configured_host(:mtls_external_url)
+    mtls_origin = configured_origin(:mtls_external_url)
 
     cond do
-      host == web_host ->
-        forward(conn, PortalWeb.Endpoint)
-
-      host == mtls_host and not websocket_upgrade?(conn) ->
+      origin == mtls_origin and not websocket_upgrade?(conn) ->
         conn
         |> Plug.Conn.send_resp(:not_found, "Not Found")
         |> Plug.Conn.halt()
+
+      origin == mtls_origin ->
+        forward(conn, PortalAPI.Endpoint)
+
+      host == web_host ->
+        forward(conn, PortalWeb.Endpoint)
 
       host in api_hosts() ->
         forward(conn, PortalAPI.Endpoint)
@@ -104,15 +108,22 @@ defmodule Portal.Endpoint do
   end
 
   defp api_hosts do
-    [:api_external_url, :rest_api_url, :flow_logs_api_url, :mtls_external_url]
+    [:api_external_url, :rest_api_url, :flow_logs_api_url]
     |> Enum.map(&configured_host/1)
     |> Enum.reject(&is_nil/1)
   end
 
   defp configured_host(key) do
+    case configured_origin(key) do
+      {host, _port} -> host
+      nil -> nil
+    end
+  end
+
+  defp configured_origin(key) do
     with url when is_binary(url) <- Portal.Config.get_env(:portal, key),
-         %URI{host: host} when is_binary(host) <- URI.parse(url) do
-      String.downcase(host)
+         %URI{host: host, port: port} when is_binary(host) and is_integer(port) <- URI.parse(url) do
+      {String.downcase(host), port}
     else
       _unconfigured -> nil
     end

--- a/elixir/lib/portal/pubsub.ex
+++ b/elixir/lib/portal/pubsub.ex
@@ -58,6 +58,7 @@ defmodule Portal.PubSub do
             | :resources
             | :sites
             | :static_device_pool_members
+            | :x509_auth_providers
 
     @spec subscribe(String.t()) :: :ok | {:error, term()}
     def subscribe(account_id) do

--- a/elixir/lib/portal/safe.ex
+++ b/elixir/lib/portal/safe.ex
@@ -874,6 +874,8 @@ defmodule Portal.Safe do
   def permit(:read, Portal.EmailOTP.AuthProvider, :api_client), do: :ok
   def permit(_action, Portal.Userpass.AuthProvider, :account_admin_user), do: :ok
   def permit(:read, Portal.Userpass.AuthProvider, :api_client), do: :ok
+  def permit(_action, Portal.X509.AuthProvider, :account_admin_user), do: :ok
+  def permit(:read, Portal.X509.AuthProvider, :api_client), do: :ok
   def permit(_action, Portal.Entra.Directory, :account_admin_user), do: :ok
   def permit(:read, Portal.Entra.Directory, :api_client), do: :ok
   def permit(_action, Portal.PostureProvider, :account_admin_user), do: :ok

--- a/elixir/lib/portal/x509/auth_provider.ex
+++ b/elixir/lib/portal/x509/auth_provider.ex
@@ -1,0 +1,41 @@
+defmodule Portal.X509.AuthProvider do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  @foreign_key_type :binary_id
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  @type t :: %__MODULE__{}
+
+  schema "x509_auth_providers" do
+    belongs_to :account, Portal.Account, primary_key: true
+    field :id, :binary_id, primary_key: true
+
+    belongs_to :auth_provider, Portal.AuthProvider,
+      foreign_key: :id,
+      define_field: false
+
+    field :name, :string
+
+    field :context, Ecto.Enum,
+      values: ~w[clients_only]a,
+      default: :clients_only
+
+    field :is_disabled, :boolean, read_after_writes: true, default: true
+
+    timestamps()
+  end
+
+  def changeset(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> validate_required([:name, :context])
+    |> assoc_constraint(:account)
+    |> assoc_constraint(:auth_provider)
+    |> unique_constraint(:account_id,
+      name: :x509_auth_providers_account_id_index,
+      message: "An X.509 authentication provider for this account already exists."
+    )
+    |> check_constraint(:context, name: :context_must_be_clients_only)
+  end
+end

--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -1840,6 +1840,67 @@ defmodule PortalAPI.Client.Channel.Shared do
   #### Handling changes from the domain ####
   ##########################################
 
+  # ACTORS
+
+  defp handle_change(
+         %Change{
+           op: :update,
+           old_struct: %Portal.Actor{id: actor_id, is_disabled: false},
+           struct: %Portal.Actor{id: actor_id, is_disabled: true}
+         },
+         %{assigns: %{subject: %{actor: %{id: actor_id}}}} = socket
+       ) do
+    handle_info(:disconnect, socket)
+  end
+
+  defp handle_change(
+         %Change{op: :delete, old_struct: %Portal.Actor{id: actor_id}},
+         %{assigns: %{subject: %{actor: %{id: actor_id}}}} = socket
+       ) do
+    handle_info(:disconnect, socket)
+  end
+
+  # X.509 AUTH PROVIDERS
+
+  defp handle_change(
+         %Change{
+           op: :update,
+           old_struct: %Portal.X509.AuthProvider{
+             id: auth_provider_id,
+             is_disabled: false
+           },
+           struct: %Portal.X509.AuthProvider{
+             id: auth_provider_id,
+             is_disabled: true
+           }
+         },
+         %{
+           assigns: %{
+             subject: %{
+               credential: %{type: :x509, auth_provider_id: auth_provider_id}
+             }
+           }
+         } = socket
+       ) do
+    handle_info(:disconnect, socket)
+  end
+
+  defp handle_change(
+         %Change{
+           op: :delete,
+           old_struct: %Portal.X509.AuthProvider{id: auth_provider_id}
+         },
+         %{
+           assigns: %{
+             subject: %{
+               credential: %{type: :x509, auth_provider_id: auth_provider_id}
+             }
+           }
+         } = socket
+       ) do
+    handle_info(:disconnect, socket)
+  end
+
   # ACCOUNTS
 
   defp handle_change(
@@ -2526,26 +2587,50 @@ defmodule PortalAPI.Client.Channel.Shared do
         :ok = PG.join(socket.assigns.subject.credential.id)
         socket = assign(socket, :pg_scope_pid, new_pid)
 
-        # Only enqueue + arm on the first successful registration; re-registrations
-        # after a PG scope crash share the same channel and session row.
-        if is_nil(current_pid) do
-          Portal.Queue.enqueue(
-            :client_session_queue,
-            session_attrs(
-              socket.assigns.client,
-              socket.assigns.session_ref,
-              socket.assigns.client.attested?
-            ),
-            metadata: %{
-              subject: Authentication.Subject.to_map(socket.assigns.subject),
-              timestamp: DateTime.utc_now()
-            }
-          )
-
-          {:noreply, arm_session_durability_timer(socket)}
+        # The account CDC subscription is already active. Checking current state
+        # after subscribing closes the connect race: an earlier disable is seen
+        # here, while a later one arrives through the CDC-derived broadcast.
+        if x509_session_enabled?(socket) do
+          register_session(socket, current_pid)
         else
-          {:noreply, socket}
+          handle_info(:disconnect, socket)
         end
+    end
+  end
+
+  defp x509_session_enabled?(%{
+         assigns: %{
+           subject: %{
+             actor: %{id: actor_id},
+             credential: %{type: :x509, auth_provider_id: auth_provider_id}
+           }
+         }
+       }) do
+    Database.x509_session_enabled?(auth_provider_id, actor_id)
+  end
+
+  defp x509_session_enabled?(_socket), do: true
+
+  # Only enqueue + arm on the first successful registration; re-registrations
+  # after a PG scope crash share the same channel and session row.
+  defp register_session(socket, current_pid) do
+    if is_nil(current_pid) do
+      Portal.Queue.enqueue(
+        :client_session_queue,
+        session_attrs(
+          socket.assigns.client,
+          socket.assigns.session_ref,
+          socket.assigns.client.attested?
+        ),
+        metadata: %{
+          subject: Authentication.Subject.to_map(socket.assigns.subject),
+          timestamp: DateTime.utc_now()
+        }
+      )
+
+      {:noreply, arm_session_durability_timer(socket)}
+    else
+      {:noreply, socket}
     end
   end
 
@@ -2647,6 +2732,19 @@ defmodule PortalAPI.Client.Channel.Shared do
 
   defmodule Database do
     import Ecto.Query, only: [from: 2]
+
+    def x509_session_enabled?(auth_provider_id, actor_id) do
+      from(auth_provider in Portal.X509.AuthProvider,
+        join: actor in Portal.Actor,
+        on: actor.account_id == auth_provider.account_id,
+        where: auth_provider.id == ^auth_provider_id,
+        where: auth_provider.is_disabled == false,
+        where: actor.id == ^actor_id,
+        where: actor.is_disabled == false
+      )
+      |> Portal.Safe.unscoped()
+      |> Portal.Safe.exists?()
+    end
 
     # Nothing else clears these when a channel stops, so a cut session would
     # otherwise leave its grants behind.

--- a/elixir/lib/portal_api/client/device_trust.ex
+++ b/elixir/lib/portal_api/client/device_trust.ex
@@ -3,7 +3,7 @@ defmodule PortalAPI.Client.DeviceTrust do
   Device attestation from the client certificate presented at connect.
 
   Clients holding an MDM-provisioned certificate connect over mutual TLS to
-  the dedicated `mtls_external_url` host. Phoenix terminates the handshake, so
+  the dedicated `mtls_external_url` origin. Phoenix terminates the handshake, so
   TLS has already proven the client holds the certificate's private key. Bandit
   exposes the leaf certificate as part of the connection's peer data.
 
@@ -316,11 +316,11 @@ defmodule PortalAPI.Client.DeviceTrust do
   ####################################
 
   # Checked before anything touches the database: a connect on the plain API
-  # host never pays for the anchor lookup.
+  # origin never pays for the anchor lookup.
   defp validate_attestation_host(connect_info) do
-    case attestation_host() do
+    case attestation_origin() do
       nil -> {:error, :not_attestation_host}
-      host -> validate_host(connect_info, host)
+      origin -> validate_origin(connect_info, origin)
     end
   end
 
@@ -348,24 +348,28 @@ defmodule PortalAPI.Client.DeviceTrust do
 
   defp presented_certificate(_connect_info), do: {:error, :no_certificate_presented}
 
-  defp attestation_host do
+  defp attestation_origin do
     with url when is_binary(url) <- Portal.Config.get_env(:portal, :mtls_external_url),
-         %URI{host: host} when is_binary(host) <- URI.parse(url) do
-      String.downcase(host)
+         %URI{host: host, port: port} when is_binary(host) and is_integer(port) <- URI.parse(url) do
+      {String.downcase(host), port}
     else
       _unconfigured -> nil
     end
   end
 
-  defp validate_host(%{uri: %URI{host: host}}, attestation_host) when is_binary(host) do
-    if String.downcase(host) == attestation_host do
+  defp validate_origin(
+         %{uri: %URI{host: host, port: port}},
+         {attestation_host, attestation_port}
+       )
+       when is_binary(host) and is_integer(port) do
+    if {String.downcase(host), port} == {attestation_host, attestation_port} do
       :ok
     else
       {:error, :not_attestation_host}
     end
   end
 
-  defp validate_host(_connect_info, _attestation_host), do: {:error, :not_attestation_host}
+  defp validate_origin(_connect_info, _attestation_origin), do: {:error, :not_attestation_host}
 
   defp decode_leaf(der) do
     case X509.decode_der_certificate(der, :otp) do

--- a/elixir/lib/portal_api/client/device_trust.ex
+++ b/elixir/lib/portal_api/client/device_trust.ex
@@ -21,6 +21,10 @@ defmodule PortalAPI.Client.DeviceTrust do
   that the holder has some certificate from the anchor CA, not which device
   it is, so it cannot attest anything.
 
+  X.509 client authentication also reads typed SAN URIs. It requires an
+  `account-id` and authenticates by `actor-id` when that claim is present,
+  otherwise falling back to the actor's normalized email.
+
   Reaching the portal through that host is the client stating it has a
   certificate to present, so failing to prove one there is fatal to the
   connect rather than a silent downgrade. Connects that arrive anywhere else
@@ -125,7 +129,7 @@ defmodule PortalAPI.Client.DeviceTrust do
           der: binary(),
           leaf: tuple(),
           account_id: Ecto.UUID.t(),
-          email: String.t()
+          identity: {:actor_id, Ecto.UUID.t()} | {:email, String.t()}
         }
 
   @type reason ::
@@ -159,8 +163,8 @@ defmodule PortalAPI.Client.DeviceTrust do
       with :ok <- validate_attestation_host(connect_info),
            {:ok, der} <- presented_certificate(connect_info),
            {:ok, leaf} <- decode_leaf(der),
-           {:ok, account_id, email} <- extract_authentication_identity(leaf) do
-        {:ok, %{der: der, leaf: leaf, account_id: account_id, email: email}}
+           {:ok, account_id, identity} <- extract_authentication_identity(leaf) do
+        {:ok, %{der: der, leaf: leaf, account_id: account_id, identity: identity}}
       else
         {:error, reason}
         when reason in [:not_attestation_host, :no_certificate_presented, :not_x509_identity] ->
@@ -185,14 +189,14 @@ defmodule PortalAPI.Client.DeviceTrust do
   @spec authenticate(prepared_authentication(), Portal.Authentication.Context.t()) ::
           {:ok, Subject.t(), verified()} | {:error, reason()}
   def authenticate(
-        %{der: der, leaf: leaf, account_id: account_id, email: email},
+        %{der: der, leaf: leaf, account_id: account_id, identity: identity},
         context
       ) do
     with {:ok, account, auth_provider} <- Database.fetch_x509_account(account_id),
          {:ok, anchors} <- fetch_anchors(account.id),
          :ok <- validate_leaf(leaf, der, anchors),
          :ok <- ensure_account_enabled(account),
-         {:ok, actor} <- Database.fetch_x509_actor(account, email),
+         {:ok, actor} <- Database.fetch_x509_actor(account, identity),
          %DateTime{} = expires_at <- X509.not_after(leaf),
          subject = %Subject{
            account: account,
@@ -220,11 +224,11 @@ defmodule PortalAPI.Client.DeviceTrust do
              :x509_user_disabled,
              :x509_user_type_not_allowed
            ] ->
-        Logger.info("X.509 client authentication failed",
-          reason: reason,
-          account_id: account_id,
-          email: email
+        Logger.info(
+          "X.509 client authentication failed",
+          [reason: reason, account_id: account_id] ++ authentication_identity_log(identity)
         )
+
         {:error, :x509_user_not_authorized}
 
       nil ->
@@ -234,6 +238,9 @@ defmodule PortalAPI.Client.DeviceTrust do
         error
     end
   end
+
+  defp authentication_identity_log({:actor_id, actor_id}), do: [actor_id: actor_id]
+  defp authentication_identity_log({:email, email}), do: [email: email]
 
   @doc false
   def revocation_endpoint_queue_opts do
@@ -724,46 +731,77 @@ defmodule PortalAPI.Client.DeviceTrust do
       leaf
       |> X509.san_uris()
       |> Enum.flat_map(&split_joined_uris/1)
-      |> Enum.reduce(%{account_ids: MapSet.new(), emails: MapSet.new()}, fn uri, claims ->
-        case Regex.run(@typed_uri_regex, uri) do
-          [_all, idtype, value] -> put_authentication_claim(claims, idtype, value)
-          nil -> claims
+      |> Enum.reduce(
+        %{
+          account_ids: MapSet.new(),
+          actor_ids: MapSet.new(),
+          actor_id_claim?: false,
+          emails: MapSet.new()
+        },
+        fn uri, claims ->
+          case Regex.run(@typed_uri_regex, uri) do
+            [_all, idtype, value] -> put_authentication_claim(claims, idtype, value)
+            nil -> claims
+          end
         end
-      end)
+      )
 
-    case {MapSet.to_list(claims.account_ids), MapSet.to_list(claims.emails)} do
-      {[account_id], [email]} -> {:ok, account_id, email}
-      {[], _emails} -> {:error, :not_x509_identity}
-      {_account_ids, []} -> {:error, :not_x509_identity}
-      {_account_ids, _emails} -> {:error, :invalid_x509_identity}
+    case {
+      MapSet.to_list(claims.account_ids),
+      MapSet.to_list(claims.actor_ids),
+      MapSet.to_list(claims.emails),
+      claims.actor_id_claim?
+    } do
+      {[account_id], [actor_id], _emails, true} ->
+        {:ok, account_id, {:actor_id, actor_id}}
+
+      {[account_id], [], [email], false} ->
+        {:ok, account_id, {:email, email}}
+
+      {[], _actor_ids, _emails, _actor_id_claim?} ->
+        {:error, :not_x509_identity}
+
+      {_account_ids, [], [], false} ->
+        {:error, :not_x509_identity}
+
+      {_account_ids, _actor_ids, _emails, _actor_id_claim?} ->
+        {:error, :invalid_x509_identity}
     end
   end
 
   defp put_authentication_claim(claims, idtype, value) do
-    case {String.downcase(idtype), decode_uri_component(value)} do
-      {"account-id", {:ok, account_id}} ->
-        case Ecto.UUID.cast(String.trim(account_id)) do
-          {:ok, account_id} ->
-            update_in(claims.account_ids, &MapSet.put(&1, account_id))
+    case String.downcase(idtype) do
+      "account-id" ->
+        put_uuid_authentication_claim(claims, :account_ids, value)
 
-          :error ->
-            claims
-        end
-
-      {"email", {:ok, email}} ->
-        case Portal.Email.normalize_for_match(email) do
-          {:ok, ""} ->
-            claims
-
-          {:ok, email} ->
-            update_in(claims.emails, &MapSet.put(&1, email))
-
-          :error ->
-            claims
-        end
-
-      {_idtype, _value} ->
+      "actor-id" ->
         claims
+        |> Map.put(:actor_id_claim?, true)
+        |> put_uuid_authentication_claim(:actor_ids, value)
+
+      "email" ->
+        put_email_authentication_claim(claims, value)
+
+      _idtype ->
+        claims
+    end
+  end
+
+  defp put_uuid_authentication_claim(claims, key, value) do
+    with {:ok, value} <- decode_uri_component(value),
+         {:ok, id} <- Ecto.UUID.cast(String.trim(value)) do
+      Map.update!(claims, key, &MapSet.put(&1, id))
+    else
+      _error -> claims
+    end
+  end
+
+  defp put_email_authentication_claim(claims, value) do
+    with {:ok, email} <- decode_uri_component(value),
+         {:ok, email} when email != "" <- Portal.Email.normalize_for_match(email) do
+      update_in(claims.emails, &MapSet.put(&1, email))
+    else
+      _error -> claims
     end
   end
 
@@ -893,12 +931,25 @@ defmodule PortalAPI.Client.DeviceTrust do
       end
     end
 
-    def fetch_x509_actor(account, email) do
+    def fetch_x509_actor(account, {:actor_id, actor_id}) do
+      query =
+        from(actor in Portal.Actor,
+          where: actor.account_id == ^account.id and actor.id == ^actor_id
+        )
+
+      authorize_x509_actor(query, [:account_user, :account_admin_user, :service_account])
+    end
+
+    def fetch_x509_actor(account, {:email, email}) do
       query =
         from(actor in Portal.Actor,
           where: actor.account_id == ^account.id and actor.email == ^email
         )
 
+      authorize_x509_actor(query, [:account_user, :account_admin_user])
+    end
+
+    defp authorize_x509_actor(query, allowed_types) do
       case query |> Safe.unscoped() |> Safe.one() do
         nil ->
           {:error, :x509_user_not_found}
@@ -906,9 +957,10 @@ defmodule PortalAPI.Client.DeviceTrust do
         %Portal.Actor{is_disabled: true} ->
           {:error, :x509_user_disabled}
 
-        %Portal.Actor{is_disabled: false, type: type} = actor
-        when type in [:account_user, :account_admin_user] ->
-          {:ok, actor}
+        %Portal.Actor{is_disabled: false, type: type} = actor ->
+          if type in allowed_types,
+            do: {:ok, actor},
+            else: {:error, :x509_user_type_not_allowed}
 
         _user_type_not_allowed ->
           {:error, :x509_user_type_not_allowed}

--- a/elixir/lib/portal_api/client/device_trust.ex
+++ b/elixir/lib/portal_api/client/device_trust.ex
@@ -28,6 +28,7 @@ defmodule PortalAPI.Client.DeviceTrust do
   resource is a policy decision, not a socket one.
   """
 
+  alias Portal.Authentication.{Credential, Subject}
   alias Portal.Crypto.X509
   alias __MODULE__.Database
   require Logger
@@ -120,8 +121,18 @@ defmodule PortalAPI.Client.DeviceTrust do
           matched_on: :mdm_device_id | :cert_identity | nil
         }
 
+  @type prepared_authentication :: %{
+          der: binary(),
+          leaf: tuple(),
+          account_id: Ecto.UUID.t(),
+          email: String.t()
+        }
+
   @type reason ::
-          :not_attestation_host
+          :not_x509_identity
+          | :invalid_x509_identity
+          | :x509_user_not_authorized
+          | :not_attestation_host
           | :no_trust_anchors
           | :no_certificate_presented
           | :invalid_certificate
@@ -133,6 +144,96 @@ defmodule PortalAPI.Client.DeviceTrust do
           | :malformed_cert_issuer
           | :no_device_identifiers
           | :certificate_revoked
+
+  @doc """
+  Decodes the bounded leaf certificate and extracts the X.509 authentication
+  identity without touching the database or validating its chain.
+
+  This intentionally cheap stage lets the socket rate-limit identity-bearing
+  certificate attempts before any account, trust-anchor, or attestation work.
+  """
+  @spec prepare_authentication(map()) ::
+          {:ok, prepared_authentication()} | {:error, reason()}
+  def prepare_authentication(connect_info) do
+    if Portal.Features.enabled?(:trust_anchors) do
+      with :ok <- validate_attestation_host(connect_info),
+           {:ok, der} <- presented_certificate(connect_info),
+           {:ok, leaf} <- decode_leaf(der),
+           {:ok, account_id, email} <- extract_authentication_identity(leaf) do
+        {:ok, %{der: der, leaf: leaf, account_id: account_id, email: email}}
+      else
+        {:error, reason}
+        when reason in [:not_attestation_host, :no_certificate_presented, :not_x509_identity] ->
+          {:error, :not_x509_identity}
+
+        error ->
+          error
+      end
+    else
+      {:error, :not_x509_identity}
+    end
+  end
+
+  @doc """
+  Authenticates a prepared X.509 identity after the socket has rate-limited it.
+
+  The certificate chain is validated before the actor lookup, so an untrusted
+  caller cannot use differing user lookup errors to enumerate active users.
+  Once X.509 identity claims are found, identity and certificate validation
+  failures must not downgrade to bearer authentication.
+  """
+  @spec authenticate(prepared_authentication(), Portal.Authentication.Context.t()) ::
+          {:ok, Subject.t(), verified()} | {:error, reason()}
+  def authenticate(
+        %{der: der, leaf: leaf, account_id: account_id, email: email},
+        context
+      ) do
+    with {:ok, account, auth_provider} <- Database.fetch_x509_account(account_id),
+         {:ok, anchors} <- fetch_anchors(account.id),
+         :ok <- validate_leaf(leaf, der, anchors),
+         :ok <- ensure_account_enabled(account),
+         {:ok, actor} <- Database.fetch_x509_actor(account, email),
+         %DateTime{} = expires_at <- X509.not_after(leaf),
+         subject = %Subject{
+           account: account,
+           actor: actor,
+           credential: %Credential{
+             type: :x509,
+             id: Ecto.UUID.generate(),
+             auth_provider_id: auth_provider.id
+           },
+           expires_at: expires_at,
+           context: context
+         },
+         {:ok, proof} <- attest_validated(der, leaf, subject) do
+      {:ok, subject, proof}
+    else
+      {:error, :x509_authentication_not_found} ->
+        {:error, :not_x509_identity}
+
+      {:error, reason}
+      when reason in [
+             :invalid_x509_identity,
+             :x509_account_not_found,
+             :x509_account_disabled,
+             :x509_user_not_found,
+             :x509_user_disabled,
+             :x509_user_type_not_allowed
+           ] ->
+        Logger.info("X.509 client authentication failed",
+          reason: reason,
+          account_id: account_id,
+          email: email
+        )
+        {:error, :x509_user_not_authorized}
+
+      nil ->
+        {:error, :invalid_certificate}
+
+      error ->
+        error
+    end
+  end
 
   @doc false
   def revocation_endpoint_queue_opts do
@@ -166,8 +267,13 @@ defmodule PortalAPI.Client.DeviceTrust do
          {:ok, der} <- presented_certificate(connect_info),
          {:ok, anchors} <- fetch_anchors(subject),
          {:ok, leaf} <- decode_leaf(der),
-         :ok <- validate_leaf(leaf, der, anchors),
-         {:ok, serial} <- cert_serial(leaf),
+         :ok <- validate_leaf(leaf, der, anchors) do
+      attest_validated(der, leaf, subject)
+    end
+  end
+
+  defp attest_validated(der, leaf, subject) do
+    with {:ok, serial} <- cert_serial(leaf),
          {:ok, issuer} <- cert_issuer(der),
          state = Database.attestation_state(issuer, serial, mdm_device_id(leaf), subject),
          :ok <- ensure_not_revoked(state, issuer, serial),
@@ -222,6 +328,9 @@ defmodule PortalAPI.Client.DeviceTrust do
       anchors -> {:ok, anchors}
     end
   end
+
+  defp ensure_account_enabled(%Portal.Account{is_disabled: false}), do: :ok
+  defp ensure_account_enabled(%Portal.Account{is_disabled: true}), do: {:error, :x509_account_disabled}
 
   defp presented_certificate(%{peer_data: %{ssl_cert: der}})
        when is_binary(der) and byte_size(der) > 0 and byte_size(der) <= @max_cert_bytes,
@@ -610,6 +719,63 @@ defmodule PortalAPI.Client.DeviceTrust do
 
   defp split_joined_uris(uri), do: uri |> String.split(@joined_uri_regex) |> clean_parts()
 
+  defp extract_authentication_identity(leaf) do
+    claims =
+      leaf
+      |> X509.san_uris()
+      |> Enum.flat_map(&split_joined_uris/1)
+      |> Enum.reduce(%{account_ids: MapSet.new(), emails: MapSet.new()}, fn uri, claims ->
+        case Regex.run(@typed_uri_regex, uri) do
+          [_all, idtype, value] -> put_authentication_claim(claims, idtype, value)
+          nil -> claims
+        end
+      end)
+
+    case {MapSet.to_list(claims.account_ids), MapSet.to_list(claims.emails)} do
+      {[account_id], [email]} -> {:ok, account_id, email}
+      {[], _emails} -> {:error, :not_x509_identity}
+      {_account_ids, []} -> {:error, :not_x509_identity}
+      {_account_ids, _emails} -> {:error, :invalid_x509_identity}
+    end
+  end
+
+  defp put_authentication_claim(claims, idtype, value) do
+    case {String.downcase(idtype), decode_uri_component(value)} do
+      {"account-id", {:ok, account_id}} ->
+        case Ecto.UUID.cast(String.trim(account_id)) do
+          {:ok, account_id} ->
+            update_in(claims.account_ids, &MapSet.put(&1, account_id))
+
+          :error ->
+            claims
+        end
+
+      {"email", {:ok, email}} ->
+        case Portal.Actor.normalize_email(email) do
+          {:ok, ""} ->
+            claims
+
+          {:ok, email} ->
+            # Actor emails use citext, so collapse claims using the same
+            # case-insensitive semantics before checking claim uniqueness.
+            email = String.downcase(email)
+            update_in(claims.emails, &MapSet.put(&1, email))
+
+          :error ->
+            claims
+        end
+
+      {_idtype, _value} ->
+        claims
+    end
+  end
+
+  defp decode_uri_component(value) do
+    {:ok, URI.decode(value)}
+  rescue
+    ArgumentError -> {:error, :invalid}
+  end
+
   # A comma is never valid in a hostname, so joined DNS SANs split plainly.
   defp split_joined_dns_names(dns_name), do: dns_name |> String.split(",") |> clean_parts()
 
@@ -699,6 +865,58 @@ defmodule PortalAPI.Client.DeviceTrust do
     import Ecto.Query
     alias Portal.Crypto.X509
     alias Portal.Safe
+
+    def fetch_x509_account(account_id) do
+      query =
+        from(account in Portal.Account,
+          left_join: auth_provider in Portal.X509.AuthProvider,
+          on: auth_provider.account_id == account.id,
+          where: account.id == ^account_id,
+          select: %{
+            account: account,
+            auth_provider: auth_provider
+          }
+        )
+
+      case query |> Safe.unscoped() |> Safe.one() do
+        nil ->
+          {:error, :x509_account_not_found}
+
+        %{auth_provider: nil} ->
+          {:error, :x509_authentication_not_found}
+
+        %{auth_provider: %Portal.X509.AuthProvider{is_disabled: true}} ->
+          {:error, :x509_authentication_not_found}
+
+        %{
+          account: %Portal.Account{} = account,
+          auth_provider: %Portal.X509.AuthProvider{is_disabled: false} = auth_provider
+        } ->
+          {:ok, account, auth_provider}
+      end
+    end
+
+    def fetch_x509_actor(account, email) do
+      query =
+        from(actor in Portal.Actor,
+          where: actor.account_id == ^account.id and actor.email == ^email
+        )
+
+      case query |> Safe.unscoped() |> Safe.one() do
+        nil ->
+          {:error, :x509_user_not_found}
+
+        %Portal.Actor{is_disabled: true} ->
+          {:error, :x509_user_disabled}
+
+        %Portal.Actor{is_disabled: false, type: type} = actor
+        when type in [:account_user, :account_admin_user] ->
+          {:ok, actor}
+
+        _user_type_not_allowed ->
+          {:error, :x509_user_type_not_allowed}
+      end
+    end
 
     # A refused read leaves the connect with no facts rather than with false
     # ones, which the caller treats the same way it treats a certificate no
@@ -828,12 +1046,27 @@ defmodule PortalAPI.Client.DeviceTrust do
       end
     end
 
-    def fetch_anchors(subject) do
+    def fetch_anchors(%Portal.Authentication.Subject{} = subject) do
       from(c in Portal.TrustAnchorCertificate,
         select: %{id: c.id, pem: c.pem}
       )
       |> Safe.scoped(subject)
       |> Safe.all()
+      |> decode_anchors()
+    end
+
+    def fetch_anchors(account_id) when is_binary(account_id) do
+      from(c in Portal.TrustAnchorCertificate,
+        where: c.account_id == ^account_id,
+        select: %{id: c.id, pem: c.pem}
+      )
+      |> Safe.unscoped()
+      |> Safe.all()
+      |> decode_anchors()
+    end
+
+    defp decode_anchors(certificates) do
+      certificates
       |> Enum.flat_map(&decode_anchor_pem/1)
       |> Enum.uniq_by(& &1.der)
     end

--- a/elixir/lib/portal_api/client/device_trust.ex
+++ b/elixir/lib/portal_api/client/device_trust.ex
@@ -751,14 +751,11 @@ defmodule PortalAPI.Client.DeviceTrust do
         end
 
       {"email", {:ok, email}} ->
-        case Portal.Actor.normalize_email(email) do
+        case Portal.Email.normalize_for_match(email) do
           {:ok, ""} ->
             claims
 
           {:ok, email} ->
-            # Actor emails use citext, so collapse claims using the same
-            # case-insensitive semantics before checking claim uniqueness.
-            email = String.downcase(email)
             update_in(claims.emails, &MapSet.put(&1, email))
 
           :error ->

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -37,9 +37,18 @@ defmodule PortalAPI.Client.Socket do
     :otel_propagator_text_map.extract(connect_info.trace_context_headers)
 
     OpenTelemetry.Tracer.with_span "client.connect" do
-      with {:ok, token} <- PortalAPI.Sockets.extract_token(attrs, connect_info),
-           :ok <- PortalAPI.Sockets.RateLimit.check(connect_info, token: token) do
-        do_connect(token, attrs, socket, connect_info)
+      context = PortalAPI.Sockets.auth_context(connect_info, :client)
+      attrs = normalize_device_attrs(attrs)
+
+      case DeviceTrust.prepare_authentication(connect_info) do
+        {:ok, authentication} ->
+          authenticate_with_certificate(authentication, context, attrs, socket, connect_info)
+
+        {:error, :not_x509_identity} ->
+          connect_with_token(context, attrs, socket, connect_info)
+
+        {:error, reason} ->
+          handle_certificate_authentication_error(reason)
       end
     end
   end
@@ -51,17 +60,47 @@ defmodule PortalAPI.Client.Socket do
 
   ## Private functions
 
-  defp do_connect(token, attrs, socket, connect_info) do
-    context = PortalAPI.Sockets.auth_context(connect_info, :client)
-    attrs = normalize_device_attrs(attrs)
+  defp authenticate_with_certificate(authentication, context, attrs, socket, connect_info) do
+    # The fixed discriminator makes this an IP-only bucket. The bearer header
+    # is irrelevant once X.509 identity claims are present, so allowing it to
+    # vary the key would let a caller evade this pre-authentication limit.
+    with :ok <- PortalAPI.Sockets.RateLimit.check(connect_info, token: "x509"),
+         {:ok, subject, proof} <- DeviceTrust.authenticate(authentication, context) do
+      do_connect(subject, nil, proof, attrs, socket)
+    else
+      {:error, :not_x509_identity} ->
+        connect_with_token(context, attrs, socket, connect_info)
 
-    with {:ok, %{credential: %{type: :client_token, id: token_id}} = subject} <-
-           Authentication.authenticate(token, context),
-         false <- Portal.Billing.client_connect_restricted?(subject.account),
+      {:error, :rate_limit} = error ->
+        error
+
+      {:error, reason} ->
+        handle_certificate_authentication_error(reason)
+    end
+  end
+
+  defp connect_with_token(context, attrs, socket, connect_info) do
+    with {:ok, token} <- PortalAPI.Sockets.extract_token(attrs, connect_info),
+         :ok <- PortalAPI.Sockets.RateLimit.check(connect_info, token: token),
+         {:ok, %{credential: %{type: :client_token, id: token_id}} = subject} <-
+           Authentication.authenticate(token, context) do
+      do_connect(subject, token_id, nil, attrs, socket, connect_info)
+    else
+      {:error, :invalid_token} ->
+        OpenTelemetry.Tracer.set_status(:error, "invalid_token")
+        {:error, :invalid_token}
+
+      error ->
+        error
+    end
+  end
+
+  defp do_connect(subject, token_id, proof, attrs, socket, connect_info \\ nil) do
+    with false <- Portal.Billing.client_connect_restricted?(subject.account),
          {:ok, public_key} <- validate_public_key(attrs),
          changeset = insert_changeset(subject.actor, subject, attrs),
          {:ok, _} <- apply_action(changeset, :validate),
-         {:ok, proof} <- attest_device(connect_info, subject),
+         {:ok, proof} <- attest_device(proof, connect_info, subject),
          {:ok, client, attested?} <- Database.resolve_client(changeset, proof, subject) do
       version = derive_version(subject.context.user_agent)
       {context, version} = PortalAPI.Sockets.truncate_session_fields(subject.context, version)
@@ -72,10 +111,6 @@ defmodule PortalAPI.Client.Socket do
 
       {:ok, assign_connect(socket, subject, client, version, attested?, proof)}
     else
-      {:error, :invalid_token} ->
-        OpenTelemetry.Tracer.set_status(:error, "invalid_token")
-        {:error, :invalid_token}
-
       true ->
         OpenTelemetry.Tracer.set_status(:error, "limits_exceeded")
         {:error, :limits_exceeded}
@@ -100,12 +135,30 @@ defmodule PortalAPI.Client.Socket do
     end
   end
 
+  defp handle_certificate_authentication_error(:certificate_revoked) do
+    OpenTelemetry.Tracer.set_status(:error, "certificate_revoked")
+    {:error, :certificate_revoked}
+  end
+
+  defp handle_certificate_authentication_error(:x509_user_not_authorized) do
+    OpenTelemetry.Tracer.set_status(:error, "x509_user_not_authorized")
+    {:error, :x509_user_not_authorized}
+  end
+
+  defp handle_certificate_authentication_error(reason) do
+    Logger.warning("Refusing client connect: X.509 authentication failed", reason: reason)
+    OpenTelemetry.Tracer.set_status(:error, "device_untrusted")
+    {:error, :device_untrusted}
+  end
+
   # Arriving on the mutual-TLS host is the client claiming it holds a device
   # certificate, so failing to prove one there refuses the connect instead of
   # silently downgrading to an unattested session. A connect on any other host
   # is unattested and carries on; whether that device may reach a given
   # resource is a policy question, not a socket one.
-  defp attest_device(connect_info, subject) do
+  defp attest_device(%{} = proof, _connect_info, _subject), do: {:ok, proof}
+
+  defp attest_device(nil, connect_info, subject) do
     case DeviceTrust.attest(connect_info, subject) do
       {:ok, proof} ->
         {:ok, proof}
@@ -258,14 +311,16 @@ defmodule PortalAPI.Client.Socket do
   end
 
   defp set_connect_attributes(token_id, client, subject, version) do
-    OpenTelemetry.Tracer.set_attributes(%{
-      token_id: token_id,
+    attributes = %{
       client_id: client.id,
       lat: subject.context.remote_ip_location_lat,
       lon: subject.context.remote_ip_location_lon,
       version: version,
       account_id: subject.account.id
-    })
+    }
+
+    attributes = if token_id, do: Map.put(attributes, :token_id, token_id), else: attributes
+    OpenTelemetry.Tracer.set_attributes(attributes)
   end
 
   defp assign_connect(socket, subject, client, version, attested?, proof) do

--- a/elixir/lib/portal_api/controllers/x509_auth_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/x509_auth_provider_controller.ex
@@ -1,0 +1,51 @@
+defmodule PortalAPI.X509AuthProviderController do
+  use PortalAPI, :controller
+  use OpenApiSpex.ControllerSpecs
+  alias PortalAPI.Error
+  alias PortalAPI.Schemas.ProblemDetails
+  alias __MODULE__.Database
+
+  tags ["X.509 Auth Providers"]
+
+  # coveralls-ignore-start
+  operation :show,
+    summary: "Show X.509 Auth Provider",
+    responses:
+      [
+        ok:
+          {"X.509 Auth Provider Response", "application/json",
+           PortalAPI.Schemas.X509AuthProvider.Response}
+      ] ++ ProblemDetails.responses([:bad_request, :unauthorized, :not_found, :too_many_requests])
+
+  # coveralls-ignore-stop
+
+  def show(conn, _params) do
+    if Portal.Features.enabled?(:trust_anchors) do
+      with {:ok, provider} <- Database.fetch_provider(conn.assigns.subject) do
+        render(conn, :show, provider: provider)
+      else
+        error -> Error.handle(conn, error)
+      end
+    else
+      Error.handle(conn, {:error, :not_found})
+    end
+  end
+
+  defmodule Database do
+    import Ecto.Query
+    alias Portal.{Safe, X509}
+
+    def fetch_provider(subject) do
+      result =
+        from(p in X509.AuthProvider)
+        |> Safe.scoped(subject)
+        |> Safe.one()
+
+      case result do
+        nil -> {:error, :not_found}
+        {:error, :unauthorized} -> {:error, :unauthorized}
+        provider -> {:ok, provider}
+      end
+    end
+  end
+end

--- a/elixir/lib/portal_api/controllers/x509_auth_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/x509_auth_provider_json.ex
@@ -1,0 +1,17 @@
+defmodule PortalAPI.X509AuthProviderJSON do
+  alias Portal.X509
+
+  def show(%{provider: provider}), do: %{data: data(provider)}
+
+  defp data(%X509.AuthProvider{} = provider) do
+    %{
+      id: provider.id,
+      account_id: provider.account_id,
+      name: provider.name,
+      context: provider.context,
+      is_disabled: provider.is_disabled,
+      inserted_at: provider.inserted_at,
+      updated_at: provider.updated_at
+    }
+  end
+end

--- a/elixir/lib/portal_api/endpoint.ex
+++ b/elixir/lib/portal_api/endpoint.ex
@@ -45,7 +45,7 @@ defmodule PortalAPI.Endpoint do
     drainer: []
 
   # Client sockets take `:uri` so device trust can tell a connect on the
-  # mutual-TLS host from one on the plain API host.
+  # mutual-TLS origin from one on the plain API origin.
   socket "/client", PortalAPI.Client.Socket,
     websocket: [
       check_origin: :conn,

--- a/elixir/lib/portal_api/router.ex
+++ b/elixir/lib/portal_api/router.ex
@@ -99,6 +99,7 @@ defmodule PortalAPI.Router do
     end
 
     resources "/email_otp_auth_providers", EmailOTPAuthProviderController, only: [:index, :show]
+    get "/x509_auth_provider", X509AuthProviderController, :show
     resources "/oidc_auth_providers", OIDCAuthProviderController, only: [:index, :show]
     resources "/google_auth_providers", GoogleAuthProviderController, only: [:index, :show]
     resources "/entra_auth_providers", EntraAuthProviderController, only: [:index, :show]

--- a/elixir/lib/portal_api/schemas/x509_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/x509_auth_provider_schema.ex
@@ -1,0 +1,42 @@
+defmodule PortalAPI.Schemas.X509AuthProvider do
+  alias OpenApiSpex.Schema
+
+  defmodule Schema do
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "X509AuthProvider",
+      description: "X.509 Auth Provider",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid, description: "Provider ID"},
+        account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
+        name: %Schema{type: :string, description: "Provider name"},
+        context: %Schema{type: :string, description: "Context", enum: ["clients_only"]},
+        is_disabled: %Schema{type: :boolean, description: "Whether provider is disabled"},
+        inserted_at: %Schema{type: :string, format: :"date-time", description: "Creation timestamp"},
+        updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
+      },
+      required: [:id, :account_id, :name, :context, :is_disabled],
+      example: %{
+        "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+        "name" => "X.509",
+        "context" => "clients_only",
+        "is_disabled" => true
+      }
+    })
+  end
+
+  defmodule Response do
+    require OpenApiSpex
+    alias PortalAPI.Schemas.X509AuthProvider
+
+    OpenApiSpex.schema(%{
+      title: "X509AuthProviderResponse",
+      description: "Response schema for a single X.509 Auth Provider",
+      type: :object,
+      properties: %{data: X509AuthProvider.Schema}
+    })
+  end
+end

--- a/elixir/lib/portal_api/sockets.ex
+++ b/elixir/lib/portal_api/sockets.ex
@@ -63,6 +63,15 @@ defmodule PortalAPI.Sockets do
           "authority. Please contact your administrator."
       )
 
+  def handle_error(conn, :x509_user_not_authorized),
+    do:
+      ProblemDetails.send(
+        conn,
+        403,
+        "This device's certificate does not identify an active user authorized to access " <>
+          "this Firezone account. Please contact your administrator."
+      )
+
   def handle_error(conn, :device_identity_conflict),
     do:
       ProblemDetails.send_with_code(

--- a/elixir/lib/portal_api/sockets.ex
+++ b/elixir/lib/portal_api/sockets.ex
@@ -65,9 +65,10 @@ defmodule PortalAPI.Sockets do
 
   def handle_error(conn, :x509_user_not_authorized),
     do:
-      ProblemDetails.send(
+      ProblemDetails.send_with_code(
         conn,
         403,
+        :x509_user_not_authorized,
         "This device's certificate does not identify an active user authorized to access " <>
           "this Firezone account. Please contact your administrator."
       )

--- a/elixir/lib/portal_api/sockets/latest_session.ex
+++ b/elixir/lib/portal_api/sockets/latest_session.ex
@@ -5,7 +5,7 @@ defmodule PortalAPI.Sockets.LatestSession do
   Each queue entry carries the session attrs plus connect-time metadata. The
   newest entry per device wins within a batch, and the update is guarded on
   `last_seen_at` so a flush from another node can never roll a device back to
-  an older session. Entries whose token or device row no longer exists are
+  an older session. Entries whose non-nil token or device row no longer exists are
   returned as failed, separately per cause, so the caller can disconnect a
   deleted token's session without touching the device's other sessions.
   """
@@ -204,6 +204,7 @@ defmodule PortalAPI.Sockets.LatestSession do
         |> Enum.map(fn {attrs, _metadata} ->
           %{account_id: attrs.account_id, token_id: Map.fetch!(attrs, token_field)}
         end)
+        |> Enum.reject(&is_nil(&1.token_id))
         |> Enum.uniq()
 
       schema = Map.fetch!(@token_schemas, token_field)
@@ -214,6 +215,8 @@ defmodule PortalAPI.Sockets.LatestSession do
       |> Enum.reject(&MapSet.member?(existing, &1))
       |> MapSet.new()
     end
+
+    defp existing_token_ids(_schema, []), do: MapSet.new()
 
     defp existing_token_ids(schema, probe_rows) do
       from(t in schema,

--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -1469,6 +1469,13 @@ defmodule PortalWeb.CoreComponents do
     }
   end
 
+  defp provider_icon_spec("x509") do
+    %{
+      type: :icon,
+      name: "ri-shield-keyhole-line"
+    }
+  end
+
   defp provider_icon_spec("splunk") do
     %{
       type: :image,

--- a/elixir/lib/portal_web/live/logs/change_logs.ex
+++ b/elixir/lib/portal_web/live/logs/change_logs.ex
@@ -439,7 +439,8 @@ defmodule PortalWeb.Logs.ChangeLogs do
       {"Resources", "resources"},
       {"Sites", "sites"},
       {"Static device pool members", "static_device_pool_members"},
-      {"Userpass auth providers", "userpass_auth_providers"}
+      {"Userpass auth providers", "userpass_auth_providers"},
+      {"X.509 auth providers", "x509_auth_providers"}
     ]
 
     def filters do

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -33,6 +33,10 @@ defmodule PortalWeb.Policies do
       |> assign_async(:policies_count, fn -> {:ok, %{policies_count: Database.count_policies(subject)}} end)
       |> assign(selected_policy: nil, policy_providers: [])
       |> assign(
+        x509_auth_provider_id: Database.x509_auth_provider_id(subject),
+        has_trust_anchors?: Database.has_trust_anchors?(subject)
+      )
+      |> assign(
         policy_authorizations: [],
         policy_authorizations_page: 1,
         policy_authorizations_has_next: false,
@@ -346,6 +350,8 @@ defmodule PortalWeb.Policies do
         account={@account}
         policy={@selected_policy}
         providers={@policy_providers}
+        x509_auth_provider_id={@x509_auth_provider_id}
+        has_trust_anchors?={@has_trust_anchors?}
         subject={@subject}
         panel={policy_panel_state(assigns)}
         conditions_state={policy_conditions_state(assigns)}
@@ -1268,7 +1274,7 @@ defmodule PortalWeb.Policies do
     end
 
     def all_active_providers(_account, subject) do
-      [
+      schemas = [
         Portal.Userpass.AuthProvider,
         Portal.EmailOTP.AuthProvider,
         Portal.OIDC.AuthProvider,
@@ -1276,11 +1282,37 @@ defmodule PortalWeb.Policies do
         Portal.Entra.AuthProvider,
         Portal.Okta.AuthProvider
       ]
-      |> Enum.flat_map(fn schema ->
+
+      schemas =
+        if Portal.Features.enabled?(:trust_anchors) do
+          [Portal.X509.AuthProvider | schemas]
+        else
+          schemas
+        end
+
+      Enum.flat_map(schemas, fn schema ->
         from(p in schema, where: not p.is_disabled)
         |> Safe.scoped(subject)
         |> Safe.all()
       end)
+    end
+
+    def x509_auth_provider_id(subject) do
+      if Portal.Features.enabled?(:trust_anchors) do
+        Portal.X509.AuthProvider
+        |> Safe.scoped(subject)
+        |> Safe.one()
+        |> case do
+          %Portal.X509.AuthProvider{id: id} -> id
+          _ -> nil
+        end
+      end
+    end
+
+    def has_trust_anchors?(subject) do
+      Portal.TrustAnchorCertificate
+      |> Safe.scoped(subject)
+      |> Safe.exists?()
     end
 
     def count_policies(subject) do

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -153,6 +153,8 @@ defmodule PortalWeb.Policies.Components do
   attr :account, :any, required: true
   attr :policy, :any, default: nil
   attr :providers, :list, default: []
+  attr :x509_auth_provider_id, :string, default: nil
+  attr :has_trust_anchors?, :boolean, default: false
   attr :subject, :any, required: true
   attr :panel, :map, required: true
   attr :conditions_state, :map, required: true
@@ -203,6 +205,8 @@ defmodule PortalWeb.Policies.Components do
         account={@account}
         subject={@subject}
         providers={@providers}
+        x509_auth_provider_id={@x509_auth_provider_id}
+        has_trust_anchors?={@has_trust_anchors?}
         panel_form={@panel.panel_form}
         panel_selected_resource={@panel.panel_selected_resource}
         panel_active_conditions={@conditions_state.panel_active_conditions}
@@ -216,6 +220,8 @@ defmodule PortalWeb.Policies.Components do
         account={@account}
         subject={@subject}
         providers={@providers}
+        x509_auth_provider_id={@x509_auth_provider_id}
+        has_trust_anchors?={@has_trust_anchors?}
         panel_form={@panel.panel_form}
         panel_selected_resource={@panel.panel_selected_resource}
         panel_active_conditions={@conditions_state.panel_active_conditions}
@@ -229,6 +235,8 @@ defmodule PortalWeb.Policies.Components do
         account={@account}
         policy={@policy}
         providers={@providers}
+        x509_auth_provider_id={@x509_auth_provider_id}
+        has_trust_anchors?={@has_trust_anchors?}
         tab={@panel.panel_tab}
         confirm_disable_policy={@confirm_state.confirm_disable_policy}
         confirm_delete_policy={@confirm_state.confirm_delete_policy}
@@ -244,6 +252,8 @@ defmodule PortalWeb.Policies.Components do
   attr :account, :any, required: true
   attr :subject, :any, required: true
   attr :providers, :list, default: []
+  attr :x509_auth_provider_id, :string, default: nil
+  attr :has_trust_anchors?, :boolean, default: false
   attr :panel_form, :any, default: nil
   attr :panel_selected_resource, :any, default: nil
   attr :panel_active_conditions, :list, default: []
@@ -267,6 +277,8 @@ defmodule PortalWeb.Policies.Components do
           mode={@mode}
           subject={@subject}
           providers={@providers}
+          x509_auth_provider_id={@x509_auth_provider_id}
+          has_trust_anchors?={@has_trust_anchors?}
           panel_form={@panel_form}
           panel_selected_resource={@panel_selected_resource}
           panel_active_conditions={@panel_active_conditions}
@@ -298,6 +310,8 @@ defmodule PortalWeb.Policies.Components do
   attr :account, :any, required: true
   attr :subject, :any, required: true
   attr :providers, :list, default: []
+  attr :x509_auth_provider_id, :string, default: nil
+  attr :has_trust_anchors?, :boolean, default: false
   attr :panel_form, :any, default: nil
   attr :panel_selected_resource, :any, default: nil
   attr :panel_active_conditions, :list, default: []
@@ -321,6 +335,8 @@ defmodule PortalWeb.Policies.Components do
         panel_active_conditions={@panel_active_conditions}
         panel_conditions_dropdown_open={@panel_conditions_dropdown_open}
         providers={@providers}
+        x509_auth_provider_id={@x509_auth_provider_id}
+        has_trust_anchors?={@has_trust_anchors?}
         conditions_state={@conditions_state}
       />
     </div>
@@ -581,6 +597,8 @@ defmodule PortalWeb.Policies.Components do
   attr :panel_active_conditions, :list, default: []
   attr :panel_conditions_dropdown_open, :boolean, default: false
   attr :providers, :list, default: []
+  attr :x509_auth_provider_id, :string, default: nil
+  attr :has_trust_anchors?, :boolean, default: false
   attr :conditions_state, :map, required: true
 
   def policy_conditions_section(assigns) do
@@ -618,6 +636,9 @@ defmodule PortalWeb.Policies.Components do
           <.policy_conditions_cards
             panel_active_conditions={@panel_active_conditions}
             providers={@providers}
+            account={@account}
+            x509_auth_provider_id={@x509_auth_provider_id}
+            has_trust_anchors?={@has_trust_anchors?}
             conditions_state={@conditions_state}
           />
       <% end %>
@@ -662,7 +683,10 @@ defmodule PortalWeb.Policies.Components do
   end
 
   attr :panel_active_conditions, :list, default: []
+  attr :account, :any, required: true
   attr :providers, :list, default: []
+  attr :x509_auth_provider_id, :string, default: nil
+  attr :has_trust_anchors?, :boolean, default: false
   attr :conditions_state, :map, required: true
 
   def policy_conditions_cards(assigns) do
@@ -677,7 +701,10 @@ defmodule PortalWeb.Policies.Components do
       <.grant_condition_card
         :for={type <- @panel_active_conditions}
         type={type}
+        account={@account}
         providers={@providers}
+        x509_auth_provider_id={@x509_auth_provider_id}
+        has_trust_anchors?={@has_trust_anchors?}
         conditions_state={@conditions_state}
       />
     </div>
@@ -734,6 +761,8 @@ defmodule PortalWeb.Policies.Components do
   attr :account, :any, required: true
   attr :policy, :any, required: true
   attr :providers, :list, default: []
+  attr :x509_auth_provider_id, :string, default: nil
+  attr :has_trust_anchors?, :boolean, default: false
   attr :tab, :atom, default: :overview
   attr :confirm_disable_policy, :boolean, default: false
   attr :confirm_delete_policy, :boolean, default: false
@@ -750,6 +779,8 @@ defmodule PortalWeb.Policies.Components do
         account={@account}
         policy={@policy}
         providers={@providers}
+        x509_auth_provider_id={@x509_auth_provider_id}
+        has_trust_anchors?={@has_trust_anchors?}
         tab={@tab}
         confirm_disable_policy={@confirm_disable_policy}
         confirm_delete_policy={@confirm_delete_policy}
@@ -765,6 +796,8 @@ defmodule PortalWeb.Policies.Components do
   attr :account, :any, required: true
   attr :policy, :any, required: true
   attr :providers, :list, default: []
+  attr :x509_auth_provider_id, :string, default: nil
+  attr :has_trust_anchors?, :boolean, default: false
   attr :tab, :atom, default: :overview
   attr :confirm_disable_policy, :boolean, default: false
   attr :confirm_delete_policy, :boolean, default: false
@@ -814,7 +847,13 @@ defmodule PortalWeb.Policies.Components do
         </div>
         <div :if={@tab == :overview} class="flex-1 overflow-y-auto">
           <.policy_access_mapping account={@account} policy={@policy} />
-          <.policy_conditions_list account={@account} policy={@policy} providers={@providers} />
+          <.policy_conditions_list
+            account={@account}
+            policy={@policy}
+            providers={@providers}
+            x509_auth_provider_id={@x509_auth_provider_id}
+            has_trust_anchors?={@has_trust_anchors?}
+          />
         </div>
         <.policy_authorizations_tab
           :if={@tab == :authorizations}
@@ -959,6 +998,8 @@ defmodule PortalWeb.Policies.Components do
   attr :account, :any, required: true
   attr :policy, :any, required: true
   attr :providers, :list, default: []
+  attr :x509_auth_provider_id, :string, default: nil
+  attr :has_trust_anchors?, :boolean, default: false
 
   def policy_conditions_list(assigns) do
     ~H"""
@@ -985,6 +1026,8 @@ defmodule PortalWeb.Policies.Components do
             account={@account}
             condition={condition}
             providers={@providers}
+            x509_auth_provider_id={@x509_auth_provider_id}
+            has_trust_anchors?={@has_trust_anchors?}
           />
         </ul>
       <% end %>
@@ -995,6 +1038,8 @@ defmodule PortalWeb.Policies.Components do
   attr :account, :any, required: true
   attr :condition, :map, required: true
   attr :providers, :list, default: []
+  attr :x509_auth_provider_id, :string, default: nil
+  attr :has_trust_anchors?, :boolean, default: false
 
   def policy_condition_row(assigns) do
     ~H"""
@@ -1005,9 +1050,17 @@ defmodule PortalWeb.Policies.Components do
       <%= if @condition.property == :current_utc_datetime do %>
         <.policy_tod_condition_values values={@condition.values} />
       <% else %>
-        <span class="text-xs text-body flex-1 min-w-0 mt-0.5">
-          {condition_values_display(@condition, @providers, @account)}
-        </span>
+        <div class="text-xs text-body flex-1 min-w-0 mt-0.5 space-y-2">
+          <span>{condition_values_display(@condition, @providers, @account)}</span>
+          <.x509_trust_anchor_warning
+            show?={
+              @condition.property == :auth_provider_id and not @has_trust_anchors? and
+                not is_nil(@x509_auth_provider_id) and
+                @x509_auth_provider_id in @condition.values
+            }
+            account={@account}
+          />
+        </div>
       <% end %>
     </li>
     """
@@ -2216,7 +2269,10 @@ defmodule PortalWeb.Policies.Components do
   @condition_input_class "w-full text-xs rounded border border-border bg-raised text-heading px-2 py-1.5 outline-none focus:border-border-focus focus:ring-1 focus:ring-border-focus/30 transition-colors"
 
   attr :type, :atom, required: true
+  attr :account, :any, default: nil
   attr :providers, :list, default: []
+  attr :x509_auth_provider_id, :string, default: nil
+  attr :has_trust_anchors?, :boolean, default: false
   attr :conditions_state, :map, required: true
 
   def grant_condition_card(assigns) do
@@ -2239,7 +2295,10 @@ defmodule PortalWeb.Policies.Components do
     <.grant_auth_provider_condition_card
       :if={@type == :auth_provider_id}
       type={@type}
+      account={@account}
       providers={@providers}
+      x509_auth_provider_id={@x509_auth_provider_id}
+      has_trust_anchors?={@has_trust_anchors?}
       auth_provider_operator={@conditions_state.auth_provider_operator}
       auth_provider_values={@conditions_state.auth_provider_values}
     />
@@ -2514,7 +2573,10 @@ defmodule PortalWeb.Policies.Components do
   end
 
   attr :type, :atom, required: true
+  attr :account, :any, default: nil
   attr :providers, :list, default: []
+  attr :x509_auth_provider_id, :string, default: nil
+  attr :has_trust_anchors?, :boolean, default: false
   attr :auth_provider_operator, :string, default: "is_in"
   attr :auth_provider_values, :list, default: []
 
@@ -2569,6 +2631,13 @@ defmodule PortalWeb.Policies.Components do
           name="policy[conditions][auth_provider_id][values][]"
           value={id}
         />
+        <.x509_trust_anchor_warning
+          show?={
+            not @has_trust_anchors? and not is_nil(@x509_auth_provider_id) and
+              @x509_auth_provider_id in @auth_provider_values
+          }
+          account={@account}
+        />
         <div :if={@auth_provider_values != []} class="flex flex-wrap gap-1 mb-2">
           <span
             :for={p <- Enum.filter(@providers, &(&1.id in @auth_provider_values))}
@@ -2603,6 +2672,27 @@ defmodule PortalWeb.Policies.Components do
         </div>
       </div>
     </div>
+    """
+  end
+
+  attr :show?, :boolean, default: false
+  attr :account, :any, required: true
+
+  defp x509_trust_anchor_warning(assigns) do
+    ~H"""
+    <p
+      :if={@show?}
+      class="flex items-start gap-1.5 rounded border border-amber-200 bg-amber-50 px-2.5 py-2 text-xs text-amber-700 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-400"
+    >
+      <.icon name="ri-error-warning-line" class="w-3.5 h-3.5 shrink-0 mt-0.5" />
+      <span>
+        No devices will be able to use this authentication provider until you add one or more
+        <.link
+          navigate={~p"/#{@account}/settings/trust_anchors"}
+          class="font-medium underline hover:no-underline"
+        >Trust Anchors</.link>.
+      </span>
+    </p>
     """
   end
 

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -604,11 +604,15 @@ defmodule PortalWeb.Settings.Authentication do
 
   defp init(socket) do
     providers =
-      Database.list_all_providers(socket.assigns.subject)
+      Database.list_all_providers(
+        socket.assigns.subject,
+        socket.assigns.trust_anchors_enabled?
+      )
       |> Database.enrich_with_session_counts(socket.assigns.subject)
 
     assign(socket,
       providers: providers,
+      has_trust_anchors?: Database.has_trust_anchors?(socket.assigns.subject),
       verification_error: nil,
       pending_confirm: nil,
       open_provider_actions_id: nil
@@ -673,6 +677,7 @@ defmodule PortalWeb.Settings.Authentication do
                 type={provider_type(provider)}
                 account={@account}
                 provider={provider}
+                has_trust_anchors?={@has_trust_anchors?}
                 pending_confirm={@pending_confirm}
                 open_provider_actions_id={@open_provider_actions_id}
               />
@@ -927,6 +932,19 @@ defmodule PortalWeb.Settings.Authentication do
               </span>
             </div>
             <div class="font-mono text-[10px] text-subtle mt-0.5">{@provider.id}</div>
+            <p
+              :if={@type == "x509" and not @has_trust_anchors?}
+              class="flex items-start gap-1.5 mt-1.5 max-w-md text-xs text-amber-600 dark:text-amber-400"
+            >
+              <.icon name="ri-error-warning-line" class="w-3.5 h-3.5 shrink-0 mt-0.5" />
+              <span>
+                No devices will be able to use this authentication provider until you add one or more
+                <.link
+                  navigate={~p"/#{@account}/settings/trust_anchors"}
+                  class="underline hover:no-underline"
+                >Trust Anchors</.link>.
+              </span>
+            </p>
           </div>
         </div>
       </td>
@@ -1063,14 +1081,15 @@ defmodule PortalWeb.Settings.Authentication do
                     <.icon name="ri-star-fill" class="w-3.5 h-3.5 shrink-0" /> Remove default
                   </button>
                   <button
-                    :if={not @can_be_default}
+                    :if={@show_default_action and not @can_be_default}
                     disabled
                     class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left text-subtle cursor-default"
                   >
                     <.icon name="ri-star-line" class="w-3.5 h-3.5 shrink-0" /> Make default
                   </button>
-                  <div class="my-1 border-t border-border"></div>
+                  <div :if={@show_default_action} class="my-1 border-t border-border"></div>
                   <.link
+                    :if={@can_be_edited}
                     patch={~p"/#{@account}/settings/authentication/#{@type}/#{@provider.id}/edit"}
                     class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-raised transition-colors text-body"
                   >
@@ -1137,7 +1156,9 @@ defmodule PortalWeb.Settings.Authentication do
     %{
       is_default: provider_default?(provider),
       can_be_default: provider_action_allowed?(type),
+      show_default_action: type != "x509",
       can_be_deleted: provider_action_allowed?(type),
+      can_be_edited: type != "x509",
       has_sessions: provider_has_sessions?(provider),
       is_pending_toggle: pending_state == :toggle,
       is_pending_delete: pending_state == :delete,
@@ -1149,7 +1170,7 @@ defmodule PortalWeb.Settings.Authentication do
 
   defp provider_default?(provider), do: Map.get(provider, :is_default, false)
 
-  defp provider_action_allowed?(type), do: type not in ["email_otp", "userpass"]
+  defp provider_action_allowed?(type), do: type not in ["email_otp", "userpass", "x509"]
 
   defp provider_has_sessions?(provider) do
     provider.client_tokens_count > 0 or provider.portal_sessions_count > 0
@@ -1171,7 +1192,8 @@ defmodule PortalWeb.Settings.Authentication do
   defp provider_portal_ttl(_provider), do: nil
 
   defp provider_client_ttl(%{context: context} = provider)
-       when context in [:clients_and_portal, :clients_only] do
+       when context in [:clients_and_portal, :clients_only] and
+              is_map_key(provider, :client_session_lifetime_secs) do
     format_duration(
       Map.get(provider, :client_session_lifetime_secs) ||
         provider.__struct__.default_client_session_lifetime_secs()
@@ -1745,7 +1767,7 @@ defmodule PortalWeb.Settings.Authentication do
       socket.assigns.providers
       |> Enum.find(fn provider -> provider.id == provider_id end)
 
-    with true <- provider_type(provider) not in ["email_otp", "userpass"],
+    with true <- provider_type(provider) not in ["email_otp", "userpass", "x509"],
          {:ok, _result} <- Database.set_default_provider(provider, socket.assigns) do
       socket =
         socket
@@ -1757,7 +1779,7 @@ defmodule PortalWeb.Settings.Authentication do
       false ->
         socket =
           socket
-          |> put_flash(:error, "Email and userpass providers cannot be set as default.")
+          |> put_flash(:error, "Built-in providers cannot be set as default.")
 
         {:noreply, socket}
 
@@ -1820,12 +1842,12 @@ defmodule PortalWeb.Settings.Authentication do
   end
 
   defmodule Database do
-    alias Portal.{AuthProvider, EmailOTP, Userpass, OIDC, Entra, Google, Okta, Safe}
+    alias Portal.{AuthProvider, EmailOTP, X509, Userpass, OIDC, Entra, Google, Okta, Safe}
     import Ecto.Query
     import Ecto.Changeset
 
-    def list_all_providers(subject) do
-      [
+    def list_all_providers(subject, include_x509?) do
+      providers = [
         EmailOTP.AuthProvider |> Safe.scoped(subject) |> Safe.all(),
         Userpass.AuthProvider |> Safe.scoped(subject) |> Safe.all(),
         Google.AuthProvider |> Safe.scoped(subject) |> Safe.all(),
@@ -1833,7 +1855,22 @@ defmodule PortalWeb.Settings.Authentication do
         Okta.AuthProvider |> Safe.scoped(subject) |> Safe.all(),
         OIDC.AuthProvider |> Safe.scoped(subject) |> Safe.all()
       ]
+
+      providers =
+        if include_x509? do
+          [X509.AuthProvider |> Safe.scoped(subject) |> Safe.all() | providers]
+        else
+          providers
+        end
+
+      providers
       |> List.flatten()
+    end
+
+    def has_trust_anchors?(subject) do
+      Portal.TrustAnchorCertificate
+      |> Safe.scoped(subject)
+      |> Safe.exists?()
     end
 
     def get_provider!(schema, id, subject) do
@@ -1853,6 +1890,8 @@ defmodule PortalWeb.Settings.Authentication do
       |> Safe.scoped(subject)
       |> Safe.update()
     end
+
+    def delete_provider!(%X509.AuthProvider{}, _subject), do: {:error, :cannot_delete}
 
     def delete_provider!(provider, subject) do
       # Delete the parent auth_provider, which will CASCADE delete the child and tokens

--- a/elixir/lib/portal_web/live/sign_up.ex
+++ b/elixir/lib/portal_web/live/sign_up.ex
@@ -847,7 +847,8 @@ defmodule PortalWeb.SignUp do
       Actor,
       AuthProvider,
       EmailOTP,
-      Safe
+      Safe,
+      X509
     }
 
     @spec find_account_by_owner_email(String.t()) :: Portal.Account.t() | nil
@@ -891,7 +892,8 @@ defmodule PortalWeb.SignUp do
     end
 
     # OTP 28 dialyzer is stricter about opaque types (MapSet) inside Ecto.Multi
-    @dialyzer {:no_opaque, [register_account: 6, create_email_provider: 1]}
+    @dialyzer {:no_opaque,
+               [register_account: 6, create_email_provider: 1, create_x509_provider: 1]}
     @spec register_account(any(), String.t(), any(), map(), any(), any()) ::
             {:ok, map()} | {:error, atom(), any(), map()}
     def register_account(
@@ -920,6 +922,9 @@ defmodule PortalWeb.SignUp do
       end)
       |> Ecto.Multi.run(:provider, fn _repo, %{account: account} ->
         create_email_provider(account)
+      end)
+      |> Ecto.Multi.run(:x509_provider, fn _repo, %{account: account} ->
+        create_x509_provider(account)
       end)
       |> Ecto.Multi.run(:actor, fn _repo, %{account: account} ->
         create_admin(account, registration.email, registration.actor.name)
@@ -974,6 +979,42 @@ defmodule PortalWeb.SignUp do
       |> Safe.transact()
       |> case do
         {:ok, %{email_otp_provider: email_provider}} -> {:ok, email_provider}
+        {:error, _step, changeset, _changes} -> {:error, changeset}
+      end
+    end
+
+    @spec create_x509_provider(Portal.Account.t()) ::
+            {:ok, Portal.X509.AuthProvider.t()} | {:error, Ecto.Changeset.t()}
+    def create_x509_provider(account) do
+      id = Ecto.UUID.generate()
+
+      parent_changeset =
+        cast(
+          %AuthProvider{},
+          %{account_id: account.id, id: id, type: :x509},
+          ~w[id account_id type]a
+        )
+
+      x509_changeset =
+        %X509.AuthProvider{}
+        |> cast(
+          %{
+            id: id,
+            account_id: account.id,
+            name: "X.509",
+            context: :clients_only,
+            is_disabled: true
+          },
+          ~w[id account_id name context is_disabled]a
+        )
+        |> X509.AuthProvider.changeset()
+
+      Ecto.Multi.new()
+      |> Ecto.Multi.insert(:auth_provider, parent_changeset)
+      |> Ecto.Multi.insert(:x509_provider, x509_changeset)
+      |> Safe.transact()
+      |> case do
+        {:ok, %{x509_provider: provider}} -> {:ok, provider}
         {:error, _step, changeset, _changes} -> {:error, changeset}
       end
     end

--- a/elixir/priv/repo/migrations/20260817000001_create_x509_auth_providers.exs
+++ b/elixir/priv/repo/migrations/20260817000001_create_x509_auth_providers.exs
@@ -1,0 +1,88 @@
+defmodule Portal.Repo.Migrations.CreateX509AuthProviders do
+  use Ecto.Migration
+
+  def up do
+    drop(constraint(:auth_providers, :type_must_be_valid))
+
+    create(
+      constraint(:auth_providers, :type_must_be_valid,
+        check: "type IN ('google', 'entra', 'okta', 'email_otp', 'oidc', 'userpass', 'x509')"
+      )
+    )
+
+    create(
+      unique_index(:auth_providers, [:account_id],
+        where: "type = 'x509'",
+        name: :auth_providers_account_id_x509_index
+      )
+    )
+
+    create table(:x509_auth_providers, primary_key: false) do
+      add(:account_id, references(:accounts, type: :binary_id, on_delete: :delete_all),
+        null: false,
+        primary_key: true
+      )
+
+      add(:id, :binary_id, null: false, primary_key: true)
+
+      add(:name, :string, null: false, default: "X.509")
+      add(:context, :string, null: false, default: "clients_only")
+      add(:is_disabled, :boolean, default: true, null: false)
+
+      timestamps()
+    end
+
+    create(
+      unique_index(:x509_auth_providers, [:account_id],
+        name: :x509_auth_providers_account_id_index
+      )
+    )
+
+    execute("""
+    ALTER TABLE x509_auth_providers
+    ADD CONSTRAINT x509_auth_providers_auth_provider_id_fkey
+    FOREIGN KEY (account_id, id)
+    REFERENCES auth_providers(account_id, id)
+    ON DELETE CASCADE
+    """)
+
+    create(
+      constraint(:x509_auth_providers, :context_must_be_clients_only,
+        check: "context = 'clients_only'"
+      )
+    )
+
+    execute("""
+    WITH providers AS (
+      SELECT id AS account_id, gen_random_uuid() AS provider_id
+      FROM accounts
+    ), inserted_parents AS (
+      INSERT INTO auth_providers (account_id, id, type)
+      SELECT account_id, provider_id, 'x509'
+      FROM providers
+      RETURNING account_id, id
+    )
+    INSERT INTO x509_auth_providers (
+      account_id, id, name, context, is_disabled, inserted_at, updated_at
+    )
+    SELECT account_id, id, 'X.509', 'clients_only', true, NOW(), NOW()
+    FROM inserted_parents
+    """)
+  end
+
+  def down do
+    execute("DELETE FROM auth_providers WHERE type = 'x509'")
+    drop(table(:x509_auth_providers))
+    drop_if_exists(
+      index(:auth_providers, [:account_id], name: :auth_providers_account_id_x509_index)
+    )
+
+    drop(constraint(:auth_providers, :type_must_be_valid))
+
+    create(
+      constraint(:auth_providers, :type_must_be_valid,
+        check: "type IN ('google', 'entra', 'okta', 'email_otp', 'oidc', 'userpass')"
+      )
+    )
+  end
+end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -31,7 +31,8 @@ defmodule Portal.Repo.Seeds do
     SessionLog,
     Site,
     ClientToken,
-    Userpass
+    Userpass,
+    X509
   }
 
   alias Portal.Types.LogId
@@ -1087,6 +1088,13 @@ defmodule Portal.Repo.Seeds do
     {:ok, _email_provider} =
       create_auth_provider(EmailOTP.AuthProvider, %{name: "Email OTP"}, system_subject)
 
+    {:ok, _x509_provider} =
+      create_auth_provider(
+        X509.AuthProvider,
+        %{name: "X.509", context: :clients_only, is_disabled: true},
+        system_subject
+      )
+
     {:ok, userpass_provider} =
       create_auth_provider(
         Userpass.AuthProvider,
@@ -1148,6 +1156,13 @@ defmodule Portal.Repo.Seeds do
 
     {:ok, _other_email_provider} =
       create_auth_provider(EmailOTP.AuthProvider, %{name: "Email OTP"}, other_system_subject)
+
+    {:ok, _other_x509_provider} =
+      create_auth_provider(
+        X509.AuthProvider,
+        %{name: "X.509", context: :clients_only, is_disabled: true},
+        other_system_subject
+      )
 
     {:ok, _other_userpass_provider} =
       create_auth_provider(

--- a/elixir/priv/static/openapi.json
+++ b/elixir/priv/static/openapi.json
@@ -2687,6 +2687,61 @@
         "title": "GatewayProvisionResponse",
         "type": "object"
       },
+      "X509AuthProvider": {
+        "description": "X.509 Auth Provider",
+        "example": {
+          "context": "clients_only",
+          "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+          "is_disabled": true,
+          "name": "X.509"
+        },
+        "properties": {
+          "account_id": {
+            "description": "Account ID",
+            "format": "uuid",
+            "type": "string"
+          },
+          "context": {
+            "description": "Context",
+            "enum": [
+              "clients_only"
+            ],
+            "type": "string"
+          },
+          "id": {
+            "description": "Provider ID",
+            "format": "uuid",
+            "type": "string"
+          },
+          "inserted_at": {
+            "description": "Creation timestamp",
+            "format": "date-time",
+            "type": "string"
+          },
+          "is_disabled": {
+            "description": "Whether provider is disabled",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "Provider name",
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "Update timestamp",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "account_id",
+          "name",
+          "context",
+          "is_disabled"
+        ],
+        "title": "X509AuthProvider",
+        "type": "object"
+      },
       "ActorsResponse": {
         "description": "Response schema for multiple Actors",
         "example": {
@@ -3098,6 +3153,16 @@
           "type"
         ],
         "title": "Resource",
+        "type": "object"
+      },
+      "X509AuthProviderResponse": {
+        "description": "Response schema for a single X.509 Auth Provider",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/X509AuthProvider"
+          }
+        },
+        "title": "X509AuthProviderResponse",
         "type": "object"
       },
       "ClientTokenCreate": {
@@ -10186,6 +10251,93 @@
         "summary": "Show an Intune posture provider",
         "tags": [
           "Intune Posture Providers"
+        ]
+      }
+    },
+    "/x509_auth_provider": {
+      "get": {
+        "callbacks": {},
+        "operationId": "PortalAPI.X509AuthProviderController.show",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X509AuthProviderResponse"
+                }
+              }
+            },
+            "description": "X.509 Auth Provider Response"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The request could not be processed.",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "type": "about:blank"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Authentication credentials were missing or invalid.",
+                  "status": 401,
+                  "title": "Unauthorized",
+                  "type": "about:blank"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The requested resource could not be found.",
+                  "status": 404,
+                  "title": "Not Found",
+                  "type": "about:blank"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Rate limit exceeded. Retry after the time indicated in the Retry-After header.",
+                  "status": 429,
+                  "title": "Too Many Requests",
+                  "type": "about:blank"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          }
+        },
+        "summary": "Show X.509 Auth Provider",
+        "tags": [
+          "X.509 Auth Providers"
         ]
       }
     },

--- a/elixir/test/portal/billing/event_handler_test.exs
+++ b/elixir/test/portal/billing/event_handler_test.exs
@@ -2,9 +2,31 @@ defmodule Portal.Billing.EventHandlerTest do
   use Portal.DataCase, async: true
 
   alias Portal.Billing.EventHandler
+  alias Portal.Billing.EventHandler.Database
   alias Portal.Mocks.Stripe
 
   import Portal.AccountFixtures
+
+  describe "Database.create_x509_provider/1" do
+    test "rolls back the parent when the child insert fails" do
+      account = account_fixture()
+      id = Ecto.UUID.generate()
+
+      Repo.insert!(%Portal.AuthProvider{id: id, account_id: account.id, type: :email_otp})
+
+      Repo.insert!(%Portal.X509.AuthProvider{
+        id: id,
+        account_id: account.id,
+        name: "Existing child",
+        context: :clients_only,
+        is_disabled: true
+      })
+
+      assert {:error, %Ecto.Changeset{}} = Database.create_x509_provider(account)
+
+      refute Repo.get_by(Portal.AuthProvider, account_id: account.id, type: :x509)
+    end
+  end
 
   describe "handle_event/1 with customer.updated" do
     setup do
@@ -210,6 +232,12 @@ defmodule Portal.Billing.EventHandlerTest do
       email_provider = Portal.Repo.get_by(Portal.EmailOTP.AuthProvider, account_id: account.id)
       assert email_provider != nil
       assert email_provider.name == "Email (OTP)"
+
+      # X.509 provider should be created disabled by default
+      x509_provider = Portal.Repo.get_by(Portal.X509.AuthProvider, account_id: account.id)
+      assert x509_provider.name == "X.509"
+      assert x509_provider.context == :clients_only
+      assert x509_provider.is_disabled
 
       # Admin actor should be created
       admin = Portal.Repo.get_by(Portal.Actor, account_id: account.id, type: :account_admin_user)

--- a/elixir/test/portal/changes/hooks/actors_test.exs
+++ b/elixir/test/portal/changes/hooks/actors_test.exs
@@ -86,6 +86,7 @@ defmodule Portal.Changes.Hooks.ActorsTest do
       refute Repo.get_by(Portal.PortalSession, account_id: account.id, id: portal_session.id)
       assert_receive %Change{op: :update, lsn: 0}
     end
+
   end
 
   describe "on_delete/2" do

--- a/elixir/test/portal/changes/hooks/x509_auth_providers_test.exs
+++ b/elixir/test/portal/changes/hooks/x509_auth_providers_test.exs
@@ -1,0 +1,56 @@
+defmodule Portal.Changes.Hooks.X509AuthProvidersTest do
+  use Portal.DataCase, async: true
+
+  import Portal.Changes.Hooks.X509AuthProviders
+  alias Portal.Changes.Change
+  alias Portal.PubSub
+  alias Portal.X509.AuthProvider
+
+  setup do
+    account_id = Ecto.UUID.generate()
+    provider_id = Ecto.UUID.generate()
+
+    data = %{
+      "id" => provider_id,
+      "account_id" => account_id,
+      "name" => "X.509",
+      "context" => "clients_only",
+      "is_disabled" => false
+    }
+
+    :ok = PubSub.Changes.subscribe(account_id, :x509_auth_providers)
+
+    %{account_id: account_id, provider_id: provider_id, data: data}
+  end
+
+  test "broadcasts an inserted X.509 auth provider", %{data: data, provider_id: provider_id} do
+    assert :ok = on_insert(1, data)
+
+    assert_receive %Change{
+      lsn: 1,
+      op: :insert,
+      struct: %AuthProvider{id: ^provider_id, context: :clients_only, is_disabled: false}
+    }
+  end
+
+  test "broadcasts an updated X.509 auth provider", %{data: data, provider_id: provider_id} do
+    assert :ok = on_update(2, data, %{data | "is_disabled" => true})
+
+    assert_receive %Change{
+      lsn: 2,
+      op: :update,
+      old_struct: %AuthProvider{id: ^provider_id, is_disabled: false},
+      struct: %AuthProvider{id: ^provider_id, is_disabled: true}
+    }
+  end
+
+  test "broadcasts a deleted X.509 auth provider", %{data: data, provider_id: provider_id} do
+    assert :ok = on_delete(3, data)
+
+    assert_receive %Change{
+      lsn: 3,
+      op: :delete,
+      old_struct: %AuthProvider{id: ^provider_id}
+    }
+  end
+end

--- a/elixir/test/portal/email_test.exs
+++ b/elixir/test/portal/email_test.exs
@@ -1,0 +1,23 @@
+defmodule Portal.EmailTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Email
+
+  describe "normalize/1" do
+    test "trims components, preserves local-part case, and IDNA-encodes the domain" do
+      assert Email.normalize("  User @ BÜCHER.example  ") ==
+               {:ok, "User@xn--bcher-kva.example"}
+    end
+
+    test "trims input without an at sign for validation by the caller" do
+      assert Email.normalize("  invalid  ") == {:ok, "invalid"}
+    end
+  end
+
+  describe "normalize_for_match/1" do
+    test "normalizes the complete address for case-insensitive matching" do
+      assert Email.normalize_for_match("  USER@BÜCHER.example  ") ==
+               {:ok, "user@xn--bcher-kva.example"}
+    end
+  end
+end

--- a/elixir/test/portal/endpoint_test.exs
+++ b/elixir/test/portal/endpoint_test.exs
@@ -166,6 +166,34 @@ defmodule Portal.EndpointTest do
     assert forwarded.private.phoenix_endpoint == PortalAPI.Endpoint
   end
 
+  test "distinguishes the mutual-TLS endpoint by hostname and port" do
+    Portal.Config.put_env_override(:portal, :web_external_url, "https://localhost:443/")
+    Portal.Config.put_env_override(:portal, :mtls_external_url, "https://localhost:4444/")
+
+    web = Endpoint.call(conn(:get, "https://localhost:443/not-found"), [])
+    assert web.private.phoenix_endpoint == PortalWeb.Endpoint
+
+    rejected = Endpoint.call(conn(:get, "https://localhost:4444/not-found"), [])
+    assert rejected.status == 404
+    assert rejected.private.phoenix_endpoint == Endpoint
+
+    forwarded =
+      :get
+      |> conn("https://localhost:4444/not-found")
+      |> put_req_header("upgrade", "websocket")
+      |> Endpoint.call([])
+
+    assert forwarded.private.phoenix_endpoint == PortalAPI.Endpoint
+
+    wrong_port =
+      :get
+      |> conn("https://localhost:4445/not-found")
+      |> put_req_header("upgrade", "websocket")
+      |> Endpoint.call([])
+
+    assert wrong_port.private.phoenix_endpoint == PortalWeb.Endpoint
+  end
+
   test "rejects unknown hostnames" do
     conn = Endpoint.call(conn(:get, "https://unknown.firezone.test/"), [])
 

--- a/elixir/test/portal/safe_test.exs
+++ b/elixir/test/portal/safe_test.exs
@@ -88,7 +88,8 @@ defmodule Portal.SafeTest do
             Portal.Okta.AuthProvider,
             Portal.OIDC.AuthProvider,
             Portal.EmailOTP.AuthProvider,
-            Portal.Userpass.AuthProvider
+            Portal.Userpass.AuthProvider,
+            Portal.X509.AuthProvider
           ] do
         assert Safe.permit(:delete, schema, :account_admin_user) == :ok
         assert Safe.permit(:read, schema, :api_client) == :ok

--- a/elixir/test/portal/x509/auth_provider_test.exs
+++ b/elixir/test/portal/x509/auth_provider_test.exs
@@ -1,0 +1,30 @@
+defmodule Portal.X509.AuthProviderTest do
+  use Portal.DataCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.AuthProviderFixtures
+
+  alias Portal.AuthProvider
+  alias Portal.X509.AuthProvider, as: X509AuthProvider
+
+  test "uses account_id and id as its composite primary key" do
+    assert X509AuthProvider.__schema__(:primary_key) == [:account_id, :id]
+  end
+
+  test "the parent table permits only one X.509 provider per account" do
+    account = account_fixture()
+    _provider = x509_provider_fixture(account: account)
+
+    changeset =
+      %AuthProvider{}
+      |> Ecto.Changeset.cast(
+        %{id: Ecto.UUID.generate(), type: :x509},
+        [:id, :type]
+      )
+      |> Ecto.Changeset.put_assoc(:account, account)
+      |> AuthProvider.changeset()
+
+    assert {:error, changeset} = Repo.insert(changeset)
+    assert "already has an X.509 authentication provider" in errors_on(changeset).account_id
+  end
+end

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -10,6 +10,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
+  import Portal.AuthProviderFixtures
   import Portal.DeviceFixtures
   import Portal.GroupFixtures
   import Portal.IdentityFixtures
@@ -1041,6 +1042,80 @@ defmodule PortalAPI.Client.ChannelTest do
       assert_push "init", _init_payload
 
       PG.deliver(client.id, :disconnect)
+
+      assert_push "disconnect", %{reason: "token_expired"}
+      assert_receive {:EXIT, _pid, :shutdown}
+    end
+
+    test "disconnects an X.509 channel when actor CDC reports it disabled", %{
+      account: account,
+      actor: actor,
+      client: client,
+      subject: subject
+    } do
+      Process.flag(:trap_exit, true)
+      provider = x509_provider_fixture(account: account, is_disabled: false)
+
+      credential = %Portal.Authentication.Credential{
+        id: Ecto.UUID.generate(),
+        type: :x509,
+        auth_provider_id: provider.id
+      }
+
+      join_channel(client, %{subject | credential: credential})
+      assert_push "init", _init_payload
+
+      actor |> Ecto.Changeset.change(is_disabled: true) |> Repo.update!()
+
+      old_data = %{
+        "id" => actor.id,
+        "account_id" => account.id,
+        "type" => actor.type,
+        "is_disabled" => false
+      }
+
+      assert :ok =
+               Portal.Changes.Hooks.Actors.on_update(
+                 1,
+                 old_data,
+                 %{old_data | "is_disabled" => true}
+               )
+
+      assert_push "disconnect", %{reason: "token_expired"}
+      assert_receive {:EXIT, _pid, :shutdown}
+    end
+
+    test "disconnects an X.509 channel when provider CDC reports it disabled", %{
+      account: account,
+      client: client,
+      subject: subject
+    } do
+      Process.flag(:trap_exit, true)
+      provider = x509_provider_fixture(account: account, is_disabled: false)
+
+      credential = %Portal.Authentication.Credential{
+        id: Ecto.UUID.generate(),
+        type: :x509,
+        auth_provider_id: provider.id
+      }
+
+      join_channel(client, %{subject | credential: credential})
+      assert_push "init", _init_payload
+
+      provider |> Ecto.Changeset.change(is_disabled: true) |> Repo.update!()
+
+      old_data = %{
+        "id" => provider.id,
+        "account_id" => account.id,
+        "is_disabled" => false
+      }
+
+      assert :ok =
+               Portal.Changes.Hooks.X509AuthProviders.on_update(
+                 1,
+                 old_data,
+                 %{old_data | "is_disabled" => true}
+               )
 
       assert_push "disconnect", %{reason: "token_expired"}
       assert_receive {:EXIT, _pid, :shutdown}

--- a/elixir/test/portal_api/client/device_trust_test.exs
+++ b/elixir/test/portal_api/client/device_trust_test.exs
@@ -11,8 +11,9 @@ defmodule PortalAPI.Client.DeviceTrustTest do
   alias PortalAPI.Client.DeviceTrust
   alias Portal.Crypto.X509
 
-  @attestation_url "https://mtls.firezone.test/"
+  @attestation_url "https://mtls.firezone.test:4443/"
   @attestation_host "mtls.firezone.test"
+  @attestation_port 4443
 
   describe "attest/2 when there is nothing to attest" do
     setup do
@@ -490,6 +491,15 @@ defmodule PortalAPI.Client.DeviceTrustTest do
       assert DeviceTrust.attest(connect_info, subject) == {:error, :not_attestation_host}
     end
 
+    test "does not attest on another port at the attestation host", %{
+      pki: pki,
+      subject: subject
+    } do
+      connect_info = connect_info(leaf(pki, :rsa), port: 443)
+
+      assert DeviceTrust.attest(connect_info, subject) == {:error, :not_attestation_host}
+    end
+
     test "does not attest a connect that carries no host", %{pki: pki, subject: subject} do
       connect_info = pki |> leaf(:rsa) |> connect_info() |> Map.delete(:uri)
 
@@ -684,9 +694,10 @@ defmodule PortalAPI.Client.DeviceTrustTest do
 
   defp connect_info_with_cert(value, opts \\ []) do
     host = Keyword.get(opts, :host, @attestation_host)
+    port = Keyword.get(opts, :port, @attestation_port)
 
     %{
-      uri: %URI{scheme: "https", host: host, port: 443, path: "/"},
+      uri: %URI{scheme: "https", host: host, port: port, path: "/"},
       peer_data: %{ssl_cert: value}
     }
   end

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -738,6 +738,30 @@ defmodule PortalAPI.Client.SocketTest do
                {:error, :missing_token}
     end
 
+    test "authenticates by token and attests by certificate when the X.509 provider is disabled",
+         %{
+           account: account,
+           actor: actor,
+           pki: pki
+         } do
+      _provider = x509_provider_fixture(account: account, is_disabled: true)
+      client_token = client_token_fixture(account: account, actor: actor)
+
+      connect_info =
+        build_connect_info(
+          token: encode_token(client_token),
+          host: "mtls.firezone.test",
+          client_cert: x509_identity_cert(pki, account, actor)
+        )
+
+      assert {:ok, socket} = connect(Socket, connect_attrs([]), connect_info: connect_info)
+      assert socket.assigns.subject.credential.type == :client_token
+      assert socket.assigns.subject.credential.id == client_token.id
+      assert socket.assigns.client.client_token_id == client_token.id
+      assert socket.assigns.client.attested?
+      assert socket.assigns.client.last_attested_cert_fingerprint
+    end
+
     test "returns a specific error when no active user matches the certificate", %{
       account: account,
       actor: actor,

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -541,6 +541,90 @@ defmodule PortalAPI.Client.SocketTest do
       assert is_nil(socket.assigns.client.client_token_id)
     end
 
+    test "authenticates a service account from an X.509 actor ID claim", %{
+      account: account,
+      pki: pki
+    } do
+      actor = actor_fixture(account: account, type: :service_account)
+      provider = x509_provider_fixture(account: account, is_disabled: false)
+
+      connect_info =
+        build_connect_info(
+          host: "mtls.firezone.test",
+          client_cert: x509_actor_id_cert(pki, account, actor)
+        )
+
+      assert {:ok, socket} = connect(Socket, connect_attrs([]), connect_info: connect_info)
+      assert socket.assigns.subject.actor.id == actor.id
+      assert socket.assigns.subject.actor.type == :service_account
+      assert socket.assigns.subject.credential.type == :x509
+      assert socket.assigns.subject.credential.auth_provider_id == provider.id
+      assert socket.assigns.client.attested?
+      assert is_nil(socket.assigns.client.client_token_id)
+    end
+
+    test "prefers an X.509 actor ID claim over an email claim", %{
+      account: account,
+      actor: email_actor,
+      pki: pki
+    } do
+      actor = actor_fixture(account: account, type: :service_account)
+      _provider = x509_provider_fixture(account: account, is_disabled: false)
+
+      connect_info =
+        build_connect_info(
+          host: "mtls.firezone.test",
+          client_cert: x509_actor_id_cert(pki, account, actor, email_actor.email)
+        )
+
+      assert {:ok, socket} = connect(Socket, connect_attrs([]), connect_info: connect_info)
+      assert socket.assigns.subject.actor.id == actor.id
+    end
+
+    test "does not fall back to email when an X.509 actor ID claim is invalid", %{
+      account: account,
+      actor: actor,
+      pki: pki
+    } do
+      _provider = x509_provider_fixture(account: account, is_disabled: false)
+
+      connect_info =
+        build_connect_info(
+          host: "mtls.firezone.test",
+          client_cert: x509_actor_id_cert(pki, account, %{id: "%ZZ"}, actor.email)
+        )
+
+      assert capture_log(fn ->
+               assert connect(Socket, connect_attrs([]), connect_info: connect_info) ==
+                        {:error, :device_untrusted}
+             end) =~ "invalid_x509_identity"
+    end
+
+    test "scopes an X.509 actor ID claim to the claimed account", %{
+      account: account,
+      pki: pki
+    } do
+      other_account = account_fixture()
+      actor = actor_fixture(account: other_account, type: :service_account)
+      _provider = x509_provider_fixture(account: account, is_disabled: false)
+
+      connect_info =
+        build_connect_info(
+          host: "mtls.firezone.test",
+          client_cert: x509_actor_id_cert(pki, account, actor)
+        )
+
+      log =
+        capture_log(fn ->
+          assert connect(Socket, connect_attrs([]), connect_info: connect_info) ==
+                   {:error, :x509_user_not_authorized}
+        end)
+
+      assert log =~ "x509_user_not_found"
+      assert log =~ "account_id=#{account.id}"
+      assert log =~ "actor_id=#{actor.id}"
+    end
+
     test "normalizes the certificate email before matching the actor", %{
       account: account,
       pki: pki
@@ -1473,6 +1557,26 @@ defmodule PortalAPI.Client.SocketTest do
         {:uniformResourceIdentifier, String.to_charlist("firezone://email/#{actor.email}")},
         {:uniformResourceIdentifier, ~c"firezone://serial/C02XK1ZGJGH5"}
       ]
+    )
+  end
+
+  defp x509_actor_id_cert(pki, account, actor, email \\ nil) do
+    email_sans =
+      if email do
+        [{:uniformResourceIdentifier, String.to_charlist("firezone://email/#{email}")}]
+      else
+        []
+      end
+
+    leaf(pki,
+      sans:
+        [
+          {:uniformResourceIdentifier,
+           String.to_charlist("firezone://account-id/#{account.id}")},
+          {:uniformResourceIdentifier, String.to_charlist("firezone://actor-id/#{actor.id}")}
+        ] ++
+          email_sans ++
+          [{:uniformResourceIdentifier, ~c"firezone://serial/C02XK1ZGJGH5"}]
     )
   end
 end

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -496,20 +496,8 @@ defmodule PortalAPI.Client.SocketTest do
     end
   end
 
-  describe "connect/3 device trust" do
-    setup do
-      Portal.Config.put_env_override(:portal, :mtls_external_url, "https://mtls.firezone.test/")
-
-      account = account_fixture()
-      enable_feature(:trust_anchors)
-      pki = pki()
-      trust_anchor_fixture(account: account, certs: [pki.ca_der])
-
-      actor = actor_fixture(account: account)
-      token = client_token_fixture(account: account, actor: actor)
-
-      %{account: account, actor: actor, pki: pki, token: encode_token(token)}
-    end
+  describe "connect/3 device attestation" do
+    setup :setup_device_trust
 
     test "attests the device from the presented certificate", %{pki: pki, token: token} do
       connect_info = attested_connect_info(pki, token)
@@ -519,6 +507,10 @@ defmodule PortalAPI.Client.SocketTest do
       assert socket.assigns.client.last_attested_device_serial == "C02XK1ZGJGH5"
       assert socket.assigns.client.last_attested_cert_fingerprint
     end
+  end
+
+  describe "connect/3 X.509 authentication" do
+    setup :setup_device_trust
 
     test "authenticates from X.509 identity claims without a client token", %{
       account: account,
@@ -598,6 +590,60 @@ defmodule PortalAPI.Client.SocketTest do
                assert connect(Socket, connect_attrs([]), connect_info: connect_info) ==
                         {:error, :device_untrusted}
              end) =~ "invalid_x509_identity"
+    end
+
+    test "rejects two distinct X.509 account ID claims", %{
+      account: account,
+      actor: actor,
+      pki: pki
+    } do
+      other_account = account_fixture()
+      _provider = x509_provider_fixture(account: account, is_disabled: false)
+
+      certificate =
+        x509_authentication_cert(pki, [
+          "firezone://account-id/#{account.id}",
+          "firezone://account-id/#{other_account.id}",
+          "firezone://email/#{actor.email}"
+        ])
+
+      assert_invalid_x509_identity(certificate)
+    end
+
+    test "rejects two distinct X.509 email claims when authenticating by email", %{
+      account: account,
+      actor: actor,
+      pki: pki
+    } do
+      other_actor = actor_fixture(account: account)
+      _provider = x509_provider_fixture(account: account, is_disabled: false)
+
+      certificate =
+        x509_authentication_cert(pki, [
+          "firezone://account-id/#{account.id}",
+          "firezone://email/#{actor.email}",
+          "firezone://email/#{other_actor.email}"
+        ])
+
+      assert_invalid_x509_identity(certificate)
+    end
+
+    test "rejects two distinct X.509 actor ID claims", %{
+      account: account,
+      actor: actor,
+      pki: pki
+    } do
+      other_actor = actor_fixture(account: account, type: :service_account)
+      _provider = x509_provider_fixture(account: account, is_disabled: false)
+
+      certificate =
+        x509_authentication_cert(pki, [
+          "firezone://account-id/#{account.id}",
+          "firezone://actor-id/#{actor.id}",
+          "firezone://actor-id/#{other_actor.id}"
+        ])
+
+      assert_invalid_x509_identity(certificate)
     end
 
     test "scopes an X.509 actor ID claim to the claimed account", %{
@@ -877,6 +923,10 @@ defmodule PortalAPI.Client.SocketTest do
       assert connect(Socket, connect_attrs([]), connect_info: connect_info_with_bogus_token) ==
                {:error, :rate_limit}
     end
+  end
+
+  describe "connect/3 device trust" do
+    setup :setup_device_trust
 
     test "connects unattested on the plain API host", %{pki: pki, token: token} do
       connect_info =
@@ -1541,6 +1591,30 @@ defmodule PortalAPI.Client.SocketTest do
     |> Enum.into(%{}, fn {k, v} -> {to_string(k), v} end)
   end
 
+  defp setup_device_trust(_context) do
+    Portal.Config.put_env_override(:portal, :mtls_external_url, "https://mtls.firezone.test/")
+
+    account = account_fixture()
+    enable_feature(:trust_anchors)
+    pki = pki()
+    trust_anchor_fixture(account: account, certs: [pki.ca_der])
+
+    actor = actor_fixture(account: account)
+    token = client_token_fixture(account: account, actor: actor)
+
+    %{account: account, actor: actor, pki: pki, token: encode_token(token)}
+  end
+
+  defp assert_invalid_x509_identity(certificate) do
+    connect_info =
+      build_connect_info(host: "mtls.firezone.test", client_cert: certificate)
+
+    assert capture_log(fn ->
+             assert connect(Socket, connect_attrs([]), connect_info: connect_info) ==
+                      {:error, :device_untrusted}
+           end) =~ "invalid_x509_identity"
+  end
+
   defp attested_connect_info(pki, token) do
     build_connect_info(
       token: token,
@@ -1550,33 +1624,31 @@ defmodule PortalAPI.Client.SocketTest do
   end
 
   defp x509_identity_cert(pki, account, actor) do
-    leaf(pki,
-      sans: [
-        {:uniformResourceIdentifier,
-         String.to_charlist("firezone://account-id/#{account.id}")},
-        {:uniformResourceIdentifier, String.to_charlist("firezone://email/#{actor.email}")},
-        {:uniformResourceIdentifier, ~c"firezone://serial/C02XK1ZGJGH5"}
-      ]
-    )
+    x509_authentication_cert(pki, [
+      "firezone://account-id/#{account.id}",
+      "firezone://email/#{actor.email}"
+    ])
   end
 
   defp x509_actor_id_cert(pki, account, actor, email \\ nil) do
-    email_sans =
-      if email do
-        [{:uniformResourceIdentifier, String.to_charlist("firezone://email/#{email}")}]
-      else
-        []
-      end
+    identity_uris = [
+      "firezone://account-id/#{account.id}",
+      "firezone://actor-id/#{actor.id}"
+    ]
+
+    identity_uris = if email, do: identity_uris ++ ["firezone://email/#{email}"], else: identity_uris
+
+    x509_authentication_cert(pki, identity_uris)
+  end
+
+  defp x509_authentication_cert(pki, identity_uris) do
+    identity_sans =
+      Enum.map(identity_uris, fn uri ->
+        {:uniformResourceIdentifier, String.to_charlist(uri)}
+      end)
 
     leaf(pki,
-      sans:
-        [
-          {:uniformResourceIdentifier,
-           String.to_charlist("firezone://account-id/#{account.id}")},
-          {:uniformResourceIdentifier, String.to_charlist("firezone://actor-id/#{actor.id}")}
-        ] ++
-          email_sans ++
-          [{:uniformResourceIdentifier, ~c"firezone://serial/C02XK1ZGJGH5"}]
+      sans: identity_sans ++ [{:uniformResourceIdentifier, ~c"firezone://serial/C02XK1ZGJGH5"}]
     )
   end
 end

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -5,6 +5,7 @@ defmodule PortalAPI.Client.SocketTest do
   import PortalAPI.Client.Socket, only: [id: 1]
   import Portal.AccountFixtures
   import Portal.ActorFixtures
+  import Portal.AuthProviderFixtures
   import Portal.TokenFixtures
   import Portal.DeviceFixtures
   import Portal.DeviceTrustFixtures
@@ -519,6 +520,164 @@ defmodule PortalAPI.Client.SocketTest do
       assert socket.assigns.client.last_attested_cert_fingerprint
     end
 
+    test "authenticates from X.509 identity claims without a client token", %{
+      account: account,
+      actor: actor,
+      pki: pki
+    } do
+      provider = x509_provider_fixture(account: account, is_disabled: false)
+
+      connect_info =
+        build_connect_info(
+          host: "mtls.firezone.test",
+          client_cert: x509_identity_cert(pki, account, actor)
+        )
+
+      assert {:ok, socket} = connect(Socket, connect_attrs([]), connect_info: connect_info)
+      assert socket.assigns.subject.actor.id == actor.id
+      assert socket.assigns.subject.credential.type == :x509
+      assert socket.assigns.subject.credential.auth_provider_id == provider.id
+      assert socket.assigns.client.attested?
+      assert is_nil(socket.assigns.client.client_token_id)
+    end
+
+    test "normalizes the certificate email before matching the actor", %{
+      account: account,
+      pki: pki
+    } do
+      actor = actor_fixture(account: account, email: "User@bücher.example")
+      _provider = x509_provider_fixture(account: account, is_disabled: false)
+
+      # URI SANs are IA5 strings, so the Unicode domain arrives percent-encoded.
+      certificate_actor = %{actor | email: "USER@b%C3%BCcher.example"}
+
+      connect_info =
+        build_connect_info(
+          host: "mtls.firezone.test",
+          client_cert: x509_identity_cert(pki, account, certificate_actor)
+        )
+
+      assert {:ok, socket} = connect(Socket, connect_attrs([]), connect_info: connect_info)
+      assert socket.assigns.subject.actor.id == actor.id
+    end
+
+    test "a certificate X.509 identity takes precedence over an invalid bearer token", %{
+      account: account,
+      actor: actor,
+      pki: pki
+    } do
+      provider = x509_provider_fixture(account: account, is_disabled: false)
+
+      connect_info =
+        build_connect_info(
+          token: "invalid",
+          host: "mtls.firezone.test",
+          client_cert: x509_identity_cert(pki, account, actor)
+        )
+
+      assert {:ok, socket} = connect(Socket, connect_attrs([]), connect_info: connect_info)
+      assert socket.assigns.subject.credential.auth_provider_id == provider.id
+      assert socket.assigns.subject.credential.type == :x509
+    end
+
+    test "requires a client token when the certificate lacks X.509 identity claims", %{pki: pki} do
+      connect_info =
+        build_connect_info(
+          host: "mtls.firezone.test",
+          client_cert: client_cert(pki, :rsa)
+        )
+
+      assert connect(Socket, connect_attrs([]), connect_info: connect_info) ==
+               {:error, :missing_token}
+    end
+
+    test "requires a client token when the X.509 provider is disabled", %{
+      account: account,
+      actor: actor,
+      pki: pki
+    } do
+      _provider = x509_provider_fixture(account: account, is_disabled: true)
+
+      connect_info =
+        build_connect_info(
+          host: "mtls.firezone.test",
+          client_cert: x509_identity_cert(pki, account, actor)
+        )
+
+      assert connect(Socket, connect_attrs([]), connect_info: connect_info) ==
+               {:error, :missing_token}
+    end
+
+    test "returns a specific error when no active user matches the certificate", %{
+      account: account,
+      actor: actor,
+      pki: pki,
+      token: token
+    } do
+      _provider = x509_provider_fixture(account: account, is_disabled: false)
+      unknown_actor = %{actor | email: "unknown@example.com"}
+
+      connect_info =
+        build_connect_info(
+          token: token,
+          host: "mtls.firezone.test",
+          client_cert: x509_identity_cert(pki, account, unknown_actor)
+        )
+
+      log =
+        capture_log(fn ->
+          assert connect(Socket, connect_attrs([]), connect_info: connect_info) ==
+                   {:error, :x509_user_not_authorized}
+        end)
+
+      assert log =~ "x509_user_not_found"
+      assert log =~ "account_id=#{account.id}"
+      assert log =~ "email=#{unknown_actor.email}"
+    end
+
+    test "returns a specific error when the certificate user is disabled", %{
+      account: account,
+      actor: actor,
+      pki: pki
+    } do
+      _provider = x509_provider_fixture(account: account, is_disabled: false)
+      actor |> Ecto.Changeset.change(is_disabled: true) |> Repo.update!()
+
+      connect_info =
+        build_connect_info(
+          host: "mtls.firezone.test",
+          client_cert: x509_identity_cert(pki, account, actor)
+        )
+
+      log =
+        capture_log(fn ->
+          assert connect(Socket, connect_attrs([]), connect_info: connect_info) ==
+                   {:error, :x509_user_not_authorized}
+        end)
+
+      assert log =~ "x509_user_disabled"
+      assert log =~ "account_id=#{account.id}"
+      assert log =~ "email=#{actor.email}"
+    end
+
+    test "requires a client token when trust anchors are globally disabled", %{
+      account: account,
+      actor: actor,
+      pki: pki
+    } do
+      _provider = x509_provider_fixture(account: account, is_disabled: false)
+      disable_feature(:trust_anchors)
+
+      connect_info =
+        build_connect_info(
+          host: "mtls.firezone.test",
+          client_cert: x509_identity_cert(pki, account, actor)
+        )
+
+      assert connect(Socket, connect_attrs([]), connect_info: connect_info) ==
+               {:error, :missing_token}
+    end
+
     test "refuses a connect through the mutual-TLS host without a certificate", %{token: token} do
       connect_info = build_connect_info(token: token, host: "mtls.firezone.test")
 
@@ -554,6 +713,85 @@ defmodule PortalAPI.Client.SocketTest do
                assert connect(Socket, connect_attrs([]), connect_info: connect_info) ==
                         {:error, :device_untrusted}
              end) =~ "no_trust_anchors"
+    end
+
+    test "does not fall back to a valid token when an X.509 identity has no trust anchors", %{
+      pki: pki
+    } do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      _provider = x509_provider_fixture(account: account, is_disabled: false)
+      token = client_token_fixture(account: account, actor: actor)
+
+      connect_info =
+        build_connect_info(
+          token: encode_token(token),
+          host: "mtls.firezone.test",
+          client_cert: x509_identity_cert(pki, account, actor)
+        )
+
+      assert capture_log(fn ->
+               assert connect(Socket, connect_attrs([]), connect_info: connect_info) ==
+                        {:error, :device_untrusted}
+             end) =~ "no_trust_anchors"
+    end
+
+    test "validates an X.509 certificate before looking up its claimed user", %{
+      account: account,
+      actor: actor,
+      token: token
+    } do
+      _provider = x509_provider_fixture(account: account, is_disabled: false)
+      unknown_actor = %{actor | email: "unknown@example.com"}
+      untrusted_pki = pki()
+
+      connect_info =
+        build_connect_info(
+          token: token,
+          host: "mtls.firezone.test",
+          client_cert: x509_identity_cert(untrusted_pki, account, unknown_actor)
+        )
+
+      log =
+        capture_log(fn ->
+          assert connect(Socket, connect_attrs([]), connect_info: connect_info) ==
+                   {:error, :device_untrusted}
+        end)
+
+      assert log =~ "untrusted_chain"
+      refute log =~ "x509_user_not_found"
+    end
+
+    test "rate limits failed X.509 authentication before repeating validation", %{
+      account: account,
+      actor: actor
+    } do
+      _provider = x509_provider_fixture(account: account, is_disabled: false)
+      untrusted_pki = pki()
+      ip = unique_ip()
+
+      connect_info =
+        build_connect_info(
+          ip: ip,
+          host: "mtls.firezone.test",
+          client_cert: x509_identity_cert(untrusted_pki, account, actor)
+        )
+
+      assert capture_log(fn ->
+               assert connect(Socket, connect_attrs([]), connect_info: connect_info) ==
+                        {:error, :device_untrusted}
+             end) =~ "untrusted_chain"
+
+      connect_info_with_bogus_token =
+        build_connect_info(
+          ip: ip,
+          token: "attacker-controlled-token",
+          host: "mtls.firezone.test",
+          client_cert: x509_identity_cert(untrusted_pki, account, actor)
+        )
+
+      assert connect(Socket, connect_attrs([]), connect_info: connect_info_with_bogus_token) ==
+               {:error, :rate_limit}
     end
 
     test "connects unattested on the plain API host", %{pki: pki, token: token} do
@@ -1224,6 +1462,17 @@ defmodule PortalAPI.Client.SocketTest do
       token: token,
       host: "mtls.firezone.test",
       client_cert: client_cert(pki, :rsa)
+    )
+  end
+
+  defp x509_identity_cert(pki, account, actor) do
+    leaf(pki,
+      sans: [
+        {:uniformResourceIdentifier,
+         String.to_charlist("firezone://account-id/#{account.id}")},
+        {:uniformResourceIdentifier, String.to_charlist("firezone://email/#{actor.email}")},
+        {:uniformResourceIdentifier, ~c"firezone://serial/C02XK1ZGJGH5"}
+      ]
     )
   end
 end

--- a/elixir/test/portal_api/controllers/x509_auth_provider_controller_test.exs
+++ b/elixir/test/portal_api/controllers/x509_auth_provider_controller_test.exs
@@ -1,0 +1,70 @@
+defmodule PortalAPI.X509AuthProviderControllerTest do
+  use PortalAPI.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.AuthProviderFixtures
+  import Portal.FeaturesFixtures
+
+  setup do
+    enable_feature(:trust_anchors)
+    account = account_fixture()
+    actor = api_client_fixture(account: account)
+
+    %{account: account, actor: actor}
+  end
+
+  describe "show/2" do
+    test "returns error when not authorized", %{conn: conn} do
+      conn = get(conn, "/x509_auth_provider")
+
+      assert %{"status" => 401, "title" => "Unauthorized"} = json_response(conn, 401)
+    end
+
+    test "shows the account's singleton X.509 provider", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      provider = x509_provider_fixture(account: account)
+      _other_provider = x509_provider_fixture()
+
+      conn = conn |> authorize_conn(actor) |> get("/x509_auth_provider")
+
+      assert %{
+               "data" => %{
+                 "id" => provider_id,
+                 "account_id" => account_id,
+                 "name" => "X.509",
+                 "context" => "clients_only",
+                 "is_disabled" => true
+               }
+             } = json_response(conn, 200)
+
+      assert provider_id == provider.id
+      assert account_id == account.id
+    end
+
+    test "returns not found when the account has no X.509 provider", %{
+      conn: conn,
+      actor: actor
+    } do
+      conn = conn |> authorize_conn(actor) |> get("/x509_auth_provider")
+
+      assert json_response(conn, 404)
+    end
+
+    test "is unavailable when trust anchors are globally disabled", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      _provider = x509_provider_fixture(account: account)
+      disable_feature(:trust_anchors)
+
+      conn = conn |> authorize_conn(actor) |> get("/x509_auth_provider")
+
+      assert json_response(conn, 404)
+    end
+  end
+end

--- a/elixir/test/portal_api/sockets/latest_session_test.exs
+++ b/elixir/test/portal_api/sockets/latest_session_test.exs
@@ -53,6 +53,18 @@ defmodule PortalAPI.Sockets.LatestSessionTest do
       device = Repo.get_by!(Portal.Device, account_id: client.account_id, id: client.id)
       assert device.firezone_id == "client-supplied"
     end
+
+    test "persists a tokenless X.509 session without treating it as revoked", %{
+      client: client,
+      token: token
+    } do
+      entry = client |> attested_entry(token) |> Map.put(:client_token_id, nil)
+
+      assert {1, [], []} = upsert(entry)
+
+      device = Repo.get_by!(Portal.Device, account_id: client.account_id, id: client.id)
+      assert is_nil(device.client_token_id)
+    end
   end
 
   defp upsert(attrs) do

--- a/elixir/test/portal_api/sockets_test.exs
+++ b/elixir/test/portal_api/sockets_test.exs
@@ -183,7 +183,7 @@ defmodule PortalAPI.SocketsTest do
                "This device's certificate does not identify an active user authorized to access " <>
                  "this Firezone account. Please contact your administrator."
 
-      assert_problem_json(result)
+      assert_problem_json(result, "x509_user_not_authorized")
     end
 
     test "returns 503 with retry-after header for rate_limit" do

--- a/elixir/test/portal_api/sockets_test.exs
+++ b/elixir/test/portal_api/sockets_test.exs
@@ -172,6 +172,20 @@ defmodule PortalAPI.SocketsTest do
       assert_problem_json(result, "gateway_already_connected")
     end
 
+    test "returns a client-facing 403 for an unauthorized X.509 user" do
+      conn = Plug.Test.conn(:get, "/")
+
+      result = Sockets.handle_error(conn, :x509_user_not_authorized)
+
+      assert result.status == 403
+
+      assert json_body(result)["detail"] ==
+               "This device's certificate does not identify an active user authorized to access " <>
+                 "this Firezone account. Please contact your administrator."
+
+      assert_problem_json(result)
+    end
+
     test "returns 503 with retry-after header for rate_limit" do
       conn = Plug.Test.conn(:get, "/")
 

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -7,12 +7,14 @@ defmodule PortalWeb.PoliciesTest do
   import Portal.AccountFixtures
   import Portal.ActorFixtures
   import Portal.AuthProviderFixtures
+  import Portal.FeaturesFixtures
   import Portal.GroupFixtures
   import Portal.MembershipFixtures
   import Portal.PolicyAuthorizationFixtures
   import Portal.PolicyFixtures
   import Portal.ResourceFixtures
   import Portal.SiteFixtures
+  import Portal.TrustAnchorFixtures
 
   setup do
     account = account_fixture()
@@ -870,6 +872,60 @@ defmodule PortalWeb.PoliciesTest do
       assert html =~ "is not in"
     end
 
+    test "warns when X.509 is selected and the account has no trust anchors", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      enable_feature(:trust_anchors)
+      x509_provider = x509_provider_fixture(account: account, is_disabled: false)
+      group = group_fixture(account: account)
+      resource = resource_fixture(account: account)
+      policy = policy_fixture(group: group, resource: resource)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies/#{policy.id}/edit")
+
+      render_click(lv, "toggle_conditions_dropdown")
+      render_click(lv, "add_condition", %{"type" => "auth_provider_id"})
+
+      html = render_click(lv, "toggle_auth_provider_value", %{"id" => x509_provider.id})
+
+      assert html =~ "No devices will be able to use this authentication provider"
+
+      assert has_element?(
+               lv,
+               "a[href='/#{account.slug}/settings/trust_anchors']",
+               "Trust Anchors"
+             )
+    end
+
+    test "does not warn for a selected X.509 provider when a trust anchor exists", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      enable_feature(:trust_anchors)
+      x509_provider = x509_provider_fixture(account: account, is_disabled: false)
+      _anchor = trust_anchor_fixture(account: account)
+      group = group_fixture(account: account)
+      resource = resource_fixture(account: account)
+      policy = policy_fixture(group: group, resource: resource)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies/#{policy.id}/edit")
+
+      render_click(lv, "toggle_conditions_dropdown")
+      render_click(lv, "add_condition", %{"type" => "auth_provider_id"})
+      html = render_click(lv, "toggle_auth_provider_value", %{"id" => x509_provider.id})
+
+      refute html =~ "No devices will be able to use this authentication provider"
+    end
+
     test "manages time-of-day conditions via add range form", %{
       conn: conn,
       account: account,
@@ -1123,6 +1179,38 @@ defmodule PortalWeb.PoliciesTest do
         |> live(~p"/#{account}/policies/#{policy.id}/edit")
 
       assert html =~ auth_provider.name
+    end
+
+    test "warns when a saved policy condition uses X.509 without a trust anchor", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      enable_feature(:trust_anchors)
+      x509_provider = x509_provider_fixture(account: account, is_disabled: false)
+      group = group_fixture(account: account)
+      resource = resource_fixture(account: account)
+
+      policy =
+        policy_fixture(
+          group: group,
+          resource: resource,
+          conditions: [
+            %{
+              property: :auth_provider_id,
+              operator: :is_in,
+              values: [x509_provider.id]
+            }
+          ]
+        )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies/#{policy.id}")
+
+      assert html =~ "No devices will be able to use this authentication provider"
+      assert html =~ "/#{account.slug}/settings/trust_anchors"
     end
 
     test "renders ip_range condition from saved policy", %{

--- a/elixir/test/portal_web/live/settings/authentication_test.exs
+++ b/elixir/test/portal_web/live/settings/authentication_test.exs
@@ -5,8 +5,10 @@ defmodule PortalWeb.Settings.AuthenticationTest do
   import Portal.AccountFixtures
   import Portal.ActorFixtures
   import Portal.AuthProviderFixtures
+  import Portal.FeaturesFixtures
   import Portal.TokenFixtures
   import Portal.PortalSessionFixtures
+  import Portal.TrustAnchorFixtures
 
   alias Portal.EmailOTP
   alias PortalWeb.Mocks
@@ -169,6 +171,67 @@ defmodule PortalWeb.Settings.AuthenticationTest do
   # =============================================================================
 
   describe "provider listing" do
+    test "renders X.509 with a trust-anchor warning when the feature is enabled", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      enable_feature(:trust_anchors)
+      provider = x509_provider_fixture(account: account)
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/authentication")
+
+      assert html =~ "X.509"
+      assert html =~ "No devices will be able to use this authentication provider"
+
+      assert has_element?(
+               lv,
+               "a[href='/#{account.slug}/settings/trust_anchors']",
+               "Trust Anchors"
+             )
+
+      actions = open_provider_actions(lv, provider.id)
+      refute actions =~ "Make default"
+      refute has_provider_action_button?(actions, "delete", provider.id)
+      refute actions =~ "/authentication/x509/#{provider.id}/edit"
+    end
+
+    test "does not warn for X.509 when the account has a trust anchor", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      enable_feature(:trust_anchors)
+      _provider = x509_provider_fixture(account: account)
+      _anchor = trust_anchor_fixture(account: account)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/authentication")
+
+      assert html =~ "X.509"
+      refute html =~ "No devices will be able to use this authentication provider"
+    end
+
+    test "hides X.509 when trust anchors are globally disabled", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      _provider = x509_provider_fixture(account: account)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/authentication")
+
+      refute html =~ "X.509"
+    end
+
     test "renders email_otp provider", %{account: account, actor: actor, conn: conn} do
       # authorize_conn creates an email_otp provider
       {:ok, _lv, html} =
@@ -1310,6 +1373,29 @@ defmodule PortalWeb.Settings.AuthenticationTest do
 
       # The email_otp provider shouldn't have a delete button
       assert Enum.empty?(delete_buttons)
+    end
+
+    test "X.509 providers cannot be deleted even with a forged event", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      enable_feature(:trust_anchors)
+      provider = x509_provider_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/authentication")
+
+      render_hook(lv, "delete_provider", %{"id" => provider.id})
+
+      assert render(lv) =~ "Failed to delete authentication provider"
+
+      assert Repo.get_by!(Portal.X509.AuthProvider,
+               account_id: account.id,
+               id: provider.id
+             )
     end
 
     test "userpass providers cannot be deleted via UI", %{

--- a/elixir/test/portal_web/live/sign_up_test.exs
+++ b/elixir/test/portal_web/live/sign_up_test.exs
@@ -285,6 +285,12 @@ defmodule PortalWeb.SignUpTest do
       assert html =~ "Your account has been created!"
       assert html =~ "Test Corp"
       assert html =~ "Sign In"
+
+      account = Portal.Repo.get_by!(Portal.Account, name: "Test Corp")
+      provider = Portal.Repo.get_by!(Portal.X509.AuthProvider, account_id: account.id)
+      assert provider.name == "X.509"
+      assert provider.context == :clients_only
+      assert provider.is_disabled
     end
 
     test "valid token for already-registered email redirects to account sign-in", %{conn: conn} do

--- a/elixir/test/support/fixtures/auth_provider_fixtures.ex
+++ b/elixir/test/support/fixtures/auth_provider_fixtures.ex
@@ -2,7 +2,7 @@ defmodule Portal.AuthProviderFixtures do
   @moduledoc """
   Test helpers for creating auth providers and related data.
 
-  Note: Auth providers have multiple subtypes (email_otp, userpass, oidc, google, okta, entra).
+  Note: Auth providers have multiple subtypes (email_otp, userpass, x509, oidc, google, okta, entra).
   This module provides basic fixtures. For more complex provider setups,
   consider using the existing Portal.Fixtures.Auth module or creating
   provider-specific fixture modules.
@@ -93,6 +93,39 @@ defmodule Portal.AuthProviderFixtures do
       |> Portal.Repo.insert()
 
     email_otp_provider
+  end
+
+  @doc """
+  Generate the singleton X.509 auth provider for an account.
+
+  This creates both the base AuthProvider and the X509.AuthProvider records.
+  """
+  def x509_provider_fixture(attrs \\ %{}) do
+    attrs = Enum.into(attrs, %{})
+    account = Map.get(attrs, :account) || account_fixture()
+
+    auth_provider =
+      Map.get_lazy(attrs, :auth_provider, fn ->
+        auth_provider_fixture(type: :x509, account: account)
+      end)
+
+    x509_attrs =
+      attrs
+      |> Map.delete(:account)
+      |> Map.put_new(:name, "X.509")
+      |> Map.put_new(:context, :clients_only)
+      |> Map.put_new(:is_disabled, true)
+
+    {:ok, provider} =
+      %Portal.X509.AuthProvider{}
+      |> Ecto.Changeset.cast(x509_attrs, [:name, :context, :is_disabled])
+      |> Ecto.Changeset.put_change(:id, auth_provider.id)
+      |> Ecto.Changeset.put_assoc(:account, account)
+      |> Ecto.Changeset.put_assoc(:auth_provider, auth_provider)
+      |> Portal.X509.AuthProvider.changeset()
+      |> Portal.Repo.insert()
+
+    provider
   end
 
   @doc """


### PR DESCRIPTION
Adds a singleton X.509 authentication provider for client mTLS authentication, modeled after Email/OTP.

### Summary

- provisions one disabled X.509 provider for every existing and new account
- enforces singleton providers with unique indexes on both auth_providers and x509_auth_providers
- authenticates clients without a bearer token when the validated leaf certificate contains unambiguous firezone account-id and email SAN claims
- preserves bearer-token authentication when those certificate identity claims are absent or the X.509 provider is disabled
- returns a client-facing 403 when certificate claims do not identify an active authorized user, while logging the detailed internal reason
- associates tokenless client sockets with the X.509 provider so policy conditions and provider disablement work correctly
- disconnects active X.509 sessions when the provider is disabled
- gates the provider and certificate flow on the global trust_anchors feature flag
- warns administrators when X.509 is selected or enabled without valid Trust Anchors
- omits edit, delete, and default-provider actions that do not apply to the singleton X.509 provider
- serves the development control plane over HTTPS/WSS and optionally requests client certificates so token-authenticated development clients continue to work
- adds the singleton GET /x509_auth_provider REST endpoint and OpenAPI schema

### Verification

- mix compile --warnings-as-errors
- mix dialyzer --plt
- mix dialyzer --format dialyxir
- mix format --check-formatted
- mix hex.audit
- mix deps.audit
- mix sobelow --skip --exit
- mix credo --strict
- mix test — 4,944 passing
- live dev TLS probe — accepted both certificate-less and client-certificate connections and exposed the client leaf to Plug

---