### PR TITLE
fix(android): opt in to experimental coroutine producer API

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -34,6 +34,7 @@ import dev.firezone.android.tunnel.model.StatusEnum
 import dev.firezone.android.tunnel.model.isInternetResource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -581,6 +582,7 @@ class TunnelService : VpnService() {
         session: SessionInterface,
         commandChannel: Channel<TunnelCommand>,
     ): StopReason {
+        @OptIn(ExperimentalCoroutinesApi::class)
         val eventChannel =
             serviceScope.produce {
                 while (isActive) {


### PR DESCRIPTION
Fixes a Kotlin compile warning by opting the tunnel event-channel producer into `ExperimentalCoroutinesApi`.
