### PR TITLE
ci: extract an action for showing compose logs

### DIFF
--- a/.github/actions/show-compose-logs/action.yml
+++ b/.github/actions/show-compose-logs/action.yml
@@ -1,0 +1,33 @@
+name: "Show compose logs"
+description: "Prints the logs of the given compose services, one log group per service. On Windows runners the logs are read from the Docker daemon inside WSL2."
+
+inputs:
+  services:
+    description: "Space-separated list of compose services"
+    required: true
+  compose-args:
+    description: "Extra arguments for `docker compose`, e.g. `-p` / `-f`"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Show logs
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        for service in ${{ inputs.services }}; do
+          echo "::group::$service"
+          docker compose ${{ inputs.compose-args }} logs "$service"
+          echo "::endgroup::"
+        done
+    - name: Show logs (WSL2)
+      if: runner.os == 'Windows'
+      shell: wsl-bash {0}
+      run: |
+        for service in ${{ inputs.services }}; do
+          echo "::group::$service"
+          docker compose ${{ inputs.compose-args }} logs "$service"
+          echo "::endgroup::"
+        done

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -259,18 +259,6 @@ jobs:
           docker compose logs client-1 client-2 | \
             grep --invert "I/O error (os error 5)" | \
             grep " WARN " && exit 1 || exit 0
-      - name: Show Client logs
-        if: "!cancelled()"
-        run: docker compose logs client-1 client-2
-
-      - name: Show Relay-1 logs
-        if: "!cancelled()"
-        run: docker compose logs relay-1
-
-      - name: Show Relay-2 logs
-        if: "!cancelled()"
-        run: docker compose logs relay-2
-
       - name: Ensure Gateway emitted no warnings
         if: "!cancelled()"
         run: |
@@ -279,17 +267,10 @@ jobs:
             grep --invert "I/O error (os error 5)" | \
             ${{ matrix.test.gateway_disable_ipv6 == 1 && 'grep --invert "Failed to add route: Received a netlink error message Permission denied (os error 13) route=fd00:2021:1111::/107" |' || '' }} \
             grep " WARN " && exit 1 || exit 0
-      - name: Show Gateway logs
+      - uses: ./.github/actions/show-compose-logs
         if: "!cancelled()"
-        run: docker compose logs gateway
-
-      - name: Show Portal logs
-        if: "!cancelled()"
-        run: docker compose logs portal
-
-      - name: Show Postgres logs
-        if: "!cancelled()"
-        run: docker compose logs postgres
+        with:
+          services: client-1 client-2 relay-1 relay-2 gateway portal postgres
 
       - name: Ensure no eBPF checksum errors on relay-1
         if: "!cancelled() && steps.client_version_check.outcome != 'failure' && steps.gateway_version_check.outcome != 'failure'"

--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -99,27 +99,10 @@ jobs:
           overwrite: true
           name: ${{ matrix.flavour }}-${{ matrix.test }}-${{ github.sha }}-perf-results
           path: ./${{ matrix.flavour }}-${{ matrix.test }}.bmf.json
-      - name: Show Client logs
+      - uses: ./.github/actions/show-compose-logs
         if: "!cancelled()"
-        run: docker compose logs client-1
-      - name: Show Relay-1 logs
-        if: "!cancelled()"
-        run: docker compose logs relay-1
-      - name: Show Relay-2 logs
-        if: "!cancelled()"
-        run: docker compose logs relay-2
-      - name: Show Gateway logs
-        if: "!cancelled()"
-        run: docker compose logs gateway
-      - name: Show Portal logs
-        if: "!cancelled()"
-        run: docker compose logs portal
-      - name: Show iperf3 logs
-        if: "!cancelled()"
-        run: docker compose logs iperf3
-      - name: Show secnetperf logs
-        if: "!cancelled()"
-        run: docker compose logs secnetperf
+        with:
+          services: client-1 relay-1 relay-2 gateway portal iperf3 secnetperf
 
       - name: Ensure no warnings are logged
         if: "!cancelled()"


### PR DESCRIPTION
Showing compose logs was one step per service, duplicated across the integration and perf workflows. Emitting them as log groups keeps them foldable in the job output.

Related: #14638