### PR TITLE
fix(android): resolve SDK from local.properties in setup-ndk

### DIFF
--- a/kotlin/android/mise-tasks/SdkDir.java
+++ b/kotlin/android/mise-tasks/SdkDir.java
@@ -1,0 +1,15 @@
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+/** Prints the `sdk.dir` property of the properties file passed as the first argument. */
+public class SdkDir {
+    public static void main(String[] args) throws Exception {
+        Properties properties = new Properties();
+        try (InputStream in = Files.newInputStream(Path.of(args[0]))) {
+            properties.load(in);
+        }
+        System.out.println(properties.getProperty("sdk.dir", ""));
+    }
+}

--- a/kotlin/android/mise-tasks/setup-ndk.sh
+++ b/kotlin/android/mise-tasks/setup-ndk.sh
@@ -2,13 +2,27 @@
 #MISE description="Install required NDK version (must match build.gradle.kts)"
 set -euo pipefail
 
-: "${ANDROID_HOME:?ANDROID_HOME must point to your Android SDK root}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${SCRIPT_DIR}/.."
+
+# Mirrors the SDK resolution order of `resolveNdkDir` in `app/build.gradle.kts` so the
+# NDK lands in the SDK the build will look in. `local.properties` is what Android Studio
+# writes, so it is often the only place the SDK location is recorded.
+sdk_dir="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+if [[ -z "$sdk_dir" && -f local.properties ]]; then
+    sdk_dir="$(awk '/^[[:space:]]*sdk\.dir[[:space:]]*=/ { sub(/^[^=]*=[[:space:]]*/, ""); sub(/[[:space:]]+$/, ""); dir = $0 } END { print dir }' local.properties)"
+fi
+
+if [[ -z "$sdk_dir" ]]; then
+    echo "Cannot locate the Android SDK. Set ANDROID_HOME or \`sdk.dir\` in local.properties." >&2
+    exit 1
+fi
 
 # Prefer the cmdline-tools sdkmanager; the legacy `tools/bin/sdkmanager` that may
 # shadow it on PATH requires Java <= 10 and crashes on modern JDKs.
-sdkmanager="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+sdkmanager="$sdk_dir/cmdline-tools/latest/bin/sdkmanager"
 if [[ ! -x "$sdkmanager" ]]; then
     sdkmanager="sdkmanager"
 fi
 
-"$sdkmanager" --sdk_root="$ANDROID_HOME" "ndk;${NDK_VERSION}"
+"$sdkmanager" --sdk_root="$sdk_dir" "ndk;${NDK_VERSION}"

--- a/kotlin/android/mise-tasks/setup-ndk.sh
+++ b/kotlin/android/mise-tasks/setup-ndk.sh
@@ -10,7 +10,9 @@ cd "${SCRIPT_DIR}/.."
 # writes, so it is often the only place the SDK location is recorded.
 sdk_dir="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
 if [[ -z "$sdk_dir" && -f local.properties ]]; then
-    sdk_dir="$(awk '/^[[:space:]]*sdk\.dir[[:space:]]*=/ { sub(/^[^=]*=[[:space:]]*/, ""); sub(/[[:space:]]+$/, ""); dir = $0 } END { print dir }' local.properties)"
+    # `Properties.load` unescapes the value, so `:`, `=` and `\` reach Gradle without
+    # the backslash Android Studio wrote them with.
+    sdk_dir="$(awk '/^[[:space:]]*sdk\.dir[[:space:]]*=/ { sub(/^[^=]*=[[:space:]]*/, ""); sub(/\r$/, ""); dir = $0 } END { print dir }' local.properties | sed 's/\\\(.\)/\1/g')"
 fi
 
 if [[ -z "$sdk_dir" ]]; then

--- a/kotlin/android/mise-tasks/setup-ndk.sh
+++ b/kotlin/android/mise-tasks/setup-ndk.sh
@@ -10,9 +10,9 @@ cd "${SCRIPT_DIR}/.."
 # writes, so it is often the only place the SDK location is recorded.
 sdk_dir="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
 if [[ -z "$sdk_dir" && -f local.properties ]]; then
-    # `Properties.load` unescapes the value, so `:`, `=` and `\` reach Gradle without
-    # the backslash Android Studio wrote them with.
-    sdk_dir="$(awk '/^[[:space:]]*sdk\.dir[[:space:]]*=/ { sub(/^[^=]*=[[:space:]]*/, ""); sub(/\r$/, ""); dir = $0 } END { print dir }' local.properties | sed 's/\\\(.\)/\1/g')"
+    # Let the JDK that `sdkmanager` needs anyway parse the file, so the escaping rules
+    # are Gradle's rather than a reimplementation of them.
+    sdk_dir="$(java "${SCRIPT_DIR}/SdkDir.java" local.properties)"
 fi
 
 if [[ -z "$sdk_dir" ]]; then


### PR DESCRIPTION
`mise run setup-ndk` aborted unless `ANDROID_HOME` was exported, which excluded the standard Android Studio setup where the SDK location is only recorded as `sdk.dir` in `local.properties`. The task now resolves the SDK the same way the build does, so the NDK is installed into the SDK that Gradle will look in.