### PR TITLE
test(logging): serialise the Windows Event Log tests

### DIFF
--- a/rust/libs/logging/tests/windows_event_log_integration.rs
+++ b/rust/libs/logging/tests/windows_event_log_integration.rs
@@ -6,9 +6,25 @@
 #![cfg(windows)]
 
 use std::process::Command;
+use std::sync::{Mutex, MutexGuard, PoisonError};
 
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
+
+/// Serialises the tests, which all mutate the shared `Application` event log.
+///
+/// `New-EventLog` and `Remove-EventLog` read, modify and write that log's list of sources, so
+/// running the tests concurrently can leave a source half-registered and make the subsequent
+/// `RegisterEventSourceW` fail with `ACCESS_DENIED`.
+static EVENT_LOG: Mutex<()> = Mutex::new(());
+
+/// Takes the [`EVENT_LOG`] lock for the rest of the current test.
+///
+/// Poisoning is ignored on purpose: one failing test would otherwise fail the other two rather
+/// than let them report their own result.
+fn serialize_event_log_access() -> MutexGuard<'static, ()> {
+    EVENT_LOG.lock().unwrap_or_else(PoisonError::into_inner)
+}
 
 /// Unique source name for testing to avoid conflicts.
 ///
@@ -105,6 +121,7 @@ fn debug_list_events(source: &str) -> String {
 #[ignore = "Requires Windows and may need admin privileges"]
 fn writes_event_to_event_log() {
     let source = test_source("writes");
+    let _serialized = serialize_event_log_access();
     let _cleanup = SourceGuard(source.clone());
 
     // Clean up any previous test runs
@@ -152,6 +169,7 @@ fn writes_event_to_event_log() {
 #[ignore = "Requires Windows and may need admin privileges"]
 fn maps_log_levels_correctly() {
     let source = test_source("levels");
+    let _serialized = serialize_event_log_access();
     let _cleanup = SourceGuard(source.clone());
 
     remove_source(&source);
@@ -201,6 +219,7 @@ fn maps_log_levels_correctly() {
 #[ignore = "Requires Windows and may need admin privileges"]
 fn captures_span_fields() {
     let source = test_source("spans");
+    let _serialized = serialize_event_log_access();
     let _cleanup = SourceGuard(source.clone());
 
     remove_source(&source);


### PR DESCRIPTION
`rust / test-windows-2025` fails intermittently on `maps_log_levels_correctly` with `Access is denied. (0x80070005)`, roughly one run in six. Because cargo stops at the first failing binary and `logging` sorts early, a single flake also costs the run every test that would have followed it.

Each of the three tests already uses its own source name, so the collision is not there. What they share is the `Application` log itself: `New-EventLog` and `Remove-EventLog` read, modify and write its list of sources, so running concurrently they can leave a source half-registered, and the `RegisterEventSourceW` that follows then fails. Two of the three passing in the same run is what rules out the runner simply lacking the rights.

The tests now take a mutex so that one at a time touches the log, acquired before the cleanup guard so that removal still happens while the lock is held. Poisoning is ignored, so a genuine failure in one test reports on its own instead of taking the other two with it.