### PR TITLE
fix(gui-client): clear account slug in telemetry on sign-out

### DIFF
--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -423,9 +423,7 @@ impl<I: GuiIntegration> Controller<I> {
         let environment = self.api_url().to_string();
         let account_slug = self.auth.session().map(|s| s.account_slug.to_owned());
 
-        if let Some(account_slug) = account_slug.clone() {
-            telemetry::set_account_slug(account_slug);
-        }
+        telemetry::set_account_slug(account_slug.clone());
 
         if !self.telemetry_allowed {
             return Ok(());

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -730,11 +730,9 @@ impl<'a> Handler<'a> {
                         telemetry::SentryMeterProvider::default(),
                     );
 
-                    if let Some(account_slug) = account_slug {
-                        telemetry::set_account_slug(account_slug.clone());
+                    telemetry::set_account_slug(account_slug.clone());
 
-                        analytics::identify(release, account_slug, None, None);
-                    }
+                    analytics::identify(release, account_slug, None, None);
                 }
             }
             #[cfg(debug_assertions)]


### PR DESCRIPTION
The GUI process and the tunnel service only ever set the telemetry account slug and never clear it, so after signing out (or when telemetry starts without a session) Sentry events and `$identify` calls keep attributing the previous account. Pass the optional slug through to `set_account_slug` instead of gating on it, and send the `$identify` event unconditionally, so a missing slug propagates as a cleared attribute.