### PR TITLE
feat(phoenix-channel): carry client identity in LoginUrl

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1294,7 +1294,6 @@ dependencies = [
  "tun",
  "tunnel-bypass-resolver",
  "uniffi",
- "url",
 ]
 
 [[package]]

--- a/rust/client-ffi/Cargo.toml
+++ b/rust/client-ffi/Cargo.toml
@@ -37,7 +37,6 @@ tracing-subscriber = { workspace = true }
 tun = { workspace = true }
 tunnel-bypass-resolver = { workspace = true }
 uniffi = { workspace = true }
-url = { workspace = true }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 oslog = { version = "0.2.0", default-features = false }

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -22,7 +22,7 @@ use backoff::ExponentialBackoffBuilder;
 use ip_network::IpNetwork;
 use itertools::Itertools as _;
 use logging::sentry_layer;
-use phoenix_channel::{LoginUrl, PhoenixChannel, get_user_agent};
+use phoenix_channel::{ClientCertificate, LoginUrl, PhoenixChannel, get_user_agent};
 use platform::RELEASE;
 use secrecy::SecretString;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
@@ -603,12 +603,12 @@ fn connect(
 
     analytics::identify(RELEASE.to_owned(), Some(account_slug));
 
-    let portal_api_url = portal_api_url(&api_url, tls_client_config.is_some())?;
     let url = LoginUrl::client(
-        portal_api_url.as_str(),
+        api_url.as_str(),
         device_id.clone(),
         device_name,
         device_info,
+        tls_client_config.map(|tls_config| ClientCertificate { tls_config }),
     )
     .context("Failed to create login URL")?;
 
@@ -627,10 +627,6 @@ fn connect(
         },
         tcp_socket_factory.clone(),
     );
-    let portal = match tls_client_config {
-        Some(config) => portal.with_tls_client_config(config),
-        None => portal,
-    };
     // The uploader lives and dies with the session (idle, it would only poll
     // and dial); registered so `drain_flow_logs` nudges it instead of racing it.
     let uploader = flow_logs_dir.clone().map(|dir| {
@@ -678,25 +674,6 @@ pub fn tls_client_config(
         .with_client_cert_resolver(resolver);
 
     Ok(Arc::new(config))
-}
-
-fn portal_api_url(api_url: &str, use_client_certificate: bool) -> Result<String> {
-    if !use_client_certificate {
-        return Ok(api_url.to_owned());
-    }
-
-    let mut url = url::Url::parse(api_url).context("Failed to parse the API URL")?;
-    let mtls_host = match url.host_str() {
-        Some("api.firez.one") => Some("mtls.firez.one"),
-        Some("api.firezone.dev") => Some("mtls.firezone.dev"),
-        _ => None,
-    };
-    if let Some(host) = mtls_host {
-        url.set_host(Some(host))
-            .map_err(|_| anyhow!("Failed to set the mTLS API host"))?;
-    }
-
-    Ok(url.into())
 }
 
 fn start_telemetry_inner(tcp: Arc<dyn SocketFactory<TcpSocket>>) {
@@ -991,36 +968,5 @@ impl From<anyhow::Error> for ConnlibError {
 impl From<uniffi::UnexpectedUniFFICallbackError> for CallbackError {
     fn from(value: uniffi::UnexpectedUniFFICallbackError) -> Self {
         Self::Failed(format!("Callback failed: {}", value.reason))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn client_certificate_uses_mtls_api_host() {
-        assert_eq!(
-            portal_api_url("wss://api.firez.one:444/custom?foo=bar", true)
-                .expect("valid production API URL"),
-            "wss://mtls.firez.one:444/custom?foo=bar"
-        );
-        assert_eq!(
-            portal_api_url("wss://api.firezone.dev/custom?foo=bar", true)
-                .expect("valid staging API URL"),
-            "wss://mtls.firezone.dev/custom?foo=bar"
-        );
-    }
-
-    #[test]
-    fn unattested_and_custom_api_urls_are_unchanged() {
-        assert_eq!(
-            portal_api_url("wss://api.firezone.dev", false).expect("valid API URL"),
-            "wss://api.firezone.dev"
-        );
-        assert_eq!(
-            portal_api_url("wss://portal.example.com/client", true).expect("valid custom API URL"),
-            "wss://portal.example.com/client"
-        );
     }
 }

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -773,6 +773,7 @@ impl<'a> Handler<'a> {
                 device_uuid: device_info::uuid(),
                 ..Default::default()
             },
+            None,
         )
         .context("Failed to create `LoginUrl`")?;
 

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -373,6 +373,7 @@ fn try_main() -> Result<()> {
             device_uuid: device_info::uuid(),
             ..Default::default()
         },
+        None,
     )?;
 
     if cli.check {

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -33,7 +33,9 @@ use tokio_tungstenite::{
 use url::Url;
 
 pub use get_user_agent::get_user_agent;
-pub use login_url::{DeviceInfo, LoginUrl, LoginUrlError, NoParams, PublicKeyParam};
+pub use login_url::{
+    ClientCertificate, DeviceInfo, LoginUrl, LoginUrlError, NoParams, PublicKeyParam,
+};
 pub use tokio_tungstenite::tungstenite::http::StatusCode;
 
 const MAX_BUFFERED_MESSAGES: usize = 32; // Chosen pretty arbitrarily. If we are connected, these should never build up.
@@ -57,7 +59,6 @@ pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     url_prototype: LoginUrl<TFinish>,
     last_url: Option<Url>,
     user_agent: String,
-    tls_client_config: Option<Arc<rustls::ClientConfig>>,
     /// The authentication token, sent via X-Authorization header.
     token: SecretString,
     make_initial_backoff: Box<dyn Fn() -> ExponentialBackoff + Send>,
@@ -393,7 +394,6 @@ where
             was_connected: false,
             url_prototype: url,
             user_agent,
-            tls_client_config: None,
             token,
             state: State::Closed,
             socket_factory,
@@ -403,16 +403,6 @@ where
             init_req,
             last_url: None,
         }
-    }
-
-    /// Uses the supplied rustls configuration for TLS connections.
-    ///
-    /// This allows callers to configure client certificate authentication, including
-    /// certificate resolvers backed by platform-managed, non-exportable private keys.
-    /// Without this, the channel uses its existing default TLS configuration.
-    pub fn with_tls_client_config(mut self, config: Arc<rustls::ClientConfig>) -> Self {
-        self.tls_client_config = Some(config);
-        self
     }
 
     /// Join our room.
@@ -501,7 +491,7 @@ where
             let user_agent = self.user_agent.clone();
             let token = self.token.clone();
             let socket_factory = self.socket_factory.clone();
-            let tls_client_config = self.tls_client_config.clone();
+            let tls_client_config = self.url_prototype.tls_client_config();
 
             async move {
                 if let Err(e) = closing.await {

--- a/rust/libs/connlib/phoenix-channel/src/login_url.rs
+++ b/rust/libs/connlib/phoenix-channel/src/login_url.rs
@@ -6,6 +6,7 @@ use std::{
     marker::PhantomData,
     net::{Ipv4Addr, Ipv6Addr},
     str::FromStr as _,
+    sync::Arc,
 };
 use url::Url;
 use uuid::Uuid;
@@ -40,7 +41,18 @@ pub struct LoginUrl<TFinish> {
     host: String,
     port: u16,
 
+    certificate: Option<ClientCertificate>,
+
     phantom: PhantomData<TFinish>,
+}
+
+/// An X.509 client certificate presented to the portal during the TLS handshake.
+///
+/// Constructing a [`LoginUrl`] with a certificate dials the portal's mTLS endpoint instead of the regular one.
+/// Platform code builds the [`rustls::ClientConfig`], typically with a certificate resolver backed by a keystore-managed, non-exportable private key, and hands it in here.
+#[derive(Clone)]
+pub struct ClientCertificate {
+    pub tls_config: Arc<rustls::ClientConfig>,
 }
 
 #[derive(Debug, Clone)]
@@ -73,7 +85,14 @@ impl LoginUrl<PublicKeyParam> {
         device_id: String,
         device_name: Option<String>,
         device_info: DeviceInfo,
+        certificate: Option<ClientCertificate>,
     ) -> Result<Self, LoginUrlError<E>> {
+        let mut url = url.try_into().map_err(LoginUrlError::InvalidUrl)?;
+
+        if certificate.is_some() {
+            set_mtls_host(&mut url);
+        }
+
         let external_id = if uuid::Uuid::from_str(&device_id).is_ok() {
             hex::encode(sha2::Sha256::digest(device_id))
         } else {
@@ -85,7 +104,7 @@ impl LoginUrl<PublicKeyParam> {
             .unwrap_or_else(|| Uuid::new_v4().to_string());
 
         let url = get_websocket_path(
-            url.try_into().map_err(LoginUrlError::InvalidUrl)?,
+            url,
             "client",
             Some("v2"),
             Some(external_id),
@@ -102,6 +121,7 @@ impl LoginUrl<PublicKeyParam> {
             host,
             port,
             url,
+            certificate,
             phantom: PhantomData,
         })
     }
@@ -138,6 +158,7 @@ impl LoginUrl<PublicKeyParam> {
             host,
             port,
             url,
+            certificate: None,
             phantom: PhantomData,
         })
     }
@@ -169,6 +190,7 @@ impl LoginUrl<NoParams> {
             host,
             port,
             url,
+            certificate: None,
             phantom: PhantomData,
         })
     }
@@ -200,6 +222,26 @@ impl<TFinish> LoginUrl<TFinish> {
 
         url.to_string()
     }
+
+    pub(crate) fn tls_client_config(&self) -> Option<Arc<rustls::ClientConfig>> {
+        let certificate = self.certificate.as_ref()?;
+
+        Some(certificate.tls_config.clone())
+    }
+}
+
+/// Replaces a SaaS API host with its mTLS counterpart, leaving other hosts untouched.
+///
+/// The portal requests a client certificate based on the host we dial, so presenting a certificate implies dialing the mTLS host.
+fn set_mtls_host(url: &mut Url) {
+    let mtls_host = match url.host_str() {
+        Some("api.firez.one") => "mtls.firez.one",
+        Some("api.firezone.dev") => "mtls.firezone.dev",
+        _ => return,
+    };
+
+    url.set_host(Some(mtls_host))
+        .expect("hard-coded hostname is valid");
 }
 
 /// Parse the host from a URL, including port if present. e.g. `example.com:8080`.
@@ -325,6 +367,7 @@ mod tests {
             "some-id".to_owned(),
             None,
             DeviceInfo::default(),
+            None,
         )
         .unwrap();
 
@@ -340,6 +383,7 @@ mod tests {
             "some-id".to_owned(),
             Some("some-name".to_owned()),
             DeviceInfo::default(),
+            None,
         )
         .unwrap();
 
@@ -347,6 +391,65 @@ mod tests {
             login_url.to_url(PublicKeyParam([0; 32])).path(),
             "/client/v2/websocket"
         )
+    }
+
+    #[test]
+    fn client_with_certificate_uses_mtls_api_host() {
+        let login_url = LoginUrl::client(
+            "wss://api.firez.one:444",
+            "some-id".to_owned(),
+            Some("some-name".to_owned()),
+            DeviceInfo::default(),
+            Some(certificate()),
+        )
+        .unwrap();
+
+        assert_eq!(login_url.host_and_port(), ("mtls.firez.one", 444));
+        assert!(login_url.tls_client_config().is_some());
+    }
+
+    #[test]
+    fn client_with_certificate_uses_mtls_staging_api_host() {
+        let login_url = LoginUrl::client(
+            "wss://api.firezone.dev",
+            "some-id".to_owned(),
+            Some("some-name".to_owned()),
+            DeviceInfo::default(),
+            Some(certificate()),
+        )
+        .unwrap();
+
+        assert_eq!(login_url.host_and_port(), ("mtls.firezone.dev", 443));
+    }
+
+    #[test]
+    fn client_with_certificate_keeps_custom_api_host() {
+        let login_url = LoginUrl::client(
+            "wss://portal.example.com",
+            "some-id".to_owned(),
+            Some("some-name".to_owned()),
+            DeviceInfo::default(),
+            Some(certificate()),
+        )
+        .unwrap();
+
+        assert_eq!(login_url.host_and_port(), ("portal.example.com", 443));
+        assert!(login_url.tls_client_config().is_some());
+    }
+
+    #[test]
+    fn client_without_certificate_keeps_api_host() {
+        let login_url = LoginUrl::client(
+            "wss://api.firezone.dev",
+            "some-id".to_owned(),
+            Some("some-name".to_owned()),
+            DeviceInfo::default(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(login_url.host_and_port(), ("api.firezone.dev", 443));
+        assert!(login_url.tls_client_config().is_none());
     }
 
     #[test]
@@ -376,5 +479,19 @@ mod tests {
         .unwrap();
 
         assert_eq!(login_url.to_url(NoParams).path(), "/relay/websocket")
+    }
+
+    fn certificate() -> ClientCertificate {
+        let tls_config = rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .with_root_certificates(rustls::RootCertStore::empty())
+        .with_no_client_auth();
+
+        ClientCertificate {
+            tls_config: Arc::new(tls_config),
+        }
     }
 }

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -631,6 +631,7 @@ fn make_test_channel(
         "test-device-id".to_string(),
         Some("test-device".to_string()),
         DeviceInfo::default(),
+        None,
     )
     .unwrap();
 

--- a/rust/tests/loadtest/src/portal.rs
+++ b/rust/tests/loadtest/src/portal.rs
@@ -59,8 +59,14 @@ pub async fn fetch_relay(
     let token = load_token(token_path)?;
 
     let device_id = uuid::Uuid::new_v4().to_string();
-    let url = LoginUrl::client(portal_url.clone(), device_id, None, DeviceInfo::default())
-        .map_err(|e| anyhow!("invalid portal URL: {e:?}"))?;
+    let url = LoginUrl::client(
+        portal_url.clone(),
+        device_id,
+        None,
+        DeviceInfo::default(),
+        None,
+    )
+    .map_err(|e| anyhow!("invalid portal URL: {e:?}"))?;
 
     let socket_factory = Arc::new(socket_factory::tcp) as Arc<dyn SocketFactory<TcpSocket>>;
 


### PR DESCRIPTION
Constructing a certificate-authenticated portal connection previously required coordinating two things by convention at every call site: rewriting the api host to the mTLS host and installing a rustls client config on `PhoenixChannel`. Getting one half wrong either fails the TLS handshake (the mTLS host demands a client certificate) or silently downgrades to an unattested session. `LoginUrl::client` now takes an optional `ClientCertificate` (a `phoenix-channel`-owned wrapper around a shared `rustls::ClientConfig`), maps the SaaS api hosts to the mTLS hosts internally, and `PhoenixChannel` reads the TLS config from its URL prototype, making the mismatched states unrepresentable and preserving both across reconnects by construction. `with_tls_client_config` and the `portal_api_url` helper in `client-ffi` are deleted; `LoginUrl::gateway` and `LoginUrl::relay` are unchanged. Platform keystore code keeps feeding the rustls config in from the app layer, so `phoenix-channel` gains no new dependencies.

Related: #14527