### PR TITLE
fix(client): pick the longest matching route on Windows

### DIFF
--- a/rust/libs/bin-shared/src/windows.rs
+++ b/rust/libs/bin-shared/src/windows.rs
@@ -6,6 +6,7 @@ use socket_factory::RoutingLoopPreventionFailed;
 use socket_factory::SocketFactory;
 use socket_factory::{TcpSocket, UdpSocket};
 use std::{
+    cmp,
     cmp::Ordering,
     io,
     mem::MaybeUninit,
@@ -403,9 +404,21 @@ struct Route {
     original: MIB_IPFORWARD_ROW2,
 }
 
+impl Route {
+    /// Windows selects routes by longest prefix first and only breaks ties on
+    /// the metric, e.g. a directly-connected subnet wins over a default route
+    /// with a better metric.
+    fn precedence(&self) -> (cmp::Reverse<u8>, u32) {
+        (
+            cmp::Reverse(self.original.DestinationPrefix.PrefixLength),
+            self.metric,
+        )
+    }
+}
+
 impl Ord for Route {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.metric.cmp(&other.metric)
+        self.precedence().cmp(&other.precedence())
     }
 }
 
@@ -417,7 +430,7 @@ impl PartialOrd for Route {
 
 impl PartialEq for Route {
     fn eq(&self, other: &Self) -> bool {
-        self.metric.eq(&other.metric) && self.addr.eq(&other.addr)
+        self.precedence() == other.precedence()
     }
 }
 
@@ -480,6 +493,7 @@ unsafe fn to_ip_addr(addr: SOCKADDR_INET, dst: IpAddr) -> Option<IpAddr> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use windows::Win32::NetworkManagement::IpHelper::IP_ADDRESS_PREFIX;
 
     #[test]
     fn best_route_ip4_does_not_panic_or_segfault() {
@@ -489,5 +503,35 @@ mod test {
     #[test]
     fn best_route_ip6_does_not_panic_or_segfault() {
         let _ = get_best_non_tunnel_route("2404:6800:4006:811::200e".parse().unwrap());
+    }
+
+    #[test]
+    fn prefers_longer_prefix_over_lower_metric() {
+        let connected_subnet = route(20, 5000);
+        let default_route = route(0, 5);
+
+        assert!(connected_subnet < default_route);
+    }
+
+    #[test]
+    fn breaks_prefix_ties_on_the_metric() {
+        let low_metric = route(0, 5);
+        let high_metric = route(0, 50);
+
+        assert!(low_metric < high_metric);
+    }
+
+    fn route(prefix_len: u8, metric: u32) -> Route {
+        Route {
+            metric,
+            addr: Ipv4Addr::UNSPECIFIED.into(),
+            original: MIB_IPFORWARD_ROW2 {
+                DestinationPrefix: IP_ADDRESS_PREFIX {
+                    PrefixLength: prefix_len,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        }
     }
 }


### PR DESCRIPTION
Route selection compared candidates by metric alone, so a default route with a low metric won over a directly-connected subnet. Windows resolves the two by prefix length first, and which route wins decides whether traffic leaves through the tunnel or around it.

Related: #14638