### PR TITLE
fix(portal): keep row action menus solid on disabled rows

### DIFF
--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1351,17 +1351,14 @@ defmodule PortalWeb.Resources.Components do
           </div>
           <div
             :if={@confirm_remove_group_id != row.group.id}
-            class={[
-              "flex items-center gap-1 pr-4 hover:bg-raised group/item",
-              if(row.policy_is_disabled,
-                do: "opacity-50 hover:opacity-75",
-                else: ""
-              )
-            ]}
+            class="flex items-center gap-1 pr-4 hover:bg-raised group/item"
           >
             <.link
               navigate={~p"/#{@account}/groups/#{row.group.id}"}
-              class="flex items-center gap-3 px-5 py-3 flex-1 min-w-0"
+              class={[
+                "flex items-center gap-3 px-5 py-3 flex-1 min-w-0",
+                row.policy_is_disabled && "opacity-50 hover:opacity-75"
+              ]}
             >
               <.provider_icon provider={provider_type_from_group(row)} size="sm" variant="circle" />
               <div class="flex-1 min-w-0 flex items-center gap-2">

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -875,6 +875,7 @@ defmodule PortalWeb.Settings.Authentication do
       assign(assigns, provider_row_state(assigns.provider, assigns.type, assigns.pending_confirm))
 
     ~H"""
+    <%!-- Dim the cells, not the row: opacity on the row also dims the actions menu. --%>
     <tr class={[
       "border-b transition-colors",
       @is_pending_toggle && "border-amber-200 bg-amber-50",
@@ -883,7 +884,7 @@ defmodule PortalWeb.Settings.Authentication do
       !@is_pending_toggle && !@is_pending_delete && !@is_pending_revoke &&
         "border-border hover:bg-raised",
       @provider.is_disabled && !@is_pending_toggle && !@is_pending_delete && !@is_pending_revoke &&
-        "opacity-60"
+        "[&>td:not(:last-child)]:opacity-60"
     ]}>
       <td class="px-6 py-3">
         <div class="flex items-center gap-3">


### PR DESCRIPTION
Fixes translucent dropdowns on disabled rows:

<img width="215" height="233" alt="Screenshot 2026-08-17 at 9 34 29 AM" src="https://github.com/user-attachments/assets/188bf155-7080-44d0-ae6c-0f224a57cd5d" />

