### PR TITLE
fix(portal): remove form-action CSP directive

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -429,8 +429,6 @@ config :portal, PortalWeb.Plugs.PutSecurityHeaders,
     "script-src 'self' 'nonce-${nonce}'",
     "object-src 'none'",
     "base-uri 'self'",
-    # Client deep link: some browsers check form-action across post-submit redirects.
-    "form-action 'self' firezone-fd0020211111:",
     "frame-ancestors 'none'"
   ]
 

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -225,7 +225,6 @@ config :portal, PortalWeb.Plugs.PutSecurityHeaders,
     "script-src 'self' 'nonce-${nonce}' https://cdn.tailwindcss.com/",
     "object-src 'none'",
     "base-uri 'self'",
-    "form-action 'self' firezone-fd0020211111:",
     "frame-ancestors 'none'"
   ],
   live_reload_frame_csp_policy: [
@@ -237,7 +236,6 @@ config :portal, PortalWeb.Plugs.PutSecurityHeaders,
     "frame-src 'self'",
     "object-src 'none'",
     "base-uri 'self'",
-    "form-action 'self'",
     "frame-ancestors 'self'"
   ]
 

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -292,7 +292,6 @@ config :portal, PortalWeb.Plugs.PutSecurityHeaders,
     "script-src 'self' 'nonce-${nonce}'",
     "object-src 'none'",
     "base-uri 'self'",
-    "form-action 'self' firezone-fd0020211111:",
     "frame-ancestors 'none'"
   ]
 

--- a/elixir/lib/portal_ops/router.ex
+++ b/elixir/lib/portal_ops/router.ex
@@ -11,7 +11,6 @@ defmodule PortalOps.Router do
          "connect-src 'self' ws: wss:; " <>
          "object-src 'none'; " <>
          "base-uri 'self'; " <>
-         "form-action 'self'; " <>
          "frame-ancestors 'none'"
 
   @secure_browser_headers PortalWeb.Plugs.PutSecurityHeaders.headers(@csp)


### PR DESCRIPTION
## Summary

- remove the recently added `form-action` CSP directive from PortalWeb policies
- remove the same directive from the PortalOps dashboard policy
- retain the other CSP hardening from #14675

The directive is causing sign-in flows to be blocked.

## Testing

- `mix test test/portal_web/controllers/home_controller_test.exs test/portal_ops/endpoint_test.exs` (20 tests, 0 failures)
- `git diff --check`