### PR TITLE
refactor: rename `is_authentication_error` to `requires_sign_in`

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -187,8 +187,12 @@ impl DisconnectError {
         self.0.to_string()
     }
 
-    pub fn is_authentication_error(&self) -> bool {
-        self.0.is_authentication_error()
+    /// Returns whether the stored token must be discarded and the user sent through sign-in again.
+    ///
+    /// This does not report whether the failure was authentication-related in general.
+    /// Only failures that render the token itself unusable require a new sign-in.
+    pub fn requires_sign_in(&self) -> bool {
+        self.0.requires_sign_in()
     }
 }
 

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -675,10 +675,10 @@ impl<I: GuiIntegration> Controller<I> {
             }
             service::ServerMsg::OnDisconnect {
                 error_msg,
-                is_authentication_error,
+                requires_sign_in,
             } => {
                 self.sign_out().await?;
-                if is_authentication_error {
+                if requires_sign_in {
                     tracing::info!(?error_msg, "Auth error");
                     self.integration.show_notification(
                         "Firezone disconnected",

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -92,7 +92,7 @@ pub enum ServerMsg {
     DisconnectedGracefully,
     OnDisconnect {
         error_msg: String,
-        is_authentication_error: bool,
+        requires_sign_in: bool,
     },
     AllGatewaysOffline {
         resource_id: ResourceId,
@@ -597,7 +597,7 @@ impl<'a> Handler<'a> {
                 self.dns_controller.deactivate()?;
                 self.send_ipc(ServerMsg::OnDisconnect {
                     error_msg: error.to_string(),
-                    is_authentication_error: error.is_authentication_error(),
+                    requires_sign_in: error.requires_sign_in(),
                 })
                 .await?
             }

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -118,12 +118,16 @@ impl From<anyhow::Error> for DisconnectError {
 }
 
 impl DisconnectError {
-    pub fn is_authentication_error(&self) -> bool {
+    /// Returns whether the stored token must be discarded and the user sent through sign-in again.
+    ///
+    /// This does not report whether the failure was authentication-related in general.
+    /// Only failures that render the token itself unusable require a new sign-in.
+    pub fn requires_sign_in(&self) -> bool {
         let Some(e) = self.0.any_downcast_ref::<phoenix_channel::Error>() else {
             return false;
         };
 
-        e.is_authentication_error()
+        e.requires_sign_in()
     }
 }
 
@@ -200,7 +204,7 @@ impl Eventloop {
                     return Ok(());
                 }
                 Err(e) => {
-                    if !e.is_authentication_error() {
+                    if !e.requires_sign_in() {
                         tracing::error!("Fatal tunnel error: {e:#}");
                     }
 

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -189,7 +189,11 @@ pub enum Error {
 }
 
 impl Error {
-    pub fn is_authentication_error(&self) -> bool {
+    /// Returns whether the stored token must be discarded and the user sent through sign-in again.
+    ///
+    /// This does not report whether the failure was authentication-related in general.
+    /// Only failures that render the token itself unusable require a new sign-in.
+    pub fn requires_sign_in(&self) -> bool {
         match self {
             Error::InvalidToken => true,
             Error::MaxRetriesReached { .. } => false,

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -479,18 +479,18 @@ actor Adapter {
 
     case .disconnected(let error):
       let errorMessage = error.message()
-      let isAuthenticationError = error.isAuthenticationError()
+      let requiresSignIn = error.requiresSignIn()
       Log.info("Received Disconnected event: \(errorMessage)")
 
       // iOS shows the notification from the tunnel process because the UI
       // process isn't guaranteed to be alive; macOS handles it from the UI.
       #if os(iOS)
-        if isAuthenticationError {
+        if requiresSignIn {
           SessionNotification.showSignedOutNotificationiOS()
         }
       #endif
 
-      let sendableError = SendableError(errorMessage, isAuthenticationError: isAuthenticationError)
+      let sendableError = SendableError(errorMessage, requiresSignIn: requiresSignIn)
       providerCommandSender.send(.cancelWithError(sendableError))
 
     case .allGatewaysOffline(let resourceId):

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -442,7 +442,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     switch command {
     case .cancelWithError(let sendableError):
       let error: Error =
-        sendableError.isAuthenticationError
+        sendableError.requiresSignIn
         ? FirezoneKit.ConnlibError.sessionExpired(sendableError.message)
         : FirezoneKit.ConnlibError.disconnected(sendableError.message)
       cancelTunnelWithError(error)

--- a/swift/apple/FirezoneNetworkExtension/ProviderCommand.swift
+++ b/swift/apple/FirezoneNetworkExtension/ProviderCommand.swift
@@ -27,10 +27,10 @@ enum ProviderCommand: Sendable {
 /// Captures the essential error information needed for tunnel cancellation.
 struct SendableError: Sendable {
   let message: String
-  let isAuthenticationError: Bool
+  let requiresSignIn: Bool
 
-  init(_ message: String, isAuthenticationError: Bool = false) {
+  init(_ message: String, requiresSignIn: Bool = false) {
     self.message = message
-    self.isAuthenticationError = isAuthenticationError
+    self.requiresSignIn = requiresSignIn
   }
 }


### PR DESCRIPTION
`is_authentication_error` reads like a general "was this an authentication failure?" predicate, but the only thing any caller does with it is decide whether to throw the stored token away and send the user through sign-in again. Those are not the same question: a portal can reject us for a reason that has nothing to do with the token being stale, and re-running sign-in would not help. Name the function after the decision it drives so the distinction is hard to miss when new failure modes are added.