### PR TITLE
refactor(apple): report a missing app group instead of aborting

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Bundle.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Bundle.swift
@@ -25,8 +25,9 @@ public enum BundleHelper {
     return String(gitSha.prefix(8))
   }
 
-  /// The app group the app shares with its extensions, or `nil` where there is no bundle to
-  /// read it from.
+  /// The app group the app shares with its extensions, or `nil` when the bundle's
+  /// Info.plist declares no `AppGroupIdentifier`, which is every process except the app
+  /// and its extensions (a test, most obviously).
   static var appGroupIdIfPresent: String? {
     Bundle.main.object(forInfoDictionaryKey: "AppGroupIdentifier") as? String
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Bundle.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Bundle.swift
@@ -25,9 +25,14 @@ public enum BundleHelper {
     return String(gitSha.prefix(8))
   }
 
+  /// The app group the app shares with its extensions, or `nil` where there is no bundle to
+  /// read it from.
+  static var appGroupIdIfPresent: String? {
+    Bundle.main.object(forInfoDictionaryKey: "AppGroupIdentifier") as? String
+  }
+
   public static var appGroupId: String {
-    guard let appGroupId = Bundle.main.object(forInfoDictionaryKey: "AppGroupIdentifier") as? String
-    else {
+    guard let appGroupId = appGroupIdIfPresent else {
       fatalError("AppGroupIdentifier missing in app's Info.plist")
     }
     return appGroupId

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
@@ -10,7 +10,8 @@ public struct SharedAccess {
   private static let applicationSupportFolderName = "Application Support"
   private static let keepAppRunningSentinelFileName = ".running"
 
-  /// The container the app shares with its extensions, or `nil` outside an app that has one.
+  /// The container the app shares with its extensions, or `nil` when no app group is
+  /// declared or the system cannot provide its container, as without the entitlement.
   ///
   /// Everything below it is already optional and its callers already carry on without it, so
   /// this reports the container's absence rather than ending the process over it.

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
@@ -10,30 +10,34 @@ public struct SharedAccess {
   private static let applicationSupportFolderName = "Application Support"
   private static let keepAppRunningSentinelFileName = ".running"
 
-  public static var baseFolderURL: URL {
-    guard
-      let url = FileManager.default.containerURL(
-        forSecurityApplicationGroupIdentifier: BundleHelper.appGroupId)
-    else {
-      fatalError("Shared folder unavailable")
-    }
-    return url
+  /// The container the app shares with its extensions, or `nil` outside an app that has one.
+  ///
+  /// Everything below it is already optional and its callers already carry on without it, so
+  /// this reports the container's absence rather than ending the process over it.
+  public static var baseFolderURL: URL? {
+    guard let appGroupId = BundleHelper.appGroupIdIfPresent else { return nil }
+
+    return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupId)
   }
 
   public static var applicationSupportFolderURL: URL? {
-    let url =
-      baseFolderURL
-      .appendingPathComponent("Library")
-      .appendingPathComponent(applicationSupportFolderName)
-    guard ensureDirectoryExists(at: url.path) else {
+    guard
+      let url =
+        baseFolderURL?
+        .appendingPathComponent("Library")
+        .appendingPathComponent(applicationSupportFolderName),
+      ensureDirectoryExists(at: url.path)
+    else {
       return nil
     }
     return url
   }
 
   public static var cacheFolderURL: URL? {
-    let url = baseFolderURL.appendingPathComponent("Library").appendingPathComponent("Caches")
-    guard ensureDirectoryExists(at: url.path) else {
+    guard
+      let url = baseFolderURL?.appendingPathComponent("Library").appendingPathComponent("Caches"),
+      ensureDirectoryExists(at: url.path)
+    else {
       return nil
     }
     return url
@@ -96,8 +100,8 @@ public struct SharedAccess {
     return nil
   }
 
-  public static var providerStopReasonURL: URL {
-    baseFolderURL.appendingPathComponent("reason")
+  public static var providerStopReasonURL: URL? {
+    baseFolderURL?.appendingPathComponent("reason")
   }
 
   public static var keepAppRunningSentinelURL: URL? {


### PR DESCRIPTION
`SharedAccess.baseFolderURL` ended the process when the app group container was unavailable, though every caller below it already returns nil and carries on when a folder is missing. A process without an app bundle (a test, most obviously) now gets that graceful path instead of a crash.

Related: #14772