### PR TITLE
feat(connlib): support client certificates on portal WebSocket

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5606,6 +5606,8 @@ dependencies = [
  "logging",
  "os_info",
  "rand 0.10.2",
+ "rustls",
+ "rustls-native-certs",
  "secrecy",
  "serde",
  "serde_json",
@@ -5617,6 +5619,8 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 1.0.9",
+ "x509-credential",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10198,6 +10198,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-credential"
+version = "0.1.0"
+dependencies = [
+ "rustls",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "libs/telemetry",
     "libs/tunnel-bypass-resolver",
     "libs/windows-security",
+    "libs/x509-credential",
     "relay/ebpf-shared",
     "relay/ebpf-turn-router",
     "relay/proto",
@@ -186,6 +187,7 @@ roxmltree = "0.21.1"
 rpassword = "7.5.3"
 rtnetlink = { version = "0.21.0", default-features = false, features = ["tokio_socket"] }
 rustls = { version = "0.23.40", default-features = false, features = ["ring"] }
+rustls-native-certs = "0.8.1"
 rustls-pki-types = "1.14.1"
 rustls-platform-verifier = "0.7.0"
 sadness-generator = "0.7.0"
@@ -258,6 +260,7 @@ windows-native-keyring-store = "1.1.0"
 windows-security = { path = "libs/windows-security" }
 windows-service = "0.8.1"
 winreg = "0.56.0"
+x509-credential = { path = "libs/x509-credential" }
 zbus = "5.15.0"
 zip = { version = "8.6.0", default-features = false }
 

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -568,6 +568,7 @@ fn connect(
         device_id.clone(),
         device_name,
         device_info,
+        None,
     )
     .context("Failed to create login URL")?;
 

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -771,6 +771,7 @@ impl<'a> Handler<'a> {
                 device_uuid: device_info::uuid(),
                 ..Default::default()
             },
+            None,
         )
         .context("Failed to create `LoginUrl`")?;
 

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -373,6 +373,7 @@ fn try_main() -> Result<()> {
             device_uuid: device_info::uuid(),
             ..Default::default()
         },
+        None,
     )?;
 
     if cli.check {

--- a/rust/libs/connlib/phoenix-channel/Cargo.toml
+++ b/rust/libs/connlib/phoenix-channel/Cargo.toml
@@ -17,6 +17,7 @@ libc = { workspace = true }
 logging = { workspace = true }
 os_info = { workspace = true }
 rand = { workspace = true }
+rustls = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -27,11 +28,14 @@ tokio = { workspace = true, features = ["net", "time"] }
 tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true, features = ["std", "v4"] }
+x509-credential = { workspace = true }
 
 [target.'cfg(not(system_certs))'.dependencies]
 tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
+webpki-roots = { workspace = true }
 
 [target.'cfg(system_certs)'.dependencies]
+rustls-native-certs = { workspace = true }
 tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/rust/libs/connlib/phoenix-channel/build.rs
+++ b/rust/libs/connlib/phoenix-channel/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // `system_certs` is set through `RUSTFLAGS` by the Nix builds, not by Cargo, so declare it
+    // here to keep `unexpected_cfgs` quiet. Setting it is what switches the portal connection to
+    // the platform's root certificates.
+    println!("cargo::rustc-check-cfg=cfg(system_certs)");
+}

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -3,6 +3,7 @@
 mod get_user_agent;
 mod login_url;
 mod problem_details;
+mod tls;
 
 use anyhow::{Context as _, Result};
 use futures::stream::FuturesUnordered;
@@ -27,16 +28,17 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use socket_factory::{SocketFactory, TcpSocket, TcpStream};
 use std::task::{Context, Poll, Waker};
 use tokio_tungstenite::tungstenite::http::header::RETRY_AFTER;
+use tokio_tungstenite::{Connector, client_async_tls_with_config, tungstenite};
 use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream,
     tungstenite::{Message, handshake::client::Request},
 };
-use tokio_tungstenite::{client_async_tls, tungstenite};
 use url::Url;
 
 pub use get_user_agent::get_user_agent;
 pub use login_url::{DeviceInfo, LoginUrl, LoginUrlError, NoParams, PublicKeyParam};
 pub use tokio_tungstenite::tungstenite::http::StatusCode;
+pub use x509_credential::ClientCertificate;
 
 const MAX_BUFFERED_MESSAGES: usize = 32; // Chosen pretty arbitrarily. If we are connected, these should never build up.
 
@@ -59,8 +61,8 @@ pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     url_prototype: LoginUrl<TFinish>,
     last_url: Option<Url>,
     user_agent: String,
-    /// The authentication token, sent via X-Authorization header.
-    token: SecretString,
+    /// The optional authentication token, sent via X-Authorization when present.
+    token: Option<SecretString>,
     make_initial_backoff: Box<dyn Fn() -> ExponentialBackoff + Send>,
     make_reconnect_backoff: Box<dyn Fn() -> ExponentialBackoff + Send>,
     backoff: Option<ExponentialBackoff>,
@@ -98,9 +100,10 @@ async fn create_and_connect_websocket(
     addresses: Vec<SocketAddr>,
     host: String,
     user_agent: String,
-    token: SecretString,
+    token: Option<SecretString>,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     connect_timeout: Duration,
+    tls_client_config: Option<Arc<rustls::ClientConfig>>,
 ) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, InternalError> {
     tracing::debug!(%host, ?addresses, %user_agent, "Connecting to portal");
 
@@ -117,9 +120,15 @@ async fn create_and_connect_websocket(
                 )
             })??;
 
-        let (stream, _) = client_async_tls(make_request(url, host, user_agent, &token), socket)
-            .await
-            .map_err(InternalError::WebSocket)?;
+        let connector = tls_client_config.map(Connector::Rustls);
+        let (stream, _) = client_async_tls_with_config(
+            make_request(url, host, user_agent, token.as_ref()),
+            socket,
+            None,
+            connector,
+        )
+        .await
+        .map_err(InternalError::WebSocket)?;
 
         Ok(stream)
     })
@@ -183,6 +192,8 @@ pub enum Error {
     /// The portal refused to authenticate us for a reason we cannot act on specifically.
     #[error("Failed to authenticate with portal: {0}")]
     AuthenticationFailed(String),
+    #[error("X.509 client certificate signing failed: {0}")]
+    ClientCertificateSigningFailed(String),
     #[error(
         "Got disconnected from portal and hit the max-retry limit. Last connection error: {final_error}"
     )]
@@ -203,6 +214,7 @@ impl Error {
             Error::InvalidToken => true,
             // The portal rejected us without naming the token, so a new one is not known to help.
             Error::AuthenticationFailed(_) => false,
+            Error::ClientCertificateSigningFailed(_) => false,
             Error::MaxRetriesReached { .. } => false,
             Error::LoginFailed(_) => false,
             Error::FatalIo(_) => false,
@@ -243,6 +255,24 @@ enum InternalError {
 }
 
 impl InternalError {
+    /// Extracts the message of a client-certificate signing failure that happened during the TLS handshake.
+    ///
+    /// Signing with a platform key can fail for good, e.g. because the user declined the keystore prompt.
+    /// Retrying such a connection is pointless, so it must not be mistaken for one of the many transient IO errors.
+    fn client_certificate_signing_error(&self) -> Option<String> {
+        let Self::WebSocket(tungstenite::Error::Io(error)) = self else {
+            return None;
+        };
+        let tls_error = error.get_ref()?.downcast_ref::<rustls::Error>()?;
+        let rustls::Error::Other(other) = tls_error else {
+            return None;
+        };
+
+        let error = other.0.downcast_ref::<x509_credential::SigningError>()?;
+
+        Some(error.to_string())
+    }
+
     /// Parses a Retry-After header value into a Duration.
     ///
     /// The header can be either:
@@ -393,7 +423,7 @@ where
     /// The provided URL must contain a host.
     pub fn disconnected(
         url: LoginUrl<TFinish>,
-        token: SecretString,
+        token: impl Into<Option<SecretString>>,
         user_agent: String,
         login: &'static str,
         init_req: TInitReq,
@@ -407,7 +437,7 @@ where
             was_connected: false,
             url_prototype: url,
             user_agent,
-            token,
+            token: token.into(),
             state: State::Closed,
             socket_factory,
             waker: None,
@@ -504,6 +534,7 @@ where
             let user_agent = self.user_agent.clone();
             let token = self.token.clone();
             let socket_factory = self.socket_factory.clone();
+            let tls_client_config = self.url_prototype.tls_client_config();
 
             async move {
                 if let Err(e) = closing.await {
@@ -519,6 +550,7 @@ where
                     token,
                     socket_factory,
                     CONNECT_TIMEOUT,
+                    tls_client_config,
                 )
                 .await
             }
@@ -619,6 +651,12 @@ where
                     {
                         self.state = State::Closed;
                         return Poll::Ready(Err(Error::from_unauthorized(&r)));
+                    }
+                    Poll::Ready(Err(e))
+                        if let Some(message) = e.client_certificate_signing_error() =>
+                    {
+                        self.state = State::Closed;
+                        return Poll::Ready(Err(Error::ClientCertificateSigningFailed(message)));
                     }
                     Poll::Ready(Err(e)) => {
                         let backoff = match e.parse_retry_after_header() {
@@ -1078,24 +1116,34 @@ impl<T> PhoenixMessage<T> {
 }
 
 // This is basically the same as tungstenite does but we add some new headers (namely user-agent)
-fn make_request(url: Url, host: String, user_agent: String, token: &SecretString) -> Request {
+fn make_request(
+    url: Url,
+    host: String,
+    user_agent: String,
+    token: Option<&SecretString>,
+) -> Request {
     let r: [u8; 16] = rand::random();
     let key = base64::engine::general_purpose::STANDARD.encode(r);
 
     let user_agent = user_agent.replace(|c: char| !c.is_ascii(), "");
-    let token = token
-        .expose_secret()
-        .replace(|c: char| c.is_whitespace(), "");
-
-    Request::builder()
+    let mut builder = Request::builder()
         .method("GET")
         .header("Host", host)
         .header("Connection", "Upgrade")
         .header("Upgrade", "websocket")
         .header("Sec-WebSocket-Version", "13")
         .header("Sec-WebSocket-Key", key)
-        .header("User-Agent", user_agent)
-        .header("X-Authorization", format!("Bearer {token}"))
+        .header("User-Agent", user_agent);
+
+    if let Some(token) = token {
+        let token = token
+            .expose_secret()
+            .replace(|c: char| c.is_whitespace(), "");
+
+        builder = builder.header("X-Authorization", format!("Bearer {token}"));
+    }
+
+    builder
         .uri(url.to_string())
         .body(())
         .expect("should always be able to build a request if we only pass strings to it")
@@ -1124,6 +1172,29 @@ fn serialize_msg(
 #[cfg(test)]
 mod tests {
     use std::net::{Ipv4Addr, SocketAddrV4};
+
+    #[test]
+    fn extracts_client_certificate_signing_error() {
+        let tls_error = rustls::Error::Other(rustls::OtherError(Arc::new(
+            x509_credential::SigningError::AccessDenied(
+                "provider interaction is unavailable".to_owned(),
+            ),
+        )));
+        let error = InternalError::WebSocket(tungstenite::Error::Io(io::Error::other(tls_error)));
+
+        assert_eq!(
+            error.client_certificate_signing_error().as_deref(),
+            Some(
+                "the keystore refused to use the private key: provider interaction is unavailable"
+            )
+        );
+    }
+
+    #[derive(Deserialize, PartialEq, Debug)]
+    #[serde(rename_all = "snake_case", tag = "event", content = "payload")] // This line makes it all work.
+    enum Msg {
+        Shout { hello: String },
+    }
 
     use tokio::net::TcpListener;
 
@@ -1180,12 +1251,6 @@ mod tests {
             error.to_string(),
             "Failed to authenticate with portal: Invalid token"
         );
-    }
-
-    #[derive(Deserialize, PartialEq, Debug)]
-    #[serde(rename_all = "snake_case", tag = "event", content = "payload")] // This line makes it all work.
-    enum Msg {
-        Shout { hello: String },
     }
 
     #[test]
@@ -1409,9 +1474,10 @@ mod tests {
             vec![addr],
             "127.0.0.1".to_string(),
             "test-agent".to_string(),
-            SecretString::from("test-token".to_string()),
+            Some(SecretString::from("test-token".to_string())),
             Arc::new(socket_factory::tcp),
             Duration::from_secs(2),
+            None,
         )
         .await;
 
@@ -1427,7 +1493,9 @@ mod tests {
             Url::parse("ws://example.com/websocket").unwrap(),
             "example.com".to_string(),
             "test-agent".to_string(),
-            &SecretString::from("valid-token-part\ninjected".to_string()),
+            Some(&SecretString::from(
+                "valid-token-part\ninjected".to_string(),
+            )),
         );
 
         assert_eq!(
@@ -1442,7 +1510,9 @@ mod tests {
             Url::parse("ws://example.com/websocket").unwrap(),
             "example.com".to_string(),
             "test-agent".to_string(),
-            &SecretString::from("valid-token-part\rinjected".to_string()),
+            Some(&SecretString::from(
+                "valid-token-part\rinjected".to_string(),
+            )),
         );
 
         assert_eq!(
@@ -1452,12 +1522,26 @@ mod tests {
     }
 
     #[test]
+    fn make_request_omits_authorization_without_token() {
+        let request = make_request(
+            Url::parse("ws://example.com/websocket").unwrap(),
+            "example.com".to_string(),
+            "test-agent".to_string(),
+            None,
+        );
+
+        assert!(!request.headers().contains_key("X-Authorization"));
+    }
+
+    #[test]
     fn make_request_accepts_valid_token() {
         let request = make_request(
             Url::parse("ws://example.com/websocket").unwrap(),
             "example.com".to_string(),
             "test-agent".to_string(),
-            &SecretString::from("a-perfectly-valid.token_123".to_string()),
+            Some(&SecretString::from(
+                "a-perfectly-valid.token_123".to_string(),
+            )),
         );
 
         assert_eq!(

--- a/rust/libs/connlib/phoenix-channel/src/login_url.rs
+++ b/rust/libs/connlib/phoenix-channel/src/login_url.rs
@@ -6,9 +6,11 @@ use std::{
     marker::PhantomData,
     net::{Ipv4Addr, Ipv6Addr},
     str::FromStr as _,
+    sync::Arc,
 };
 use url::Url;
 use uuid::Uuid;
+use x509_credential::ClientCertificate;
 
 // From https://man7.org/linux/man-pages/man2/gethostname.2.html
 // SUSv2 guarantees that "Host names are limited to 255 bytes".
@@ -39,6 +41,9 @@ pub struct LoginUrl<TFinish> {
     // If we don't duplicate it, we'd have to do extra error handling in several places instead of just one place.
     host: String,
     port: u16,
+
+    /// The configuration to dial with, built once because it may load the platform's root certificates.
+    tls_config: Option<Arc<rustls::ClientConfig>>,
 
     phantom: PhantomData<TFinish>,
 }
@@ -73,7 +78,22 @@ impl LoginUrl<PublicKeyParam> {
         device_id: String,
         device_name: Option<String>,
         device_info: DeviceInfo,
+        certificate: Option<ClientCertificate>,
     ) -> Result<Self, LoginUrlError<E>> {
+        let mut url = url.try_into().map_err(LoginUrlError::InvalidUrl)?;
+
+        let tls_config = match &certificate {
+            Some(certificate) => {
+                require_tls(&url)?;
+
+                let mtls_host = mtls_host(&url)?;
+                set_host(&mut url, mtls_host);
+
+                Some(crate::tls::client_config(certificate).map_err(LoginUrlError::Tls)?)
+            }
+            None => None,
+        };
+
         let external_id = if uuid::Uuid::from_str(&device_id).is_ok() {
             hex::encode(sha2::Sha256::digest(device_id))
         } else {
@@ -85,7 +105,7 @@ impl LoginUrl<PublicKeyParam> {
             .unwrap_or_else(|| Uuid::new_v4().to_string());
 
         let url = get_websocket_path(
-            url.try_into().map_err(LoginUrlError::InvalidUrl)?,
+            url,
             "client",
             Some("v2"),
             Some(external_id),
@@ -102,6 +122,7 @@ impl LoginUrl<PublicKeyParam> {
             host,
             port,
             url,
+            tls_config,
             phantom: PhantomData,
         })
     }
@@ -138,6 +159,7 @@ impl LoginUrl<PublicKeyParam> {
             host,
             port,
             url,
+            tls_config: None,
             phantom: PhantomData,
         })
     }
@@ -169,6 +191,7 @@ impl LoginUrl<NoParams> {
             host,
             port,
             url,
+            tls_config: None,
             phantom: PhantomData,
         })
     }
@@ -200,6 +223,30 @@ impl<TFinish> LoginUrl<TFinish> {
 
         url.to_string()
     }
+
+    pub(crate) fn tls_client_config(&self) -> Option<Arc<rustls::ClientConfig>> {
+        self.tls_config.clone()
+    }
+}
+
+/// Returns the mTLS counterpart of a SaaS API host.
+///
+/// The portal requests a client certificate based on the host we dial, so presenting a certificate implies dialing the mTLS host.
+/// Only the SaaS portals operate one; a self-hosted portal cannot authenticate us by certificate, so we refuse rather than silently dial it without one.
+fn mtls_host<E>(url: &Url) -> Result<&'static str, LoginUrlError<E>> {
+    let host = url.host_str().ok_or(LoginUrlError::MissingHost)?;
+
+    match host {
+        "api.firez.one" => Ok("mtls.firez.one"),
+        "api.firezone.dev" => Ok("mtls.firezone.dev"),
+        other => Err(LoginUrlError::CertificateNotSupported(other.to_owned())),
+    }
+}
+
+/// Points the URL at a hard-coded host.
+fn set_host(url: &mut Url, host: &'static str) {
+    url.set_host(Some(host))
+        .expect("hard-coded hostname is valid");
 }
 
 /// Parse the host from a URL, including port if present. e.g. `example.com:8080`.
@@ -216,10 +263,16 @@ fn parse_host<E>(url: &Url) -> Result<(String, u16), LoginUrlError<E>> {
 pub enum LoginUrlError<E> {
     #[error("invalid scheme `{0}`; only http(s) and ws(s) are allowed")]
     InvalidUrlScheme(String),
+    #[error("scheme `{0}` cannot present a client certificate; use https or wss")]
+    InsecureUrlWithCertificate(String),
+    #[error("`{0}` does not support signing in with a client certificate")]
+    CertificateNotSupported(String),
     #[error("failed to parse URL: {0}")]
     InvalidUrl(E),
     #[error("the url is missing a host")]
     MissingHost,
+    #[error("failed to build the TLS configuration: {0}")]
+    Tls(rustls::Error),
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -301,6 +354,14 @@ fn get_websocket_path<E>(
     Ok(api_url)
 }
 
+/// Rejects a plaintext URL, which would drop the client certificate from the handshake.
+fn require_tls<E>(url: &Url) -> Result<(), LoginUrlError<E>> {
+    match url.scheme() {
+        "https" | "wss" => Ok(()),
+        other => Err(LoginUrlError::InsecureUrlWithCertificate(other.to_owned())),
+    }
+}
+
 fn set_ws_scheme<E>(url: &mut Url) -> Result<(), LoginUrlError<E>> {
     let scheme = match url.scheme() {
         "http" | "ws" => "ws",
@@ -325,6 +386,7 @@ mod tests {
             "some-id".to_owned(),
             None,
             DeviceInfo::default(),
+            None,
         )
         .unwrap();
 
@@ -340,6 +402,7 @@ mod tests {
             "some-id".to_owned(),
             Some("some-name".to_owned()),
             DeviceInfo::default(),
+            None,
         )
         .unwrap();
 
@@ -347,6 +410,113 @@ mod tests {
             login_url.to_url(PublicKeyParam([0; 32])).path(),
             "/client/v2/websocket"
         )
+    }
+
+    #[test]
+    fn client_with_certificate_rejects_plaintext_url() {
+        for url in ["http://api.firez.one", "ws://api.firez.one"] {
+            let result = LoginUrl::client(
+                url,
+                "some-id".to_owned(),
+                Some("some-name".to_owned()),
+                DeviceInfo::default(),
+                Some(certificate()),
+            );
+
+            assert!(matches!(
+                result,
+                Err(LoginUrlError::InsecureUrlWithCertificate(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn client_without_certificate_allows_plaintext_url() {
+        let login_url = LoginUrl::client(
+            "http://localhost:8081",
+            "some-id".to_owned(),
+            Some("some-name".to_owned()),
+            DeviceInfo::default(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(login_url.host_and_port(), ("localhost", 8081));
+    }
+
+    #[test]
+    fn client_with_certificate_uses_mtls_api_host() {
+        let login_url = LoginUrl::client(
+            "wss://api.firez.one:444",
+            "some-id".to_owned(),
+            Some("some-name".to_owned()),
+            DeviceInfo::default(),
+            Some(certificate()),
+        )
+        .unwrap();
+
+        assert_eq!(login_url.host_and_port(), ("mtls.firez.one", 444));
+        assert!(login_url.tls_client_config().is_some());
+    }
+
+    #[test]
+    fn client_with_certificate_uses_mtls_staging_api_host() {
+        let login_url = LoginUrl::client(
+            "wss://api.firezone.dev",
+            "some-id".to_owned(),
+            Some("some-name".to_owned()),
+            DeviceInfo::default(),
+            Some(certificate()),
+        )
+        .unwrap();
+
+        assert_eq!(login_url.host_and_port(), ("mtls.firezone.dev", 443));
+    }
+
+    #[test]
+    fn client_with_certificate_rejects_self_hosted_portal() {
+        let result = LoginUrl::client(
+            "wss://portal.example.com",
+            "some-id".to_owned(),
+            Some("some-name".to_owned()),
+            DeviceInfo::default(),
+            Some(certificate()),
+        );
+
+        assert!(matches!(
+            result,
+            Err(LoginUrlError::CertificateNotSupported(host)) if host == "portal.example.com"
+        ));
+    }
+
+    #[test]
+    fn client_without_certificate_keeps_self_hosted_portal() {
+        let login_url = LoginUrl::client(
+            "wss://portal.example.com",
+            "some-id".to_owned(),
+            Some("some-name".to_owned()),
+            DeviceInfo::default(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(login_url.host_and_port(), ("portal.example.com", 443));
+        assert!(login_url.tls_client_config().is_none());
+    }
+
+    #[test]
+    fn client_without_certificate_keeps_api_host() {
+        let login_url = LoginUrl::client(
+            "wss://api.firezone.dev",
+            "some-id".to_owned(),
+            Some("some-name".to_owned()),
+            DeviceInfo::default(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(login_url.host_and_port(), ("api.firezone.dev", 443));
+        assert!(login_url.tls_client_config().is_none());
     }
 
     #[test]
@@ -376,5 +546,34 @@ mod tests {
         .unwrap();
 
         assert_eq!(login_url.to_url(NoParams).path(), "/relay/websocket")
+    }
+
+    fn certificate() -> ClientCertificate {
+        ClientCertificate::new(
+            vec![rustls::pki_types::CertificateDer::from(vec![1, 2, 3])],
+            Arc::new(StubKey),
+        )
+        .expect("a single-element chain should be accepted")
+    }
+
+    #[derive(Debug)]
+    struct StubKey;
+
+    impl x509_credential::PrivateKey for StubKey {
+        fn supported_schemes(&self) -> Vec<rustls::SignatureScheme> {
+            vec![rustls::SignatureScheme::ECDSA_NISTP256_SHA256]
+        }
+
+        fn algorithm(&self) -> rustls::SignatureAlgorithm {
+            rustls::SignatureAlgorithm::ECDSA
+        }
+
+        fn sign(
+            &self,
+            _: rustls::SignatureScheme,
+            _: &[u8],
+        ) -> Result<Vec<u8>, x509_credential::SigningError> {
+            unimplemented!("these tests never complete a handshake")
+        }
     }
 }

--- a/rust/libs/connlib/phoenix-channel/src/login_url.rs
+++ b/rust/libs/connlib/phoenix-channel/src/login_url.rs
@@ -2,6 +2,7 @@ use base64::{Engine, engine::general_purpose::STANDARD};
 use serde::Deserialize;
 use sha2::Digest as _;
 use std::{
+    borrow::Cow,
     iter,
     marker::PhantomData,
     net::{Ipv4Addr, Ipv6Addr},
@@ -86,8 +87,8 @@ impl LoginUrl<PublicKeyParam> {
             Some(certificate) => {
                 require_tls(&url)?;
 
-                let mtls_host = mtls_host(&url)?;
-                set_host(&mut url, mtls_host);
+                let mtls_host = mtls_host(&url, std::env::var(MTLS_HOST_ENV_VAR).ok())?;
+                set_host(&mut url, &mtls_host)?;
 
                 Some(crate::tls::client_config(certificate).map_err(LoginUrlError::Tls)?)
             }
@@ -229,24 +230,33 @@ impl<TFinish> LoginUrl<TFinish> {
     }
 }
 
-/// Returns the mTLS counterpart of a SaaS API host.
+/// The environment variable naming the mTLS host of a portal we do not know.
+pub const MTLS_HOST_ENV_VAR: &str = "FIREZONE_MTLS_HOST";
+
+/// Returns the mTLS counterpart of an API host.
 ///
 /// The portal requests a client certificate based on the host we dial, so presenting a certificate implies dialing the mTLS host.
-/// Only the SaaS portals operate one; a self-hosted portal cannot authenticate us by certificate, so we refuse rather than silently dial it without one.
-fn mtls_host<E>(url: &Url) -> Result<&'static str, LoginUrlError<E>> {
+/// The SaaS portals have a known counterpart. Any other portal has to name its own through [`MTLS_HOST_ENV_VAR`], because dialing one that never asks for a certificate would sign us in without the identity the caller asked for.
+fn mtls_host<E>(
+    url: &Url,
+    override_host: Option<String>,
+) -> Result<Cow<'static, str>, LoginUrlError<E>> {
     let host = url.host_str().ok_or(LoginUrlError::MissingHost)?;
 
     match host {
-        "api.firez.one" => Ok("mtls.firez.one"),
-        "api.firezone.dev" => Ok("mtls.firezone.dev"),
-        other => Err(LoginUrlError::CertificateNotSupported(other.to_owned())),
+        "api.firez.one" => Ok(Cow::Borrowed("mtls.firez.one")),
+        "api.firezone.dev" => Ok(Cow::Borrowed("mtls.firezone.dev")),
+        other => override_host
+            .filter(|host| !host.trim().is_empty())
+            .map(Cow::Owned)
+            .ok_or_else(|| LoginUrlError::CertificateNotSupported(other.to_owned())),
     }
 }
 
-/// Points the URL at a hard-coded host.
-fn set_host(url: &mut Url, host: &'static str) {
+/// Points the URL at the given host.
+fn set_host<E>(url: &mut Url, host: &str) -> Result<(), LoginUrlError<E>> {
     url.set_host(Some(host))
-        .expect("hard-coded hostname is valid");
+        .map_err(|_| LoginUrlError::InvalidMtlsHost(host.to_owned()))
 }
 
 /// Parse the host from a URL, including port if present. e.g. `example.com:8080`.
@@ -267,6 +277,8 @@ pub enum LoginUrlError<E> {
     InsecureUrlWithCertificate(String),
     #[error("`{0}` does not support signing in with a client certificate")]
     CertificateNotSupported(String),
+    #[error("`{0}` is not a valid hostname")]
+    InvalidMtlsHost(String),
     #[error("failed to parse URL: {0}")]
     InvalidUrl(E),
     #[error("the url is missing a host")]
@@ -442,6 +454,44 @@ mod tests {
         .unwrap();
 
         assert_eq!(login_url.host_and_port(), ("localhost", 8081));
+    }
+
+    #[test]
+    fn an_unknown_host_can_name_its_mtls_counterpart() {
+        let url = Url::parse("wss://api.example.com:444").unwrap();
+
+        let host = mtls_host::<url::ParseError>(&url, Some("mtls.example.com".to_owned())).unwrap();
+
+        assert_eq!(host, "mtls.example.com");
+    }
+
+    #[test]
+    fn an_unknown_host_without_an_override_is_refused() {
+        let url = Url::parse("wss://api.example.com:444").unwrap();
+
+        let error = mtls_host::<url::ParseError>(&url, None).unwrap_err();
+
+        assert!(
+            matches!(error, LoginUrlError::CertificateNotSupported(host) if host == "api.example.com")
+        );
+    }
+
+    #[test]
+    fn a_blank_override_counts_as_unset() {
+        let url = Url::parse("wss://api.example.com:444").unwrap();
+
+        let error = mtls_host::<url::ParseError>(&url, Some("  ".to_owned())).unwrap_err();
+
+        assert!(matches!(error, LoginUrlError::CertificateNotSupported(_)));
+    }
+
+    #[test]
+    fn an_override_does_not_displace_a_known_saas_host() {
+        let url = Url::parse("wss://api.firez.one:444").unwrap();
+
+        let host = mtls_host::<url::ParseError>(&url, Some("mtls.example.com".to_owned())).unwrap();
+
+        assert_eq!(host, "mtls.firez.one");
     }
 
     #[test]

--- a/rust/libs/connlib/phoenix-channel/src/tls.rs
+++ b/rust/libs/connlib/phoenix-channel/src/tls.rs
@@ -1,0 +1,53 @@
+//! Assembling the TLS configuration for the portal connection.
+//!
+//! Only a connection that presents a client certificate needs one built here; without a certificate `tokio-tungstenite` builds an equivalent configuration itself.
+//! Keeping the assembly in this crate is what stops a client certificate from also deciding how the portal is verified.
+
+use std::sync::Arc;
+
+use x509_credential::ClientCertificate;
+
+/// Builds the TLS configuration that presents `certificate` to the portal.
+///
+/// The portal is verified against the same roots as a connection that presents no certificate, so offering a client identity cannot change who we trust.
+///
+/// # Errors
+///
+/// Returns a [`rustls::Error`] if the crypto provider does not support the default protocol versions.
+pub(crate) fn client_config(
+    certificate: &ClientCertificate,
+) -> Result<Arc<rustls::ClientConfig>, rustls::Error> {
+    let config = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()?
+    .with_root_certificates(root_store())
+    .with_client_cert_resolver(certificate.resolver());
+
+    Ok(Arc::new(config))
+}
+
+/// The roots bundled with the binary.
+#[cfg(not(system_certs))]
+fn root_store() -> rustls::RootCertStore {
+    rustls::RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    }
+}
+
+/// The roots the platform trusts.
+#[cfg(system_certs)]
+fn root_store() -> rustls::RootCertStore {
+    let native = rustls_native_certs::load_native_certs();
+
+    for error in &native.errors {
+        tracing::warn!("Failed to load a native root certificate: {error}");
+    }
+
+    let mut store = rustls::RootCertStore::empty();
+    let (added, ignored) = store.add_parsable_certificates(native.certs);
+
+    tracing::debug!(%added, %ignored, "Loaded native root certificates");
+
+    store
+}

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -687,6 +687,7 @@ fn make_test_channel(
         "test-device-id".to_string(),
         Some("test-device".to_string()),
         DeviceInfo::default(),
+        None,
     )
     .unwrap();
 

--- a/rust/libs/x509-credential/Cargo.toml
+++ b/rust/libs/x509-credential/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "x509-credential"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+rustls = { workspace = true, features = ["std"] }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/libs/x509-credential/src/lib.rs
+++ b/rust/libs/x509-credential/src/lib.rs
@@ -1,0 +1,273 @@
+//! Client-side TLS building blocks for authenticating to the portal with an X.509 client certificate.
+//!
+//! The private key of such a certificate is managed by a platform keystore and is not exportable, so signing is delegated to the keystore through [`PrivateKey`].
+//! Adapting that interface to rustls happens here, which keeps the keystore backends and the portal connection unaware of each other.
+//! Backends implement [`PrivateKey`]: the Apple clients through UniFFI, Windows through CNG and Linux through PKCS#11.
+
+use std::{fmt, sync::Arc};
+
+use rustls::{
+    SignatureAlgorithm, SignatureScheme,
+    client::ResolvesClientCert,
+    pki_types::CertificateDer,
+    sign::{CertifiedKey, Signer, SigningKey, SingleCertAndKey},
+};
+
+/// An X.509 client certificate presented to the portal during the TLS handshake.
+///
+/// Constructing a `phoenix_channel::LoginUrl` with a certificate dials the portal's mTLS endpoint instead of the regular one.
+/// This carries the client identity alone: how the portal's own certificate is verified belongs to `phoenix-channel`, so presenting a certificate cannot change it.
+#[derive(Debug, Clone)]
+pub struct ClientCertificate(Arc<CertifiedKey>);
+
+impl ClientCertificate {
+    /// Builds a client identity from a DER-encoded certificate chain and a platform-held key.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EmptyCertificateChain`] if the chain has no elements; rustls expects the end-entity certificate as its first one.
+    pub fn new(
+        chain: Vec<CertificateDer<'static>>,
+        key: Arc<dyn PrivateKey>,
+    ) -> Result<Self, EmptyCertificateChain> {
+        if chain.is_empty() {
+            return Err(EmptyCertificateChain);
+        }
+
+        let certified_key = CertifiedKey::new(chain, Arc::new(PlatformSigningKey(key)));
+
+        Ok(Self(Arc::new(certified_key)))
+    }
+
+    /// Offers this certificate whenever the portal asks for a client identity.
+    pub fn resolver(&self) -> Arc<dyn ResolvesClientCert> {
+        Arc::new(SingleCertAndKey::from(self.0.clone()))
+    }
+}
+
+/// A private key that is held by a platform keystore.
+///
+/// Implementations sign by asking the keystore to do so; the key material itself never becomes available to us.
+pub trait PrivateKey: fmt::Debug + Send + Sync {
+    /// Returns the TLS signature schemes this key can sign with, most preferred first.
+    fn supported_schemes(&self) -> Vec<SignatureScheme>;
+
+    /// Returns the algorithm of this key.
+    fn algorithm(&self) -> SignatureAlgorithm;
+
+    /// Signs the unhashed TLS handshake message with the requested scheme.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`SigningError`] if the keystore refuses or fails to sign, or if `scheme` is not one of [`PrivateKey::supported_schemes`].
+    fn sign(&self, scheme: SignatureScheme, message: &[u8]) -> Result<Vec<u8>, SigningError>;
+}
+
+/// A platform keystore failed to sign a TLS handshake message.
+///
+/// [`rustls::Error::Other`] carries this error through the TLS stack with its type intact, allowing `phoenix-channel` to downcast it back out.
+/// The concrete type is what makes a failed client signature distinguishable from a failed server certificate verification, which rustls reports as [`rustls::Error::General`] or as [`rustls::Error::Other`] depending on the verifier.
+///
+/// Variants name the cause as the platform reports it, so that the decision of which causes are terminal is made once here rather than separately by each keystore implementation.
+#[derive(Debug, thiserror::Error)]
+pub enum SigningError {
+    /// The keystore no longer holds the private key of the certificate we selected.
+    #[error("the keystore no longer holds the private key: {0}")]
+    KeyUnavailable(String),
+    /// The keystore refused to use the private key, e.g. because a confirmation prompt was declined or we lack permission on the key.
+    #[error("the keystore refused to use the private key: {0}")]
+    AccessDenied(String),
+    /// The keystore cannot produce a signature for the scheme rustls picked.
+    #[error("the keystore cannot sign with {0:?}")]
+    UnsupportedScheme(SignatureScheme),
+    /// The keystore failed to sign for a reason that is neither the key's absence nor a refusal.
+    #[error("the keystore failed to sign: {0}")]
+    Keystore(String),
+}
+
+/// A certificate chain offered as a client identity had no elements.
+#[derive(Debug, thiserror::Error)]
+#[error("the client certificate chain is empty")]
+pub struct EmptyCertificateChain;
+
+#[derive(Debug)]
+struct PlatformSigningKey(Arc<dyn PrivateKey>);
+
+impl SigningKey for PlatformSigningKey {
+    fn choose_scheme(&self, offered: &[SignatureScheme]) -> Option<Box<dyn Signer>> {
+        let scheme = self
+            .0
+            .supported_schemes()
+            .into_iter()
+            .find(|scheme| offered.contains(scheme))?;
+
+        Some(Box::new(PlatformSigner {
+            key: self.0.clone(),
+            scheme,
+        }))
+    }
+
+    fn algorithm(&self) -> SignatureAlgorithm {
+        self.0.algorithm()
+    }
+}
+
+#[derive(Debug)]
+struct PlatformSigner {
+    key: Arc<dyn PrivateKey>,
+    scheme: SignatureScheme,
+}
+
+impl Signer for PlatformSigner {
+    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
+        let signature = self
+            .key
+            .sign(self.scheme, message)
+            .map_err(|e| rustls::Error::Other(rustls::OtherError(Arc::new(e))))?;
+
+        Ok(signature)
+    }
+
+    fn scheme(&self) -> SignatureScheme {
+        self.scheme
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chooses_a_mutually_supported_scheme_and_delegates_signing() {
+        let certificate = ClientCertificate::new(
+            vec![CertificateDer::from(vec![1, 2, 3])],
+            Arc::new(MockKey {
+                schemes: vec![
+                    SignatureScheme::RSA_PSS_SHA512,
+                    SignatureScheme::RSA_PSS_SHA256,
+                ],
+            }),
+        )
+        .expect("mock key should produce a client certificate");
+
+        let signer = certificate
+            .0
+            .key
+            .choose_scheme(&[
+                SignatureScheme::ECDSA_NISTP256_SHA256,
+                SignatureScheme::RSA_PSS_SHA256,
+            ])
+            .expect("RSA-PSS SHA-256 should be mutually supported");
+
+        assert_eq!(signer.scheme(), SignatureScheme::RSA_PSS_SHA256);
+        assert_eq!(
+            signer.sign(&[4, 5]).expect("mock signing should succeed"),
+            vec![4, 5, 0x08, 0x04]
+        );
+    }
+
+    #[test]
+    fn rejects_an_empty_certificate_chain() {
+        let error = ClientCertificate::new(
+            Vec::new(),
+            Arc::new(MockKey {
+                schemes: vec![SignatureScheme::ECDSA_NISTP256_SHA256],
+            }),
+        )
+        .expect_err("an empty chain should be rejected");
+
+        assert_eq!(error.to_string(), "the client certificate chain is empty");
+    }
+
+    #[test]
+    fn offers_the_certificate_to_a_server_that_asks_for_one() {
+        let certificate = ClientCertificate::new(
+            vec![CertificateDer::from(vec![1, 2, 3])],
+            Arc::new(MockKey {
+                schemes: vec![SignatureScheme::RSA_PSS_SHA256],
+            }),
+        )
+        .expect("mock key should produce a client certificate");
+
+        let resolver = certificate.resolver();
+
+        assert!(resolver.has_certs());
+        assert_eq!(
+            resolver
+                .resolve(&[], &[SignatureScheme::RSA_PSS_SHA256])
+                .expect("the certificate should be offered")
+                .cert,
+            vec![CertificateDer::from(vec![1, 2, 3])]
+        );
+    }
+
+    #[test]
+    fn reports_signing_failures_as_a_downcastable_other_error() {
+        let certificate = ClientCertificate::new(
+            vec![CertificateDer::from(vec![1, 2, 3])],
+            Arc::new(FailingKey),
+        )
+        .expect("failing key should produce a client certificate");
+        let signer = certificate
+            .0
+            .key
+            .choose_scheme(&[SignatureScheme::ECDSA_NISTP256_SHA256])
+            .expect("ECDSA NIST P-256 should be mutually supported");
+
+        let error = signer
+            .sign(&[4, 5])
+            .expect_err("the failing key should not sign");
+
+        let rustls::Error::Other(other) = error else {
+            panic!("expected `rustls::Error::Other`, got {error:?}");
+        };
+        let signing_error = other
+            .0
+            .downcast_ref::<SigningError>()
+            .expect("expected a `SigningError`");
+        assert!(
+            matches!(signing_error, SigningError::AccessDenied(_)),
+            "got {signing_error:?}"
+        );
+    }
+
+    #[derive(Debug)]
+    struct MockKey {
+        schemes: Vec<SignatureScheme>,
+    }
+
+    impl PrivateKey for MockKey {
+        fn supported_schemes(&self) -> Vec<SignatureScheme> {
+            self.schemes.clone()
+        }
+
+        fn algorithm(&self) -> SignatureAlgorithm {
+            SignatureAlgorithm::RSA
+        }
+
+        fn sign(&self, scheme: SignatureScheme, message: &[u8]) -> Result<Vec<u8>, SigningError> {
+            assert_eq!(scheme, SignatureScheme::RSA_PSS_SHA256);
+
+            Ok([message, &[0x08, 0x04]].concat())
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingKey;
+
+    impl PrivateKey for FailingKey {
+        fn supported_schemes(&self) -> Vec<SignatureScheme> {
+            vec![SignatureScheme::ECDSA_NISTP256_SHA256]
+        }
+
+        fn algorithm(&self) -> SignatureAlgorithm {
+            SignatureAlgorithm::ECDSA
+        }
+
+        fn sign(&self, _: SignatureScheme, _: &[u8]) -> Result<Vec<u8>, SigningError> {
+            Err(SigningError::AccessDenied(
+                "the user declined the keystore prompt".to_owned(),
+            ))
+        }
+    }
+}

--- a/rust/tests/loadtest/src/portal.rs
+++ b/rust/tests/loadtest/src/portal.rs
@@ -59,8 +59,14 @@ pub async fn fetch_relay(
     let token = load_token(token_path)?;
 
     let device_id = uuid::Uuid::new_v4().to_string();
-    let url = LoginUrl::client(portal_url.clone(), device_id, None, DeviceInfo::default())
-        .map_err(|e| anyhow!("invalid portal URL: {e:?}"))?;
+    let url = LoginUrl::client(
+        portal_url.clone(),
+        device_id,
+        None,
+        DeviceInfo::default(),
+        None,
+    )
+    .map_err(|e| anyhow!("invalid portal URL: {e:?}"))?;
 
     let socket_factory = Arc::new(socket_factory::tcp) as Arc<dyn SocketFactory<TcpSocket>>;
 


### PR DESCRIPTION
Today, Firezone Clients and Gateways authenticate to the portal via a TLS-protected WebSocket connection. A standard TLS connection only authenticates the server and says nothing about the client. To authenticate those, we send a token in the HTTP upgrade request.

In order to provide strong device authentication, this PR introduces the ability for the `phoenix-channel` module to use mTLS for the WebSocket connection. A new `x509-credential` crate defines the necessary shared abstraction that allows us to do this in a cross-platform way. The actual signing mechanism is abstracted away with a trait which allows us to plug in hardware-backed certificates where the actual key-material never leaves the device's secret store.

Related: #14712