### PR TITLE
ci: groundwork for a Windows Client integration test

### DIFF
--- a/.github/actions/show-compose-logs/action.yml
+++ b/.github/actions/show-compose-logs/action.yml
@@ -1,0 +1,33 @@
+name: "Show compose logs"
+description: "Prints the logs of the given compose services, one log group per service. On Windows runners the logs are read from the Docker daemon inside WSL2."
+
+inputs:
+  services:
+    description: "Space-separated list of compose services"
+    required: true
+  compose-args:
+    description: "Extra arguments for `docker compose`, e.g. `-p` / `-f`"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Show logs
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        for service in ${{ inputs.services }}; do
+          echo "::group::$service"
+          docker compose ${{ inputs.compose-args }} logs "$service"
+          echo "::endgroup::"
+        done
+    - name: Show logs (WSL2)
+      if: runner.os == 'Windows'
+      shell: wsl-bash {0}
+      run: |
+        for service in ${{ inputs.services }}; do
+          echo "::group::$service"
+          docker compose ${{ inputs.compose-args }} logs "$service"
+          echo "::endgroup::"
+        done

--- a/.github/actions/write-compose-env/action.yml
+++ b/.github/actions/write-compose-env/action.yml
@@ -1,0 +1,71 @@
+name: "Write compose env file"
+description: "Writes the image and tag variables shared by the compose-based test workflows into `.env`, which `docker compose` loads from the project directory"
+
+inputs:
+  portal_image:
+    required: false
+    default: ""
+  portal_tag:
+    required: false
+    default: ""
+  elixir_image:
+    required: false
+    default: ""
+  elixir_tag:
+    required: false
+    default: ""
+  relay_image:
+    required: false
+    default: ""
+  relay_tag:
+    required: false
+    default: ""
+  gateway_image:
+    required: false
+    default: ""
+  gateway_tag:
+    required: false
+    default: ""
+  client_image:
+    required: false
+    default: ""
+  client_tag:
+    required: false
+    default: ""
+  http_test_server_image:
+    required: false
+    default: ""
+  http_test_server_tag:
+    required: false
+    default: ""
+  extra:
+    description: "Additional KEY=VALUE lines to append"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    # An empty value still falls back to the compose file's `:-` default.
+    - name: Write .env
+      shell: bash
+      run: |
+        {
+          echo "PORTAL_IMAGE=${{ inputs.portal_image }}"
+          echo "PORTAL_TAG=${{ inputs.portal_tag }}"
+          echo "ELIXIR_IMAGE=${{ inputs.elixir_image }}"
+          echo "ELIXIR_TAG=${{ inputs.elixir_tag }}"
+          echo "RELAY_IMAGE=${{ inputs.relay_image }}"
+          echo "RELAY_TAG=${{ inputs.relay_tag }}"
+          echo "GATEWAY_IMAGE=${{ inputs.gateway_image }}"
+          echo "GATEWAY_TAG=${{ inputs.gateway_tag }}"
+          echo "CLIENT_IMAGE=${{ inputs.client_image }}"
+          echo "CLIENT_TAG=${{ inputs.client_tag }}"
+          echo "HTTP_TEST_SERVER_IMAGE=${{ inputs.http_test_server_image }}"
+          echo "HTTP_TEST_SERVER_TAG=${{ inputs.http_test_server_tag }}"
+          if [ -n "${{ inputs.extra }}" ]; then
+            printf '%s\n' "${{ inputs.extra }}"
+          fi
+        } > .env
+
+        cat .env

--- a/.github/actions/write-compose-env/action.yml
+++ b/.github/actions/write-compose-env/action.yml
@@ -67,5 +67,3 @@ runs:
             printf '%s\n' "${{ inputs.extra }}"
           fi
         } > .env
-
-        cat .env

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -261,18 +261,6 @@ jobs:
           docker compose logs client-1 client-2 | \
             grep --invert "I/O error (os error 5)" | \
             grep " WARN " && exit 1 || exit 0
-      - name: Show Client logs
-        if: "!cancelled()"
-        run: docker compose logs client-1 client-2
-
-      - name: Show Relay-1 logs
-        if: "!cancelled()"
-        run: docker compose logs relay-1
-
-      - name: Show Relay-2 logs
-        if: "!cancelled()"
-        run: docker compose logs relay-2
-
       - name: Ensure Gateway emitted no warnings
         if: "!cancelled()"
         run: |
@@ -281,17 +269,10 @@ jobs:
             grep --invert "I/O error (os error 5)" | \
             ${{ matrix.test.gateway_disable_ipv6 == 1 && 'grep --invert "Failed to add route: Received a netlink error message Permission denied (os error 13) route=fd00:2021:1111::/107" |' || '' }} \
             grep " WARN " && exit 1 || exit 0
-      - name: Show Gateway logs
+      - uses: ./.github/actions/show-compose-logs
         if: "!cancelled()"
-        run: docker compose logs gateway
-
-      - name: Show Portal logs
-        if: "!cancelled()"
-        run: docker compose logs portal
-
-      - name: Show Postgres logs
-        if: "!cancelled()"
-        run: docker compose logs postgres
+        with:
+          services: client-1 client-2 relay-1 relay-2 gateway portal postgres
 
       - name: Ensure no eBPF checksum errors on relay-1
         if: "!cancelled() && steps.client_version_check.outcome != 'failure' && steps.gateway_version_check.outcome != 'failure'"

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -85,18 +85,6 @@ jobs:
       id-token: write # OIDC auth
       pull-requests: write # post test result comments
     env:
-      PORTAL_IMAGE: ${{ inputs.portal_image }}
-      PORTAL_TAG: ${{ inputs.portal_tag }}
-      RELAY_IMAGE: ${{ inputs.relay_image }}
-      RELAY_TAG: ${{ inputs.relay_tag }}
-      GATEWAY_IMAGE: ${{ inputs.gateway_image }}
-      GATEWAY_TAG: ${{ inputs.gateway_tag }}
-      CLIENT_IMAGE: ${{ inputs.client_image }}
-      CLIENT_TAG: ${{ inputs.client_tag }}
-      ELIXIR_IMAGE: ${{ inputs.elixir_image }}
-      ELIXIR_TAG: ${{ inputs.elixir_tag }}
-      HTTP_TEST_SERVER_IMAGE: ${{ inputs.http_test_server_image }}
-      HTTP_TEST_SERVER_TAG: ${{ inputs.http_test_server_tag }}
       FIREZONE_INC_BUF: true
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
@@ -162,6 +150,20 @@ jobs:
             rust_log: debug,path_agent=trace,flow_logs=trace # Too noisy can cause flaky tests due to the amount of data
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/write-compose-env
+        with:
+          portal_image: ${{ inputs.portal_image }}
+          portal_tag: ${{ inputs.portal_tag }}
+          relay_image: ${{ inputs.relay_image }}
+          relay_tag: ${{ inputs.relay_tag }}
+          gateway_image: ${{ inputs.gateway_image }}
+          gateway_tag: ${{ inputs.gateway_tag }}
+          client_image: ${{ inputs.client_image }}
+          client_tag: ${{ inputs.client_tag }}
+          elixir_image: ${{ inputs.elixir_image }}
+          elixir_tag: ${{ inputs.elixir_tag }}
+          http_test_server_image: ${{ inputs.http_test_server_image }}
+          http_test_server_tag: ${{ inputs.http_test_server_tag }}
       - uses: ./.github/actions/setup-docker
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -29,16 +29,6 @@ jobs:
       id-token: write # OIDC auth
       pull-requests: write # post perf result comments
     env:
-      PORTAL_IMAGE: "ghcr.io/firezone/portal"
-      PORTAL_TAG: ${{ github.sha }}
-      ELIXIR_IMAGE: "ghcr.io/firezone/elixir"
-      ELIXIR_TAG: ${{ github.sha }}
-      GATEWAY_IMAGE: "ghcr.io/firezone/perf/gateway"
-      GATEWAY_TAG: ${{ github.sha }}
-      CLIENT_IMAGE: "ghcr.io/firezone/perf/client"
-      CLIENT_TAG: ${{ github.sha }}
-      RELAY_IMAGE: "ghcr.io/firezone/perf/relay"
-      RELAY_TAG: ${{ github.sha }}
       FIREZONE_INC_BUF: true
     strategy:
       matrix:
@@ -54,6 +44,18 @@ jobs:
           - relayed
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/write-compose-env
+        with:
+          portal_image: "ghcr.io/firezone/portal"
+          portal_tag: ${{ github.sha }}
+          elixir_image: "ghcr.io/firezone/elixir"
+          elixir_tag: ${{ github.sha }}
+          gateway_image: "ghcr.io/firezone/perf/gateway"
+          gateway_tag: ${{ github.sha }}
+          client_image: "ghcr.io/firezone/perf/client"
+          client_tag: ${{ github.sha }}
+          relay_image: "ghcr.io/firezone/perf/relay"
+          relay_tag: ${{ github.sha }}
       - uses: ./.github/actions/setup-docker
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -101,27 +101,10 @@ jobs:
           overwrite: true
           name: ${{ matrix.flavour }}-${{ matrix.test }}-${{ github.sha }}-perf-results
           path: ./${{ matrix.flavour }}-${{ matrix.test }}.bmf.json
-      - name: Show Client logs
+      - uses: ./.github/actions/show-compose-logs
         if: "!cancelled()"
-        run: docker compose logs client-1
-      - name: Show Relay-1 logs
-        if: "!cancelled()"
-        run: docker compose logs relay-1
-      - name: Show Relay-2 logs
-        if: "!cancelled()"
-        run: docker compose logs relay-2
-      - name: Show Gateway logs
-        if: "!cancelled()"
-        run: docker compose logs gateway
-      - name: Show Portal logs
-        if: "!cancelled()"
-        run: docker compose logs portal
-      - name: Show iperf3 logs
-        if: "!cancelled()"
-        run: docker compose logs iperf3
-      - name: Show secnetperf logs
-        if: "!cancelled()"
-        run: docker compose logs secnetperf
+        with:
+          services: client-1 relay-1 relay-2 gateway portal iperf3 secnetperf
 
       - name: Ensure no warnings are logged
         if: "!cancelled()"

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,3 @@ gha-creds-*.json
 buildServer.json
 
 erl_crash.dump
-
-# Written by .github/actions/write-compose-env in CI
-.env

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ gha-creds-*.json
 buildServer.json
 
 erl_crash.dump
+
+# Written by .github/actions/write-compose-env in CI
+.env

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -105,7 +105,7 @@ After this you will have running:
 - A gateway connected to the portal
 - A headless Linux client connected to the portal
 - A relay connected to the portal
-- A resource with IP `172.20.0.100` on a separate network shared with the
+- A resource with IP `10.20.0.100` on a separate network shared with the
   gateway
 
 ### Generating a self-signed cert
@@ -147,7 +147,7 @@ macOS system keychain by default. To trust the certificate in Firefox, either:
 
 ```sh
 # To test that a client can ping the resource
-docker compose exec -it client ping 172.20.0.100
+docker compose exec -it client ping 10.20.0.100
 
 # You can also directly use the client
 docker compose exec -it client /bin/sh

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -2027,8 +2027,8 @@ defmodule Portal.Repo.Seeds do
         %{
           type: :cidr,
           name: "MyCorp Network",
-          address: "172.20.0.0/16",
-          address_description: "172.20.0.0/16",
+          address: "10.20.0.0/16",
+          address_description: "10.20.0.0/16",
           site_id: site.id,
           filters: []
         },
@@ -2040,8 +2040,8 @@ defmodule Portal.Repo.Seeds do
         %{
           type: :cidr,
           name: "MyCorp Network (IPv6)",
-          address: "172:20::/64",
-          address_description: "172:20::/64",
+          address: "10:20::/64",
+          address_description: "10:20::/64",
           site_id: site.id,
           filters: []
         },

--- a/rust/libs/bin-shared/src/windows.rs
+++ b/rust/libs/bin-shared/src/windows.rs
@@ -6,6 +6,7 @@ use socket_factory::RoutingLoopPreventionFailed;
 use socket_factory::SocketFactory;
 use socket_factory::{TcpSocket, UdpSocket};
 use std::{
+    cmp,
     cmp::Ordering,
     io,
     mem::MaybeUninit,
@@ -403,9 +404,21 @@ struct Route {
     original: MIB_IPFORWARD_ROW2,
 }
 
+impl Route {
+    /// Windows selects routes by longest prefix first and only breaks ties on
+    /// the metric, e.g. a directly-connected subnet wins over a default route
+    /// with a better metric.
+    fn precedence(&self) -> (cmp::Reverse<u8>, u32) {
+        (
+            cmp::Reverse(self.original.DestinationPrefix.PrefixLength),
+            self.metric,
+        )
+    }
+}
+
 impl Ord for Route {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.metric.cmp(&other.metric)
+        self.precedence().cmp(&other.precedence())
     }
 }
 
@@ -417,7 +430,7 @@ impl PartialOrd for Route {
 
 impl PartialEq for Route {
     fn eq(&self, other: &Self) -> bool {
-        self.metric.eq(&other.metric) && self.addr.eq(&other.addr)
+        self.precedence() == other.precedence()
     }
 }
 
@@ -480,6 +493,7 @@ unsafe fn to_ip_addr(addr: SOCKADDR_INET, dst: IpAddr) -> Option<IpAddr> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use windows::Win32::NetworkManagement::IpHelper::IP_ADDRESS_PREFIX;
 
     #[test]
     fn best_route_ip4_does_not_panic_or_segfault() {
@@ -489,5 +503,35 @@ mod test {
     #[test]
     fn best_route_ip6_does_not_panic_or_segfault() {
         let _ = get_best_non_tunnel_route("2404:6800:4006:811::200e".parse().unwrap());
+    }
+
+    #[test]
+    fn prefers_longer_prefix_over_lower_metric() {
+        let connected_subnet = route(20, 5000);
+        let default_route = route(0, 5);
+
+        assert!(connected_subnet < default_route);
+    }
+
+    #[test]
+    fn breaks_prefix_ties_on_the_metric() {
+        let low_metric = route(0, 5);
+        let high_metric = route(0, 50);
+
+        assert!(low_metric < high_metric);
+    }
+
+    fn route(prefix_len: u8, metric: u32) -> Route {
+        Route {
+            metric,
+            addr: Ipv4Addr::UNSPECIFIED.into(),
+            original: MIB_IPFORWARD_ROW2 {
+                DestinationPrefix: IP_ADDRESS_PREFIX {
+                    PrefixLength: prefix_len,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        }
     }
 }

--- a/scripts/compose/resources.yml
+++ b/scripts/compose/resources.yml
@@ -7,8 +7,8 @@ services:
       test: ["CMD-SHELL", "ps -C gunicorn"]
     networks:
       resources:
-        ipv4_address: 172.20.0.100
-        ipv6_address: 172:20:0::100
+        ipv4_address: 10.20.0.100
+        ipv6_address: 10:20:0::100
 
   download.httpbin: # Named after `httpbin` because that is how DNS resources are configured for the test setup.
     build:
@@ -46,8 +46,8 @@ services:
     command: -s -V
     networks:
       resources:
-        ipv4_address: 172.20.0.110
-        ipv6_address: 172:20:0::110
+        ipv4_address: 10.20.0.110
+        ipv6_address: 10:20:0::110
       dns_resources:
         ipv4_address: 172.21.0.110
         aliases:
@@ -61,8 +61,8 @@ services:
       test: ["CMD-SHELL", "grep -q :1151 /proc/net/udp /proc/net/udp6"]
     networks:
       resources:
-        ipv4_address: 172.20.0.111
-        ipv6_address: 172:20:0::111
+        ipv4_address: 10.20.0.111
+        ipv6_address: 10:20:0::111
 
 networks:
   dns_resources:
@@ -74,5 +74,9 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-        - subnet: 172.20.0.0/24
-        - subnet: 172:20:0::/64
+        # Kept outside `172.16.0.0/12`: the Windows Client test routes the
+        # covering CIDR resource into the tunnel while talking to a WSL2 VM,
+        # which picks its NAT subnet from that range on every boot. The IPv6
+        # range mirrors the IPv4 one.
+        - subnet: 10.20.0.0/24
+        - subnet: 10:20:0::/64

--- a/scripts/tests/create-flow-from-icmp-error.sh
+++ b/scripts/tests/create-flow-from-icmp-error.sh
@@ -3,20 +3,20 @@
 source "./scripts/tests/lib.sh"
 
 # Authorize resource 1
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"
 
 # Authorize resource 2 (important, otherwise the Gateway will close the connection on the last resource being removed)
 client_ping download.httpbin
 
 # Revoke access to resource 1
-portal_send_reject_access "AWS US-East" "MyCorp Network"        # This is the 172.20.0.1/16 network
-portal_send_reject_access "AWS US-East" "MyCorp Network (IPv6)" # This is the 172:20:0::1/64 network
+portal_send_reject_access "AWS US-East" "MyCorp Network"        # This is the 10.20.0.0/16 network
+portal_send_reject_access "AWS US-East" "MyCorp Network (IPv6)" # This is the 10:20:0::1/64 network
 
 # Try to access resource 1 again
 # First one for each IP will fail because we get an ICMP error.
-expect_error client_curl "172.20.0.100/get"
-expect_error client_curl "[172:20:0::100]/get"
+expect_error client_curl "10.20.0.100/get"
+expect_error client_curl "[10:20:0::100]/get"
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"

--- a/scripts/tests/curl-ecn.sh
+++ b/scripts/tests/curl-ecn.sh
@@ -4,5 +4,5 @@ source "./scripts/tests/lib.sh"
 
 client sysctl -w net.ipv4.tcp_ecn=1
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"

--- a/scripts/tests/curl-portal-down.sh
+++ b/scripts/tests/curl-portal-down.sh
@@ -2,10 +2,10 @@
 
 source "./scripts/tests/lib.sh"
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"
 
 docker compose stop portal
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"

--- a/scripts/tests/curl-portal-restart.sh
+++ b/scripts/tests/curl-portal-restart.sh
@@ -2,10 +2,10 @@
 
 source "./scripts/tests/lib.sh"
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"
 
 docker compose restart portal
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"

--- a/scripts/tests/direct-curl-gateway-restart.sh
+++ b/scripts/tests/direct-curl-gateway-restart.sh
@@ -2,10 +2,10 @@
 
 source "./scripts/tests/lib.sh"
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"
 
 docker compose restart gateway
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"

--- a/scripts/tests/perf/quic-client2server.sh
+++ b/scripts/tests/perf/quic-client2server.sh
@@ -5,7 +5,7 @@ set -euox pipefail
 source "./scripts/tests/lib.sh"
 
 docker compose run --rm -T secnetperf-client secnetperf \
-    -target:172.20.0.111 \
+    -target:10.20.0.111 \
     -exec:maxtput \
     -up:30s \
     -ptput:1 |

--- a/scripts/tests/perf/quic-server2client.sh
+++ b/scripts/tests/perf/quic-server2client.sh
@@ -5,7 +5,7 @@ set -euox pipefail
 source "./scripts/tests/lib.sh"
 
 docker compose run --rm -T secnetperf-client secnetperf \
-    -target:172.20.0.111 \
+    -target:10.20.0.111 \
     -exec:maxtput \
     -down:30s \
     -ptput:1 |

--- a/scripts/tests/perf/tcp-client2server.sh
+++ b/scripts/tests/perf/tcp-client2server.sh
@@ -6,7 +6,7 @@ source "./scripts/tests/lib.sh"
 
 docker compose exec --env RUST_LOG=info -it client-1 /bin/sh -c 'iperf3 \
   --time 30 \
-  --client 172.20.0.110 \
+  --client 10.20.0.110 \
   --json' >"${TEST_NAME}.json"
 
 jq --arg name "${TEST_NAME}" \

--- a/scripts/tests/perf/tcp-server2client.sh
+++ b/scripts/tests/perf/tcp-server2client.sh
@@ -7,7 +7,7 @@ source "./scripts/tests/lib.sh"
 docker compose exec --env RUST_LOG=info -it client-1 /bin/sh -c 'iperf3 \
   --time 30 \
   --reverse \
-  --client 172.20.0.110 \
+  --client 10.20.0.110 \
   --json' >"${TEST_NAME}.json"
 
 jq --arg name "${TEST_NAME}" \

--- a/scripts/tests/perf/udp-client2server.sh
+++ b/scripts/tests/perf/udp-client2server.sh
@@ -8,7 +8,7 @@ docker compose exec --env RUST_LOG=info -it client-1 /bin/sh -c "iperf3 \
     --time 30 \
     --udp \
     --bandwidth ${UDP_BITRATE:-450M} \
-    --client 172.20.0.110 \
+    --client 10.20.0.110 \
     --json" >"${TEST_NAME}.json"
 
 jq --arg name "${TEST_NAME}" \

--- a/scripts/tests/perf/udp-server2client.sh
+++ b/scripts/tests/perf/udp-server2client.sh
@@ -9,7 +9,7 @@ docker compose exec --env RUST_LOG=info -it client-1 /bin/sh -c "iperf3 \
   --reverse \
   --udp \
   --bandwidth ${UDP_BITRATE:-450M} \
-  --client 172.20.0.110 \
+  --client 10.20.0.110 \
   --json" >"${TEST_NAME}.json"
 
 jq --arg name "${TEST_NAME}" \


### PR DESCRIPTION
Prepares the shared test setup for running the headless Client on a Windows CI runner, with the containers in WSL2 alongside it.

Passing the image references through a compose env file instead of job-level environment is what makes that possible at all: `wsl.exe` does not forward Windows environment variables into the VM. The resource range moves out of `172.16.0.0/12` because WSL2 picks its NAT subnet at random from that range on every boot and Windows Server 2022 offers no supported way to pin it, so a Client on the host can otherwise end up routing the VM it talks to into its own tunnel.

Also fixes route selection on Windows, which compared candidates by metric alone and so preferred a low-metric default route over a directly-connected subnet.