### PR TITLE
fix(portal): prevent membership churn in REST API

### DIFF
--- a/elixir/lib/portal_api/controllers/membership_controller.ex
+++ b/elixir/lib/portal_api/controllers/membership_controller.ex
@@ -5,7 +5,6 @@ defmodule PortalAPI.MembershipController do
   alias PortalAPI.Error
   alias PortalAPI.Schemas.ProblemDetails
   alias __MODULE__.Database
-  import Ecto.Changeset
 
   tags ["Memberships"]
 
@@ -46,6 +45,19 @@ defmodule PortalAPI.MembershipController do
   # coveralls-ignore-start - OpenApiSpex operation specs are compile-time, not executable
   operation :update_put,
     summary: "Update Memberships",
+    description: """
+    Replaces the Group's entire membership list with the given Actors.
+
+    Any Actor not named in the request is removed from the Group. To add or
+    remove individual Actors without disturbing the rest, use `PATCH`.
+
+    Members that are not changing keep their membership rows, so a replace that
+    leaves the list untouched is a no-op rather than a full rewrite.
+
+    Repeating an Actor in the request body is not an error; the list is
+    deduplicated. `actor_ids` in the response is sorted, not returned in
+    request order.
+    """,
     parameters: [
       group_id: [
         in: :path,
@@ -74,17 +86,16 @@ defmodule PortalAPI.MembershipController do
   # coveralls-ignore-stop
 
   @spec update_put(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def update_put(
-        conn,
-        %{"group_id" => group_id, "memberships" => attrs}
-      ) do
+  def update_put(conn, %{"group_id" => group_id, "memberships" => members})
+      when is_list(members) do
     subject = conn.assigns.subject
 
     with {:ok, group} <- Database.fetch_group(group_id, subject),
          :ok <- validate_group_editable(group),
-         changeset <- update_group_memberships_changeset(group, attrs),
-         {:ok, group} <- Database.update_group(changeset, subject) do
-      render(conn, :memberships, memberships: group.memberships)
+         {:ok, actor_ids} <- extract_actor_ids(members),
+         :ok <- Database.validate_actors(actor_ids, subject),
+         {:ok, actor_ids} <- Database.replace_members(group, actor_ids, subject) do
+      render(conn, :memberships, actor_ids: actor_ids)
     else
       error -> Error.handle(conn, error)
     end
@@ -97,6 +108,18 @@ defmodule PortalAPI.MembershipController do
   # coveralls-ignore-start - OpenApiSpex operation specs are compile-time, not executable
   operation :update_patch,
     summary: "Update an Membership",
+    description: """
+    Adds and/or removes individual Actors, leaving every other member of the
+    Group untouched.
+
+    Both operations are idempotent: adding an Actor already in the Group and
+    removing one that isn't are both no-ops. `remove` is applied before `add`,
+    so an Actor named in both ends up in the Group. Retrying a request that may
+    already have been applied is therefore safe.
+
+    Repeating an Actor within `add` or `remove` is not an error; both lists are
+    deduplicated. `actor_ids` in the response is sorted.
+    """,
     parameters: [
       group_id: [
         in: :path,
@@ -125,20 +148,17 @@ defmodule PortalAPI.MembershipController do
   # coveralls-ignore-stop
 
   @spec update_patch(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def update_patch(
-        conn,
-        %{"group_id" => group_id, "memberships" => params}
-      ) do
-    add = Map.get(params, "add", [])
-    remove = Map.get(params, "remove", [])
+  def update_patch(conn, %{"group_id" => group_id, "memberships" => params})
+      when is_map(params) do
     subject = conn.assigns.subject
 
     with {:ok, group} <- Database.fetch_group(group_id, subject),
          :ok <- validate_group_editable(group),
-         membership_attrs <- prepare_membership_attrs(group, add, remove),
-         changeset <- update_group_memberships_changeset(group, membership_attrs),
-         {:ok, group} <- Database.update_group(changeset, subject) do
-      render(conn, :memberships, memberships: group.memberships)
+         {:ok, add} <- extract_id_list(params, "add"),
+         {:ok, remove} <- extract_id_list(params, "remove"),
+         :ok <- Database.validate_actors(add, subject),
+         {:ok, actor_ids} <- Database.patch_members(group, add, remove, subject) do
+      render(conn, :memberships, actor_ids: actor_ids)
     else
       error -> Error.handle(conn, error)
     end
@@ -156,53 +176,72 @@ defmodule PortalAPI.MembershipController do
     end
   end
 
-  defp update_group_memberships_changeset(group, attrs) do
-    # Ensure all membership attrs include the account_id from the group
-    attrs_with_account =
-      Enum.map(attrs, fn membership_attrs ->
-        Map.put_new(membership_attrs, "account_id", group.account_id)
+  # Both PATCH lists are plain arrays of Actor IDs. Neither is checked against
+  # real Actors before "remove" reaches the delete query, so a malformed ID
+  # would raise an Ecto.Query.CastError - a 500 for what is just a malformed
+  # request. Checking the format here turns it into a 422 naming the value.
+  defp extract_id_list(params, field) do
+    values = List.wrap(Map.get(params, field, []))
+
+    case Enum.reject(values, &valid_actor_id?/1) do
+      [] ->
+        {:ok, Enum.uniq(values)}
+
+      invalid ->
+        {:error, :unprocessable_entity,
+         validation_errors: %{memberships: Enum.map(invalid, &invalid_id_message/1)}}
+    end
+  end
+
+  # Rejects malformed entries rather than skipping them. Dropping one would be
+  # silent data loss on a replace: an entry missing actor_id would shrink the
+  # list, and a body where every entry is malformed - {"memberships": [{}]} -
+  # would look like an empty list and clear the Group while returning 200.
+  #
+  # An explicitly empty list is still how a caller clears a Group. The
+  # distinction is between "no members" and "members I could not read".
+  defp extract_actor_ids(members) do
+    {actor_ids, invalid} =
+      Enum.reduce(members, {[], []}, fn
+        %{"actor_id" => actor_id}, {ids, invalid} ->
+          if valid_actor_id?(actor_id),
+            do: {[actor_id | ids], invalid},
+            else: {ids, [invalid_id_message(actor_id) | invalid]}
+
+        _entry, {ids, invalid} ->
+          {ids, ["entry is missing an Actor ID" | invalid]}
       end)
 
-    group
-    |> cast(%{memberships: attrs_with_account}, [])
-    |> cast_assoc(:memberships, with: &membership_changeset/2)
+    case invalid do
+      [] -> {:ok, actor_ids |> Enum.reverse() |> Enum.uniq()}
+      invalid -> {:error, :unprocessable_entity,
+                  validation_errors: %{memberships: Enum.reverse(invalid)}}
+    end
   end
 
-  defp membership_changeset(membership, attrs) do
-    import Ecto.Changeset
-
-    membership
-    |> cast(attrs, [:actor_id, :account_id])
-    |> Portal.Membership.changeset()
+  defp valid_actor_id?(value) when is_binary(value) do
+    match?({:ok, _uuid}, Ecto.UUID.cast(value))
   end
 
-  defp prepare_membership_attrs(group, add, remove) do
-    to_add = MapSet.new(add) |> MapSet.reject(&(String.trim(&1) == ""))
-    to_remove = MapSet.new(remove) |> MapSet.reject(&(String.trim(&1) == ""))
-    member_ids = Enum.map(group.memberships, & &1.actor_id) |> MapSet.new()
+  defp valid_actor_id?(_value), do: false
 
-    membership_ids =
-      MapSet.difference(member_ids, to_remove)
-      |> MapSet.union(to_add)
-
-    if MapSet.size(membership_ids) == 0,
-      do: [],
-      else: Enum.map(membership_ids, &%{"actor_id" => &1, "account_id" => group.account_id})
-  end
+  defp invalid_id_message(value) when is_binary(value), do: "#{value} is not a valid Actor ID"
+  defp invalid_id_message(value), do: "#{inspect(value)} is not a valid Actor ID"
 
   defmodule Database do
     import Ecto.Query
+    alias Portal.Actor
+    alias Portal.Membership
     alias Portal.Safe
 
     def list_actors(subject, opts) do
-      from(a in Portal.Actor, as: :actors)
+      from(a in Actor, as: :actors)
       |> Safe.scoped(subject)
       |> Safe.list(__MODULE__, opts)
     end
 
     def fetch_group(id, subject) do
       from(g in Portal.Group, where: g.id == ^id)
-      |> preload(:memberships)
       |> Safe.scoped(subject)
       |> Safe.one()
       |> case do
@@ -212,10 +251,126 @@ defmodule PortalAPI.MembershipController do
       end
     end
 
-    def update_group(changeset, subject) do
-      changeset
+    @doc """
+    Verifies every given ID names an Actor in the subject's account.
+
+    The `memberships_actor_id_fkey` constraint would reject a nonexistent
+    Actor anyway, but only as an opaque constraint error at insert time - and
+    a cross-account ID would surface the same way. Checking up front turns
+    both into one 422 that names the offending IDs, and keeps the scoped query
+    from confirming that an Actor in another account exists.
+    """
+    def validate_actors([], _subject), do: :ok
+
+    def validate_actors(actor_ids, subject) do
+      actor_ids = Enum.uniq(actor_ids)
+
+      found =
+        from(a in Actor, where: a.id in ^actor_ids, select: a.id)
+        |> Safe.scoped(subject)
+        |> Safe.all()
+
+      case actor_ids -- List.wrap(found) do
+        [] ->
+          :ok
+
+        missing ->
+          {:error, :unprocessable_entity,
+           validation_errors: %{
+             memberships: Enum.map(missing, &"#{&1} is not an Actor in this account")
+           }}
+      end
+    end
+
+    @doc """
+    Replaces the Group's membership with `actor_ids`.
+
+    Diffs against what's stored and applies only the difference, so members
+    that aren't changing keep their rows - and their IDs - rather than being
+    deleted and reinserted. Reinserting would cascade away their
+    `policy_authorizations` and churn the replication stream the data plane
+    consumes.
+    """
+    def replace_members(group, actor_ids, subject) do
+      actor_ids = Enum.uniq(actor_ids)
+
+      Safe.transact(fn ->
+        existing = existing_member_ids(group, subject)
+
+        with :ok <- delete_members(group, existing -- actor_ids, subject),
+             :ok <- insert_members(group, actor_ids -- existing, subject) do
+          {:ok, Enum.sort(actor_ids)}
+        end
+      end)
+    end
+
+    @doc """
+    Adds and removes individual members, leaving the rest of the Group alone.
+    Removals are applied first, so an ID in both lists stays.
+    """
+    def patch_members(group, add, remove, subject) do
+      add = Enum.uniq(add)
+      # An ID in both lists is kept: remove runs first, then add puts it back,
+      # so dropping it from remove up front is the same outcome with one less
+      # write.
+      remove = Enum.uniq(remove) -- add
+
+      Safe.transact(fn ->
+        existing = existing_member_ids(group, subject)
+
+        # Deleting an ID that isn't a member matches no rows, so remove needs
+        # no intersection with existing first.
+        with :ok <- delete_members(group, remove, subject),
+             :ok <- insert_members(group, add -- existing, subject) do
+          {:ok, Enum.sort(Enum.uniq((existing -- remove) ++ add))}
+        end
+      end)
+    end
+
+    defp existing_member_ids(group, subject) do
+      from(m in Membership, where: m.group_id == ^group.id, select: m.actor_id)
       |> Safe.scoped(subject)
-      |> Safe.update()
+      |> Safe.all()
+      |> case do
+        {:error, _reason} -> []
+        ids -> ids
+      end
+    end
+
+    defp delete_members(_group, [], _subject), do: :ok
+
+    defp delete_members(group, actor_ids, subject) do
+      from(m in Membership, where: m.group_id == ^group.id and m.actor_id in ^actor_ids)
+      |> Safe.scoped(subject)
+      |> Safe.delete_all()
+      |> case do
+        {:error, reason} -> {:error, reason}
+        {_count, _} -> :ok
+      end
+    end
+
+    defp insert_members(_group, [], _subject), do: :ok
+
+    defp insert_members(group, actor_ids, subject) do
+      entries =
+        Enum.map(actor_ids, fn actor_id ->
+          %{
+            id: Ecto.UUID.generate(),
+            account_id: group.account_id,
+            group_id: group.id,
+            actor_id: actor_id
+          }
+        end)
+
+      Safe.scoped(subject)
+      |> Safe.insert_all(Membership, entries,
+        on_conflict: :nothing,
+        conflict_target: [:actor_id, :group_id]
+      )
+      |> case do
+        {:error, reason} -> {:error, reason}
+        {_count, _} -> :ok
+      end
     end
 
     def cursor_fields do
@@ -241,7 +396,7 @@ defmodule PortalAPI.MembershipController do
         dynamic(
           [actors: a],
           a.id in subquery(
-            from(m in Portal.Membership,
+            from(m in Membership,
               where: m.group_id == ^group_id,
               select: m.actor_id
             )

--- a/elixir/lib/portal_api/controllers/membership_controller.ex
+++ b/elixir/lib/portal_api/controllers/membership_controller.ex
@@ -265,21 +265,29 @@ defmodule PortalAPI.MembershipController do
     def validate_actors(actor_ids, subject) do
       actor_ids = Enum.uniq(actor_ids)
 
-      found =
-        from(a in Actor, where: a.id in ^actor_ids, select: a.id)
-        |> Safe.scoped(subject)
-        |> Safe.all()
-
-      case actor_ids -- List.wrap(found) do
-        [] ->
-          :ok
-
-        missing ->
-          {:error, :unprocessable_entity,
-           validation_errors: %{
-             memberships: Enum.map(missing, &"#{&1} is not an Actor in this account")
-           }}
+      case existing_actor_ids(actor_ids, subject) do
+        # Safe.all/1 returns {:error, :unauthorized} for a subject that may
+        # not read Actors. An account_user reaches here - it may read a Group
+        # but not an Actor - so this has to propagate rather than be treated
+        # as "found nothing", which would report every ID as nonexistent.
+        {:error, reason} -> {:error, reason}
+        found -> validate_none_missing(actor_ids -- found)
       end
+    end
+
+    defp existing_actor_ids(actor_ids, subject) do
+      from(a in Actor, where: a.id in ^actor_ids, select: a.id)
+      |> Safe.scoped(subject)
+      |> Safe.all()
+    end
+
+    defp validate_none_missing([]), do: :ok
+
+    defp validate_none_missing(missing) do
+      {:error, :unprocessable_entity,
+       validation_errors: %{
+         memberships: Enum.map(missing, &"#{&1} is not an Actor in this account")
+       }}
     end
 
     @doc """

--- a/elixir/lib/portal_api/controllers/membership_json.ex
+++ b/elixir/lib/portal_api/controllers/membership_json.ex
@@ -15,8 +15,7 @@ defmodule PortalAPI.MembershipJSON do
   @doc """
   Renders a list of Actor IDs for an Actor Group
   """
-  def memberships(%{memberships: memberships}) do
-    actor_ids = for(membership <- memberships, do: membership.actor_id)
+  def memberships(%{actor_ids: actor_ids}) do
     %{data: %{actor_ids: actor_ids}}
   end
 

--- a/elixir/lib/portal_api/controllers/pool_member_controller.ex
+++ b/elixir/lib/portal_api/controllers/pool_member_controller.ex
@@ -293,22 +293,30 @@ defmodule PortalAPI.PoolMemberController do
     def validate_client_devices(device_ids, subject) do
       device_ids = Enum.uniq(device_ids)
 
-      found =
-        from(d in Device, where: d.id in ^device_ids and d.type == :client, select: d.id)
-        |> Safe.scoped(subject)
-        |> Safe.all()
-
-      case device_ids -- List.wrap(found) do
-        [] ->
-          :ok
-
-        missing ->
-          {:error, :unprocessable_entity,
-           validation_errors: %{
-             pool_members:
-               Enum.map(missing, &"#{&1} is not a Client in this account")
-           }}
+      case existing_client_device_ids(device_ids, subject) do
+        # Safe.all/1 returns {:error, :unauthorized} for a subject that may
+        # not read Devices. No actor type can reach here without that
+        # permission today, but treating the tuple as an empty result would
+        # answer an authorization failure with a 422 claiming every ID is
+        # nonexistent, so it propagates instead.
+        {:error, reason} -> {:error, reason}
+        found -> validate_none_missing(device_ids -- found)
       end
+    end
+
+    defp existing_client_device_ids(device_ids, subject) do
+      from(d in Device, where: d.id in ^device_ids and d.type == :client, select: d.id)
+      |> Safe.scoped(subject)
+      |> Safe.all()
+    end
+
+    defp validate_none_missing([]), do: :ok
+
+    defp validate_none_missing(missing) do
+      {:error, :unprocessable_entity,
+       validation_errors: %{
+         pool_members: Enum.map(missing, &"#{&1} is not a Client in this account")
+       }}
     end
 
     @doc """

--- a/elixir/priv/static/openapi.json
+++ b/elixir/priv/static/openapi.json
@@ -10340,6 +10340,7 @@
       },
       "patch": {
         "callbacks": {},
+        "description": "Adds and/or removes individual Actors, leaving every other member of the\nGroup untouched.\n\nBoth operations are idempotent: adding an Actor already in the Group and\nremoving one that isn't are both no-ops. `remove` is applied before `add`,\nso an Actor named in both ends up in the Group. Retrying a request that may\nalready have been applied is therefore safe.\n\nRepeating an Actor within `add` or `remove` is not an error; both lists are\ndeduplicated. `actor_ids` in the response is sorted.\n",
         "operationId": "PortalAPI.MembershipController.update_patch",
         "parameters": [
           {
@@ -10484,6 +10485,7 @@
       },
       "put": {
         "callbacks": {},
+        "description": "Replaces the Group's entire membership list with the given Actors.\n\nAny Actor not named in the request is removed from the Group. To add or\nremove individual Actors without disturbing the rest, use `PATCH`.\n\nMembers that are not changing keep their membership rows, so a replace that\nleaves the list untouched is a no-op rather than a full rewrite.\n\nRepeating an Actor in the request body is not an error; the list is\ndeduplicated. `actor_ids` in the response is sorted, not returned in\nrequest order.\n",
         "operationId": "PortalAPI.MembershipController.update_put",
         "parameters": [
           {

--- a/elixir/test/portal_api/controllers/membership_controller_test.exs
+++ b/elixir/test/portal_api/controllers/membership_controller_test.exs
@@ -5,6 +5,10 @@ defmodule PortalAPI.MembershipControllerTest do
   import Portal.ActorFixtures
   import Portal.GroupFixtures
   import Portal.MembershipFixtures
+  import Portal.PolicyAuthorizationFixtures
+  import Ecto.Query
+
+  alias Portal.Repo
 
   setup do
     account = account_fixture()
@@ -167,7 +171,10 @@ defmodule PortalAPI.MembershipControllerTest do
       assert resp = json_response(conn, 422)
       assert %{"type" => "about:blank", "status" => 422} = resp
       assert %{"validation_errors" => %{"memberships" => memberships}} = resp
-      assert [%{"actor" => ["does not exist"]}] = memberships
+
+      assert memberships == [
+               "00000000-0000-0000-0000-000000000000 is not an Actor in this account"
+             ]
     end
 
     test "returns forbidden when group is not editable", %{
@@ -224,7 +231,7 @@ defmodule PortalAPI.MembershipControllerTest do
       resp = json_response(conn, 422)
       assert %{"type" => "about:blank", "status" => 422} = resp
       assert %{"validation_errors" => %{"memberships" => memberships}} = resp
-      assert [%{"actor_id" => ["is invalid"]}] = memberships
+      assert memberships == ["<no value> is not a valid Actor ID"]
     end
 
     test "removes actor from group", %{conn: conn, account: account, actor: api_actor} do
@@ -336,7 +343,7 @@ defmodule PortalAPI.MembershipControllerTest do
       resp = json_response(conn, 422)
       assert %{"type" => "about:blank", "status" => 422} = resp
       assert %{"validation_errors" => %{"memberships" => memberships}} = resp
-      assert [%{"actor_id" => ["is invalid"]}] = memberships
+      assert memberships == ["<no value> is not a valid Actor ID"]
     end
 
     test "removes actor from group", %{conn: conn, account: account, actor: api_actor} do
@@ -376,6 +383,394 @@ defmodule PortalAPI.MembershipControllerTest do
 
       assert %{"data" => data} = json_response(conn, 200)
       assert Enum.sort(data["actor_ids"]) == Enum.sort([actor1.id, actor3.id])
+    end
+  end
+
+  describe "membership row stability" do
+    # Regression for the API equivalent of #12074. The controller used to hand
+    # the full desired member list to cast_assoc(:memberships). Membership's
+    # primary key is composite - [account_id, id] - and the attrs carried no
+    # id, so Ecto matched nothing, deleted every row and reinserted it with a
+    # fresh id on every request. That cascaded away policy_authorizations and
+    # pushed a delete/insert pair to every connected client of every member.
+    defp membership_ids(group_id) do
+      from(m in Portal.Membership, where: m.group_id == ^group_id, select: m.id)
+      |> Repo.all()
+      |> Enum.sort()
+    end
+
+    test "PATCH with an empty body does not rewrite any row", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      group = group_fixture(account: account)
+
+      for _ <- 1..3,
+          do: membership_fixture(account: account, group: group)
+
+      before_ids = membership_ids(group.id)
+
+      conn
+      |> authorize_conn(api_actor)
+      |> put_req_header("content-type", "application/json")
+      |> patch("/groups/#{group.id}/memberships", memberships: %{})
+      |> json_response(200)
+
+      assert membership_ids(group.id) == before_ids
+    end
+
+    test "PATCH adding one actor leaves existing rows untouched", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      group = group_fixture(account: account)
+
+      for _ <- 1..3,
+          do: membership_fixture(account: account, group: group)
+
+      before_ids = membership_ids(group.id)
+      new_actor = actor_fixture(account: account)
+
+      conn
+      |> authorize_conn(api_actor)
+      |> put_req_header("content-type", "application/json")
+      |> patch("/groups/#{group.id}/memberships", memberships: %{"add" => [new_actor.id]})
+      |> json_response(200)
+
+      after_ids = membership_ids(group.id)
+      assert length(after_ids) == 4
+      assert before_ids -- after_ids == []
+    end
+
+    test "PUT with an unchanged member list does not rewrite any row", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      group = group_fixture(account: account)
+      actor1 = actor_fixture(account: account)
+      actor2 = actor_fixture(account: account)
+      membership_fixture(account: account, actor: actor1, group: group)
+      membership_fixture(account: account, actor: actor2, group: group)
+
+      before_ids = membership_ids(group.id)
+      attrs = [%{"actor_id" => actor1.id}, %{"actor_id" => actor2.id}]
+
+      conn
+      |> authorize_conn(api_actor)
+      |> put_req_header("content-type", "application/json")
+      |> put("/groups/#{group.id}/memberships", memberships: attrs)
+      |> json_response(200)
+
+      assert membership_ids(group.id) == before_ids
+    end
+
+    test "PUT adding one actor leaves existing rows untouched", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      group = group_fixture(account: account)
+      actor1 = actor_fixture(account: account)
+      actor2 = actor_fixture(account: account)
+      membership_fixture(account: account, actor: actor1, group: group)
+      membership_fixture(account: account, actor: actor2, group: group)
+
+      before_ids = membership_ids(group.id)
+      actor3 = actor_fixture(account: account)
+
+      attrs = [
+        %{"actor_id" => actor1.id},
+        %{"actor_id" => actor2.id},
+        %{"actor_id" => actor3.id}
+      ]
+
+      conn
+      |> authorize_conn(api_actor)
+      |> put_req_header("content-type", "application/json")
+      |> put("/groups/#{group.id}/memberships", memberships: attrs)
+      |> json_response(200)
+
+      after_ids = membership_ids(group.id)
+      assert length(after_ids) == 3
+      assert before_ids -- after_ids == []
+    end
+
+    test "PATCH preserves policy authorizations of unaffected members", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      group = group_fixture(account: account)
+      member = actor_fixture(account: account)
+      membership = membership_fixture(account: account, actor: member, group: group)
+
+      authorization =
+        policy_authorization_fixture(
+          account: account,
+          actor: member,
+          group: group,
+          membership: membership
+        )
+
+      other = actor_fixture(account: account)
+
+      conn
+      |> authorize_conn(api_actor)
+      |> put_req_header("content-type", "application/json")
+      |> patch("/groups/#{group.id}/memberships", memberships: %{"add" => [other.id]})
+      |> json_response(200)
+
+      # policy_authorizations references memberships(account_id, id) ON DELETE
+      # CASCADE, so churning the row would have taken this with it.
+      assert Repo.get_by(Portal.PolicyAuthorization,
+               account_id: account.id,
+               id: authorization.id
+             )
+    end
+  end
+
+  describe "idempotency and concurrency" do
+    test "PATCH adding an actor already in the group is a no-op", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      group = group_fixture(account: account)
+      member = actor_fixture(account: account)
+      membership_fixture(account: account, actor: member, group: group)
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> patch("/groups/#{group.id}/memberships", memberships: %{"add" => [member.id]})
+
+      assert %{"data" => %{"actor_ids" => [id]}} = json_response(conn, 200)
+      assert id == member.id
+      assert Repo.aggregate(from(m in Portal.Membership, where: m.group_id == ^group.id), :count) == 1
+    end
+
+    test "PATCH removing an actor that is not a member is a no-op", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      group = group_fixture(account: account)
+      member = actor_fixture(account: account)
+      membership_fixture(account: account, actor: member, group: group)
+      stranger = actor_fixture(account: account)
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> patch("/groups/#{group.id}/memberships", memberships: %{"remove" => [stranger.id]})
+
+      assert %{"data" => %{"actor_ids" => [id]}} = json_response(conn, 200)
+      assert id == member.id
+    end
+
+    test "PATCH keeps an actor named in both add and remove", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      group = group_fixture(account: account)
+      member = actor_fixture(account: account)
+
+      attrs = %{"add" => [member.id], "remove" => [member.id]}
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> patch("/groups/#{group.id}/memberships", memberships: attrs)
+
+      assert %{"data" => %{"actor_ids" => [id]}} = json_response(conn, 200)
+      assert id == member.id
+    end
+
+    test "a membership deleted between read and write does not raise", %{
+      account: account,
+      actor: api_actor
+    } do
+      # Interleaved rather than genuinely parallel: the async SQL sandbox gives
+      # each process its own connection, so two real requests could not see one
+      # another's uncommitted work. Deleting the row between the fetch and the
+      # write reproduces the same interleaving the old cast_assoc path turned
+      # into an unrescued Ecto.StaleEntryError -> 409 with an HTML body.
+      group = group_fixture(account: account)
+      actor1 = actor_fixture(account: account)
+      actor2 = actor_fixture(account: account)
+      membership_fixture(account: account, actor: actor1, group: group)
+      membership_fixture(account: account, actor: actor2, group: group)
+
+      subject = Portal.SubjectFixtures.subject_fixture(account: account, actor: api_actor)
+
+      {:ok, group} = PortalAPI.MembershipController.Database.fetch_group(group.id, subject)
+
+      # A concurrent request removes actor1 first.
+      from(m in Portal.Membership, where: m.group_id == ^group.id and m.actor_id == ^actor1.id)
+      |> Repo.delete_all()
+
+      actor3 = actor_fixture(account: account)
+
+      assert {:ok, actor_ids} =
+               PortalAPI.MembershipController.Database.patch_members(
+                 group,
+                 [actor3.id],
+                 [actor1.id],
+                 subject
+               )
+
+      assert Enum.sort(actor_ids) == Enum.sort([actor2.id, actor3.id])
+    end
+  end
+
+  describe "input validation" do
+    test "PATCH rejects a malformed uuid in remove", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      group = group_fixture(account: account)
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> patch("/groups/#{group.id}/memberships", memberships: %{"remove" => ["not-a-uuid"]})
+
+      resp = json_response(conn, 422)
+      assert %{"validation_errors" => %{"memberships" => memberships}} = resp
+      assert memberships == ["not-a-uuid is not a valid Actor ID"]
+    end
+
+    test "PUT rejects an entry with no actor_id", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      group = group_fixture(account: account)
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/groups/#{group.id}/memberships", memberships: [%{}])
+
+      resp = json_response(conn, 422)
+      assert %{"validation_errors" => %{"memberships" => memberships}} = resp
+      assert memberships == ["entry is missing an Actor ID"]
+    end
+
+    test "PUT with an explicitly empty list clears the group", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      group = group_fixture(account: account)
+      membership_fixture(account: account, group: group)
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/groups/#{group.id}/memberships", memberships: [])
+
+      assert %{"data" => %{"actor_ids" => []}} = json_response(conn, 200)
+    end
+  end
+
+  describe "response contract" do
+    # These pin behaviour that changed when the controller moved off
+    # cast_assoc, so a future refactor cannot flip it back silently. Before,
+    # PUT echoed the request order and rejected a repeated actor_id with a 422
+    # ("has already been taken"); PATCH already sorted and already deduplicated.
+    test "PUT returns actor_ids sorted, not in request order", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      group = group_fixture(account: account)
+      actors = for _ <- 1..5, do: actor_fixture(account: account)
+      sorted = actors |> Enum.map(& &1.id) |> Enum.sort()
+      attrs = sorted |> Enum.reverse() |> Enum.map(&%{"actor_id" => &1})
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/groups/#{group.id}/memberships", memberships: attrs)
+
+      assert %{"data" => %{"actor_ids" => actor_ids}} = json_response(conn, 200)
+      assert actor_ids == sorted
+    end
+
+    test "PATCH returns actor_ids sorted", %{conn: conn, account: account, actor: api_actor} do
+      group = group_fixture(account: account)
+      actors = for _ <- 1..5, do: actor_fixture(account: account)
+      for a <- actors, do: membership_fixture(account: account, actor: a, group: group)
+      sorted = actors |> Enum.map(& &1.id) |> Enum.sort()
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> patch("/groups/#{group.id}/memberships", memberships: %{})
+
+      assert %{"data" => %{"actor_ids" => actor_ids}} = json_response(conn, 200)
+      assert actor_ids == sorted
+    end
+
+    test "PUT deduplicates a repeated actor_id instead of rejecting it", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      group = group_fixture(account: account)
+      actor = actor_fixture(account: account)
+      attrs = [%{"actor_id" => actor.id}, %{"actor_id" => actor.id}]
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/groups/#{group.id}/memberships", memberships: attrs)
+
+      assert %{"data" => %{"actor_ids" => [id]}} = json_response(conn, 200)
+      assert id == actor.id
+
+      assert Repo.aggregate(from(m in Portal.Membership, where: m.group_id == ^group.id), :count) ==
+               1
+    end
+
+    test "PATCH deduplicates repeated ids in add and remove", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      group = group_fixture(account: account)
+      keep = actor_fixture(account: account)
+      drop = actor_fixture(account: account)
+      membership_fixture(account: account, actor: drop, group: group)
+
+      attrs = %{"add" => [keep.id, keep.id], "remove" => [drop.id, drop.id]}
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> patch("/groups/#{group.id}/memberships", memberships: attrs)
+
+      assert %{"data" => %{"actor_ids" => [id]}} = json_response(conn, 200)
+      assert id == keep.id
+
+      assert Repo.aggregate(from(m in Portal.Membership, where: m.group_id == ^group.id), :count) ==
+               1
     end
   end
 end

--- a/elixir/test/portal_api/controllers/membership_controller_test.exs
+++ b/elixir/test/portal_api/controllers/membership_controller_test.exs
@@ -685,6 +685,46 @@ defmodule PortalAPI.MembershipControllerTest do
     end
   end
 
+  describe "authorization" do
+    # An account_user may read a Group (permit(:read, Portal.Group,
+    # :account_user)) but has no Portal.Actor clause, so it clears
+    # fetch_group and then fails the Actor lookup. validate_actors/2 has to
+    # propagate that rather than read an empty result as "no such actor",
+    # which would answer an authorization failure with a 422 claiming every
+    # ID is nonexistent.
+    test "PATCH returns unauthorized, not a validation error, when the subject cannot read Actors",
+         %{conn: conn, account: account} do
+      group = group_fixture(account: account)
+      target = actor_fixture(account: account)
+      account_user = actor_fixture(account: account, type: :account_user)
+
+      conn =
+        conn
+        |> authorize_conn(account_user)
+        |> put_req_header("content-type", "application/json")
+        |> patch("/groups/#{group.id}/memberships", memberships: %{"add" => [target.id]})
+
+      assert %{"type" => "about:blank", "status" => 401, "title" => "Unauthorized"} =
+               json_response(conn, 401)
+    end
+
+    test "PUT returns unauthorized, not a validation error, when the subject cannot read Actors",
+         %{conn: conn, account: account} do
+      group = group_fixture(account: account)
+      target = actor_fixture(account: account)
+      account_user = actor_fixture(account: account, type: :account_user)
+
+      conn =
+        conn
+        |> authorize_conn(account_user)
+        |> put_req_header("content-type", "application/json")
+        |> put("/groups/#{group.id}/memberships", memberships: [%{"actor_id" => target.id}])
+
+      assert %{"type" => "about:blank", "status" => 401, "title" => "Unauthorized"} =
+               json_response(conn, 401)
+    end
+  end
+
   describe "response contract" do
     # These pin behaviour that changed when the controller moved off
     # cast_assoc, so a future refactor cannot flip it back silently. Before,


### PR DESCRIPTION
The membership endpoints rebuilt a Group's entire membership association on every write. Because Membership has a composite primary key and the submitted attributes carried no row ID, Ecto matched nothing against what was stored and deleted then reinserted every row, even for a request that changed nothing.

That cascaded away the affected members' policy_authorizations, pushed a membership delete followed by an insert to every connected Client of every member, and made the write cost scale with the size of the Group rather than the size of the change. Overlapping requests could also lose updates outright, or surface an unhandled Ecto.StaleEntryError to the caller as a 409 with an HTML body.

Both verbs now write only the rows that actually change, inside a transaction, mirroring the approach PoolMemberController already takes. PATCH becomes genuinely idempotent and safe to retry; PUT remains a full replace but preserves the rows it isn't changing. Dropping the changeset path means input validation moves in front of the write, which changes the shape of the 422 body and makes both verbs tolerate duplicate IDs.

This is the same defect as #12074, on the API surface rather than the portal UI.

Related: #12074