### PR TITLE
ci(windows): build the GUI client for aarch64

### DIFF
--- a/.github/actions/setup-tauri-v2/action.yml
+++ b/.github/actions/setup-tauri-v2/action.yml
@@ -68,13 +68,14 @@ runs:
       id: cache-webview2-installer
       with:
         path: WebView2Installer.exe
-        key: webview2-offline-installer
+        key: webview2-offline-installer-${{ runner.arch }}
     - name: Download the WebView2 standalone installer
       if: ${{ runner.os == 'Windows' && inputs.runtime == 'true' && steps.webview2.outputs.installed != 'true' && steps.cache-webview2-installer.outputs.cache-hit != 'true' }}
       # The "Evergreen" standalone installer from Microsoft
       # <https://developer.microsoft.com/en-us/microsoft-edge/webview2/?form=MA13LH#download>
       # It always serves the current version, so the installed version is not pinned.
-      run: Invoke-WebRequest -Uri https://go.microsoft.com/fwlink/?linkid=2124701 -OutFile WebView2Installer.exe
+      # The installer is per-architecture: `2135522` is ARM64, `2124701` is x64.
+      run: Invoke-WebRequest -Uri https://go.microsoft.com/fwlink/?linkid=${{ runner.arch == 'ARM64' && '2135522' || '2124701' }} -OutFile WebView2Installer.exe
       shell: pwsh
     - name: Install WebView2
       if: ${{ runner.os == 'Windows' && inputs.runtime == 'true' && steps.webview2.outputs.installed != 'true' }}

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -157,10 +157,6 @@ jobs:
       - uses: ./.github/actions/setup-tauri-v2
         # Installing new packages can take time
         timeout-minutes: 15
-      - uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2.0.0
-        with:
-          token: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          organization: firezone-inc
       - name: Install pnpm deps
         run: pnpm install
       - uses: ./.github/actions/setup-azure-sign-tool
@@ -242,8 +238,15 @@ jobs:
 
       - name: Upload debug symbols to Sentry
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
+        # `matbour/setup-sentry-cli` has no `win32/arm64` build, so the CLI
+        # comes from npm here, which ships one for every runner we use.
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: firezone-inc
         shell: bash
-        run: ${{ env.SYMBOLS_SCRIPT }}
+        run: |
+          npm install --global @sentry/cli@3.6.2
+          ${{ env.SYMBOLS_SCRIPT }}
 
       - name: Upload Release Assets
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -159,7 +159,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check sentry-cli runs
         shell: bash
-        run: sentry-cli --version
+        run: mise exec -- sentry-cli --version
       - name: Install pnpm deps
         run: pnpm install
       - uses: ./.github/actions/setup-azure-sign-tool
@@ -245,7 +245,9 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: firezone-inc
         shell: bash
-        run: ${{ env.SYMBOLS_SCRIPT }}
+        # `mise exec` puts `sentry-cli` on PATH for the script. The shims the
+        # mise action sets up are regenerated before it installs, not after.
+        run: mise exec -- bash ${{ env.SYMBOLS_SCRIPT }}
 
       - name: Upload Release Assets
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -84,11 +84,6 @@ jobs:
         timeout-minutes: 15
         with:
           runtime: true
-      - uses: ./.github/actions/setup-mise
-        with:
-          install_args: "--cd rust github:mozilla/dump_syms"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm install
       - run: pnpm vite build
       - name: Build client
@@ -157,6 +152,14 @@ jobs:
       - uses: ./.github/actions/setup-tauri-v2
         # Installing new packages can take time
         timeout-minutes: 15
+      - uses: ./.github/actions/setup-mise
+        with:
+          install_args: "--cd rust github:getsentry/sentry-cli"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check sentry-cli runs
+        shell: bash
+        run: sentry-cli --version
       - name: Install pnpm deps
         run: pnpm install
       - uses: ./.github/actions/setup-azure-sign-tool
@@ -238,15 +241,11 @@ jobs:
 
       - name: Upload debug symbols to Sentry
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
-        # `matbour/setup-sentry-cli` has no `win32/arm64` build, so the CLI
-        # comes from npm here, which ships one for every runner we use.
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: firezone-inc
         shell: bash
-        run: |
-          npm install --global @sentry/cli@3.6.2
-          ${{ env.SYMBOLS_SCRIPT }}
+        run: ${{ env.SYMBOLS_SCRIPT }}
 
       - name: Upload Release Assets
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -56,7 +56,14 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
-        runs-on: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
+        runs-on:
+          [
+            ubuntu-22.04,
+            ubuntu-24.04,
+            windows-2022,
+            windows-2025,
+            windows-11-arm,
+          ]
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:
@@ -112,6 +119,10 @@ jobs:
             pkg-extension: deb
           - runs-on: windows-2022
             arch: x86_64
+            os: windows
+            pkg-extension: msi
+          - runs-on: windows-11-arm
+            arch: aarch64
             os: windows
             pkg-extension: msi
     env:

--- a/rust/mise.lock
+++ b/rust/mise.lock
@@ -213,6 +213,10 @@ url = "https://github.com/mozilla/dump_syms/releases/download/v2.3.7/dump_syms-a
 checksum = "sha256:4aded3cddac80aed06db65bab1c3d8228c0608296d7fa4168ab0eb12f2022683"
 url = "https://github.com/mozilla/dump_syms/releases/download/v2.3.7/dump_syms-x86_64-apple-darwin.tar.xz"
 
+[tools."github:mozilla/dump_syms"."platforms.windows-arm64"]
+checksum = "sha256:bd42a87409c39be18709b788f793fcdbfe1fde79511404112358b18511bb24f8"
+url = "https://github.com/mozilla/dump_syms/releases/download/v2.3.7/dump_syms-x86_64-pc-windows-msvc.zip"
+
 [tools."github:mozilla/dump_syms"."platforms.windows-x64"]
 checksum = "sha256:bd42a87409c39be18709b788f793fcdbfe1fde79511404112358b18511bb24f8"
 url = "https://github.com/mozilla/dump_syms/releases/download/v2.3.7/dump_syms-x86_64-pc-windows-msvc.zip"

--- a/rust/mise.lock
+++ b/rust/mise.lock
@@ -193,33 +193,49 @@ url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/ca
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392416"
 provenance = "github-attestations"
 
-[[tools."github:mozilla/dump_syms"]]
-version = "2.3.7"
-backend = "github:mozilla/dump_syms"
+[[tools."github:getsentry/sentry-cli"]]
+version = "3.6.2"
+backend = "github:getsentry/sentry-cli"
 
-[tools."github:mozilla/dump_syms"."platforms.linux-x64"]
-checksum = "sha256:928f9902244f63be4b3b0acf56963ecad97b7227ecfd9ee645d73683f75a9285"
-url = "https://github.com/mozilla/dump_syms/releases/download/v2.3.7/dump_syms-x86_64-unknown-linux-gnu.tar.xz"
+[tools."github:getsentry/sentry-cli"."platforms.linux-arm64"]
+checksum = "sha256:e21f19f0880bdb624cd9d603184a09a4211ac96117953571234a0349ee28511d"
+url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-linux-arm64-3.6.2.tgz"
+url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164026"
 
-[tools."github:mozilla/dump_syms"."platforms.linux-x64-musl"]
-checksum = "sha256:928f9902244f63be4b3b0acf56963ecad97b7227ecfd9ee645d73683f75a9285"
-url = "https://github.com/mozilla/dump_syms/releases/download/v2.3.7/dump_syms-x86_64-unknown-linux-gnu.tar.xz"
+[tools."github:getsentry/sentry-cli"."platforms.linux-arm64-musl"]
+checksum = "sha256:e21f19f0880bdb624cd9d603184a09a4211ac96117953571234a0349ee28511d"
+url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-linux-arm64-3.6.2.tgz"
+url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164026"
 
-[tools."github:mozilla/dump_syms"."platforms.macos-arm64"]
-checksum = "sha256:a96949068ccc62d5dfe9f642e15ecc62910217c661e256eb91e2d0e6266895e7"
-url = "https://github.com/mozilla/dump_syms/releases/download/v2.3.7/dump_syms-aarch64-apple-darwin.tar.xz"
+[tools."github:getsentry/sentry-cli"."platforms.linux-x64"]
+checksum = "sha256:6d32e314a2745b340a9e9f6d22b760b206217316495a360b3fb3f667a6167e73"
+url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-linux-x64-3.6.2.tgz"
+url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164029"
 
-[tools."github:mozilla/dump_syms"."platforms.macos-x64"]
-checksum = "sha256:4aded3cddac80aed06db65bab1c3d8228c0608296d7fa4168ab0eb12f2022683"
-url = "https://github.com/mozilla/dump_syms/releases/download/v2.3.7/dump_syms-x86_64-apple-darwin.tar.xz"
+[tools."github:getsentry/sentry-cli"."platforms.linux-x64-musl"]
+checksum = "sha256:6d32e314a2745b340a9e9f6d22b760b206217316495a360b3fb3f667a6167e73"
+url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-linux-x64-3.6.2.tgz"
+url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164029"
 
-[tools."github:mozilla/dump_syms"."platforms.windows-arm64"]
-checksum = "sha256:bd42a87409c39be18709b788f793fcdbfe1fde79511404112358b18511bb24f8"
-url = "https://github.com/mozilla/dump_syms/releases/download/v2.3.7/dump_syms-x86_64-pc-windows-msvc.zip"
+[tools."github:getsentry/sentry-cli"."platforms.macos-arm64"]
+checksum = "sha256:5a497deb1e388cc6445c09ddd6d2da4fc2aae8295405d6393c2e0ee635ca3687"
+url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-Darwin-arm64"
+url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164028"
 
-[tools."github:mozilla/dump_syms"."platforms.windows-x64"]
-checksum = "sha256:bd42a87409c39be18709b788f793fcdbfe1fde79511404112358b18511bb24f8"
-url = "https://github.com/mozilla/dump_syms/releases/download/v2.3.7/dump_syms-x86_64-pc-windows-msvc.zip"
+[tools."github:getsentry/sentry-cli"."platforms.macos-x64"]
+checksum = "sha256:efe0a5289cdd0ea8ff727b1228a1bea6c840f2da38152e8f9f5ced05bd6659cd"
+url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-Darwin-x86_64"
+url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164033"
+
+[tools."github:getsentry/sentry-cli"."platforms.windows-arm64"]
+checksum = "sha256:93ee7916c05c113a35daccf107c034af96f279561c103aa832668e4eecca3fb4"
+url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-Windows-aarch64.exe"
+url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164036"
+
+[tools."github:getsentry/sentry-cli"."platforms.windows-x64"]
+checksum = "sha256:5c90cb0045cef3d3c36113c2aa21a7dcae11627d2d6e3098b679dea5b6681be3"
+url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-Windows-x86_64.exe"
+url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164038"
 
 [[tools."github:taiki-e/cargo-llvm-cov"]]
 version = "0.6.21"

--- a/rust/mise.lock
+++ b/rust/mise.lock
@@ -197,25 +197,28 @@ provenance = "github-attestations"
 version = "3.6.2"
 backend = "github:getsentry/sentry-cli"
 
+[tools."github:getsentry/sentry-cli".options]
+matching_regex = "^sentry-cli-(Darwin|Linux|Windows)-"
+
 [tools."github:getsentry/sentry-cli"."platforms.linux-arm64"]
-checksum = "sha256:e21f19f0880bdb624cd9d603184a09a4211ac96117953571234a0349ee28511d"
-url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-linux-arm64-3.6.2.tgz"
-url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164026"
+checksum = "sha256:ff112ecf694b7d6b3629a6228ed4e3f7a0d51401bdf48a5051a79d8749dccd06"
+url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-Linux-aarch64"
+url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164039"
 
 [tools."github:getsentry/sentry-cli"."platforms.linux-arm64-musl"]
-checksum = "sha256:e21f19f0880bdb624cd9d603184a09a4211ac96117953571234a0349ee28511d"
-url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-linux-arm64-3.6.2.tgz"
-url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164026"
+checksum = "sha256:ff112ecf694b7d6b3629a6228ed4e3f7a0d51401bdf48a5051a79d8749dccd06"
+url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-Linux-aarch64"
+url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164039"
 
 [tools."github:getsentry/sentry-cli"."platforms.linux-x64"]
-checksum = "sha256:6d32e314a2745b340a9e9f6d22b760b206217316495a360b3fb3f667a6167e73"
-url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-linux-x64-3.6.2.tgz"
-url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164029"
+checksum = "sha256:3a4bbf2c0d06378d4e59b337647483751a0a2b1603db5fd4991847d0cfd6478c"
+url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-Linux-x86_64"
+url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164037"
 
 [tools."github:getsentry/sentry-cli"."platforms.linux-x64-musl"]
-checksum = "sha256:6d32e314a2745b340a9e9f6d22b760b206217316495a360b3fb3f667a6167e73"
-url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-linux-x64-3.6.2.tgz"
-url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164029"
+checksum = "sha256:3a4bbf2c0d06378d4e59b337647483751a0a2b1603db5fd4991847d0cfd6478c"
+url = "https://github.com/getsentry/sentry-cli/releases/download/3.6.2/sentry-cli-Linux-x86_64"
+url_api = "https://api.github.com/repos/getsentry/sentry-cli/releases/assets/486164037"
 
 [tools."github:getsentry/sentry-cli"."platforms.macos-arm64"]
 checksum = "sha256:5a497deb1e388cc6445c09ddd6d2da4fc2aae8295405d6393c2e0ee635ca3687"

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -9,7 +9,7 @@ auto_install = false
 "github:aya-rs/bpf-linker" = { version = "0.10.3", os = ["linux"] }
 "cargo:cargo-deb" = { version = "3.7.0", os = ["linux"] }
 "github:taiki-e/cargo-llvm-cov" = "0.6.21"
-"github:mozilla/dump_syms" = "2.3.7"
+"github:getsentry/sentry-cli" = "3.6.2"
 "github:tauri-apps/tauri" = { version = "2.11.2", version_prefix = "tauri-cli-v" }
 
 # The eBPF program is compiled with this exact nightly toolchain: `aya_build`

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -9,7 +9,9 @@ auto_install = false
 "github:aya-rs/bpf-linker" = { version = "0.10.3", os = ["linux"] }
 "cargo:cargo-deb" = { version = "3.7.0", os = ["linux"] }
 "github:taiki-e/cargo-llvm-cov" = "0.6.21"
-"github:getsentry/sentry-cli" = "3.6.2"
+# `matching_regex` skips the npm tarballs the release also carries, so every
+# platform gets the bare binary; `bin` gives it a name the shim can use.
+"github:getsentry/sentry-cli" = { version = "3.6.2", bin = "sentry-cli", matching_regex = "^sentry-cli-(Darwin|Linux|Windows)-" }
 "github:tauri-apps/tauri" = { version = "2.11.2", version_prefix = "tauri-cli-v" }
 
 # The eBPF program is compiled with this exact nightly toolchain: `aya_build`

--- a/rust/tests/gui-smoke-test/src/main.rs
+++ b/rust/tests/gui-smoke-test/src/main.rs
@@ -5,7 +5,6 @@
 use anyhow::{Context as _, Result, bail};
 use clap::Parser;
 use std::{
-    ffi::OsStr,
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -47,8 +46,6 @@ fn main() -> Result<()> {
     let cli = Cli::try_parse()?;
 
     let app = App::new()?;
-
-    dump_syms().context("Failed to run `dump_syms`")?;
 
     // Run normal smoke test
     tracing::info!("=== normal smoke test: GUI starts, connects to tunnel, quits gracefully ===");
@@ -357,37 +354,6 @@ impl App {
     }
 }
 
-// Get debug symbols from the exe / pdb
-fn dump_syms() -> Result<()> {
-    Exec::cmd("dump_syms")
-        .args([
-            debug_db_path().as_os_str(),
-            gui_path().as_os_str(),
-            OsStr::new("--output"),
-            syms_path().as_os_str(),
-        ])
-        .join()?
-        .fz_exit_ok()?;
-    Ok(())
-}
-
-#[cfg(target_os = "linux")]
-fn debug_db_path() -> PathBuf {
-    Path::new("target").join("debug").join(GUI_NAME)
-}
-
-#[cfg(target_os = "macos")]
-fn debug_db_path() -> PathBuf {
-    Path::new("target").join("debug").join(GUI_NAME)
-}
-
-#[cfg(target_os = "windows")]
-fn debug_db_path() -> PathBuf {
-    Path::new("target")
-        .join("debug")
-        .join("firezone_gui_client.pdb")
-}
-
 #[cfg(target_os = "linux")]
 fn tunnel_service_command() -> Exec {
     Exec::cmd("sudo").args([
@@ -440,8 +406,4 @@ fn tunnel_path() -> PathBuf {
         .join("debug")
         .join(TUNNEL_NAME)
         .with_extension(EXE_EXTENSION)
-}
-
-fn syms_path() -> PathBuf {
-    gui_path().with_extension("syms")
 }

--- a/scripts/build/build-msix-windows.sh
+++ b/scripts/build/build-msix-windows.sh
@@ -31,7 +31,12 @@ ls -la "$TARGET_DIR" 2>&1 | head -40 || true
 # `windows-2022` runner image but isn't on PATH. We can't pin a
 # specific SDK build (newer images bring newer SDK versions and the
 # old ones aren't necessarily kept) so we glob all installed SDKs and
-# pick the highest version that ships an x64 MakeAppx.
+# pick the highest version that ships a MakeAppx for the host.
+case "$(uname -m)" in
+    aarch64 | arm64) HOST_ARCHES=(arm64 x64) ;;
+    *) HOST_ARCHES=(x64) ;;
+esac
+
 MAKEAPPX="${MAKEAPPX:-}"
 if [ -z "$MAKEAPPX" ]; then
     if command -v MakeAppx.exe >/dev/null 2>&1; then
@@ -39,21 +44,24 @@ if [ -z "$MAKEAPPX" ]; then
     else
         # Find candidates from both x86 and x64 SDK roots, sort
         # version-aware and take the newest.
-        mapfile -t CANDIDATES < <(
-            find \
-                "/c/Program Files (x86)/Windows Kits/10/bin" \
-                "/c/Program Files/Windows Kits/10/bin" \
-                -maxdepth 3 -type f -iname MakeAppx.exe -path '*/x64/*' 2>/dev/null \
-                | sort -V
-        )
-        if [ "${#CANDIDATES[@]}" -gt 0 ]; then
-            MAKEAPPX="${CANDIDATES[-1]}"
-        fi
+        for sdk_arch in "${HOST_ARCHES[@]}"; do
+            mapfile -t CANDIDATES < <(
+                find \
+                    "/c/Program Files (x86)/Windows Kits/10/bin" \
+                    "/c/Program Files/Windows Kits/10/bin" \
+                    -maxdepth 3 -type f -iname MakeAppx.exe -path "*/$sdk_arch/*" 2>/dev/null \
+                    | sort -V
+            )
+            if [ "${#CANDIDATES[@]}" -gt 0 ]; then
+                MAKEAPPX="${CANDIDATES[-1]}"
+                break
+            fi
+        done
     fi
 fi
 if [ -z "$MAKEAPPX" ] || [ ! -x "$MAKEAPPX" ]; then
     echo "MakeAppx.exe not found. Set \$MAKEAPPX or install the Windows 10 SDK." >&2
-    echo "Searched: PATH and /c/Program Files*/Windows Kits/10/bin/*/x64/MakeAppx.exe" >&2
+    echo "Searched: PATH and /c/Program Files*/Windows Kits/10/bin/*/{${HOST_ARCHES[*]}}/MakeAppx.exe" >&2
     exit 1
 fi
 echo "Using MakeAppx: $MAKEAPPX"


### PR DESCRIPTION
Windows on ARM was blocked on tools that did not exist yet: a crash handler, `ring`, an MSI bundler that knew about arm64, and a runner image with Bash. All of them work now, so the GUI client builds on the `windows-11-arm` runner. It produces a signed MSI, that MSI installs on an ARM machine, and the smoke test passes.

Four support pieces assumed x64 and now pick the right build for the runner. The MSIX packer looked only for an x64 `MakeAppx.exe`, and the WebView2 setup downloaded only the x64 installer. `sentry-cli` comes from npm because the action we used has no ARM64 Windows build. `dump_syms` uses its x64 build under emulation because Mozilla publishes none for ARM64.

After this merges, a release run also uploads an aarch64 MSI. Users cannot reach it until the download page on the website links to it.

Related: #2992
