### PR TITLE
refactor(apple): let a mock Store be built outside the app

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -14,16 +14,16 @@
 #if DEBUG
   import Foundation
   @preconcurrency import NetworkExtension
-  #if os(iOS)
-    import UserNotifications
-  #endif
+  import UserNotifications
 
   extension Store {
     /// A `Store` wired to mock dependencies for the `--mock-tunnel` demo.
     #if os(macOS)
       public static func mock() -> Store {
         Store(
+          sessionNotification: MockSessionNotification(),
           systemExtensionManager: MockSystemExtensionManager(),
+          updateChecker: MockUpdateChecker(),
           tunnelManagerFactory: MockTunnelProviderManagerFactory()
         )
       }
@@ -97,7 +97,10 @@
   /// session for the lifetime of the app.
   @MainActor
   private final class MockTunnelProviderManagerFactory: TunnelProviderManagerFactory {
-    private let manager = MockTunnelProviderManager()
+    // Built on demand: the manager derives the network extension's identifier from the main
+    // bundle, which only exists once the app is running. Creating the factory must stay free
+    // of that so a `Store` can be built in a test.
+    private lazy var manager = MockTunnelProviderManager()
 
     func loadAllFromPreferences() async throws -> [any TunnelProviderManager] { [manager] }
     func createManager() -> any TunnelProviderManager { manager }
@@ -130,18 +133,37 @@
       func check() async throws -> SystemExtensionStatus { .installed }
       func tryInstall() async throws -> SystemExtensionStatus { .installed }
     }
-  #else
-    /// Reports notifications as already authorised so the iOS app routes straight to the
-    /// session UI instead of `GrantNotificationsView`.
-    @MainActor
-    private final class MockSessionNotification: SessionNotificationProtocol {
-      var signInHandler: () async -> Void = {}
 
-      func askUserForNotificationPermissions() async throws -> UNAuthorizationStatus { .authorized }
-      func loadAuthorizationStatus() async -> UNAuthorizationStatus { .authorized }
-      func showResourceNotification(title: String, body: String) async {}
+    /// Reports the client as up to date, so the menu bar shows no update item.
+    ///
+    /// The real `UpdateChecker` would poll firezone.dev on a timer and register a
+    /// notification category, neither of which a demo or a test should be doing.
+    @MainActor
+    private final class MockUpdateChecker: UpdateCheckerProtocol {
+      let updateAvailable = false
     }
   #endif
+
+  /// Reports notifications as already authorised so the iOS app routes straight to the
+  /// session UI instead of `GrantNotificationsView`.
+  ///
+  /// Both platforms use it: the real `SessionNotification` reaches
+  /// `UNUserNotificationCenter`, which raises rather than returning an error when the
+  /// process has no app bundle, so it cannot be built from a test.
+  @MainActor
+  private final class MockSessionNotification: SessionNotificationProtocol {
+    var signInHandler: () async -> Void = {}
+
+    func askUserForNotificationPermissions() async throws -> UNAuthorizationStatus { .authorized }
+    func loadAuthorizationStatus() async -> UNAuthorizationStatus { .authorized }
+    func showResourceNotification(title: String, body: String) async {}
+
+    #if os(macOS)
+      func showSignedOutAlertMacOS(_ message: String?) async {}
+      func showDisconnectedAlertMacOS(_ message: String?) async {}
+      func showRestartRequiredAlertMacOS() {}
+    #endif
+  }
 
   private enum MockFixtures {
     static let resources: [Resource] = {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -97,10 +97,7 @@
   /// session for the lifetime of the app.
   @MainActor
   private final class MockTunnelProviderManagerFactory: TunnelProviderManagerFactory {
-    // Built on demand: the manager derives the network extension's identifier from the main
-    // bundle, which only exists once the app is running. Creating the factory must stay free
-    // of that so a `Store` can be built in a test.
-    private lazy var manager = MockTunnelProviderManager()
+    private let manager = MockTunnelProviderManager()
 
     func loadAllFromPreferences() async throws -> [any TunnelProviderManager] { [manager] }
     func createManager() -> any TunnelProviderManager { manager }
@@ -118,12 +115,9 @@
     init() {
       let proto = NETunnelProviderProtocol()
       proto.providerConfiguration = Configuration().toProviderConfiguration()
-      // `VPNConfigurationManager.bundleIdentifier` force-unwraps the main bundle, which a
-      // test process does not have. The mock derives the identifier the same way and
-      // settles for the shipped one when there is no bundle to ask.
-      proto.providerBundleIdentifier =
-        Bundle.main.bundleIdentifier.map { "\($0).network-extension" }
-        ?? "dev.firezone.firezone.network-extension"
+      // Only the system would read this, to launch the extension; the mock never talks to
+      // the system, so the shipped identifier serves as well as a derived one.
+      proto.providerBundleIdentifier = "dev.firezone.firezone.network-extension"
       proto.serverAddress = "Firezone"
       protocolConfiguration = proto
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -118,7 +118,12 @@
     init() {
       let proto = NETunnelProviderProtocol()
       proto.providerConfiguration = Configuration().toProviderConfiguration()
-      proto.providerBundleIdentifier = VPNConfigurationManager.bundleIdentifier
+      // `VPNConfigurationManager.bundleIdentifier` force-unwraps the main bundle, which a
+      // test process does not have. The mock derives the identifier the same way and
+      // settles for the shipped one when there is no bundle to ask.
+      proto.providerBundleIdentifier =
+        Bundle.main.bundleIdentifier.map { "\($0).network-extension" }
+        ?? "dev.firezone.firezone.network-extension"
       proto.serverAddress = "Firezone"
       protocolConfiguration = proto
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -115,9 +115,7 @@
     init() {
       let proto = NETunnelProviderProtocol()
       proto.providerConfiguration = Configuration().toProviderConfiguration()
-      // Only the system would read this, to launch the extension; the mock never talks to
-      // the system, so the shipped identifier serves as well as a derived one.
-      proto.providerBundleIdentifier = "dev.firezone.firezone.network-extension"
+      proto.providerBundleIdentifier = VPNConfigurationManager.bundleIdentifier
       proto.serverAddress = "Firezone"
       protocolConfiguration = proto
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -58,7 +58,7 @@ public final class Store: ObservableObject {
 
   private(set) var sessionNotification: SessionNotificationProtocol
   #if os(macOS)
-    let updateChecker: UpdateChecker
+    let updateChecker: any UpdateCheckerProtocol
     private let systemExtensionManager: any SystemExtensionManagerProtocol
   #endif
 
@@ -97,12 +97,14 @@ public final class Store: ObservableObject {
       configuration: Configuration? = nil,
       sessionNotification: SessionNotificationProtocol = SessionNotification(),
       systemExtensionManager: (any SystemExtensionManagerProtocol)? = nil,
+      updateChecker: (any UpdateCheckerProtocol)? = nil,
       tunnelManagerFactory: TunnelProviderManagerFactory = NETunnelProviderManagerFactory(),
       // swiftlint:disable:next no_userdefaults_standard
       userDefaults: UserDefaults = .standard
     ) {
       self.configuration = configuration ?? Configuration.shared
-      self.updateChecker = UpdateChecker(configuration: configuration, userDefaults: userDefaults)
+      self.updateChecker =
+        updateChecker ?? UpdateChecker(configuration: configuration, userDefaults: userDefaults)
       self.sessionNotification = sessionNotification
       self.systemExtensionManager = systemExtensionManager ?? SystemExtensionManager()
       self.tunnelManagerFactory = tunnelManagerFactory

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
@@ -10,8 +10,19 @@
   import UserNotifications
   import Cocoa
 
+  /// The one thing the UI needs from the update check.
+  ///
+  /// `UpdateChecker` reaches the network, installs a repeating timer and registers with
+  /// `UNUserNotificationCenter`, which raises when the process has no app bundle, so it
+  /// cannot be built from a test. Taking the check as a dependency lets a `Store` be built
+  /// with a canned answer instead.
   @MainActor
-  class UpdateChecker {
+  public protocol UpdateCheckerProtocol {
+    var updateAvailable: Bool { get }
+  }
+
+  @MainActor
+  class UpdateChecker: UpdateCheckerProtocol {
     enum UpdateError: Error {
       case invalidVersion(String)
 


### PR DESCRIPTION
`Store` built its collaborators as concrete classes, so every `Store` carried the real `UpdateChecker` with its release poll timer and notification category. The update check is now behind `UpdateCheckerProtocol`, taken as a dependency with the real checker as the default, and `SessionNotificationProtocol` gains a macOS mock so a mock `Store` stops reaching `UNUserNotificationCenter`.

Related: #14772