### PR TITLE
feat(clients): sign with Linux PKCS#11 keys

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -91,6 +91,13 @@ jobs:
       - run: mise run //rust:install-ebpf-toolchain
         if: runner.os == 'Linux'
       - uses: ./.github/actions/free-disk-space
+      # `x509-keystore`'s PKCS#11 tests sign with a SoftHSM token served through
+      # `p11-kit remote`. They fail rather than skip when either piece is missing, so that
+      # a run cannot report coverage it did not have.
+      - uses: ./.github/actions/apt-install
+        if: runner.os == 'Linux'
+        with:
+          packages: softhsm2 p11-kit
       - name: "cargo test"
         shell: bash
         run: cargo llvm-cov --all-features ${{ steps.setup-rust.outputs.test-packages }} --lcov --output-path lcov.info -- --include-ignored --nocapture

--- a/mise-tasks/x509/gen-certificate.sh
+++ b/mise-tasks/x509/gen-certificate.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Issue a throwaway X.509 client certificate and pack it as a PKCS#12"
 #USAGE cmd "user" help="Carries an actor, so a Client can sign in as a portal identity" {
-#USAGE     flag "--email <email>" help="Actor email to put in the certificate" required=#true
+#USAGE     flag "--email <email>" help="Actor email to put in the certificate"
+#USAGE     flag "--actor-id <actor_id>" help="Actor UUID to put in the certificate"
 #USAGE     flag "--account-id <account_id>" help="Account UUID to put in the certificate" required=#true
 #USAGE     flag "--serial <serial>" help="Device serial to attest as; read from this machine when omitted"
 #USAGE     flag "--alias <alias>" help="Name the key is stored under [default: firezone-client]"
@@ -120,10 +121,23 @@ URI.1 = firezone://serial/${serial}
 EOF
 
 if [ "$kind" = "user" ]; then
-    cat >>"${OUT_DIR}/client.cnf" <<EOF
-URI.2 = firezone://email/${usage_email:?}
-URI.3 = firezone://account-id/${usage_account_id:?}
-EOF
+    # The portal matches the actor by email or by UUID, so a certificate carrying neither
+    # claims nobody.
+    if [ -z "${usage_email:-}" ] && [ -z "${usage_actor_id:-}" ]; then
+        echo "error: a user certificate needs --email and/or --actor-id" >&2
+        exit 1
+    fi
+
+    san=2
+    if [ -n "${usage_email:-}" ]; then
+        echo "URI.${san} = firezone://email/${usage_email}" >>"${OUT_DIR}/client.cnf"
+        san=$((san + 1))
+    fi
+    if [ -n "${usage_actor_id:-}" ]; then
+        echo "URI.${san} = firezone://actor-id/${usage_actor_id}" >>"${OUT_DIR}/client.cnf"
+        san=$((san + 1))
+    fi
+    echo "URI.${san} = firezone://account-id/${usage_account_id:?}" >>"${OUT_DIR}/client.cnf"
 fi
 
 echo "==> Issuing a ${kind} certificate as ${SUBJECT_CN}..."

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1643,6 +1643,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cryptoki"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff765b99fc49f3116c9a908484486a2b92fd73c48da45c3a69716471c6cc56c6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cryptoki-sys",
+ "libloading 0.8.9",
+ "log",
+ "secrecy",
+]
+
+[[package]]
+name = "cryptoki-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fd850498411e4057f1cba79e6e2bc7cbe960544c1046ab46d4685c403a1121"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4544,12 +4566,12 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -10120,7 +10142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da99be64b5aa3de869c16977994314d0759a698d9a73ab0a5b1d52e2282033ae"
 dependencies = [
  "c2rust-bitfields",
- "libloading 0.8.7",
+ "libloading 0.8.9",
  "log",
  "thiserror 1.0.69",
  "windows-sys 0.52.0",
@@ -10348,8 +10370,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow-ext",
  "base64 0.23.1",
+ "cryptoki",
  "ring",
  "rustls",
+ "secrecy",
  "serde",
  "sha2 0.11.0",
  "tracing",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -98,6 +98,7 @@ clock = { path = "libs/clock" }
 connlib-model = { path = "libs/connlib/model" }
 crc32fast = "1.5.0"
 crossbeam-queue = "0.3.12"
+cryptoki = "0.12.0"
 dashmap = "6.2.1"
 dbus-secret-service-keyring-store = { version = "1.0.0", features = ["crypto-rust"] }
 derive_more = { version = "2.1.1", default-features = false }

--- a/rust/libs/x509-keystore/Cargo.toml
+++ b/rust/libs/x509-keystore/Cargo.toml
@@ -12,6 +12,11 @@ serde = { workspace = true, features = ["derive"] }
 x509-claims = { workspace = true }
 x509-credential = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+secrecy = { workspace = true }
+sha2 = { workspace = true }
+tracing = { workspace = true }
+
 [target.'cfg(target_os = "windows")'.dependencies]
 sha2 = { workspace = true }
 tracing = { workspace = true }
@@ -20,6 +25,11 @@ windows = { workspace = true, features = [
     "Win32_Security_Cryptography",
 ] }
 windows-core = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+cryptoki = { workspace = true }
+ring = { workspace = true }
+x509-parser = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 base64 = { workspace = true, features = ["std"] }

--- a/rust/libs/x509-keystore/src/lib.rs
+++ b/rust/libs/x509-keystore/src/lib.rs
@@ -23,6 +23,11 @@ pub use x509_claims::{
 /// Re-exported because [`Identity::client_certificate`] hands out a [`ClientCertificate`].
 pub use x509_credential::ClientCertificate;
 
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+use linux as keystore;
+
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 mod sign;
 
@@ -31,9 +36,9 @@ mod windows;
 #[cfg(target_os = "windows")]
 use windows as keystore;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 mod unsupported;
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 use unsupported as keystore;
 
 /// The subject common name of the certificates Firezone's MDM integrations provision.
@@ -83,7 +88,8 @@ impl Identity {
 pub enum Error {
     /// The Windows certificate store could not be read.
     UnreadableStore { store: String, error: String },
-    /// No PKCS#11 module is registered, so there is no keystore to read certificates through.
+    /// No PKCS#11 module is registered, or p11-kit itself is missing, so there is no keystore
+    /// to read certificates through.
     ///
     /// The clients recommend p11-kit rather than depend on it, so a machine without it is a
     /// supported installation that has to be told what is missing instead of failing to connect.
@@ -124,7 +130,7 @@ impl fmt::Display for Error {
                 "The Windows certificate store {store} could not be read: {error}"
             ),
             Self::MissingP11Kit => formatter.write_str(
-                "No PKCS#11 module is registered, so no X.509 client identity certificate can be found. Firezone reads certificates through PKCS#11 modules registered with p11-kit. See https://www.firezone.dev/kb/install/linux for what to install.",
+                "No PKCS#11 module is registered, or p11-kit is not installed, so no X.509 client identity certificate can be found. Firezone reads certificates through PKCS#11 modules registered with p11-kit. See https://www.firezone.dev/kb/install/linux for what to install.",
             ),
             Self::UnreadablePkcs11Keystore { modules } => write!(
                 formatter,

--- a/rust/libs/x509-keystore/src/linux.rs
+++ b/rust/libs/x509-keystore/src/linux.rs
@@ -13,7 +13,7 @@ use std::{
     time::SystemTime,
 };
 
-use anyhow::{Context as _, Result, anyhow, bail};
+use anyhow::{Context as _, Result, bail};
 use rustls::{SignatureScheme, pki_types::CertificateDer};
 use secrecy::{ExposeSecret as _, SecretString};
 use sha2::{Digest as _, Sha256, Sha384, Sha512};
@@ -35,16 +35,12 @@ const PIN_FILE: &str = "/etc/firezone/pkcs11-pin";
 
 pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>, Error> {
     let Some(p11_kit) = p11_kit_command() else {
-        return Err(Error::identity_unavailable(anyhow!(
-            "Failed to find the p11-kit command: Firezone reads PKCS#11 tokens through p11-kit, which has to be installed"
-        )));
+        return Err(Error::MissingP11Kit);
     };
     let modules = registered_modules();
 
     if modules.is_empty() {
-        return Err(Error::identity_unavailable(anyhow!(
-            "No PKCS#11 module is registered with p11-kit, so there is no keystore to read certificates through"
-        )));
+        return Err(Error::MissingP11Kit);
     }
 
     identity_on(&p11_kit, &modules, Path::new(PIN_FILE), subject_cn)

--- a/rust/libs/x509-keystore/src/linux.rs
+++ b/rust/libs/x509-keystore/src/linux.rs
@@ -1,0 +1,912 @@
+//! X.509 client identities held by a PKCS#11 token.
+
+mod rpc;
+#[cfg(test)]
+mod tests;
+
+use std::{
+    fs::File,
+    io::Read as _,
+    os::unix::fs::MetadataExt as _,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::SystemTime,
+};
+
+use anyhow::{Context as _, Result, anyhow, bail};
+use rustls::{SignatureScheme, pki_types::CertificateDer};
+use secrecy::{ExposeSecret as _, SecretString};
+use sha2::{Digest as _, Sha256, Sha384, Sha512};
+use x509_claims::{ParsedCertificate, SigningAlgorithm, parse_certificate};
+use x509_credential::SigningError;
+
+use crate::{CandidateCertificate, Error, Identity, selected_certificate, sign};
+use rpc::{Attribute, Mechanism, ReturnValue};
+
+/// The directories p11-kit module configuration is read from, the administrator's first.
+///
+/// Whichever driver an administrator installed for their token registers itself here, so it is
+/// reachable without Firezone being told about it.
+const MODULE_CONFIGURATION_DIRECTORIES: [&str; 2] =
+    ["/etc/pkcs11/modules", "/usr/share/p11-kit/modules"];
+
+/// The file a token's PIN is read from.
+const PIN_FILE: &str = "/etc/firezone/pkcs11-pin";
+
+pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>, Error> {
+    let Some(p11_kit) = p11_kit_command() else {
+        return Err(Error::identity_unavailable(anyhow!(
+            "Failed to find the p11-kit command: Firezone reads PKCS#11 tokens through p11-kit, which has to be installed"
+        )));
+    };
+    let modules = registered_modules();
+
+    if modules.is_empty() {
+        return Err(Error::identity_unavailable(anyhow!(
+            "No PKCS#11 module is registered with p11-kit, so there is no keystore to read certificates through"
+        )));
+    }
+
+    identity_on(&p11_kit, &modules, Path::new(PIN_FILE), subject_cn)
+}
+
+fn identity_on(
+    p11_kit: &Path,
+    modules: &[PathBuf],
+    pin_file: &Path,
+    subject_cn: &str,
+) -> Result<Option<Identity>, Error> {
+    let mut failures = Vec::new();
+
+    for module in modules {
+        // A module that cannot be read leaves its tokens out of reach, the same as holding
+        // none: it may fail to serve, as when its driver is broken, or fail to enumerate,
+        // as when the service behind it is not running. One broken module must not hide
+        // the tokens of the others.
+        let candidate = match find_token(p11_kit, module, subject_cn) {
+            Ok(Some(candidate)) => candidate,
+            Ok(None) => continue,
+            Err(error) => {
+                tracing::debug!(module = %module.display(), "Skipping a PKCS#11 module: {error:#}");
+                // Only the short top-level cause: the raw child and driver messages behind it
+                // are long, and the log carries the full chain.
+                failures.push(format!("{}: {error}", module.display()));
+
+                continue;
+            }
+        };
+
+        // A matching token's verdict is final rather than falling through to another module:
+        // when nothing on it can sign, the debug log says why and no identity is handed out.
+        return select_identity(candidate, pin_file);
+    }
+
+    // A machine whose every module failed has an unreadable keystore, not a missing
+    // certificate, and which of the two the administrator reads decides what they fix.
+    if failures.len() == modules.len() {
+        return Err(Error::UnreadablePkcs11Keystore { modules: failures });
+    }
+
+    tracing::debug!("No PKCS#11 token holds a Firezone client identity");
+
+    Ok(None)
+}
+
+/// Unlocks the candidate's token and selects the certificate it presents for mutual TLS.
+fn select_identity(candidate: Candidate, pin_file: &Path) -> Result<Option<Identity>, Error> {
+    let Token {
+        session,
+        objects,
+        mut certificates,
+    } = unlock_token(candidate, pin_file).map_err(Error::identity_unavailable)?;
+
+    let Some(index) = selected_certificate(&certificates) else {
+        return Ok(None);
+    };
+    let certificate = certificates.swap_remove(index);
+
+    let chain = certificate_chain(&certificate.der, &objects)
+        .into_iter()
+        .map(CertificateDer::from)
+        .collect();
+    let key = Arc::new(sign::Key::new(
+        certificate.algorithm,
+        Pkcs11Key {
+            session,
+            key: certificate.key,
+        },
+    ));
+
+    tracing::debug!(
+        fingerprint = %certificate.metadata.fingerprint,
+        "Selected a PKCS#11 X.509 identity for mutual TLS"
+    );
+
+    Ok(Some(Identity {
+        chain,
+        key,
+        certificate: certificate.metadata,
+    }))
+}
+
+/// A private key on a PKCS#11 token, reached through the session that unlocked it.
+///
+/// The session is opened and logged into once, while the identity is discovered, and lives as
+/// long as the identity does. A token that wants a PIN would otherwise want one for every
+/// handshake signature, including the ones a reconnect or a change of network makes. Holding
+/// the session also keeps the `p11-kit remote` child hosting the module running, which is what
+/// keeps the module from being finalized underneath it.
+#[derive(Debug)]
+struct Pkcs11Key {
+    session: rpc::Session,
+    key: u64,
+}
+
+impl sign::Signer for Pkcs11Key {
+    fn sign(&self, scheme: SignatureScheme, message: &[u8]) -> Result<Vec<u8>, SigningError> {
+        let signature = sign_with_key(&self.session, self.key, scheme, message)?;
+
+        Ok(signature)
+    }
+}
+
+#[expect(
+    clippy::wildcard_enum_match_arm,
+    reason = "rustls only ever asks for a scheme we advertised in `supported_schemes`"
+)]
+fn sign_with_key(
+    session: &rpc::Session,
+    key: u64,
+    scheme: SignatureScheme,
+    message: &[u8],
+) -> Result<Vec<u8>, SigningError> {
+    let signature = match scheme {
+        SignatureScheme::RSA_PSS_SHA256 => session.sign(&Mechanism::Sha256RsaPkcsPss, key, message),
+        SignatureScheme::RSA_PSS_SHA384 => session.sign(&Mechanism::Sha384RsaPkcsPss, key, message),
+        SignatureScheme::RSA_PSS_SHA512 => session.sign(&Mechanism::Sha512RsaPkcsPss, key, message),
+        SignatureScheme::RSA_PKCS1_SHA256 => session.sign(&Mechanism::Sha256RsaPkcs, key, message),
+        SignatureScheme::RSA_PKCS1_SHA384 => session.sign(&Mechanism::Sha384RsaPkcs, key, message),
+        SignatureScheme::RSA_PKCS1_SHA512 => session.sign(&Mechanism::Sha512RsaPkcs, key, message),
+        SignatureScheme::ECDSA_NISTP256_SHA256 => {
+            session.sign(&Mechanism::Ecdsa, key, &Sha256::digest(message))
+        }
+        SignatureScheme::ECDSA_NISTP384_SHA384 => {
+            session.sign(&Mechanism::Ecdsa, key, &Sha384::digest(message))
+        }
+        SignatureScheme::ECDSA_NISTP521_SHA512 => {
+            session.sign(&Mechanism::Ecdsa, key, &Sha512::digest(message))
+        }
+        _ => return Err(SigningError::UnsupportedScheme(scheme)),
+    }
+    .map_err(pkcs11_error)?;
+
+    Ok(signature)
+}
+
+/// Names the cause behind a failure that carries a PKCS#11 return value.
+fn pkcs11_error(error: rpc::Error) -> SigningError {
+    let reason = error.to_string();
+    let rpc::Error::Token(value) = error else {
+        return SigningError::Keystore(reason);
+    };
+
+    classify_return_value(value, reason)
+}
+
+/// Tells a token that lost the key from one that refuses to use it.
+///
+/// A PIN the token rejected and a key whose attributes forbid signing are both refusals: the
+/// token is present and answers, it just will not sign for us.
+fn classify_return_value(value: ReturnValue, reason: String) -> SigningError {
+    match value.0 {
+        rpc::CKR_DEVICE_REMOVED => SigningError::KeyUnavailable(reason),
+        rpc::CKR_TOKEN_NOT_PRESENT => SigningError::KeyUnavailable(reason),
+        rpc::CKR_KEY_HANDLE_INVALID => SigningError::KeyUnavailable(reason),
+        rpc::CKR_OBJECT_HANDLE_INVALID => SigningError::KeyUnavailable(reason),
+        rpc::CKR_SESSION_HANDLE_INVALID => SigningError::KeyUnavailable(reason),
+        rpc::CKR_SESSION_CLOSED => SigningError::KeyUnavailable(reason),
+        rpc::CKR_PIN_INCORRECT => SigningError::AccessDenied(reason),
+        rpc::CKR_PIN_EXPIRED => SigningError::AccessDenied(reason),
+        rpc::CKR_PIN_LOCKED => SigningError::AccessDenied(reason),
+        rpc::CKR_USER_NOT_LOGGED_IN => SigningError::AccessDenied(reason),
+        rpc::CKR_KEY_FUNCTION_NOT_PERMITTED => SigningError::AccessDenied(reason),
+        rpc::CKR_FUNCTION_CANCELED => SigningError::AccessDenied(reason),
+        _ => SigningError::Keystore(reason),
+    }
+}
+
+/// Returns the p11-kit command the registered modules are served through.
+fn p11_kit_command() -> Option<PathBuf> {
+    std::env::var_os("PATH")
+        .map(|path| std::env::split_paths(&path).collect::<Vec<_>>())
+        .unwrap_or_default()
+        .into_iter()
+        .chain([PathBuf::from("/usr/bin")])
+        .map(|directory| directory.join("p11-kit"))
+        .find(|candidate| candidate.is_file())
+}
+
+/// Returns every PKCS#11 module registered on this machine, most preferred first.
+///
+/// The modules are read from p11-kit's configuration rather than through its proxy: the proxy
+/// collapses every module into one `C_GetSlotList`, so a single broken module would take the
+/// tokens of all the others down with it. Serving each module through its own child keeps
+/// them independent.
+fn registered_modules() -> Vec<PathBuf> {
+    let directories = module_directories(multiarch_directories());
+    let program = program_name();
+
+    configured_modules(
+        configuration_files_by_name(),
+        &directories,
+        &|module| module.is_file(),
+        program.as_deref(),
+    )
+}
+
+/// Returns the contents of every module configuration file, each under the name that the
+/// administrator's directory overrides the packaged one by.
+fn configuration_files_by_name() -> Vec<(String, String)> {
+    MODULE_CONFIGURATION_DIRECTORIES
+        .into_iter()
+        .flat_map(|directory| configuration_files(Path::new(directory)))
+        .filter_map(|file| {
+            let name = file.file_stem()?.to_str()?.to_owned();
+            let contents = std::fs::read_to_string(&file)
+                .inspect_err(|error| {
+                    tracing::debug!(
+                        file = %file.display(),
+                        "Skipping an unreadable p11-kit module configuration: {error}"
+                    );
+                })
+                .ok()?;
+
+            Some((name, contents))
+        })
+        .collect()
+}
+
+/// Returns the `*.module` files below `directory` in name order, none for a missing directory.
+fn configuration_files(directory: &Path) -> Vec<PathBuf> {
+    let mut files = std::fs::read_dir(directory)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "module")
+        })
+        .collect::<Vec<_>>();
+
+    files.sort();
+
+    files
+}
+
+/// Returns the modules `files` register, resolved and deduplicated, most preferred first.
+///
+/// p11-kit's own rules are mirrored: the first configuration under a given name wins, so an
+/// administrator's copy of a packaged file replaces it; a module named by two surviving
+/// configurations is loaded once; a module stays out unless it is enabled for `program`; and
+/// the modules are ordered by descending `priority:`, ties by configuration name.
+fn configured_modules(
+    files: impl IntoIterator<Item = (String, String)>,
+    directories: &[PathBuf],
+    installed: &dyn Fn(&Path) -> bool,
+    program: Option<&str>,
+) -> Vec<PathBuf> {
+    let mut configurations = Vec::<(String, ModuleConfiguration)>::new();
+    for (name, contents) in files {
+        if configurations.iter().any(|(seen, _)| *seen == name) {
+            continue;
+        }
+
+        configurations.push((name, parse_configuration(&contents)));
+    }
+
+    let mut registered = configurations
+        .into_iter()
+        .filter_map(|(name, configuration)| {
+            if !is_enabled(&configuration, program) {
+                tracing::debug!(module = name, "Skipping a disabled PKCS#11 module");
+
+                return None;
+            }
+            let value = configuration.module?;
+            if value.is_empty() {
+                return None;
+            }
+            let module = resolve_module(&value, directories, installed)?;
+
+            Some((name, configuration.priority, module))
+        })
+        .collect::<Vec<_>>();
+    registered.sort_by(|(name_a, priority_a, _), (name_b, priority_b, _)| {
+        priority_b.cmp(priority_a).then_with(|| name_a.cmp(name_b))
+    });
+
+    let mut modules = Vec::new();
+    for (_, _, module) in registered {
+        if !modules.contains(&module) {
+            modules.push(module);
+        }
+    }
+
+    modules
+}
+
+/// The settings of one p11-kit module configuration file that bear on loading its module.
+#[derive(Default)]
+struct ModuleConfiguration {
+    module: Option<String>,
+    enable_in: Option<String>,
+    disable_in: Option<String>,
+    priority: i64,
+}
+
+/// Reads the `key: value` lines of a configuration file, the last mention of a key winning.
+fn parse_configuration(contents: &str) -> ModuleConfiguration {
+    let mut configuration = ModuleConfiguration::default();
+
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.trim();
+
+        match key.trim() {
+            "module" => configuration.module = Some(value.to_owned()),
+            "enable-in" => configuration.enable_in = Some(value.to_owned()),
+            "disable-in" => configuration.disable_in = Some(value.to_owned()),
+            "priority" => configuration.priority = leading_integer(value),
+            _ => {}
+        }
+    }
+
+    configuration
+}
+
+/// Says whether the configuration enables its module for the program `program`.
+///
+/// `enable-in` lists the only programs that may load the module and `disable-in` the programs
+/// that may not, either naming us by our executable's name. In particular, the common
+/// `disable-in: p11-kit-proxy` hides a module from the proxy, which we are not, so it stays
+/// loaded.
+fn is_enabled(configuration: &ModuleConfiguration, program: Option<&str>) -> bool {
+    if let Some(enable_in) = &configuration.enable_in {
+        return program.is_some_and(|name| list_contains(enable_in, name));
+    }
+    if let Some(disable_in) = &configuration.disable_in {
+        return program.is_none_or(|name| !list_contains(disable_in, name));
+    }
+
+    true
+}
+
+/// Says whether a comma or whitespace separated list has `name` as an entry.
+fn list_contains(list: &str, name: &str) -> bool {
+    list.split(|character: char| character == ',' || character.is_whitespace())
+        .any(|entry| entry == name)
+}
+
+/// Reads the integer a value begins with, 0 when it begins with none.
+///
+/// p11-kit reads `priority:` with `atoi`, which stops at the first character that is not part
+/// of a number, so a value that goes on after the number still counts.
+fn leading_integer(value: &str) -> i64 {
+    let sign = usize::from(value.starts_with(['+', '-']));
+    let digits = value[sign..]
+        .bytes()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+
+    value[..sign + digits].parse().unwrap_or(0)
+}
+
+/// The name p11-kit's `enable-in` and `disable-in` settings know a program by.
+fn program_name() -> Option<String> {
+    let executable = std::env::current_exe().ok()?;
+    let name = executable.file_name()?.to_str()?.to_owned();
+
+    Some(name)
+}
+
+/// Returns the path a `module:` setting names, as a path to load.
+///
+/// A relative value is looked up in `directories`, most preferred first; one that is nowhere
+/// `installed` resolves against the most preferred directory, so that loading it fails under
+/// the path the configuration meant.
+fn resolve_module(
+    value: &str,
+    directories: &[PathBuf],
+    installed: &dyn Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    let module = Path::new(value);
+
+    if module.is_absolute() {
+        return Some(module.to_owned());
+    }
+
+    directories
+        .iter()
+        .map(|directory| directory.join(module))
+        .find(|candidate| installed(candidate))
+        .or_else(|| Some(directories.first()?.join(module)))
+}
+
+/// The directories a registered PKCS#11 module may be installed into, most preferred first.
+///
+/// Distributions keep driver modules below a `pkcs11` subdirectory of the library directory:
+/// `/usr/lib64/pkcs11` on Fedora and RHEL, below the multiarch directory on Debian and Ubuntu.
+/// `/usr/lib64` has to come before `/usr/lib`, whose modules are the 32-bit builds on a machine
+/// with the i686 packages installed.
+fn module_directories(multiarch_directories: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut directories = vec![PathBuf::from("/usr/lib64")];
+    directories.extend(multiarch_directories);
+    directories.push(PathBuf::from("/usr/lib"));
+
+    directories
+        .into_iter()
+        .map(|directory| directory.join("pkcs11"))
+        .collect()
+}
+
+/// Debian keeps libraries below a directory named after the architecture triplet, e.g.
+/// `/usr/lib/x86_64-linux-gnu`.
+fn multiarch_directories() -> Vec<PathBuf> {
+    std::fs::read_dir("/usr/lib")
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|entry| entry.path())
+        .collect()
+}
+
+/// The token Firezone authenticates with, and everything it holds that bears on that.
+struct Token {
+    /// The unlocked session every signature made with this token goes through.
+    session: rpc::Session,
+    /// Every X.509 object on the token, which is what the chain of a certificate is built from.
+    objects: Vec<CertificateObject>,
+    /// The matching certificates the token can sign with.
+    certificates: Vec<Certificate>,
+}
+
+/// Returns the first token holding a certificate for `subject_cn`, not yet unlocked.
+///
+/// Certificates are public objects, so every token can be searched without logging in, and
+/// [`unlock_token`] then unlocks only the one that turns out to hold ours. Logging into each
+/// token in turn would instead spend the PIN attempts of tokens that have nothing to do with
+/// Firezone.
+fn find_token(p11_kit: &Path, module: &Path, subject_cn: &str) -> Result<Option<Candidate>> {
+    let pkcs11 = rpc::Module::load(p11_kit, module)
+        .with_context(|| format!("Failed to load {}", module.display()))?;
+    let slots = pkcs11
+        .slots_with_tokens()
+        .context("Failed to enumerate PKCS#11 tokens")?;
+
+    for slot in slots {
+        let Some(candidate) = search_slot(&pkcs11, slot, subject_cn)
+            .inspect_err(|error| tracing::debug!(slot, "Skipping a PKCS#11 token: {error:#}"))
+            .ok()
+            .flatten()
+        else {
+            continue;
+        };
+
+        return Ok(Some(candidate));
+    }
+
+    Ok(None)
+}
+
+/// Unlocks the candidate's token and pairs each matching certificate with its private key.
+fn unlock_token(candidate: Candidate, pin_file: &Path) -> Result<Token> {
+    let Candidate {
+        flags,
+        session,
+        objects,
+        matches,
+    } = candidate;
+
+    unlock(&session, flags, pin_file)?;
+
+    let certificates = matches
+        .into_iter()
+        .filter_map(|(object, metadata)| signable_certificate(&session, &objects[object], metadata))
+        .collect();
+
+    Ok(Token {
+        session,
+        objects,
+        certificates,
+    })
+}
+
+/// A token that holds at least one certificate for the subject common name we look for.
+struct Candidate {
+    flags: LoginFlags,
+    session: rpc::Session,
+    objects: Vec<CertificateObject>,
+    /// The index of each matching object in `objects`, alongside what its certificate says.
+    matches: Vec<(usize, ParsedCertificate)>,
+}
+
+/// Reads the certificates on `slot`, before any login, to see whether the token is one of ours.
+fn search_slot(pkcs11: &rpc::Module, slot: u64, subject_cn: &str) -> Result<Option<Candidate>> {
+    let flags = pkcs11
+        .token_flags(slot)
+        .context("Failed to read the token information")?;
+    let flags = LoginFlags::from_bits(flags);
+    let session = pkcs11
+        .open_session(slot)
+        .context("Failed to open the token")?;
+    let objects = certificate_objects(&session)?;
+    let now = SystemTime::now();
+    let matches = objects
+        .iter()
+        .enumerate()
+        .filter_map(|(index, object)| {
+            let Some(metadata) = parse_certificate(&object.der, now) else {
+                tracing::debug!(
+                    object_label = ?object.label,
+                    "Ignoring an invalid PKCS#11 X.509 certificate"
+                );
+
+                return None;
+            };
+
+            (metadata.subject_cn.as_deref() == Some(subject_cn)).then_some((index, metadata))
+        })
+        .collect::<Vec<_>>();
+
+    if matches.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(Candidate {
+        flags,
+        session,
+        objects,
+        matches,
+    }))
+}
+
+/// Unlocks the token, if it asks to be, with the PIN Firezone keeps on disk.
+fn unlock(session: &rpc::Session, flags: LoginFlags, pin_file: &Path) -> Result<()> {
+    match login_requirement(flags)? {
+        Login::NotRequired => {
+            tracing::debug!("The PKCS#11 token hands out its keys without a login");
+        }
+        Login::Pin => {
+            let pin = read_pin(pin_file)?;
+
+            log_in(session, &pin).with_context(|| rejected_pin_reason(flags))?;
+        }
+    }
+
+    Ok(())
+}
+
+/// What a token asks for before it hands out the private key of an identity.
+#[derive(Debug)]
+enum Login {
+    /// The token's keys are usable as they are.
+    NotRequired,
+    /// The token wants the PIN Firezone keeps on disk.
+    Pin,
+}
+
+/// The `C_GetTokenInfo` flags that decide whether and how Firezone logs into a token.
+#[derive(Clone, Copy)]
+struct LoginFlags {
+    login_required: bool,
+    protected_authentication_path: bool,
+    user_pin_locked: bool,
+    user_pin_final_try: bool,
+    user_pin_count_low: bool,
+}
+
+impl LoginFlags {
+    fn from_bits(flags: u64) -> Self {
+        Self {
+            login_required: flags & rpc::TOKEN_FLAG_LOGIN_REQUIRED != 0,
+            protected_authentication_path: flags & rpc::TOKEN_FLAG_PROTECTED_AUTHENTICATION_PATH
+                != 0,
+            user_pin_locked: flags & rpc::TOKEN_FLAG_USER_PIN_LOCKED != 0,
+            user_pin_final_try: flags & rpc::TOKEN_FLAG_USER_PIN_FINAL_TRY != 0,
+            user_pin_count_low: flags & rpc::TOKEN_FLAG_USER_PIN_COUNT_LOW != 0,
+        }
+    }
+}
+
+/// Decides how Firezone logs into a token from what the token says about itself.
+///
+/// # Errors
+///
+/// Returns an error for a token Firezone cannot log into at all: one that wants its PIN typed on
+/// the reader's own keypad, or one that has already locked its user PIN.
+fn login_requirement(flags: LoginFlags) -> Result<Login> {
+    if !flags.login_required {
+        return Ok(Login::NotRequired);
+    }
+
+    if flags.protected_authentication_path {
+        bail!(
+            "The PKCS#11 token wants its PIN typed on the reader's own keypad, which Firezone cannot do: the Tunnel service runs in the background and prompts nobody"
+        );
+    }
+
+    if flags.user_pin_locked {
+        bail!(
+            "The PKCS#11 token has locked its user PIN, which has to be unblocked with the token's PUK before Firezone can use it"
+        );
+    }
+
+    Ok(Login::Pin)
+}
+
+/// Says how much of the token's patience the PIN it just rejected used up.
+fn rejected_pin_reason(flags: LoginFlags) -> String {
+    if flags.user_pin_final_try {
+        return "Failed to unlock the PKCS#11 token, which had one attempt left before locking its user PIN".to_owned();
+    }
+
+    if flags.user_pin_count_low {
+        return "Failed to unlock the PKCS#11 token, which was already counting down to locking its user PIN".to_owned();
+    }
+
+    "Failed to unlock the PKCS#11 token".to_owned()
+}
+
+/// Logs into the token, treating a login an overlapping session already did as success.
+///
+/// PKCS#11 tracks the login per token rather than per session, so a token that another session
+/// on this module unlocked is unlocked for this one too, and logging in again is refused.
+fn log_in(session: &rpc::Session, pin: &SecretString) -> Result<()> {
+    let Err(error) = session.login_user(pin.expose_secret().as_bytes()) else {
+        return Ok(());
+    };
+
+    if matches!(
+        error,
+        rpc::Error::Token(ReturnValue(rpc::CKR_USER_ALREADY_LOGGED_IN))
+    ) {
+        return Ok(());
+    }
+
+    Err(error.into())
+}
+
+/// Reads the token's PIN from `path`.
+///
+/// Ownership and permissions are checked on the open file rather than on its path, so that a file
+/// swapped in between the check and the read cannot get its contents used.
+///
+/// # Errors
+///
+/// Returns an error if the file is missing or unreadable, or if it is not root's alone.
+fn read_pin(path: &Path) -> Result<SecretString> {
+    let mut file = File::open(path)
+        .with_context(|| format!("Failed to open the PKCS#11 PIN file '{}'", path.display()))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("Failed to read the metadata of '{}'", path.display()))?;
+
+    ensure_root_only(metadata.mode(), metadata.uid(), path)?;
+
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)
+        .with_context(|| format!("Failed to read '{}'", path.display()))?;
+
+    // A PIN may deliberately begin or end with a space, so only the line ending is stripped.
+    Ok(SecretString::from(contents.trim_end_matches(['\n', '\r'])))
+}
+
+/// Refuses a PIN file that any account other than root can get at.
+///
+/// The Tunnel service runs as root, so a PIN file another account owns or can read is one a
+/// compromised account could use to authenticate the device.
+fn ensure_root_only(mode: u32, uid: u32, path: &Path) -> Result<()> {
+    if mode & 0o077 != 0 {
+        bail!(
+            "Permissions 0{:o} for '{}' are too open; the PKCS#11 PIN file must not be accessible by group or others",
+            mode & 0o777,
+            path.display()
+        );
+    }
+
+    if uid != 0 {
+        bail!(
+            "'{}' is owned by uid {uid} rather than by root; only root may hold the PKCS#11 PIN",
+            path.display()
+        );
+    }
+
+    Ok(())
+}
+
+/// A matching certificate we can present: the token holds a private key we sign with.
+struct Certificate {
+    der: Vec<u8>,
+    metadata: ParsedCertificate,
+    key: u64,
+    algorithm: SigningAlgorithm,
+}
+
+/// Pairs a matching certificate with the private key the token signs for it, [`None`] when the
+/// token cannot sign with it.
+///
+/// A certificate we cannot sign a TLS handshake with authenticates nothing; selecting it anyway
+/// would only shadow an older certificate that still works, so it is skipped and the debug log
+/// says why.
+fn signable_certificate(
+    session: &rpc::Session,
+    object: &CertificateObject,
+    metadata: ParsedCertificate,
+) -> Option<Certificate> {
+    let Some(algorithm) = metadata.signing_algorithm else {
+        tracing::debug!(
+            fingerprint = %metadata.fingerprint,
+            "Skipping a matching certificate: no scheme we sign with holds its key algorithm"
+        );
+
+        return None;
+    };
+    let key = match find_private_key(
+        session,
+        object.id.as_deref(),
+        object.label.as_deref(),
+        algorithm,
+    ) {
+        Ok(Some(key)) => key,
+        Ok(None) => {
+            tracing::debug!(
+                fingerprint = %metadata.fingerprint,
+                "Skipping a matching certificate: the token holds no private key for it"
+            );
+
+            return None;
+        }
+        Err(error) => {
+            tracing::debug!(
+                fingerprint = %metadata.fingerprint,
+                "Skipping a matching certificate: {error:#}"
+            );
+
+            return None;
+        }
+    };
+
+    Some(Certificate {
+        der: object.der.clone(),
+        metadata,
+        key,
+        algorithm,
+    })
+}
+
+impl CandidateCertificate for Certificate {
+    fn not_before_timestamp(&self) -> i64 {
+        self.metadata.not_before_timestamp
+    }
+}
+
+struct CertificateObject {
+    der: Vec<u8>,
+    id: Option<Vec<u8>>,
+    label: Option<String>,
+}
+
+fn certificate_objects(session: &rpc::Session) -> Result<Vec<CertificateObject>> {
+    let handles = session
+        .find_objects(&[
+            Attribute::ulong(rpc::ATTRIBUTE_CLASS, rpc::OBJECT_CLASS_CERTIFICATE),
+            Attribute::ulong(rpc::ATTRIBUTE_CERTIFICATE_TYPE, rpc::CERTIFICATE_TYPE_X_509),
+        ])
+        .context("Failed to enumerate PKCS#11 certificates")?;
+    let mut certificates = Vec::new();
+
+    for handle in handles {
+        let attributes = match session.byte_array_attributes(
+            handle,
+            &[
+                rpc::ATTRIBUTE_VALUE,
+                rpc::ATTRIBUTE_ID,
+                rpc::ATTRIBUTE_LABEL,
+            ],
+        ) {
+            Ok(attributes) => attributes,
+            Err(error) => {
+                tracing::warn!(?error, "Failed to read a PKCS#11 certificate object");
+                continue;
+            }
+        };
+
+        let Ok([der, id, label]) = <[Option<Vec<u8>>; 3]>::try_from(attributes) else {
+            continue;
+        };
+        let Some(der) = der else {
+            continue;
+        };
+
+        certificates.push(CertificateObject {
+            der,
+            id,
+            label: label.and_then(|bytes| String::from_utf8(bytes).ok()),
+        });
+    }
+
+    Ok(certificates)
+}
+
+fn find_private_key(
+    session: &rpc::Session,
+    id: Option<&[u8]>,
+    label: Option<&str>,
+    algorithm: SigningAlgorithm,
+) -> Result<Option<u64>> {
+    let key_type = match algorithm {
+        SigningAlgorithm::RsaSha256 => rpc::KEY_TYPE_RSA,
+        SigningAlgorithm::EcdsaSha256 => rpc::KEY_TYPE_EC,
+        SigningAlgorithm::EcdsaSha384 => rpc::KEY_TYPE_EC,
+        SigningAlgorithm::EcdsaSha512 => rpc::KEY_TYPE_EC,
+    };
+    let mut template = vec![
+        Attribute::ulong(rpc::ATTRIBUTE_CLASS, rpc::OBJECT_CLASS_PRIVATE_KEY),
+        Attribute::ulong(rpc::ATTRIBUTE_KEY_TYPE, key_type),
+    ];
+    match (id, label) {
+        (Some(id), _) => template.push(Attribute::bytes(rpc::ATTRIBUTE_ID, id.to_vec())),
+        (None, Some(label)) => {
+            template.push(Attribute::bytes(
+                rpc::ATTRIBUTE_LABEL,
+                label.as_bytes().to_vec(),
+            ));
+        }
+        (None, None) => return Ok(None),
+    }
+
+    let key = session
+        .find_objects(&template)
+        .context("Failed to locate the PKCS#11 private key")?
+        .into_iter()
+        .next();
+
+    Ok(key)
+}
+
+/// Walks up from the leaf, collecting the issuers the token holds.
+///
+/// Stops at the first issuer the token does not have, leaving the portal to complete the chain
+/// from its own trust store.
+fn certificate_chain(leaf: &[u8], issuers: &[CertificateObject]) -> Vec<Vec<u8>> {
+    let now = SystemTime::now();
+    let mut chain = vec![leaf.to_vec()];
+    let Some(mut current) = parse_certificate(leaf, now) else {
+        return chain;
+    };
+
+    while current.subject != current.issuer {
+        let Some((der, metadata)) = issuers.iter().find_map(|candidate| {
+            if chain.contains(&candidate.der) {
+                return None;
+            }
+            let metadata = parse_certificate(&candidate.der, now)?;
+
+            (metadata.subject == current.issuer).then_some((&candidate.der, metadata))
+        }) else {
+            break;
+        };
+
+        chain.push(der.clone());
+        current = metadata;
+    }
+
+    chain
+}

--- a/rust/libs/x509-keystore/src/linux/rpc.rs
+++ b/rust/libs/x509-keystore/src/linux/rpc.rs
@@ -1,0 +1,1165 @@
+//! A PKCS#11 client that reaches each module through a `p11-kit remote` child process.
+//!
+//! PKCS#11 driver modules are shared libraries, which a statically linked client cannot
+//! load. The system's own p11-kit can host any module in a child process instead, speaking
+//! its RPC protocol on the child's standard streams, so the modules stay loadable however
+//! the client itself is built. This is the client side of that protocol, covering only the
+//! calls the keystore walk makes; the reference implementation lives in p11-kit's
+//! `rpc-message.c` and `rpc-client.c`.
+
+use std::{
+    io::{Read as _, Write as _},
+    path::Path,
+    process::{Child, ChildStdin, ChildStdout, Command, Stdio},
+    sync::{Arc, Mutex, MutexGuard, PoisonError},
+};
+
+/// `CKO_CERTIFICATE`, the class of certificate objects.
+pub(crate) const OBJECT_CLASS_CERTIFICATE: u64 = 0x0000_0001;
+/// `CKO_PRIVATE_KEY`, the class of private-key objects.
+pub(crate) const OBJECT_CLASS_PRIVATE_KEY: u64 = 0x0000_0003;
+/// `CKC_X_509`, the certificate type of X.509 certificates.
+pub(crate) const CERTIFICATE_TYPE_X_509: u64 = 0x0000_0000;
+/// `CKK_RSA`, the key type of RSA keys.
+pub(crate) const KEY_TYPE_RSA: u64 = 0x0000_0000;
+/// `CKK_EC`, the key type of elliptic-curve keys.
+pub(crate) const KEY_TYPE_EC: u64 = 0x0000_0003;
+
+/// `CKA_CLASS`, the attribute holding an object's class.
+pub(crate) const ATTRIBUTE_CLASS: u64 = 0x0000_0000;
+/// `CKA_LABEL`, the attribute holding an object's label.
+pub(crate) const ATTRIBUTE_LABEL: u64 = 0x0000_0003;
+/// `CKA_VALUE`, the attribute holding a certificate's DER encoding.
+pub(crate) const ATTRIBUTE_VALUE: u64 = 0x0000_0011;
+/// `CKA_CERTIFICATE_TYPE`, the attribute holding a certificate object's type.
+pub(crate) const ATTRIBUTE_CERTIFICATE_TYPE: u64 = 0x0000_0080;
+/// `CKA_KEY_TYPE`, the attribute holding a key object's type.
+pub(crate) const ATTRIBUTE_KEY_TYPE: u64 = 0x0000_0100;
+/// `CKA_ID`, the attribute pairing a certificate with its key.
+pub(crate) const ATTRIBUTE_ID: u64 = 0x0000_0102;
+
+/// `CKF_LOGIN_REQUIRED` of `CK_TOKEN_INFO.flags`.
+pub(crate) const TOKEN_FLAG_LOGIN_REQUIRED: u64 = 0x0000_0004;
+/// `CKF_PROTECTED_AUTHENTICATION_PATH` of `CK_TOKEN_INFO.flags`.
+pub(crate) const TOKEN_FLAG_PROTECTED_AUTHENTICATION_PATH: u64 = 0x0000_0100;
+/// `CKF_USER_PIN_COUNT_LOW` of `CK_TOKEN_INFO.flags`.
+pub(crate) const TOKEN_FLAG_USER_PIN_COUNT_LOW: u64 = 0x0001_0000;
+/// `CKF_USER_PIN_FINAL_TRY` of `CK_TOKEN_INFO.flags`.
+pub(crate) const TOKEN_FLAG_USER_PIN_FINAL_TRY: u64 = 0x0002_0000;
+/// `CKF_USER_PIN_LOCKED` of `CK_TOKEN_INFO.flags`.
+pub(crate) const TOKEN_FLAG_USER_PIN_LOCKED: u64 = 0x0004_0000;
+
+pub(crate) const CKR_ATTRIBUTE_SENSITIVE: u64 = 0x0000_0011;
+pub(crate) const CKR_ATTRIBUTE_TYPE_INVALID: u64 = 0x0000_0012;
+pub(crate) const CKR_DEVICE_REMOVED: u64 = 0x0000_0032;
+pub(crate) const CKR_FUNCTION_CANCELED: u64 = 0x0000_0050;
+pub(crate) const CKR_KEY_HANDLE_INVALID: u64 = 0x0000_0060;
+pub(crate) const CKR_KEY_FUNCTION_NOT_PERMITTED: u64 = 0x0000_0068;
+pub(crate) const CKR_OBJECT_HANDLE_INVALID: u64 = 0x0000_0082;
+pub(crate) const CKR_PIN_INCORRECT: u64 = 0x0000_00a0;
+pub(crate) const CKR_PIN_EXPIRED: u64 = 0x0000_00a3;
+pub(crate) const CKR_PIN_LOCKED: u64 = 0x0000_00a4;
+pub(crate) const CKR_SESSION_CLOSED: u64 = 0x0000_00b0;
+pub(crate) const CKR_SESSION_HANDLE_INVALID: u64 = 0x0000_00b3;
+pub(crate) const CKR_TOKEN_NOT_PRESENT: u64 = 0x0000_00e0;
+pub(crate) const CKR_USER_ALREADY_LOGGED_IN: u64 = 0x0000_0100;
+pub(crate) const CKR_USER_NOT_LOGGED_IN: u64 = 0x0000_0101;
+pub(crate) const CKR_BUFFER_TOO_SMALL: u64 = 0x0000_0150;
+
+/// Why a call into the module did not produce its answer.
+#[derive(Debug)]
+pub(crate) enum Error {
+    /// The module answered with a PKCS#11 return value other than `CKR_OK`.
+    Token(ReturnValue),
+    /// The child could not be spawned or reached, e.g. because it exited.
+    Transport(std::io::Error),
+    /// The child answered outside the protocol, e.g. with a version we do not speak.
+    Protocol(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Token(value) => write!(formatter, "The PKCS#11 module answered {value}"),
+            Self::Transport(error) => {
+                write!(formatter, "The p11-kit child could not be reached: {error}")
+            }
+            Self::Protocol(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// A `CK_RV` as the module reported it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ReturnValue(pub(crate) u64);
+
+impl std::fmt::Display for ReturnValue {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self.0 {
+            0x0000_0005 => "CKR_GENERAL_ERROR",
+            0x0000_0006 => "CKR_FUNCTION_FAILED",
+            0x0000_0007 => "CKR_ARGUMENTS_BAD",
+            CKR_ATTRIBUTE_SENSITIVE => "CKR_ATTRIBUTE_SENSITIVE",
+            CKR_ATTRIBUTE_TYPE_INVALID => "CKR_ATTRIBUTE_TYPE_INVALID",
+            0x0000_0030 => "CKR_DEVICE_ERROR",
+            CKR_DEVICE_REMOVED => "CKR_DEVICE_REMOVED",
+            CKR_FUNCTION_CANCELED => "CKR_FUNCTION_CANCELED",
+            0x0000_0054 => "CKR_FUNCTION_NOT_SUPPORTED",
+            CKR_KEY_HANDLE_INVALID => "CKR_KEY_HANDLE_INVALID",
+            CKR_KEY_FUNCTION_NOT_PERMITTED => "CKR_KEY_FUNCTION_NOT_PERMITTED",
+            0x0000_0070 => "CKR_MECHANISM_INVALID",
+            CKR_OBJECT_HANDLE_INVALID => "CKR_OBJECT_HANDLE_INVALID",
+            0x0000_0090 => "CKR_OPERATION_NOT_INITIALIZED",
+            CKR_PIN_INCORRECT => "CKR_PIN_INCORRECT",
+            CKR_PIN_EXPIRED => "CKR_PIN_EXPIRED",
+            CKR_PIN_LOCKED => "CKR_PIN_LOCKED",
+            CKR_SESSION_CLOSED => "CKR_SESSION_CLOSED",
+            CKR_SESSION_HANDLE_INVALID => "CKR_SESSION_HANDLE_INVALID",
+            CKR_TOKEN_NOT_PRESENT => "CKR_TOKEN_NOT_PRESENT",
+            CKR_USER_ALREADY_LOGGED_IN => "CKR_USER_ALREADY_LOGGED_IN",
+            CKR_USER_NOT_LOGGED_IN => "CKR_USER_NOT_LOGGED_IN",
+            CKR_BUFFER_TOO_SMALL => "CKR_BUFFER_TOO_SMALL",
+            other => return write!(formatter, "CKR 0x{other:08X}"),
+        };
+
+        formatter.write_str(name)
+    }
+}
+
+/// A PKCS#11 module, hosted by the `p11-kit remote` child that loaded it.
+pub(crate) struct Module {
+    connection: Arc<Connection>,
+}
+
+impl Module {
+    /// Spawns `p11-kit remote <module>` and initializes the module behind it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the child cannot be spawned, exits before serving, offers a
+    /// protocol version we do not speak, or fails `C_Initialize`.
+    pub(crate) fn load(p11_kit: &Path, module: &Path) -> Result<Self, Error> {
+        let mut child = Command::new(p11_kit)
+            .arg("remote")
+            .arg(module)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(Error::Transport)?;
+        let (Some(stdin), Some(stdout)) = (child.stdin.take(), child.stdout.take()) else {
+            let _ = child.kill();
+            let _ = child.wait();
+
+            return Err(Error::Protocol(
+                "The spawned p11-kit child is missing its piped streams".to_owned(),
+            ));
+        };
+
+        let mut transport = Transport {
+            child,
+            stdin,
+            stdout,
+            next_code: FIRST_MESSAGE_CODE,
+        };
+
+        let protocol_version = match negotiate_and_initialize(&mut transport) {
+            Ok(protocol_version) => protocol_version,
+            Err(error) => return Err(transport.abort(error)),
+        };
+
+        Ok(Self {
+            connection: Arc::new(Connection {
+                transport: Mutex::new(transport),
+                protocol_version,
+            }),
+        })
+    }
+
+    /// Returns the ID of every slot that holds a token.
+    pub(crate) fn slots_with_tokens(&self) -> Result<Vec<u64>, Error> {
+        let mut probe = Request::new(&GET_SLOT_LIST);
+        probe.byte(1);
+        probe.buffer_size(0);
+        let count = match self.connection.call(&GET_SLOT_LIST, probe)?.ulong_array()? {
+            UlongArray::Values(slots) => return Ok(slots),
+            UlongArray::Length(count) => count,
+        };
+        if count == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut fetch = Request::new(&GET_SLOT_LIST);
+        fetch.byte(1);
+        fetch.buffer_size(count);
+        let slots = match self.connection.call(&GET_SLOT_LIST, fetch)?.ulong_array()? {
+            UlongArray::Values(slots) => slots,
+            UlongArray::Length(_) => {
+                return Err(Error::Protocol(
+                    "The slot list is missing from the response".to_owned(),
+                ));
+            }
+        };
+
+        Ok(slots)
+    }
+
+    /// Returns the `CK_TOKEN_INFO.flags` of the token in `slot`.
+    pub(crate) fn token_flags(&self, slot: u64) -> Result<u64, Error> {
+        let mut request = Request::new(&GET_TOKEN_INFO);
+        request.ulong(slot);
+        let mut response = self.connection.call(&GET_TOKEN_INFO, request)?;
+
+        // The label, manufacturer, model and serial number precede the flags.
+        response.space_string(32)?;
+        response.space_string(32)?;
+        response.space_string(16)?;
+        response.space_string(16)?;
+        let flags = response.ulong()?;
+
+        Ok(flags)
+    }
+
+    /// Opens a read-only session on the token in `slot`.
+    pub(crate) fn open_session(&self, slot: u64) -> Result<Session, Error> {
+        /// `CKF_SERIAL_SESSION`, which every session must set; read-only is its absence of
+        /// `CKF_RW_SESSION`.
+        const SERIAL_SESSION: u64 = 0x0000_0004;
+
+        let mut request = Request::new(&OPEN_SESSION);
+        request.ulong(slot);
+        request.ulong(SERIAL_SESSION);
+        let handle = self.connection.call(&OPEN_SESSION, request)?.ulong()?;
+
+        Ok(Session {
+            connection: Arc::clone(&self.connection),
+            handle,
+        })
+    }
+}
+
+/// A session on one token, usable from any thread.
+///
+/// The session keeps the `p11-kit remote` child hosting its module alive, so a held
+/// session, and with it the identity's private key, survives the walk that found it.
+#[derive(Debug)]
+pub(crate) struct Session {
+    connection: Arc<Connection>,
+    handle: u64,
+}
+
+impl Session {
+    /// Logs the token's user in with `pin`.
+    pub(crate) fn login_user(&self, pin: &[u8]) -> Result<(), Error> {
+        /// `CKU_USER`, the ordinary user of a token.
+        const USER: u64 = 0x0000_0001;
+
+        let mut request = Request::new(&LOGIN);
+        request.ulong(self.handle);
+        request.ulong(USER);
+        request.byte_array(pin);
+        self.connection.call(&LOGIN, request)?;
+
+        Ok(())
+    }
+
+    /// Returns the handle of every object matching `template`.
+    pub(crate) fn find_objects(&self, template: &[Attribute]) -> Result<Vec<u64>, Error> {
+        let mut init = Request::new(&FIND_OBJECTS_INIT);
+        init.ulong(self.handle);
+        init.attributes(template);
+        self.connection.call(&FIND_OBJECTS_INIT, init)?;
+
+        let mut handles = Vec::new();
+        loop {
+            const BATCH: u32 = 16;
+
+            let mut next = Request::new(&FIND_OBJECTS);
+            next.ulong(self.handle);
+            next.buffer_size(BATCH);
+            let batch = match self.connection.call(&FIND_OBJECTS, next)?.ulong_array()? {
+                UlongArray::Values(handles) => handles,
+                UlongArray::Length(_) => {
+                    return Err(Error::Protocol(
+                        "The object handles are missing from the response".to_owned(),
+                    ));
+                }
+            };
+
+            if batch.is_empty() {
+                break;
+            }
+            handles.extend(batch);
+        }
+
+        let mut done = Request::new(&FIND_OBJECTS_FINAL);
+        done.ulong(self.handle);
+        self.connection.call(&FIND_OBJECTS_FINAL, done)?;
+
+        Ok(handles)
+    }
+
+    /// Reads byte-array attributes of `object`, [`None`] where the object does not carry one.
+    ///
+    /// Every type asked for must be one PKCS#11 defines as a byte array, such as `CKA_VALUE`
+    /// or `CKA_ID`: the protocol encodes each attribute after its type, so this cannot
+    /// decode e.g. a `CK_ULONG` attribute.
+    pub(crate) fn byte_array_attributes(
+        &self,
+        object: u64,
+        types: &[u64],
+    ) -> Result<Vec<Option<Vec<u8>>>, Error> {
+        let sizes = types.iter().map(|&attribute| (attribute, 0)).collect();
+        let lengths = self.attribute_values(object, sizes, |response, length| {
+            response.skipped_byte_array()?;
+
+            Ok(length)
+        })?;
+
+        let known = lengths
+            .iter()
+            .zip(types)
+            .filter_map(|(length, &attribute)| Some((attribute, (*length)?)))
+            .filter(|(_, length)| *length > 0)
+            .collect::<Vec<_>>();
+        let fetched = if known.is_empty() {
+            Vec::new()
+        } else {
+            self.attribute_values(object, known, |response, _| {
+                response.raw_byte_array().map(Option::unwrap_or_default)
+            })?
+        };
+        let mut fetched = fetched.into_iter();
+
+        let values = lengths
+            .into_iter()
+            .map(|length| match length {
+                Some(0) => Some(Vec::new()),
+                Some(_) => fetched.next().flatten(),
+                None => None,
+            })
+            .collect();
+
+        Ok(values)
+    }
+
+    /// Runs one `C_GetAttributeValue` call, reading each answered value with `value`.
+    ///
+    /// `sizes` names the attributes and the value buffer offered for each; a probe offers
+    /// zero-length buffers and learns the lengths to offer next time.
+    fn attribute_values<T>(
+        &self,
+        object: u64,
+        sizes: Vec<(u64, u32)>,
+        value: impl Fn(&mut Response, u32) -> Result<T, Error>,
+    ) -> Result<Vec<Option<T>>, Error> {
+        /// Larger than any attribute a certificate or key object carries.
+        const MAX_ATTRIBUTE_LENGTH: u32 = 1024 * 1024;
+
+        let mut request = Request::new(&GET_ATTRIBUTE_VALUE);
+        request.ulong(self.handle);
+        request.ulong(object);
+        request.attribute_buffer(&sizes);
+        let mut response = self.connection.call(&GET_ATTRIBUTE_VALUE, request)?;
+
+        let count = response.u32()?;
+        if count as usize != sizes.len() {
+            return Err(Error::Protocol(format!(
+                "The response answers {count} attributes where {} were asked for",
+                sizes.len()
+            )));
+        }
+
+        let mut values = Vec::with_capacity(sizes.len());
+        for (attribute, _) in sizes {
+            let answered = response.u32()?;
+            if u64::from(answered) != attribute {
+                return Err(Error::Protocol(format!(
+                    "The response answers attribute {answered} where {attribute} was asked for"
+                )));
+            }
+
+            let available = response.byte()? != 0;
+            if !available {
+                values.push(None);
+                continue;
+            }
+
+            let length = response.u32()?;
+            if length > MAX_ATTRIBUTE_LENGTH {
+                return Err(Error::Protocol(format!(
+                    "The response carries an implausibly large attribute of {length} bytes"
+                )));
+            }
+
+            values.push(Some(value(&mut response, length)?));
+        }
+
+        // The verdict of the call follows the attributes; the codes below say some
+        // attributes are missing, which the validity of each already told us.
+        let verdict = response.ulong()?;
+        match verdict {
+            0 => {}
+            CKR_ATTRIBUTE_SENSITIVE => {}
+            CKR_ATTRIBUTE_TYPE_INVALID => {}
+            CKR_BUFFER_TOO_SMALL => {}
+            other => return Err(Error::Token(ReturnValue(other))),
+        }
+
+        Ok(values)
+    }
+
+    /// Signs `data` with `key` in one go.
+    pub(crate) fn sign(
+        &self,
+        mechanism: &Mechanism,
+        key: u64,
+        data: &[u8],
+    ) -> Result<Vec<u8>, Error> {
+        /// Larger than any signature a TLS client key produces.
+        const SIGNATURE_CAPACITY: u32 = 16 * 1024;
+
+        // One lock spans both calls: `C_SignInit` starts an operation that `C_Sign`
+        // consumes, so another thread's pair interleaving here would corrupt both.
+        let mut transport = self.connection.lock();
+
+        let mut init = Request::new(&SIGN_INIT);
+        init.ulong(self.handle);
+        init.mechanism(mechanism, self.connection.protocol_version);
+        init.ulong(key);
+        call(&mut transport, &SIGN_INIT, init)?;
+
+        let mut request = Request::new(&SIGN);
+        request.ulong(self.handle);
+        request.byte_array(data);
+        request.buffer_size(SIGNATURE_CAPACITY);
+        let signature = call(&mut transport, &SIGN, request)?.byte_array()?;
+
+        Ok(signature)
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        let mut request = Request::new(&CLOSE_SESSION);
+        request.ulong(self.handle);
+        let _ = self.connection.call(&CLOSE_SESSION, request);
+    }
+}
+
+/// The signing mechanisms the keystore uses, with the parameters each carries.
+#[derive(Debug)]
+pub(crate) enum Mechanism {
+    Sha256RsaPkcs,
+    Sha384RsaPkcs,
+    Sha512RsaPkcs,
+    Sha256RsaPkcsPss,
+    Sha384RsaPkcsPss,
+    Sha512RsaPkcsPss,
+    Ecdsa,
+}
+
+impl Mechanism {
+    /// Writes the mechanism the way a server speaking `protocol_version` reads one.
+    ///
+    /// Version 2 of the protocol, p11-kit 0.26, reframed mechanisms: under it a
+    /// parameterless mechanism ends after its type and parameters follow a presence byte,
+    /// while versions 0 and 1 follow a parameterless type with the null byte-array marker
+    /// and parameters directly. A server decodes by its own build's framing, which the
+    /// version it negotiated names.
+    fn encode(&self, buffer: &mut Vec<u8>, protocol_version: u8) {
+        const CKM_SHA256_RSA_PKCS: u32 = 0x0000_0040;
+        const CKM_SHA384_RSA_PKCS: u32 = 0x0000_0041;
+        const CKM_SHA512_RSA_PKCS: u32 = 0x0000_0042;
+        const CKM_SHA256_RSA_PKCS_PSS: u32 = 0x0000_0043;
+        const CKM_SHA384_RSA_PKCS_PSS: u32 = 0x0000_0044;
+        const CKM_SHA512_RSA_PKCS_PSS: u32 = 0x0000_0045;
+        const CKM_ECDSA: u32 = 0x0000_1041;
+        const CKM_SHA256: u64 = 0x0000_0250;
+        const CKM_SHA384: u64 = 0x0000_0260;
+        const CKM_SHA512: u64 = 0x0000_0270;
+        const MGF1_SHA256: u64 = 0x0000_0002;
+        const MGF1_SHA384: u64 = 0x0000_0003;
+        const MGF1_SHA512: u64 = 0x0000_0004;
+
+        let (mechanism, pss) = match self {
+            Self::Sha256RsaPkcs => (CKM_SHA256_RSA_PKCS, None),
+            Self::Sha384RsaPkcs => (CKM_SHA384_RSA_PKCS, None),
+            Self::Sha512RsaPkcs => (CKM_SHA512_RSA_PKCS, None),
+            Self::Sha256RsaPkcsPss => {
+                (CKM_SHA256_RSA_PKCS_PSS, Some((CKM_SHA256, MGF1_SHA256, 32)))
+            }
+            Self::Sha384RsaPkcsPss => {
+                (CKM_SHA384_RSA_PKCS_PSS, Some((CKM_SHA384, MGF1_SHA384, 48)))
+            }
+            Self::Sha512RsaPkcsPss => {
+                (CKM_SHA512_RSA_PKCS_PSS, Some((CKM_SHA512, MGF1_SHA512, 64)))
+            }
+            Self::Ecdsa => (CKM_ECDSA, None),
+        };
+
+        const NULL_MARKER: u32 = 0xffff_ffff;
+
+        let reframed = protocol_version >= 2;
+
+        push_u32(buffer, mechanism);
+        let Some((hash, mask_generation_function, salt_length)) = pss else {
+            if !reframed {
+                push_u32(buffer, NULL_MARKER);
+            }
+
+            return;
+        };
+        if reframed {
+            buffer.push(1);
+        }
+        push_u64(buffer, hash);
+        push_u64(buffer, mask_generation_function);
+        push_u64(buffer, salt_length);
+    }
+}
+
+/// One attribute of a search template.
+#[derive(Debug, Clone)]
+pub(crate) struct Attribute {
+    attribute_type: u64,
+    value: AttributeValue,
+}
+
+#[derive(Debug, Clone)]
+enum AttributeValue {
+    Ulong(u64),
+    Bytes(Vec<u8>),
+}
+
+impl Attribute {
+    pub(crate) fn ulong(attribute_type: u64, value: u64) -> Self {
+        Self {
+            attribute_type,
+            value: AttributeValue::Ulong(value),
+        }
+    }
+
+    pub(crate) fn bytes(attribute_type: u64, value: Vec<u8>) -> Self {
+        Self {
+            attribute_type,
+            value: AttributeValue::Bytes(value),
+        }
+    }
+
+    fn encode(&self, buffer: &mut Vec<u8>) {
+        /// What a native client reports as `ulValueLen` of a `CK_ULONG` attribute; the
+        /// server checks it against its own `CK_ULONG`, so it has to be ours.
+        const ULONG_LENGTH: u32 = size_of::<std::ffi::c_ulong>() as u32;
+
+        push_u32(buffer, self.attribute_type as u32);
+        buffer.push(1);
+        match &self.value {
+            AttributeValue::Ulong(value) => {
+                push_u32(buffer, ULONG_LENGTH);
+                push_u64(buffer, *value);
+            }
+            AttributeValue::Bytes(bytes) => {
+                push_u32(buffer, bytes.len() as u32);
+                push_u32(buffer, bytes.len() as u32);
+                buffer.extend_from_slice(bytes);
+            }
+        }
+    }
+}
+
+/// One call of the protocol: its numeric ID and the argument signatures both sides verify.
+struct Call {
+    id: u32,
+    request: &'static str,
+    response: &'static str,
+}
+
+const ERROR_CALL_ID: u32 = 0;
+const INITIALIZE: Call = Call {
+    id: 1,
+    request: "ayyay",
+    response: "",
+};
+const FINALIZE: Call = Call {
+    id: 2,
+    request: "",
+    response: "",
+};
+const GET_SLOT_LIST: Call = Call {
+    id: 4,
+    request: "yfu",
+    response: "au",
+};
+const GET_TOKEN_INFO: Call = Call {
+    id: 6,
+    request: "u",
+    response: "ssssuuuuuuuuuuuvvs",
+};
+const OPEN_SESSION: Call = Call {
+    id: 10,
+    request: "uu",
+    response: "u",
+};
+const CLOSE_SESSION: Call = Call {
+    id: 11,
+    request: "u",
+    response: "",
+};
+const LOGIN: Call = Call {
+    id: 18,
+    request: "uuay",
+    response: "",
+};
+const GET_ATTRIBUTE_VALUE: Call = Call {
+    id: 24,
+    request: "uufA",
+    response: "aAu",
+};
+const FIND_OBJECTS_INIT: Call = Call {
+    id: 26,
+    request: "uaA",
+    response: "",
+};
+const FIND_OBJECTS: Call = Call {
+    id: 27,
+    request: "ufu",
+    response: "au",
+};
+const FIND_OBJECTS_FINAL: Call = Call {
+    id: 28,
+    request: "u",
+    response: "",
+};
+const SIGN_INIT: Call = Call {
+    id: 42,
+    request: "uMu",
+    response: "",
+};
+const SIGN: Call = Call {
+    id: 43,
+    request: "uayfy",
+    response: "ay",
+};
+
+/// The newest protocol version we offer the child.
+///
+/// The child answers with the version it will speak, at most what was offered. Any answer up
+/// to our offer is usable: the calls the versions added, the PKCS#11 3.0 calls at 1 and
+/// `C_DeriveKey2` at 2, lie outside our subset, and [`Mechanism::encode`] follows the framing
+/// the answered version names.
+const OFFERED_PROTOCOL_VERSION: u8 = 2;
+
+/// What p11-kit's `C_Initialize` sends in place of the reserved arguments.
+const INITIALIZE_HANDSHAKE: &[u8] = b"PRIVATE-GNOME-KEYRING-PKCS11-PROTOCOL-V-1";
+
+/// Where p11-kit starts numbering the messages on a connection.
+const FIRST_MESSAGE_CODE: u32 = 0x10;
+
+/// Longer than any response the calls we make can produce.
+const MAX_RESPONSE_LENGTH: u32 = 8 * 1024 * 1024;
+
+/// Negotiates the protocol version and initializes the module.
+///
+/// Returns the version the child answered with.
+fn negotiate_and_initialize(transport: &mut Transport) -> Result<u8, Error> {
+    transport
+        .stdin
+        .write_all(&[OFFERED_PROTOCOL_VERSION])
+        .map_err(Error::Transport)?;
+    transport.stdin.flush().map_err(Error::Transport)?;
+
+    let mut version = [0u8];
+    transport
+        .stdout
+        .read_exact(&mut version)
+        .map_err(Error::Transport)?;
+    let [version] = version;
+    if version > OFFERED_PROTOCOL_VERSION {
+        return Err(Error::Protocol(format!(
+            "The p11-kit child wants to speak RPC protocol version {version}, and we only speak up to {OFFERED_PROTOCOL_VERSION}"
+        )));
+    }
+
+    let mut request = Request::new(&INITIALIZE);
+    request.byte_array(INITIALIZE_HANDSHAKE);
+    request.byte(0);
+    request.byte_array(&[0]);
+    call(transport, &INITIALIZE, request)?;
+
+    Ok(version)
+}
+
+/// The child process and the streams the protocol runs on.
+#[derive(Debug)]
+struct Transport {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: ChildStdout,
+    next_code: u32,
+}
+
+impl Transport {
+    /// Sends one framed message and returns the payload of the answer to it.
+    ///
+    /// A frame is three big-endian `u32`s, the message code, options length and payload
+    /// length, followed by the options and the payload. The options ride along unused in
+    /// either direction.
+    fn roundtrip(&mut self, request: &[u8]) -> Result<Vec<u8>, Error> {
+        let code = self.next_code;
+        self.next_code = self.next_code.wrapping_add(1);
+
+        let mut header = [0u8; 12];
+        header[0..4].copy_from_slice(&code.to_be_bytes());
+        header[8..12].copy_from_slice(&(request.len() as u32).to_be_bytes());
+        self.stdin.write_all(&header).map_err(Error::Transport)?;
+        self.stdin.write_all(request).map_err(Error::Transport)?;
+        self.stdin.flush().map_err(Error::Transport)?;
+
+        let mut header = [0u8; 12];
+        self.stdout
+            .read_exact(&mut header)
+            .map_err(Error::Transport)?;
+        let answered = u32::from_be_bytes([header[0], header[1], header[2], header[3]]);
+        let options_length = u32::from_be_bytes([header[4], header[5], header[6], header[7]]);
+        let payload_length = u32::from_be_bytes([header[8], header[9], header[10], header[11]]);
+        if answered != code {
+            return Err(Error::Protocol(format!(
+                "The child answered message {answered} where {code} was awaited"
+            )));
+        }
+        if options_length > MAX_RESPONSE_LENGTH || payload_length > MAX_RESPONSE_LENGTH {
+            return Err(Error::Protocol(format!(
+                "The child answered with an implausibly long message of {options_length}+{payload_length} bytes"
+            )));
+        }
+
+        let mut options = vec![0u8; options_length as usize];
+        self.stdout
+            .read_exact(&mut options)
+            .map_err(Error::Transport)?;
+        let mut payload = vec![0u8; payload_length as usize];
+        self.stdout
+            .read_exact(&mut payload)
+            .map_err(Error::Transport)?;
+
+        Ok(payload)
+    }
+
+    /// Ends a connection that never became usable, naming what the child said on stderr.
+    fn abort(mut self, error: Error) -> Error {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+
+        // The child has exited, so the read cannot block on it.
+        let Some(mut stderr) = self.child.stderr.take() else {
+            return error;
+        };
+        let mut complaint = String::new();
+        if stderr.read_to_string(&mut complaint).is_err() {
+            return error;
+        }
+        let complaint = complaint.split_whitespace().collect::<Vec<_>>().join(" ");
+        if complaint.is_empty() {
+            return error;
+        }
+
+        Error::Protocol(format!("{error} ({complaint})"))
+    }
+}
+
+/// The transport, shared by the module and its sessions for as long as either lives.
+#[derive(Debug)]
+struct Connection {
+    transport: Mutex<Transport>,
+    protocol_version: u8,
+}
+
+impl Connection {
+    fn call(&self, of: &Call, request: Request) -> Result<Response, Error> {
+        let mut transport = self.lock();
+
+        call(&mut transport, of, request)
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Transport> {
+        self.transport
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        let transport = self
+            .transport
+            .get_mut()
+            .unwrap_or_else(PoisonError::into_inner);
+
+        // Finalizing lets the module flush its state; the kill then only reaps a child
+        // with nothing left to do, or one that stopped answering.
+        let _ = call(transport, &FINALIZE, Request::new(&FINALIZE));
+        let _ = transport.child.kill();
+        let _ = transport.child.wait();
+    }
+}
+
+fn call(transport: &mut Transport, of: &Call, request: Request) -> Result<Response, Error> {
+    let payload = transport.roundtrip(&request.buffer)?;
+
+    Response::parse(of, payload)
+}
+
+/// A request payload under construction: the call ID and signature, then the arguments.
+struct Request {
+    buffer: Vec<u8>,
+}
+
+impl Request {
+    fn new(call: &Call) -> Self {
+        let mut buffer = Vec::new();
+        push_u32(&mut buffer, call.id);
+        push_u32(&mut buffer, call.request.len() as u32);
+        buffer.extend_from_slice(call.request.as_bytes());
+
+        Self { buffer }
+    }
+
+    /// Writes a `y` argument.
+    fn byte(&mut self, value: u8) {
+        self.buffer.push(value);
+    }
+
+    /// Writes a `u` argument.
+    fn ulong(&mut self, value: u64) {
+        push_u64(&mut self.buffer, value);
+    }
+
+    /// Writes an `ay` argument.
+    fn byte_array(&mut self, bytes: &[u8]) {
+        self.buffer.push(1);
+        push_u32(&mut self.buffer, bytes.len() as u32);
+        self.buffer.extend_from_slice(bytes);
+    }
+
+    /// Writes an `fy` or `fu` argument: how many items the response may carry.
+    fn buffer_size(&mut self, count: u32) {
+        push_u32(&mut self.buffer, count);
+    }
+
+    /// Writes an `aA` argument.
+    fn attributes(&mut self, template: &[Attribute]) {
+        push_u32(&mut self.buffer, template.len() as u32);
+        for attribute in template {
+            attribute.encode(&mut self.buffer);
+        }
+    }
+
+    /// Writes an `fA` argument: the attribute types asked for and the bytes offered to each.
+    fn attribute_buffer(&mut self, sizes: &[(u64, u32)]) {
+        push_u32(&mut self.buffer, sizes.len() as u32);
+        for (attribute, length) in sizes {
+            push_u32(&mut self.buffer, *attribute as u32);
+            push_u32(&mut self.buffer, *length);
+        }
+    }
+
+    /// Writes an `M` argument.
+    fn mechanism(&mut self, mechanism: &Mechanism, protocol_version: u8) {
+        mechanism.encode(&mut self.buffer, protocol_version);
+    }
+}
+
+fn push_u32(buffer: &mut Vec<u8>, value: u32) {
+    buffer.extend_from_slice(&value.to_be_bytes());
+}
+
+fn push_u64(buffer: &mut Vec<u8>, value: u64) {
+    buffer.extend_from_slice(&value.to_be_bytes());
+}
+
+/// A `CK_ULONG` array of a response, or only its length when the response holds no items.
+enum UlongArray {
+    Values(Vec<u64>),
+    Length(u32),
+}
+
+/// A response payload, verified to answer the sent call, read argument by argument.
+struct Response {
+    payload: Vec<u8>,
+    offset: usize,
+}
+
+impl Response {
+    fn parse(call: &Call, payload: Vec<u8>) -> Result<Self, Error> {
+        let mut response = Self { payload, offset: 0 };
+
+        let answered = response.u32()?;
+        let signature = response.signature()?;
+        if answered == ERROR_CALL_ID {
+            if signature != "u" {
+                return Err(Error::Protocol(
+                    "The error response does not carry a return value".to_owned(),
+                ));
+            }
+            let value = response.ulong()?;
+            if value == 0 {
+                return Err(Error::Protocol(
+                    "The error response answers that nothing is wrong".to_owned(),
+                ));
+            }
+
+            return Err(Error::Token(ReturnValue(value)));
+        }
+        if answered != call.id {
+            return Err(Error::Protocol(format!(
+                "The child answered call {answered} where {} was awaited",
+                call.id
+            )));
+        }
+        if signature != call.response {
+            return Err(Error::Protocol(format!(
+                "The child answered with signature '{signature}' where '{}' was awaited",
+                call.response
+            )));
+        }
+
+        Ok(response)
+    }
+
+    fn signature(&mut self) -> Result<String, Error> {
+        let length = self.u32()?;
+        let bytes = self.take(length as usize)?;
+
+        Ok(String::from_utf8_lossy(bytes).into_owned())
+    }
+
+    /// Reads a `y` value.
+    fn byte(&mut self) -> Result<u8, Error> {
+        let bytes = self.take(1)?;
+
+        Ok(bytes[0])
+    }
+
+    /// Reads a `u` value.
+    fn ulong(&mut self) -> Result<u64, Error> {
+        let bytes = self.take(8)?;
+        let mut value = [0u8; 8];
+        value.copy_from_slice(bytes);
+
+        Ok(u64::from_be_bytes(value))
+    }
+
+    fn u32(&mut self) -> Result<u32, Error> {
+        let bytes = self.take(4)?;
+        let mut value = [0u8; 4];
+        value.copy_from_slice(bytes);
+
+        Ok(u32::from_be_bytes(value))
+    }
+
+    /// Reads an `s` value, which must be exactly `length` bytes of padded text.
+    fn space_string(&mut self, length: usize) -> Result<(), Error> {
+        let carried = self.u32()?;
+        if carried as usize != length {
+            return Err(Error::Protocol(format!(
+                "The response carries a string of {carried} bytes where {length} were awaited"
+            )));
+        }
+        self.take(length)?;
+
+        Ok(())
+    }
+
+    /// Reads an `ay` value.
+    fn byte_array(&mut self) -> Result<Vec<u8>, Error> {
+        let present = self.byte()? != 0;
+        if !present {
+            // Only the needed length follows: the buffer we offered was too small.
+            let _needed = self.u32()?;
+
+            return Err(Error::Token(ReturnValue(CKR_BUFFER_TOO_SMALL)));
+        }
+
+        let bytes = self.raw_byte_array()?.unwrap_or_default();
+
+        Ok(bytes)
+    }
+
+    /// Reads a bare length-prefixed byte array, [`None`] for the null marker.
+    fn raw_byte_array(&mut self) -> Result<Option<Vec<u8>>, Error> {
+        const NULL_MARKER: u32 = 0xffff_ffff;
+
+        let length = self.u32()?;
+        if length == NULL_MARKER {
+            return Ok(None);
+        }
+        let bytes = self.take(length as usize)?;
+
+        Ok(Some(bytes.to_vec()))
+    }
+
+    /// Reads and discards a bare length-prefixed byte array.
+    fn skipped_byte_array(&mut self) -> Result<(), Error> {
+        self.raw_byte_array()?;
+
+        Ok(())
+    }
+
+    /// Reads an `au` value.
+    fn ulong_array(&mut self) -> Result<UlongArray, Error> {
+        let present = self.byte()? != 0;
+        let count = self.u32()?;
+        if !present {
+            return Ok(UlongArray::Length(count));
+        }
+        if count > MAX_RESPONSE_LENGTH / 8 {
+            return Err(Error::Protocol(format!(
+                "The response carries an implausibly long array of {count} items"
+            )));
+        }
+
+        let values = (0..count)
+            .map(|_| self.ulong())
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(UlongArray::Values(values))
+    }
+
+    fn take(&mut self, length: usize) -> Result<&[u8], Error> {
+        let remaining = self.payload.len() - self.offset;
+        if remaining < length {
+            return Err(Error::Protocol(format!(
+                "The response ends after {remaining} bytes where {length} more were awaited"
+            )));
+        }
+
+        let bytes = &self.payload[self.offset..self.offset + length];
+        self.offset += length;
+
+        Ok(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_a_search_template_the_way_p11_kit_does() {
+        let mut request = Request::new(&FIND_OBJECTS_INIT);
+        request.ulong(0x11);
+        request.attributes(&[
+            Attribute::ulong(ATTRIBUTE_CLASS, OBJECT_CLASS_CERTIFICATE),
+            Attribute::bytes(ATTRIBUTE_ID, vec![0xab, 0xcd]),
+        ]);
+
+        #[rustfmt::skip]
+        let expected = [
+            0, 0, 0, 26, // The call ID of C_FindObjectsInit.
+            0, 0, 0, 3, b'u', b'a', b'A', // Its request signature.
+            0, 0, 0, 0, 0, 0, 0, 0x11, // The session handle.
+            0, 0, 0, 2, // Two attributes follow.
+            0, 0, 0, 0, // CKA_CLASS.
+            1, // Valid.
+            0, 0, 0, 8, // The length of a CK_ULONG.
+            0, 0, 0, 0, 0, 0, 0, 1, // CKO_CERTIFICATE.
+            0, 0, 1, 2, // CKA_ID.
+            1, // Valid.
+            0, 0, 0, 2, // Two bytes of value.
+            0, 0, 0, 2, 0xab, 0xcd, // The value, a length-prefixed byte array.
+        ];
+        assert_eq!(request.buffer, expected);
+    }
+
+    #[test]
+    fn frames_a_mechanism_by_the_negotiated_version() {
+        let framed = |mechanism: &Mechanism, protocol_version| {
+            let mut buffer = Vec::new();
+            mechanism.encode(&mut buffer, protocol_version);
+
+            buffer
+        };
+
+        assert_eq!(
+            framed(&Mechanism::Ecdsa, 1),
+            [0, 0, 0x10, 0x41, 0xff, 0xff, 0xff, 0xff],
+            "before version 2, a parameterless mechanism ends with the null marker"
+        );
+        assert_eq!(
+            framed(&Mechanism::Ecdsa, 2),
+            [0, 0, 0x10, 0x41],
+            "under version 2, a parameterless mechanism ends after its type"
+        );
+        #[rustfmt::skip]
+        let old_pss = [
+            0, 0, 0, 0x43, // CKM_SHA256_RSA_PKCS_PSS.
+            0, 0, 0, 0, 0, 0, 0x02, 0x50, // CKM_SHA256.
+            0, 0, 0, 0, 0, 0, 0, 2, // MGF1 with SHA-256.
+            0, 0, 0, 0, 0, 0, 0, 32, // The salt length.
+        ];
+        assert_eq!(
+            framed(&Mechanism::Sha256RsaPkcsPss, 1),
+            old_pss,
+            "before version 2, the parameters follow the type directly"
+        );
+        let mut new_pss = old_pss.to_vec();
+        new_pss.insert(4, 1);
+        assert_eq!(
+            framed(&Mechanism::Sha256RsaPkcsPss, 2),
+            new_pss,
+            "under version 2, a presence byte leads the parameters"
+        );
+    }
+
+    #[test]
+    fn an_error_response_carries_the_return_value() {
+        let mut payload = Vec::new();
+        push_u32(&mut payload, ERROR_CALL_ID);
+        push_u32(&mut payload, 1);
+        payload.push(b'u');
+        push_u64(&mut payload, CKR_PIN_INCORRECT);
+
+        let Err(Error::Token(value)) = Response::parse(&LOGIN, payload) else {
+            panic!("an error response should surface as a token error");
+        };
+
+        assert_eq!(value, ReturnValue(CKR_PIN_INCORRECT));
+        assert_eq!(value.to_string(), "CKR_PIN_INCORRECT");
+    }
+
+    #[test]
+    fn a_probed_slot_list_answers_with_its_length() {
+        let mut payload = Vec::new();
+        push_u32(&mut payload, GET_SLOT_LIST.id);
+        push_u32(&mut payload, 2);
+        payload.extend_from_slice(b"au");
+        payload.push(0);
+        push_u32(&mut payload, 3);
+
+        let mut response =
+            Response::parse(&GET_SLOT_LIST, payload).expect("the response should parse");
+
+        let UlongArray::Length(count) = response.ulong_array().expect("the array should parse")
+        else {
+            panic!("a probe response should carry only the length");
+        };
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn a_truncated_response_is_refused() {
+        let mut payload = Vec::new();
+        push_u32(&mut payload, OPEN_SESSION.id);
+        push_u32(&mut payload, 1);
+        payload.push(b'u');
+        push_u32(&mut payload, 7); // Half of the session handle is missing.
+
+        let mut response =
+            Response::parse(&OPEN_SESSION, payload).expect("the envelope should parse");
+
+        assert!(matches!(response.ulong(), Err(Error::Protocol(_))));
+    }
+}

--- a/rust/libs/x509-keystore/src/linux/tests.rs
+++ b/rust/libs/x509-keystore/src/linux/tests.rs
@@ -1,0 +1,1022 @@
+//! Tests for the PKCS#11 backend, including its calls into a token.
+//!
+//! The tests that reach into a token run against SoftHSM, served through `p11-kit remote` the
+//! way a deployment's modules are, though named directly rather than found through the
+//! registration. Each of them initialises its own token below a temporary directory that
+//! `SOFTHSM2_CONF` names, so they never touch a developer's real token store and cannot collide
+//! with one another. Provisioning the tokens loads SoftHSM in-process through `cryptoki`,
+//! which is what a real PKCS#11 device's enrollment tooling does.
+
+use std::{
+    fs,
+    os::unix::fs::PermissionsExt as _,
+    path::{Path, PathBuf},
+    sync::{Mutex, MutexGuard, PoisonError},
+};
+
+use cryptoki::{
+    context::{CInitializeArgs, CInitializeFlags, Pkcs11},
+    mechanism::Mechanism,
+    object::{Attribute, AttributeType, CertificateType, ObjectClass, ObjectHandle},
+    session::{Session, UserType},
+    slot::Slot,
+    types::{AuthPin, Ulong},
+};
+use ring::signature::{
+    ECDSA_P256_SHA256_ASN1, RSA_PKCS1_2048_8192_SHA256, RSA_PKCS1_2048_8192_SHA384,
+    RSA_PKCS1_2048_8192_SHA512, RSA_PSS_2048_8192_SHA256, RSA_PSS_2048_8192_SHA384,
+    RSA_PSS_2048_8192_SHA512, UnparsedPublicKey, VerificationAlgorithm,
+};
+use rustls::SignatureAlgorithm;
+use secrecy::ExposeSecret as _;
+use x509_parser::prelude::{FromDer as _, X509Certificate};
+
+use super::*;
+use crate::DetailField;
+use crate::sign::{der_encode_ecdsa_signature, der_integer, encode_der_length};
+
+#[test]
+fn an_unloadable_module_is_an_unreadable_keystore() {
+    let modules = [PathBuf::from("/nonexistent/example-pkcs11.so")];
+    let pin_file = Path::new("/nonexistent/pkcs11-pin");
+
+    let Err(error) = identity_on(
+        Path::new("/nonexistent/p11-kit"),
+        &modules,
+        pin_file,
+        "dev.firezone.device-trust",
+    ) else {
+        panic!("a keystore whose every module failed should be reported as unreadable");
+    };
+
+    let Error::UnreadablePkcs11Keystore { modules } = &error else {
+        panic!("expected an unreadable keystore, got {error:?}");
+    };
+    assert_eq!(
+        modules[..],
+        ["/nonexistent/example-pkcs11.so: Failed to load /nonexistent/example-pkcs11.so"],
+        "the entries show the short cause; the log carries the full chain"
+    );
+    let warning = error.to_string();
+    assert!(
+        warning.contains("https://www.firezone.dev/kb/install/linux"),
+        "{warning} should point at the knowledge base"
+    );
+}
+
+#[test]
+fn reads_the_module_a_configuration_file_names() {
+    let directories = [
+        PathBuf::from("/usr/lib64/pkcs11"),
+        PathBuf::from("/usr/lib/pkcs11"),
+    ];
+    let installed = |module: &Path| module == Path::new("/usr/lib/pkcs11/opensc-pkcs11.so");
+    let files = [(
+        "opensc".to_owned(),
+        "# The OpenSC driver.\nmodule: opensc-pkcs11.so\ndisable-in: p11-kit-proxy\n".to_owned(),
+    )];
+
+    let modules = configured_modules(files, &directories, &installed, Some("firezone-tunnel"));
+
+    assert_eq!(
+        modules,
+        [PathBuf::from("/usr/lib/pkcs11/opensc-pkcs11.so")],
+        "a relative module resolves against the directory that holds it, and `disable-in` \
+         only disables a module for the proxy, which we are not"
+    );
+}
+
+#[test]
+fn an_absolute_module_is_loaded_from_where_the_configuration_says() {
+    let files = [(
+        "example".to_owned(),
+        "module: /opt/example/example-pkcs11.so\n".to_owned(),
+    )];
+
+    let modules = configured_modules(
+        files,
+        &[PathBuf::from("/usr/lib64/pkcs11")],
+        &|_: &Path| false,
+        None,
+    );
+
+    assert_eq!(modules, [PathBuf::from("/opt/example/example-pkcs11.so")]);
+}
+
+#[test]
+fn registered_modules_are_deduplicated_by_resolved_path() {
+    let directories = [PathBuf::from("/usr/lib64/pkcs11")];
+    let files = [
+        (
+            "a-softhsm".to_owned(),
+            "module: libsofthsm2.so\n".to_owned(),
+        ),
+        (
+            "b-softhsm-again".to_owned(),
+            "module: /usr/lib64/pkcs11/libsofthsm2.so\n".to_owned(),
+        ),
+        ("c-empty".to_owned(), "trust-policy: yes\n".to_owned()),
+        (
+            "d-trust".to_owned(),
+            "module: p11-kit-trust.so\ndisable-in: p11-kit-proxy\n".to_owned(),
+        ),
+    ];
+
+    let modules = configured_modules(files, &directories, &|_: &Path| false, None);
+
+    assert_eq!(
+        modules,
+        [
+            // A module that is nowhere keeps the most preferred guess, so its load failure
+            // names the path the configuration meant.
+            PathBuf::from("/usr/lib64/pkcs11/libsofthsm2.so"),
+            PathBuf::from("/usr/lib64/pkcs11/p11-kit-trust.so"),
+        ],
+        "one file without a `module:` line and one duplicate should be dropped"
+    );
+}
+
+#[test]
+fn modules_follow_their_configured_priority() {
+    let directories = [PathBuf::from("/usr/lib64/pkcs11")];
+    let files = [
+        ("b".to_owned(), "module: b.so\n".to_owned()),
+        (
+            "c".to_owned(),
+            "module: c.so\npriority: 10 # The highest.\n".to_owned(),
+        ),
+        ("a".to_owned(), "module: a.so\npriority: 0\n".to_owned()),
+    ];
+
+    let modules = configured_modules(files, &directories, &|_: &Path| false, None);
+
+    assert_eq!(
+        modules,
+        [
+            PathBuf::from("/usr/lib64/pkcs11/c.so"),
+            PathBuf::from("/usr/lib64/pkcs11/a.so"),
+            PathBuf::from("/usr/lib64/pkcs11/b.so"),
+        ],
+        "the highest priority goes first and a tie falls back to the configuration name, \
+         with a comment after the number ignored the way p11-kit's `atoi` ignores it"
+    );
+}
+
+#[test]
+fn a_module_reserved_for_other_programs_is_skipped() {
+    let directories = [PathBuf::from("/usr/lib64/pkcs11")];
+    let files = [
+        (
+            "gnome".to_owned(),
+            "module: gnome.so\nenable-in: seahorse, gnome-keyring\n".to_owned(),
+        ),
+        (
+            "blocked".to_owned(),
+            "module: blocked.so\ndisable-in: firezone-tunnel\n".to_owned(),
+        ),
+        ("open".to_owned(), "module: open.so\n".to_owned()),
+    ];
+
+    let modules = configured_modules(
+        files,
+        &directories,
+        &|_: &Path| false,
+        Some("firezone-tunnel"),
+    );
+
+    assert_eq!(
+        modules,
+        [PathBuf::from("/usr/lib64/pkcs11/open.so")],
+        "`enable-in` reserves a module for the programs it lists, and `disable-in` \
+         withholds one from them"
+    );
+}
+
+#[test]
+fn the_administrators_configuration_overrides_the_packaged_one() {
+    let directories = [PathBuf::from("/usr/lib64/pkcs11")];
+    let files = [
+        (
+            "softhsm2".to_owned(),
+            "module: /opt/custom/libsofthsm2.so\n".to_owned(),
+        ),
+        ("softhsm2".to_owned(), "module: libsofthsm2.so\n".to_owned()),
+    ];
+
+    let modules = configured_modules(files, &directories, &|_: &Path| false, None);
+
+    assert_eq!(
+        modules,
+        [PathBuf::from("/opt/custom/libsofthsm2.so")],
+        "of two configurations under one name, the first one offered wins entirely"
+    );
+}
+
+#[test]
+#[ignore = "Requires the SoftHSM PKCS#11 module and writes to a temporary token store"]
+fn signs_with_the_token_key_of_an_rsa_certificate() {
+    let _serialized = serialize_token_access();
+    let token = provision_token("rsa", KeyAlgorithm::Rsa);
+
+    let identity = token
+        .identity()
+        .expect("the SoftHSM token should be readable")
+        .expect("the provisioned certificate should be selected as the client identity");
+
+    assert_eq!(leaf_of(&identity), token.certificate);
+    assert_eq!(identity.key.algorithm(), SignatureAlgorithm::RSA);
+    assert_signs_every_advertised_scheme(&identity, &token.certificate);
+}
+
+#[test]
+#[ignore = "Requires the SoftHSM PKCS#11 module and writes to a temporary token store"]
+fn signs_with_the_token_key_of_an_ecdsa_certificate() {
+    let _serialized = serialize_token_access();
+    let token = provision_token("ecdsa", KeyAlgorithm::EcdsaP256);
+
+    let identity = token
+        .identity()
+        .expect("the SoftHSM token should be readable")
+        .expect("the provisioned certificate should be selected as the client identity");
+
+    assert_eq!(leaf_of(&identity), token.certificate);
+    assert_eq!(identity.key.algorithm(), SignatureAlgorithm::ECDSA);
+    assert_eq!(
+        identity.key.supported_schemes(),
+        vec![SignatureScheme::ECDSA_NISTP256_SHA256]
+    );
+    assert_signs_every_advertised_scheme(&identity, &token.certificate);
+}
+
+#[test]
+#[ignore = "Requires the SoftHSM PKCS#11 module and writes to a temporary token store"]
+fn describes_the_provisioned_certificate_it_loads() {
+    let _serialized = serialize_token_access();
+    let token = provision_token("describe", KeyAlgorithm::Rsa);
+
+    let identity = token
+        .identity()
+        .expect("the SoftHSM token should be readable")
+        .expect("the provisioned certificate should be selected as the client identity");
+
+    let fields = identity.certificate.detail_fields();
+    assert_eq!(
+        field_value(&fields, "Common Name"),
+        Some(token.subject_cn.as_str())
+    );
+    assert_eq!(
+        field_value(&fields, "Signing Algorithm"),
+        Some("SHA256withRSA")
+    );
+}
+
+#[test]
+#[ignore = "Requires the SoftHSM PKCS#11 module and writes to a temporary token store"]
+fn reports_no_identity_when_no_certificate_matches() {
+    let _serialized = serialize_token_access();
+    let token = provision_token("absent", KeyAlgorithm::Rsa);
+    let subject_cn = unique_subject_cn("absent-other");
+
+    let identity = token
+        .identity_of(&subject_cn)
+        .expect("the SoftHSM token should be readable");
+
+    assert!(identity.is_none());
+}
+
+#[test]
+#[ignore = "Requires the SoftHSM PKCS#11 module and writes to a temporary token store"]
+fn signs_after_a_second_session_read_the_token() {
+    let _serialized = serialize_token_access();
+    let token = provision_token("overlapping", KeyAlgorithm::Rsa);
+
+    let identity = token
+        .identity()
+        .expect("the SoftHSM token should be readable")
+        .expect("the provisioned certificate should be selected as the client identity");
+    // Stands in for the certificate screen's re-read, which opens and closes its own session on
+    // the token the identity holds one on.
+    token
+        .identity()
+        .expect("the token should be readable while an identity holds a session on it")
+        .expect("the second read should select the same certificate");
+
+    identity
+        .key
+        .sign(SignatureScheme::RSA_PKCS1_SHA256, MESSAGE)
+        .expect("the token should still sign for the identity it unlocked");
+}
+
+/// Proves that the session an identity holds still satisfies the bounds rustls puts on a signer.
+#[test]
+fn the_key_can_be_shared_across_threads() {
+    fn assert_send_and_sync<T: Send + Sync>() {}
+
+    assert_send_and_sync::<Pkcs11Key>();
+}
+
+#[test]
+#[ignore = "Requires the SoftHSM PKCS#11 module and writes to a temporary token store"]
+fn refuses_an_identity_whose_token_it_cannot_unlock() {
+    let _serialized = serialize_token_access();
+    let token = provision_token("no-pin", KeyAlgorithm::Rsa);
+    fs::remove_file(&token.pin_file).expect("the PIN file should be removable");
+
+    let Err(refused) = token.identity() else {
+        panic!("a token that wants a PIN it cannot read should not yield an identity");
+    };
+
+    assert!(
+        format!("{refused:#}").contains(&token.pin_file.display().to_string()),
+        "{refused:#} should name the PIN file it could not read"
+    );
+}
+
+#[test]
+#[ignore = "Requires the SoftHSM PKCS#11 module and writes to a temporary token store"]
+fn refuses_an_identity_whose_pin_the_token_rejects() {
+    let _serialized = serialize_token_access();
+    let token = provision_token("wrong-pin", KeyAlgorithm::Rsa);
+    write_pin_file(&token.pin_file, "not-the-pin");
+
+    let Err(refused) = token.identity() else {
+        panic!("a token that rejects the PIN should not yield an identity");
+    };
+
+    assert!(
+        format!("{refused:#}").contains("Failed to unlock the PKCS#11 token"),
+        "{refused:#} should say the token turned the PIN down"
+    );
+}
+
+#[test]
+fn reads_no_pin_for_a_token_that_wants_none() {
+    let flags = LoginFlags {
+        login_required: false,
+        ..pin_protected()
+    };
+
+    assert!(matches!(
+        login_requirement(flags).expect("a token without a login is usable"),
+        Login::NotRequired
+    ));
+}
+
+#[test]
+fn refuses_a_token_that_asks_for_its_pin_on_a_keypad() {
+    let flags = LoginFlags {
+        protected_authentication_path: true,
+        ..pin_protected()
+    };
+
+    let refused = login_requirement(flags).expect_err("Firezone prompts nobody for a PIN");
+
+    assert!(
+        refused.to_string().contains("keypad"),
+        "{refused} should say why the reader cannot be used"
+    );
+}
+
+#[test]
+fn refuses_a_token_that_already_locked_its_pin() {
+    let flags = LoginFlags {
+        user_pin_locked: true,
+        ..pin_protected()
+    };
+
+    let refused = login_requirement(flags).expect_err("a locked PIN cannot be spent again");
+
+    assert!(
+        refused.to_string().contains("PUK"),
+        "{refused} should say how the token is unblocked"
+    );
+}
+
+#[test]
+fn counts_down_the_attempts_a_rejected_pin_leaves() {
+    let final_try = rejected_pin_reason(LoginFlags {
+        user_pin_final_try: true,
+        ..pin_protected()
+    });
+    let count_low = rejected_pin_reason(LoginFlags {
+        user_pin_count_low: true,
+        ..pin_protected()
+    });
+
+    assert!(final_try.contains("one attempt left"), "{final_try}");
+    assert!(count_low.contains("counting down"), "{count_low}");
+}
+
+#[test]
+fn probes_the_64_bit_module_directory_before_the_32_bit_one() {
+    let directories = module_directories(vec![PathBuf::from("/usr/lib/x86_64-linux-gnu")]);
+
+    let position = |path: &str| {
+        directories
+            .iter()
+            .position(|directory| directory == Path::new(path))
+            .unwrap_or_else(|| panic!("{path} should be probed"))
+    };
+
+    assert!(
+        position("/usr/lib64/pkcs11") < position("/usr/lib/pkcs11"),
+        "an i686 package puts 32-bit modules into /usr/lib, which must not shadow /usr/lib64"
+    );
+    assert!(
+        position("/usr/lib/x86_64-linux-gnu/pkcs11") < position("/usr/lib/pkcs11"),
+        "the multiarch directory is where Debian installs modules"
+    );
+}
+
+#[test]
+fn refuses_a_pin_file_others_can_read() {
+    let refused = ensure_root_only(0o640, 0, Path::new("/etc/firezone/pkcs11-pin"))
+        .expect_err("a group-readable PIN file should be refused");
+
+    assert!(
+        refused.to_string().contains("Permissions 0640"),
+        "{refused} should report the mode the way ssh does"
+    );
+}
+
+#[test]
+fn refuses_a_pin_file_root_does_not_own() {
+    assert!(ensure_root_only(0o600, 1000, Path::new("/etc/firezone/pkcs11-pin")).is_err());
+    assert!(ensure_root_only(0o600, 0, Path::new("/etc/firezone/pkcs11-pin")).is_ok());
+    assert!(ensure_root_only(0o400, 0, Path::new("/etc/firezone/pkcs11-pin")).is_ok());
+}
+
+#[test]
+fn strips_only_the_line_ending_of_a_pin() {
+    let directory = std::env::temp_dir().join(format!("keystore-pin-{}", std::process::id()));
+    fs::create_dir_all(&directory).expect("the PIN directory should be creatable");
+    let path = directory.join("pin");
+    write_pin_file(&path, " space \r\n");
+
+    let pin = read_pin(&path).expect("the PIN file should be readable");
+
+    assert_eq!(pin.expose_secret(), " space ");
+
+    fs::remove_dir_all(&directory).expect("the PIN directory should be removable");
+}
+
+#[test]
+fn names_the_cause_behind_a_token_failure() {
+    /// `CKR_DEVICE_ERROR`, which the classification has no case for.
+    const DEVICE_ERROR: u64 = 0x0000_0030;
+
+    assert!(matches!(
+        classify_return_value(ReturnValue(rpc::CKR_DEVICE_REMOVED), String::new()),
+        SigningError::KeyUnavailable(_)
+    ));
+    assert!(matches!(
+        classify_return_value(ReturnValue(rpc::CKR_SESSION_HANDLE_INVALID), String::new()),
+        SigningError::KeyUnavailable(_)
+    ));
+    assert!(matches!(
+        classify_return_value(ReturnValue(rpc::CKR_PIN_LOCKED), String::new()),
+        SigningError::AccessDenied(_)
+    ));
+    assert!(matches!(
+        classify_return_value(ReturnValue(DEVICE_ERROR), String::new()),
+        SigningError::Keystore(_)
+    ));
+}
+
+/// Returns the flags of a token that wants a PIN and has all of its attempts left.
+fn pin_protected() -> LoginFlags {
+    LoginFlags {
+        login_required: true,
+        protected_authentication_path: false,
+        user_pin_locked: false,
+        user_pin_final_try: false,
+        user_pin_count_low: false,
+    }
+}
+
+/// The bytes the tests ask the token to sign, standing in for a TLS handshake transcript.
+const MESSAGE: &[u8] = b"x509-keystore PKCS#11 signing test";
+
+/// The PIN the tests give the token, both for its security officer and for its user.
+const PIN: &str = "firezone-test-pin";
+
+/// Serialises the tests, which all point `SOFTHSM2_CONF` at their own temporary token store.
+///
+/// That variable is process-wide and SoftHSM reads it while the backend loads the module, so two
+/// tests running at once would each see whichever store the other set up last.
+static TOKEN_STORE: Mutex<()> = Mutex::new(());
+
+/// Takes the [`TOKEN_STORE`] lock for the rest of the current test.
+///
+/// Poisoning is ignored on purpose: one failing test would otherwise fail the others rather than
+/// let them report their own result.
+fn serialize_token_access() -> MutexGuard<'static, ()> {
+    TOKEN_STORE.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Returns a subject CN that no other test uses.
+fn unique_subject_cn(suffix: &str) -> String {
+    format!("dev.firezone.test-{}-{suffix}", std::process::id())
+}
+
+/// Returns the end-entity certificate the backend put first in the chain.
+fn leaf_of(identity: &Identity) -> Vec<u8> {
+    let leaf = identity
+        .chain
+        .first()
+        .expect("the identity should carry a certificate chain");
+
+    leaf.to_vec()
+}
+
+/// Returns the value of the row labelled `label`, if the certificate's rows have one.
+fn field_value<'a>(fields: &'a [DetailField], label: &str) -> Option<&'a str> {
+    let field = fields.iter().find(|field| field.label == label)?;
+
+    field.value.as_deref()
+}
+
+/// Signs [`MESSAGE`] with every scheme the key advertises and verifies each signature against the
+/// public key of the certificate it belongs to.
+///
+/// Verifying is what separates a signature that is merely well-formed from one a TLS peer accepts:
+/// the padding mode, the hash, the PSS salt length and, for ECDSA, the DER encoding all have to
+/// match the scheme rustls asked for. Covering every advertised scheme holds the backend to what it
+/// promised rustls it could do.
+fn assert_signs_every_advertised_scheme(identity: &Identity, certificate: &[u8]) {
+    let (_, parsed) =
+        X509Certificate::from_der(certificate).expect("the provisioned certificate should parse");
+    let public_key = parsed.public_key().subject_public_key.data.as_ref();
+
+    for scheme in identity.key.supported_schemes() {
+        let signature = identity
+            .key
+            .sign(scheme, MESSAGE)
+            .unwrap_or_else(|error| panic!("the token should sign with {scheme:?}: {error}"));
+
+        UnparsedPublicKey::new(verification_algorithm(scheme), public_key)
+            .verify(MESSAGE, &signature)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "the {scheme:?} signature should verify against the certificate's public key"
+                )
+            });
+    }
+}
+
+/// Returns the `ring` algorithm that verifies signatures made with `scheme`.
+#[expect(
+    clippy::wildcard_enum_match_arm,
+    reason = "the tests only ever ask for a scheme `signature_schemes` advertises"
+)]
+fn verification_algorithm(scheme: SignatureScheme) -> &'static dyn VerificationAlgorithm {
+    match scheme {
+        SignatureScheme::RSA_PSS_SHA256 => &RSA_PSS_2048_8192_SHA256,
+        SignatureScheme::RSA_PSS_SHA384 => &RSA_PSS_2048_8192_SHA384,
+        SignatureScheme::RSA_PSS_SHA512 => &RSA_PSS_2048_8192_SHA512,
+        SignatureScheme::RSA_PKCS1_SHA256 => &RSA_PKCS1_2048_8192_SHA256,
+        SignatureScheme::RSA_PKCS1_SHA384 => &RSA_PKCS1_2048_8192_SHA384,
+        SignatureScheme::RSA_PKCS1_SHA512 => &RSA_PKCS1_2048_8192_SHA512,
+        SignatureScheme::ECDSA_NISTP256_SHA256 => &ECDSA_P256_SHA256_ASN1,
+        unexpected => panic!("no `ring` verifier for {unexpected:?}"),
+    }
+}
+
+/// A SoftHSM token holding one key and the certificate that names it, erased when the test ends.
+struct Token {
+    directory: PathBuf,
+    subject_cn: String,
+    p11_kit: PathBuf,
+    module: PathBuf,
+    pin_file: PathBuf,
+    certificate: Vec<u8>,
+}
+
+impl Token {
+    fn identity(&self) -> Result<Option<Identity>, Error> {
+        self.identity_of(&self.subject_cn)
+    }
+
+    fn identity_of(&self, subject_cn: &str) -> Result<Option<Identity>, Error> {
+        super::identity_on(
+            &self.p11_kit,
+            std::slice::from_ref(&self.module),
+            &self.pin_file,
+            subject_cn,
+        )
+    }
+}
+
+impl Drop for Token {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.directory);
+    }
+}
+
+/// The key algorithms whose signatures take different paths through [`sign_with_key`].
+#[derive(Clone, Copy)]
+enum KeyAlgorithm {
+    Rsa,
+    EcdsaP256,
+}
+
+/// Initialises a token that holds one key pair and a certificate satisfying Firezone's rules.
+///
+/// The key never leaves the token: it is generated there and the certificate is built around the
+/// public half the token reports, which is how a real PKCS#11 device is enrolled.
+fn provision_token(suffix: &str, algorithm: KeyAlgorithm) -> Token {
+    let module = softhsm_module();
+    let label = format!("keystore-{}-{suffix}", std::process::id());
+    let subject_cn = unique_subject_cn(suffix);
+    let directory = std::env::temp_dir().join(&label);
+    let configuration = directory.join("softhsm2.conf");
+    let pin_file = directory.join("pin");
+
+    let _ = fs::remove_dir_all(&directory);
+    fs::create_dir_all(directory.join("tokens")).expect("the token store should be creatable");
+    fs::write(
+        &configuration,
+        format!(
+            "directories.tokendir = {}\nobjectstore.backend = file\n",
+            directory.join("tokens").display()
+        ),
+    )
+    .expect("the SoftHSM configuration should be writable");
+    write_pin_file(&pin_file, PIN);
+
+    // SAFETY: `serialize_token_access` holds off every other test that sets or reads this variable,
+    // and the remaining tests in this binary are pure functions that never touch the environment.
+    // The `p11-kit remote` children inherit the variable when the backend spawns them.
+    unsafe { std::env::set_var("SOFTHSM2_CONF", &configuration) };
+
+    let certificate = initialize_token(&module, &label, &subject_cn, algorithm);
+
+    Token {
+        directory,
+        subject_cn,
+        p11_kit: p11_kit_command(),
+        module,
+        pin_file,
+        certificate,
+    }
+}
+
+/// Writes a PIN file the backend accepts, which means one only its owner can read.
+///
+/// The tests run as root, both here and in CI, so the file is root's as the backend demands.
+fn write_pin_file(path: &Path, pin: &str) {
+    fs::write(path, pin).expect("the PIN file should be writable");
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+        .expect("the PIN file should be lockable down");
+}
+
+/// Returns the SoftHSM module the tests load.
+///
+/// A missing module fails the test rather than skipping it: a skipped test reports coverage the run
+/// does not have.
+fn softhsm_module() -> PathBuf {
+    const CANDIDATES: [&str; 2] = [
+        "/usr/lib/softhsm/libsofthsm2.so",
+        "/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so",
+    ];
+
+    CANDIDATES
+        .into_iter()
+        .map(PathBuf::from)
+        .find(|candidate| candidate.exists())
+        .unwrap_or_else(|| {
+            panic!("None of {CANDIDATES:?} exist; install the `softhsm2` package to run this test")
+        })
+}
+
+/// Returns the p11-kit command the backend serves the module through.
+///
+/// A missing command fails the test rather than skipping it: a skipped test reports coverage
+/// the run does not have.
+fn p11_kit_command() -> PathBuf {
+    super::p11_kit_command().unwrap_or_else(|| {
+        panic!("p11-kit is missing; install the `p11-kit` package to run this test")
+    })
+}
+
+/// Sets up the token's PINs, generates its key pair and stores a certificate for it.
+///
+/// Returns the certificate, having closed everything it opened, so that the module is unloaded
+/// again by the time the backend initializes its own context against this store.
+fn initialize_token(
+    module: &Path,
+    label: &str,
+    subject_cn: &str,
+    algorithm: KeyAlgorithm,
+) -> Vec<u8> {
+    let pkcs11 = Pkcs11::new(module).expect("SoftHSM should load");
+    pkcs11
+        .initialize(CInitializeArgs::new(CInitializeFlags::OS_LOCKING_OK))
+        .expect("SoftHSM should initialize");
+
+    let free = *pkcs11
+        .get_all_slots()
+        .expect("SoftHSM should report its slots")
+        .first()
+        .expect("a fresh token store should offer an uninitialized slot");
+    pkcs11
+        .init_token(free, &AuthPin::new(PIN.into()), label)
+        .expect("SoftHSM should initialize the token");
+
+    let slot = slot_of(&pkcs11, label);
+    let session = pkcs11
+        .open_rw_session(slot)
+        .expect("the token should open a read-write session");
+    session
+        .login(UserType::So, Some(&AuthPin::new(PIN.into())))
+        .expect("the security officer should be able to log in");
+    session
+        .init_pin(&AuthPin::new(PIN.into()))
+        .expect("the security officer should be able to set the user PIN");
+    session
+        .logout()
+        .expect("the security officer should log out");
+    session
+        .login(UserType::User, Some(&AuthPin::new(PIN.into())))
+        .expect("the user should be able to log in");
+
+    let certificate = store_identity(&session, label, subject_cn, algorithm);
+
+    drop(session);
+
+    certificate
+}
+
+/// Returns the slot of the token labelled `label`.
+fn slot_of(pkcs11: &Pkcs11, label: &str) -> Slot {
+    pkcs11
+        .get_slots_with_token()
+        .expect("SoftHSM should report its tokens")
+        .into_iter()
+        .find(|slot| {
+            pkcs11
+                .get_token_info(*slot)
+                .is_ok_and(|info| info.label().trim() == label)
+        })
+        .unwrap_or_else(|| panic!("the token labelled '{label}' should be in a slot"))
+}
+
+/// Generates the key pair on the token and stores a certificate that addresses it.
+fn store_identity(
+    session: &Session,
+    label: &str,
+    subject_cn: &str,
+    algorithm: KeyAlgorithm,
+) -> Vec<u8> {
+    let id = vec![0x01];
+    let (public, private) = generate_key_pair(session, label, &id, algorithm);
+    let public_key = read_public_key(session, public, algorithm);
+    let certificate = self_signed_certificate(subject_cn, &public_key, |tbs| {
+        sign_certificate(session, private, algorithm, tbs)
+    });
+
+    session
+        .create_object(&[
+            Attribute::Class(ObjectClass::CERTIFICATE),
+            Attribute::CertificateType(CertificateType::X_509),
+            Attribute::Token(true),
+            Attribute::Label(label.as_bytes().to_vec()),
+            Attribute::Id(id),
+            Attribute::Subject(distinguished_name(subject_cn)),
+            Attribute::Value(certificate.clone()),
+        ])
+        .expect("the token should store the certificate");
+
+    certificate
+}
+
+fn generate_key_pair(
+    session: &Session,
+    label: &str,
+    id: &[u8],
+    algorithm: KeyAlgorithm,
+) -> (ObjectHandle, ObjectHandle) {
+    let mut public_template = vec![
+        Attribute::Token(true),
+        Attribute::Verify(true),
+        Attribute::Label(label.as_bytes().to_vec()),
+        Attribute::Id(id.to_vec()),
+    ];
+    let private_template = vec![
+        Attribute::Token(true),
+        Attribute::Private(true),
+        Attribute::Sign(true),
+        Attribute::Label(label.as_bytes().to_vec()),
+        Attribute::Id(id.to_vec()),
+    ];
+    let mechanism = match algorithm {
+        KeyAlgorithm::Rsa => {
+            public_template.push(Attribute::ModulusBits(Ulong::new(2048)));
+            public_template.push(Attribute::PublicExponent(vec![0x01, 0x00, 0x01]));
+
+            Mechanism::RsaPkcsKeyPairGen
+        }
+        KeyAlgorithm::EcdsaP256 => {
+            public_template.push(Attribute::EcParams(object_identifier(OID_PRIME256V1)));
+
+            Mechanism::EccKeyPairGen
+        }
+    };
+
+    session
+        .generate_key_pair(&mechanism, &public_template, &private_template)
+        .expect("the token should generate the key pair")
+}
+
+/// The public half of a generated key pair, as the token reports it.
+enum PublicKey {
+    Rsa { modulus: Vec<u8>, exponent: Vec<u8> },
+    EcdsaP256 { point: Vec<u8> },
+}
+
+fn read_public_key(session: &Session, key: ObjectHandle, algorithm: KeyAlgorithm) -> PublicKey {
+    match algorithm {
+        KeyAlgorithm::Rsa => PublicKey::Rsa {
+            modulus: byte_attribute(session, key, AttributeType::Modulus),
+            exponent: byte_attribute(session, key, AttributeType::PublicExponent),
+        },
+        KeyAlgorithm::EcdsaP256 => PublicKey::EcdsaP256 {
+            point: uncompressed_point(&byte_attribute(session, key, AttributeType::EcPoint)),
+        },
+    }
+}
+
+fn byte_attribute(session: &Session, key: ObjectHandle, attribute: AttributeType) -> Vec<u8> {
+    let reported = session
+        .get_attributes(key, &[attribute])
+        .unwrap_or_else(|error| panic!("the token should report {attribute:?}: {error}"));
+
+    match reported.as_slice() {
+        [
+            Attribute::Modulus(value)
+            | Attribute::PublicExponent(value)
+            | Attribute::EcPoint(value),
+        ] => value.clone(),
+        reported => panic!("the token reported {reported:?} instead of {attribute:?}"),
+    }
+}
+
+/// Unwraps the DER octet string PKCS#11 puts around the uncompressed EC point.
+fn uncompressed_point(attribute: &[u8]) -> Vec<u8> {
+    let [0x04, length, point @ ..] = attribute else {
+        panic!("the token should report the EC point as a DER octet string");
+    };
+    assert_eq!(
+        usize::from(*length),
+        point.len(),
+        "the EC point should be as long as its DER header says"
+    );
+
+    point.to_vec()
+}
+
+fn sign_certificate(
+    session: &Session,
+    key: ObjectHandle,
+    algorithm: KeyAlgorithm,
+    tbs_certificate: &[u8],
+) -> Vec<u8> {
+    match algorithm {
+        KeyAlgorithm::Rsa => session
+            .sign(&Mechanism::Sha256RsaPkcs, key, tbs_certificate)
+            .expect("the token should sign the certificate"),
+        KeyAlgorithm::EcdsaP256 => {
+            let raw = session
+                .sign(&Mechanism::Ecdsa, key, &Sha256::digest(tbs_certificate))
+                .expect("the token should sign the certificate");
+
+            der_encode_ecdsa_signature(&raw).expect("the token's signature should encode")
+        }
+    }
+}
+
+/// `2.5.4.3`, the common name attribute.
+const OID_COMMON_NAME: &[u8] = &[0x55, 0x04, 0x03];
+/// `2.5.29.15`, the key usage extension.
+const OID_KEY_USAGE: &[u8] = &[0x55, 0x1d, 0x0f];
+/// `2.5.29.37`, the extended key usage extension.
+const OID_EXTENDED_KEY_USAGE: &[u8] = &[0x55, 0x1d, 0x25];
+/// `1.3.6.1.5.5.7.3.2`, the TLS client authentication purpose.
+const OID_CLIENT_AUTH: &[u8] = &[0x2b, 0x06, 0x01, 0x05, 0x05, 0x07, 0x03, 0x02];
+/// `1.2.840.113549.1.1.1`, an RSA public key.
+const OID_RSA_ENCRYPTION: &[u8] = &[0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01];
+/// `1.2.840.113549.1.1.11`, an RSA signature over a SHA-256 digest.
+const OID_SHA256_WITH_RSA: &[u8] = &[0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b];
+/// `1.2.840.10045.2.1`, an elliptic curve public key.
+const OID_EC_PUBLIC_KEY: &[u8] = &[0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01];
+/// `1.2.840.10045.3.1.7`, the NIST P-256 curve.
+const OID_PRIME256V1: &[u8] = &[0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07];
+/// `1.2.840.10045.4.3.2`, an ECDSA signature over a SHA-256 digest.
+const OID_ECDSA_WITH_SHA256: &[u8] = &[0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02];
+
+/// The validity the tests give their certificates, wide enough to never need a clock.
+const NOT_BEFORE: &[u8] = b"200101000000Z";
+const NOT_AFTER: &[u8] = b"491231235959Z";
+
+/// Builds the certificate the token stores for `public_key`, signed by `sign`.
+///
+/// It carries the client authentication purpose, a key usage allowing digital signatures and a
+/// subject CN, which is how the keystore finds it.
+fn self_signed_certificate(
+    subject_cn: &str,
+    public_key: &PublicKey,
+    sign: impl FnOnce(&[u8]) -> Vec<u8>,
+) -> Vec<u8> {
+    let algorithm = signature_algorithm(public_key);
+    let name = distinguished_name(subject_cn);
+    let tbs_certificate = sequence(&[
+        &der(0xa0, &der(0x02, &[2])), // Version v3.
+        &der(0x02, &[1]),             // Serial number.
+        &algorithm,
+        &name,
+        &sequence(&[&der(0x17, NOT_BEFORE), &der(0x17, NOT_AFTER)]),
+        &name,
+        &subject_public_key_info(public_key),
+        &der(0xa3, &sequence(&[&key_usage(), &extended_key_usage()])),
+    ]);
+    let signature = sign(&tbs_certificate);
+
+    sequence(&[&tbs_certificate, &algorithm, &bit_string(&signature)])
+}
+
+fn signature_algorithm(public_key: &PublicKey) -> Vec<u8> {
+    match public_key {
+        PublicKey::Rsa { .. } => sequence(&[
+            &object_identifier(OID_SHA256_WITH_RSA),
+            &der(0x05, &[]), // The NULL parameters RFC 4055 requires of RSA.
+        ]),
+        PublicKey::EcdsaP256 { .. } => sequence(&[&object_identifier(OID_ECDSA_WITH_SHA256)]),
+    }
+}
+
+fn subject_public_key_info(public_key: &PublicKey) -> Vec<u8> {
+    match public_key {
+        PublicKey::Rsa { modulus, exponent } => sequence(&[
+            &sequence(&[&object_identifier(OID_RSA_ENCRYPTION), &der(0x05, &[])]),
+            &bit_string(&sequence(&[&der_integer(modulus), &der_integer(exponent)])),
+        ]),
+        PublicKey::EcdsaP256 { point } => sequence(&[
+            &sequence(&[
+                &object_identifier(OID_EC_PUBLIC_KEY),
+                &object_identifier(OID_PRIME256V1),
+            ]),
+            &bit_string(point),
+        ]),
+    }
+}
+
+fn distinguished_name(common_name: &str) -> Vec<u8> {
+    sequence(&[&der(
+        0x31,
+        &sequence(&[
+            &object_identifier(OID_COMMON_NAME),
+            &der(0x0c, common_name.as_bytes()),
+        ]),
+    )])
+}
+
+/// The critical key usage extension allowing only digital signatures.
+fn key_usage() -> Vec<u8> {
+    sequence(&[
+        &object_identifier(OID_KEY_USAGE),
+        &der(0x01, &[0xff]),
+        &der(0x04, &der(0x03, &[7, 0x80])),
+    ])
+}
+
+/// The extended key usage extension naming TLS client authentication.
+fn extended_key_usage() -> Vec<u8> {
+    sequence(&[
+        &object_identifier(OID_EXTENDED_KEY_USAGE),
+        &der(0x04, &sequence(&[&object_identifier(OID_CLIENT_AUTH)])),
+    ])
+}
+
+/// Wraps `contents` in the DER tag-length-value of `tag`.
+fn der(tag: u8, contents: &[u8]) -> Vec<u8> {
+    let mut output = vec![tag];
+    encode_der_length(&mut output, contents.len());
+    output.extend_from_slice(contents);
+
+    output
+}
+
+fn sequence(elements: &[&[u8]]) -> Vec<u8> {
+    der(0x30, &elements.concat())
+}
+
+fn object_identifier(oid: &[u8]) -> Vec<u8> {
+    der(0x06, oid)
+}
+
+fn bit_string(contents: &[u8]) -> Vec<u8> {
+    let mut body = vec![0]; // No unused bits in the final byte.
+    body.extend_from_slice(contents);
+
+    der(0x03, &body)
+}


### PR DESCRIPTION
Linux has no single system certificate store, so a managed client identity lives on whatever PKCS#11 token the organisation provisions: a smartcard, a TPM behind a PKCS#11 module or a software token.

This backend opens the configured module, finds the identity matching how Firezone's MDM integrations provision certificates, and asks the token to sign each TLS handshake message. As on Windows, we never read the key out, so a token that refuses to export works fine.