### PR TITLE
fix(phoenix-channel): act on the portal's rejection reason

### DIFF
--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -201,7 +201,8 @@ impl Error {
     pub fn requires_sign_in(&self) -> bool {
         match self {
             Error::InvalidToken => true,
-            Error::AuthenticationFailed(_) => true,
+            // The portal rejected us without naming the token, so a new one is not known to help.
+            Error::AuthenticationFailed(_) => false,
             Error::MaxRetriesReached { .. } => false,
             Error::LoginFailed(_) => false,
             Error::FatalIo(_) => false,
@@ -1174,7 +1175,7 @@ mod tests {
 
         let error = Error::from_unauthorized(&response);
 
-        assert!(error.requires_sign_in());
+        assert!(!error.requires_sign_in());
         assert_eq!(
             error.to_string(),
             "Failed to authenticate with portal: Invalid token"

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod get_user_agent;
 mod login_url;
+mod problem_details;
 
 use anyhow::{Context as _, Result};
 use futures::stream::FuturesUnordered;
@@ -20,6 +21,7 @@ use futures::future::BoxFuture;
 use futures::{FutureExt, SinkExt, StreamExt};
 use itertools::Itertools as _;
 use logging::err_with_src;
+use problem_details::ProblemDetails;
 use secrecy::{ExposeSecret as _, SecretString};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use socket_factory::{SocketFactory, TcpSocket, TcpStream};
@@ -178,6 +180,9 @@ async fn connect(
 pub enum Error {
     #[error("Authentication token invalid")]
     InvalidToken,
+    /// The portal refused to authenticate us for a reason we cannot act on specifically.
+    #[error("Failed to authenticate with portal: {0}")]
+    AuthenticationFailed(String),
     #[error(
         "Got disconnected from portal and hit the max-retry limit. Last connection error: {final_error}"
     )]
@@ -196,9 +201,28 @@ impl Error {
     pub fn requires_sign_in(&self) -> bool {
         match self {
             Error::InvalidToken => true,
+            Error::AuthenticationFailed(_) => true,
             Error::MaxRetriesReached { .. } => false,
             Error::LoginFailed(_) => false,
             Error::FatalIo(_) => false,
+        }
+    }
+
+    /// Classifies a rejected connection attempt by the reason the portal reported.
+    ///
+    /// Reasons the client cannot act on specifically map to [`Error::AuthenticationFailed`],
+    /// as do responses without problem details, e.g. an error page from an intermediary proxy.
+    fn from_unauthorized(response: &tungstenite::handshake::client::Response) -> Self {
+        let problem = ProblemDetails::from_response(response).unwrap_or_default();
+
+        match problem.code.as_deref() {
+            Some("invalid_token") => Error::InvalidToken,
+            Some("missing_token") => Error::InvalidToken,
+            _ => Error::AuthenticationFailed(
+                problem
+                    .detail
+                    .unwrap_or_else(|| "no reason provided".to_owned()),
+            ),
         }
     }
 }
@@ -593,7 +617,7 @@ where
                         if r.status() == StatusCode::UNAUTHORIZED =>
                     {
                         self.state = State::Closed;
-                        return Poll::Ready(Err(Error::InvalidToken));
+                        return Poll::Ready(Err(Error::from_unauthorized(&r)));
                     }
                     Poll::Ready(Err(e)) => {
                         let backoff = match e.parse_retry_after_header() {
@@ -1121,6 +1145,40 @@ mod tests {
         let error = anyhow::Error::msg("some other failure").context("Connection hiccup");
 
         assert_eq!(http_error_body(&error), None);
+    }
+
+    #[test]
+    fn unauthorized_with_invalid_token_code_blames_the_token() {
+        let response = tungstenite::http::Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header("content-type", "application/problem+json; charset=utf-8")
+            .body(Some(
+                br#"{"title":"Unauthorized","status":401,"detail":"Invalid token","code":"invalid_token"}"#.to_vec(),
+            ))
+            .unwrap();
+
+        let error = Error::from_unauthorized(&response);
+
+        assert!(matches!(error, Error::InvalidToken), "got {error:?}");
+    }
+
+    #[test]
+    fn unauthorized_without_code_does_not_blame_the_token() {
+        let response = tungstenite::http::Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header("content-type", "application/problem+json; charset=utf-8")
+            .body(Some(
+                br#"{"title":"Unauthorized","status":401,"detail":"Invalid token"}"#.to_vec(),
+            ))
+            .unwrap();
+
+        let error = Error::from_unauthorized(&response);
+
+        assert!(error.requires_sign_in());
+        assert_eq!(
+            error.to_string(),
+            "Failed to authenticate with portal: Invalid token"
+        );
     }
 
     #[derive(Deserialize, PartialEq, Debug)]

--- a/rust/libs/connlib/phoenix-channel/src/problem_details.rs
+++ b/rust/libs/connlib/phoenix-channel/src/problem_details.rs
@@ -1,0 +1,142 @@
+use serde::Deserialize;
+use tokio_tungstenite::tungstenite::{handshake::client::Response, http::header::CONTENT_TYPE};
+
+const PROBLEM_JSON: &str = "application/problem+json";
+
+/// Why the portal rejected a request, as defined by [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457).
+///
+/// Only the members the client acts upon are captured, the portal may send more.
+#[derive(Debug, Default, PartialEq, Deserialize)]
+pub(crate) struct ProblemDetails {
+    /// A machine-readable identifier of the problem.
+    ///
+    /// Older portals don't send this yet.
+    pub(crate) code: Option<String>,
+    /// A human-readable explanation of the problem.
+    pub(crate) detail: Option<String>,
+}
+
+impl ProblemDetails {
+    /// Extracts the problem details from an HTTP response.
+    ///
+    /// Returns [`None`] for responses that aren't `application/problem+json` or whose body cannot be parsed,
+    /// such as an error page served by an intermediary proxy.
+    pub(crate) fn from_response(response: &Response) -> Option<Self> {
+        let content_type = response.headers().get(CONTENT_TYPE)?.to_str().ok()?;
+
+        if !is_problem_json(content_type) {
+            return None;
+        }
+
+        let body = response.body().as_deref()?;
+        let details = serde_json::from_slice(body).ok()?;
+
+        Some(details)
+    }
+}
+
+/// Checks whether the given `Content-Type` header value announces problem details.
+///
+/// Media types are case-insensitive and may carry parameters like `charset`.
+fn is_problem_json(content_type: &str) -> bool {
+    let media_type = content_type
+        .split_once(';')
+        .map_or(content_type, |(media_type, _)| media_type);
+
+    media_type.trim().eq_ignore_ascii_case(PROBLEM_JSON)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio_tungstenite::tungstenite::http;
+
+    #[test]
+    fn parses_known_code() {
+        let response = problem_details_response(
+            r#"{"type":"about:blank","title":"Unauthorized","status":401,"detail":"Invalid token","code":"invalid_token"}"#,
+        );
+
+        let details = ProblemDetails::from_response(&response).unwrap();
+
+        assert_eq!(details.code.as_deref(), Some("invalid_token"));
+        assert_eq!(details.detail.as_deref(), Some("Invalid token"));
+    }
+
+    #[test]
+    fn parses_unknown_code() {
+        let response = problem_details_response(
+            r#"{"status":403,"detail":"Device is not trusted","code":"device_untrusted"}"#,
+        );
+
+        let details = ProblemDetails::from_response(&response).unwrap();
+
+        assert_eq!(details.code.as_deref(), Some("device_untrusted"));
+    }
+
+    #[test]
+    fn parses_body_without_code() {
+        let response = problem_details_response(
+            r#"{"type":"about:blank","title":"Unauthorized","status":401,"detail":"Invalid token"}"#,
+        );
+
+        let details = ProblemDetails::from_response(&response).unwrap();
+
+        assert_eq!(details.code, None);
+        assert_eq!(details.detail.as_deref(), Some("Invalid token"));
+    }
+
+    #[test]
+    fn ignores_malformed_json() {
+        let response = problem_details_response("{not json");
+
+        let details = ProblemDetails::from_response(&response);
+
+        assert_eq!(details, None);
+    }
+
+    #[test]
+    fn ignores_other_content_type() {
+        let response = response("text/html", "<html>Gateway timeout</html>");
+
+        let details = ProblemDetails::from_response(&response);
+
+        assert_eq!(details, None);
+    }
+
+    #[test]
+    fn ignores_missing_content_type() {
+        let response = http::Response::builder()
+            .status(http::StatusCode::UNAUTHORIZED)
+            .body(Some(br#"{"code":"invalid_token"}"#.to_vec()))
+            .unwrap();
+
+        let details = ProblemDetails::from_response(&response);
+
+        assert_eq!(details, None);
+    }
+
+    #[test]
+    fn matches_content_type_regardless_of_case_and_parameters() {
+        let response = response(
+            "Application/Problem+JSON; charset=utf-8",
+            r#"{"code":"missing_token"}"#,
+        );
+
+        let details = ProblemDetails::from_response(&response).unwrap();
+
+        assert_eq!(details.code.as_deref(), Some("missing_token"));
+    }
+
+    fn problem_details_response(body: &str) -> Response {
+        response("application/problem+json; charset=utf-8", body)
+    }
+
+    fn response(content_type: &str, body: &str) -> Response {
+        http::Response::builder()
+            .status(http::StatusCode::UNAUTHORIZED)
+            .header(CONTENT_TYPE, content_type)
+            .body(Some(body.as_bytes().to_vec()))
+            .unwrap()
+    }
+}

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -490,8 +490,12 @@ async fn http_400_returns_client_error() {
 }
 
 #[tokio::test]
-async fn http_401_returns_invalid_token() {
-    let port = http_status_server(http::StatusCode::UNAUTHORIZED).await;
+async fn http_401_with_invalid_token_code_returns_invalid_token() {
+    let port = http_problem_details_server(
+        http::StatusCode::UNAUTHORIZED,
+        r#"{"type":"about:blank","title":"Unauthorized","status":401,"detail":"Invalid token","code":"invalid_token"}"#,
+    )
+    .await;
 
     let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
 
@@ -509,7 +513,59 @@ async fn http_401_returns_invalid_token() {
 
     assert!(
         matches!(result, Err(phoenix_channel::Error::InvalidToken)),
-        "expected Error::InvalidToken for 401, got {result:?}"
+        "expected Error::InvalidToken for 401 with `invalid_token` code, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn http_401_without_code_returns_authentication_failed() {
+    let port = http_problem_details_server(
+        http::StatusCode::UNAUTHORIZED,
+        r#"{"type":"about:blank","title":"Unauthorized","status":401,"detail":"Invalid token"}"#,
+    )
+    .await;
+
+    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
+
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        future::poll_fn(|cx| channel.poll(cx)).await
+    })
+    .await
+    .expect("should not timeout");
+
+    assert!(
+        matches!(result, Err(phoenix_channel::Error::AuthenticationFailed(_))),
+        "expected Error::AuthenticationFailed for 401 without code, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn http_401_without_problem_details_returns_authentication_failed() {
+    let port = http_status_server(http::StatusCode::UNAUTHORIZED).await;
+
+    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
+
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        future::poll_fn(|cx| channel.poll(cx)).await
+    })
+    .await
+    .expect("should not timeout");
+
+    assert!(
+        matches!(result, Err(phoenix_channel::Error::AuthenticationFailed(_))),
+        "expected Error::AuthenticationFailed for 401 without problem details, got {result:?}"
     );
 }
 
@@ -671,6 +727,21 @@ async fn http_status_server(code: http::StatusCode) -> u16 {
          Content-Length: 0\r\n\r\n",
         status = code.as_u16(),
         reason = code.as_str()
+    ))
+    .await
+}
+
+/// Spawns a server that rejects the WebSocket upgrade with RFC 9457 problem details.
+async fn http_problem_details_server(code: http::StatusCode, body: &str) -> u16 {
+    http_response_server(format!(
+        "HTTP/1.1 {status} {reason}\r\n\
+         Connection: close\r\n\
+         Content-Type: application/problem+json; charset=utf-8\r\n\
+         Content-Length: {length}\r\n\r\n\
+         {body}",
+        status = code.as_u16(),
+        reason = code.canonical_reason().unwrap_or_default(),
+        length = body.len()
     ))
     .await
 }


### PR DESCRIPTION
Every `401` from the portal is currently read as "your token is invalid", which then discards the token and sends the user through sign-in again. That is only correct for some rejections: the portal can turn us away for reasons a new token would not fix, and a `401` may not even come from the portal at all, e.g. an error page served by an intermediary proxy.

The portal now states the reason as RFC 9457 problem details, so parse those and only blame the token when the portal actually names it. Anything else surfaces as a generic authentication failure carrying the portal's own explanation.

Related: #14735