### PR TITLE
feat(portal): add machine-readable problem codes

### DIFF
--- a/elixir/lib/portal_api/problem_details.ex
+++ b/elixir/lib/portal_api/problem_details.ex
@@ -32,4 +32,17 @@ defmodule PortalAPI.ProblemDetails do
     |> Plug.Conn.send_resp(status, Phoenix.json_library().encode_to_iodata!(body))
     |> halt()
   end
+
+  @doc """
+  Sends an RFC 9457 problem details JSON response carrying a machine-readable `code`.
+
+  `code` is an atom naming the failure reason. It is emitted as a top-level `code`
+  extension member holding its snake_case string form, so clients can branch on the
+  reason instead of parsing `detail` or guessing from `status`. Several reasons map
+  onto the same status code, so `status` alone cannot discriminate between them.
+  """
+  @spec send_with_code(Plug.Conn.t(), integer(), atom(), String.t(), map()) :: Plug.Conn.t()
+  def send_with_code(conn, status, code, detail, extensions \\ %{}) when is_atom(code) do
+    send(conn, status, detail, Map.put(extensions, :code, Atom.to_string(code)))
+  end
 end

--- a/elixir/lib/portal_api/sockets.ex
+++ b/elixir/lib/portal_api/sockets.ex
@@ -78,13 +78,19 @@ defmodule PortalAPI.Sockets do
       ProblemDetails.send_with_code(
         conn,
         409,
-        :conflict,
+        :gateway_already_connected,
         "A gateway with this ID is already connected"
       )
 
   def handle_error(conn, %Ecto.Changeset{} = changeset) do
     Logger.error("Invalid connection request", changeset: inspect(changeset))
-    ProblemDetails.send_with_code(conn, 400, :invalid_request, changeset_error_detail(changeset))
+
+    ProblemDetails.send_with_code(
+      conn,
+      400,
+      :invalid_connect_params,
+      changeset_error_detail(changeset)
+    )
   end
 
   # We use 503 instead of 429 because connlib treats 429 as fatal until
@@ -102,7 +108,12 @@ defmodule PortalAPI.Sockets do
   def handle_error(conn, reason) do
     Logger.error("Unhandled socket connect error", reason: inspect(reason))
 
-    ProblemDetails.send_with_code(conn, 500, :internal_error, "An unexpected error occurred.")
+    ProblemDetails.send_with_code(
+      conn,
+      500,
+      :unhandled_connect_error,
+      "An unexpected error occurred."
+    )
   end
 
   def auth_context(%{user_agent: user_agent, x_headers: x_headers, peer_data: peer_data}, type) do

--- a/elixir/lib/portal_api/sockets.ex
+++ b/elixir/lib/portal_api/sockets.ex
@@ -22,59 +22,69 @@ defmodule PortalAPI.Sockets do
   end
 
   def handle_error(conn, :invalid_token),
-    do: ProblemDetails.send(conn, 401, "Invalid token")
+    do: ProblemDetails.send_with_code(conn, 401, :invalid_token, "Invalid token")
 
   def handle_error(conn, :missing_token),
-    do: ProblemDetails.send(conn, 401, "Missing token")
+    do: ProblemDetails.send_with_code(conn, 401, :missing_token, "Missing token")
 
   def handle_error(conn, :limits_exceeded),
     do:
-      ProblemDetails.send(
+      ProblemDetails.send_with_code(
         conn,
         402,
+        :limits_exceeded,
         "This account is temporarily suspended from client authentication " <>
           "due to exceeding billing limits. Please contact your administrator to add more seats."
       )
 
   def handle_error(conn, :account_disabled),
-    do: ProblemDetails.send(conn, 403, "The account is disabled")
+    do: ProblemDetails.send_with_code(conn, 403, :account_disabled, "The account is disabled")
 
   def handle_error(conn, :unauthenticated),
-    do: ProblemDetails.send(conn, 403, "Forbidden")
+    do: ProblemDetails.send_with_code(conn, 403, :unauthenticated, "Forbidden")
 
   def handle_error(conn, :device_untrusted),
     do:
-      ProblemDetails.send(
+      ProblemDetails.send_with_code(
         conn,
         403,
+        :device_untrusted,
         "This device did not present a valid certificate from a certificate authority " <>
           "your organization trusts. Please contact your administrator."
       )
 
   def handle_error(conn, :certificate_revoked),
     do:
-      ProblemDetails.send(
+      ProblemDetails.send_with_code(
         conn,
         403,
+        :certificate_revoked,
         "This device's certificate has been revoked by your organization's certificate " <>
           "authority. Please contact your administrator."
       )
 
   def handle_error(conn, :device_identity_conflict),
     do:
-      ProblemDetails.send(
+      ProblemDetails.send_with_code(
         conn,
         409,
+        :device_identity_conflict,
         "This device's certificate reports different hardware than the device already " <>
           "registered under the same MDM device ID. Please contact your administrator."
       )
 
   def handle_error(conn, :conflict),
-    do: ProblemDetails.send(conn, 409, "A gateway with this ID is already connected")
+    do:
+      ProblemDetails.send_with_code(
+        conn,
+        409,
+        :conflict,
+        "A gateway with this ID is already connected"
+      )
 
   def handle_error(conn, %Ecto.Changeset{} = changeset) do
     Logger.error("Invalid connection request", changeset: inspect(changeset))
-    ProblemDetails.send(conn, 400, changeset_error_detail(changeset))
+    ProblemDetails.send_with_code(conn, 400, :invalid_request, changeset_error_detail(changeset))
   end
 
   # We use 503 instead of 429 because connlib treats 429 as fatal until
@@ -85,7 +95,14 @@ defmodule PortalAPI.Sockets do
       "retry-after",
       Integer.to_string(PortalAPI.Sockets.RateLimit.retry_after_seconds())
     )
-    |> ProblemDetails.send(503, "Service Unavailable")
+    |> ProblemDetails.send_with_code(503, :rate_limit, "Service Unavailable")
+  end
+
+  # Must stay last so it cannot shadow the clauses above.
+  def handle_error(conn, reason) do
+    Logger.error("Unhandled socket connect error", reason: inspect(reason))
+
+    ProblemDetails.send_with_code(conn, 500, :internal_error, "An unexpected error occurred.")
   end
 
   def auth_context(%{user_agent: user_agent, x_headers: x_headers, peer_data: peer_data}, type) do

--- a/elixir/test/portal_api/problem_details_test.exs
+++ b/elixir/test/portal_api/problem_details_test.exs
@@ -49,13 +49,17 @@ defmodule PortalAPI.ProblemDetailsTest do
 
     test "keeps extension members alongside the code" do
       conn =
-        ProblemDetails.send_with_code(Plug.Test.conn(:get, "/"), 400, :invalid_request, "Bad", %{
-          validation_errors: %{"name" => ["can't be blank"]}
-        })
+        ProblemDetails.send_with_code(
+          Plug.Test.conn(:get, "/"),
+          400,
+          :invalid_connect_params,
+          "Bad",
+          %{validation_errors: %{"name" => ["can't be blank"]}}
+        )
 
       body = json_body(conn)
 
-      assert body["code"] == "invalid_request"
+      assert body["code"] == "invalid_connect_params"
       assert body["validation_errors"] == %{"name" => ["can't be blank"]}
     end
   end

--- a/elixir/test/portal_api/problem_details_test.exs
+++ b/elixir/test/portal_api/problem_details_test.exs
@@ -1,0 +1,69 @@
+defmodule PortalAPI.ProblemDetailsTest do
+  use ExUnit.Case, async: true
+
+  alias PortalAPI.ProblemDetails
+
+  describe "send/4" do
+    test "builds an RFC 9457 body without a code member" do
+      conn = ProblemDetails.send(Plug.Test.conn(:get, "/"), 404, "Not here")
+
+      assert conn.status == 404
+      assert conn.halted
+      assert content_type(conn) =~ "application/problem+json"
+
+      assert json_body(conn) == %{
+               "type" => "about:blank",
+               "title" => "Not Found",
+               "status" => 404,
+               "detail" => "Not here"
+             }
+    end
+
+    test "merges extension members into the body" do
+      conn =
+        ProblemDetails.send(Plug.Test.conn(:get, "/"), 422, "Invalid", %{
+          validation_errors: %{"name" => ["can't be blank"]}
+        })
+
+      assert json_body(conn)["validation_errors"] == %{"name" => ["can't be blank"]}
+    end
+  end
+
+  describe "send_with_code/5" do
+    test "emits the code as a top-level string alongside the standard members" do
+      conn =
+        ProblemDetails.send_with_code(Plug.Test.conn(:get, "/"), 403, :device_untrusted, "Nope")
+
+      assert conn.status == 403
+      assert conn.halted
+      assert content_type(conn) =~ "application/problem+json"
+
+      assert json_body(conn) == %{
+               "type" => "about:blank",
+               "title" => "Forbidden",
+               "status" => 403,
+               "detail" => "Nope",
+               "code" => "device_untrusted"
+             }
+    end
+
+    test "keeps extension members alongside the code" do
+      conn =
+        ProblemDetails.send_with_code(Plug.Test.conn(:get, "/"), 400, :invalid_request, "Bad", %{
+          validation_errors: %{"name" => ["can't be blank"]}
+        })
+
+      body = json_body(conn)
+
+      assert body["code"] == "invalid_request"
+      assert body["validation_errors"] == %{"name" => ["can't be blank"]}
+    end
+  end
+
+  defp json_body(conn), do: JSON.decode!(conn.resp_body)
+
+  defp content_type(conn) do
+    [content_type] = Plug.Conn.get_resp_header(conn, "content-type")
+    content_type
+  end
+end

--- a/elixir/test/portal_api/sockets_test.exs
+++ b/elixir/test/portal_api/sockets_test.exs
@@ -169,7 +169,7 @@ defmodule PortalAPI.SocketsTest do
 
       assert result.status == 409
       assert json_body(result)["detail"] == "A gateway with this ID is already connected"
-      assert_problem_json(result, "conflict")
+      assert_problem_json(result, "gateway_already_connected")
     end
 
     test "returns 503 with retry-after header for rate_limit" do
@@ -195,7 +195,7 @@ defmodule PortalAPI.SocketsTest do
 
       assert result.status == 400
       assert json_body(result)["detail"] =~ "name"
-      assert_problem_json(result, "invalid_request")
+      assert_problem_json(result, "invalid_connect_params")
     end
 
     test "returns 500 and logs for an unhandled reason" do
@@ -205,7 +205,7 @@ defmodule PortalAPI.SocketsTest do
 
       assert result.status == 500
       assert json_body(result)["detail"] == "An unexpected error occurred."
-      assert_problem_json(result, "internal_error")
+      assert_problem_json(result, "unhandled_connect_error")
       assert log =~ "Unhandled socket connect error"
       assert log =~ "some_new_reason"
     end

--- a/elixir/test/portal_api/sockets_test.exs
+++ b/elixir/test/portal_api/sockets_test.exs
@@ -1,5 +1,8 @@
 defmodule PortalAPI.SocketsTest do
   use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
   alias PortalAPI.Sockets
 
   describe "extract_token/2" do
@@ -82,7 +85,7 @@ defmodule PortalAPI.SocketsTest do
 
       assert result.status == 401
       assert json_body(result)["detail"] == "Invalid token"
-      assert_problem_json(result)
+      assert_problem_json(result, "invalid_token")
     end
 
     test "returns 401 for missing_token" do
@@ -92,7 +95,7 @@ defmodule PortalAPI.SocketsTest do
 
       assert result.status == 401
       assert json_body(result)["detail"] == "Missing token"
-      assert_problem_json(result)
+      assert_problem_json(result, "missing_token")
     end
 
     test "returns 402 for seats_limit_exceeded" do
@@ -106,7 +109,7 @@ defmodule PortalAPI.SocketsTest do
                "This account is temporarily suspended from client authentication " <>
                  "due to exceeding billing limits. Please contact your administrator to add more seats."
 
-      assert_problem_json(result)
+      assert_problem_json(result, "limits_exceeded")
     end
 
     test "returns 403 for account_disabled" do
@@ -116,7 +119,7 @@ defmodule PortalAPI.SocketsTest do
 
       assert result.status == 403
       assert json_body(result)["detail"] == "The account is disabled"
-      assert_problem_json(result)
+      assert_problem_json(result, "account_disabled")
     end
 
     test "returns 403 for unauthenticated" do
@@ -126,7 +129,47 @@ defmodule PortalAPI.SocketsTest do
 
       assert result.status == 403
       assert json_body(result)["detail"] == "Forbidden"
-      assert_problem_json(result)
+      assert_problem_json(result, "unauthenticated")
+    end
+
+    test "returns 403 for device_untrusted" do
+      conn = Plug.Test.conn(:get, "/")
+
+      result = Sockets.handle_error(conn, :device_untrusted)
+
+      assert result.status == 403
+      assert json_body(result)["detail"] =~ "did not present a valid certificate"
+      assert_problem_json(result, "device_untrusted")
+    end
+
+    test "returns 403 for certificate_revoked" do
+      conn = Plug.Test.conn(:get, "/")
+
+      result = Sockets.handle_error(conn, :certificate_revoked)
+
+      assert result.status == 403
+      assert json_body(result)["detail"] =~ "has been revoked"
+      assert_problem_json(result, "certificate_revoked")
+    end
+
+    test "returns 409 for device_identity_conflict" do
+      conn = Plug.Test.conn(:get, "/")
+
+      result = Sockets.handle_error(conn, :device_identity_conflict)
+
+      assert result.status == 409
+      assert json_body(result)["detail"] =~ "reports different hardware"
+      assert_problem_json(result, "device_identity_conflict")
+    end
+
+    test "returns 409 for conflict" do
+      conn = Plug.Test.conn(:get, "/")
+
+      result = Sockets.handle_error(conn, :conflict)
+
+      assert result.status == 409
+      assert json_body(result)["detail"] == "A gateway with this ID is already connected"
+      assert_problem_json(result, "conflict")
     end
 
     test "returns 503 with retry-after header for rate_limit" do
@@ -137,7 +180,7 @@ defmodule PortalAPI.SocketsTest do
       assert result.status == 503
       assert json_body(result)["detail"] == "Service Unavailable"
       assert Plug.Conn.get_resp_header(result, "retry-after") == ["1"]
-      assert_problem_json(result)
+      assert_problem_json(result, "rate_limit")
     end
 
     test "returns 400 with changeset errors" do
@@ -152,18 +195,31 @@ defmodule PortalAPI.SocketsTest do
 
       assert result.status == 400
       assert json_body(result)["detail"] =~ "name"
-      assert_problem_json(result)
+      assert_problem_json(result, "invalid_request")
+    end
+
+    test "returns 500 and logs for an unhandled reason" do
+      conn = Plug.Test.conn(:get, "/")
+
+      {result, log} = with_log(fn -> Sockets.handle_error(conn, :some_new_reason) end)
+
+      assert result.status == 500
+      assert json_body(result)["detail"] == "An unexpected error occurred."
+      assert_problem_json(result, "internal_error")
+      assert log =~ "Unhandled socket connect error"
+      assert log =~ "some_new_reason"
     end
   end
 
   defp json_body(conn), do: JSON.decode!(conn.resp_body)
 
-  defp assert_problem_json(conn) do
+  defp assert_problem_json(conn, code) do
     [content_type] = Plug.Conn.get_resp_header(conn, "content-type")
     assert content_type =~ "application/problem+json"
     body = json_body(conn)
     assert body["type"] == "about:blank"
-    assert is_integer(body["status"])
+    assert body["code"] == code
+    assert body["status"] == conn.status
     assert is_binary(body["title"])
   end
 end


### PR DESCRIPTION
A client whose socket connect is refused currently has no reliable way to tell why. The problem response carries an HTTP status and a human-readable sentence, but four distinct reasons share 403, so the status cannot discriminate and the sentence is prose that changes freely. Clients are left either matching on English or inferring the reason from what they sent, and neither survives contact with a new reason.

For x509 in particular, Clients need to know, why the WebSocket connection was refused. Invalid certificates are terminal errors whereas an invalid token should prompt the user for re-authentication.

Every socket problem response now carries a `code` member naming the reason in a stable, machine-readable form, alongside the existing `type`, `title`, `status`, and `detail`. The codes match the reason atoms, so the correspondence stays checkable by eye. Statuses, details, and the `retry-after` header on rate limiting are unchanged, and the REST call sites keep using the existing helper, so their responses are byte-identical.

The socket error handler also gains a catch-all clause. It previously had no fallback, so a reason without a matching clause raised inside the error handler rather than returning a response; the relay socket's missing-address path is one that can reach it today.

The RFC 9457 `type` URI stays as it is. Giving each problem a documented type URI is worth doing, but it needs somewhere for those URIs to resolve to, so it follows separately.