### PR TITLE
ci: extract an action for writing the compose env file

### DIFF
--- a/.github/actions/write-compose-env/action.yml
+++ b/.github/actions/write-compose-env/action.yml
@@ -1,0 +1,20 @@
+name: "Write compose env file"
+description: "Serialises the image and tag variables from the job's environment into a `.env` file for `docker compose --env-file`"
+
+runs:
+  using: "composite"
+  steps:
+    # Needed wherever the compose project runs somewhere that the job's
+    # environment does not reach, e.g. inside WSL2: `wsl.exe` does not forward
+    # Windows environment variables into the VM. Reading the values from the
+    # environment rather than taking them as inputs keeps callers declaring
+    # them the same way they always have. A variable that is unset here still
+    # falls back to the compose file's `:-` default.
+    - name: Write .env
+      shell: bash
+      run: |
+        for var in PORTAL_IMAGE PORTAL_TAG ELIXIR_IMAGE ELIXIR_TAG \
+          RELAY_IMAGE RELAY_TAG GATEWAY_IMAGE GATEWAY_TAG \
+          CLIENT_IMAGE CLIENT_TAG HTTP_TEST_SERVER_IMAGE HTTP_TEST_SERVER_TAG; do
+          printf '%s=%s\n' "$var" "${!var}"
+        done > .env

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -162,6 +162,7 @@ jobs:
             rust_log: debug,path_agent=trace,flow_logs=trace # Too noisy can cause flaky tests due to the amount of data
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/write-compose-env
       - uses: ./.github/actions/setup-docker
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -54,6 +54,7 @@ jobs:
           - relayed
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/write-compose-env
       - uses: ./.github/actions/setup-docker
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
The integration and perf tests declared the same image and tag variables as job-level environment. Passing them through a compose env file instead also works for a job whose containers run inside a VM: `wsl.exe` does not forward Windows environment variables into WSL2.

Related: #14638