### PR TITLE
feat(portal): route workload repos through PgBouncer

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -54,10 +54,11 @@ config :portal, Portal.Repo,
   start_apps_before_migration: [:ssl, :logger_json, :req],
   parameters: [application_name: "portal"]
 
-# Isolated connection pools (web/api/poller)
+# Isolated connection pools (web/api/job/poller)
 for {repo, app_name} <- [
       {Portal.Repo.Web, "web"},
       {Portal.Repo.Api, "api"},
+      {Portal.Repo.Job, "job"},
       {Portal.Repo.Poller, "poller"}
     ] do
   config :portal, repo,

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -12,7 +12,7 @@ db_ssl =
     "false" -> false
   end
 
-db_opts = [
+direct_db_opts = [
   database: System.get_env("DATABASE_NAME", "firezone_dev"),
   username: System.get_env("DATABASE_USER", "postgres"),
   hostname: System.get_env("DATABASE_HOST", "localhost"),
@@ -21,24 +21,36 @@ db_opts = [
   ssl: db_ssl
 ]
 
+pgbouncer_db_opts =
+  case System.get_env("DATABASE_PGBOUNCER_PORT") do
+    nil ->
+      direct_db_opts
+
+    port ->
+      direct_db_opts
+      |> Keyword.put(:port, String.to_integer(port))
+      |> Keyword.put(:prepare, :unnamed)
+  end
+
 ###############################
 ##### Portal ##################
 ###############################
 
-config :portal, Portal.Repo, db_opts
-config :portal, Portal.Repo.Web, db_opts
-config :portal, Portal.Repo.Api, db_opts
-config :portal, Portal.Repo.Poller, db_opts
+config :portal, Portal.Repo, direct_db_opts
+config :portal, Portal.Repo.Web, pgbouncer_db_opts
+config :portal, Portal.Repo.Api, pgbouncer_db_opts
+config :portal, Portal.Repo.Job, pgbouncer_db_opts
+config :portal, Portal.Repo.Poller, direct_db_opts
 
 # Poll fast locally so live updates and change logs appear without a wait
 config :portal, Portal.ChangeLogs.Consumer,
-  replication_slot_name: db_opts[:database] <> "_clog_slot",
-  publication_name: db_opts[:database] <> "_clog_pub",
+  replication_slot_name: direct_db_opts[:database] <> "_clog_slot",
+  publication_name: direct_db_opts[:database] <> "_clog_pub",
   poll_interval: :timer.seconds(1)
 
 config :portal, Portal.Changes.Consumer,
-  replication_slot_name: db_opts[:database] <> "_changes_slot",
-  publication_name: db_opts[:database] <> "_changes_pub",
+  replication_slot_name: direct_db_opts[:database] <> "_changes_slot",
+  publication_name: direct_db_opts[:database] <> "_changes_pub",
   poll_interval: 250
 
 config :portal, outbound_email_adapter_configured?: true
@@ -67,6 +79,7 @@ worker_dev_schedule = System.get_env("WORKER_DEV_SCHEDULE", "* * * * *")
 # Oban has its own config validation that prevents overriding config in runtime.exs,
 # so we explicitly set the config in dev.exs, test.exs, and runtime.exs (for prod) only.
 config :portal, Oban,
+  notifier: Oban.Notifiers.PG,
   plugins: [
     # Keep the last 7 days of completed, cancelled, and discarded jobs
     {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
@@ -152,7 +165,7 @@ config :portal, Oban,
     outbound_emails: 1
   ],
   engine: Oban.Engines.Basic,
-  repo: Portal.Repo
+  repo: Portal.Repo.Job
 
 config :portal, Portal.Okta.AuthProvider,
   redirect_uri: "https://localhost:#{web_port}/auth/oidc/callback"

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -55,7 +55,6 @@ if config_env() == :prod do
     [
       {:database, env_var_to_config!(:database_name)},
       {:username, env_var_to_config!(:database_user)},
-      {:port, env_var_to_config!(:database_port)},
       {:queue_target, env_var_to_config!(:database_queue_target)},
       {:queue_interval, env_var_to_config!(:database_queue_interval)},
       {:ssl, env_var_to_config!(:database_ssl)}
@@ -70,19 +69,33 @@ if config_env() == :prod do
         else: [{:hostname, env_var_to_config!(:database_host)}]
       )
 
+  direct_pool_base_opts =
+    [{:port, env_var_to_config!(:database_port)}] ++ pool_base_opts
+
+  pgbouncer_pool_base_opts =
+    case env_var_to_config(:database_pgbouncer_port) do
+      nil ->
+        direct_pool_base_opts
+
+      port ->
+        [{:port, port}, {:prepare, :unnamed}] ++ pool_base_opts
+    end
+
   database_parameters = env_var_to_config!(:database_parameters)
 
-  # Isolated connection pools
+  # Transaction-pooled connection pools. When DATABASE_PGBOUNCER_PORT is not
+  # set they fall back to the direct PostgreSQL endpoint for compatibility.
   for {repo, pool_size_key, app_name} <- [
         {Portal.Repo.Web, :database_pool_size_web, "web"},
-        {Portal.Repo.Api, :database_pool_size_api, "api"}
+        {Portal.Repo.Api, :database_pool_size_api, "api"},
+        {Portal.Repo.Job, :database_pool_size_job, "job"}
       ] do
     config :portal,
            repo,
            [
              {:pool_size, env_var_to_config!(pool_size_key)},
              {:parameters, Keyword.merge(database_parameters, application_name: app_name)}
-           ] ++ pool_base_opts
+           ] ++ pgbouncer_pool_base_opts
   end
 
   # Isolated poller connection pool, sized for the two slot pollers: poll
@@ -93,7 +106,7 @@ if config_env() == :prod do
          [
            {:pool_size, 2},
            {:parameters, Keyword.merge(database_parameters, application_name: "poller")}
-         ] ++ pool_base_opts
+         ] ++ direct_pool_base_opts
 
   config :portal, Portal.ChangeLogs.Consumer,
     enabled: env_var_to_config!(:change_logs_replication_enabled),
@@ -321,6 +334,7 @@ if config_env() == :prod do
   ]
 
   config :portal, Oban,
+    notifier: Oban.Notifiers.PG,
     peer: Oban.Peers.Database,
     plugins: [
       {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
@@ -361,7 +375,7 @@ if config_env() == :prod do
       outbound_emails: 1
     ],
     engine: Oban.Engines.Basic,
-    repo: Portal.Repo
+    repo: Portal.Repo.Job
 
   ###############################
   ##### Public Endpoint #########

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -24,6 +24,7 @@ config :portal, Portal.Repo,
 for repo <- [
       Portal.Repo.Web,
       Portal.Repo.Api,
+      Portal.Repo.Job,
       Portal.Repo.Poller
     ] do
   config :portal, repo,
@@ -36,6 +37,7 @@ end
 # Oban has its own config validation that prevents overriding config in runtime.exs,
 # so we explicitly set the config in dev.exs, test.exs, and runtime.exs (for prod) only.
 config :portal, Oban,
+  notifier: Oban.Notifiers.PG,
   # Periodic jobs don't make sense in tests
   plugins: [
     # Keep the last 90 days of completed, cancelled, and discarded jobs

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -18,6 +18,7 @@ defmodule Portal.Application do
     :ok = OpentelemetryEcto.setup([:portal, :repo])
     :ok = OpentelemetryEcto.setup([:portal, :repo, :web])
     :ok = OpentelemetryEcto.setup([:portal, :repo, :api])
+    :ok = OpentelemetryEcto.setup([:portal, :repo, :job])
     :ok = Portal.Telemetry.OtelBandit.setup()
     :ok = OpentelemetryPhoenix.setup(adapter: :bandit)
     :ok = OpentelemetryOban.setup()
@@ -40,9 +41,10 @@ defmodule Portal.Application do
     base_children = token_caches() ++ [
       # Core services
       Portal.Repo,
-      # Isolated connection pools (web/api/poller)
+      # Isolated connection pools (web/api/job/poller)
       Portal.Repo.Web,
       Portal.Repo.Api,
+      Portal.Repo.Job,
       Portal.Repo.Poller,
       {Task.Supervisor, name: Portal.Analytics.TaskSupervisor},
       # Default pg scope for distributed process discovery (used by replication)
@@ -195,7 +197,7 @@ defmodule Portal.Application do
     # generating the OpenAPI spec without a Postgres service). Oban 2.22+
     # verifies migrations at supervisor start, which requires a live DB.
     if Portal.Config.env_var_to_config!(:oban_enabled) do
-      [{Oban, Application.fetch_env!(:portal, Oban)}]
+      [{Portal.Oban, Application.fetch_env!(:portal, Oban)}]
     else
       []
     end

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -403,9 +403,17 @@ defmodule Portal.Config.Definitions do
   defconfig(:database_socket_dir, :string, default: nil)
 
   @doc """
-  PostgreSQL port.
+  Direct PostgreSQL port used by migrations, cluster discovery, and replication polling.
   """
   defconfig(:database_port, :integer, default: 5432)
+
+  @doc """
+  PgBouncer port used by the Web, API, and background job connection pools.
+
+  When unset, these pools use `DATABASE_PORT` to preserve compatibility with
+  deployments that don't run PgBouncer.
+  """
+  defconfig(:database_pgbouncer_port, :integer, default: nil)
 
   @doc """
   Name of the PostgreSQL database.
@@ -453,6 +461,11 @@ defmodule Portal.Config.Definitions do
   Size of the connection pool for PortalAPI (REST + Sockets) queries.
   """
   defconfig(:database_pool_size_api, :integer, default: 10)
+
+  @doc """
+  Size of the connection pool for Oban and background job queries.
+  """
+  defconfig(:database_pool_size_job, :integer, default: 4)
 
   @doc """
   The target threshold for the length of time in milliseconds that a query should wait in the queue

--- a/elixir/lib/portal/health.ex
+++ b/elixir/lib/portal/health.ex
@@ -55,7 +55,8 @@ defmodule Portal.Health do
   @repos [
     Portal.Repo,
     Portal.Repo.Web,
-    Portal.Repo.Api
+    Portal.Repo.Api,
+    Portal.Repo.Job
   ]
 
   defp repos_ready? do

--- a/elixir/lib/portal/oban.ex
+++ b/elixir/lib/portal/oban.ex
@@ -1,0 +1,23 @@
+defmodule Portal.Oban do
+  @moduledoc """
+  Supervises Oban with its configured Repo as the dynamic Repo for all workers.
+
+  Oban uses its `:repo` option for internal job storage, but domain code called
+  from `c:Oban.Worker.perform/1` uses `Portal.Repo`. Storing the configured Repo
+  on this supervisor lets `Portal.Repo.DynamicRepoResolver` route all descendant
+  worker queries to the same isolated job pool.
+  """
+
+  use Supervisor
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
+    Portal.Repo.put_dynamic_repo(Keyword.fetch!(opts, :repo))
+
+    Supervisor.init([{Oban, opts}], strategy: :one_for_one)
+  end
+end

--- a/elixir/lib/portal/repo/job.ex
+++ b/elixir/lib/portal/repo/job.ex
@@ -1,0 +1,13 @@
+defmodule Portal.Repo.Job do
+  @moduledoc """
+  Isolated connection pool for Oban and the domain queries executed by its workers.
+
+  Keeping job traffic separate prevents background work from exhausting the Web
+  or API pools while PgBouncer can still multiplex all three workloads onto the
+  same upstream PostgreSQL connection pool.
+  """
+
+  use Ecto.Repo,
+    otp_app: :portal,
+    adapter: Ecto.Adapters.Postgres
+end

--- a/elixir/test/portal/application_test.exs
+++ b/elixir/test/portal/application_test.exs
@@ -8,6 +8,19 @@ defmodule Portal.ApplicationTest do
                "expected Geolix database #{inspect(id)} to be loaded"
       end
     end
+
+    test "Oban descendants inherit the configured job repo" do
+      oban_repo = Application.fetch_env!(:portal, Oban) |> Keyword.fetch!(:repo)
+      ancestors = Process.get(:"$ancestors", [])
+
+      Process.put(:"$ancestors", [Portal.Oban])
+
+      try do
+        assert Portal.Repo.DynamicRepoResolver.inherit(Portal.Repo) == oban_repo
+      after
+        Process.put(:"$ancestors", ancestors)
+      end
+    end
   end
 
   describe "stop/1" do

--- a/elixir/test/portal/health_test.exs
+++ b/elixir/test/portal/health_test.exs
@@ -95,7 +95,8 @@ defmodule Portal.HealthTest do
         repos: [
           Portal.Repo,
           Portal.Repo.Web,
-          Portal.Repo.Api
+          Portal.Repo.Api,
+          Portal.Repo.Job
         ]
       )
 
@@ -114,7 +115,8 @@ defmodule Portal.HealthTest do
         repos: [
           Portal.Repo,
           Portal.Repo.Web,
-          Portal.Repo.Api
+          Portal.Repo.Api,
+          Portal.Repo.Job
         ],
         repo_check_query: "SELECT 1 FROM pg_sleep(0.25)"
       )


### PR DESCRIPTION
## Summary

- add an optional `DATABASE_PGBOUNCER_PORT` for the Web, API, and background-job Ecto pools
- keep `Portal.Repo` and `Portal.Repo.Poller` on the direct `DATABASE_PORT` connection
- add `Portal.Repo.Job` with an independently configurable `DATABASE_POOL_SIZE_JOB`
- run Oban internals and worker domain queries through the job pool
- switch Oban to the distributed-Erlang `Oban.Notifiers.PG` notifier for transaction-pooling compatibility
- use unnamed Postgrex prepares whenever the PgBouncer endpoint is configured

When `DATABASE_PGBOUNCER_PORT` is unset, the workload pools fall back to the direct PostgreSQL port for backward compatibility.

## Validation

- `mix format --check-formatted`
- `mix credo --strict lib/portal/oban.ex lib/portal/repo/job.ex lib/portal/application.ex lib/portal/health.ex`
- `mix test test/portal/application_test.exs test/portal/health_test.exs test/portal/repo/get_dynamic_repo_test.exs test/portal/repo/dynamic_repo_resolver_test.exs` (28 tests)
