### PR TITLE
refactor(apple): split Store construction from startup

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -28,6 +28,9 @@ struct FirezoneApp: App {
     #else
       let store = Store()
     #endif
+
+    store.start()
+
     _store = StateObject(wrappedValue: store)
 
     #if os(macOS)

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -29,7 +29,9 @@ struct FirezoneApp: App {
       let store = Store()
     #endif
 
-    store.start()
+    // Not `.task` on a view: the main window closes right after launch on macOS, and
+    // startup must not be cancelled with it.
+    Task { await store.start() }
 
     _store = StateObject(wrappedValue: store)
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -169,9 +169,16 @@ public final class Store: ObservableObject {
         self?.objectWillChange.send()
       }
       .store(in: &cancellables)
+  }
 
-    // Load our state from the system. Based on what's loaded, we may need to ask the user for permission for things.
-    // When everything loads correctly, we attempt to start the tunnel if connectOnStart is enabled.
+  /// Loads our state from the system. Based on what's loaded, we may need to ask the user for
+  /// permission for things. When everything loads correctly, we attempt to start the tunnel if
+  /// connectOnStart is enabled.
+  ///
+  /// Kept out of `init` so that constructing a `Store` only wires it up: installing a system
+  /// extension and connecting a tunnel are things the app asks for, not things that happen
+  /// because a value was created. Previews and tests build a `Store` and never call this.
+  public func start() {
     Task {
       do {
         try await LaunchAgentManager.syncKeepAppRunning()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -178,17 +178,18 @@ public final class Store: ObservableObject {
   /// Kept out of `init` so that constructing a `Store` only wires it up: installing a system
   /// extension and connecting a tunnel are things the app asks for, not things that happen
   /// because a value was created. Previews and tests build a `Store` and never call this.
-  public func start() {
-    Task {
-      do {
-        try await LaunchAgentManager.syncKeepAppRunning()
-      } catch {
-        Log.error(error)
-      }
-
-      await startupSequence()
-      await initNotifications()
+  ///
+  /// `async` so the caller decides how to run it; the app fires and forgets, but that is
+  /// its call to make, not this function's.
+  public func start() async {
+    do {
+      try await LaunchAgentManager.syncKeepAppRunning()
+    } catch {
+      Log.error(error)
     }
+
+    await startupSequence()
+    await initNotifications()
   }
 
   #if os(macOS)


### PR DESCRIPTION
Constructing a `Store` used to end by spawning a task that installed the system extension, wrote the VPN configuration and connected the tunnel. Creating a value should not ask the user for permissions, so that work now lives in `Store.start()` and the app asks for it by name, right where construction already happened.

Related: #14772