### PR TITLE
feat(connlib): bridge X.509 identities across the FFI

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -350,6 +350,7 @@ class TunnelService : VpnService() {
                                     deviceInfo = deviceInfo,
                                 ),
                             protectSocket = protectSocketCallback,
+                            tlsIdentity = null,
                         ).use { session ->
                             startNetworkMonitoring()
                             startLogCleanup()

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1343,6 +1343,7 @@ dependencies = [
  "tunnel-bypass-resolver",
  "uniffi",
  "x509-claims-ffi",
+ "x509-credential",
 ]
 
 [[package]]

--- a/rust/client-ffi/Cargo.toml
+++ b/rust/client-ffi/Cargo.toml
@@ -37,6 +37,7 @@ tun = { workspace = true }
 tunnel-bypass-resolver = { workspace = true }
 uniffi = { workspace = true }
 x509-claims-ffi = { workspace = true }
+x509-credential = { workspace = true }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 oslog = { version = "0.2.0", default-features = false }

--- a/rust/client-ffi/src/client_identity.rs
+++ b/rust/client-ffi/src/client_identity.rs
@@ -36,7 +36,9 @@ struct PlatformKey {
 
 impl PlatformKey {
     fn new(identity: Arc<dyn ClientTlsIdentity>) -> Result<Self> {
-        let schemes = identity.supported_signature_schemes();
+        let schemes = identity
+            .supported_signature_schemes()
+            .context("Failed to read the supported TLS signature schemes")?;
 
         let Some(first) = schemes.first().copied() else {
             bail!("The client identity supports no TLS signature schemes");
@@ -128,10 +130,10 @@ mod tests {
     #[test]
     fn signs_with_the_scheme_rustls_picked() {
         let key = PlatformKey::new(Arc::new(StubIdentity {
-            schemes: vec![
+            schemes: Ok(vec![
                 TlsSignatureScheme::RsaPssSha512,
                 TlsSignatureScheme::RsaPssSha256,
-            ],
+            ]),
         }))
         .expect("stub identity should yield a key");
 
@@ -146,10 +148,10 @@ mod tests {
     #[test]
     fn reports_a_failing_keystore_with_its_message() {
         let key = PlatformKey::new(Arc::new(StubIdentity {
-            schemes: vec![
+            schemes: Ok(vec![
                 TlsSignatureScheme::RsaPssSha256,
                 TlsSignatureScheme::RsaPssSha512,
-            ],
+            ]),
         }))
         .expect("stub identity should yield a key");
 
@@ -166,7 +168,7 @@ mod tests {
     #[test]
     fn rejects_a_scheme_the_identity_did_not_advertise() {
         let key = PlatformKey::new(Arc::new(StubIdentity {
-            schemes: vec![TlsSignatureScheme::RsaPssSha256],
+            schemes: Ok(vec![TlsSignatureScheme::RsaPssSha256]),
         }))
         .expect("stub identity should yield a key");
 
@@ -180,10 +182,10 @@ mod tests {
     #[test]
     fn rejects_an_identity_that_mixes_key_algorithms() {
         let error = PlatformKey::new(Arc::new(StubIdentity {
-            schemes: vec![
+            schemes: Ok(vec![
                 TlsSignatureScheme::RsaPssSha256,
                 TlsSignatureScheme::EcdsaNistp256Sha256,
-            ],
+            ]),
         }))
         .expect_err("a key cannot be RSA and ECDSA at once");
 
@@ -193,9 +195,22 @@ mod tests {
         );
     }
 
+    #[test]
+    fn reports_a_keystore_that_cannot_list_its_schemes() {
+        let error = PlatformKey::new(Arc::new(StubIdentity {
+            schemes: Err("the keystore is locked".to_owned()),
+        }))
+        .expect_err("a locked keystore cannot list its schemes");
+
+        assert_eq!(
+            format!("{error:#}"),
+            "Failed to read the supported TLS signature schemes: the keystore is locked"
+        );
+    }
+
     #[derive(Debug)]
     struct StubIdentity {
-        schemes: Vec<TlsSignatureScheme>,
+        schemes: Result<Vec<TlsSignatureScheme>, String>,
     }
 
     impl ClientTlsIdentity for StubIdentity {
@@ -203,8 +218,8 @@ mod tests {
             Ok(vec![vec![1, 2, 3]])
         }
 
-        fn supported_signature_schemes(&self) -> Vec<TlsSignatureScheme> {
-            self.schemes.clone()
+        fn supported_signature_schemes(&self) -> Result<Vec<TlsSignatureScheme>, CallbackError> {
+            self.schemes.clone().map_err(CallbackError::Failed)
         }
 
         fn sign(

--- a/rust/client-ffi/src/client_identity.rs
+++ b/rust/client-ffi/src/client_identity.rs
@@ -159,7 +159,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "the platform keystore failed to sign: the keystore is locked"
+            "the keystore failed to sign: the keystore is locked"
         );
     }
 
@@ -174,7 +174,7 @@ mod tests {
             .sign(SignatureScheme::ED25519, &[4, 5])
             .expect_err("Ed25519 is not advertised");
 
-        assert_eq!(error.to_string(), "the key cannot sign with ED25519");
+        assert_eq!(error.to_string(), "the keystore cannot sign with ED25519");
     }
 
     #[test]

--- a/rust/client-ffi/src/client_identity.rs
+++ b/rust/client-ffi/src/client_identity.rs
@@ -1,0 +1,222 @@
+//! Adapts a [`ClientTlsIdentity`] handed to us by the platform bindings to the `x509-credential` interfaces.
+
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result, bail};
+use rustls::{SignatureAlgorithm, SignatureScheme, pki_types::CertificateDer};
+use x509_credential::{ClientCertificate, PrivateKey, SigningError};
+
+use crate::{ClientTlsIdentity, TlsSignatureScheme};
+
+/// Turns the platform's TLS identity into the client certificate we present to the portal.
+///
+/// # Errors
+///
+/// Returns an error if the identity does not yield a usable certificate chain and key.
+pub(crate) fn certificate(identity: Arc<dyn ClientTlsIdentity>) -> Result<ClientCertificate> {
+    let chain = identity
+        .certificate_chain()
+        .context("Failed to read the client certificate chain")?
+        .into_iter()
+        .map(CertificateDer::from)
+        .collect();
+    let key = PlatformKey::new(identity)?;
+    let certificate = ClientCertificate::new(chain, Arc::new(key))?;
+
+    Ok(certificate)
+}
+
+/// A private key whose signatures are produced by the platform bindings.
+#[derive(Debug)]
+struct PlatformKey {
+    identity: Arc<dyn ClientTlsIdentity>,
+    schemes: Vec<TlsSignatureScheme>,
+    algorithm: SignatureAlgorithm,
+}
+
+impl PlatformKey {
+    fn new(identity: Arc<dyn ClientTlsIdentity>) -> Result<Self> {
+        let schemes = identity.supported_signature_schemes();
+
+        let Some(first) = schemes.first().copied() else {
+            bail!("The client identity supports no TLS signature schemes");
+        };
+        let algorithm = SignatureAlgorithm::from(first);
+
+        if schemes
+            .iter()
+            .any(|scheme| SignatureAlgorithm::from(*scheme) != algorithm)
+        {
+            bail!("The client identity mixes signature schemes of different key algorithms");
+        }
+
+        Ok(Self {
+            identity,
+            schemes,
+            algorithm,
+        })
+    }
+}
+
+impl PrivateKey for PlatformKey {
+    fn supported_schemes(&self) -> Vec<SignatureScheme> {
+        self.schemes
+            .iter()
+            .copied()
+            .map(SignatureScheme::from)
+            .collect()
+    }
+
+    fn algorithm(&self) -> SignatureAlgorithm {
+        self.algorithm
+    }
+
+    fn sign(&self, scheme: SignatureScheme, message: &[u8]) -> Result<Vec<u8>, SigningError> {
+        let scheme = self
+            .schemes
+            .iter()
+            .copied()
+            .find(|supported| SignatureScheme::from(*supported) == scheme)
+            .ok_or(SigningError::UnsupportedScheme(scheme))?;
+
+        let signature = self
+            .identity
+            .sign(scheme, message.to_vec())
+            .map_err(|e| SigningError::Keystore(e.to_string()))?;
+
+        Ok(signature)
+    }
+}
+
+impl From<TlsSignatureScheme> for SignatureScheme {
+    fn from(value: TlsSignatureScheme) -> Self {
+        match value {
+            TlsSignatureScheme::RsaPkcs1Sha256 => Self::RSA_PKCS1_SHA256,
+            TlsSignatureScheme::RsaPkcs1Sha384 => Self::RSA_PKCS1_SHA384,
+            TlsSignatureScheme::RsaPkcs1Sha512 => Self::RSA_PKCS1_SHA512,
+            TlsSignatureScheme::RsaPssSha256 => Self::RSA_PSS_SHA256,
+            TlsSignatureScheme::RsaPssSha384 => Self::RSA_PSS_SHA384,
+            TlsSignatureScheme::RsaPssSha512 => Self::RSA_PSS_SHA512,
+            TlsSignatureScheme::EcdsaNistp256Sha256 => Self::ECDSA_NISTP256_SHA256,
+            TlsSignatureScheme::EcdsaNistp384Sha384 => Self::ECDSA_NISTP384_SHA384,
+            TlsSignatureScheme::EcdsaNistp521Sha512 => Self::ECDSA_NISTP521_SHA512,
+        }
+    }
+}
+
+impl From<TlsSignatureScheme> for SignatureAlgorithm {
+    fn from(value: TlsSignatureScheme) -> Self {
+        match value {
+            TlsSignatureScheme::RsaPkcs1Sha256 => Self::RSA,
+            TlsSignatureScheme::RsaPkcs1Sha384 => Self::RSA,
+            TlsSignatureScheme::RsaPkcs1Sha512 => Self::RSA,
+            TlsSignatureScheme::RsaPssSha256 => Self::RSA,
+            TlsSignatureScheme::RsaPssSha384 => Self::RSA,
+            TlsSignatureScheme::RsaPssSha512 => Self::RSA,
+            TlsSignatureScheme::EcdsaNistp256Sha256 => Self::ECDSA,
+            TlsSignatureScheme::EcdsaNistp384Sha384 => Self::ECDSA,
+            TlsSignatureScheme::EcdsaNistp521Sha512 => Self::ECDSA,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CallbackError;
+
+    #[test]
+    fn signs_with_the_scheme_rustls_picked() {
+        let key = PlatformKey::new(Arc::new(StubIdentity {
+            schemes: vec![
+                TlsSignatureScheme::RsaPssSha512,
+                TlsSignatureScheme::RsaPssSha256,
+            ],
+        }))
+        .expect("stub identity should yield a key");
+
+        let signature = key
+            .sign(SignatureScheme::RSA_PSS_SHA256, &[4, 5])
+            .expect("stub identity should sign");
+
+        assert_eq!(key.algorithm(), SignatureAlgorithm::RSA);
+        assert_eq!(signature, vec![4, 5, 0x08, 0x04]);
+    }
+
+    #[test]
+    fn reports_a_failing_keystore_with_its_message() {
+        let key = PlatformKey::new(Arc::new(StubIdentity {
+            schemes: vec![
+                TlsSignatureScheme::RsaPssSha256,
+                TlsSignatureScheme::RsaPssSha512,
+            ],
+        }))
+        .expect("stub identity should yield a key");
+
+        let error = key
+            .sign(SignatureScheme::RSA_PSS_SHA512, &[4, 5])
+            .expect_err("the stub keystore should refuse SHA-512");
+
+        assert_eq!(
+            error.to_string(),
+            "the platform keystore failed to sign: the keystore is locked"
+        );
+    }
+
+    #[test]
+    fn rejects_a_scheme_the_identity_did_not_advertise() {
+        let key = PlatformKey::new(Arc::new(StubIdentity {
+            schemes: vec![TlsSignatureScheme::RsaPssSha256],
+        }))
+        .expect("stub identity should yield a key");
+
+        let error = key
+            .sign(SignatureScheme::ED25519, &[4, 5])
+            .expect_err("Ed25519 is not advertised");
+
+        assert_eq!(error.to_string(), "the key cannot sign with ED25519");
+    }
+
+    #[test]
+    fn rejects_an_identity_that_mixes_key_algorithms() {
+        let error = PlatformKey::new(Arc::new(StubIdentity {
+            schemes: vec![
+                TlsSignatureScheme::RsaPssSha256,
+                TlsSignatureScheme::EcdsaNistp256Sha256,
+            ],
+        }))
+        .expect_err("a key cannot be RSA and ECDSA at once");
+
+        assert_eq!(
+            error.to_string(),
+            "The client identity mixes signature schemes of different key algorithms"
+        );
+    }
+
+    #[derive(Debug)]
+    struct StubIdentity {
+        schemes: Vec<TlsSignatureScheme>,
+    }
+
+    impl ClientTlsIdentity for StubIdentity {
+        fn certificate_chain(&self) -> Result<Vec<Vec<u8>>, CallbackError> {
+            Ok(vec![vec![1, 2, 3]])
+        }
+
+        fn supported_signature_schemes(&self) -> Vec<TlsSignatureScheme> {
+            self.schemes.clone()
+        }
+
+        fn sign(
+            &self,
+            scheme: TlsSignatureScheme,
+            message: Vec<u8>,
+        ) -> Result<Vec<u8>, CallbackError> {
+            if scheme != TlsSignatureScheme::RsaPssSha256 {
+                return Err(CallbackError::Failed("the keystore is locked".to_owned()));
+            }
+
+            Ok([message.as_slice(), &[0x08, 0x04]].concat())
+        }
+    }
+}

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -4,6 +4,7 @@
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+mod client_identity;
 mod fd;
 mod platform;
 
@@ -55,6 +56,37 @@ pub enum CallbackError {
     Failed(String),
 }
 
+/// The TLS handshake signature schemes a platform-held key can sign with.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum TlsSignatureScheme {
+    RsaPkcs1Sha256,
+    RsaPkcs1Sha384,
+    RsaPkcs1Sha512,
+    RsaPssSha256,
+    RsaPssSha384,
+    RsaPssSha512,
+    EcdsaNistp256Sha256,
+    EcdsaNistp384Sha384,
+    EcdsaNistp521Sha512,
+}
+
+/// A certificate chain and a non-exportable platform key, presented to the portal for mutual TLS.
+///
+/// The key material stays in the platform keystore, so we ask it for a signature whenever the TLS handshake needs one.
+#[uniffi::export(with_foreign)]
+pub trait ClientTlsIdentity: Send + Sync + fmt::Debug {
+    /// Returns the DER-encoded certificate chain, end-entity certificate first.
+    fn certificate_chain(&self) -> Result<Vec<Vec<u8>>, CallbackError>;
+
+    /// Returns the signature schemes the key can sign with, most preferred first.
+    ///
+    /// All of them must belong to the same key algorithm.
+    fn supported_signature_schemes(&self) -> Vec<TlsSignatureScheme>;
+
+    /// Signs the unhashed TLS handshake message with the requested scheme.
+    fn sign(&self, scheme: TlsSignatureScheme, message: Vec<u8>) -> Result<Vec<u8>, CallbackError>;
+}
+
 #[derive(uniffi::Object, Debug)]
 pub struct DisconnectError(client_shared::DisconnectError);
 
@@ -82,7 +114,7 @@ pub struct DeviceInfo {
 #[derive(uniffi::Record)]
 pub struct AndroidSessionConfig {
     pub api_url: String,
-    pub token: String,
+    pub token: Option<String>,
     pub device_id: String,
     pub account_slug: String,
     pub device_name: String,
@@ -227,10 +259,11 @@ pub trait ProtectSocket: Send + Sync + fmt::Debug {
 #[uniffi::export]
 #[cfg(target_os = "android")]
 impl Session {
-    #[uniffi::constructor]
+    #[uniffi::constructor(default(tls_identity = None))]
     pub fn new_android(
         config: AndroidSessionConfig,
         protect_socket: Arc<dyn ProtectSocket>,
+        tls_identity: Option<Arc<dyn ClientTlsIdentity>>,
     ) -> Result<Self, ConnlibError> {
         let AndroidSessionConfig {
             api_url,
@@ -252,6 +285,7 @@ impl Session {
             Some(device_name),
             device_info,
             is_internet_resource_active,
+            tls_identity,
             tcp_socket_factory,
             udp_socket_factory,
         )
@@ -261,15 +295,20 @@ impl Session {
 #[uniffi::export]
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 impl Session {
-    #[uniffi::constructor]
+    #[uniffi::constructor(default(tls_identity = None))]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "This is the API we want to expose over FFI."
+    )]
     pub fn new_apple(
         api_url: String,
-        token: String,
+        token: Option<String>,
         device_id: String,
         account_slug: String,
         device_name: Option<String>,
         device_info: DeviceInfo,
         is_internet_resource_active: bool,
+        tls_identity: Option<Arc<dyn ClientTlsIdentity>>,
     ) -> Result<Self, ConnlibError> {
         // iOS doesn't need socket protection like Android
         let tcp_socket_factory = Arc::new(socket_factory::tcp);
@@ -288,6 +327,7 @@ impl Session {
             device_name,
             device_info,
             is_internet_resource_active,
+            tls_identity,
             tcp_socket_factory,
             udp_socket_factory,
         )?;
@@ -300,18 +340,23 @@ impl Session {
 
 #[uniffi::export]
 impl Session {
-    #[uniffi::constructor]
+    #[uniffi::constructor(default(tls_identity = None))]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "This is the API we want to expose over FFI."
+    )]
     /// Dummy constructor that isn't feature-gated by an OS.
     ///
     /// This only exists to make working on the FFI module from Linux/Windows more convenient without many "unused code" warnings.
     pub fn new_dummy(
         api_url: String,
-        token: String,
+        token: Option<String>,
         device_id: String,
         account_slug: String,
         device_name: Option<String>,
         device_info: DeviceInfo,
         is_internet_resource_active: bool,
+        tls_identity: Option<Arc<dyn ClientTlsIdentity>>,
     ) -> Result<Self, ConnlibError> {
         let tcp_socket_factory = Arc::new(socket_factory::tcp);
         let udp_socket_factory = Arc::new(socket_factory::udp);
@@ -324,6 +369,7 @@ impl Session {
             device_name,
             device_info,
             is_internet_resource_active,
+            tls_identity,
             tcp_socket_factory,
             udp_socket_factory,
         )?;
@@ -508,12 +554,13 @@ impl Drop for Session {
 
 fn connect(
     api_url: String,
-    token: String,
+    token: Option<String>,
     device_id: String,
     account_slug: String,
     device_name: Option<String>,
     device_info: DeviceInfo,
     is_internet_resource_active: bool,
+    tls_identity: Option<Arc<dyn ClientTlsIdentity>>,
     tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
 ) -> Result<Session, ConnlibError> {
@@ -524,7 +571,11 @@ fn connect(
         identifier_for_vendor: device_info.identifier_for_vendor,
         firebase_installation_id: device_info.firebase_installation_id,
     };
-    let secret = SecretString::from(token);
+    let token = token.map(SecretString::from);
+
+    if token.is_none() && tls_identity.is_none() {
+        return Err(anyhow!("Cannot authenticate without a token or a client certificate").into());
+    }
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(1)
@@ -551,12 +602,17 @@ fn connect(
 
     analytics::identify(RELEASE.to_owned(), account_slug, None, None);
 
+    let certificate = tls_identity
+        .map(client_identity::certificate)
+        .transpose()
+        .context("Failed to set up the client certificate")?;
+
     let url = LoginUrl::client(
         api_url.as_str(),
         device_id.clone(),
         device_name,
         device_info,
-        None,
+        certificate,
     )
     .context("Failed to create login URL")?;
 
@@ -564,7 +620,7 @@ fn connect(
 
     let portal = PhoenixChannel::disconnected(
         url,
-        secret,
+        token,
         get_user_agent(platform::COMPONENT, platform::VERSION),
         "client",
         (),

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -81,7 +81,11 @@ pub trait ClientTlsIdentity: Send + Sync + fmt::Debug {
     /// Returns the signature schemes the key can sign with, most preferred first.
     ///
     /// All of them must belong to the same key algorithm.
-    fn supported_signature_schemes(&self) -> Vec<TlsSignatureScheme>;
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the keystore cannot be consulted.
+    fn supported_signature_schemes(&self) -> Result<Vec<TlsSignatureScheme>, CallbackError>;
 
     /// Signs the unhashed TLS handshake message with the requested scheme.
     fn sign(&self, scheme: TlsSignatureScheme, message: Vec<u8>) -> Result<Vec<u8>, CallbackError>;

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -259,7 +259,7 @@ pub trait ProtectSocket: Send + Sync + fmt::Debug {
 #[uniffi::export]
 #[cfg(target_os = "android")]
 impl Session {
-    #[uniffi::constructor(default(tls_identity = None))]
+    #[uniffi::constructor]
     pub fn new_android(
         config: AndroidSessionConfig,
         protect_socket: Arc<dyn ProtectSocket>,
@@ -295,7 +295,7 @@ impl Session {
 #[uniffi::export]
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 impl Session {
-    #[uniffi::constructor(default(tls_identity = None))]
+    #[uniffi::constructor]
     #[expect(
         clippy::too_many_arguments,
         reason = "This is the API we want to expose over FFI."
@@ -340,7 +340,7 @@ impl Session {
 
 #[uniffi::export]
 impl Session {
-    #[uniffi::constructor(default(tls_identity = None))]
+    #[uniffi::constructor]
     #[expect(
         clippy::too_many_arguments,
         reason = "This is the API we want to expose over FFI."

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -211,7 +211,8 @@ actor Adapter {
         accountSlug: accountSlug,
         deviceName: deviceName,
         deviceInfo: deviceInfo,
-        isInternetResourceActive: internetResourceEnabled
+        isInternetResourceActive: internetResourceEnabled,
+        tlsIdentity: nil
       )
     } catch let error as ConnlibError {
       throw AdapterError.connlibConnectError(error.message())


### PR DESCRIPTION
The Apple and Android Clients keep their X.509 identity in a platform keystore where the private key is not exportable. Signing has to happen inside the keystore, so the platform cannot just hand Rust a key and let it run the handshake.

Instead, a `ClientTlsIdentity` foreign trait carries the identity across the FFI boundary: the DER certificate chain, the signature schemes the key supports and a signing callback. Rust adapts it to the private key interface the portal connection expects. The keystore stays on the platform side, the handshake stays in Rust.

The connlib constructors take such an identity optionally and the auth token becomes optional alongside it, because a certificate naming the actor replaces the bearer token instead of accompanying it. Presenting neither is rejected up front instead of at the portal.