### PR TITLE
chore(fuzz): propose a corpus update per target

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -3,10 +3,10 @@ name: Fuzz corpora (nightly)
 run-name: Triggered from ${{ github.event_name }} on ${{ github.ref_name }}
 # Grows and minimizes every committed fuzz corpus, refreshing the
 # uncovered-region ceilings alongside. The scheduled run works on main and
-# proposes the result as one bot PR; dispatching the workflow on any other
-# branch pushes the result back to that branch instead, e.g. to re-grow the
-# corpus for a PR that changes the harness. Pull-request CI only replays
-# committed inputs; coverage discovery happens here.
+# proposes each target's result as its own bot PR; dispatching the workflow on
+# any other branch pushes the result back to that branch instead, e.g. to
+# re-grow the corpus for a PR that changes the harness. Pull-request CI only
+# replays committed inputs; coverage discovery happens here.
 "on":
   schedule:
     - cron: "0 4 * * *" # daily, 04:00 UTC
@@ -72,17 +72,23 @@ jobs:
           if-no-files-found: error
 
   propose:
-    name: propose-corpus-update
-    needs: [discover]
+    name: propose-${{ matrix.fuzz-target }}
+    needs: [targets, discover]
     if: ${{ !cancelled() }}
+    strategy:
+      fail-fast: false
+      # One at a time: every job in this matrix pushes, and on a dispatched
+      # branch they all push to the same ref.
+      max-parallel: 1
+      matrix:
+        fuzz-target: ${{ fromJSON(needs.targets.outputs.targets) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: fuzz-*
+          name: fuzz-${{ matrix.fuzz-target }}
           path: rust/tests/fuzz
-          merge-multiple: true
       - name: Set up GnuPG for the corpus commit
         uses: ./.github/actions/setup-gpg
         id: setup-gpg
@@ -94,6 +100,7 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_PR_BOT_GITHUB_TOKEN }}
           REF: ${{ github.ref_name }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          TARGET: ${{ matrix.fuzz-target }}
         run: |
           set -euo pipefail
 
@@ -102,12 +109,12 @@ jobs:
           git config --local user.signingkey "${{ steps.setup-gpg.outputs.key_id }}"
           git config --local commit.gpgsign true
 
-          git add -A tests/fuzz/corpora tests/fuzz/expected-coverage
+          git add -A "tests/fuzz/corpora/$TARGET.tar.gz" "tests/fuzz/expected-coverage/$TARGET.json"
           if git diff --cached --quiet; then
-            echo "Corpora unchanged; nothing to push."
+            echo "The $TARGET corpus is unchanged; nothing to push."
             exit 0
           fi
-          git commit -m "chore(fuzz): grow committed corpora"
+          git commit -m "chore(fuzz): grow the $TARGET corpus"
 
           # Do not use checkout's GITHUB_TOKEN for the push: pushes made with
           # it do not trigger the pull request's workflows.
@@ -123,13 +130,15 @@ jobs:
             exit 0
           fi
 
-          branch="chore/fuzz-corpora"
+          # A branch per target, so a corpus that carries a crashing input only
+          # holds up its own review.
+          branch="chore/fuzz-corpora-$TARGET"
           git checkout -B "$branch"
           git push -u origin HEAD --force
 
           if [ -z "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
             gh pr create \
-              --title "chore(fuzz): grow committed corpora" \
-              --body "The nightly fuzz jobs discovered new coverage and refreshed each target's uncovered-region ceiling." \
+              --title "chore(fuzz): grow the $TARGET corpus" \
+              --body "The nightly fuzz job discovered new coverage for \`$TARGET\` and refreshed its uncovered-region ceiling." \
               --reviewer firezone/engineering
           fi

--- a/rust/tests/fuzz/README.md
+++ b/rust/tests/fuzz/README.md
@@ -15,7 +15,7 @@ The mise tasks unpack it into the ignored `corpus/<target>` directory before inv
 Pull-request CI only replays these inputs, making fuzz regression and coverage checks deterministic.
 It never performs random coverage discovery.
 
-The nightly `fuzz-nightly.yml` workflow runs every target from `targets.json` on `main`, minimizes and repacks the grown corpora, refreshes their coverage baselines, and opens one bot PR with the results.
+The nightly `fuzz-nightly.yml` workflow runs every target from `targets.json` on `main`, minimizes and repacks the grown corpora, refreshes their coverage baselines, and opens a bot PR per target, so a corpus that carries a crashing input only holds up its own review.
 
 Tunnel inputs are decoded positionally with `arbitrary::Unstructured`.
 Changing the generator in `src/arb/` can therefore reinterpret existing inputs; after a substantial generator change, re-minimize and grow the corpus before updating the archive.


### PR DESCRIPTION
The nightly run collects every grown corpus into a single commit and a single PR, which is only mergeable if every target's result is. A target that picks up a crashing input therefore holds back the coverage the other targets found, which is the opposite of what the run is for.

Each target now gets its own branch, commit and PR, so its result stands or falls on its own.