### PR TITLE
feat(clients): sign with Windows CNG keys

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10349,6 +10349,10 @@ dependencies = [
  "anyhow-ext",
  "rustls",
  "serde",
+ "sha2 0.11.0",
+ "tracing",
+ "windows",
+ "windows-core",
  "x509-claims",
  "x509-credential",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10347,6 +10347,8 @@ name = "x509-keystore"
 version = "0.1.0"
 dependencies = [
  "anyhow-ext",
+ "base64 0.23.1",
+ "ring",
  "rustls",
  "serde",
  "sha2 0.11.0",
@@ -10355,6 +10357,7 @@ dependencies = [
  "windows-core",
  "x509-claims",
  "x509-credential",
+ "x509-parser",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -185,6 +185,7 @@ rcgen = { version = "0.14.9", default-features = false, features = ["ring"] }
 relay-proto = { path = "relay/proto" }
 reqwest = { version = "0.13.4", default-features = false }
 resolv-conf = "0.7.6"
+ring = "0.17.14"
 ringbuffer = "0.16.0"
 roxmltree = "0.21.1"
 rpassword = "7.5.3"

--- a/rust/libs/x509-keystore/Cargo.toml
+++ b/rust/libs/x509-keystore/Cargo.toml
@@ -21,5 +21,10 @@ windows = { workspace = true, features = [
 ] }
 windows-core = { workspace = true }
 
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+base64 = { workspace = true, features = ["std"] }
+ring = { workspace = true }
+x509-parser = { workspace = true }
+
 [lints]
 workspace = true

--- a/rust/libs/x509-keystore/Cargo.toml
+++ b/rust/libs/x509-keystore/Cargo.toml
@@ -12,5 +12,14 @@ serde = { workspace = true, features = ["derive"] }
 x509-claims = { workspace = true }
 x509-credential = { workspace = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+sha2 = { workspace = true }
+tracing = { workspace = true }
+windows = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_Security_Cryptography",
+] }
+windows-core = { workspace = true }
+
 [lints]
 workspace = true

--- a/rust/libs/x509-keystore/src/lib.rs
+++ b/rust/libs/x509-keystore/src/lib.rs
@@ -26,8 +26,14 @@ pub use x509_credential::ClientCertificate;
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 mod sign;
 
-mod unsupported;
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "windows")]
+use windows as keystore;
 
+#[cfg(not(target_os = "windows"))]
+mod unsupported;
+#[cfg(not(target_os = "windows"))]
 use unsupported as keystore;
 
 /// The subject common name of the certificates Firezone's MDM integrations provision.

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -54,30 +54,33 @@ pub(crate) fn status(subject_cn: &str) -> Result<Status> {
         );
     }
 
-    let usable = certificates
-        .iter()
-        .filter(|certificate| certificate.usable)
-        .count();
-    let sections = certificates
+    let selected = selected_certificate(&certificates);
+    let selected_section = selected.map(|index| DetailSection {
+        title: "Certificate".to_owned(),
+        fields: certificates[index].detail_fields(),
+    });
+    let unused_sections = certificates
         .iter()
         .enumerate()
-        .map(|(index, certificate)| DetailSection {
-            title: format!("Matching Certificate {}", index + 1),
+        .filter(|(index, _)| Some(*index) != selected)
+        .map(|(_, certificate)| DetailSection {
+            title: "Unused Certificate".to_owned(),
             fields: certificate.detail_fields(),
-        })
+        });
+    let sections = selected_section
+        .into_iter()
+        .chain(unused_sections)
         .collect();
 
-    let certificate_summary = match (usable, certificates.len()) {
-        (0, 0) => format!(
+    let certificate_summary = match (selected, certificates.len()) {
+        (None, 0) => format!(
             "No X.509 certificate with subject CN '{subject_cn}' is in the Windows certificate stores."
         ),
-        (0, count) => format!(
-            "Found {count} matching X.509 certificate(s), but none of them are usable as a client identity: {}",
+        (None, _) => format!(
+            "Matching certificates are in the Windows certificate store, but none is usable as a client identity: {}",
             unusable_reasons(&certificates).join("; ")
         ),
-        (count, _) => {
-            format!("{count} X.509 client identity certificate(s) are available for mutual TLS.")
-        }
+        (Some(_), _) => "An X.509 client identity is available for mutual TLS.".to_owned(),
     };
     let summary = match store_errors.is_empty() {
         true => certificate_summary,
@@ -86,10 +89,10 @@ pub(crate) fn status(subject_cn: &str) -> Result<Status> {
             store_errors.join("; ")
         ),
     };
-    let severity = match (usable, store_errors.is_empty()) {
-        (0, _) => StatusSeverity::Warning,
-        (_, false) => StatusSeverity::Warning,
-        (_, true) => StatusSeverity::Ok,
+    let severity = match (selected, store_errors.is_empty()) {
+        (None, _) => StatusSeverity::Warning,
+        (Some(_), false) => StatusSeverity::Warning,
+        (Some(_), true) => StatusSeverity::Ok,
     };
 
     Ok(Status {
@@ -100,7 +103,7 @@ pub(crate) fn status(subject_cn: &str) -> Result<Status> {
 }
 
 pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
-    let (certificates, store_errors) = enumerate_matching(subject_cn);
+    let (mut certificates, store_errors) = enumerate_matching(subject_cn);
     if certificates.is_empty() && !store_errors.is_empty() {
         bail!(
             "The Windows certificate store could not be read: {}",
@@ -110,11 +113,7 @@ pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
 
     let unusable = unusable_reasons(&certificates);
 
-    let Some(certificate) = certificates
-        .into_iter()
-        .filter(|certificate| certificate.usable)
-        .max_by_key(|certificate| certificate.metadata.not_before_timestamp)
-    else {
+    let Some(index) = selected_certificate(&certificates) else {
         // Only a store that holds nothing for us is the ordinary no-certificate case. Skipping a
         // certificate that was provisioned for Firezone reads to an administrator as if none had
         // been, so say which rule it failed instead of connecting without it.
@@ -127,6 +126,7 @@ pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
 
         return Ok(None);
     };
+    let certificate = certificates.swap_remove(index);
 
     let algorithm = certificate
         .metadata
@@ -526,6 +526,19 @@ impl Drop for Certificate {
             let _ = CertFreeCertificateContext(Some(self.context));
         }
     }
+}
+
+/// The certificate [`identity`] presents, as an index into `certificates`.
+///
+/// The most recently issued usable certificate wins, so a rotation hands over the renewal
+/// rather than the certificate it replaced.
+fn selected_certificate(certificates: &[Certificate]) -> Option<usize> {
+    certificates
+        .iter()
+        .enumerate()
+        .filter(|(_, certificate)| certificate.usable)
+        .max_by_key(|(_, certificate)| certificate.metadata.not_before_timestamp)
+        .map(|(index, _)| index)
 }
 
 /// Says why each certificate that matched the subject common name cannot be used.

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -36,7 +36,7 @@ use windows::{
 use x509_claims::{ParsedCertificate, SigningAlgorithm, parse_certificate};
 use x509_credential::{PrivateKey, SigningError};
 
-use crate::{DetailField, DetailSection, Identity, Status, StatusSeverity, field};
+use crate::{DetailField, DetailSection, Identity, Status, StatusSeverity, absent_field, field, invalid_field};
 
 /// The store MDM-provisioned identities land in.
 ///
@@ -457,33 +457,31 @@ impl Certificate {
     fn detail_fields(&self) -> Vec<DetailField> {
         let mut fields = vec![
             field("Store", self.store),
-            field(
-                "Private Key Access",
-                if self.key_available {
-                    "Available through Windows CNG"
-                } else {
-                    "Unavailable"
-                },
-            ),
-            field(
-                "Usable With Its Private Key",
-                if self.usable { "Yes" } else { "No" },
-            ),
+            if self.key_available {
+                field("Private Key Access", "Available through Windows CNG")
+            } else {
+                absent_field("Private Key Access")
+            },
+            if self.usable {
+                field("Usable With Its Private Key", "Yes")
+            } else {
+                invalid_field("Usable With Its Private Key", "No")
+            },
         ];
         if let Some(error) = &self.key_error {
-            fields.push(field("Private Key Error", error));
+            fields.push(invalid_field("Private Key Error", error));
         }
         if let Some(metadata) = &self.key_metadata {
-            fields.push(field(
-                "Private Key Provider",
-                metadata.provider.as_deref().unwrap_or("Unavailable"),
-            ));
+            fields.push(match metadata.provider.as_deref() {
+                Some(provider) => field("Private Key Provider", provider),
+                None => absent_field("Private Key Provider"),
+            });
             fields.push(field("Private Key Storage", metadata.storage));
             if let Some(container) = &metadata.container {
                 fields.push(field("Private Key Container", container));
             }
             if !metadata.errors.is_empty() {
-                fields.push(field(
+                fields.push(invalid_field(
                     "Private Key Metadata Errors",
                     metadata.errors.join("\n"),
                 ));
@@ -494,7 +492,7 @@ impl Certificate {
             self.chain.len().to_string(),
         ));
         if let Some(error) = &self.chain_error {
-            fields.push(field("Certificate Chain Error", error));
+            fields.push(invalid_field("Certificate Chain Error", error));
         }
         fields.extend(
             self.metadata

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -107,11 +107,27 @@ pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
         );
     }
 
+    let unusable = certificates
+        .iter()
+        .filter(|certificate| !certificate.usable)
+        .map(unusable_reason)
+        .collect::<Vec<_>>();
+
     let Some(certificate) = certificates
         .into_iter()
         .filter(|certificate| certificate.usable)
         .max_by_key(|certificate| certificate.metadata.not_before_timestamp)
     else {
+        // Only a store that holds nothing for us is the ordinary no-certificate case. Skipping a
+        // certificate that was provisioned for Firezone reads to an administrator as if none had
+        // been, so say which rule it failed instead of connecting without it.
+        if !unusable.is_empty() {
+            bail!(
+                "The Windows certificate store holds no usable Firezone client identity: {}",
+                unusable.join("; ")
+            );
+        }
+
         return Ok(None);
     };
 
@@ -500,6 +516,35 @@ impl Drop for Certificate {
             let _ = CertFreeCertificateContext(Some(self.context));
         }
     }
+}
+
+/// Says why a certificate that matched the subject common name cannot be used.
+fn unusable_reason(certificate: &Certificate) -> String {
+    let metadata = &certificate.metadata;
+
+    let reason = if !metadata.has_client_auth_eku {
+        "it has no TLS client authentication extended key usage"
+    } else if !metadata.digital_signature_allowed {
+        "its key usage does not allow digital signatures"
+    } else if !metadata.is_currently_valid {
+        "it is expired or not yet valid"
+    } else if metadata.signing_algorithm.is_none() {
+        "it holds a key algorithm we cannot sign with"
+    } else if !certificate.key_available {
+        // CNG refuses a key held by a legacy CSP rather than a KSP, which is what an older
+        // certificate template provisions.
+        return match &certificate.key_error {
+            Some(error) => format!(
+                "{} has a private key CNG will not use: {error}",
+                metadata.fingerprint
+            ),
+            None => format!("{} has no usable private key", metadata.fingerprint),
+        };
+    } else {
+        "it does not match the requested common name"
+    };
+
+    format!("{} is unusable because {reason}", metadata.fingerprint)
 }
 
 fn enumerate_matching(subject_cn: &str) -> (Vec<Certificate>, Vec<String>) {

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -346,11 +346,11 @@ impl CandidateCertificate for Certificate {
             self.metadata.signing_algorithm,
             self.usable,
         ) {
-            (Some(error), _, _) => Some(UnusableCause::WindowsKeyRefused {
+            (Some(error), _, _) => Some(UnusableCause::KeyRefused {
                 error: error.clone(),
             }),
             (None, None, _) => Some(UnusableCause::UnsupportedKeyAlgorithm),
-            (None, Some(_), false) => Some(UnusableCause::WindowsKeyMissing),
+            (None, Some(_), false) => Some(UnusableCause::KeyMissing),
             (None, Some(_), true) => None,
         }
     }

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -34,8 +34,9 @@ use x509_claims::{ParsedCertificate, parse_certificate};
 use x509_credential::SigningError;
 
 use crate::{
-    CandidateCertificate, DetailField, DetailSection, Identity, Status, invalid_field,
-    selected_certificate, sign, unusable_reasons,
+    CandidateCertificate, DetailField, DetailSection, Identity, Problem, Status, UnreadableStore,
+    UnusableCause, UnusableCertificate, failed_field, join, selected_certificate, sign,
+    unusable_certificates,
 };
 
 /// The store MDM-provisioned identities land in.
@@ -50,7 +51,7 @@ pub(crate) fn status(subject_cn: &str) -> Result<Status> {
     if certificates.is_empty() && !store_errors.is_empty() {
         bail!(
             "The Windows certificate store could not be read: {}",
-            store_errors.join("; ")
+            join(&store_errors, "; ")
         );
     }
 
@@ -72,29 +73,24 @@ pub(crate) fn status(subject_cn: &str) -> Result<Status> {
         .chain(unused_sections)
         .collect();
 
-    let certificate_warning = match (selected, certificates.len()) {
-        (None, 0) => Some(format!(
-            "No X.509 certificate with subject CN '{subject_cn}' is in the Windows certificate stores."
-        )),
-        (None, _) => Some(format!(
-            "Matching certificates are in the Windows certificate store, but none is usable as a client identity: {}",
-            unusable_reasons(&certificates).join("; ")
-        )),
+    let certificate_problem = match (selected, certificates.len()) {
+        (None, 0) => Some(Problem::NoWindowsCertificate {
+            subject_cn: subject_cn.to_owned(),
+        }),
+        (None, _) => Some(Problem::NoUsableWindowsCertificate {
+            certificates: unusable_certificates(&certificates),
+        }),
         (Some(_), _) => None,
     };
-    let store_warning = (!store_errors.is_empty()).then(|| {
-        format!(
-            "Some Windows certificate stores could not be read: {}",
-            store_errors.join("; ")
-        )
+    let store_problem = (!store_errors.is_empty()).then_some(Problem::UnreadableWindowsStores {
+        stores: store_errors,
     });
-    let warning = match (certificate_warning, store_warning) {
-        (Some(certificate), Some(store)) => Some(format!("{certificate} {store}")),
-        (Some(certificate), None) => Some(certificate),
-        (None, store) => store,
-    };
+    let problems = certificate_problem
+        .into_iter()
+        .chain(store_problem)
+        .collect();
 
-    Ok(Status { warning, sections })
+    Ok(Status { problems, sections })
 }
 
 pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
@@ -102,11 +98,11 @@ pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
     if certificates.is_empty() && !store_errors.is_empty() {
         bail!(
             "The Windows certificate store could not be read: {}",
-            store_errors.join("; ")
+            join(&store_errors, "; ")
         );
     }
 
-    let unusable = unusable_reasons(&certificates);
+    let unusable = unusable_certificates(&certificates);
 
     let Some(index) = selected_certificate(&certificates) else {
         // Only a store that holds nothing for us is the ordinary no-certificate case. Skipping a
@@ -115,7 +111,7 @@ pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
         if !unusable.is_empty() {
             bail!(
                 "The Windows certificate store holds no usable Firezone client identity: {}",
-                unusable.join("; ")
+                join(&unusable, "; ")
             );
         }
 
@@ -362,10 +358,10 @@ impl Certificate {
             .collect::<Vec<_>>();
 
         if let Some(error) = &self.key_error {
-            fields.push(invalid_field("Private Key Error", error));
+            fields.push(failed_field("Private Key Error", error));
         }
         if let Some(error) = &self.chain_error {
-            fields.push(invalid_field("Certificate Chain Error", error));
+            fields.push(failed_field("Certificate Chain Error", error));
         }
 
         fields
@@ -381,19 +377,27 @@ impl CandidateCertificate for Certificate {
         self.metadata.not_before_timestamp
     }
 
-    fn unusable_reason(&self) -> String {
-        let fingerprint = &self.metadata.fingerprint;
+    fn unusable(&self) -> UnusableCertificate {
+        let fingerprint = self.metadata.fingerprint.clone();
+        let reasons = self.metadata.unusable_reasons();
 
-        let Some(summary) = self.metadata.unusable_summary() else {
+        if reasons.is_empty() {
             // CNG refuses a key held by a legacy CSP rather than a KSP, which is what an older
             // certificate template provisions.
-            return match &self.key_error {
-                Some(error) => format!("{fingerprint} has a private key CNG will not use: {error}"),
-                None => format!("{fingerprint} has no usable private key"),
+            let cause = match &self.key_error {
+                Some(error) => UnusableCause::WindowsKeyRefused {
+                    error: error.clone(),
+                },
+                None => UnusableCause::WindowsKeyMissing,
             };
-        };
 
-        format!("{fingerprint} is unusable: {summary}")
+            return UnusableCertificate { fingerprint, cause };
+        }
+
+        UnusableCertificate {
+            fingerprint,
+            cause: UnusableCause::FailsRules { reasons },
+        }
     }
 }
 
@@ -405,7 +409,7 @@ impl Drop for Certificate {
     }
 }
 
-fn enumerate_matching(subject_cn: &str) -> (Vec<Certificate>, Vec<String>) {
+fn enumerate_matching(subject_cn: &str) -> (Vec<Certificate>, Vec<UnreadableStore>) {
     let mut certificates = Vec::new();
     let mut errors = Vec::new();
 
@@ -419,7 +423,10 @@ fn enumerate_matching(subject_cn: &str) -> (Vec<Certificate>, Vec<String>) {
                 ?error,
                 "Failed to read Windows certificate store"
             );
-            errors.push(format!("{label}: {error:#}"));
+            errors.push(UnreadableStore {
+                store: label.to_owned(),
+                error: format!("{error:#}"),
+            });
         }
     }
 

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -34,9 +34,9 @@ use x509_claims::{ParsedCertificate, parse_certificate};
 use x509_credential::SigningError;
 
 use crate::{
-    CandidateCertificate, ClientIdentity, DetailField, DetailSection, Identity, Problem, Status,
-    UnreadableStore, UnusableCause, UnusableCertificate, failed_field, join, selected_certificate,
-    sign, unusable_certificates,
+    CandidateCertificate, ClientIdentity, DetailField, Identity, Problem, Status, UnreadableStore,
+    UnusableCause, certificate_sections, failed_field, join, selected_certificate, sign,
+    unusable_causes,
 };
 
 /// The store MDM-provisioned identities land in.
@@ -56,32 +56,13 @@ pub(crate) fn status(subject_cn: &str) -> Result<Status> {
     }
 
     let selected = selected_certificate(&certificates);
-    let selected_section = selected.map(|index| DetailSection {
-        title: "Certificate".to_owned(),
-        fields: certificates[index].detail_fields(),
-    });
-    let unused_sections = certificates
-        .iter()
-        .enumerate()
-        .filter(|(index, _)| Some(*index) != selected)
-        .map(|(_, certificate)| DetailSection {
-            title: "Unused Certificate".to_owned(),
-            fields: certificate.detail_fields(),
-        });
-    let sections = selected_section
-        .into_iter()
-        .chain(unused_sections)
-        .collect();
+    let sections = certificate_sections(&certificates, selected);
 
-    let certificate_problem = match (selected, certificates.len()) {
-        (None, 0) => Some(Problem::NoWindowsCertificate {
+    let certificate_problem = certificates
+        .is_empty()
+        .then(|| Problem::NoWindowsCertificate {
             subject_cn: subject_cn.to_owned(),
-        }),
-        (None, _) => Some(Problem::NoUsableWindowsCertificate {
-            certificates: unusable_certificates(&certificates),
-        }),
-        (Some(_), _) => None,
-    };
+        });
     let store_problem = (!store_errors.is_empty()).then_some(Problem::UnreadableWindowsStores {
         stores: store_errors,
     });
@@ -110,7 +91,7 @@ pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
         );
     }
 
-    let unusable = unusable_certificates(&certificates);
+    let unusable = unusable_causes(&certificates);
 
     let Some(index) = selected_certificate(&certificates) else {
         // Only a store that holds nothing for us is the ordinary no-certificate case. Skipping a
@@ -356,7 +337,28 @@ struct Certificate {
     usable: bool,
 }
 
-impl Certificate {
+impl CandidateCertificate for Certificate {
+    fn unusable(&self) -> Option<UnusableCause> {
+        // CNG refuses a key held by a legacy CSP rather than a KSP, which is what an older
+        // certificate template provisions.
+        match (
+            &self.key_error,
+            self.metadata.signing_algorithm,
+            self.usable,
+        ) {
+            (Some(error), _, _) => Some(UnusableCause::WindowsKeyRefused {
+                error: error.clone(),
+            }),
+            (None, None, _) => Some(UnusableCause::UnsupportedKeyAlgorithm),
+            (None, Some(_), false) => Some(UnusableCause::WindowsKeyMissing),
+            (None, Some(_), true) => None,
+        }
+    }
+
+    fn not_before_timestamp(&self) -> i64 {
+        self.metadata.not_before_timestamp
+    }
+
     fn detail_fields(&self) -> Vec<DetailField> {
         let mut fields = self
             .metadata
@@ -365,41 +367,11 @@ impl Certificate {
             .map(DetailField::from)
             .collect::<Vec<_>>();
 
-        if let Some(error) = &self.key_error {
-            fields.push(failed_field("Private Key Error", error));
-        }
         if let Some(error) = &self.chain_error {
             fields.push(failed_field("Certificate Chain Error", error));
         }
 
         fields
-    }
-}
-
-impl CandidateCertificate for Certificate {
-    fn usable(&self) -> bool {
-        self.usable
-    }
-
-    fn not_before_timestamp(&self) -> i64 {
-        self.metadata.not_before_timestamp
-    }
-
-    fn unusable(&self) -> UnusableCertificate {
-        // CNG refuses a key held by a legacy CSP rather than a KSP, which is what an older
-        // certificate template provisions.
-        let cause = match (&self.key_error, self.metadata.signing_algorithm) {
-            (Some(error), _) => UnusableCause::WindowsKeyRefused {
-                error: error.clone(),
-            },
-            (None, None) => UnusableCause::UnsupportedKeyAlgorithm,
-            (None, Some(_)) => UnusableCause::WindowsKeyMissing,
-        };
-
-        UnusableCertificate {
-            fingerprint: self.metadata.fingerprint.clone(),
-            cause,
-        }
     }
 }
 

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -20,12 +20,12 @@ use windows::{
             CERT_CHAIN_DISABLE_AIA, CERT_CHAIN_PARA, CERT_CONTEXT, CERT_KEY_PROV_INFO_PROP_ID,
             CERT_KEY_SPEC, CERT_OPEN_STORE_FLAGS, CERT_QUERY_ENCODING_TYPE,
             CERT_STORE_OPEN_EXISTING_FLAG, CERT_STORE_PROV_SYSTEM_W, CERT_STORE_READONLY_FLAG,
-            CERT_SYSTEM_STORE_CURRENT_USER, CERT_SYSTEM_STORE_LOCAL_MACHINE,
-            CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG, CRYPT_ACQUIRE_SILENT_FLAG, CRYPT_KEY_PROV_INFO,
-            CertCloseStore, CertDuplicateCertificateContext, CertEnumCertificatesInStore,
-            CertFreeCertificateChain, CertFreeCertificateContext, CertGetCertificateChain,
-            CertGetCertificateContextProperty, CertOpenStore, CryptAcquireCertificatePrivateKey,
-            HCERTSTORE, HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, NCRYPT_FLAGS, NCRYPT_HANDLE,
+            CERT_SYSTEM_STORE_LOCAL_MACHINE, CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG,
+            CRYPT_ACQUIRE_SILENT_FLAG, CRYPT_KEY_PROV_INFO, CertCloseStore,
+            CertDuplicateCertificateContext, CertEnumCertificatesInStore, CertFreeCertificateChain,
+            CertFreeCertificateContext, CertGetCertificateChain, CertGetCertificateContextProperty,
+            CertOpenStore, CryptAcquireCertificatePrivateKey, HCERTSTORE,
+            HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, NCRYPT_FLAGS, NCRYPT_HANDLE,
             NCRYPT_IMPL_HARDWARE_FLAG, NCRYPT_IMPL_SOFTWARE_FLAG, NCRYPT_IMPL_TYPE_PROPERTY,
             NCRYPT_KEY_HANDLE, NCRYPT_PAD_PKCS1_FLAG, NCRYPT_PAD_PSS_FLAG, NCRYPT_PROV_HANDLE,
             NCRYPT_PROVIDER_HANDLE_PROPERTY, NCryptFreeObject, NCryptGetProperty, NCryptSignHash,
@@ -38,17 +38,18 @@ use x509_credential::{PrivateKey, SigningError};
 
 use crate::{DetailField, DetailSection, Identity, Status, field};
 
-/// The stores that MDM-provisioned identities land in, most privileged first.
-const STORES: &[(u32, &str)] = &[
-    (CERT_SYSTEM_STORE_LOCAL_MACHINE, "LocalMachine\\My"),
-    (CERT_SYSTEM_STORE_CURRENT_USER, "CurrentUser\\My"),
-];
+/// The store MDM-provisioned identities land in.
+///
+/// The Tunnel service runs as LocalSystem, so `CERT_SYSTEM_STORE_CURRENT_USER` would resolve to
+/// the SYSTEM profile rather than to the signed-in user, and reading it would only ever find
+/// certificates nobody provisioned there. Device-scope profiles write here.
+const STORE: (u32, &str) = (CERT_SYSTEM_STORE_LOCAL_MACHINE, "LocalMachine\\My");
 
 pub(crate) fn status(subject_cn: &str) -> Result<Status> {
     let (certificates, store_errors) = enumerate_matching(subject_cn);
-    if certificates.is_empty() && store_errors.len() == STORES.len() {
+    if certificates.is_empty() && !store_errors.is_empty() {
         bail!(
-            "The Windows certificate stores could not be read: {}",
+            "The Windows certificate store could not be read: {}",
             store_errors.join("; ")
         );
     }
@@ -60,7 +61,7 @@ pub(crate) fn status(subject_cn: &str) -> Result<Status> {
     let mut sections = vec![DetailSection {
         title: "Windows Certificate Store".to_owned(),
         fields: vec![
-            field("Searched Stores", "LocalMachine\\My\nCurrentUser\\My"),
+            field("Searched Store", STORE.1),
             field("Requested Common Name", subject_cn),
             field(
                 "Store Read Errors",
@@ -99,9 +100,9 @@ pub(crate) fn status(subject_cn: &str) -> Result<Status> {
 
 pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
     let (certificates, store_errors) = enumerate_matching(subject_cn);
-    if certificates.is_empty() && store_errors.len() == STORES.len() {
+    if certificates.is_empty() && !store_errors.is_empty() {
         bail!(
-            "The Windows certificate stores could not be read: {}",
+            "The Windows certificate store could not be read: {}",
             store_errors.join("; ")
         );
     }
@@ -505,17 +506,17 @@ fn enumerate_matching(subject_cn: &str) -> (Vec<Certificate>, Vec<String>) {
     let mut certificates = Vec::new();
     let mut errors = Vec::new();
 
-    for &(location, label) in STORES {
-        match unsafe { enumerate_store(location, label, subject_cn) } {
-            Ok(mut found) => certificates.append(&mut found),
-            Err(error) => {
-                tracing::warn!(
-                    store = label,
-                    ?error,
-                    "Failed to read Windows certificate store"
-                );
-                errors.push(format!("{label}: {error:#}"));
-            }
+    let (location, label) = STORE;
+
+    match unsafe { enumerate_store(location, label, subject_cn) } {
+        Ok(mut found) => certificates.append(&mut found),
+        Err(error) => {
+            tracing::warn!(
+                store = label,
+                ?error,
+                "Failed to read Windows certificate store"
+            );
+            errors.push(format!("{label}: {error:#}"));
         }
     }
 

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -37,8 +37,8 @@ use x509_claims::{ParsedCertificate, parse_certificate};
 use x509_credential::SigningError;
 
 use crate::{
-    DetailField, DetailSection, Identity, Status, StatusSeverity, absent_field, field,
-    invalid_field, sign,
+    CandidateCertificate, DetailField, DetailSection, Identity, Status, StatusSeverity,
+    absent_field, field, invalid_field, selected_certificate, sign, unusable_reasons,
 };
 
 /// The store MDM-provisioned identities land in.
@@ -418,8 +418,17 @@ impl Certificate {
 
         fields
     }
+}
 
-    /// Says why this certificate cannot be presented for mutual TLS.
+impl CandidateCertificate for Certificate {
+    fn usable(&self) -> bool {
+        self.usable
+    }
+
+    fn not_before_timestamp(&self) -> i64 {
+        self.metadata.not_before_timestamp
+    }
+
     fn unusable_reason(&self) -> String {
         let fingerprint = &self.metadata.fingerprint;
 
@@ -442,28 +451,6 @@ impl Drop for Certificate {
             let _ = CertFreeCertificateContext(Some(self.context));
         }
     }
-}
-
-/// The certificate [`identity`] presents, as an index into `certificates`.
-///
-/// The most recently issued usable certificate wins, so a rotation hands over the renewal
-/// rather than the certificate it replaced.
-fn selected_certificate(certificates: &[Certificate]) -> Option<usize> {
-    certificates
-        .iter()
-        .enumerate()
-        .filter(|(_, certificate)| certificate.usable)
-        .max_by_key(|(_, certificate)| certificate.metadata.not_before_timestamp)
-        .map(|(index, _)| index)
-}
-
-/// Says why each certificate that matched the subject common name cannot be used.
-fn unusable_reasons(certificates: &[Certificate]) -> Vec<String> {
-    certificates
-        .iter()
-        .filter(|certificate| !certificate.usable)
-        .map(Certificate::unusable_reason)
-        .collect()
 }
 
 fn enumerate_matching(subject_cn: &str) -> (Vec<Certificate>, Vec<String>) {

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -37,8 +37,8 @@ use x509_claims::{ParsedCertificate, parse_certificate};
 use x509_credential::SigningError;
 
 use crate::{
-    CandidateCertificate, DetailField, DetailSection, Identity, Status, StatusSeverity,
-    absent_field, field, invalid_field, selected_certificate, sign, unusable_reasons,
+    CandidateCertificate, DetailField, DetailSection, Identity, Status, absent_field, field,
+    invalid_field, selected_certificate, sign, unusable_reasons,
 };
 
 /// The store MDM-provisioned identities land in.
@@ -75,34 +75,29 @@ pub(crate) fn status(subject_cn: &str) -> Result<Status> {
         .chain(unused_sections)
         .collect();
 
-    let certificate_summary = match (selected, certificates.len()) {
-        (None, 0) => format!(
+    let certificate_warning = match (selected, certificates.len()) {
+        (None, 0) => Some(format!(
             "No X.509 certificate with subject CN '{subject_cn}' is in the Windows certificate stores."
-        ),
-        (None, _) => format!(
+        )),
+        (None, _) => Some(format!(
             "Matching certificates are in the Windows certificate store, but none is usable as a client identity: {}",
             unusable_reasons(&certificates).join("; ")
-        ),
-        (Some(_), _) => "An X.509 client identity is available for mutual TLS.".to_owned(),
+        )),
+        (Some(_), _) => None,
     };
-    let summary = match store_errors.is_empty() {
-        true => certificate_summary,
-        false => format!(
-            "{certificate_summary} Some Windows certificate stores could not be read: {}",
+    let store_warning = (!store_errors.is_empty()).then(|| {
+        format!(
+            "Some Windows certificate stores could not be read: {}",
             store_errors.join("; ")
-        ),
-    };
-    let severity = match (selected, store_errors.is_empty()) {
-        (None, _) => StatusSeverity::Warning,
-        (Some(_), false) => StatusSeverity::Warning,
-        (Some(_), true) => StatusSeverity::Ok,
+        )
+    });
+    let warning = match (certificate_warning, store_warning) {
+        (Some(certificate), Some(store)) => Some(format!("{certificate} {store}")),
+        (Some(certificate), None) => Some(certificate),
+        (None, store) => store,
     };
 
-    Ok(Status {
-        severity,
-        summary,
-        sections,
-    })
+    Ok(Status { warning, sections })
 }
 
 pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -30,14 +30,10 @@ use windows::{
     },
     core::w,
 };
-use x509_claims::{ParsedCertificate, parse_certificate};
+use x509_claims::{ParsedCertificate, SigningAlgorithm, parse_certificate};
 use x509_credential::SigningError;
 
-use crate::{
-    CandidateCertificate, ClientIdentity, DetailField, Identity, Problem, Status, UnreadableStore,
-    UnusableCause, certificate_sections, failed_field, join, selected_certificate, sign,
-    unusable_causes,
-};
+use crate::{CandidateCertificate, Error, Identity, selected_certificate, sign};
 
 /// The store MDM-provisioned identities land in.
 ///
@@ -46,75 +42,19 @@ use crate::{
 /// certificates nobody provisioned there. Device-scope profiles write here.
 const STORE: (u32, &str) = (CERT_SYSTEM_STORE_LOCAL_MACHINE, "LocalMachine\\My");
 
-pub(crate) fn status(subject_cn: &str) -> Result<Status> {
-    let (certificates, store_errors) = enumerate_matching(subject_cn);
-    if certificates.is_empty() && !store_errors.is_empty() {
-        bail!(
-            "The Windows certificate store could not be read: {}",
-            join(&store_errors, "; ")
-        );
-    }
-
-    let selected = selected_certificate(&certificates);
-    let sections = certificate_sections(&certificates, selected);
-
-    let certificate_problem = certificates
-        .is_empty()
-        .then(|| Problem::NoWindowsCertificate {
-            subject_cn: subject_cn.to_owned(),
-        });
-    let store_problem = (!store_errors.is_empty()).then_some(Problem::UnreadableWindowsStores {
-        stores: store_errors,
-    });
-    let problems = certificate_problem
-        .into_iter()
-        .chain(store_problem)
-        .collect();
-
-    let identity = selected
-        .map(|index| certificates[index].metadata.identity())
-        .unwrap_or(ClientIdentity::Absent);
-
-    Ok(Status {
-        problems,
-        sections,
-        identity,
-    })
-}
-
-pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
-    let (mut certificates, store_errors) = enumerate_matching(subject_cn);
-    if certificates.is_empty() && !store_errors.is_empty() {
-        bail!(
-            "The Windows certificate store could not be read: {}",
-            join(&store_errors, "; ")
-        );
-    }
-
-    let unusable = unusable_causes(&certificates);
+pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>, Error> {
+    let mut certificates = enumerate_matching(subject_cn)?;
 
     let Some(index) = selected_certificate(&certificates) else {
-        // Only a store that holds nothing for us is the ordinary no-certificate case. Skipping a
-        // certificate that was provisioned for Firezone reads to an administrator as if none had
-        // been, so say which rule it failed instead of connecting without it.
-        if !unusable.is_empty() {
-            bail!(
-                "The Windows certificate store holds no usable Firezone client identity: {}",
-                join(&unusable, "; ")
-            );
-        }
-
         return Ok(None);
     };
     let certificate = certificates.swap_remove(index);
 
-    let algorithm = certificate
-        .metadata
-        .signing_algorithm
-        .context("The selected Windows certificate uses an unsupported key algorithm")?;
     let signing_context = unsafe { CertDuplicateCertificateContext(Some(certificate.context)) };
     if signing_context.is_null() {
-        bail!("Failed to retain the selected Windows certificate context");
+        return Err(Error::IdentityUnavailable {
+            message: "Failed to retain the selected Windows certificate context".to_owned(),
+        });
     }
 
     let chain = certificate
@@ -124,19 +64,23 @@ pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
         .map(CertificateDer::from)
         .collect();
     let key = Arc::new(sign::Key::new(
-        algorithm,
+        certificate.algorithm,
         CngKey {
             context: Arc::new(CertificateContext(signing_context)),
         },
     ));
 
     tracing::debug!(
-        store = certificate.store,
+        store = STORE.1,
         fingerprint = %certificate.metadata.fingerprint,
         "Selected a Windows X.509 identity for mutual TLS"
     );
 
-    Ok(Some(Identity { chain, key }))
+    Ok(Some(Identity {
+        chain,
+        key,
+        certificate: certificate.metadata.clone(),
+    }))
 }
 
 /// A certificate context whose CNG private key signs the TLS handshake.
@@ -326,52 +270,17 @@ unsafe fn sign_hash(
     Ok(signature)
 }
 
-/// A certificate in one of the searched stores whose subject CN is the one we look for.
+/// A matching certificate we can present: CNG signs with its private key.
 struct Certificate {
-    store: &'static str,
     context: *mut CERT_CONTEXT,
     chain: Vec<Vec<u8>>,
-    chain_error: Option<String>,
     metadata: ParsedCertificate,
-    key_error: Option<String>,
-    usable: bool,
+    algorithm: SigningAlgorithm,
 }
 
 impl CandidateCertificate for Certificate {
-    fn unusable(&self) -> Option<UnusableCause> {
-        // CNG refuses a key held by a legacy CSP rather than a KSP, which is what an older
-        // certificate template provisions.
-        match (
-            &self.key_error,
-            self.metadata.signing_algorithm,
-            self.usable,
-        ) {
-            (Some(error), _, _) => Some(UnusableCause::KeyRefused {
-                error: error.clone(),
-            }),
-            (None, None, _) => Some(UnusableCause::UnsupportedKeyAlgorithm),
-            (None, Some(_), false) => Some(UnusableCause::KeyMissing),
-            (None, Some(_), true) => None,
-        }
-    }
-
     fn not_before_timestamp(&self) -> i64 {
         self.metadata.not_before_timestamp
-    }
-
-    fn detail_fields(&self) -> Vec<DetailField> {
-        let mut fields = self
-            .metadata
-            .detail_fields()
-            .into_iter()
-            .map(DetailField::from)
-            .collect::<Vec<_>>();
-
-        if let Some(error) = &self.chain_error {
-            fields.push(failed_field("Certificate Chain Error", error));
-        }
-
-        fields
     }
 }
 
@@ -383,28 +292,26 @@ impl Drop for Certificate {
     }
 }
 
-fn enumerate_matching(subject_cn: &str) -> (Vec<Certificate>, Vec<UnreadableStore>) {
-    let mut certificates = Vec::new();
-    let mut errors = Vec::new();
-
+fn enumerate_matching(subject_cn: &str) -> Result<Vec<Certificate>, Error> {
     let (location, label) = STORE;
 
-    match unsafe { enumerate_store(location, label, subject_cn) } {
-        Ok(mut found) => certificates.append(&mut found),
+    let certificates = match unsafe { enumerate_store(location, label, subject_cn) } {
+        Ok(found) => found,
         Err(error) => {
             tracing::warn!(
                 store = label,
                 ?error,
                 "Failed to read Windows certificate store"
             );
-            errors.push(UnreadableStore {
+
+            return Err(Error::UnreadableStore {
                 store: label.to_owned(),
                 error: format!("{error:#}"),
             });
         }
-    }
+    };
 
-    (certificates, errors)
+    Ok(certificates)
 }
 
 unsafe fn enumerate_store(
@@ -439,19 +346,36 @@ unsafe fn enumerate_store(
             continue;
         }
 
-        let (key_available, key_error) = match unsafe { acquire_key(context) } {
-            Ok(_) => (true, None),
-            Err(error) => (false, Some(error.to_string())),
+        // A certificate we cannot sign a TLS handshake with authenticates nothing; selecting
+        // it anyway would only shadow an older certificate that still works.
+        let Some(algorithm) = metadata.signing_algorithm else {
+            tracing::debug!(
+                store = label,
+                fingerprint = %metadata.fingerprint,
+                "Skipping a matching certificate: no scheme we sign with holds its key algorithm"
+            );
+            continue;
         };
-        let (chain, chain_error) = match unsafe { certificate_chain(context) } {
-            Ok(chain) => (chain, None),
+        if let Err(error) = unsafe { acquire_key(context) } {
+            tracing::debug!(
+                store = label,
+                fingerprint = %metadata.fingerprint,
+                %error,
+                "Skipping a matching certificate: CNG will not hand over its private key"
+            );
+            continue;
+        }
+
+        let chain = match unsafe { certificate_chain(context) } {
+            Ok(chain) => chain,
             Err(error) => {
                 tracing::warn!(
                     store = label,
                     ?error,
                     "Failed to build the Windows certificate chain; sending the leaf only"
                 );
-                (vec![der.clone()], Some(format!("{error:#}")))
+
+                vec![der.clone()]
             }
         };
         let owned_context = unsafe { CertDuplicateCertificateContext(Some(context)) };
@@ -464,13 +388,10 @@ unsafe fn enumerate_store(
         }
 
         certificates.push(Certificate {
-            store: label,
             context: owned_context,
             chain,
-            chain_error,
-            usable: metadata.signing_algorithm.is_some() && key_available,
             metadata,
-            key_error,
+            algorithm,
         });
     }
 

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -378,25 +378,19 @@ impl CandidateCertificate for Certificate {
     }
 
     fn unusable(&self) -> UnusableCertificate {
-        let fingerprint = self.metadata.fingerprint.clone();
-        let reasons = self.metadata.unusable_reasons();
-
-        if reasons.is_empty() {
-            // CNG refuses a key held by a legacy CSP rather than a KSP, which is what an older
-            // certificate template provisions.
-            let cause = match &self.key_error {
-                Some(error) => UnusableCause::WindowsKeyRefused {
-                    error: error.clone(),
-                },
-                None => UnusableCause::WindowsKeyMissing,
-            };
-
-            return UnusableCertificate { fingerprint, cause };
-        }
+        // CNG refuses a key held by a legacy CSP rather than a KSP, which is what an older
+        // certificate template provisions.
+        let cause = match (&self.key_error, self.metadata.signing_algorithm) {
+            (Some(error), _) => UnusableCause::WindowsKeyRefused {
+                error: error.clone(),
+            },
+            (None, None) => UnusableCause::UnsupportedKeyAlgorithm,
+            (None, Some(_)) => UnusableCause::WindowsKeyMissing,
+        };
 
         UnusableCertificate {
-            fingerprint,
-            cause: UnusableCause::FailsRules { reasons },
+            fingerprint: self.metadata.fingerprint.clone(),
+            cause,
         }
     }
 }
@@ -494,7 +488,7 @@ unsafe fn enumerate_store(
             context: owned_context,
             chain,
             chain_error,
-            usable: metadata.is_usable(subject_cn) && key_available,
+            usable: metadata.signing_algorithm.is_some() && key_available,
             metadata,
             key_error,
         });

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -351,7 +351,6 @@ struct Certificate {
     chain: Vec<Vec<u8>>,
     chain_error: Option<String>,
     metadata: ParsedCertificate,
-    key_available: bool,
     key_error: Option<String>,
     key_metadata: Option<PrivateKeyMetadata>,
     usable: bool,
@@ -374,16 +373,6 @@ impl Certificate {
             .collect::<Vec<_>>();
 
         fields.push(field("Store", self.store));
-        fields.push(if self.key_available {
-            field("Private Key Access", "Available through Windows CNG")
-        } else {
-            absent_field("Private Key Access")
-        });
-        fields.push(if self.usable {
-            field("Usable With Its Private Key", "Yes")
-        } else {
-            invalid_field("Usable With Its Private Key", "No")
-        });
         if let Some(error) = &self.key_error {
             fields.push(invalid_field("Private Key Error", error));
         }
@@ -536,7 +525,6 @@ unsafe fn enumerate_store(
             chain_error,
             usable: metadata.is_usable(subject_cn) && key_available,
             metadata,
-            key_available,
             key_error,
             key_metadata,
         });

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -6,7 +6,7 @@ mod tests;
 use std::{ffi::c_void, fmt, ptr, slice, sync::Arc, time::SystemTime};
 
 use anyhow::{Context as _, Result, bail};
-use rustls::{SignatureAlgorithm, SignatureScheme, pki_types::CertificateDer};
+use rustls::{SignatureScheme, pki_types::CertificateDer};
 use sha2::{Digest as _, Sha256, Sha384, Sha512};
 use windows::{
     Win32::{
@@ -33,10 +33,13 @@ use windows::{
     },
     core::w,
 };
-use x509_claims::{ParsedCertificate, SigningAlgorithm, parse_certificate};
-use x509_credential::{PrivateKey, SigningError};
+use x509_claims::{ParsedCertificate, parse_certificate};
+use x509_credential::SigningError;
 
-use crate::{DetailField, DetailSection, Identity, Status, StatusSeverity, absent_field, field, invalid_field};
+use crate::{
+    DetailField, DetailSection, Identity, Status, StatusSeverity, absent_field, field,
+    invalid_field, sign,
+};
 
 /// The store MDM-provisioned identities land in.
 ///
@@ -143,10 +146,12 @@ pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
         .cloned()
         .map(CertificateDer::from)
         .collect();
-    let key = Arc::new(CngKey {
-        context: Arc::new(CertificateContext(signing_context)),
+    let key = Arc::new(sign::Key::new(
         algorithm,
-    });
+        CngKey {
+            context: Arc::new(CertificateContext(signing_context)),
+        },
+    ));
 
     tracing::debug!(
         store = certificate.store,
@@ -163,43 +168,13 @@ pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
 #[derive(Debug)]
 struct CngKey {
     context: Arc<CertificateContext>,
-    algorithm: SigningAlgorithm,
 }
 
-impl PrivateKey for CngKey {
-    fn supported_schemes(&self) -> Vec<SignatureScheme> {
-        signature_schemes(self.algorithm).to_vec()
-    }
-
-    fn algorithm(&self) -> SignatureAlgorithm {
-        match self.algorithm {
-            SigningAlgorithm::RsaSha256 => SignatureAlgorithm::RSA,
-            SigningAlgorithm::EcdsaSha256 => SignatureAlgorithm::ECDSA,
-            SigningAlgorithm::EcdsaSha384 => SignatureAlgorithm::ECDSA,
-            SigningAlgorithm::EcdsaSha512 => SignatureAlgorithm::ECDSA,
-        }
-    }
-
+impl sign::Signer for CngKey {
     fn sign(&self, scheme: SignatureScheme, message: &[u8]) -> Result<Vec<u8>, SigningError> {
         let signature = unsafe { sign_with_certificate(self.context.0, scheme, message) }?;
 
         Ok(signature)
-    }
-}
-
-fn signature_schemes(algorithm: SigningAlgorithm) -> &'static [SignatureScheme] {
-    match algorithm {
-        SigningAlgorithm::RsaSha256 => &[
-            SignatureScheme::RSA_PSS_SHA512,
-            SignatureScheme::RSA_PSS_SHA384,
-            SignatureScheme::RSA_PSS_SHA256,
-            SignatureScheme::RSA_PKCS1_SHA512,
-            SignatureScheme::RSA_PKCS1_SHA384,
-            SignatureScheme::RSA_PKCS1_SHA256,
-        ],
-        SigningAlgorithm::EcdsaSha256 => &[SignatureScheme::ECDSA_NISTP256_SHA256],
-        SigningAlgorithm::EcdsaSha384 => &[SignatureScheme::ECDSA_NISTP384_SHA384],
-        SigningAlgorithm::EcdsaSha512 => &[SignatureScheme::ECDSA_NISTP521_SHA512],
     }
 }
 
@@ -257,42 +232,30 @@ unsafe fn sign_with_certificate(
                 &Sha512::digest(message),
             )
         },
-        SignatureScheme::ECDSA_NISTP256_SHA256 => {
-            let raw = unsafe {
-                sign_hash(
-                    key.handle,
-                    None,
-                    &Sha256::digest(message),
-                    NCRYPT_FLAGS::default(),
-                )
-            }?;
-
-            der_encode_ecdsa_signature(&raw)
-        }
-        SignatureScheme::ECDSA_NISTP384_SHA384 => {
-            let raw = unsafe {
-                sign_hash(
-                    key.handle,
-                    None,
-                    &Sha384::digest(message),
-                    NCRYPT_FLAGS::default(),
-                )
-            }?;
-
-            der_encode_ecdsa_signature(&raw)
-        }
-        SignatureScheme::ECDSA_NISTP521_SHA512 => {
-            let raw = unsafe {
-                sign_hash(
-                    key.handle,
-                    None,
-                    &Sha512::digest(message),
-                    NCRYPT_FLAGS::default(),
-                )
-            }?;
-
-            der_encode_ecdsa_signature(&raw)
-        }
+        SignatureScheme::ECDSA_NISTP256_SHA256 => unsafe {
+            sign_hash(
+                key.handle,
+                None,
+                &Sha256::digest(message),
+                NCRYPT_FLAGS::default(),
+            )
+        },
+        SignatureScheme::ECDSA_NISTP384_SHA384 => unsafe {
+            sign_hash(
+                key.handle,
+                None,
+                &Sha384::digest(message),
+                NCRYPT_FLAGS::default(),
+            )
+        },
+        SignatureScheme::ECDSA_NISTP521_SHA512 => unsafe {
+            sign_hash(
+                key.handle,
+                None,
+                &Sha512::digest(message),
+                NCRYPT_FLAGS::default(),
+            )
+        },
         _ => Err(SigningError::UnsupportedScheme(scheme)),
     }
 }
@@ -384,53 +347,6 @@ unsafe fn sign_hash(
     signature.truncate(written as usize);
 
     Ok(signature)
-}
-
-/// Wraps the fixed-width `r` and `s` values CNG returns into the DER sequence TLS expects.
-fn der_encode_ecdsa_signature(raw: &[u8]) -> Result<Vec<u8>, SigningError> {
-    if raw.is_empty() || !raw.len().is_multiple_of(2) {
-        return Err(SigningError::Keystore(format!(
-            "CNG returned a {}-byte ECDSA signature",
-            raw.len()
-        )));
-    }
-
-    let half = raw.len() / 2;
-    let r = der_integer(&raw[..half]);
-    let s = der_integer(&raw[half..]);
-    let mut output = vec![0x30];
-    encode_der_length(&mut output, r.len() + s.len());
-    output.extend(r);
-    output.extend(s);
-
-    Ok(output)
-}
-
-fn der_integer(value: &[u8]) -> Vec<u8> {
-    let first_nonzero = value
-        .iter()
-        .position(|byte| *byte != 0)
-        .unwrap_or(value.len().saturating_sub(1));
-    let value = &value[first_nonzero..];
-    let needs_padding = value.first().is_some_and(|byte| byte & 0x80 != 0);
-    let mut output = vec![0x02];
-    encode_der_length(&mut output, value.len() + usize::from(needs_padding));
-    if needs_padding {
-        output.push(0);
-    }
-    output.extend(value);
-
-    output
-}
-
-fn encode_der_length(output: &mut Vec<u8>, length: usize) {
-    if length < 0x80 {
-        output.push(length as u8);
-    } else if length < 0x100 {
-        output.extend([0x81, length as u8]);
-    } else {
-        output.extend([0x82, (length >> 8) as u8, length as u8]);
-    }
 }
 
 /// A certificate in one of the searched stores whose subject CN is the one we look for.

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -36,7 +36,7 @@ use windows::{
 use x509_claims::{ParsedCertificate, SigningAlgorithm, parse_certificate};
 use x509_credential::{PrivateKey, SigningError};
 
-use crate::{DetailField, DetailSection, Identity, Status, field};
+use crate::{DetailField, DetailSection, Identity, Status, StatusSeverity, field};
 
 /// The store MDM-provisioned identities land in.
 ///
@@ -58,44 +58,45 @@ pub(crate) fn status(subject_cn: &str) -> Result<Status> {
         .iter()
         .filter(|certificate| certificate.usable)
         .count();
-    let mut sections = vec![DetailSection {
-        title: "Windows Certificate Store".to_owned(),
-        fields: vec![
-            field("Searched Store", STORE.1),
-            field("Requested Common Name", subject_cn),
-            field(
-                "Store Read Errors",
-                if store_errors.is_empty() {
-                    "None".to_owned()
-                } else {
-                    store_errors.join("\n")
-                },
-            ),
-        ],
-    }];
-    sections.extend(
-        certificates
-            .iter()
-            .enumerate()
-            .map(|(index, certificate)| DetailSection {
-                title: format!("Matching Certificate {}", index + 1),
-                fields: certificate.detail_fields(),
-            }),
-    );
+    let sections = certificates
+        .iter()
+        .enumerate()
+        .map(|(index, certificate)| DetailSection {
+            title: format!("Matching Certificate {}", index + 1),
+            fields: certificate.detail_fields(),
+        })
+        .collect();
 
-    let summary = match (usable, certificates.len()) {
+    let certificate_summary = match (usable, certificates.len()) {
         (0, 0) => format!(
             "No X.509 certificate with subject CN '{subject_cn}' is in the Windows certificate stores."
         ),
         (0, count) => format!(
-            "Found {count} matching X.509 certificate(s), but none of them are usable as a client identity."
+            "Found {count} matching X.509 certificate(s), but none of them are usable as a client identity: {}",
+            unusable_reasons(&certificates).join("; ")
         ),
         (count, _) => {
             format!("{count} X.509 client identity certificate(s) are available for mutual TLS.")
         }
     };
+    let summary = match store_errors.is_empty() {
+        true => certificate_summary,
+        false => format!(
+            "{certificate_summary} Some Windows certificate stores could not be read: {}",
+            store_errors.join("; ")
+        ),
+    };
+    let severity = match (usable, store_errors.is_empty()) {
+        (0, _) => StatusSeverity::Warning,
+        (_, false) => StatusSeverity::Warning,
+        (_, true) => StatusSeverity::Ok,
+    };
 
-    Ok(Status { summary, sections })
+    Ok(Status {
+        severity,
+        summary,
+        sections,
+    })
 }
 
 pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
@@ -107,11 +108,7 @@ pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
         );
     }
 
-    let unusable = certificates
-        .iter()
-        .filter(|certificate| !certificate.usable)
-        .map(unusable_reason)
-        .collect::<Vec<_>>();
+    let unusable = unusable_reasons(&certificates);
 
     let Some(certificate) = certificates
         .into_iter()
@@ -469,7 +466,7 @@ impl Certificate {
                 },
             ),
             field(
-                "Usable as a Client Identity",
+                "Usable With Its Private Key",
                 if self.usable { "Yes" } else { "No" },
             ),
         ];
@@ -508,6 +505,22 @@ impl Certificate {
 
         fields
     }
+
+    /// Says why this certificate cannot be presented for mutual TLS.
+    fn unusable_reason(&self) -> String {
+        let fingerprint = &self.metadata.fingerprint;
+
+        let Some(summary) = self.metadata.unusable_summary() else {
+            // CNG refuses a key held by a legacy CSP rather than a KSP, which is what an older
+            // certificate template provisions.
+            return match &self.key_error {
+                Some(error) => format!("{fingerprint} has a private key CNG will not use: {error}"),
+                None => format!("{fingerprint} has no usable private key"),
+            };
+        };
+
+        format!("{fingerprint} is unusable: {summary}")
+    }
 }
 
 impl Drop for Certificate {
@@ -518,33 +531,13 @@ impl Drop for Certificate {
     }
 }
 
-/// Says why a certificate that matched the subject common name cannot be used.
-fn unusable_reason(certificate: &Certificate) -> String {
-    let metadata = &certificate.metadata;
-
-    let reason = if !metadata.has_client_auth_eku {
-        "it has no TLS client authentication extended key usage"
-    } else if !metadata.digital_signature_allowed {
-        "its key usage does not allow digital signatures"
-    } else if !metadata.is_currently_valid {
-        "it is expired or not yet valid"
-    } else if metadata.signing_algorithm.is_none() {
-        "it holds a key algorithm we cannot sign with"
-    } else if !certificate.key_available {
-        // CNG refuses a key held by a legacy CSP rather than a KSP, which is what an older
-        // certificate template provisions.
-        return match &certificate.key_error {
-            Some(error) => format!(
-                "{} has a private key CNG will not use: {error}",
-                metadata.fingerprint
-            ),
-            None => format!("{} has no usable private key", metadata.fingerprint),
-        };
-    } else {
-        "it does not match the requested common name"
-    };
-
-    format!("{} is unusable because {reason}", metadata.fingerprint)
+/// Says why each certificate that matched the subject common name cannot be used.
+fn unusable_reasons(certificates: &[Certificate]) -> Vec<String> {
+    certificates
+        .iter()
+        .filter(|certificate| !certificate.usable)
+        .map(Certificate::unusable_reason)
+        .collect()
 }
 
 fn enumerate_matching(subject_cn: &str) -> (Vec<Certificate>, Vec<String>) {

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -1,0 +1,941 @@
+//! X.509 client identities from the Windows certificate stores, signed through CNG.
+
+use std::{ffi::c_void, fmt, ptr, slice, sync::Arc, time::SystemTime};
+
+use anyhow::{Context as _, Result, bail};
+use rustls::{SignatureAlgorithm, SignatureScheme, pki_types::CertificateDer};
+use sha2::{Digest as _, Sha256, Sha384, Sha512};
+use windows::{
+    Win32::{
+        Foundation::{
+            E_ACCESSDENIED, NTE_BAD_KEYSET, NTE_NO_KEY, NTE_NOT_FOUND, NTE_PERM,
+            NTE_SILENT_CONTEXT, NTE_USER_CANCELLED, SCARD_W_CANCELLED_BY_USER,
+        },
+        Security::Cryptography::{
+            BCRYPT_PKCS1_PADDING_INFO, BCRYPT_PSS_PADDING_INFO, BCRYPT_SHA256_ALGORITHM,
+            BCRYPT_SHA384_ALGORITHM, BCRYPT_SHA512_ALGORITHM, CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL,
+            CERT_CHAIN_DISABLE_AIA, CERT_CHAIN_PARA, CERT_CONTEXT, CERT_KEY_PROV_INFO_PROP_ID,
+            CERT_KEY_SPEC, CERT_OPEN_STORE_FLAGS, CERT_QUERY_ENCODING_TYPE,
+            CERT_STORE_OPEN_EXISTING_FLAG, CERT_STORE_PROV_SYSTEM_W, CERT_STORE_READONLY_FLAG,
+            CERT_SYSTEM_STORE_CURRENT_USER, CERT_SYSTEM_STORE_LOCAL_MACHINE,
+            CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG, CRYPT_ACQUIRE_SILENT_FLAG, CRYPT_KEY_PROV_INFO,
+            CertCloseStore, CertDuplicateCertificateContext, CertEnumCertificatesInStore,
+            CertFreeCertificateChain, CertFreeCertificateContext, CertGetCertificateChain,
+            CertGetCertificateContextProperty, CertOpenStore, CryptAcquireCertificatePrivateKey,
+            HCERTSTORE, HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, NCRYPT_FLAGS, NCRYPT_HANDLE,
+            NCRYPT_IMPL_HARDWARE_FLAG, NCRYPT_IMPL_SOFTWARE_FLAG, NCRYPT_IMPL_TYPE_PROPERTY,
+            NCRYPT_KEY_HANDLE, NCRYPT_PAD_PKCS1_FLAG, NCRYPT_PAD_PSS_FLAG, NCRYPT_PROV_HANDLE,
+            NCRYPT_PROVIDER_HANDLE_PROPERTY, NCryptFreeObject, NCryptGetProperty, NCryptSignHash,
+        },
+    },
+    core::w,
+};
+use x509_claims::{ParsedCertificate, SigningAlgorithm, parse_certificate};
+use x509_credential::{PrivateKey, SigningError};
+
+use crate::{DetailField, DetailSection, Identity, Status, field};
+
+/// The stores that MDM-provisioned identities land in, most privileged first.
+const STORES: &[(u32, &str)] = &[
+    (CERT_SYSTEM_STORE_LOCAL_MACHINE, "LocalMachine\\My"),
+    (CERT_SYSTEM_STORE_CURRENT_USER, "CurrentUser\\My"),
+];
+
+pub(crate) fn status(subject_cn: &str) -> Result<Status> {
+    let (certificates, store_errors) = enumerate_matching(subject_cn);
+    if certificates.is_empty() && store_errors.len() == STORES.len() {
+        bail!(
+            "The Windows certificate stores could not be read: {}",
+            store_errors.join("; ")
+        );
+    }
+
+    let usable = certificates
+        .iter()
+        .filter(|certificate| certificate.usable)
+        .count();
+    let mut sections = vec![DetailSection {
+        title: "Windows Certificate Store".to_owned(),
+        fields: vec![
+            field("Searched Stores", "LocalMachine\\My\nCurrentUser\\My"),
+            field("Requested Common Name", subject_cn),
+            field(
+                "Store Read Errors",
+                if store_errors.is_empty() {
+                    "None".to_owned()
+                } else {
+                    store_errors.join("\n")
+                },
+            ),
+        ],
+    }];
+    sections.extend(
+        certificates
+            .iter()
+            .enumerate()
+            .map(|(index, certificate)| DetailSection {
+                title: format!("Matching Certificate {}", index + 1),
+                fields: certificate.detail_fields(),
+            }),
+    );
+
+    let summary = match (usable, certificates.len()) {
+        (0, 0) => format!(
+            "No X.509 certificate with subject CN '{subject_cn}' is in the Windows certificate stores."
+        ),
+        (0, count) => format!(
+            "Found {count} matching X.509 certificate(s), but none of them are usable as a client identity."
+        ),
+        (count, _) => {
+            format!("{count} X.509 client identity certificate(s) are available for mutual TLS.")
+        }
+    };
+
+    Ok(Status { summary, sections })
+}
+
+pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {
+    let (certificates, store_errors) = enumerate_matching(subject_cn);
+    if certificates.is_empty() && store_errors.len() == STORES.len() {
+        bail!(
+            "The Windows certificate stores could not be read: {}",
+            store_errors.join("; ")
+        );
+    }
+
+    let Some(certificate) = certificates
+        .into_iter()
+        .filter(|certificate| certificate.usable)
+        .max_by_key(|certificate| certificate.metadata.not_before_timestamp)
+    else {
+        return Ok(None);
+    };
+
+    let algorithm = certificate
+        .metadata
+        .signing_algorithm
+        .context("The selected Windows certificate uses an unsupported key algorithm")?;
+    let signing_context = unsafe { CertDuplicateCertificateContext(Some(certificate.context)) };
+    if signing_context.is_null() {
+        bail!("Failed to retain the selected Windows certificate context");
+    }
+
+    let chain = certificate
+        .chain
+        .iter()
+        .cloned()
+        .map(CertificateDer::from)
+        .collect();
+    let key = Arc::new(CngKey {
+        context: Arc::new(CertificateContext(signing_context)),
+        algorithm,
+    });
+
+    tracing::debug!(
+        store = certificate.store,
+        fingerprint = %certificate.metadata.fingerprint,
+        "Selected a Windows X.509 identity for mutual TLS"
+    );
+
+    Ok(Some(Identity { chain, key }))
+}
+
+/// A certificate context whose CNG private key signs the TLS handshake.
+///
+/// The key is only ever referenced by handle, so its material stays inside the CNG provider.
+#[derive(Debug)]
+struct CngKey {
+    context: Arc<CertificateContext>,
+    algorithm: SigningAlgorithm,
+}
+
+impl PrivateKey for CngKey {
+    fn supported_schemes(&self) -> Vec<SignatureScheme> {
+        signature_schemes(self.algorithm).to_vec()
+    }
+
+    fn algorithm(&self) -> SignatureAlgorithm {
+        match self.algorithm {
+            SigningAlgorithm::RsaSha256 => SignatureAlgorithm::RSA,
+            SigningAlgorithm::EcdsaSha256 => SignatureAlgorithm::ECDSA,
+            SigningAlgorithm::EcdsaSha384 => SignatureAlgorithm::ECDSA,
+            SigningAlgorithm::EcdsaSha512 => SignatureAlgorithm::ECDSA,
+        }
+    }
+
+    fn sign(&self, scheme: SignatureScheme, message: &[u8]) -> Result<Vec<u8>, SigningError> {
+        let signature = unsafe { sign_with_certificate(self.context.0, scheme, message) }?;
+
+        Ok(signature)
+    }
+}
+
+fn signature_schemes(algorithm: SigningAlgorithm) -> &'static [SignatureScheme] {
+    match algorithm {
+        SigningAlgorithm::RsaSha256 => &[
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA256,
+        ],
+        SigningAlgorithm::EcdsaSha256 => &[SignatureScheme::ECDSA_NISTP256_SHA256],
+        SigningAlgorithm::EcdsaSha384 => &[SignatureScheme::ECDSA_NISTP384_SHA384],
+        SigningAlgorithm::EcdsaSha512 => &[SignatureScheme::ECDSA_NISTP521_SHA512],
+    }
+}
+
+#[expect(
+    clippy::wildcard_enum_match_arm,
+    reason = "rustls only ever asks for a scheme we advertised in `supported_schemes`"
+)]
+unsafe fn sign_with_certificate(
+    context: *mut CERT_CONTEXT,
+    scheme: SignatureScheme,
+    message: &[u8],
+) -> Result<Vec<u8>, SigningError> {
+    let key = unsafe { acquire_key(context) }.map_err(classify_signing_error)?;
+
+    match scheme {
+        SignatureScheme::RSA_PSS_SHA256 => unsafe {
+            sign_rsa_pss(
+                key.handle,
+                BCRYPT_SHA256_ALGORITHM,
+                &Sha256::digest(message),
+            )
+        },
+        SignatureScheme::RSA_PSS_SHA384 => unsafe {
+            sign_rsa_pss(
+                key.handle,
+                BCRYPT_SHA384_ALGORITHM,
+                &Sha384::digest(message),
+            )
+        },
+        SignatureScheme::RSA_PSS_SHA512 => unsafe {
+            sign_rsa_pss(
+                key.handle,
+                BCRYPT_SHA512_ALGORITHM,
+                &Sha512::digest(message),
+            )
+        },
+        SignatureScheme::RSA_PKCS1_SHA256 => unsafe {
+            sign_rsa_pkcs1(
+                key.handle,
+                BCRYPT_SHA256_ALGORITHM,
+                &Sha256::digest(message),
+            )
+        },
+        SignatureScheme::RSA_PKCS1_SHA384 => unsafe {
+            sign_rsa_pkcs1(
+                key.handle,
+                BCRYPT_SHA384_ALGORITHM,
+                &Sha384::digest(message),
+            )
+        },
+        SignatureScheme::RSA_PKCS1_SHA512 => unsafe {
+            sign_rsa_pkcs1(
+                key.handle,
+                BCRYPT_SHA512_ALGORITHM,
+                &Sha512::digest(message),
+            )
+        },
+        SignatureScheme::ECDSA_NISTP256_SHA256 => {
+            let raw = unsafe {
+                sign_hash(
+                    key.handle,
+                    None,
+                    &Sha256::digest(message),
+                    NCRYPT_FLAGS::default(),
+                )
+            }?;
+
+            der_encode_ecdsa_signature(&raw)
+        }
+        SignatureScheme::ECDSA_NISTP384_SHA384 => {
+            let raw = unsafe {
+                sign_hash(
+                    key.handle,
+                    None,
+                    &Sha384::digest(message),
+                    NCRYPT_FLAGS::default(),
+                )
+            }?;
+
+            der_encode_ecdsa_signature(&raw)
+        }
+        SignatureScheme::ECDSA_NISTP521_SHA512 => {
+            let raw = unsafe {
+                sign_hash(
+                    key.handle,
+                    None,
+                    &Sha512::digest(message),
+                    NCRYPT_FLAGS::default(),
+                )
+            }?;
+
+            der_encode_ecdsa_signature(&raw)
+        }
+        _ => Err(SigningError::UnsupportedScheme(scheme)),
+    }
+}
+
+/// Names the cause behind a failed CNG key operation.
+///
+/// Windows reports a declined confirmation prompt and a missing key-usage permission as different
+/// codes, but both mean the same to us: the keystore is there and refuses to use the key.
+fn classify_signing_error(error: windows_core::Error) -> SigningError {
+    let reason = error.to_string();
+
+    match error.code() {
+        NTE_NO_KEY => SigningError::KeyUnavailable(reason),
+        NTE_BAD_KEYSET => SigningError::KeyUnavailable(reason),
+        NTE_NOT_FOUND => SigningError::KeyUnavailable(reason),
+        NTE_PERM => SigningError::AccessDenied(reason),
+        NTE_SILENT_CONTEXT => SigningError::AccessDenied(reason),
+        NTE_USER_CANCELLED => SigningError::AccessDenied(reason),
+        SCARD_W_CANCELLED_BY_USER => SigningError::AccessDenied(reason),
+        E_ACCESSDENIED => SigningError::AccessDenied(reason),
+        _ => SigningError::Keystore(reason),
+    }
+}
+
+unsafe fn sign_rsa_pss(
+    key: NCRYPT_KEY_HANDLE,
+    hash_algorithm: windows_core::PCWSTR,
+    hash: &[u8],
+) -> Result<Vec<u8>, SigningError> {
+    let padding = BCRYPT_PSS_PADDING_INFO {
+        pszAlgId: hash_algorithm,
+        cbSalt: hash.len() as u32,
+    };
+    let signature = unsafe {
+        sign_hash(
+            key,
+            Some((&raw const padding).cast()),
+            hash,
+            NCRYPT_PAD_PSS_FLAG,
+        )
+    }?;
+
+    Ok(signature)
+}
+
+unsafe fn sign_rsa_pkcs1(
+    key: NCRYPT_KEY_HANDLE,
+    hash_algorithm: windows_core::PCWSTR,
+    hash: &[u8],
+) -> Result<Vec<u8>, SigningError> {
+    let padding = BCRYPT_PKCS1_PADDING_INFO {
+        pszAlgId: hash_algorithm,
+    };
+    let signature = unsafe {
+        sign_hash(
+            key,
+            Some((&raw const padding).cast()),
+            hash,
+            NCRYPT_PAD_PKCS1_FLAG,
+        )
+    }?;
+
+    Ok(signature)
+}
+
+unsafe fn sign_hash(
+    key: NCRYPT_KEY_HANDLE,
+    padding: Option<*const c_void>,
+    hash: &[u8],
+    flags: NCRYPT_FLAGS,
+) -> Result<Vec<u8>, SigningError> {
+    let mut needed = 0;
+    unsafe { NCryptSignHash(key, padding, hash, None, &mut needed, flags) }
+        .map_err(classify_signing_error)?;
+
+    let mut signature = vec![0; needed as usize];
+    let mut written = 0;
+    unsafe {
+        NCryptSignHash(
+            key,
+            padding,
+            hash,
+            Some(&mut signature),
+            &mut written,
+            flags,
+        )
+    }
+    .map_err(classify_signing_error)?;
+    signature.truncate(written as usize);
+
+    Ok(signature)
+}
+
+/// Wraps the fixed-width `r` and `s` values CNG returns into the DER sequence TLS expects.
+fn der_encode_ecdsa_signature(raw: &[u8]) -> Result<Vec<u8>, SigningError> {
+    if raw.is_empty() || !raw.len().is_multiple_of(2) {
+        return Err(SigningError::Keystore(format!(
+            "CNG returned a {}-byte ECDSA signature",
+            raw.len()
+        )));
+    }
+
+    let half = raw.len() / 2;
+    let r = der_integer(&raw[..half]);
+    let s = der_integer(&raw[half..]);
+    let mut output = vec![0x30];
+    encode_der_length(&mut output, r.len() + s.len());
+    output.extend(r);
+    output.extend(s);
+
+    Ok(output)
+}
+
+fn der_integer(value: &[u8]) -> Vec<u8> {
+    let first_nonzero = value
+        .iter()
+        .position(|byte| *byte != 0)
+        .unwrap_or(value.len().saturating_sub(1));
+    let value = &value[first_nonzero..];
+    let needs_padding = value.first().is_some_and(|byte| byte & 0x80 != 0);
+    let mut output = vec![0x02];
+    encode_der_length(&mut output, value.len() + usize::from(needs_padding));
+    if needs_padding {
+        output.push(0);
+    }
+    output.extend(value);
+
+    output
+}
+
+fn encode_der_length(output: &mut Vec<u8>, length: usize) {
+    if length < 0x80 {
+        output.push(length as u8);
+    } else if length < 0x100 {
+        output.extend([0x81, length as u8]);
+    } else {
+        output.extend([0x82, (length >> 8) as u8, length as u8]);
+    }
+}
+
+/// A certificate in one of the searched stores whose subject CN is the one we look for.
+struct Certificate {
+    store: &'static str,
+    context: *mut CERT_CONTEXT,
+    chain: Vec<Vec<u8>>,
+    chain_error: Option<String>,
+    metadata: ParsedCertificate,
+    key_available: bool,
+    key_error: Option<String>,
+    key_metadata: Option<PrivateKeyMetadata>,
+    usable: bool,
+}
+
+struct PrivateKeyMetadata {
+    provider: Option<String>,
+    container: Option<String>,
+    storage: &'static str,
+    errors: Vec<String>,
+}
+
+impl Certificate {
+    fn detail_fields(&self) -> Vec<DetailField> {
+        let mut fields = vec![
+            field("Store", self.store),
+            field(
+                "Private Key Access",
+                if self.key_available {
+                    "Available through Windows CNG"
+                } else {
+                    "Unavailable"
+                },
+            ),
+            field(
+                "Usable as a Client Identity",
+                if self.usable { "Yes" } else { "No" },
+            ),
+        ];
+        if let Some(error) = &self.key_error {
+            fields.push(field("Private Key Error", error));
+        }
+        if let Some(metadata) = &self.key_metadata {
+            fields.push(field(
+                "Private Key Provider",
+                metadata.provider.as_deref().unwrap_or("Unavailable"),
+            ));
+            fields.push(field("Private Key Storage", metadata.storage));
+            if let Some(container) = &metadata.container {
+                fields.push(field("Private Key Container", container));
+            }
+            if !metadata.errors.is_empty() {
+                fields.push(field(
+                    "Private Key Metadata Errors",
+                    metadata.errors.join("\n"),
+                ));
+            }
+        }
+        fields.push(field(
+            "Certificate Chain Count",
+            self.chain.len().to_string(),
+        ));
+        if let Some(error) = &self.chain_error {
+            fields.push(field("Certificate Chain Error", error));
+        }
+        fields.extend(
+            self.metadata
+                .detail_fields()
+                .into_iter()
+                .map(DetailField::from),
+        );
+
+        fields
+    }
+}
+
+impl Drop for Certificate {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CertFreeCertificateContext(Some(self.context));
+        }
+    }
+}
+
+fn enumerate_matching(subject_cn: &str) -> (Vec<Certificate>, Vec<String>) {
+    let mut certificates = Vec::new();
+    let mut errors = Vec::new();
+
+    for &(location, label) in STORES {
+        match unsafe { enumerate_store(location, label, subject_cn) } {
+            Ok(mut found) => certificates.append(&mut found),
+            Err(error) => {
+                tracing::warn!(
+                    store = label,
+                    ?error,
+                    "Failed to read Windows certificate store"
+                );
+                errors.push(format!("{label}: {error:#}"));
+            }
+        }
+    }
+
+    (certificates, errors)
+}
+
+unsafe fn enumerate_store(
+    location: u32,
+    label: &'static str,
+    subject_cn: &str,
+) -> Result<Vec<Certificate>> {
+    let store = unsafe { open_store(location) }.with_context(|| format!("Opening {label}"))?;
+    let mut certificates = Vec::new();
+    let mut previous: *mut CERT_CONTEXT = ptr::null_mut();
+
+    loop {
+        let context = unsafe {
+            CertEnumCertificatesInStore(
+                store,
+                (!previous.is_null()).then_some(previous as *const CERT_CONTEXT),
+            )
+        };
+        if context.is_null() {
+            break;
+        }
+        previous = context;
+
+        let der = unsafe {
+            let context = &*context;
+            slice::from_raw_parts(context.pbCertEncoded, context.cbCertEncoded as usize).to_vec()
+        };
+        let Some(metadata) = parse_certificate(&der, SystemTime::now()) else {
+            continue;
+        };
+        if metadata.subject_cn.as_deref() != Some(subject_cn) {
+            continue;
+        }
+
+        let (key_available, key_error, key_metadata) = match unsafe { acquire_key(context) } {
+            Ok(key) => (
+                true,
+                None,
+                Some(unsafe { private_key_metadata(context, &key) }),
+            ),
+            Err(error) => (false, Some(error.to_string()), None),
+        };
+        let (chain, chain_error) = match unsafe { certificate_chain(context) } {
+            Ok(chain) => (chain, None),
+            Err(error) => {
+                tracing::warn!(
+                    store = label,
+                    ?error,
+                    "Failed to build the Windows certificate chain; sending the leaf only"
+                );
+                (vec![der.clone()], Some(format!("{error:#}")))
+            }
+        };
+        let owned_context = unsafe { CertDuplicateCertificateContext(Some(context)) };
+        if owned_context.is_null() {
+            tracing::warn!(
+                store = label,
+                "Failed to retain a Windows certificate context"
+            );
+            continue;
+        }
+
+        certificates.push(Certificate {
+            store: label,
+            context: owned_context,
+            chain,
+            chain_error,
+            usable: metadata.is_usable(subject_cn) && key_available,
+            metadata,
+            key_available,
+            key_error,
+            key_metadata,
+        });
+    }
+
+    unsafe {
+        let _ = CertCloseStore(Some(store), 0);
+    }
+
+    Ok(certificates)
+}
+
+unsafe fn open_store(location: u32) -> Result<HCERTSTORE> {
+    let flags = CERT_OPEN_STORE_FLAGS(
+        location | CERT_STORE_READONLY_FLAG.0 | CERT_STORE_OPEN_EXISTING_FLAG.0,
+    );
+    let store = unsafe {
+        CertOpenStore(
+            CERT_STORE_PROV_SYSTEM_W,
+            CERT_QUERY_ENCODING_TYPE::default(),
+            None,
+            flags,
+            Some(w!("MY").as_ptr().cast::<c_void>()),
+        )
+    }
+    .context("CertOpenStore failed")?;
+    if store.is_invalid() {
+        bail!("CertOpenStore returned an invalid handle");
+    }
+
+    Ok(store)
+}
+
+/// Collects the leaf and every issuer Windows can resolve from its local caches.
+///
+/// Fetching missing issuers over the network would stall the handshake, so authority information
+/// access is disabled and the portal is left to complete the chain from its own trust store.
+unsafe fn certificate_chain(context: *const CERT_CONTEXT) -> Result<Vec<Vec<u8>>> {
+    let parameters = CERT_CHAIN_PARA {
+        cbSize: std::mem::size_of::<CERT_CHAIN_PARA>() as u32,
+        ..Default::default()
+    };
+    let mut chain_context = ptr::null_mut();
+    unsafe {
+        CertGetCertificateChain(
+            None,
+            context,
+            None,
+            None,
+            &raw const parameters,
+            CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL | CERT_CHAIN_DISABLE_AIA,
+            None,
+            &mut chain_context,
+        )
+    }
+    .context("CertGetCertificateChain failed")?;
+
+    let result = (|| {
+        let chain_context = unsafe { chain_context.as_ref() }
+            .context("CertGetCertificateChain returned a null context")?;
+        anyhow::ensure!(
+            chain_context.cChain > 0,
+            "Windows returned no certificate chains"
+        );
+        let simple_chain = unsafe { chain_context.rgpChain.as_ref() }
+            .context("Windows returned a null certificate-chain list")?;
+        let simple_chain = *simple_chain;
+        let simple_chain = unsafe { simple_chain.as_ref() }
+            .context("Windows returned a null certificate chain")?;
+        let elements = unsafe { simple_chain.rgpElement.as_ref() }
+            .context("Windows returned a null certificate-chain element list")?;
+        let mut certificates = Vec::with_capacity(simple_chain.cElement as usize);
+
+        for index in 0..simple_chain.cElement as usize {
+            let element = if index == 0 {
+                *elements
+            } else {
+                unsafe { *simple_chain.rgpElement.add(index) }
+            };
+            let element = unsafe { element.as_ref() }
+                .context("Windows returned a null certificate-chain element")?;
+            let certificate = unsafe { element.pCertContext.as_ref() }
+                .context("Windows returned a null certificate context")?;
+            certificates.push(unsafe {
+                slice::from_raw_parts(
+                    certificate.pbCertEncoded,
+                    certificate.cbCertEncoded as usize,
+                )
+                .to_vec()
+            });
+        }
+
+        Ok(certificates)
+    })();
+
+    unsafe { CertFreeCertificateChain(chain_context) };
+
+    result
+}
+
+/// A duplicated, reference-counted certificate context shared by every signing operation.
+struct CertificateContext(*mut CERT_CONTEXT);
+
+// SAFETY: Windows permits certificate contexts and their associated CNG key providers to be used
+// from different threads; each signing call acquires its own key handle.
+unsafe impl Send for CertificateContext {}
+// SAFETY: see the `Send` implementation above. The pointed-to context is immutable.
+unsafe impl Sync for CertificateContext {}
+
+impl fmt::Debug for CertificateContext {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CertificateContext(..)")
+    }
+}
+
+impl Drop for CertificateContext {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CertFreeCertificateContext(Some(self.0));
+        }
+    }
+}
+
+struct AcquiredKey {
+    handle: NCRYPT_KEY_HANDLE,
+    must_free: bool,
+}
+
+impl AcquiredKey {
+    fn implementation_type(&self) -> Result<u32> {
+        let provider: NCRYPT_PROV_HANDLE = unsafe {
+            ncrypt_property(
+                NCRYPT_HANDLE(self.handle.0),
+                NCRYPT_PROVIDER_HANDLE_PROPERTY,
+            )
+        }
+        .context("Reading the CNG provider handle failed")?;
+        let implementation_type =
+            unsafe { ncrypt_property(NCRYPT_HANDLE(provider.0), NCRYPT_IMPL_TYPE_PROPERTY) }
+                .context("Reading the CNG implementation type failed")?;
+
+        Ok(implementation_type)
+    }
+}
+
+impl Drop for AcquiredKey {
+    fn drop(&mut self) {
+        if self.must_free {
+            unsafe {
+                let _ = NCryptFreeObject(NCRYPT_HANDLE(self.handle.0));
+            }
+        }
+    }
+}
+
+/// Opens the certificate's CNG key without ever showing UI.
+///
+/// The Tunnel service runs without a desktop, so a key that insists on a confirmation prompt is
+/// reported as [`SigningError::AccessDenied`] rather than hanging the connection.
+unsafe fn acquire_key(context: *mut CERT_CONTEXT) -> windows_core::Result<AcquiredKey> {
+    let mut handle = HCRYPTPROV_OR_NCRYPT_KEY_HANDLE::default();
+    let mut key_spec = CERT_KEY_SPEC::default();
+    let mut must_free = windows_core::BOOL(0);
+    unsafe {
+        CryptAcquireCertificatePrivateKey(
+            context,
+            CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG | CRYPT_ACQUIRE_SILENT_FLAG,
+            None,
+            &mut handle,
+            Some(&mut key_spec),
+            Some(&mut must_free),
+        )
+    }?;
+
+    Ok(AcquiredKey {
+        handle: NCRYPT_KEY_HANDLE(handle.0),
+        must_free: must_free.as_bool(),
+    })
+}
+
+unsafe fn private_key_metadata(
+    context: *const CERT_CONTEXT,
+    key: &AcquiredKey,
+) -> PrivateKeyMetadata {
+    let mut errors = Vec::new();
+    let (provider, container) = match unsafe { certificate_key_provider_info(context) } {
+        Ok(info) => info,
+        Err(error) => {
+            errors.push(format!("Provider: {error:#}"));
+            (None, None)
+        }
+    };
+    let implementation_type = match key.implementation_type() {
+        Ok(value) => Some(value),
+        Err(error) => {
+            errors.push(format!("Implementation type: {error:#}"));
+            None
+        }
+    };
+
+    PrivateKeyMetadata {
+        storage: classify_private_key_storage(provider.as_deref(), implementation_type),
+        provider,
+        container,
+        errors,
+    }
+}
+
+unsafe fn certificate_key_provider_info(
+    context: *const CERT_CONTEXT,
+) -> Result<(Option<String>, Option<String>)> {
+    let mut needed = 0;
+    unsafe {
+        CertGetCertificateContextProperty(context, CERT_KEY_PROV_INFO_PROP_ID, None, &mut needed)
+    }
+    .context("Reading the CNG provider metadata size failed")?;
+    anyhow::ensure!(
+        needed as usize >= std::mem::size_of::<CRYPT_KEY_PROV_INFO>(),
+        "Windows returned invalid CNG provider metadata"
+    );
+
+    // The property contains a CRYPT_KEY_PROV_INFO followed by referenced strings,
+    // so allocate in pointer-sized units to preserve the struct's alignment.
+    let words = (needed as usize).div_ceil(std::mem::size_of::<usize>());
+    let mut buffer = vec![0usize; words];
+    unsafe {
+        CertGetCertificateContextProperty(
+            context,
+            CERT_KEY_PROV_INFO_PROP_ID,
+            Some(buffer.as_mut_ptr().cast()),
+            &mut needed,
+        )
+    }
+    .context("Reading the CNG provider metadata failed")?;
+
+    let info = unsafe { &*buffer.as_ptr().cast::<CRYPT_KEY_PROV_INFO>() };
+    let provider = unsafe { wide_string(info.pwszProvName) };
+    let container = unsafe { wide_string(info.pwszContainerName) };
+
+    Ok((provider, container))
+}
+
+unsafe fn ncrypt_property<T: Default>(
+    handle: NCRYPT_HANDLE,
+    property: windows_core::PCWSTR,
+) -> Result<T> {
+    let mut value = T::default();
+    let output = unsafe {
+        slice::from_raw_parts_mut((&raw mut value).cast::<u8>(), std::mem::size_of::<T>())
+    };
+    let mut written = 0;
+    unsafe {
+        NCryptGetProperty(
+            handle,
+            property,
+            Some(output),
+            &mut written,
+            Default::default(),
+        )
+    }
+    .context("NCryptGetProperty failed")?;
+    anyhow::ensure!(
+        written as usize == std::mem::size_of::<T>(),
+        "NCryptGetProperty returned {written} bytes, expected {}",
+        std::mem::size_of::<T>()
+    );
+
+    Ok(value)
+}
+
+unsafe fn wide_string(value: windows_core::PWSTR) -> Option<String> {
+    if value.is_null() {
+        return None;
+    }
+
+    unsafe { value.to_string().ok() }
+}
+
+fn classify_private_key_storage(
+    provider: Option<&str>,
+    implementation_type: Option<u32>,
+) -> &'static str {
+    if provider
+        .is_some_and(|provider| provider.eq_ignore_ascii_case("Microsoft Platform Crypto Provider"))
+    {
+        return "TPM (hardware-backed keystore)";
+    }
+    if implementation_type.is_some_and(|value| value & NCRYPT_IMPL_HARDWARE_FLAG != 0) {
+        return "Hardware-backed keystore";
+    }
+    if provider.is_some_and(|provider| {
+        provider.eq_ignore_ascii_case("Microsoft Software Key Storage Provider")
+    }) || implementation_type.is_some_and(|value| value & NCRYPT_IMPL_SOFTWARE_FLAG != 0)
+    {
+        return "Software keystore";
+    }
+
+    "CNG provider (hardware backing unknown)"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_windows_key_storage() {
+        assert_eq!(
+            classify_private_key_storage(Some("Microsoft Platform Crypto Provider"), None),
+            "TPM (hardware-backed keystore)"
+        );
+        assert_eq!(
+            classify_private_key_storage(Some("Microsoft Software Key Storage Provider"), None),
+            "Software keystore"
+        );
+        assert_eq!(
+            classify_private_key_storage(Some("Third-party KSP"), Some(NCRYPT_IMPL_HARDWARE_FLAG)),
+            "Hardware-backed keystore"
+        );
+    }
+
+    #[test]
+    fn names_the_cause_behind_a_cng_failure() {
+        assert!(matches!(
+            classify_signing_error(NTE_NO_KEY.into()),
+            SigningError::KeyUnavailable(_)
+        ));
+        assert!(matches!(
+            classify_signing_error(NTE_SILENT_CONTEXT.into()),
+            SigningError::AccessDenied(_)
+        ));
+        assert!(matches!(
+            classify_signing_error(SCARD_W_CANCELLED_BY_USER.into()),
+            SigningError::AccessDenied(_)
+        ));
+        assert!(matches!(
+            classify_signing_error(windows::Win32::Foundation::E_UNEXPECTED.into()),
+            SigningError::Keystore(_)
+        ));
+    }
+
+    #[test]
+    fn ecdsa_signature_is_der_encoded() {
+        let mut raw = vec![0; 64];
+        raw[31] = 1;
+        raw[63] = 2;
+
+        assert_eq!(
+            der_encode_ecdsa_signature(&raw).expect("signature should encode"),
+            vec![0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02]
+        );
+    }
+}

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -1,5 +1,8 @@
 //! X.509 client identities from the Windows certificate stores, signed through CNG.
 
+#[cfg(test)]
+mod tests;
+
 use std::{ffi::c_void, fmt, ptr, slice, sync::Arc, time::SystemTime};
 
 use anyhow::{Context as _, Result, bail};
@@ -885,57 +888,4 @@ fn classify_private_key_storage(
     }
 
     "CNG provider (hardware backing unknown)"
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn classifies_windows_key_storage() {
-        assert_eq!(
-            classify_private_key_storage(Some("Microsoft Platform Crypto Provider"), None),
-            "TPM (hardware-backed keystore)"
-        );
-        assert_eq!(
-            classify_private_key_storage(Some("Microsoft Software Key Storage Provider"), None),
-            "Software keystore"
-        );
-        assert_eq!(
-            classify_private_key_storage(Some("Third-party KSP"), Some(NCRYPT_IMPL_HARDWARE_FLAG)),
-            "Hardware-backed keystore"
-        );
-    }
-
-    #[test]
-    fn names_the_cause_behind_a_cng_failure() {
-        assert!(matches!(
-            classify_signing_error(NTE_NO_KEY.into()),
-            SigningError::KeyUnavailable(_)
-        ));
-        assert!(matches!(
-            classify_signing_error(NTE_SILENT_CONTEXT.into()),
-            SigningError::AccessDenied(_)
-        ));
-        assert!(matches!(
-            classify_signing_error(SCARD_W_CANCELLED_BY_USER.into()),
-            SigningError::AccessDenied(_)
-        ));
-        assert!(matches!(
-            classify_signing_error(windows::Win32::Foundation::E_UNEXPECTED.into()),
-            SigningError::Keystore(_)
-        ));
-    }
-
-    #[test]
-    fn ecdsa_signature_is_der_encoded() {
-        let mut raw = vec![0; 64];
-        raw[31] = 1;
-        raw[63] = 2;
-
-        assert_eq!(
-            der_encode_ecdsa_signature(&raw).expect("signature should encode"),
-            vec![0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02]
-        );
-    }
 }

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -34,9 +34,9 @@ use x509_claims::{ParsedCertificate, parse_certificate};
 use x509_credential::SigningError;
 
 use crate::{
-    CandidateCertificate, DetailField, DetailSection, Identity, Problem, Status, UnreadableStore,
-    UnusableCause, UnusableCertificate, failed_field, join, selected_certificate, sign,
-    unusable_certificates,
+    CandidateCertificate, ClientIdentity, DetailField, DetailSection, Identity, Problem, Status,
+    UnreadableStore, UnusableCause, UnusableCertificate, failed_field, join, selected_certificate,
+    sign, unusable_certificates,
 };
 
 /// The store MDM-provisioned identities land in.
@@ -90,7 +90,15 @@ pub(crate) fn status(subject_cn: &str) -> Result<Status> {
         .chain(store_problem)
         .collect();
 
-    Ok(Status { problems, sections })
+    let identity = selected
+        .map(|index| certificates[index].metadata.identity())
+        .unwrap_or(ClientIdentity::Absent);
+
+    Ok(Status {
+        problems,
+        sections,
+        identity,
+    })
 }
 
 pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>> {

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -17,18 +17,15 @@ use windows::{
         Security::Cryptography::{
             BCRYPT_PKCS1_PADDING_INFO, BCRYPT_PSS_PADDING_INFO, BCRYPT_SHA256_ALGORITHM,
             BCRYPT_SHA384_ALGORITHM, BCRYPT_SHA512_ALGORITHM, CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL,
-            CERT_CHAIN_DISABLE_AIA, CERT_CHAIN_PARA, CERT_CONTEXT, CERT_KEY_PROV_INFO_PROP_ID,
-            CERT_KEY_SPEC, CERT_OPEN_STORE_FLAGS, CERT_QUERY_ENCODING_TYPE,
-            CERT_STORE_OPEN_EXISTING_FLAG, CERT_STORE_PROV_SYSTEM_W, CERT_STORE_READONLY_FLAG,
-            CERT_SYSTEM_STORE_LOCAL_MACHINE, CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG,
-            CRYPT_ACQUIRE_SILENT_FLAG, CRYPT_KEY_PROV_INFO, CertCloseStore,
+            CERT_CHAIN_DISABLE_AIA, CERT_CHAIN_PARA, CERT_CONTEXT, CERT_KEY_SPEC,
+            CERT_OPEN_STORE_FLAGS, CERT_QUERY_ENCODING_TYPE, CERT_STORE_OPEN_EXISTING_FLAG,
+            CERT_STORE_PROV_SYSTEM_W, CERT_STORE_READONLY_FLAG, CERT_SYSTEM_STORE_LOCAL_MACHINE,
+            CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG, CRYPT_ACQUIRE_SILENT_FLAG, CertCloseStore,
             CertDuplicateCertificateContext, CertEnumCertificatesInStore, CertFreeCertificateChain,
-            CertFreeCertificateContext, CertGetCertificateChain, CertGetCertificateContextProperty,
-            CertOpenStore, CryptAcquireCertificatePrivateKey, HCERTSTORE,
-            HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, NCRYPT_FLAGS, NCRYPT_HANDLE,
-            NCRYPT_IMPL_HARDWARE_FLAG, NCRYPT_IMPL_SOFTWARE_FLAG, NCRYPT_IMPL_TYPE_PROPERTY,
-            NCRYPT_KEY_HANDLE, NCRYPT_PAD_PKCS1_FLAG, NCRYPT_PAD_PSS_FLAG, NCRYPT_PROV_HANDLE,
-            NCRYPT_PROVIDER_HANDLE_PROPERTY, NCryptFreeObject, NCryptGetProperty, NCryptSignHash,
+            CertFreeCertificateContext, CertGetCertificateChain, CertOpenStore,
+            CryptAcquireCertificatePrivateKey, HCERTSTORE, HCRYPTPROV_OR_NCRYPT_KEY_HANDLE,
+            NCRYPT_FLAGS, NCRYPT_HANDLE, NCRYPT_KEY_HANDLE, NCRYPT_PAD_PKCS1_FLAG,
+            NCRYPT_PAD_PSS_FLAG, NCryptFreeObject, NCryptSignHash,
         },
     },
     core::w,
@@ -37,8 +34,8 @@ use x509_claims::{ParsedCertificate, parse_certificate};
 use x509_credential::SigningError;
 
 use crate::{
-    CandidateCertificate, DetailField, DetailSection, Identity, Status, absent_field, field,
-    invalid_field, selected_certificate, sign, unusable_reasons,
+    CandidateCertificate, DetailField, DetailSection, Identity, Status, invalid_field,
+    selected_certificate, sign, unusable_reasons,
 };
 
 /// The store MDM-provisioned identities land in.
@@ -352,15 +349,7 @@ struct Certificate {
     chain_error: Option<String>,
     metadata: ParsedCertificate,
     key_error: Option<String>,
-    key_metadata: Option<PrivateKeyMetadata>,
     usable: bool,
-}
-
-struct PrivateKeyMetadata {
-    provider: Option<String>,
-    container: Option<String>,
-    storage: &'static str,
-    errors: Vec<String>,
 }
 
 impl Certificate {
@@ -372,30 +361,9 @@ impl Certificate {
             .map(DetailField::from)
             .collect::<Vec<_>>();
 
-        fields.push(field("Store", self.store));
         if let Some(error) = &self.key_error {
             fields.push(invalid_field("Private Key Error", error));
         }
-        if let Some(metadata) = &self.key_metadata {
-            fields.push(match metadata.provider.as_deref() {
-                Some(provider) => field("Private Key Provider", provider),
-                None => absent_field("Private Key Provider"),
-            });
-            fields.push(field("Private Key Storage", metadata.storage));
-            if let Some(container) = &metadata.container {
-                fields.push(field("Private Key Container", container));
-            }
-            if !metadata.errors.is_empty() {
-                fields.push(invalid_field(
-                    "Private Key Metadata Errors",
-                    metadata.errors.join("\n"),
-                ));
-            }
-        }
-        fields.push(field(
-            "Certificate Chain Count",
-            self.chain.len().to_string(),
-        ));
         if let Some(error) = &self.chain_error {
             fields.push(invalid_field("Certificate Chain Error", error));
         }
@@ -490,13 +458,9 @@ unsafe fn enumerate_store(
             continue;
         }
 
-        let (key_available, key_error, key_metadata) = match unsafe { acquire_key(context) } {
-            Ok(key) => (
-                true,
-                None,
-                Some(unsafe { private_key_metadata(context, &key) }),
-            ),
-            Err(error) => (false, Some(error.to_string()), None),
+        let (key_available, key_error) = match unsafe { acquire_key(context) } {
+            Ok(_) => (true, None),
+            Err(error) => (false, Some(error.to_string())),
         };
         let (chain, chain_error) = match unsafe { certificate_chain(context) } {
             Ok(chain) => (chain, None),
@@ -526,7 +490,6 @@ unsafe fn enumerate_store(
             usable: metadata.is_usable(subject_cn) && key_available,
             metadata,
             key_error,
-            key_metadata,
         });
     }
 
@@ -653,23 +616,6 @@ struct AcquiredKey {
     must_free: bool,
 }
 
-impl AcquiredKey {
-    fn implementation_type(&self) -> Result<u32> {
-        let provider: NCRYPT_PROV_HANDLE = unsafe {
-            ncrypt_property(
-                NCRYPT_HANDLE(self.handle.0),
-                NCRYPT_PROVIDER_HANDLE_PROPERTY,
-            )
-        }
-        .context("Reading the CNG provider handle failed")?;
-        let implementation_type =
-            unsafe { ncrypt_property(NCRYPT_HANDLE(provider.0), NCRYPT_IMPL_TYPE_PROPERTY) }
-                .context("Reading the CNG implementation type failed")?;
-
-        Ok(implementation_type)
-    }
-}
-
 impl Drop for AcquiredKey {
     fn drop(&mut self) {
         if self.must_free {
@@ -703,124 +649,4 @@ unsafe fn acquire_key(context: *mut CERT_CONTEXT) -> windows_core::Result<Acquir
         handle: NCRYPT_KEY_HANDLE(handle.0),
         must_free: must_free.as_bool(),
     })
-}
-
-unsafe fn private_key_metadata(
-    context: *const CERT_CONTEXT,
-    key: &AcquiredKey,
-) -> PrivateKeyMetadata {
-    let mut errors = Vec::new();
-    let (provider, container) = match unsafe { certificate_key_provider_info(context) } {
-        Ok(info) => info,
-        Err(error) => {
-            errors.push(format!("Provider: {error:#}"));
-            (None, None)
-        }
-    };
-    let implementation_type = match key.implementation_type() {
-        Ok(value) => Some(value),
-        Err(error) => {
-            errors.push(format!("Implementation type: {error:#}"));
-            None
-        }
-    };
-
-    PrivateKeyMetadata {
-        storage: classify_private_key_storage(provider.as_deref(), implementation_type),
-        provider,
-        container,
-        errors,
-    }
-}
-
-unsafe fn certificate_key_provider_info(
-    context: *const CERT_CONTEXT,
-) -> Result<(Option<String>, Option<String>)> {
-    let mut needed = 0;
-    unsafe {
-        CertGetCertificateContextProperty(context, CERT_KEY_PROV_INFO_PROP_ID, None, &mut needed)
-    }
-    .context("Reading the CNG provider metadata size failed")?;
-    anyhow::ensure!(
-        needed as usize >= std::mem::size_of::<CRYPT_KEY_PROV_INFO>(),
-        "Windows returned invalid CNG provider metadata"
-    );
-
-    // The property contains a CRYPT_KEY_PROV_INFO followed by referenced strings,
-    // so allocate in pointer-sized units to preserve the struct's alignment.
-    let words = (needed as usize).div_ceil(std::mem::size_of::<usize>());
-    let mut buffer = vec![0usize; words];
-    unsafe {
-        CertGetCertificateContextProperty(
-            context,
-            CERT_KEY_PROV_INFO_PROP_ID,
-            Some(buffer.as_mut_ptr().cast()),
-            &mut needed,
-        )
-    }
-    .context("Reading the CNG provider metadata failed")?;
-
-    let info = unsafe { &*buffer.as_ptr().cast::<CRYPT_KEY_PROV_INFO>() };
-    let provider = unsafe { wide_string(info.pwszProvName) };
-    let container = unsafe { wide_string(info.pwszContainerName) };
-
-    Ok((provider, container))
-}
-
-unsafe fn ncrypt_property<T: Default>(
-    handle: NCRYPT_HANDLE,
-    property: windows_core::PCWSTR,
-) -> Result<T> {
-    let mut value = T::default();
-    let output = unsafe {
-        slice::from_raw_parts_mut((&raw mut value).cast::<u8>(), std::mem::size_of::<T>())
-    };
-    let mut written = 0;
-    unsafe {
-        NCryptGetProperty(
-            handle,
-            property,
-            Some(output),
-            &mut written,
-            Default::default(),
-        )
-    }
-    .context("NCryptGetProperty failed")?;
-    anyhow::ensure!(
-        written as usize == std::mem::size_of::<T>(),
-        "NCryptGetProperty returned {written} bytes, expected {}",
-        std::mem::size_of::<T>()
-    );
-
-    Ok(value)
-}
-
-unsafe fn wide_string(value: windows_core::PWSTR) -> Option<String> {
-    if value.is_null() {
-        return None;
-    }
-
-    unsafe { value.to_string().ok() }
-}
-
-fn classify_private_key_storage(
-    provider: Option<&str>,
-    implementation_type: Option<u32>,
-) -> &'static str {
-    if provider
-        .is_some_and(|provider| provider.eq_ignore_ascii_case("Microsoft Platform Crypto Provider"))
-    {
-        return "TPM (hardware-backed keystore)";
-    }
-    if implementation_type.is_some_and(|value| value & NCRYPT_IMPL_HARDWARE_FLAG != 0) {
-        return "Hardware-backed keystore";
-    }
-    if provider.is_some_and(|provider| {
-        provider.eq_ignore_ascii_case("Microsoft Software Key Storage Provider")
-    }) || implementation_type.is_some_and(|value| value & NCRYPT_IMPL_SOFTWARE_FLAG != 0)
-    {
-        return "Software keystore";
-    }
-
-    "CNG provider (hardware backing unknown)"
 }

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -455,19 +455,24 @@ struct PrivateKeyMetadata {
 
 impl Certificate {
     fn detail_fields(&self) -> Vec<DetailField> {
-        let mut fields = vec![
-            field("Store", self.store),
-            if self.key_available {
-                field("Private Key Access", "Available through Windows CNG")
-            } else {
-                absent_field("Private Key Access")
-            },
-            if self.usable {
-                field("Usable With Its Private Key", "Yes")
-            } else {
-                invalid_field("Usable With Its Private Key", "No")
-            },
-        ];
+        let mut fields = self
+            .metadata
+            .detail_fields()
+            .into_iter()
+            .map(DetailField::from)
+            .collect::<Vec<_>>();
+
+        fields.push(field("Store", self.store));
+        fields.push(if self.key_available {
+            field("Private Key Access", "Available through Windows CNG")
+        } else {
+            absent_field("Private Key Access")
+        });
+        fields.push(if self.usable {
+            field("Usable With Its Private Key", "Yes")
+        } else {
+            invalid_field("Usable With Its Private Key", "No")
+        });
         if let Some(error) = &self.key_error {
             fields.push(invalid_field("Private Key Error", error));
         }
@@ -494,12 +499,6 @@ impl Certificate {
         if let Some(error) = &self.chain_error {
             fields.push(invalid_field("Certificate Chain Error", error));
         }
-        fields.extend(
-            self.metadata
-                .detail_fields()
-                .into_iter()
-                .map(DetailField::from),
-        );
 
         fields
     }

--- a/rust/libs/x509-keystore/src/windows/mint-certificate.ps1
+++ b/rust/libs/x509-keystore/src/windows/mint-certificate.ps1
@@ -1,0 +1,49 @@
+<#
+.SYNOPSIS
+    Creates a self-signed client identity certificate in the CurrentUser\My store.
+
+.DESCRIPTION
+    Writes the thumbprint of the new certificate on the first line of standard output and its
+    Base64-encoded DER on the second.
+#>
+
+param(
+    [Parameter(Mandatory)]
+    [string]$SubjectCn,
+
+    [Parameter(Mandatory)]
+    [ValidateSet('Rsa', 'EcdsaP256')]
+    [string]$Algorithm
+)
+
+$ErrorActionPreference = 'Stop'
+
+# `2.5.29.37` is the Extended Key Usage extension and `1.3.6.1.5.5.7.3.2` within it is clientAuth.
+$parameters = @{
+    Type              = 'Custom'
+    Subject           = "CN=$SubjectCn"
+    CertStoreLocation = 'Cert:\CurrentUser\My'
+    Provider          = 'Microsoft Software Key Storage Provider'
+    KeyExportPolicy   = 'NonExportable'
+    KeyUsage          = 'DigitalSignature'
+    TextExtension     = @('2.5.29.37={text}1.3.6.1.5.5.7.3.2')
+}
+
+switch ($Algorithm) {
+    'Rsa' {
+        $parameters.KeyAlgorithm = 'RSA'
+        $parameters.KeyLength = 2048
+    }
+    'EcdsaP256' {
+        $parameters.KeyAlgorithm = 'ECDSA_nistP256'
+        # `CurveName` makes the certificate name its curve by OID instead of spelling out the curve
+        # parameters, which is the encoding `x509-claims` reads the key algorithm from.
+        $parameters.CurveExport = 'CurveName'
+    }
+}
+
+$certificate = New-SelfSignedCertificate @parameters
+
+# `[Console]::Out` bypasses PowerShell's formatter, which would wrap the long Base64 line.
+[Console]::Out.WriteLine($certificate.Thumbprint)
+[Console]::Out.WriteLine([Convert]::ToBase64String($certificate.RawData))

--- a/rust/libs/x509-keystore/src/windows/mint-certificate.ps1
+++ b/rust/libs/x509-keystore/src/windows/mint-certificate.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Creates a self-signed client identity certificate in the CurrentUser\My store.
+    Creates a self-signed client identity certificate in the LocalMachine\My store.
 
 .DESCRIPTION
     Writes the thumbprint of the new certificate on the first line of standard output and its
@@ -22,7 +22,7 @@ $ErrorActionPreference = 'Stop'
 $parameters = @{
     Type              = 'Custom'
     Subject           = "CN=$SubjectCn"
-    CertStoreLocation = 'Cert:\CurrentUser\My'
+    CertStoreLocation = 'Cert:\LocalMachine\My'
     Provider          = 'Microsoft Software Key Storage Provider'
     KeyExportPolicy   = 'NonExportable'
     KeyUsage          = 'DigitalSignature'

--- a/rust/libs/x509-keystore/src/windows/remove-certificate.ps1
+++ b/rust/libs/x509-keystore/src/windows/remove-certificate.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Removes a certificate and its private key from the CurrentUser\My store.
+    Removes a certificate and its private key from the LocalMachine\My store.
 #>
 
 param(
@@ -13,4 +13,4 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-Remove-Item -Path "Cert:\CurrentUser\My\$Thumbprint" -DeleteKey -Confirm:$false
+Remove-Item -Path "Cert:\LocalMachine\My\$Thumbprint" -DeleteKey -Confirm:$false

--- a/rust/libs/x509-keystore/src/windows/remove-certificate.ps1
+++ b/rust/libs/x509-keystore/src/windows/remove-certificate.ps1
@@ -1,0 +1,16 @@
+<#
+.SYNOPSIS
+    Removes a certificate and its private key from the CurrentUser\My store.
+#>
+
+param(
+    # The certificate provider ignores `-LiteralPath`, so only a thumbprint free of wildcards and
+    # path separators addresses exactly one certificate.
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[0-9A-Fa-f]+$')]
+    [string]$Thumbprint
+)
+
+$ErrorActionPreference = 'Stop'
+
+Remove-Item -Path "Cert:\CurrentUser\My\$Thumbprint" -DeleteKey -Confirm:$false

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -1,0 +1,345 @@
+//! Tests for the Windows certificate-store backend, including its calls into CNG.
+//!
+//! The tests that reach into CNG mint their own certificate in `CurrentUser\My`, which needs no
+//! administrator rights, and look it up by a subject CN that is unique to the test process. That
+//! keeps them off whatever real certificate the machine holds.
+
+use std::{
+    process::Command,
+    sync::{Mutex, MutexGuard, PoisonError},
+};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use ring::signature::{
+    ECDSA_P256_SHA256_ASN1, RSA_PKCS1_2048_8192_SHA256, RSA_PKCS1_2048_8192_SHA384,
+    RSA_PKCS1_2048_8192_SHA512, RSA_PSS_2048_8192_SHA256, RSA_PSS_2048_8192_SHA384,
+    RSA_PSS_2048_8192_SHA512, UnparsedPublicKey, VerificationAlgorithm,
+};
+use x509_parser::prelude::{FromDer as _, X509Certificate};
+
+use super::*;
+
+#[test]
+#[ignore = "Requires Windows and writes to the CurrentUser certificate store"]
+fn signs_with_the_cng_key_of_an_rsa_certificate() {
+    let _serialized = serialize_certificate_store_access();
+    let subject_cn = unique_subject_cn("rsa");
+    let minted = mint_certificate(&subject_cn, KeyAlgorithm::Rsa);
+
+    let identity = super::identity(&subject_cn)
+        .expect("the Windows certificate stores should be readable")
+        .expect("the minted certificate should be selected as the client identity");
+
+    assert_eq!(leaf_of(&identity), minted.der);
+    assert_eq!(identity.key.algorithm(), SignatureAlgorithm::RSA);
+    assert_signs_every_advertised_scheme(&identity, &minted.der);
+}
+
+#[test]
+#[ignore = "Requires Windows and writes to the CurrentUser certificate store"]
+fn signs_with_the_cng_key_of_an_ecdsa_certificate() {
+    let _serialized = serialize_certificate_store_access();
+    let subject_cn = unique_subject_cn("ecdsa");
+    let minted = mint_certificate(&subject_cn, KeyAlgorithm::EcdsaP256);
+
+    let identity = super::identity(&subject_cn)
+        .expect("the Windows certificate stores should be readable")
+        .expect("the minted certificate should be selected as the client identity");
+
+    assert_eq!(leaf_of(&identity), minted.der);
+    assert_eq!(identity.key.algorithm(), SignatureAlgorithm::ECDSA);
+    assert_eq!(
+        identity.key.supported_schemes(),
+        vec![SignatureScheme::ECDSA_NISTP256_SHA256]
+    );
+    assert_signs_every_advertised_scheme(&identity, &minted.der);
+}
+
+#[test]
+#[ignore = "Requires Windows and writes to the CurrentUser certificate store"]
+fn describes_a_minted_certificate_in_the_diagnostics() {
+    let _serialized = serialize_certificate_store_access();
+    let subject_cn = unique_subject_cn("status");
+    let _minted = mint_certificate(&subject_cn, KeyAlgorithm::Rsa);
+
+    let status =
+        super::status(&subject_cn).expect("the Windows certificate stores should be readable");
+
+    assert_eq!(
+        status.summary,
+        "1 X.509 client identity certificate(s) are available for mutual TLS."
+    );
+    let section = status
+        .sections
+        .iter()
+        .find(|section| section.title == "Matching Certificate 1")
+        .expect("the diagnostics should describe the minted certificate");
+    assert_eq!(field_value(section, "Store"), Some("CurrentUser\\My"));
+    assert_eq!(
+        field_value(section, "Private Key Access"),
+        Some("Available through Windows CNG")
+    );
+    assert_eq!(
+        field_value(section, "Usable as a Client Identity"),
+        Some("Yes")
+    );
+    assert_eq!(
+        field_value(section, "Private Key Provider"),
+        Some("Microsoft Software Key Storage Provider")
+    );
+    assert_eq!(
+        field_value(section, "Private Key Storage"),
+        Some("Software keystore")
+    );
+    assert_eq!(
+        field_value(section, "Common Name"),
+        Some(subject_cn.as_str())
+    );
+    assert_eq!(field_value(section, "Private Key Error"), None);
+    assert_eq!(field_value(section, "Certificate Chain Error"), None);
+    assert_eq!(field_value(section, "Private Key Metadata Errors"), None);
+}
+
+#[test]
+#[ignore = "Requires Windows and reads the CurrentUser certificate store"]
+fn reports_no_identity_when_no_certificate_matches() {
+    let _serialized = serialize_certificate_store_access();
+    let subject_cn = unique_subject_cn("absent");
+
+    let identity =
+        super::identity(&subject_cn).expect("the Windows certificate stores should be readable");
+    let status =
+        super::status(&subject_cn).expect("the Windows certificate stores should be readable");
+
+    assert!(identity.is_none());
+    assert_eq!(
+        status.summary,
+        format!(
+            "No X.509 certificate with subject CN '{subject_cn}' is in the Windows certificate stores."
+        )
+    );
+}
+
+#[test]
+fn classifies_windows_key_storage() {
+    assert_eq!(
+        classify_private_key_storage(Some("Microsoft Platform Crypto Provider"), None),
+        "TPM (hardware-backed keystore)"
+    );
+    assert_eq!(
+        classify_private_key_storage(Some("Microsoft Software Key Storage Provider"), None),
+        "Software keystore"
+    );
+    assert_eq!(
+        classify_private_key_storage(Some("Third-party KSP"), Some(NCRYPT_IMPL_HARDWARE_FLAG)),
+        "Hardware-backed keystore"
+    );
+}
+
+#[test]
+fn names_the_cause_behind_a_cng_failure() {
+    assert!(matches!(
+        classify_signing_error(NTE_NO_KEY.into()),
+        SigningError::KeyUnavailable(_)
+    ));
+    assert!(matches!(
+        classify_signing_error(NTE_SILENT_CONTEXT.into()),
+        SigningError::AccessDenied(_)
+    ));
+    assert!(matches!(
+        classify_signing_error(SCARD_W_CANCELLED_BY_USER.into()),
+        SigningError::AccessDenied(_)
+    ));
+    assert!(matches!(
+        classify_signing_error(windows::Win32::Foundation::E_UNEXPECTED.into()),
+        SigningError::Keystore(_)
+    ));
+}
+
+#[test]
+fn ecdsa_signature_is_der_encoded() {
+    let mut raw = vec![0; 64];
+    raw[31] = 1;
+    raw[63] = 2;
+
+    assert_eq!(
+        der_encode_ecdsa_signature(&raw).expect("signature should encode"),
+        vec![0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02]
+    );
+}
+
+/// The bytes the tests ask CNG to sign, standing in for a TLS handshake transcript.
+const MESSAGE: &[u8] = b"x509-keystore Windows CNG signing test";
+
+/// Serialises the tests, which all add to and remove from the shared `CurrentUser\My` store.
+///
+/// [`enumerate_store`] walks that store while a concurrent test mints or removes its own
+/// certificate in it, which makes both what the walk observes and what PowerShell reports depend
+/// on the timing of the other test.
+static CERTIFICATE_STORE: Mutex<()> = Mutex::new(());
+
+/// Takes the [`CERTIFICATE_STORE`] lock for the rest of the current test.
+///
+/// Poisoning is ignored on purpose: one failing test would otherwise fail the others rather than
+/// let them report their own result.
+fn serialize_certificate_store_access() -> MutexGuard<'static, ()> {
+    CERTIFICATE_STORE
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Returns a subject CN that no other test and no real certificate uses.
+fn unique_subject_cn(suffix: &str) -> String {
+    format!("dev.firezone.test-{}-{suffix}", std::process::id())
+}
+
+/// Returns the end-entity certificate the backend put first in the chain.
+fn leaf_of(identity: &Identity) -> Vec<u8> {
+    let leaf = identity
+        .chain
+        .first()
+        .expect("the identity should carry a certificate chain");
+
+    leaf.to_vec()
+}
+
+/// Returns the value of the diagnostics row labelled `label`, if the section has one.
+fn field_value<'a>(section: &'a DetailSection, label: &str) -> Option<&'a str> {
+    let field = section.fields.iter().find(|field| field.label == label)?;
+
+    Some(field.value.as_str())
+}
+
+/// Signs [`MESSAGE`] with every scheme the key advertises and verifies each signature against the
+/// public key of the certificate it belongs to.
+///
+/// Verifying is what separates a signature that is merely well-formed from one a TLS peer accepts:
+/// the padding mode, the hash and, for ECDSA, the DER encoding all have to match the scheme rustls
+/// asked for. Covering every advertised scheme holds the backend to what it promised rustls it
+/// could do.
+fn assert_signs_every_advertised_scheme(identity: &Identity, certificate: &[u8]) {
+    let (_, parsed) =
+        X509Certificate::from_der(certificate).expect("the minted certificate should parse");
+    let public_key = parsed.public_key().subject_public_key.data.as_ref();
+
+    for scheme in identity.key.supported_schemes() {
+        let signature = identity
+            .key
+            .sign(scheme, MESSAGE)
+            .unwrap_or_else(|error| panic!("CNG should sign with {scheme:?}: {error}"));
+
+        UnparsedPublicKey::new(verification_algorithm(scheme), public_key)
+            .verify(MESSAGE, &signature)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "the {scheme:?} signature should verify against the certificate's public key"
+                )
+            });
+    }
+}
+
+/// Returns the `ring` algorithm that verifies signatures made with `scheme`.
+#[expect(
+    clippy::wildcard_enum_match_arm,
+    reason = "the tests only ever ask for a scheme `signature_schemes` advertises"
+)]
+fn verification_algorithm(scheme: SignatureScheme) -> &'static dyn VerificationAlgorithm {
+    match scheme {
+        SignatureScheme::RSA_PSS_SHA256 => &RSA_PSS_2048_8192_SHA256,
+        SignatureScheme::RSA_PSS_SHA384 => &RSA_PSS_2048_8192_SHA384,
+        SignatureScheme::RSA_PSS_SHA512 => &RSA_PSS_2048_8192_SHA512,
+        SignatureScheme::RSA_PKCS1_SHA256 => &RSA_PKCS1_2048_8192_SHA256,
+        SignatureScheme::RSA_PKCS1_SHA384 => &RSA_PKCS1_2048_8192_SHA384,
+        SignatureScheme::RSA_PKCS1_SHA512 => &RSA_PKCS1_2048_8192_SHA512,
+        SignatureScheme::ECDSA_NISTP256_SHA256 => &ECDSA_P256_SHA256_ASN1,
+        unexpected => panic!("no `ring` verifier for {unexpected:?}"),
+    }
+}
+
+/// A certificate in `CurrentUser\My` that is removed again when the test ends.
+struct MintedCertificate {
+    thumbprint: String,
+    der: Vec<u8>,
+}
+
+/// The key algorithms whose signatures take different paths through [`sign_with_certificate`].
+enum KeyAlgorithm {
+    Rsa,
+    EcdsaP256,
+}
+
+/// Creates a certificate for `subject_cn` that satisfies Firezone's rules for a client identity.
+fn mint_certificate(subject_cn: &str, algorithm: KeyAlgorithm) -> MintedCertificate {
+    let output = powershell(&format!(
+        "$ErrorActionPreference = 'Stop'; \
+         $certificate = New-SelfSignedCertificate \
+         -Type Custom \
+         -Subject 'CN={subject_cn}' \
+         -CertStoreLocation 'Cert:\\CurrentUser\\My' \
+         -Provider 'Microsoft Software Key Storage Provider' \
+         -KeyExportPolicy NonExportable \
+         -KeyUsage DigitalSignature \
+         -TextExtension @('2.5.29.37={{text}}1.3.6.1.5.5.7.3.2') \
+         {}; \
+         [Console]::Out.WriteLine($certificate.Thumbprint); \
+         [Console]::Out.WriteLine([Convert]::ToBase64String($certificate.RawData))",
+        algorithm.parameters()
+    ))
+    .unwrap_or_else(|error| panic!("PowerShell should mint a certificate: {error:#}"));
+
+    let mut lines = output.lines();
+    let thumbprint = lines
+        .next()
+        .expect("New-SelfSignedCertificate should report a thumbprint")
+        .trim()
+        .to_owned();
+    let der = BASE64_STANDARD
+        .decode(
+            lines
+                .next()
+                .expect("New-SelfSignedCertificate should report the certificate")
+                .trim(),
+        )
+        .expect("the certificate should be Base64");
+
+    MintedCertificate { thumbprint, der }
+}
+
+impl KeyAlgorithm {
+    /// Returns the `New-SelfSignedCertificate` arguments that select this algorithm.
+    ///
+    /// `CurveExport CurveName` makes the certificate name its curve by OID instead of spelling out
+    /// the curve parameters, which is the encoding `x509-claims` reads the key algorithm from.
+    fn parameters(&self) -> &'static str {
+        match self {
+            Self::Rsa => "-KeyAlgorithm RSA -KeyLength 2048",
+            Self::EcdsaP256 => "-KeyAlgorithm ECDSA_nistP256 -CurveExport CurveName",
+        }
+    }
+}
+
+impl Drop for MintedCertificate {
+    fn drop(&mut self) {
+        let _ = powershell(&format!(
+            "Remove-Item -Path 'Cert:\\CurrentUser\\My\\{}' -DeleteKey -Confirm:$false",
+            self.thumbprint
+        ));
+    }
+}
+
+/// Runs `script` through Windows PowerShell and returns what it wrote to standard output.
+fn powershell(script: &str) -> Result<String> {
+    let output = Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", script])
+        .output()
+        .context("Failed to run PowerShell")?;
+    anyhow::ensure!(
+        output.status.success(),
+        "PowerShell exited with {}: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+
+    Ok(stdout)
+}

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -20,7 +20,7 @@ use x509_parser::prelude::{FromDer as _, X509Certificate};
 use super::*;
 
 #[test]
-#[ignore = "Requires Windows and writes to the CurrentUser certificate store"]
+#[ignore = "Writes to the CurrentUser certificate store"]
 fn signs_with_the_cng_key_of_an_rsa_certificate() {
     let _serialized = serialize_certificate_store_access();
     let subject_cn = unique_subject_cn("rsa");
@@ -36,7 +36,7 @@ fn signs_with_the_cng_key_of_an_rsa_certificate() {
 }
 
 #[test]
-#[ignore = "Requires Windows and writes to the CurrentUser certificate store"]
+#[ignore = "Writes to the CurrentUser certificate store"]
 fn signs_with_the_cng_key_of_an_ecdsa_certificate() {
     let _serialized = serialize_certificate_store_access();
     let subject_cn = unique_subject_cn("ecdsa");
@@ -56,7 +56,7 @@ fn signs_with_the_cng_key_of_an_ecdsa_certificate() {
 }
 
 #[test]
-#[ignore = "Requires Windows and writes to the CurrentUser certificate store"]
+#[ignore = "Writes to the CurrentUser certificate store"]
 fn describes_a_minted_certificate_in_the_diagnostics() {
     let _serialized = serialize_certificate_store_access();
     let subject_cn = unique_subject_cn("status");
@@ -101,7 +101,7 @@ fn describes_a_minted_certificate_in_the_diagnostics() {
 }
 
 #[test]
-#[ignore = "Requires Windows and reads the CurrentUser certificate store"]
+#[ignore = "Reads the CurrentUser certificate store"]
 fn reports_no_identity_when_no_certificate_matches() {
     let _serialized = serialize_certificate_store_access();
     let subject_cn = unique_subject_cn("absent");

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -67,11 +67,7 @@ fn describes_a_minted_certificate_in_the_diagnostics() {
     let status =
         super::status(&subject_cn).expect("the Windows certificate stores should be readable");
 
-    assert_eq!(status.severity, StatusSeverity::Ok);
-    assert_eq!(
-        status.summary,
-        "An X.509 client identity is available for mutual TLS."
-    );
+    assert_eq!(status.warning, None);
     let section = status
         .sections
         .iter()
@@ -119,12 +115,11 @@ fn reports_no_identity_when_no_certificate_matches() {
         super::status(&subject_cn).expect("the Windows certificate stores should be readable");
 
     assert!(identity.is_none());
-    assert_eq!(status.severity, StatusSeverity::Warning);
     assert_eq!(
-        status.summary,
-        format!(
+        status.warning,
+        Some(format!(
             "No X.509 certificate with subject CN '{subject_cn}' is in the Windows certificate stores."
-        )
+        ))
     );
 }
 

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -20,6 +20,7 @@ use rustls::SignatureAlgorithm;
 use x509_parser::prelude::{FromDer as _, X509Certificate};
 
 use super::*;
+use crate::DetailSection;
 
 #[test]
 #[ignore = "Writes to the LocalMachine certificate store"]
@@ -77,7 +78,8 @@ fn describes_a_minted_certificate_in_the_diagnostics() {
         field_value(section, "Common Name"),
         Some(subject_cn.as_str())
     );
-    assert_eq!(field_value(section, "Private Key Error"), None);
+    // Only a certificate we cannot present carries a Private Key row.
+    assert!(!section.fields.iter().any(|row| row.label == "Private Key"));
     assert_eq!(field_value(section, "Certificate Chain Error"), None);
     // The diagnostics describe the certificate, not where Windows keeps it.
     assert_eq!(field_value(section, "Store"), None);

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -20,7 +20,7 @@ use rustls::SignatureAlgorithm;
 use x509_parser::prelude::{FromDer as _, X509Certificate};
 
 use super::*;
-use crate::DetailSection;
+use crate::DetailField;
 
 #[test]
 #[ignore = "Writes to the LocalMachine certificate store"]
@@ -60,30 +60,24 @@ fn signs_with_the_cng_key_of_an_ecdsa_certificate() {
 
 #[test]
 #[ignore = "Writes to the LocalMachine certificate store"]
-fn describes_a_minted_certificate_in_the_diagnostics() {
+fn describes_the_minted_certificate_it_loads() {
     let _serialized = serialize_certificate_store_access();
-    let subject_cn = unique_subject_cn("status");
+    let subject_cn = unique_subject_cn("describe");
     let _minted = mint_certificate(&subject_cn, KeyAlgorithm::Rsa);
 
-    let status =
-        super::status(&subject_cn).expect("the Windows certificate stores should be readable");
+    let identity = super::identity(&subject_cn)
+        .expect("the Windows certificate stores should be readable")
+        .expect("the minted certificate should be selected as the client identity");
 
-    assert_eq!(status.problems, []);
-    let section = status
-        .sections
-        .iter()
-        .find(|section| section.title == "Certificate")
-        .expect("the diagnostics should describe the minted certificate");
+    let fields = identity.certificate.detail_fields();
     assert_eq!(
-        field_value(section, "Common Name"),
+        field_value(&fields, "Common Name"),
         Some(subject_cn.as_str())
     );
-    // Only a certificate we cannot present carries a Private Key row.
-    assert!(!section.fields.iter().any(|row| row.label == "Private Key"));
-    assert_eq!(field_value(section, "Certificate Chain Error"), None);
-    // The diagnostics describe the certificate, not where Windows keeps it.
-    assert_eq!(field_value(section, "Store"), None);
-    assert_eq!(field_value(section, "Private Key Provider"), None);
+    assert_eq!(
+        field_value(&fields, "Signing Algorithm"),
+        Some("SHA256withRSA")
+    );
 }
 
 #[test]
@@ -94,14 +88,8 @@ fn reports_no_identity_when_no_certificate_matches() {
 
     let identity =
         super::identity(&subject_cn).expect("the Windows certificate stores should be readable");
-    let status =
-        super::status(&subject_cn).expect("the Windows certificate stores should be readable");
 
     assert!(identity.is_none());
-    assert_eq!(
-        status.problems,
-        [Problem::NoWindowsCertificate { subject_cn }]
-    );
 }
 
 #[test]
@@ -159,9 +147,9 @@ fn leaf_of(identity: &Identity) -> Vec<u8> {
     leaf.to_vec()
 }
 
-/// Returns the value of the diagnostics row labelled `label`, if the section has one.
-fn field_value<'a>(section: &'a DetailSection, label: &str) -> Option<&'a str> {
-    let field = section.fields.iter().find(|field| field.label == label)?;
+/// Returns the value of the row labelled `label`, if the certificate's rows have one.
+fn field_value<'a>(fields: &'a [DetailField], label: &str) -> Option<&'a str> {
+    let field = fields.iter().find(|field| field.label == label)?;
 
     field.value.as_deref()
 }

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -73,26 +73,15 @@ fn describes_a_minted_certificate_in_the_diagnostics() {
         .iter()
         .find(|section| section.title == "Certificate")
         .expect("the diagnostics should describe the minted certificate");
-    assert_eq!(field_value(section, "Store"), Some("LocalMachine\\My"));
-    assert_eq!(
-        field_value(section, "Private Key Provider"),
-        Some("Microsoft Software Key Storage Provider")
-    );
-    assert_eq!(
-        field_value(section, "Private Key Storage"),
-        Some("Software keystore")
-    );
     assert_eq!(
         field_value(section, "Common Name"),
         Some(subject_cn.as_str())
     );
     assert_eq!(field_value(section, "Private Key Error"), None);
     assert_eq!(field_value(section, "Certificate Chain Error"), None);
-    assert_eq!(field_value(section, "Private Key Metadata Errors"), None);
-    assert!(
-        position(section, "SHA-256 Fingerprint") < position(section, "Store"),
-        "what the certificate says should read before where Windows keeps it"
-    );
+    // The diagnostics describe the certificate, not where Windows keeps it.
+    assert_eq!(field_value(section, "Store"), None);
+    assert_eq!(field_value(section, "Private Key Provider"), None);
 }
 
 #[test]
@@ -112,22 +101,6 @@ fn reports_no_identity_when_no_certificate_matches() {
         Some(format!(
             "No X.509 certificate with subject CN '{subject_cn}' is in the Windows certificate stores."
         ))
-    );
-}
-
-#[test]
-fn classifies_windows_key_storage() {
-    assert_eq!(
-        classify_private_key_storage(Some("Microsoft Platform Crypto Provider"), None),
-        "TPM (hardware-backed keystore)"
-    );
-    assert_eq!(
-        classify_private_key_storage(Some("Microsoft Software Key Storage Provider"), None),
-        "Software keystore"
-    );
-    assert_eq!(
-        classify_private_key_storage(Some("Third-party KSP"), Some(NCRYPT_IMPL_HARDWARE_FLAG)),
-        "Hardware-backed keystore"
     );
 }
 
@@ -184,15 +157,6 @@ fn leaf_of(identity: &Identity) -> Vec<u8> {
         .expect("the identity should carry a certificate chain");
 
     leaf.to_vec()
-}
-
-/// Returns the position of the diagnostics row labelled `label` in the section.
-fn position(section: &DetailSection, label: &str) -> usize {
-    section
-        .fields
-        .iter()
-        .position(|field| field.label == label)
-        .unwrap_or_else(|| panic!("the diagnostics should show {label}"))
 }
 
 /// Returns the value of the diagnostics row labelled `label`, if the section has one.

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -268,23 +268,19 @@ enum KeyAlgorithm {
     EcdsaP256,
 }
 
+/// The script that mints a certificate, resolved at compile time so the tests do not depend on the
+/// working directory.
+const MINT_CERTIFICATE_SCRIPT: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/src/windows/mint-certificate.ps1"
+);
+
 /// Creates a certificate for `subject_cn` that satisfies Firezone's rules for a client identity.
 fn mint_certificate(subject_cn: &str, algorithm: KeyAlgorithm) -> MintedCertificate {
-    let output = powershell(&format!(
-        "$ErrorActionPreference = 'Stop'; \
-         $certificate = New-SelfSignedCertificate \
-         -Type Custom \
-         -Subject 'CN={subject_cn}' \
-         -CertStoreLocation 'Cert:\\CurrentUser\\My' \
-         -Provider 'Microsoft Software Key Storage Provider' \
-         -KeyExportPolicy NonExportable \
-         -KeyUsage DigitalSignature \
-         -TextExtension @('2.5.29.37={{text}}1.3.6.1.5.5.7.3.2') \
-         {}; \
-         [Console]::Out.WriteLine($certificate.Thumbprint); \
-         [Console]::Out.WriteLine([Convert]::ToBase64String($certificate.RawData))",
-        algorithm.parameters()
-    ))
+    let output = powershell(
+        MINT_CERTIFICATE_SCRIPT,
+        &["-SubjectCn", subject_cn, "-Algorithm", algorithm.argument()],
+    )
     .unwrap_or_else(|error| panic!("PowerShell should mint a certificate: {error:#}"));
 
     let mut lines = output.lines();
@@ -306,31 +302,46 @@ fn mint_certificate(subject_cn: &str, algorithm: KeyAlgorithm) -> MintedCertific
 }
 
 impl KeyAlgorithm {
-    /// Returns the `New-SelfSignedCertificate` arguments that select this algorithm.
-    ///
-    /// `CurveExport CurveName` makes the certificate name its curve by OID instead of spelling out
-    /// the curve parameters, which is the encoding `x509-claims` reads the key algorithm from.
-    fn parameters(&self) -> &'static str {
+    /// Returns the value [`MINT_CERTIFICATE_SCRIPT`] expects for its `-Algorithm` parameter.
+    fn argument(&self) -> &'static str {
         match self {
-            Self::Rsa => "-KeyAlgorithm RSA -KeyLength 2048",
-            Self::EcdsaP256 => "-KeyAlgorithm ECDSA_nistP256 -CurveExport CurveName",
+            Self::Rsa => "Rsa",
+            Self::EcdsaP256 => "EcdsaP256",
         }
     }
 }
 
+/// The script that removes a minted certificate together with its private key.
+const REMOVE_CERTIFICATE_SCRIPT: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/src/windows/remove-certificate.ps1"
+);
+
 impl Drop for MintedCertificate {
     fn drop(&mut self) {
-        let _ = powershell(&format!(
-            "Remove-Item -Path 'Cert:\\CurrentUser\\My\\{}' -DeleteKey -Confirm:$false",
-            self.thumbprint
-        ));
+        let _ = powershell(
+            REMOVE_CERTIFICATE_SCRIPT,
+            &["-Thumbprint", &self.thumbprint],
+        );
     }
 }
 
-/// Runs `script` through Windows PowerShell and returns what it wrote to standard output.
-fn powershell(script: &str) -> Result<String> {
+/// Runs the PowerShell script at `script` with `arguments` and returns what it wrote to standard
+/// output.
+///
+/// The scripts ship unsigned next to the tests, so the execution policy is bypassed to keep the
+/// tests independent of how the machine happens to be configured.
+fn powershell(script: &str, arguments: &[&str]) -> Result<String> {
     let output = Command::new("powershell")
-        .args(["-NoProfile", "-NonInteractive", "-Command", script])
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            script,
+        ])
+        .args(arguments)
         .output()
         .context("Failed to run PowerShell")?;
     anyhow::ensure!(

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -210,7 +210,7 @@ fn leaf_of(identity: &Identity) -> Vec<u8> {
 fn field_value<'a>(section: &'a DetailSection, label: &str) -> Option<&'a str> {
     let field = section.fields.iter().find(|field| field.label == label)?;
 
-    Some(field.value.as_str())
+    Some(field.value.text())
 }
 
 /// Signs [`MESSAGE`] with every scheme the key advertises and verifies each signature against the

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -69,12 +69,12 @@ fn describes_a_minted_certificate_in_the_diagnostics() {
     assert_eq!(status.severity, StatusSeverity::Ok);
     assert_eq!(
         status.summary,
-        "1 X.509 client identity certificate(s) are available for mutual TLS."
+        "An X.509 client identity is available for mutual TLS."
     );
     let section = status
         .sections
         .iter()
-        .find(|section| section.title == "Matching Certificate 1")
+        .find(|section| section.title == "Certificate")
         .expect("the diagnostics should describe the minted certificate");
     assert_eq!(field_value(section, "Store"), Some("LocalMachine\\My"));
     assert_eq!(

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -1,8 +1,9 @@
 //! Tests for the Windows certificate-store backend, including its calls into CNG.
 //!
-//! The tests that reach into CNG mint their own certificate in `CurrentUser\My`, which needs no
-//! administrator rights, and look it up by a subject CN that is unique to the test process. That
-//! keeps them off whatever real certificate the machine holds.
+//! The tests that reach into CNG mint their own certificate in `LocalMachine\My`, the one store
+//! the keystore reads, and look it up by a subject CN that is unique to the test process. That
+//! keeps them off whatever real certificate the machine holds. Writing there needs administrator
+//! rights, which the CI runner has.
 
 use std::{
     process::Command,
@@ -20,7 +21,7 @@ use x509_parser::prelude::{FromDer as _, X509Certificate};
 use super::*;
 
 #[test]
-#[ignore = "Writes to the CurrentUser certificate store"]
+#[ignore = "Writes to the LocalMachine certificate store"]
 fn signs_with_the_cng_key_of_an_rsa_certificate() {
     let _serialized = serialize_certificate_store_access();
     let subject_cn = unique_subject_cn("rsa");
@@ -36,7 +37,7 @@ fn signs_with_the_cng_key_of_an_rsa_certificate() {
 }
 
 #[test]
-#[ignore = "Writes to the CurrentUser certificate store"]
+#[ignore = "Writes to the LocalMachine certificate store"]
 fn signs_with_the_cng_key_of_an_ecdsa_certificate() {
     let _serialized = serialize_certificate_store_access();
     let subject_cn = unique_subject_cn("ecdsa");
@@ -56,7 +57,7 @@ fn signs_with_the_cng_key_of_an_ecdsa_certificate() {
 }
 
 #[test]
-#[ignore = "Writes to the CurrentUser certificate store"]
+#[ignore = "Writes to the LocalMachine certificate store"]
 fn describes_a_minted_certificate_in_the_diagnostics() {
     let _serialized = serialize_certificate_store_access();
     let subject_cn = unique_subject_cn("status");
@@ -74,7 +75,7 @@ fn describes_a_minted_certificate_in_the_diagnostics() {
         .iter()
         .find(|section| section.title == "Matching Certificate 1")
         .expect("the diagnostics should describe the minted certificate");
-    assert_eq!(field_value(section, "Store"), Some("CurrentUser\\My"));
+    assert_eq!(field_value(section, "Store"), Some("LocalMachine\\My"));
     assert_eq!(
         field_value(section, "Private Key Access"),
         Some("Available through Windows CNG")
@@ -101,7 +102,7 @@ fn describes_a_minted_certificate_in_the_diagnostics() {
 }
 
 #[test]
-#[ignore = "Reads the CurrentUser certificate store"]
+#[ignore = "Reads the LocalMachine certificate store"]
 fn reports_no_identity_when_no_certificate_matches() {
     let _serialized = serialize_certificate_store_access();
     let subject_cn = unique_subject_cn("absent");
@@ -171,7 +172,7 @@ fn ecdsa_signature_is_der_encoded() {
 /// The bytes the tests ask CNG to sign, standing in for a TLS handshake transcript.
 const MESSAGE: &[u8] = b"x509-keystore Windows CNG signing test";
 
-/// Serialises the tests, which all add to and remove from the shared `CurrentUser\My` store.
+/// Serialises the tests, which all add to and remove from the shared `LocalMachine\My` store.
 ///
 /// [`enumerate_store`] walks that store while a concurrent test mints or removes its own
 /// certificate in it, which makes both what the walk observes and what PowerShell reports depend
@@ -256,7 +257,7 @@ fn verification_algorithm(scheme: SignatureScheme) -> &'static dyn VerificationA
     }
 }
 
-/// A certificate in `CurrentUser\My` that is removed again when the test ends.
+/// A certificate in `LocalMachine\My` that is removed again when the test ends.
 struct MintedCertificate {
     thumbprint: String,
     der: Vec<u8>,

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -67,7 +67,7 @@ fn describes_a_minted_certificate_in_the_diagnostics() {
     let status =
         super::status(&subject_cn).expect("the Windows certificate stores should be readable");
 
-    assert_eq!(status.warning, None);
+    assert_eq!(status.problems, []);
     let section = status
         .sections
         .iter()
@@ -97,10 +97,8 @@ fn reports_no_identity_when_no_certificate_matches() {
 
     assert!(identity.is_none());
     assert_eq!(
-        status.warning,
-        Some(format!(
-            "No X.509 certificate with subject CN '{subject_cn}' is in the Windows certificate stores."
-        ))
+        status.problems,
+        [Problem::NoWindowsCertificate { subject_cn }]
     );
 }
 

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -100,6 +100,10 @@ fn describes_a_minted_certificate_in_the_diagnostics() {
     assert_eq!(field_value(section, "Private Key Error"), None);
     assert_eq!(field_value(section, "Certificate Chain Error"), None);
     assert_eq!(field_value(section, "Private Key Metadata Errors"), None);
+    assert!(
+        position(section, "SHA-256 Fingerprint") < position(section, "Store"),
+        "what the certificate says should read before where Windows keeps it"
+    );
 }
 
 #[test]
@@ -204,6 +208,15 @@ fn leaf_of(identity: &Identity) -> Vec<u8> {
         .expect("the identity should carry a certificate chain");
 
     leaf.to_vec()
+}
+
+/// Returns the position of the diagnostics row labelled `label` in the section.
+fn position(section: &DetailSection, label: &str) -> usize {
+    section
+        .fields
+        .iter()
+        .position(|field| field.label == label)
+        .unwrap_or_else(|| panic!("the diagnostics should show {label}"))
 }
 
 /// Returns the value of the diagnostics row labelled `label`, if the section has one.

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -16,6 +16,7 @@ use ring::signature::{
     RSA_PKCS1_2048_8192_SHA512, RSA_PSS_2048_8192_SHA256, RSA_PSS_2048_8192_SHA384,
     RSA_PSS_2048_8192_SHA512, UnparsedPublicKey, VerificationAlgorithm,
 };
+use rustls::SignatureAlgorithm;
 use x509_parser::prelude::{FromDer as _, X509Certificate};
 
 use super::*;
@@ -161,18 +162,6 @@ fn names_the_cause_behind_a_cng_failure() {
         classify_signing_error(windows::Win32::Foundation::E_UNEXPECTED.into()),
         SigningError::Keystore(_)
     ));
-}
-
-#[test]
-fn ecdsa_signature_is_der_encoded() {
-    let mut raw = vec![0; 64];
-    raw[31] = 1;
-    raw[63] = 2;
-
-    assert_eq!(
-        der_encode_ecdsa_signature(&raw).expect("signature should encode"),
-        vec![0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02]
-    );
 }
 
 /// The bytes the tests ask CNG to sign, standing in for a TLS handshake transcript.

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -66,6 +66,7 @@ fn describes_a_minted_certificate_in_the_diagnostics() {
     let status =
         super::status(&subject_cn).expect("the Windows certificate stores should be readable");
 
+    assert_eq!(status.severity, StatusSeverity::Ok);
     assert_eq!(
         status.summary,
         "1 X.509 client identity certificate(s) are available for mutual TLS."
@@ -81,7 +82,7 @@ fn describes_a_minted_certificate_in_the_diagnostics() {
         Some("Available through Windows CNG")
     );
     assert_eq!(
-        field_value(section, "Usable as a Client Identity"),
+        field_value(section, "Usable With Its Private Key"),
         Some("Yes")
     );
     assert_eq!(
@@ -113,6 +114,7 @@ fn reports_no_identity_when_no_certificate_matches() {
         super::status(&subject_cn).expect("the Windows certificate stores should be readable");
 
     assert!(identity.is_none());
+    assert_eq!(status.severity, StatusSeverity::Warning);
     assert_eq!(
         status.summary,
         format!(

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -161,7 +161,7 @@ fn leaf_of(identity: &Identity) -> Vec<u8> {
 fn field_value<'a>(section: &'a DetailSection, label: &str) -> Option<&'a str> {
     let field = section.fields.iter().find(|field| field.label == label)?;
 
-    Some(field.value.text())
+    field.value.as_deref()
 }
 
 /// Signs [`MESSAGE`] with every scheme the key advertises and verifies each signature against the

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -75,14 +75,6 @@ fn describes_a_minted_certificate_in_the_diagnostics() {
         .expect("the diagnostics should describe the minted certificate");
     assert_eq!(field_value(section, "Store"), Some("LocalMachine\\My"));
     assert_eq!(
-        field_value(section, "Private Key Access"),
-        Some("Available through Windows CNG")
-    );
-    assert_eq!(
-        field_value(section, "Usable With Its Private Key"),
-        Some("Yes")
-    );
-    assert_eq!(
         field_value(section, "Private Key Provider"),
         Some("Microsoft Software Key Storage Provider")
     );


### PR DESCRIPTION
To use either device or user certificates with Firezone on Windows, we need to read them from the Windows certificate store. This PR implements the `x509-keystore` backend for Windows to do exactly that.