### PR TITLE
feat(portal): serve an MCP server from the REST API

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -54,22 +54,110 @@ Prerequisites:
 
 Steps:
 
-- Reset and seed the database (seeds use static IDs that correspond to staging setup on Stripe):
+- Start the portal as described above.
+
+- Add the server:
 
   ```
-  mix do ecto.reset, ecto.seed
+  claude mcp add --transport http firezone https://localhost:13001/mcp
   ```
 
-- Start Stripe CLI webhook proxy:
+  In the Claude app, add a custom connector pointing at the same URL instead.
+  Either way it runs on the same machine, so no tunnel is needed.
+
+- Get past the dev certificate. Claude Code is compiled with Bun, which neither
+  reads the system trust store nor honours `NODE_EXTRA_CA_CERTS` for the
+  requests it makes to an MCP server. A certificate that `curl` and the browser
+  already accept still fails, with `unable to verify the first certificate`.
+
+  Until Claude Code supports a custom CA, the way through is to turn
+  verification off for that one process:
 
   ```
-  stripe listen --forward-to localhost:13001/integrations/stripe/webhooks
+  NODE_TLS_REJECT_UNAUTHORIZED=0 claude
   ```
 
-- Start the Phoenix server with enabled billing from the elixir/ folder using a test mode token:
+  That disables certificate verification for everything the process does, so
+  use it only for local development against localhost, and keep it out of your
+  shell rc.
+
+- Check it worked before going further:
+
   ```
-  cd elixir/
-  BILLING_ENABLED=true STRIPE_SECRET_KEY="...copy from stripe dashboard..." STRIPE_WEBHOOK_SIGNING_SECRET="...copy from stripe cli tool.." mix phx.server
+  NODE_TLS_REJECT_UNAUTHORIZED=0 claude mcp get firezone
   ```
 
-When updating the billing plan in stripe, use the Stripe Testing Docs for how to add test payment info
+  `Needs authentication` means TLS is out of the way and the OAuth flow is
+  next. `Failed to connect` means it is not.
+
+- Run `/mcp` in Claude Code to start the OAuth flow, or open the connector in
+  the app.
+
+- Claude opens a browser to approve the connection. Sign in with a seeded
+  account; `mix ecto.seed` sets every actor's password to `Firezone1234`.
+
+- The consent screen lists the permissions Claude asked for. Approving mints an
+  access token, and Claude's tool list is then whatever those scopes allow.
+
+The server advertises no scopes, so a client asks for none and the consent
+screen is where the choice is made: tick the permissions to grant, and nothing
+is granted until at least one is ticked. A client can still ask for a specific
+set, which arrives pre-ticked. In Claude Code:
+
+```
+claude mcp add-json firezone \
+  '{"type":"http","url":"https://localhost:13001/mcp","oauth":{"scopes":"policies:read policies:write"}}'
+```
+
+To disconnect afterwards, open **Your settings** from the account menu and use
+the Disconnect button under Connected apps. That revokes the token immediately.
+
+#### How the clients identify themselves
+
+This authorization server identifies clients by a metadata document they host
+themselves, advertised as `client_id_metadata_document_supported` in
+`/.well-known/oauth-authorization-server`. It does not implement RFC 7591
+dynamic client registration, and there is no `registration_endpoint`.
+
+Both supported clients cope with that:
+
+- Claude Code supports Client ID Metadata Documents and discovers them
+  automatically when dynamic registration is unavailable.
+- ChatGPT recommends CIMD with public-client token exchange (`none`), which is
+  the only method this server advertises.
+
+So neither needs anything hosted or registered on your side.
+
+#### Connecting something other than Claude
+
+Any client works provided it identifies itself the same way. Its `client_id`
+must be an `https` URL with a non-empty path, serving a document that names
+itself:
+
+```json
+{
+  "client_id": "https://example.com/mcp-client.json",
+  "client_name": "My Local MCP Client",
+  "redirect_uris": ["http://127.0.0.1:33418/callback"]
+}
+```
+
+Redirect URIs are matched exactly, with no prefix or wildcard matching.
+
+That document is fetched with SSRF protection, which refuses private and
+reserved addresses, so the document cannot be served from `localhost`. Note
+that `HTTP_CLIENT_SSRF_PROTECTION_ENABLED` does not help here: it is only read
+inside the production branch of `config/runtime.exs`, while the plugin is
+attached for every environment in `config/config.exs`.
+
+Two request parameters are easy to miss:
+
+- `scope` is required. Scopes name individual entities, so there is no sensible
+  default and a request without one is refused. Draw values from
+  `scopes_supported` in either metadata document.
+- `resource` must be `https://localhost:13001/mcp`. Tokens are minted for that
+  exact audience and refused anywhere else.
+
+A client running off the machine needs `api_external_url` and `web_external_url`
+pointed at a reachable hostname, such as a tunnel, since the metadata documents
+and the token audience are all derived from them.

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -62,6 +62,9 @@ defmodule Portal.Application do
     ]
 
     endpoint_children = [
+      # Builds the MCP tool table from the API spec; must be ready before the
+      # API endpoint starts serving /mcp.
+      PortalAPI.MCP.Tools,
       # Give Phoenix socket drain enough time to gracefully close channel topics
       # before transports are force-terminated.
       {PortalWeb.Endpoint, shutdown: 40_000},

--- a/elixir/lib/portal_api/api_spec.ex
+++ b/elixir/lib/portal_api/api_spec.ex
@@ -35,7 +35,10 @@ defmodule PortalAPI.ApiSpec do
   # runs, so the flow-log ingest schemas would never be discovered - and
   # they have to stay published as contracts even though the operation
   # isn't advertised.
-  @excluded_prefixes ["/openapi", "/swaggerui", "/integrations"]
+  # /mcp is the Model Context Protocol endpoint. It speaks JSON-RPC rather than
+  # REST and derives its tools from this very spec, so publishing it as an API
+  # operation would be circular.
+  @excluded_prefixes ["/openapi", "/swaggerui", "/integrations", "/mcp"]
 
   defp api_paths do
     Router

--- a/elixir/lib/portal_api/controllers/mcp_controller.ex
+++ b/elixir/lib/portal_api/controllers/mcp_controller.ex
@@ -1,0 +1,347 @@
+defmodule PortalAPI.MCPController do
+  @moduledoc """
+  The MCP endpoint: one stateless POST that speaks JSON-RPC 2.0.
+
+  Rate limiting and request logging are charged exactly once per call. A
+  `tools/call` is metered and logged by the inner REST request that
+  `PortalAPI.MCP.Dispatch` runs, so the audit trail names the operation that
+  actually ran (`POST /resources`) rather than `POST /mcp`. The methods that
+  never reach a controller - `server/discover` and `tools/list` - are metered
+  and logged here instead.
+  """
+
+  use PortalAPI, :controller
+
+  alias Portal.Scope
+  alias PortalAPI.MCP
+  alias PortalAPI.MCP.Dispatch
+  alias PortalAPI.MCP.Scopes
+  alias PortalAPI.MCP.Tool
+  alias PortalAPI.MCP.Tools
+
+  @discover_ttl_ms :timer.hours(1)
+  @tools_ttl_ms :timer.minutes(5)
+
+  @base64_prefix "=?base64?"
+  @base64_suffix "?="
+
+  plug :validate_origin
+
+  @spec handle(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def handle(conn, _params) do
+    case classify(conn.body_params) do
+      {:request, id, method, params} ->
+        handle_request(conn, id, method, params)
+
+      {:notification, _method} ->
+        send_resp(conn, 202, "")
+
+      :invalid ->
+        send_rpc(
+          conn,
+          400,
+          MCP.error(nil, MCP.invalid_request(), "Body is not a JSON-RPC 2.0 request.")
+        )
+    end
+  end
+
+  @spec method_not_allowed(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def method_not_allowed(conn, _params) do
+    send_rpc(
+      conn,
+      405,
+      MCP.error(
+        nil,
+        MCP.invalid_request(),
+        "The MCP endpoint accepts POST only. Protocol revision #{MCP.protocol_version()} " <>
+          "removed the GET stream and the DELETE session teardown."
+      )
+    )
+  end
+
+  defp handle_request(conn, id, method, params) do
+    with :ok <- validate_protocol_version(conn, params),
+         :ok <- validate_header(conn, "mcp-method", method, "Mcp-Method"),
+         :ok <- validate_name_header(conn, method, params),
+         :ok <- validate_client_capabilities(params) do
+      dispatch(conn, id, method, params)
+    else
+      {:error, status, code, message, data} ->
+        send_rpc(conn, status, MCP.error(id, code, message, data))
+    end
+  end
+
+  defp dispatch(conn, id, "server/discover", _params) do
+    with %Plug.Conn{halted: false} = conn <- meter(conn) do
+      send_rpc(
+        conn,
+        200,
+        MCP.result(id, %{
+          supportedVersions: MCP.supported_versions(),
+          capabilities: %{tools: %{}},
+          instructions: MCP.instructions(),
+          ttlMs: @discover_ttl_ms,
+          cacheScope: "public"
+        })
+      )
+    end
+  end
+
+  defp dispatch(conn, id, "tools/list", params) do
+    case Map.get(params, "cursor") do
+      nil ->
+        with %Plug.Conn{halted: false} = conn <- meter(conn) do
+          tools =
+            conn.assigns.subject.credential.scopes
+            |> Tools.list()
+            |> Enum.map(&Tool.to_definition/1)
+
+          send_rpc(
+            conn,
+            200,
+            MCP.result(id, %{tools: tools, ttlMs: @tools_ttl_ms, cacheScope: "private"})
+          )
+        end
+
+      _cursor ->
+        send_rpc(
+          conn,
+          400,
+          MCP.error(
+            id,
+            MCP.invalid_params(),
+            "This server returns every tool in one page and never issues a cursor."
+          )
+        )
+    end
+  end
+
+  defp dispatch(conn, id, "tools/call", params) do
+    name = Map.get(params, "name")
+    arguments = Map.get(params, "arguments") || %{}
+
+    with {:ok, tool} <- fetch_tool(conn, name),
+         {:ok, status, body} <- Dispatch.call(tool, arguments, conn) do
+      send_tool_result(conn, id, status, body)
+    else
+      {:error, :unknown_tool, message} ->
+        send_rpc(conn, 400, MCP.error(id, MCP.invalid_params(), message))
+
+      {:error, :insufficient_scope, scope} ->
+        conn
+        |> put_resp_header("www-authenticate", MCP.insufficient_scope_challenge(scope))
+        |> send_rpc(
+          403,
+          MCP.error(id, MCP.invalid_request(), "This tool requires the #{scope} scope.")
+        )
+
+      {:error, message} when is_binary(message) ->
+        send_rpc(conn, 200, MCP.result(id, tool_error(message)))
+    end
+  end
+
+  defp dispatch(conn, id, method, _params) do
+    send_rpc(conn, 404, MCP.error(id, MCP.method_not_found(), "Unknown method: #{method}"))
+  end
+
+  # A tool that carries no entity cannot be scoped, and is reported the same way
+  # as one that does not exist: no scope would unlock it, so naming one would
+  # send the client on a pointless authorization round trip.
+  defp fetch_tool(conn, name) when is_binary(name) do
+    scopes = conn.assigns.subject.credential.scopes
+
+    with {:ok, tool} <- Tools.fetch(name),
+         {:ok, required} <- Scopes.required_scope(tool) do
+      if Scope.satisfies?(scopes, required) do
+        {:ok, tool}
+      else
+        {:error, :insufficient_scope, required}
+      end
+    else
+      :error -> {:error, :unknown_tool, "Unknown tool: #{name}"}
+    end
+  end
+
+  defp fetch_tool(_conn, _name) do
+    {:error, :unknown_tool, "tools/call requires a string `name`."}
+  end
+
+  # An inner 401 means the credential stopped being valid mid-request. Surfacing
+  # it as an HTTP 401 lets the client re-authorize rather than hand the model a
+  # tool error it cannot act on.
+  defp send_tool_result(conn, id, 401, body) do
+    send_rpc(conn, 401, MCP.error(id, MCP.invalid_request(), detail(body, "Unauthorized")))
+  end
+
+  defp send_tool_result(conn, id, status, body) when status >= 400 do
+    send_rpc(conn, 200, MCP.result(id, tool_error(detail(body, "The API request failed."))))
+  end
+
+  defp send_tool_result(conn, id, _status, body) do
+    send_rpc(
+      conn,
+      200,
+      MCP.result(id, %{
+        content: [%{type: "text", text: encode(body)}],
+        structuredContent: body,
+        isError: false
+      })
+    )
+  end
+
+  defp tool_error(message) do
+    %{content: [%{type: "text", text: message}], isError: true}
+  end
+
+  defp detail(%{"detail" => detail} = body, _fallback) when is_binary(detail) do
+    case Map.get(body, "validation_errors") do
+      nil -> detail
+      errors -> detail <> " " <> encode(errors)
+    end
+  end
+
+  defp detail(body, _fallback) when is_map(body), do: encode(body)
+  defp detail(_body, fallback), do: fallback
+
+  defp classify(%{"jsonrpc" => "2.0", "method" => method, "id" => id} = body)
+       when is_binary(method) and (is_binary(id) or is_integer(id)) do
+    {:request, id, method, params(body)}
+  end
+
+  defp classify(%{"jsonrpc" => "2.0", "method" => method}) when is_binary(method) do
+    {:notification, method}
+  end
+
+  defp classify(_body), do: :invalid
+
+  defp params(body) do
+    case Map.get(body, "params") do
+      params when is_map(params) -> params
+      _other -> %{}
+    end
+  end
+
+  defp validate_header(conn, header, expected, label) do
+    case get_req_header(conn, header) do
+      [value | _rest] ->
+        if decode_header_value(value) == expected do
+          :ok
+        else
+          header_mismatch("#{label} header value does not match the request body.")
+        end
+
+      [] ->
+        header_mismatch("#{label} header is required.")
+    end
+  end
+
+  defp validate_name_header(conn, "tools/call", params) do
+    validate_header(conn, "mcp-name", Map.get(params, "name"), "Mcp-Name")
+  end
+
+  defp validate_name_header(_conn, _method, _params), do: :ok
+
+  # The version is carried twice - in the header for intermediaries, in `_meta`
+  # for the server - and the two must agree, so that a gateway routing on the
+  # header can never disagree with the server acting on the body.
+  defp validate_protocol_version(conn, params) do
+    header = conn |> get_req_header("mcp-protocol-version") |> List.first()
+    body = get_in(params, ["_meta", MCP.protocol_version_key()])
+
+    cond do
+      is_nil(header) ->
+        header_mismatch("MCP-Protocol-Version header is required.")
+
+      is_nil(body) ->
+        {:error, 400, MCP.invalid_params(),
+         "`_meta.#{MCP.protocol_version_key()}` is required on every request.", nil}
+
+      header != body ->
+        header_mismatch("MCP-Protocol-Version header does not match the request body.")
+
+      not MCP.supported_version?(body) ->
+        {:error, 400, MCP.unsupported_protocol_version(),
+         "Unsupported protocol version: #{body}", %{supported: MCP.supported_versions()}}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_client_capabilities(params) do
+    if is_map(get_in(params, ["_meta", MCP.client_capabilities_key()])) do
+      :ok
+    else
+      {:error, 400, MCP.invalid_params(),
+       "`_meta.#{MCP.client_capabilities_key()}` is required on every request.", nil}
+    end
+  end
+
+  defp header_mismatch(message) do
+    {:error, 400, MCP.header_mismatch(), message, nil}
+  end
+
+  # Header values that cannot be carried as plain ASCII arrive Base64 encoded
+  # behind a sentinel, and must be decoded before they are compared to the body.
+  defp decode_header_value(@base64_prefix <> rest) do
+    case String.split(rest, @base64_suffix, parts: 2) do
+      [encoded, ""] ->
+        case Base.decode64(encoded) do
+          {:ok, decoded} -> decoded
+          :error -> nil
+        end
+
+      _other ->
+        @base64_prefix <> rest
+    end
+  end
+
+  defp decode_header_value(value), do: value
+
+  defp validate_origin(conn, _opts) do
+    case get_req_header(conn, "origin") do
+      [] ->
+        conn
+
+      [origin | _rest] ->
+        if allowed_origin?(conn, origin) do
+          conn
+        else
+          conn
+          |> send_rpc(
+            403,
+            MCP.error(nil, MCP.invalid_request(), "Origin #{origin} is not allowed.")
+          )
+          |> halt()
+        end
+    end
+  end
+
+  # Guards against DNS rebinding: a browser page on another origin must not be
+  # able to drive this endpoint with the user's ambient credentials.
+  defp allowed_origin?(conn, origin) do
+    case URI.parse(origin) do
+      %URI{host: host} when is_binary(host) -> host == conn.host
+      _other -> false
+    end
+  end
+
+  defp meter(conn) do
+    conn
+    |> PortalAPI.Plugs.RateLimit.call(PortalAPI.Plugs.RateLimit.init([]))
+    |> case do
+      %Plug.Conn{halted: true} = conn -> conn
+      conn -> PortalAPI.Plugs.RequestLog.call(conn, PortalAPI.Plugs.RequestLog.init([]))
+    end
+  end
+
+  defp send_rpc(conn, status, payload) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(status, Phoenix.json_library().encode_to_iodata!(payload))
+  end
+
+  # Renders a value as the JSON string that goes inside a text content block,
+  # which has to be a binary rather than the iodata the response body takes.
+  defp encode(payload), do: Phoenix.json_library().encode!(payload)
+end

--- a/elixir/lib/portal_api/controllers/oauth_metadata_controller.ex
+++ b/elixir/lib/portal_api/controllers/oauth_metadata_controller.ex
@@ -1,0 +1,29 @@
+defmodule PortalAPI.OAuthMetadataController do
+  @moduledoc """
+  Publishes this MCP server's OAuth protected resource metadata (RFC 9728).
+
+  Unauthenticated by design: a client reads this before it has any credential,
+  to learn which authorization server can issue one.
+
+  `scopes_supported` is deliberately absent, though RFC 9728 allows it. A client
+  with no scopes configured asks for whatever this document advertises, so
+  listing them here would have every permission pre-ticked and reduce the
+  consent screen to a rubber stamp. The authorization server metadata still
+  publishes the vocabulary for anyone who wants to discover it.
+  """
+
+  use PortalAPI, :controller
+
+  alias PortalAPI.MCP
+
+  @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def show(conn, _params) do
+    conn
+    |> put_resp_header("cache-control", "public, max-age=3600")
+    |> json(%{
+      resource: MCP.resource_uri(),
+      authorization_servers: [MCP.authorization_server()],
+      bearer_methods_supported: ["header"]
+    })
+  end
+end

--- a/elixir/lib/portal_api/mcp.ex
+++ b/elixir/lib/portal_api/mcp.ex
@@ -1,0 +1,162 @@
+defmodule PortalAPI.MCP do
+  @moduledoc """
+  Model Context Protocol server for the Firezone REST API.
+
+  Implements revision `2026-07-28`, which is stateless: there is no
+  `initialize` handshake and no session, every request carries its own protocol
+  version and client capabilities in `_meta`, and the transport is a single
+  POST endpoint. That maps onto a plain Phoenix controller with no supervised
+  state of its own.
+
+  Tools are derived from the same `OpenApiSpex` operation specs that generate
+  `openapi.json`, and every tool call is dispatched back through
+  `PortalAPI.Router`. An MCP tool call and the equivalent REST call therefore
+  run the same authentication, rate limiting, request logging, and controller
+  code - see `PortalAPI.MCP.Dispatch`.
+  """
+
+  @protocol_version "2026-07-28"
+  @supported_versions [@protocol_version]
+
+  @meta_prefix "io.modelcontextprotocol/"
+  @protocol_version_key @meta_prefix <> "protocolVersion"
+  @client_capabilities_key @meta_prefix <> "clientCapabilities"
+  @client_info_key @meta_prefix <> "clientInfo"
+  @server_info_key @meta_prefix <> "serverInfo"
+
+  # JSON-RPC 2.0 general failures.
+  @parse_error -32_700
+  @invalid_request -32_600
+  @method_not_found -32_601
+  @invalid_params -32_602
+  @internal_error -32_603
+
+  # Allocated to the MCP specification out of the JSON-RPC implementation-defined
+  # range. Never emit an undefined code from -32020..-32099.
+  @header_mismatch -32_020
+  @missing_required_client_capability -32_021
+  @unsupported_protocol_version -32_022
+
+  @doc "The newest protocol revision this server implements."
+  def protocol_version, do: @protocol_version
+
+  @doc "Every protocol revision this server accepts on a request."
+  def supported_versions, do: @supported_versions
+
+  def supported_version?(version), do: version in @supported_versions
+
+  def protocol_version_key, do: @protocol_version_key
+  def client_capabilities_key, do: @client_capabilities_key
+  def client_info_key, do: @client_info_key
+  def server_info_key, do: @server_info_key
+
+  def parse_error, do: @parse_error
+  def invalid_request, do: @invalid_request
+  def method_not_found, do: @method_not_found
+  def invalid_params, do: @invalid_params
+  def internal_error, do: @internal_error
+  def header_mismatch, do: @header_mismatch
+  def missing_required_client_capability, do: @missing_required_client_capability
+  def unsupported_protocol_version, do: @unsupported_protocol_version
+
+  @doc """
+  The canonical URI of this MCP server.
+
+  Defined by the authorization server, which mints tokens for this exact
+  audience; this server checks every request against it, so a token issued for
+  anything else is refused even while it is otherwise valid.
+  """
+  defdelegate resource_uri, to: Portal.OAuth
+
+  @doc "Where a client fetches this resource's OAuth metadata."
+  def resource_metadata_url do
+    PortalAPI.Endpoint.url() <> "/.well-known/oauth-protected-resource/mcp"
+  end
+
+  @doc "The authorization server that issues tokens for this resource."
+  def authorization_server, do: PortalWeb.Endpoint.url()
+
+  @doc """
+  The `WWW-Authenticate` value for an unauthenticated request.
+
+  Without it a conforming client has no way to discover where to authenticate,
+  and can only report a bare failure.
+
+  No scope is advertised. A client that has none configured then asks for none,
+  and the person choosing on the consent screen decides what to grant rather
+  than rubber-stamping a list the client picked.
+  """
+  def challenge do
+    ~s(Bearer resource_metadata="#{resource_metadata_url()}")
+  end
+
+  @doc "The `WWW-Authenticate` value telling a client which scopes it still needs."
+  def insufficient_scope_challenge(required) do
+    ~s(Bearer error="insufficient_scope", ) <>
+      ~s(scope="#{Portal.Scope.encode(List.wrap(required))}", ) <>
+      ~s(resource_metadata="#{resource_metadata_url()}")
+  end
+
+  @doc """
+  Name and version this server reports as `serverInfo`.
+
+  Self-reported and unverified by the protocol, so it is for display and
+  debugging only.
+  """
+  def server_info do
+    %{name: "firezone", version: Application.spec(:portal, :vsn) |> to_string()}
+  end
+
+  @doc """
+  Guidance handed to the model alongside the tool list.
+  """
+  def instructions do
+    """
+    Tools on this server administer a Firezone account through its REST API. \
+    Each tool maps to one API operation and acts only within the account the \
+    access token belongs to.
+
+    Resources are the things people connect to. Sites group the Gateways that \
+    serve them. Policies grant a Group access to a Resource, so access is \
+    granted by writing a Policy, never by editing an Actor or a Resource \
+    directly. Actors are people or API clients, and Groups collect Actors.
+
+    List operations are paginated: pass the `page_cursor` returned in a \
+    response to fetch the next page. Prefer filtering with the documented \
+    query parameters over listing everything and filtering afterwards.
+    """
+  end
+
+  @doc """
+  Wraps a successful JSON-RPC result, stamping the fields every result carries.
+  """
+  def result(id, payload) when is_map(payload) do
+    %{
+      jsonrpc: "2.0",
+      id: id,
+      result:
+        payload
+        |> Map.put(:resultType, "complete")
+        |> Map.put(:_meta, %{@server_info_key => server_info()})
+    }
+  end
+
+  @doc """
+  Wraps a JSON-RPC error response. `id` is `nil` when the request was too
+  malformed to read one.
+  """
+  def error(id, code, message, data \\ nil) do
+    error = %{code: code, message: message}
+
+    %{
+      jsonrpc: "2.0",
+      id: id,
+      error:
+        if data == nil do
+          error
+        else
+          Map.put(error, :data, data)
+        end
+    }
+  end
+end

--- a/elixir/lib/portal_api/mcp/capture_adapter.ex
+++ b/elixir/lib/portal_api/mcp/capture_adapter.ex
@@ -1,0 +1,86 @@
+defmodule PortalAPI.MCP.CaptureAdapter do
+  @moduledoc """
+  A `Plug.Conn.Adapter` that captures a response instead of writing it to a
+  socket.
+
+  `PortalAPI.MCP.Dispatch` runs each tool call back through `PortalAPI.Router`.
+  That inner request must not touch the real connection, so it is given this
+  adapter: the controller renders as usual, and the status, headers, and body
+  are read back out of the conn afterwards.
+
+  Only the callbacks a JSON API reaches are implemented. Streaming responses
+  raise, because reaching one would mean an operation returned something the
+  MCP layer cannot represent, and failing loudly beats truncating it.
+  """
+
+  @behaviour Plug.Conn.Adapter
+
+  defstruct peer_data: %{address: {127, 0, 0, 1}, port: 0, ssl_cert: nil},
+            sock_data: %{address: {127, 0, 0, 1}, port: 0},
+            ssl_data: nil,
+            http_protocol: :"HTTP/1.1"
+
+  @doc "Builds the adapter payload, inheriting connection data from `conn`."
+  def payload(%Plug.Conn{} = conn) do
+    %__MODULE__{
+      peer_data: from_adapter(conn, :get_peer_data, %__MODULE__{}.peer_data),
+      sock_data: from_adapter(conn, :get_sock_data, %__MODULE__{}.sock_data),
+      ssl_data: from_adapter(conn, :get_ssl_data, nil),
+      http_protocol: from_adapter(conn, :get_http_protocol, :"HTTP/1.1")
+    }
+  end
+
+  @impl Plug.Conn.Adapter
+  def send_resp(payload, _status, _headers, body) do
+    {:ok, IO.iodata_to_binary(body), payload}
+  end
+
+  @impl Plug.Conn.Adapter
+  def send_file(_payload, _status, _headers, _path, _offset, _length) do
+    raise "PortalAPI.MCP cannot dispatch an operation that responds with send_file/6"
+  end
+
+  @impl Plug.Conn.Adapter
+  def send_chunked(_payload, _status, _headers) do
+    raise "PortalAPI.MCP cannot dispatch an operation that responds with a chunked body"
+  end
+
+  @impl Plug.Conn.Adapter
+  def chunk(_payload, _body) do
+    raise "PortalAPI.MCP cannot dispatch an operation that responds with a chunked body"
+  end
+
+  @impl Plug.Conn.Adapter
+  def read_req_body(payload, _options), do: {:ok, "", payload}
+
+  @impl Plug.Conn.Adapter
+  def push(_payload, _path, _headers), do: {:error, :not_supported}
+
+  @impl Plug.Conn.Adapter
+  def inform(_payload, _status, _headers), do: {:error, :not_supported}
+
+  @impl Plug.Conn.Adapter
+  def upgrade(_payload, _protocol, _opts), do: {:error, :not_supported}
+
+  @impl Plug.Conn.Adapter
+  def get_peer_data(%__MODULE__{} = payload), do: payload.peer_data
+
+  @impl Plug.Conn.Adapter
+  def get_sock_data(%__MODULE__{} = payload), do: payload.sock_data
+
+  @impl Plug.Conn.Adapter
+  def get_ssl_data(%__MODULE__{} = payload), do: payload.ssl_data
+
+  @impl Plug.Conn.Adapter
+  def get_http_protocol(%__MODULE__{} = payload), do: payload.http_protocol
+
+  defp from_adapter(%Plug.Conn{adapter: {adapter, payload}}, function, default) do
+    if function_exported?(adapter, function, 1) do
+      apply(adapter, function, [payload])
+    else
+      default
+    end
+  rescue
+    _error -> default
+  end
+end

--- a/elixir/lib/portal_api/mcp/dispatch.ex
+++ b/elixir/lib/portal_api/mcp/dispatch.ex
@@ -1,0 +1,171 @@
+defmodule PortalAPI.MCP.Dispatch do
+  @moduledoc """
+  Runs a `tools/call` as the REST request it stands for.
+
+  The call is re-entered through `PortalAPI.Router` on a synthetic connection
+  carrying the original request's headers and a `PortalAPI.MCP.CaptureAdapter`,
+  so the response is captured instead of sent. Everything the REST pipeline
+  does still happens: the bearer token is re-authenticated, the account's rate
+  limit is charged, an `api_request_logs` row is written, and the same
+  controller and view render the result.
+
+  Dispatching this way rather than calling controller actions directly is what
+  keeps MCP from becoming a second, subtly different API surface.
+
+  The subject authenticated for the MCP request is handed to the inner one
+  rather than being derived again. Re-authenticating would fail outright, since
+  an OAuth access token is not a credential the REST pipeline accepts, and even
+  where it did work it would stamp the token's last-seen columns twice for one
+  request.
+  """
+
+  alias PortalAPI.MCP.CaptureAdapter
+  alias PortalAPI.MCP.Tool
+
+  @doc """
+  Runs `tool` with `arguments` on behalf of the authenticated `conn`.
+
+  Returns the inner response's status and decoded JSON body, or
+  `{:error, reason}` when the arguments cannot be turned into a request.
+  """
+  def call(%Tool{} = tool, arguments, %Plug.Conn{} = conn) when is_map(arguments) do
+    with :ok <- validate_arguments(tool, arguments) do
+      body = build_body(tool, arguments)
+      encoded_body = encode_body(body)
+
+      response =
+        tool
+        |> build_conn(arguments, body, encoded_body, conn)
+        |> PortalAPI.Router.call([])
+
+      {:ok, response.status, decode_body(response.resp_body)}
+    end
+  end
+
+  defp validate_arguments(%Tool{} = tool, arguments) do
+    known = MapSet.new(tool.path_params ++ tool.query_params ++ tool.body_params)
+    provided = MapSet.new(Map.keys(arguments))
+
+    missing = Enum.reject(tool.path_params, &Map.has_key?(arguments, &1))
+    unknown = provided |> MapSet.difference(known) |> MapSet.to_list() |> Enum.sort()
+
+    cond do
+      missing != [] ->
+        {:error, "missing required argument(s): #{Enum.join(missing, ", ")}"}
+
+      unknown != [] ->
+        {:error,
+         "unknown argument(s): #{Enum.join(unknown, ", ")}. " <>
+           "Accepted arguments are: #{known |> MapSet.to_list() |> Enum.sort() |> Enum.join(", ")}"}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp build_conn(%Tool{} = tool, arguments, body, encoded_body, %Plug.Conn{} = conn) do
+    path = build_path(tool, arguments)
+    query_string = build_query_string(tool, arguments)
+
+    %Plug.Conn{
+      conn
+      | adapter: {CaptureAdapter, CaptureAdapter.payload(conn)},
+        owner: nil,
+        method: tool.method |> to_string() |> String.upcase(),
+        request_path: path,
+        path_info: String.split(path, "/", trim: true),
+        path_params: %{},
+        query_string: query_string,
+        query_params: %Plug.Conn.Unfetched{aspect: :query_params},
+        body_params: body,
+        params: %Plug.Conn.Unfetched{aspect: :params},
+        req_headers: req_headers(conn, encoded_body),
+        halted: false,
+        state: :unset,
+        status: nil,
+        resp_body: nil,
+        resp_headers: correlation_headers(conn),
+        resp_cookies: %{},
+        private: inner_private(conn)
+    }
+  end
+
+  # Endpoint-level state stays (the endpoint, the Ecto sandbox, the session),
+  # but everything a dispatch sets for itself is cleared. `put_new_view` in
+  # particular keeps whatever view is already there, so leaving the MCP
+  # controller's view in place would make every operation render through it.
+  # `before_send` callbacks belong to the outer response, not to this one.
+  defp inner_private(%Plug.Conn{} = conn) do
+    conn.private
+    |> Map.put(PortalAPI.Plugs.Auth.subject_key(), conn.assigns.subject)
+    |> Map.drop([
+      :before_send,
+      :phoenix_action,
+      :phoenix_controller,
+      :phoenix_format,
+      :phoenix_layout,
+      :phoenix_pipelines,
+      :phoenix_root_layout,
+      :phoenix_route,
+      :phoenix_template,
+      :phoenix_view
+    ])
+  end
+
+  # The inner request is the same HTTP request, so it keeps the request id the
+  # endpoint assigned. Everything else the outer response has set is dropped.
+  defp correlation_headers(%Plug.Conn{} = conn) do
+    Enum.filter(conn.resp_headers, fn {name, _value} -> name == "x-request-id" end)
+  end
+
+  defp build_path(%Tool{} = tool, arguments) do
+    Enum.reduce(tool.path_params, tool.path_template, fn name, path ->
+      String.replace(path, "{#{name}}", arguments |> Map.fetch!(name) |> to_string() |> URI.encode_www_form())
+    end)
+  end
+
+  defp build_query_string(%Tool{} = tool, arguments) do
+    tool.query_params
+    |> Enum.flat_map(fn name ->
+      case Map.fetch(arguments, name) do
+        {:ok, nil} -> []
+        {:ok, value} -> [{name, to_string(value)}]
+        :error -> []
+      end
+    end)
+    |> URI.encode_query()
+  end
+
+  defp build_body(%Tool{body_params: []}, _arguments), do: %{}
+
+  defp build_body(%Tool{} = tool, arguments) do
+    Map.take(arguments, tool.body_params)
+  end
+
+  defp encode_body(body) when map_size(body) == 0, do: ""
+  defp encode_body(body), do: Phoenix.json_library().encode!(body)
+
+  defp req_headers(%Plug.Conn{} = conn, encoded_body) do
+    conn.req_headers
+    |> Enum.reject(fn {name, _value} ->
+      name in ["accept", "content-type", "content-length"]
+    end)
+    |> then(
+      &[
+        {"accept", "application/json"},
+        {"content-type", "application/json"},
+        {"content-length", encoded_body |> byte_size() |> Integer.to_string()} | &1
+      ]
+    )
+  end
+
+  defp decode_body(nil), do: nil
+  defp decode_body(""), do: nil
+
+  defp decode_body(body) do
+    case Phoenix.json_library().decode(body) do
+      {:ok, decoded} -> decoded
+      {:error, _reason} -> nil
+    end
+  end
+end

--- a/elixir/lib/portal_api/mcp/dispatch.ex
+++ b/elixir/lib/portal_api/mcp/dispatch.ex
@@ -49,6 +49,10 @@ defmodule PortalAPI.MCP.Dispatch do
     missing = Enum.reject(tool.path_params, &Map.has_key?(arguments, &1))
     unknown = provided |> MapSet.difference(known) |> MapSet.to_list() |> Enum.sort()
 
+    non_scalar =
+      (tool.path_params ++ tool.query_params)
+      |> Enum.filter(&(not scalar?(Map.get(arguments, &1))))
+
     cond do
       missing != [] ->
         {:error, "missing required argument(s): #{Enum.join(missing, ", ")}"}
@@ -58,9 +62,17 @@ defmodule PortalAPI.MCP.Dispatch do
          "unknown argument(s): #{Enum.join(unknown, ", ")}. " <>
            "Accepted arguments are: #{known |> MapSet.to_list() |> Enum.sort() |> Enum.join(", ")}"}
 
+      non_scalar != [] ->
+        {:error,
+         "argument(s) must be a string, number, or boolean: #{Enum.join(non_scalar, ", ")}"}
+
       true ->
         :ok
     end
+  end
+
+  defp scalar?(value) do
+    is_nil(value) or is_binary(value) or is_number(value) or is_boolean(value)
   end
 
   defp build_conn(%Tool{} = tool, arguments, body, encoded_body, %Plug.Conn{} = conn) do

--- a/elixir/lib/portal_api/mcp/json_schema.ex
+++ b/elixir/lib/portal_api/mcp/json_schema.ex
@@ -1,0 +1,225 @@
+defmodule PortalAPI.MCP.JSONSchema do
+  @moduledoc """
+  Converts the OpenAPI 3.0 schemas behind `openapi.json` into the JSON Schema
+  2020-12 dialect that MCP tool definitions use.
+
+  References are inlined rather than emitted as `$ref`. MCP clients are only
+  required to resolve local references, and an inlined schema is the shape
+  models handle most reliably. The spec's schemas are shallow enough that the
+  duplication costs little.
+  """
+
+  alias OpenApiSpex.Reference
+  alias OpenApiSpex.Schema
+
+  @max_depth 12
+
+  @doc """
+  Converts one OpenAPI schema into a JSON Schema map with string keys.
+
+  `schemas` is the spec's `components.schemas` map, used to inline references.
+  """
+  def convert(schema, schemas) do
+    convert(schema, schemas, 0)
+  end
+
+  @doc """
+  Builds the object schema for a tool from an operation's parameters and
+  request body.
+
+  Path and query parameters become top-level properties. A request body object
+  contributes its own properties at the same level, which keeps arguments flat
+  for the model. Bodies in this API are single-key wrappers (`{"resource":
+  {...}}`), so the merge stays shallow and readable.
+  """
+  def build_input_schema(parameters, body_schema, schemas) do
+    {param_properties, param_required} = convert_parameters(parameters, schemas)
+    {body_properties, body_required} = convert_body(body_schema, schemas)
+
+    case MapSet.intersection(
+           MapSet.new(Map.keys(param_properties)),
+           MapSet.new(Map.keys(body_properties))
+         )
+         |> MapSet.to_list() do
+      [] ->
+        %{
+          "type" => "object",
+          "properties" => Map.merge(param_properties, body_properties),
+          "required" => Enum.uniq(param_required ++ body_required),
+          "additionalProperties" => false
+        }
+
+      collisions ->
+        raise ArgumentError,
+              "request body properties collide with parameter names: #{Enum.join(collisions, ", ")}"
+    end
+  end
+
+  defp convert_parameters(parameters, schemas) do
+    Enum.reduce(parameters, {%{}, []}, fn parameter, {properties, required} ->
+      name = to_string(parameter.name)
+      converted = convert(parameter.schema, schemas, 0)
+
+      converted =
+        case parameter.description do
+          nil -> converted
+          description -> Map.put_new(converted, "description", description)
+        end
+
+      {Map.put(properties, name, converted),
+       if parameter.required do
+         [name | required]
+       else
+         required
+       end}
+    end)
+  end
+
+  defp convert_body(nil, _schemas), do: {%{}, []}
+
+  defp convert_body(body_schema, schemas) do
+    case convert(body_schema, schemas, 0) do
+      %{"properties" => properties} = converted ->
+        {properties, Map.get(converted, "required", [])}
+
+      _other ->
+        {%{}, []}
+    end
+  end
+
+  defp convert(_schema, _schemas, depth) when depth > @max_depth do
+    %{"type" => "object"}
+  end
+
+  defp convert(%Reference{"$ref": "#/components/schemas/" <> name}, schemas, depth) do
+    case Map.fetch(schemas, name) do
+      {:ok, schema} -> convert(schema, schemas, depth + 1)
+      :error -> %{}
+    end
+  end
+
+  defp convert(%Schema{} = schema, schemas, depth) do
+    %{}
+    |> put_type(schema)
+    |> put_description(schema)
+    |> put_enum(schema)
+    |> put_format(schema)
+    |> put_properties(schema, schemas, depth)
+    |> put_items(schema, schemas, depth)
+    |> put_composition(schema, schemas, depth)
+    |> put_bounds(schema)
+    |> put_example(schema)
+  end
+
+  defp convert(schema, _schemas, _depth) when is_map(schema) do
+    schema
+  end
+
+  defp convert(_schema, _schemas, _depth), do: %{}
+
+  defp put_type(converted, %Schema{type: nil}), do: converted
+
+  defp put_type(converted, %Schema{type: type, nullable: true}) do
+    Map.put(converted, "type", [to_string(type), "null"])
+  end
+
+  defp put_type(converted, %Schema{type: type}) do
+    Map.put(converted, "type", to_string(type))
+  end
+
+  defp put_description(converted, %Schema{description: nil}), do: converted
+
+  defp put_description(converted, %Schema{description: description}) do
+    Map.put(converted, "description", description)
+  end
+
+  defp put_enum(converted, %Schema{enum: nil}), do: converted
+
+  defp put_enum(converted, %Schema{enum: values}) do
+    Map.put(converted, "enum", Enum.map(values, &enum_value/1))
+  end
+
+  defp put_format(converted, %Schema{format: nil}), do: converted
+
+  defp put_format(converted, %Schema{format: format}) do
+    Map.put(converted, "format", to_string(format))
+  end
+
+  defp put_properties(converted, %Schema{properties: nil}, _schemas, _depth), do: converted
+
+  defp put_properties(converted, %Schema{} = schema, schemas, depth) do
+    properties =
+      Map.new(schema.properties, fn {name, property} ->
+        {to_string(name), convert(property, schemas, depth + 1)}
+      end)
+
+    converted
+    |> Map.put("properties", properties)
+    |> put_required(schema)
+  end
+
+  defp put_required(converted, %Schema{required: nil}), do: converted
+  defp put_required(converted, %Schema{required: []}), do: converted
+
+  defp put_required(converted, %Schema{required: required}) do
+    Map.put(converted, "required", Enum.map(required, &to_string/1))
+  end
+
+  defp put_items(converted, %Schema{items: nil}, _schemas, _depth), do: converted
+
+  defp put_items(converted, %Schema{items: items}, schemas, depth) do
+    Map.put(converted, "items", convert(items, schemas, depth + 1))
+  end
+
+  defp put_composition(converted, %Schema{} = schema, schemas, depth) do
+    Enum.reduce([{:oneOf, "oneOf"}, {:anyOf, "anyOf"}, {:allOf, "allOf"}], converted, fn
+      {key, json_key}, acc ->
+        case Map.get(schema, key) do
+          nil ->
+            acc
+
+          [] ->
+            acc
+
+          subschemas ->
+            Map.put(acc, json_key, Enum.map(subschemas, &convert(&1, schemas, depth + 1)))
+        end
+    end)
+  end
+
+  defp put_bounds(converted, %Schema{} = schema) do
+    Enum.reduce(
+      [
+        {:minimum, "minimum"},
+        {:maximum, "maximum"},
+        {:minLength, "minLength"},
+        {:maxLength, "maxLength"},
+        {:minItems, "minItems"},
+        {:maxItems, "maxItems"},
+        {:pattern, "pattern"}
+      ],
+      converted,
+      fn {key, json_key}, acc ->
+        case Map.get(schema, key) do
+          nil -> acc
+          value -> Map.put(acc, json_key, bound_value(value))
+        end
+      end
+    )
+  end
+
+  defp put_example(converted, %Schema{example: nil}), do: converted
+
+  defp put_example(converted, %Schema{example: example}) do
+    Map.put(converted, "examples", [example])
+  end
+
+  defp bound_value(%Regex{} = regex), do: Regex.source(regex)
+  defp bound_value(value), do: value
+
+  defp enum_value(value) when is_atom(value) and not is_boolean(value) and not is_nil(value) do
+    Atom.to_string(value)
+  end
+
+  defp enum_value(value), do: value
+end

--- a/elixir/lib/portal_api/mcp/scopes.ex
+++ b/elixir/lib/portal_api/mcp/scopes.ex
@@ -1,0 +1,38 @@
+defmodule PortalAPI.MCP.Scopes do
+  @moduledoc """
+  Which tools a request's credential may reach.
+
+  Scopes come from the access token, which carries what the resource owner
+  consented to on the browser consent screen. They are the same per-entity
+  scopes the REST API uses, so a tool and the equivalent REST call require the
+  same thing.
+
+  Tools outside the granted scopes are left out of `tools/list` entirely, which
+  the specification allows: a server's tool set may vary by the authorization
+  presented on the request.
+
+  This only filters what is advertised. A `tools/call` is dispatched back
+  through `PortalAPI.Router`, where `PortalAPI.Plugs.Scope` checks the same
+  scopes again, so a tool reached without being listed is still refused.
+  """
+
+  alias Portal.Scope
+  alias PortalAPI.MCP.Tool
+
+  @doc "Whether the granted `scopes` permit `tool`."
+  def permits?(scopes, %Tool{} = tool) do
+    case required_scope(tool) do
+      {:ok, required} -> Scope.satisfies?(scopes, required)
+      :error -> false
+    end
+  end
+
+  @doc """
+  The scope `tool` requires, for the challenge sent when it is missing.
+
+  A tool with no entity cannot be scoped, and is refused rather than treated as
+  freely available.
+  """
+  def required_scope(%Tool{entity: nil}), do: :error
+  def required_scope(%Tool{entity: entity, method: method}), do: {:ok, Scope.required(entity, method)}
+end

--- a/elixir/lib/portal_api/mcp/tool.ex
+++ b/elixir/lib/portal_api/mcp/tool.ex
@@ -1,0 +1,44 @@
+defmodule PortalAPI.MCP.Tool do
+  @moduledoc """
+  One MCP tool, derived from a single REST operation.
+
+  Carries both the client-facing definition (`name`, `description`,
+  `input_schema`, `annotations`) and everything `PortalAPI.MCP.Dispatch` needs
+  to turn a `tools/call` into the equivalent request against
+  `PortalAPI.Router`.
+
+  `entity` is the `Portal.Scope` entity the underlying operation is scoped by,
+  resolved once when the table is built rather than per request.
+  """
+
+  @enforce_keys [:name, :method, :path_template, :input_schema]
+  defstruct [
+    :name,
+    :title,
+    :description,
+    :method,
+    :path_template,
+    :input_schema,
+    :annotations,
+    path_params: [],
+    query_params: [],
+    body_params: [],
+    write?: false,
+    entity: nil
+  ]
+
+  @type t :: %__MODULE__{}
+
+  @doc """
+  Renders the tool as the JSON object returned by `tools/list`.
+  """
+  def to_definition(%__MODULE__{} = tool) do
+    %{
+      name: tool.name,
+      title: tool.title,
+      description: tool.description,
+      inputSchema: tool.input_schema,
+      annotations: tool.annotations
+    }
+  end
+end

--- a/elixir/lib/portal_api/mcp/tools.ex
+++ b/elixir/lib/portal_api/mcp/tools.ex
@@ -1,0 +1,318 @@
+defmodule PortalAPI.MCP.Tools do
+  @moduledoc """
+  Builds and holds the MCP tool table.
+
+  Every REST operation `PortalAPI.ApiSpec` publishes becomes one tool, so the
+  tool surface and the documented API can never drift. The table is built once
+  at boot into an ETS table rather than at compile time: building it calls
+  `OpenApiSpex.Paths.from_router/1`, which loads every plug in the router, and
+  doing that at compile time would make the router and this module circular.
+
+  `PUT` and `PATCH` on the same path usually dispatch to the same controller
+  action, in which case they collapse into one tool. Where they are genuinely
+  different actions - replacing a membership list versus adding to it - both
+  survive, as `replace_*` and `update_*`.
+  """
+
+  use GenServer
+
+  alias PortalAPI.MCP.JSONSchema
+  alias PortalAPI.MCP.Tool
+
+  @table __MODULE__
+  @action_verbs ~w[verify unverify rotate]
+  @methods [:get, :post, :put, :patch, :delete]
+
+  # Two routes mint Gateway tokens and derive the same name from their paths:
+  # one is shared across a Site, the other is owned by a single Gateway. Only a
+  # human can say which is which, so they are named here.
+  @name_overrides %{
+    {:post, "/sites/{site_id}/gateways/{gateway_id}/token"} =>
+      "create_single_owner_gateway_token",
+    {:post, "/sites/{site_id}/gateways/{gateway_id}/token/rotate"} =>
+      "rotate_single_owner_gateway_token"
+  }
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Every tool, ordered by name.
+
+  The ordering is deterministic so clients can cache `tools/list` and so the
+  tool block stays prompt-cache friendly.
+  """
+  def all do
+    case :ets.lookup(@table, :all) do
+      [{:all, tools}] -> tools
+      [] -> []
+    end
+  end
+
+  @doc "Tools the given scopes permit, ordered by name."
+  def list(scopes) do
+    Enum.filter(all(), &PortalAPI.MCP.Scopes.permits?(scopes, &1))
+  end
+
+  @doc "Looks a tool up by name."
+  def fetch(name) when is_binary(name) do
+    case :ets.lookup(@table, {:tool, name}) do
+      [{{:tool, ^name}, tool}] -> {:ok, tool}
+      [] -> :error
+    end
+  end
+
+  @doc """
+  Builds the tool table from the API spec. Exposed so tests can assert on the
+  generated surface without reaching into ETS.
+  """
+  def build do
+    spec = PortalAPI.ApiSpec.spec()
+    schemas = spec.components.schemas
+
+    tools =
+      spec.paths
+      |> Enum.sort_by(fn {path, _path_item} -> path end)
+      |> Enum.flat_map(fn {path, path_item} ->
+        path
+        |> operations(path_item)
+        |> Enum.map(fn {method, operation, name_style} ->
+          build_tool(method, path, operation, name_style, schemas)
+        end)
+      end)
+      |> Enum.sort_by(& &1.name)
+
+    assert_unique_names!(tools)
+    assert_overrides_used!(tools)
+
+    tools
+  end
+
+  @impl GenServer
+  def init(_opts) do
+    table = :ets.new(@table, [:named_table, :protected, :set, read_concurrency: true])
+    tools = build()
+
+    :ets.insert(table, {:all, tools})
+    :ets.insert(table, Enum.map(tools, &{{:tool, &1.name}, &1}))
+
+    {:ok, table}
+  end
+
+  defp operations(_path, path_item) do
+    operations =
+      Enum.flat_map(@methods, fn method ->
+        case Map.get(path_item, method) do
+          nil -> []
+          operation -> [{method, operation}]
+        end
+      end)
+      |> collapse_update_aliases()
+
+    distinct_update_pair? =
+      List.keymember?(operations, :put, 0) and List.keymember?(operations, :patch, 0)
+
+    Enum.map(operations, fn {method, operation} ->
+      if method == :put and distinct_update_pair? do
+        {method, operation, :replace}
+      else
+        {method, operation, :default}
+      end
+    end)
+  end
+
+  defp collapse_update_aliases(operations) do
+    with {:put, put_operation} <- List.keyfind(operations, :put, 0),
+         {:patch, patch_operation} <- List.keyfind(operations, :patch, 0),
+         true <- base_operation_id(put_operation) == base_operation_id(patch_operation) do
+      List.keydelete(operations, :patch, 0)
+    else
+      _other -> operations
+    end
+  end
+
+  defp base_operation_id(%{operationId: nil}), do: nil
+
+  defp base_operation_id(%{operationId: operation_id}) do
+    String.replace(operation_id, ~r/ \(\d+\)$/, "")
+  end
+
+  defp build_tool(method, path, operation, name_style, schemas) do
+    parameters = operation.parameters || []
+    body_schema = request_body_schema(operation)
+
+    {body_properties, _required} =
+      case body_schema && JSONSchema.convert(body_schema, schemas) do
+        %{"properties" => properties} -> {Map.keys(properties), []}
+        _other -> {[], []}
+      end
+
+    %Tool{
+      name: tool_name(method, path, name_style),
+      title: operation.summary,
+      description: description(method, path, operation, body_schema, schemas),
+      method: method,
+      path_template: path,
+      input_schema: JSONSchema.build_input_schema(parameters, body_schema, schemas),
+      annotations: annotations(method),
+      path_params: parameter_names(parameters, :path),
+      query_params: parameter_names(parameters, :query),
+      body_params: body_properties,
+      write?: method != :get,
+      entity: entity_for(method, path)
+    }
+  end
+
+  # Resolved here rather than per request: the router match is the same every
+  # time, and a tool whose route cannot be resolved is left without an entity so
+  # that it is refused rather than silently reachable.
+  defp entity_for(method, path) do
+    concrete = String.replace(path, ~r/\{[a-z_]+\}/, "00000000-0000-0000-0000-000000000000")
+    verb = method |> Atom.to_string() |> String.upcase()
+
+    case Phoenix.Router.route_info(PortalAPI.Router, verb, concrete, "localhost") do
+      %{plug: controller} ->
+        case PortalAPI.Scopes.entity_for(controller) do
+          {:ok, entity} -> entity
+          :error -> nil
+        end
+
+      :error ->
+        nil
+    end
+  end
+
+  defp request_body_schema(%{requestBody: nil}), do: nil
+
+  defp request_body_schema(%{requestBody: request_body}) do
+    get_in(request_body.content, ["application/json", Access.key(:schema)])
+  end
+
+  defp parameter_names(parameters, location) do
+    parameters
+    |> Enum.filter(&(&1.in == location))
+    |> Enum.map(&to_string(&1.name))
+  end
+
+  defp description(method, path, operation, body_schema, schemas) do
+    body_description =
+      case body_schema && JSONSchema.convert(body_schema, schemas) do
+        %{"description" => description} -> description
+        _other -> nil
+      end
+
+    [
+      operation.description || operation.summary,
+      body_description,
+      "Calls `#{method |> to_string() |> String.upcase()} #{path}` on the Firezone REST API."
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n\n")
+  end
+
+  defp annotations(method) do
+    %{
+      readOnlyHint: method == :get,
+      destructiveHint: method == :delete,
+      idempotentHint: method in [:get, :put, :delete],
+      openWorldHint: true
+    }
+  end
+
+  defp tool_name(method, path, name_style) do
+    Map.get_lazy(@name_overrides, {method, path}, fn ->
+      derive_tool_name(method, path, name_style)
+    end)
+  end
+
+  defp derive_tool_name(method, path, name_style) do
+    segments = String.split(path, "/", trim: true)
+    statics = Enum.reject(segments, &param_segment?/1)
+    ends_with_param? = segments |> List.last() |> param_segment?()
+
+    {verb, statics} = split_action_verb(statics)
+    singular_subject? = verb != nil or ends_with_param? or method == :post
+    prefix = verb || prefix(method, statics, ends_with_param?, name_style)
+
+    Enum.join([prefix | subject(statics, singular_subject?)], "_")
+  end
+
+  defp split_action_verb(statics) do
+    case List.last(statics) do
+      verb when verb in @action_verbs -> {verb, Enum.drop(statics, -1)}
+      _other -> {nil, statics}
+    end
+  end
+
+  defp subject(statics, singular_subject?) do
+    {leading, [last]} = Enum.split(statics, -1)
+
+    Enum.map(leading, &singularize/1) ++
+      [
+        if singular_subject? do
+          singularize(last)
+        else
+          last
+        end
+      ]
+  end
+
+  defp prefix(:get, _statics, true, _name_style), do: "get"
+  defp prefix(:post, _statics, _ends_with_param?, _name_style), do: "create"
+  defp prefix(:put, _statics, _ends_with_param?, :replace), do: "replace"
+  defp prefix(method, _statics, true, _name_style) when method in [:put, :patch], do: "update"
+  defp prefix(:delete, _statics, true, _name_style), do: "delete"
+  defp prefix(:delete, _statics, false, _name_style), do: "delete_all"
+  defp prefix(method, _statics, false, _name_style) when method in [:put, :patch], do: "update"
+
+  defp prefix(:get, statics, false, _name_style) do
+    last = List.last(statics)
+
+    if singularize(last) == last do
+      "get"
+    else
+      "list"
+    end
+  end
+
+  defp param_segment?(nil), do: false
+  defp param_segment?(segment), do: String.starts_with?(segment, "{")
+
+  defp singularize(word) do
+    cond do
+      String.ends_with?(word, "ies") -> String.slice(word, 0..-4//1) <> "y"
+      String.ends_with?(word, "ss") -> word
+      String.ends_with?(word, "s") -> String.slice(word, 0..-2//1)
+      true -> word
+    end
+  end
+
+  defp assert_unique_names!(tools) do
+    duplicates =
+      tools
+      |> Enum.frequencies_by(& &1.name)
+      |> Enum.filter(fn {_name, count} -> count > 1 end)
+      |> Enum.map(fn {name, _count} -> name end)
+
+    if duplicates != [] do
+      raise "MCP tool names collide: #{Enum.join(duplicates, ", ")}. " <>
+              "Add the new route to @name_overrides in #{inspect(__MODULE__)}."
+    end
+
+    tools
+  end
+
+  defp assert_overrides_used!(tools) do
+    names = MapSet.new(tools, & &1.name)
+
+    case Enum.reject(Map.values(@name_overrides), &MapSet.member?(names, &1)) do
+      [] ->
+        tools
+
+      stale ->
+        raise "@name_overrides in #{inspect(__MODULE__)} names tools that no longer exist: " <>
+                Enum.join(stale, ", ")
+    end
+  end
+end

--- a/elixir/lib/portal_api/plugs/auth.ex
+++ b/elixir/lib/portal_api/plugs/auth.ex
@@ -1,7 +1,28 @@
 defmodule PortalAPI.Plugs.Auth do
+  @moduledoc """
+  Authenticates a REST request from its bearer token.
+
+  A request carrying an already-authenticated subject under
+  `#{inspect(__MODULE__)}.subject_key/0` skips the token lookup. That is set
+  only by `PortalAPI.MCP.Dispatch`, which re-enters the router with a subject it
+  authenticated a moment earlier. Connection private state cannot be set by a
+  request, so this cannot be reached from outside the application, and without
+  it an MCP tool call would be re-authenticated against the wrong credential
+  type and fail.
+  """
+
   import Plug.Conn
 
+  @subject_key :portal_api_authenticated_subject
+
+  @doc "Private key carrying a subject that was authenticated upstream."
+  def subject_key, do: @subject_key
+
   def init(opts), do: Keyword.get(opts, :context_type, :api_client)
+
+  def call(%Plug.Conn{private: %{@subject_key => subject}} = conn, _context_type) do
+    assign(conn, :subject, subject)
+  end
 
   def call(conn, context_type) do
     user_agent = conn.assigns[:user_agent]

--- a/elixir/lib/portal_api/plugs/mcp_auth.ex
+++ b/elixir/lib/portal_api/plugs/mcp_auth.ex
@@ -1,0 +1,57 @@
+defmodule PortalAPI.Plugs.MCPAuth do
+  @moduledoc """
+  Authenticates an MCP request from its OAuth access token.
+
+  Separate from `PortalAPI.Plugs.Auth` because the two accept different
+  credentials on purpose. The REST API takes API tokens; this endpoint takes
+  only tokens minted for it by the portal's authorization server, and checks
+  that the token names this server as its audience. Accepting a token issued for
+  something else, even a valid one, is the confused deputy the audience check
+  exists to prevent.
+
+  A rejected request carries a `WWW-Authenticate` challenge, which is how a
+  client discovers where to authenticate.
+  """
+
+  import Plug.Conn
+
+  alias Portal.Authentication
+  alias Portal.Authentication.Context
+  alias Portal.Authentication.Credential
+  alias Portal.Authentication.Subject
+  alias PortalAPI.MCP
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    context =
+      Context.build(conn.remote_ip, conn.assigns[:user_agent], conn.req_headers, :mcp)
+
+    with ["Bearer " <> encoded_token] <- get_req_header(conn, "authorization"),
+         {:ok, subject} <- Authentication.authenticate(encoded_token, context),
+         :ok <- validate_audience(subject) do
+      assign(conn, :subject, subject)
+    else
+      _other -> unauthorized(conn)
+    end
+  end
+
+  defp validate_audience(%Subject{credential: %Credential.OAuthToken{resource: resource}}) do
+    if resource == MCP.resource_uri() do
+      :ok
+    else
+      {:error, :wrong_audience}
+    end
+  end
+
+  defp validate_audience(%Subject{}), do: {:error, :wrong_credential}
+
+  defp unauthorized(conn) do
+    conn
+    |> put_resp_header("www-authenticate", MCP.challenge())
+    |> PortalAPI.ProblemDetails.send(
+      401,
+      "An OAuth access token issued for this MCP server is required."
+    )
+  end
+end

--- a/elixir/lib/portal_api/router.ex
+++ b/elixir/lib/portal_api/router.ex
@@ -43,6 +43,38 @@ defmodule PortalAPI.Router do
     get "/", OpenApiSpex.Plug.SwaggerUI, path: "/openapi.json"
   end
 
+  # The MCP endpoint is deliberately thinner than the :api pipeline. Rate
+  # limiting and request logging are charged once per call inside
+  # PortalAPI.MCPController - a tools/call re-enters this router, and metering
+  # here as well would charge every tool call twice.
+  pipeline :mcp do
+    plug Plug.Parsers,
+      parsers: [:json],
+      pass: ["*/*"],
+      json_decoder: Phoenix.json_library()
+
+    plug :accepts, ["json"]
+    plug PortalAPI.Plugs.MCPAuth
+  end
+
+  # Read before the client holds any credential, so it cannot be authenticated.
+  # Both paths are served: a client tries the one scoped to the MCP endpoint's
+  # path first and falls back to the root.
+  scope "/.well-known", PortalAPI do
+    pipe_through :public
+
+    get "/oauth-protected-resource/mcp", OAuthMetadataController, :show
+    get "/oauth-protected-resource", OAuthMetadataController, :show
+  end
+
+  scope "/mcp", PortalAPI do
+    pipe_through :mcp
+
+    post "/", MCPController, :handle
+    get "/", MCPController, :method_not_allowed
+    delete "/", MCPController, :method_not_allowed
+  end
+
   pipeline :ingestion do
     plug :accepts, ["json"]
     # Rate limiting is keyed on the source IP and runs before token

--- a/elixir/test/portal_api/controllers/mcp_controller_test.exs
+++ b/elixir/test/portal_api/controllers/mcp_controller_test.exs
@@ -408,6 +408,21 @@ defmodule PortalAPI.MCPControllerTest do
       assert text =~ "unknown argument"
     end
 
+    test "returns a tool error for a path parameter that is not a scalar", %{
+      conn: conn,
+      actor: actor
+    } do
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> call_tool("get_resource", %{"id" => %{"$ne" => nil}})
+
+      assert %{"result" => %{"isError" => true, "content" => [%{"text" => text}]}} =
+               json_response(conn, 200)
+
+      assert text =~ "must be a string, number, or boolean: id"
+    end
+
     test "returns a tool error for a missing path parameter", %{conn: conn, actor: actor} do
       conn = conn |> authorize_mcp_conn(actor) |> call_tool("get_resource", %{})
 

--- a/elixir/test/portal_api/controllers/mcp_controller_test.exs
+++ b/elixir/test/portal_api/controllers/mcp_controller_test.exs
@@ -1,0 +1,495 @@
+defmodule PortalAPI.MCPControllerTest do
+  use PortalAPI.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.FeaturesFixtures
+  import Portal.ResourceFixtures
+  import Portal.SiteFixtures
+
+  alias PortalAPI.MCP
+
+  setup do
+    account = account_fixture()
+    actor = actor_fixture(type: :account_admin_user, account: account)
+
+    %{account: account, actor: actor}
+  end
+
+  describe "transport" do
+    test "rejects an unauthenticated request with a discovery challenge", %{conn: conn} do
+      conn = rpc(conn, "server/discover")
+
+      assert %{"status" => 401} = json_response(conn, 401)
+
+      assert [challenge] = get_resp_header(conn, "www-authenticate")
+      assert challenge =~ ~s(resource_metadata=")
+      assert challenge =~ "/.well-known/oauth-protected-resource/mcp"
+
+      # No scope is advertised, so a client with none configured asks for none
+      # and the person picks on the consent screen.
+      refute challenge =~ "scope="
+    end
+
+    test "rejects an API token, which is not a credential for this endpoint", %{
+      conn: conn,
+      account: account
+    } do
+      api_actor = actor_fixture(type: :api_client, account: account)
+      conn = conn |> authorize_conn(api_actor) |> rpc("server/discover")
+
+      assert json_response(conn, 401)
+    end
+
+    test "rejects a token minted for another audience", %{conn: conn, actor: actor} do
+      {_token, encoded, _refresh} =
+        Portal.OAuthFixtures.oauth_token_fixture(
+          account: actor.account,
+          actor: actor,
+          resource: "https://mcp.evil.example.com/mcp"
+        )
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer " <> encoded)
+        |> rpc("server/discover")
+
+      assert json_response(conn, 401)
+    end
+
+    test "rejects an expired token", %{conn: conn, actor: actor} do
+      {_token, encoded, _refresh} =
+        Portal.OAuthFixtures.oauth_token_fixture(
+          account: actor.account,
+          actor: actor,
+          expires_at: DateTime.add(DateTime.utc_now(), -60, :second)
+        )
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer " <> encoded)
+        |> rpc("server/discover")
+
+      assert json_response(conn, 401)
+    end
+
+    test "answers GET with 405", %{conn: conn, actor: actor} do
+      conn = conn |> authorize_mcp_conn(actor) |> get("/mcp")
+
+      assert %{"error" => %{"code" => code}} = json_response(conn, 405)
+      assert code == MCP.invalid_request()
+    end
+
+    test "answers DELETE with 405", %{conn: conn, actor: actor} do
+      conn = conn |> authorize_mcp_conn(actor) |> delete("/mcp")
+
+      assert json_response(conn, 405)
+    end
+
+    test "rejects a cross-origin request", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> put_req_header("origin", "https://evil.example.com")
+        |> rpc("server/discover")
+
+      assert %{"error" => %{"message" => message}} = json_response(conn, 403)
+      assert message =~ "not allowed"
+    end
+
+    test "allows a same-origin request", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> put_req_header("origin", "http://www.example.com")
+        |> rpc("server/discover")
+
+      assert json_response(conn, 200)
+    end
+
+    test "returns 202 with no body for a notification", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/mcp", Jason.encode!(%{"jsonrpc" => "2.0", "method" => "notifications/anything"}))
+
+      assert response(conn, 202) == ""
+    end
+
+    test "rejects a body that is not JSON-RPC", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/mcp", Jason.encode!(%{"hello" => "world"}))
+
+      assert %{"error" => %{"code" => code}} = json_response(conn, 400)
+      assert code == MCP.invalid_request()
+    end
+
+    test "returns 404 and -32601 for an unknown method", %{conn: conn, actor: actor} do
+      conn = conn |> authorize_mcp_conn(actor) |> rpc("resources/list")
+
+      assert %{"error" => %{"code" => code, "message" => message}} = json_response(conn, 404)
+      assert code == MCP.method_not_found()
+      assert message =~ "resources/list"
+    end
+  end
+
+  describe "header validation" do
+    test "rejects a missing MCP-Protocol-Version header", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("mcp-method", "server/discover")
+        |> post("/mcp", Jason.encode!(request("server/discover")))
+
+      assert %{"error" => %{"code" => code}} = json_response(conn, 400)
+      assert code == MCP.header_mismatch()
+    end
+
+    test "rejects a header that disagrees with the body", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> headers("server/discover")
+        |> put_req_header("mcp-method", "tools/list")
+        |> post("/mcp", Jason.encode!(request("server/discover")))
+
+      assert %{"error" => %{"code" => code, "message" => message}} = json_response(conn, 400)
+      assert code == MCP.header_mismatch()
+      assert message =~ "Mcp-Method"
+    end
+
+    test "rejects an unsupported protocol version", %{conn: conn, actor: actor} do
+      body = request("server/discover") |> put_in(["params", "_meta", MCP.protocol_version_key()], "2024-11-05")
+
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> headers("server/discover")
+        |> put_req_header("mcp-protocol-version", "2024-11-05")
+        |> post("/mcp", Jason.encode!(body))
+
+      assert %{"error" => %{"code" => code, "data" => data}} = json_response(conn, 400)
+      assert code == MCP.unsupported_protocol_version()
+      assert data == %{"supported" => MCP.supported_versions()}
+    end
+
+    test "rejects a request missing clientCapabilities", %{conn: conn, actor: actor} do
+      body = request("server/discover") |> pop_in(["params", "_meta", MCP.client_capabilities_key()]) |> elem(1)
+
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> headers("server/discover")
+        |> post("/mcp", Jason.encode!(body))
+
+      assert %{"error" => %{"code" => code}} = json_response(conn, 400)
+      assert code == MCP.invalid_params()
+    end
+
+    test "decodes a base64 encoded Mcp-Name header", %{conn: conn, actor: actor} do
+      encoded = "=?base64?" <> Base.encode64("list_resources") <> "?="
+
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> headers("tools/call")
+        |> put_req_header("mcp-name", encoded)
+        |> post("/mcp", Jason.encode!(request("tools/call", %{"name" => "list_resources"})))
+
+      assert %{"result" => %{"isError" => false}} = json_response(conn, 200)
+    end
+
+    test "rejects an Mcp-Name that disagrees with the body", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> headers("tools/call")
+        |> put_req_header("mcp-name", "get_account")
+        |> post("/mcp", Jason.encode!(request("tools/call", %{"name" => "list_resources"})))
+
+      assert %{"error" => %{"code" => code}} = json_response(conn, 400)
+      assert code == MCP.header_mismatch()
+    end
+  end
+
+  describe "server/discover" do
+    test "reports versions, capabilities, and caching hints", %{conn: conn, actor: actor} do
+      conn = conn |> authorize_mcp_conn(actor) |> rpc("server/discover")
+
+      assert %{"result" => result} = json_response(conn, 200)
+
+      assert result["resultType"] == "complete"
+      assert result["supportedVersions"] == MCP.supported_versions()
+      assert result["capabilities"] == %{"tools" => %{}}
+      assert result["cacheScope"] == "public"
+      assert result["ttlMs"] > 0
+      assert result["instructions"] =~ "Firezone"
+      assert %{"name" => "firezone"} = result["_meta"][MCP.server_info_key()]
+    end
+  end
+
+  describe "tools/list" do
+    test "lists only read tools when writes are disabled", %{conn: conn, actor: actor} do
+      conn = conn |> authorize_mcp_conn(actor) |> rpc("tools/list")
+
+      assert %{"result" => %{"tools" => tools}} = json_response(conn, 200)
+
+      names = Enum.map(tools, & &1["name"])
+      assert "list_resources" in names
+      refute "create_resource" in names
+      refute "delete_actor" in names
+
+      assert Enum.all?(tools, & &1["annotations"]["readOnlyHint"])
+    end
+
+    test "lists a write tool only for the entities the scope covers", %{
+      conn: conn,
+      actor: actor
+    } do
+      conn =
+        conn
+        |> authorize_mcp_conn(actor, ~w[resources:write])
+        |> rpc("tools/list")
+
+      assert %{"result" => %{"tools" => tools}} = json_response(conn, 200)
+
+      names = Enum.map(tools, & &1["name"])
+      assert "create_resource" in names
+      assert "list_resources" in names, "write implies read"
+      refute "delete_actor" in names, "actors were never granted"
+      refute "list_policies" in names, "policies were never granted"
+    end
+
+    test "returns tools in a stable order with cache hints", %{conn: conn, actor: actor} do
+      conn = conn |> authorize_mcp_conn(actor) |> rpc("tools/list")
+
+      assert %{"result" => result} = json_response(conn, 200)
+
+      names = Enum.map(result["tools"], & &1["name"])
+      assert names == Enum.sort(names)
+      assert result["cacheScope"] == "private"
+      assert result["ttlMs"] > 0
+      refute Map.has_key?(result, "nextCursor")
+    end
+
+    test "every tool carries a name, description, and object input schema", %{
+      conn: conn,
+      actor: actor
+    } do
+      conn = conn |> authorize_mcp_conn(actor) |> rpc("tools/list")
+
+      assert %{"result" => %{"tools" => tools}} = json_response(conn, 200)
+
+      for tool <- tools do
+        assert is_binary(tool["name"])
+        assert String.match?(tool["name"], ~r/^[a-z0-9_]+$/)
+        assert is_binary(tool["description"]) and tool["description"] != ""
+        assert %{"type" => "object", "properties" => _} = tool["inputSchema"]
+      end
+    end
+
+    test "rejects a cursor it never issued", %{conn: conn, actor: actor} do
+      conn = conn |> authorize_mcp_conn(actor) |> rpc("tools/list", %{"cursor" => "made-up"})
+
+      assert %{"error" => %{"code" => code}} = json_response(conn, 400)
+      assert code == MCP.invalid_params()
+    end
+  end
+
+  describe "tools/call" do
+    test "runs a read tool and returns structured content", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+      resource = resource_fixture(account: account, site: site)
+
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> call_tool("list_resources", %{})
+
+      assert %{"result" => result} = json_response(conn, 200)
+      assert result["isError"] == false
+      assert %{"data" => [%{"id" => id}]} = result["structuredContent"]
+      assert id == resource.id
+
+      assert [%{"type" => "text", "text" => text}] = result["content"]
+      assert Jason.decode!(text) == result["structuredContent"]
+    end
+
+    test "passes path parameters through to the REST route", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+      resource = resource_fixture(account: account, site: site)
+
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> call_tool("get_resource", %{"id" => resource.id})
+
+      assert %{"result" => %{"structuredContent" => %{"data" => data}}} = json_response(conn, 200)
+      assert data["id"] == resource.id
+    end
+
+    test "passes query parameters through as filters", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+      resource = resource_fixture(account: account, site: site, name: "findable")
+      _other = resource_fixture(account: account, site: site, name: "hidden")
+
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> call_tool("list_resources", %{"name" => "findable"})
+
+      assert %{"result" => %{"structuredContent" => %{"data" => [found]}}} =
+               json_response(conn, 200)
+
+      assert found["id"] == resource.id
+    end
+
+    test "creates a record through a write tool", %{conn: conn, account: account, actor: actor} do
+      site = site_fixture(account: account)
+
+      conn =
+        conn
+        |> authorize_mcp_conn(actor, ~w[policies:read policies:write resources:read resources:write])
+        |> call_tool("create_resource", %{
+          "resource" => %{
+            "name" => "From MCP",
+            "type" => "dns",
+            "address" => "example.com",
+            "site_id" => site.id
+          }
+        })
+
+      assert %{"result" => result} = json_response(conn, 200)
+      assert result["isError"] == false
+      assert result["structuredContent"]["data"]["name"] == "From MCP"
+    end
+
+    test "challenges for the write scope when the token lacks it", %{conn: conn, actor: actor} do
+      conn = conn |> authorize_mcp_conn(actor) |> call_tool("delete_actor", %{"id" => actor.id})
+
+      assert json_response(conn, 403)
+      assert [challenge] = get_resp_header(conn, "www-authenticate")
+      assert challenge =~ ~s(error="insufficient_scope")
+      assert challenge =~ ~s(scope="actors:write")
+      assert challenge =~ "oauth-protected-resource"
+    end
+
+    test "returns a protocol error for an unknown tool", %{conn: conn, actor: actor} do
+      conn = conn |> authorize_mcp_conn(actor) |> call_tool("drop_database", %{})
+
+      assert %{"error" => %{"code" => code, "message" => message}} = json_response(conn, 400)
+      assert code == MCP.invalid_params()
+      assert message =~ "Unknown tool"
+    end
+
+    test "returns a tool error for an unknown argument", %{conn: conn, actor: actor} do
+      conn = conn |> authorize_mcp_conn(actor) |> call_tool("list_resources", %{"nope" => "1"})
+
+      assert %{"result" => result} = json_response(conn, 200)
+      assert result["isError"] == true
+      assert [%{"text" => text}] = result["content"]
+      assert text =~ "unknown argument"
+    end
+
+    test "returns a tool error for a missing path parameter", %{conn: conn, actor: actor} do
+      conn = conn |> authorize_mcp_conn(actor) |> call_tool("get_resource", %{})
+
+      assert %{"result" => %{"isError" => true, "content" => [%{"text" => text}]}} =
+               json_response(conn, 200)
+
+      assert text =~ "missing required argument"
+    end
+
+    test "surfaces an API error as a tool error, not a protocol error", %{
+      conn: conn,
+      actor: actor
+    } do
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> call_tool("get_resource", %{"id" => Ecto.UUID.generate()})
+
+      assert %{"result" => %{"isError" => true, "content" => [%{"text" => text}]}} =
+               json_response(conn, 200)
+
+      assert text =~ "could not be found"
+    end
+
+    test "scopes results to the caller's account", %{conn: conn, actor: actor} do
+      other_account = account_fixture()
+      other_site = site_fixture(account: other_account)
+      other_resource = resource_fixture(account: other_account, site: other_site)
+
+      conn =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> call_tool("get_resource", %{"id" => other_resource.id})
+
+      assert %{"result" => %{"isError" => true}} = json_response(conn, 200)
+    end
+
+    test "writes one api_request_logs row naming the REST operation", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      conn |> authorize_mcp_conn(actor) |> call_tool("list_resources", %{})
+
+      logs = Portal.Repo.all(Portal.APIRequestLog)
+
+      assert [log] = Enum.filter(logs, &(&1.account_id == account.id))
+      assert log.method == "GET"
+      assert log.path == "/resources"
+    end
+  end
+
+  defp request(method, params \\ %{}) do
+    %{
+      "jsonrpc" => "2.0",
+      "id" => 1,
+      "method" => method,
+      "params" =>
+        Map.put(params, "_meta", %{
+          MCP.protocol_version_key() => MCP.protocol_version(),
+          MCP.client_capabilities_key() => %{}
+        })
+    }
+  end
+
+  defp headers(conn, method) do
+    conn
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("mcp-protocol-version", MCP.protocol_version())
+    |> put_req_header("mcp-method", method)
+  end
+
+  defp rpc(conn, method, params \\ %{}) do
+    conn
+    |> headers(method)
+    |> post("/mcp", Jason.encode!(request(method, params)))
+  end
+
+  defp call_tool(conn, name, arguments) do
+    conn
+    |> headers("tools/call")
+    |> put_req_header("mcp-name", name)
+    |> post("/mcp", Jason.encode!(request("tools/call", %{"name" => name, "arguments" => arguments})))
+  end
+end

--- a/elixir/test/portal_api/controllers/oauth_metadata_controller_test.exs
+++ b/elixir/test/portal_api/controllers/oauth_metadata_controller_test.exs
@@ -1,0 +1,39 @@
+defmodule PortalAPI.OAuthMetadataControllerTest do
+  use PortalAPI.ConnCase, async: true
+
+  alias PortalAPI.MCP
+
+  test "publishes the protected resource metadata at the path scoped url", %{conn: conn} do
+    conn = get(conn, "/.well-known/oauth-protected-resource/mcp")
+
+    assert metadata = json_response(conn, 200)
+
+    assert metadata["resource"] == MCP.resource_uri()
+    assert metadata["authorization_servers"] == [MCP.authorization_server()]
+    # Absent on purpose: a client with no scopes configured asks for whatever
+    # this advertises, and everything would arrive pre-ticked on consent.
+    refute Map.has_key?(metadata, "scopes_supported")
+    assert metadata["bearer_methods_supported"] == ["header"]
+  end
+
+  test "publishes the same document at the root url", %{conn: conn} do
+    root = conn |> get("/.well-known/oauth-protected-resource") |> json_response(200)
+    scoped = build_conn() |> get("/.well-known/oauth-protected-resource/mcp") |> json_response(200)
+
+    assert root == scoped
+  end
+
+  test "is readable without a credential", %{conn: conn} do
+    assert conn |> get("/.well-known/oauth-protected-resource/mcp") |> json_response(200)
+  end
+
+  test "the challenge on 401 points at this document", %{conn: conn} do
+    conn =
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> post("/mcp", "{}")
+
+    assert [challenge] = get_resp_header(conn, "www-authenticate")
+    assert challenge =~ MCP.resource_metadata_url()
+  end
+end

--- a/elixir/test/portal_api/mcp/tools_test.exs
+++ b/elixir/test/portal_api/mcp/tools_test.exs
@@ -1,0 +1,144 @@
+defmodule PortalAPI.MCP.ToolsTest do
+  use ExUnit.Case, async: true
+
+  alias PortalAPI.MCP.Tool
+  alias PortalAPI.MCP.Tools
+
+  setup_all do
+    %{tools: Tools.build()}
+  end
+
+  test "covers every operation the API spec publishes", %{tools: tools} do
+    operations =
+      PortalAPI.ApiSpec.spec().paths
+      |> Enum.flat_map(fn {path, path_item} ->
+        for method <- [:get, :post, :put, :patch, :delete],
+            operation = Map.get(path_item, method),
+            not is_nil(operation),
+            do: {method, path, operation.operationId}
+      end)
+
+    # PUT and PATCH that dispatch to the same controller action are one tool.
+    aliased =
+      operations
+      |> Enum.filter(fn {method, _path, _id} -> method in [:put, :patch] end)
+      |> Enum.group_by(fn {_method, path, _id} -> path end)
+      |> Enum.count(fn {_path, pair} ->
+        match?([_, _], pair) and
+          pair
+          |> Enum.map(fn {_method, _path, id} -> String.replace(id, ~r/ \(\d+\)$/, "") end)
+          |> Enum.uniq()
+          |> length() == 1
+      end)
+
+    assert length(tools) == length(operations) - aliased
+  end
+
+  test "names are unique, lowercase, and underscore separated", %{tools: tools} do
+    names = Enum.map(tools, & &1.name)
+
+    assert names == Enum.uniq(names)
+    assert Enum.all?(names, &String.match?(&1, ~r/^[a-z][a-z0-9_]*$/))
+  end
+
+  test "derives conventional CRUD names", %{tools: tools} do
+    assert %Tool{method: :get, path_template: "/resources"} = fetch(tools, "list_resources")
+    assert %Tool{method: :get, path_template: "/resources/{id}"} = fetch(tools, "get_resource")
+    assert %Tool{method: :post, path_template: "/resources"} = fetch(tools, "create_resource")
+    assert %Tool{method: :put, path_template: "/resources/{id}"} = fetch(tools, "update_resource")
+    assert %Tool{method: :delete} = fetch(tools, "delete_resource")
+  end
+
+  test "singularizes parent segments in nested paths", %{tools: tools} do
+    assert %Tool{path_template: "/sites/{site_id}/gateways"} = fetch(tools, "list_site_gateways")
+
+    assert %Tool{path_template: "/actors/{actor_id}/external_identities/{id}"} =
+             fetch(tools, "get_actor_external_identity")
+  end
+
+  test "names a singleton resource with get rather than list", %{tools: tools} do
+    assert %Tool{method: :get, path_template: "/account"} = fetch(tools, "get_account")
+  end
+
+  test "names bulk deletes apart from single deletes", %{tools: tools} do
+    assert %Tool{path_template: "/actors/{actor_id}/client_tokens"} =
+             fetch(tools, "delete_all_actor_client_tokens")
+
+    assert %Tool{path_template: "/actors/{actor_id}/client_tokens/{id}"} =
+             fetch(tools, "delete_actor_client_token")
+  end
+
+  test "uses the trailing verb for action routes", %{tools: tools} do
+    assert %Tool{method: :put, path_template: "/clients/{id}/verify"} =
+             fetch(tools, "verify_client")
+
+    assert %Tool{method: :put} = fetch(tools, "unverify_client")
+    assert %Tool{method: :post} = fetch(tools, "rotate_single_owner_gateway_token")
+  end
+
+  test "keeps PUT and PATCH apart only when they are different actions", %{tools: tools} do
+    assert %Tool{method: :put} = fetch(tools, "replace_group_memberships")
+    assert %Tool{method: :patch} = fetch(tools, "update_group_memberships")
+
+    # /clients/{id} exposes both verbs for one action, so it yields one tool.
+    assert %Tool{method: :put} = fetch(tools, "update_client")
+    refute Enum.any?(tools, &(&1.method == :patch and &1.path_template == "/clients/{id}"))
+  end
+
+  test "marks every non-GET tool as a write", %{tools: tools} do
+    for tool <- tools do
+      assert tool.write? == (tool.method != :get)
+      assert tool.annotations.readOnlyHint == (tool.method == :get)
+      assert tool.annotations.destructiveHint == (tool.method == :delete)
+    end
+  end
+
+  test "input schemas are closed objects listing path parameters as required", %{tools: tools} do
+    for tool <- tools do
+      assert %{"type" => "object", "additionalProperties" => false} = tool.input_schema
+
+      required = Map.get(tool.input_schema, "required", [])
+      properties = Map.keys(tool.input_schema["properties"])
+
+      assert Enum.all?(tool.path_params, &(&1 in required))
+      assert Enum.all?(tool.path_params ++ tool.query_params, &(&1 in properties))
+    end
+  end
+
+  test "inlines referenced schemas rather than emitting $ref", %{tools: tools} do
+    schema = fetch(tools, "create_resource").input_schema
+    filters = get_in(schema, ["properties", "resource", "properties", "filters"])
+
+    assert filters["type"] == "array"
+    assert get_in(filters, ["items", "properties", "protocol", "enum"]) == ~w[tcp udp icmp]
+    refute schema |> Jason.encode!() |> String.contains?("$ref")
+  end
+
+  test "represents a nullable OpenAPI field as a JSON Schema union", %{tools: tools} do
+    address =
+      get_in(fetch(tools, "create_resource").input_schema, [
+        "properties",
+        "resource",
+        "properties",
+        "address",
+        "type"
+      ])
+
+    assert address == ["string", "null"]
+  end
+
+  test "descriptions carry the summary, the body notes, and the route", %{tools: tools} do
+    description = fetch(tools, "create_resource").description
+
+    assert description =~ "Create Resource"
+    assert description =~ "Device pools"
+    assert description =~ "POST /resources"
+  end
+
+  defp fetch(tools, name) do
+    case Enum.find(tools, &(&1.name == name)) do
+      nil -> flunk("no tool named #{name}")
+      tool -> tool
+    end
+  end
+end

--- a/elixir/test/support/api_conn_case.ex
+++ b/elixir/test/support/api_conn_case.ex
@@ -53,6 +53,22 @@ defmodule PortalAPI.ConnCase do
     Plug.Conn.put_req_header(conn, "authorization", "Bearer " <> encoded_fragment)
   end
 
+  @doc """
+  Authorizes a connection for the MCP endpoint, which takes OAuth access tokens
+  rather than the API tokens the REST API accepts.
+  """
+  def authorize_mcp_conn(conn, %Portal.Actor{account: account} = actor, scopes \\ read_scopes()) do
+    {_token, encoded, _refresh} =
+      Portal.OAuthFixtures.oauth_token_fixture(account: account, actor: actor, scopes: scopes)
+
+    Plug.Conn.put_req_header(conn, "authorization", "Bearer " <> encoded)
+  end
+
+  @doc "Every entity, read only - the usual starting point for an MCP client."
+  def read_scopes do
+    Enum.map(Portal.Scope.entities(), &Portal.Scope.to_string(&1, :read))
+  end
+
   def equal_ids?(list1, list2) do
     MapSet.equal?(MapSet.new(list1), MapSet.new(list2))
   end


### PR DESCRIPTION
This adds a Model Context Protocol endpoint at `POST /mcp` on the API host, so Claude, ChatGPT and other MCP clients can administer a Firezone account by asking for things in plain language. It is protected by the OAuth 2.1 authorization server that landed in #14911.

The tool list is generated from the same OpenAPI spec that produces `openapi.json`, and every tool call is dispatched back through the REST router. A tool call and the equivalent REST call therefore run the same controller, authentication, rate limiting and request logging, so there is no second code path to keep in sync or to secure separately.

That is also why there is no separate permission system here. A dispatched tool call goes through the same scope check as any other API request, so what a client can do is exactly what the person approved on the consent screen. Tools the token cannot reach are left out of the tool list entirely, and a call that needs a scope the token lacks is told which one.

Related: #14911
