### PR TITLE
ci(fuzz): allow dispatching a single fuzz target

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -5,12 +5,19 @@ run-name: Triggered from ${{ github.event_name }} on ${{ github.ref_name }}
 # uncovered-region ceilings alongside. The scheduled run works on main and
 # proposes the result as one bot PR; dispatching the workflow on any other
 # branch pushes the result back to that branch instead, e.g. to re-grow the
-# corpus for a PR that changes the harness. Pull-request CI only replays
-# committed inputs; coverage discovery happens here.
+# corpus for a PR that changes the harness. A dispatch can also narrow the run
+# to a subset of targets. Pull-request CI only replays committed inputs;
+# coverage discovery happens here.
 "on":
   schedule:
     - cron: "0 4 * * *" # daily, 04:00 UTC
   workflow_dispatch:
+    inputs:
+      targets:
+        description: "Space-separated fuzz targets to work on, e.g. 'ip-packet tunnel-proto'. Leave empty for every target in tests/fuzz/targets.json."
+        required: false
+        type: string
+        default: ""
 
 defaults:
   run:
@@ -34,7 +41,28 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: targets
-        run: echo "targets=$(jq -c . tests/fuzz/targets.json)" >> "$GITHUB_OUTPUT"
+        env:
+          # Empty for the schedule, which cannot pass inputs.
+          REQUESTED_TARGETS: ${{ inputs.targets }}
+        run: |
+          set -euo pipefail
+
+          read -ra requested <<<"$REQUESTED_TARGETS"
+
+          if [[ ${#requested[@]} -eq 0 ]]; then
+            echo "targets=$(jq -c . tests/fuzz/targets.json)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Reject an unknown name instead of fuzzing nothing: an empty matrix
+          # would let the run succeed without discovering any coverage.
+          unknown=$(jq -r '$ARGS.positional - . | join(", ")' tests/fuzz/targets.json --args "${requested[@]}")
+          if [[ -n "$unknown" ]]; then
+            echo "::error::Unknown fuzz target(s): $unknown. Known targets: $(jq -r 'join(", ")' tests/fuzz/targets.json)"
+            exit 1
+          fi
+
+          echo "targets=$(jq -c '$ARGS.positional' tests/fuzz/targets.json --args "${requested[@]}")" >> "$GITHUB_OUTPUT"
 
   discover:
     name: discover-${{ matrix.fuzz-target }}

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -14,7 +14,7 @@ run-name: Triggered from ${{ github.event_name }} on ${{ github.ref_name }}
   workflow_dispatch:
     inputs:
       targets:
-        description: "Space-separated fuzz targets to work on, e.g. 'ip-packet tunnel-proto'. Leave empty for every target in tests/fuzz/targets.json."
+        description: "Space-separated fuzz targets to work on, e.g. 'ip-packet tunnel-proto'. Leave empty for every target in rust/tests/fuzz/targets.json."
         required: false
         type: string
         default: ""

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -47,23 +47,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          read -r requested extra <<<"$REQUESTED_TARGET"
+          read -r requested _ <<<"$REQUESTED_TARGET"
 
           if [[ -z "$requested" ]]; then
             echo "targets=$(jq -c . tests/fuzz/targets.json)" >> "$GITHUB_OUTPUT"
             exit 0
-          fi
-
-          if [[ -n "$extra" ]]; then
-            echo "::error::Dispatch one target at a time, or none for all of them; got '$REQUESTED_TARGET'."
-            exit 1
-          fi
-
-          # Reject an unknown name instead of fuzzing nothing: an empty matrix
-          # would let the run succeed without discovering any coverage.
-          if ! jq -e --arg target "$requested" 'index($target) != null' tests/fuzz/targets.json > /dev/null; then
-            echo "::error::Unknown fuzz target '$requested'. Known targets: $(jq -r 'join(", ")' tests/fuzz/targets.json)"
-            exit 1
           fi
 
           echo "targets=$(jq -nc --arg target "$requested" '[$target]')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -6,15 +6,15 @@ run-name: Triggered from ${{ github.event_name }} on ${{ github.ref_name }}
 # proposes the result as one bot PR; dispatching the workflow on any other
 # branch pushes the result back to that branch instead, e.g. to re-grow the
 # corpus for a PR that changes the harness. A dispatch can also narrow the run
-# to a subset of targets. Pull-request CI only replays committed inputs;
+# to a single target. Pull-request CI only replays committed inputs;
 # coverage discovery happens here.
 "on":
   schedule:
     - cron: "0 4 * * *" # daily, 04:00 UTC
   workflow_dispatch:
     inputs:
-      targets:
-        description: "Space-separated fuzz targets to work on, e.g. 'ip-packet tunnel-proto'. Leave empty for every target in rust/tests/fuzz/targets.json."
+      target:
+        description: "A single fuzz target to work on, e.g. 'tunnel-proto'. Leave empty for every target in rust/tests/fuzz/targets.json."
         required: false
         type: string
         default: ""
@@ -43,26 +43,30 @@ jobs:
       - id: targets
         env:
           # Empty for the schedule, which cannot pass inputs.
-          REQUESTED_TARGETS: ${{ inputs.targets }}
+          REQUESTED_TARGET: ${{ inputs.target }}
         run: |
           set -euo pipefail
 
-          read -ra requested <<<"$REQUESTED_TARGETS"
+          read -r requested extra <<<"$REQUESTED_TARGET"
 
-          if [[ ${#requested[@]} -eq 0 ]]; then
+          if [[ -z "$requested" ]]; then
             echo "targets=$(jq -c . tests/fuzz/targets.json)" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Reject an unknown name instead of fuzzing nothing: an empty matrix
-          # would let the run succeed without discovering any coverage.
-          unknown=$(jq -r '$ARGS.positional - . | join(", ")' tests/fuzz/targets.json --args "${requested[@]}")
-          if [[ -n "$unknown" ]]; then
-            echo "::error::Unknown fuzz target(s): $unknown. Known targets: $(jq -r 'join(", ")' tests/fuzz/targets.json)"
+          if [[ -n "$extra" ]]; then
+            echo "::error::Dispatch one target at a time, or none for all of them; got '$REQUESTED_TARGET'."
             exit 1
           fi
 
-          echo "targets=$(jq -c '$ARGS.positional' tests/fuzz/targets.json --args "${requested[@]}")" >> "$GITHUB_OUTPUT"
+          # Reject an unknown name instead of fuzzing nothing: an empty matrix
+          # would let the run succeed without discovering any coverage.
+          if ! jq -e --arg target "$requested" 'index($target) != null' tests/fuzz/targets.json > /dev/null; then
+            echo "::error::Unknown fuzz target '$requested'. Known targets: $(jq -r 'join(", ")' tests/fuzz/targets.json)"
+            exit 1
+          fi
+
+          echo "targets=$(jq -nc --arg target "$requested" '[$target]')" >> "$GITHUB_OUTPUT"
 
   discover:
     name: discover-${{ matrix.fuzz-target }}

--- a/rust/tests/fuzz/README.md
+++ b/rust/tests/fuzz/README.md
@@ -16,7 +16,7 @@ Pull-request CI only replays these inputs, making fuzz regression and coverage c
 It never performs random coverage discovery.
 
 The nightly `fuzz-nightly.yml` workflow runs every target from `targets.json` on `main`, minimizes and repacks the grown corpora, refreshes their coverage baselines, and opens one bot PR with the results.
-Dispatching it manually takes an optional space-separated `targets` input to work on a subset of `targets.json`, and on a branch other than `main` it pushes the result back to that branch instead of opening a PR.
+Dispatching it manually takes an optional `target` input to work on one entry of `targets.json` instead of all of them, and on a branch other than `main` it pushes the result back to that branch instead of opening a PR.
 
 Tunnel inputs are decoded positionally with `arbitrary::Unstructured`.
 Changing the generator in `src/arb/` can therefore reinterpret existing inputs; after a substantial generator change, re-minimize and grow the corpus before updating the archive.

--- a/rust/tests/fuzz/README.md
+++ b/rust/tests/fuzz/README.md
@@ -16,6 +16,7 @@ Pull-request CI only replays these inputs, making fuzz regression and coverage c
 It never performs random coverage discovery.
 
 The nightly `fuzz-nightly.yml` workflow runs every target from `targets.json` on `main`, minimizes and repacks the grown corpora, refreshes their coverage baselines, and opens one bot PR with the results.
+Dispatching it manually takes an optional space-separated `targets` input to work on a subset of `targets.json`, and on a branch other than `main` it pushes the result back to that branch instead of opening a PR.
 
 Tunnel inputs are decoded positionally with `arbitrary::Unstructured`.
 Changing the generator in `src/arb/` can therefore reinterpret existing inputs; after a substantial generator change, re-minimize and grow the corpus before updating the archive.


### PR DESCRIPTION
Each fuzz target takes up to an hour, so growing one corpus should not mean waiting for all of them. The nightly workflow now takes an optional target name when dispatched manually.

Leaving the input empty keeps the current behaviour of working on every target in `rust/tests/fuzz/targets.json`, which is also the path the schedule takes.