### PR TITLE
refactor(android): navigate settings with a navigation bar

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
@@ -26,21 +26,22 @@ internal class SettingsActivity : AppCompatActivity() {
     private var lastFocusedView: View? = null
     private var lastSelectedPage = -1
 
-    /** The navigation item for each page of the pager, in order. */
-    private val pageMenuItems =
+    /** The navigation item and the page it shows, in order. */
+    private val pages: List<Pair<Int, () -> Fragment>> =
         listOf(
-            R.id.settingsGeneral,
-            R.id.settingsAdvanced,
-            R.id.settingsLogs,
+            R.id.settingsGeneral to { GeneralSettingsFragment() },
+            R.id.settingsAdvanced to { AdvancedSettingsFragment() },
+            R.id.settingsLogs to { LogSettingsFragment() },
         )
 
     private val navigationSelectionSync =
         object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
-                // Checking the item directly rather than assigning `selectedItemId`, which would
+                // By id rather than by menu position, which would assume the menu is ordered like
+                // the pager. Checking the item rather than assigning `selectedItemId`, which would
                 // call back into the item listener and drive the pager again.
                 binding.bottomNavigation.menu
-                    .getItem(position)
+                    .findItem(pages[position].first)
                     .isChecked = true
             }
         }
@@ -94,7 +95,7 @@ internal class SettingsActivity : AppCompatActivity() {
             viewPager.registerOnPageChangeCallback(navigationSelectionSync)
 
             bottomNavigation.setOnItemSelectedListener { item ->
-                val position = pageMenuItems.indexOf(item.itemId)
+                val position = pages.indexOfFirst { it.first == item.itemId }
 
                 if (position < 0) {
                     return@setOnItemSelectedListener false
@@ -170,14 +171,8 @@ internal class SettingsActivity : AppCompatActivity() {
     private inner class SettingsPagerAdapter(
         activity: FragmentActivity,
     ) : FragmentStateAdapter(activity) {
-        override fun getItemCount(): Int = pageMenuItems.size
+        override fun getItemCount(): Int = pages.size
 
-        override fun createFragment(position: Int): Fragment =
-            when (position) {
-                0 -> GeneralSettingsFragment()
-                1 -> AdvancedSettingsFragment()
-                2 -> LogSettingsFragment()
-                else -> throw IllegalArgumentException("Invalid page position: $position")
-            }
+        override fun createFragment(position: Int): Fragment = pages[position].second()
     }
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
-import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import dev.firezone.android.R
 import dev.firezone.android.databinding.ActivitySettingsBinding
@@ -26,6 +25,25 @@ internal class SettingsActivity : AppCompatActivity() {
     private val viewModel: SettingsViewModel by viewModels()
     private var lastFocusedView: View? = null
     private var lastSelectedPage = -1
+
+    /** The navigation item for each page of the pager, in order. */
+    private val pageMenuItems =
+        listOf(
+            R.id.settingsGeneral,
+            R.id.settingsAdvanced,
+            R.id.settingsLogs,
+        )
+
+    private val navigationSelectionSync =
+        object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                // Checking the item directly rather than assigning `selectedItemId`, which would
+                // call back into the item listener and drive the pager again.
+                binding.bottomNavigation.menu
+                    .getItem(position)
+                    .isChecked = true
+            }
+        }
 
     private val focusTracker =
         ViewTreeObserver.OnGlobalFocusChangeListener { _, newFocus ->
@@ -73,29 +91,21 @@ internal class SettingsActivity : AppCompatActivity() {
             // See https://issuetracker.google.com/issues/140656866
             window.decorView.viewTreeObserver.addOnGlobalFocusChangeListener(focusTracker)
             viewPager.registerOnPageChangeCallback(pageReselectionFocusRestorer)
+            viewPager.registerOnPageChangeCallback(navigationSelectionSync)
 
-            TabLayoutMediator(tabLayout, viewPager) { tab, position ->
-                when (position) {
-                    0 -> {
-                        tab.setIcon(R.drawable.rounded_discover_tune_black_24dp)
-                        tab.setText("General")
-                    }
+            bottomNavigation.setOnItemSelectedListener { item ->
+                val position = pageMenuItems.indexOf(item.itemId)
 
-                    1 -> {
-                        tab.setIcon(R.drawable.rounded_settings_black_24dp)
-                        tab.setText("Advanced")
-                    }
-
-                    2 -> {
-                        tab.setIcon(R.drawable.rounded_description_black_24dp)
-                        tab.setText("Logs")
-                    }
-
-                    else -> {
-                        throw IllegalArgumentException("Invalid tab position: $position")
-                    }
+                if (position < 0) {
+                    return@setOnItemSelectedListener false
                 }
-            }.attach()
+
+                // Without smooth scrolling, so that jumping across the bar does not create and
+                // then discard every fragment in between.
+                viewPager.setCurrentItem(position, false)
+
+                true
+            }
 
             val isUserSignedIn = intent.getBooleanExtra("isUserSignedIn", false)
             if (isUserSignedIn) {
@@ -152,6 +162,7 @@ internal class SettingsActivity : AppCompatActivity() {
     override fun onDestroy() {
         window.decorView.viewTreeObserver.removeOnGlobalFocusChangeListener(focusTracker)
         binding.viewPager.unregisterOnPageChangeCallback(pageReselectionFocusRestorer)
+        binding.viewPager.unregisterOnPageChangeCallback(navigationSelectionSync)
         lastFocusedView = null
         super.onDestroy()
     }
@@ -159,14 +170,14 @@ internal class SettingsActivity : AppCompatActivity() {
     private inner class SettingsPagerAdapter(
         activity: FragmentActivity,
     ) : FragmentStateAdapter(activity) {
-        override fun getItemCount(): Int = 3 // Three tabs
+        override fun getItemCount(): Int = pageMenuItems.size
 
         override fun createFragment(position: Int): Fragment =
             when (position) {
                 0 -> GeneralSettingsFragment()
                 1 -> AdvancedSettingsFragment()
                 2 -> LogSettingsFragment()
-                else -> throw IllegalArgumentException("Invalid tab position: $position")
+                else -> throw IllegalArgumentException("Invalid page position: $position")
             }
     }
 }

--- a/kotlin/android/app/src/main/res/layout/activity_settings.xml
+++ b/kotlin/android/app/src/main/res/layout/activity_settings.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="@dimen/spacing_medium"
+    android:paddingTop="@dimen/spacing_medium"
     android:fitsSystemWindows="true">
 
     <com.google.android.material.button.MaterialButton
@@ -12,7 +12,7 @@
         style="@style/Widget.MaterialComponents.Button.TextButton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
+        android:layout_marginStart="@dimen/spacing_medium"
         android:enabled="true"
         android:text="@android:string/cancel"
         app:layout_constraintStart_toStartOf="parent"
@@ -35,6 +35,7 @@
         style="@style/Widget.MaterialComponents.Button.TextButton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/spacing_medium"
         android:enabled="false"
         android:text="@string/save"
         app:layout_constraintEnd_toEndOf="parent"
@@ -56,6 +57,7 @@
         android:id="@+id/bottomNavigation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="?attr/colorSurface"
         app:labelVisibilityMode="labeled"
         app:menu="@menu/settings_navigation"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/kotlin/android/app/src/main/res/layout/activity_settings.xml
+++ b/kotlin/android/app/src/main/res/layout/activity_settings.xml
@@ -44,7 +44,7 @@
         android:id="@+id/viewPager"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/tabLayout"
+        app:layout_constraintBottom_toTopOf="@+id/bottomNavigation"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
@@ -52,34 +52,14 @@
 
     </androidx.viewpager2.widget.ViewPager2>
 
-    <com.google.android.material.tabs.TabLayout
-        android:id="@+id/tabLayout"
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottomNavigation"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
+        app:labelVisibilityMode="labeled"
+        app:menu="@menu/settings_navigation"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="1.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:tabInlineLabel="true">
-
-        <com.google.android.material.tabs.TabItem
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:icon="@drawable/rounded_discover_tune_black_24dp"
-            android:text="@string/general_settings_title" />
-
-        <com.google.android.material.tabs.TabItem
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:icon="@drawable/rounded_settings_black_24dp"
-            android:text="@string/advanced_settings_title" />
-
-        <com.google.android.material.tabs.TabItem
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:icon="@drawable/rounded_description_black_24dp"
-            android:text="@string/log_settings_title" />
-
-    </com.google.android.material.tabs.TabLayout>
+        app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/kotlin/android/app/src/main/res/menu/settings_navigation.xml
+++ b/kotlin/android/app/src/main/res/menu/settings_navigation.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/settingsGeneral"
+        android:icon="@drawable/rounded_discover_tune_black_24dp"
+        android:title="@string/general_settings_title" />
+
+    <item
+        android:id="@+id/settingsAdvanced"
+        android:icon="@drawable/rounded_settings_black_24dp"
+        android:title="@string/advanced_settings_title" />
+
+    <item
+        android:id="@+id/settingsLogs"
+        android:icon="@drawable/rounded_description_black_24dp"
+        android:title="@string/log_settings_title" />
+
+</menu>


### PR DESCRIPTION
A `TabLayout` splits the screen evenly between its tabs and truncates whatever does not fit, where a navigation bar sizes a handful of bottom-level destinations for the width it has.

The tabs it replaces were declared twice, statically in the layout and again in the mediator that overwrote them, with the labels hardcoded in English in the second copy.

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/bd908ab9-2b27-4ae0-be99-c6a10e7b7009" />