### PR TITLE
refactor(apple): let settings open on a chosen tab

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -129,7 +129,7 @@ public struct SettingsView: View {
   }
 
   /// The tabs of the settings screen.
-  public enum Tab {
+  public enum Tab: Hashable {
     case general
     case advanced
     case logs
@@ -152,23 +152,26 @@ public struct SettingsView: View {
             .ignoresSafeArea()
 
           VStack {
-            TabView {
+            TabView(selection: $selectedTab) {
               generalTab
                 .tabItem {
                   Image(systemName: "slider.horizontal.3")
                   Text("General")
                 }
+                .tag(Tab.general)
               advancedTab
                 .tabItem {
                   Image(systemName: "gearshape.2")
                   Text("Advanced")
                 }
                 .badge(viewModel.isValid() ? nil : "!")
+                .tag(Tab.advanced)
               logsTab
                 .tabItem {
                   Image(systemName: "doc.text")
                   Text("Diagnostic Logs")
                 }
+                .tag(Tab.logs)
             }
           }
           .padding(.bottom, 10)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -128,10 +128,20 @@ public struct SettingsView: View {
     )
   }
 
-  public init(store: Store) {
+  /// The tabs of the settings screen.
+  public enum Tab {
+    case general
+    case advanced
+    case logs
+  }
+
+  @State private var selectedTab: Tab
+
+  public init(store: Store, selectedTab: Tab = .general) {
     self.store = store
     self.configuration = store.configuration
     _viewModel = StateObject(wrappedValue: SettingsViewModel())
+    _selectedTab = State(initialValue: selectedTab)
   }
 
   public var body: some View {
@@ -200,19 +210,22 @@ public struct SettingsView: View {
       }
     #elseif os(macOS)
       VStack {
-        TabView {
+        TabView(selection: $selectedTab) {
           generalTab
             .tabItem {
               Text("General")
             }
+            .tag(Tab.general)
           advancedTab
             .tabItem {
               Text("Advanced")
             }
+            .tag(Tab.advanced)
           logsTab
             .tabItem {
               Text("Diagnostic Logs")
             }
+            .tag(Tab.logs)
         }
         .padding(20)
         Spacer()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -107,6 +107,8 @@ public struct SettingsView: View {
 
   @State private var calculateLogSizeTask: Task<(), Never>?
 
+  @State private var selectedTab: Tab
+
   #if os(iOS)
     @State private var logTempZipFileURL: URL?
     @State private var isPresentingExportLogShareSheet = false
@@ -134,8 +136,6 @@ public struct SettingsView: View {
     case advanced
     case logs
   }
-
-  @State private var selectedTab: Tab
 
   public init(store: Store, selectedTab: Tab = .general) {
     self.store = store


### PR DESCRIPTION
The settings screen always opened on the General tab because the `TabView` owned its selection internally. The selection now lives in explicit state that a caller may seed with an initial tab, so each tab of the whole screen can be rendered by the screenshot test. The app keeps opening on General.

Related: #14772