### PR TITLE
ci: move the test resource range out of WSL2's NAT pool

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -105,7 +105,7 @@ After this you will have running:
 - A gateway connected to the portal
 - A headless Linux client connected to the portal
 - A relay connected to the portal
-- A resource with IP `172.20.0.100` on a separate network shared with the
+- A resource with IP `10.20.0.100` on a separate network shared with the
   gateway
 
 ### Generating a self-signed cert
@@ -147,7 +147,7 @@ macOS system keychain by default. To trust the certificate in Firefox, either:
 
 ```sh
 # To test that a client can ping the resource
-docker compose exec -it client ping 172.20.0.100
+docker compose exec -it client ping 10.20.0.100
 
 # You can also directly use the client
 docker compose exec -it client /bin/sh

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -2027,8 +2027,8 @@ defmodule Portal.Repo.Seeds do
         %{
           type: :cidr,
           name: "MyCorp Network",
-          address: "172.20.0.0/16",
-          address_description: "172.20.0.0/16",
+          address: "10.20.0.0/16",
+          address_description: "10.20.0.0/16",
           site_id: site.id,
           filters: []
         },
@@ -2040,8 +2040,8 @@ defmodule Portal.Repo.Seeds do
         %{
           type: :cidr,
           name: "MyCorp Network (IPv6)",
-          address: "172:20::/64",
-          address_description: "172:20::/64",
+          address: "10:20::/64",
+          address_description: "10:20::/64",
           site_id: site.id,
           filters: []
         },

--- a/scripts/compose/resources.yml
+++ b/scripts/compose/resources.yml
@@ -7,8 +7,8 @@ services:
       test: ["CMD-SHELL", "ps -C gunicorn"]
     networks:
       resources:
-        ipv4_address: 172.20.0.100
-        ipv6_address: 172:20:0::100
+        ipv4_address: 10.20.0.100
+        ipv6_address: 10:20:0::100
 
   download.httpbin: # Named after `httpbin` because that is how DNS resources are configured for the test setup.
     build:
@@ -46,8 +46,8 @@ services:
     command: -s -V
     networks:
       resources:
-        ipv4_address: 172.20.0.110
-        ipv6_address: 172:20:0::110
+        ipv4_address: 10.20.0.110
+        ipv6_address: 10:20:0::110
       dns_resources:
         ipv4_address: 172.21.0.110
         aliases:
@@ -61,8 +61,8 @@ services:
       test: ["CMD-SHELL", "grep -q :1151 /proc/net/udp /proc/net/udp6"]
     networks:
       resources:
-        ipv4_address: 172.20.0.111
-        ipv6_address: 172:20:0::111
+        ipv4_address: 10.20.0.111
+        ipv6_address: 10:20:0::111
 
 networks:
   dns_resources:
@@ -74,5 +74,9 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-        - subnet: 172.20.0.0/24
-        - subnet: 172:20:0::/64
+        # Kept outside `172.16.0.0/12`: the Windows Client test routes the
+        # covering CIDR resource into the tunnel while talking to a WSL2 VM,
+        # which picks its NAT subnet from that range on every boot. The IPv6
+        # range mirrors the IPv4 one.
+        - subnet: 10.20.0.0/24
+        - subnet: 10:20:0::/64

--- a/scripts/tests/create-flow-from-icmp-error.sh
+++ b/scripts/tests/create-flow-from-icmp-error.sh
@@ -3,20 +3,20 @@
 source "./scripts/tests/lib.sh"
 
 # Authorize resource 1
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"
 
 # Authorize resource 2 (important, otherwise the Gateway will close the connection on the last resource being removed)
 client_ping download.httpbin
 
 # Revoke access to resource 1
-portal_send_reject_access "AWS US-East" "MyCorp Network"        # This is the 172.20.0.1/16 network
-portal_send_reject_access "AWS US-East" "MyCorp Network (IPv6)" # This is the 172:20:0::1/64 network
+portal_send_reject_access "AWS US-East" "MyCorp Network"        # This is the 10.20.0.0/16 network
+portal_send_reject_access "AWS US-East" "MyCorp Network (IPv6)" # This is the 10:20:0::1/64 network
 
 # Try to access resource 1 again
 # First one for each IP will fail because we get an ICMP error.
-expect_error client_curl "172.20.0.100/get"
-expect_error client_curl "[172:20:0::100]/get"
+expect_error client_curl "10.20.0.100/get"
+expect_error client_curl "[10:20:0::100]/get"
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"

--- a/scripts/tests/curl-ecn.sh
+++ b/scripts/tests/curl-ecn.sh
@@ -4,5 +4,5 @@ source "./scripts/tests/lib.sh"
 
 client sysctl -w net.ipv4.tcp_ecn=1
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"

--- a/scripts/tests/curl-portal-down.sh
+++ b/scripts/tests/curl-portal-down.sh
@@ -2,10 +2,10 @@
 
 source "./scripts/tests/lib.sh"
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"
 
 docker compose stop portal
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"

--- a/scripts/tests/curl-portal-restart.sh
+++ b/scripts/tests/curl-portal-restart.sh
@@ -2,10 +2,10 @@
 
 source "./scripts/tests/lib.sh"
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"
 
 docker compose restart portal
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"

--- a/scripts/tests/direct-curl-gateway-restart.sh
+++ b/scripts/tests/direct-curl-gateway-restart.sh
@@ -2,10 +2,10 @@
 
 source "./scripts/tests/lib.sh"
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"
 
 docker compose restart gateway
 
-client_curl "172.20.0.100/get"
-client_curl "[172:20:0::100]/get"
+client_curl "10.20.0.100/get"
+client_curl "[10:20:0::100]/get"

--- a/scripts/tests/perf/quic-client2server.sh
+++ b/scripts/tests/perf/quic-client2server.sh
@@ -5,7 +5,7 @@ set -euox pipefail
 source "./scripts/tests/lib.sh"
 
 docker compose run --rm -T secnetperf-client secnetperf \
-    -target:172.20.0.111 \
+    -target:10.20.0.111 \
     -exec:maxtput \
     -up:30s \
     -ptput:1 |

--- a/scripts/tests/perf/quic-server2client.sh
+++ b/scripts/tests/perf/quic-server2client.sh
@@ -5,7 +5,7 @@ set -euox pipefail
 source "./scripts/tests/lib.sh"
 
 docker compose run --rm -T secnetperf-client secnetperf \
-    -target:172.20.0.111 \
+    -target:10.20.0.111 \
     -exec:maxtput \
     -down:30s \
     -ptput:1 |

--- a/scripts/tests/perf/tcp-client2server.sh
+++ b/scripts/tests/perf/tcp-client2server.sh
@@ -6,7 +6,7 @@ source "./scripts/tests/lib.sh"
 
 docker compose exec --env RUST_LOG=info -it client-1 /bin/sh -c 'iperf3 \
   --time 30 \
-  --client 172.20.0.110 \
+  --client 10.20.0.110 \
   --json' >"${TEST_NAME}.json"
 
 jq --arg name "${TEST_NAME}" \

--- a/scripts/tests/perf/tcp-server2client.sh
+++ b/scripts/tests/perf/tcp-server2client.sh
@@ -7,7 +7,7 @@ source "./scripts/tests/lib.sh"
 docker compose exec --env RUST_LOG=info -it client-1 /bin/sh -c 'iperf3 \
   --time 30 \
   --reverse \
-  --client 172.20.0.110 \
+  --client 10.20.0.110 \
   --json' >"${TEST_NAME}.json"
 
 jq --arg name "${TEST_NAME}" \

--- a/scripts/tests/perf/udp-client2server.sh
+++ b/scripts/tests/perf/udp-client2server.sh
@@ -8,7 +8,7 @@ docker compose exec --env RUST_LOG=info -it client-1 /bin/sh -c "iperf3 \
     --time 30 \
     --udp \
     --bandwidth ${UDP_BITRATE:-450M} \
-    --client 172.20.0.110 \
+    --client 10.20.0.110 \
     --json" >"${TEST_NAME}.json"
 
 jq --arg name "${TEST_NAME}" \

--- a/scripts/tests/perf/udp-server2client.sh
+++ b/scripts/tests/perf/udp-server2client.sh
@@ -9,7 +9,7 @@ docker compose exec --env RUST_LOG=info -it client-1 /bin/sh -c "iperf3 \
   --reverse \
   --udp \
   --bandwidth ${UDP_BITRATE:-450M} \
-  --client 172.20.0.110 \
+  --client 10.20.0.110 \
   --json" >"${TEST_NAME}.json"
 
 jq --arg name "${TEST_NAME}" \


### PR DESCRIPTION
WSL2 picks its NAT subnet at random from `172.16.0.0/12` on every boot and Windows Server 2022 offers no supported way to pin it, so a Client running on a Windows CI runner and reaching its containers inside WSL2 can end up routing the VM it talks to into its own tunnel. The IPv6 range keeps mirroring the IPv4 one.

Related: #14638