### PR TITLE
chore(rust): bump toolchain to 1.98.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784216271,
-        "narHash": "sha256-bvaxxdk7mmMQ88AuXQGTUtk+PcUujHpgxqpryqTWvTU=",
+        "lastModified": 1787246814,
+        "narHash": "sha256-pEd4/iPY3Zm/EhhHmeB1QnIWXJSLx7gJzD/05mm2MCo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1f69c7203034a4a974d7a4eac0f19b54af30804d",
+        "rev": "c84e121aaede7ef8c7bd9fb5154ccc1599e07816",
         "type": "github"
       },
       "original": {

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -62,7 +62,7 @@ COPY ${PACKAGE} .
 FROM runtime AS dev
 
 ARG PACKAGE
-ARG RUST_VERSION="1.97.1" # Keep in sync with `rust-toolchain.toml`
+ARG RUST_VERSION="1.98.0" # Keep in sync with `rust-toolchain.toml`
 
 WORKDIR /app
 

--- a/rust/gui-client/src-tauri/src/gui/system_tray/compositor.rs
+++ b/rust/gui-client/src-tauri/src/gui/system_tray/compositor.rs
@@ -60,7 +60,10 @@ pub fn compose<'a, I: IntoIterator<Item = &'a [u8]>>(layers: I) -> Result<Image>
         let gamma = 2.2;
         let inv_gamma = 1.0 / gamma;
 
-        for (src, dst) in rgba.chunks_exact(4).zip(dst.rgba.chunks_exact_mut(4)) {
+        let (src_pixels, _) = rgba.as_chunks::<4>();
+        let (dst_pixels, _) = dst.rgba.as_chunks_mut::<4>();
+
+        for (src, dst) in src_pixels.iter().zip(dst_pixels) {
             let src_a = src[3] as f32 / 255.0;
 
             for (src_int, dst_int) in (src[0..3]).iter().zip(&mut dst[0..3]) {

--- a/rust/gui-client/src-tauri/src/gui/system_tray/tray_ksni.rs
+++ b/rust/gui-client/src-tauri/src/gui/system_tray/tray_ksni.rs
@@ -186,7 +186,7 @@ impl ksni::Tray for FzTray {
         let composed = compose_icon(&self.icon);
         // ksni wants ARGB32 (network byte order); the compositor produces RGBA.
         let mut data = Vec::with_capacity(composed.rgba.len());
-        for px in composed.rgba.chunks_exact(4) {
+        for px in composed.rgba.as_chunks::<4>().0 {
             data.extend_from_slice(&[px[3], px[0], px[1], px[2]]);
         }
         vec![KsniIcon {

--- a/rust/libs/connlib/dns-over-tcp/src/client.rs
+++ b/rust/libs/connlib/dns-over-tcp/src/client.rs
@@ -787,7 +787,7 @@ mod tests {
         assert_eq!(query_result.server, server);
         assert_eq!(
             query_result.result.unwrap_err().to_string(),
-            format!("DNS query timed out after 10s"),
+            "DNS query timed out after 10s",
         );
     }
 

--- a/rust/libs/connlib/ip-packet/src/checksum.rs
+++ b/rust/libs/connlib/ip-packet/src/checksum.rs
@@ -18,19 +18,19 @@ pub fn sum(bytes: &[u8], initial: u64) -> u64 {
     // 16-bit halves separately: the high bits just carry down later in [`fold`]. A `u64`
     // accumulator holds the sum of ~8k such words without overflowing, so no intermediate
     // fold is needed for a single packet (at most 65535 bytes).
-    let mut chunks = bytes.chunks_exact(8);
-    for chunk in chunks.by_ref() {
-        let word = u64::from_be_bytes(chunk.try_into().expect("chunk is 8 bytes"));
+    let (chunks, rest) = bytes.as_chunks::<8>();
+    for chunk in chunks {
+        let word = u64::from_be_bytes(*chunk);
         acc += word >> 32;
         acc += word & 0xFFFF_FFFF;
     }
 
-    let mut tail = chunks.remainder().chunks_exact(2);
-    for chunk in tail.by_ref() {
-        acc += u64::from(u16::from_be_bytes([chunk[0], chunk[1]]));
+    let (words, tail) = rest.as_chunks::<2>();
+    for word in words {
+        acc += u64::from(u16::from_be_bytes(*word));
     }
 
-    if let [last] = tail.remainder() {
+    if let [last] = tail {
         acc += u64::from(u16::from_be_bytes([*last, 0]));
     }
 
@@ -129,11 +129,11 @@ mod tests {
         // across every chunk / tail / remainder combination.
         fn naive(bytes: &[u8]) -> u16 {
             let mut acc = 0u64;
-            let mut words = bytes.chunks_exact(2);
-            for word in words.by_ref() {
-                acc += u64::from(u16::from_be_bytes([word[0], word[1]]));
+            let (words, remainder) = bytes.as_chunks::<2>();
+            for word in words {
+                acc += u64::from(u16::from_be_bytes(*word));
             }
-            if let [last] = words.remainder() {
+            if let [last] = remainder {
                 acc += u64::from(u16::from_be_bytes([*last, 0]));
             }
             fold(acc)

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.97.1" # Keep in sync with `Dockerfile`
+channel = "1.98.0" # Keep in sync with `Dockerfile`
 components = ["rust-src", "rust-analyzer", "clippy"]
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Rust 1.98.0 is the current stable release.

It enables the `chunks_exact_to_as_chunks` clippy lint by default. CI builds with `--deny warnings`, so the call sites it flags move to `as_chunks`.

Nix resolves the toolchain through `rust-overlay`, whose pin predates the release and carries no manifest for it, so that input is updated alongside.