### PR TITLE
chore: pin secnetperf image to v2.6.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,7 +165,7 @@ services:
   # namespace of `client-1` so its traffic is routed through the tunnel.
   # Run with `docker compose run --rm secnetperf-client secnetperf -target:...`.
   secnetperf-client:
-    image: ghcr.io/firezone/secnetperf:latest
+    image: ghcr.io/firezone/secnetperf:v2.6.0
     network_mode: service:client-1
     depends_on:
       client-1:

--- a/scripts/compose/resources.yml
+++ b/scripts/compose/resources.yml
@@ -54,7 +54,7 @@ services:
           - iperf3.test
 
   secnetperf:
-    image: ghcr.io/firezone/secnetperf:latest
+    image: ghcr.io/firezone/secnetperf:v2.6.0
     command: secnetperf -exec:maxtput -stats:1
     healthcheck:
       # 4433 (the default secnetperf port) in hex


### PR DESCRIPTION
The QUIC perf tests pulled `ghcr.io/firezone/secnetperf:latest`, so msquic updates changed the test tooling silently. Pin the image to the released version so future bumps show up as explicit diffs.

Related: firezone/secnetperf#3