### PR TITLE
refactor(apple): ask the manager for the extension identifier

### DIFF
--- a/swift/apple/Firezone/CLI/ConnectCommand.swift
+++ b/swift/apple/Firezone/CLI/ConnectCommand.swift
@@ -95,7 +95,7 @@ extension FirezoneCLI {
         vpnManager = existing
       } else {
         Log.info("Creating VPN configuration...")
-        vpnManager = try await VPNConfigurationManager(manager: factory.createManager())
+        vpnManager = try await VPNConfigurationManager.create(using: factory)
       }
 
       // The extension reads providerConfiguration at start, so save before starting.

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/SystemExtensionManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/SystemExtensionManager.swift
@@ -5,6 +5,7 @@
 //
 
 #if os(macOS)
+  import NetworkExtension
   import SystemExtensions
 
   enum SystemExtensionError: Error, CustomStringConvertible, LocalizedError {
@@ -83,12 +84,6 @@
   {
     // Delegate methods complete with either a true or false outcome or an Error
     private var continuation: CheckedContinuation<SystemExtensionStatus, Error>?
-
-    private var extensionBundleIdentifier: String {
-      // App cannot run without bundle identifier - force unwrap is safe
-      // swiftlint:disable:next force_unwrapping
-      "\(Bundle.main.bundleIdentifier!).network-extension"
-    }
 
     override public init() {
       super.init()
@@ -191,7 +186,7 @@
       try await withCheckedThrowingContinuation { continuation in
         sendRequest(
           requestType: .check,
-          identifier: extensionBundleIdentifier,
+          identifier: NETunnelProviderManager.extensionBundleIdentifier,
           continuation: continuation
         )
       }
@@ -201,7 +196,7 @@
       try await withCheckedThrowingContinuation { continuation in
         sendRequest(
           requestType: .install,
-          identifier: extensionBundleIdentifier,
+          identifier: NETunnelProviderManager.extensionBundleIdentifier,
           continuation: continuation
         )
       }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/SystemExtensionManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/SystemExtensionManager.swift
@@ -84,6 +84,12 @@
     // Delegate methods complete with either a true or false outcome or an Error
     private var continuation: CheckedContinuation<SystemExtensionStatus, Error>?
 
+    private var extensionBundleIdentifier: String {
+      // App cannot run without bundle identifier - force unwrap is safe
+      // swiftlint:disable:next force_unwrapping
+      "\(Bundle.main.bundleIdentifier!).network-extension"
+    }
+
     override public init() {
       super.init()
     }
@@ -185,7 +191,7 @@
       try await withCheckedThrowingContinuation { continuation in
         sendRequest(
           requestType: .check,
-          identifier: VPNConfigurationManager.bundleIdentifier,
+          identifier: extensionBundleIdentifier,
           continuation: continuation
         )
       }
@@ -195,7 +201,7 @@
       try await withCheckedThrowingContinuation { continuation in
         sendRequest(
           requestType: .install,
-          identifier: VPNConfigurationManager.bundleIdentifier,
+          identifier: extensionBundleIdentifier,
           continuation: continuation
         )
       }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -37,15 +37,19 @@ public protocol TunnelProviderManagerFactory {
 // MARK: - NetworkExtension Conformances
 
 extension NETunnelProviderManager: TunnelProviderManager {
-  public var tunnelSession: (any TunnelSessionProtocol)? {
-    connection as? NETunnelProviderSession
-  }
-
-  public var extensionBundleIdentifier: String {
+  /// The identifier of the network extension the app ships, in one place for every
+  /// caller that must name it.
+  public static var extensionBundleIdentifier: String {
     // App cannot run without bundle identifier - force unwrap is safe
     // swiftlint:disable:next force_unwrapping
     "\(Bundle.main.bundleIdentifier!).network-extension"
   }
+
+  public var tunnelSession: (any TunnelSessionProtocol)? {
+    connection as? NETunnelProviderSession
+  }
+
+  public var extensionBundleIdentifier: String { Self.extensionBundleIdentifier }
 }
 
 @MainActor

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -20,6 +20,9 @@ public protocol TunnelProviderManager: AnyObject {
   /// The tunnel session backing this manager, if its connection is a provider
   /// session. Mockable counterpart of the concrete, un-mockable `connection`.
   var tunnelSession: (any TunnelSessionProtocol)? { get }
+  /// The identifier of the network extension this manager launches; production
+  /// derives it from the app bundle, so a test can substitute a fixed one.
+  var extensionBundleIdentifier: String { get }
 
   func saveToPreferences() async throws
   func loadFromPreferences() async throws
@@ -36,6 +39,12 @@ public protocol TunnelProviderManagerFactory {
 extension NETunnelProviderManager: TunnelProviderManager {
   public var tunnelSession: (any TunnelSessionProtocol)? {
     connection as? NETunnelProviderSession
+  }
+
+  public var extensionBundleIdentifier: String {
+    // App cannot run without bundle identifier - force unwrap is safe
+    // swiftlint:disable:next force_unwrapping
+    "\(Bundle.main.bundleIdentifier!).network-extension"
   }
 }
 
@@ -74,9 +83,6 @@ enum VPNConfigurationManagerError: Error {
 public final class VPNConfigurationManager {
   let manager: any TunnelProviderManager
 
-  // App cannot run without bundle identifier - force unwrap is safe
-  // swiftlint:disable:next force_unwrapping
-  public static let bundleIdentifier: String = "\(Bundle.main.bundleIdentifier!).network-extension"
   static let bundleDescription = "Firezone"
 
   // Initialize and save a new VPN configuration in system Preferences
@@ -87,7 +93,7 @@ public final class VPNConfigurationManager {
     // the migrator runs separately and is responsible for flipping the flag.
     protocolConfiguration.providerConfiguration =
       Configuration().toProviderConfiguration(markUserDefaultsMigrated: false)
-    protocolConfiguration.providerBundleIdentifier = VPNConfigurationManager.bundleIdentifier
+    protocolConfiguration.providerBundleIdentifier = manager.extensionBundleIdentifier
     protocolConfiguration.serverAddress = "Firezone"  // can be any non-empty string
     manager.localizedDescription = VPNConfigurationManager.bundleDescription
     manager.protocolConfiguration = protocolConfiguration

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -85,8 +85,15 @@ public final class VPNConfigurationManager {
 
   static let bundleDescription = "Firezone"
 
-  // Initialize and save a new VPN configuration in system Preferences
-  public init(manager: any TunnelProviderManager) async throws {
+  init(from manager: any TunnelProviderManager) {
+    self.manager = manager
+  }
+
+  // Create and save a new VPN configuration in system Preferences
+  public static func create(using factory: TunnelProviderManagerFactory) async throws
+    -> VPNConfigurationManager
+  {
+    let manager = factory.createManager()
     let protocolConfiguration = NETunnelProviderProtocol()
 
     // Seed with defaults (and any forced overrides) but don't mark migrated;
@@ -101,11 +108,7 @@ public final class VPNConfigurationManager {
     try await manager.saveToPreferences()
     try await manager.loadFromPreferences()
 
-    self.manager = manager
-  }
-
-  init(from manager: any TunnelProviderManager) {
-    self.manager = manager
+    return VPNConfigurationManager(from: manager)
   }
 
   public static func load(using factory: TunnelProviderManagerFactory) async throws

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -109,13 +109,16 @@
     var localizedDescription: String? = VPNConfigurationManager.bundleDescription
     var protocolConfiguration: NEVPNProtocol?
     var tunnelSession: (any TunnelSessionProtocol)? { session }
+    // Only the system would read this, to launch the extension; the mock never talks to
+    // the system, so the shipped identifier serves as well as a derived one.
+    let extensionBundleIdentifier = "dev.firezone.firezone.network-extension"
 
     private let session = MockTunnelSession()
 
     init() {
       let proto = NETunnelProviderProtocol()
       proto.providerConfiguration = Configuration().toProviderConfiguration()
-      proto.providerBundleIdentifier = VPNConfigurationManager.bundleIdentifier
+      proto.providerBundleIdentifier = extensionBundleIdentifier
       proto.serverAddress = "Firezone"
       protocolConfiguration = proto
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -453,8 +453,8 @@ public final class Store: ObservableObject {
   }
   func installVPNConfiguration() async throws {
     // Create a new VPN configuration in system settings.
-    self.vpnConfigurationManager = try await VPNConfigurationManager(
-      manager: tunnelManagerFactory.createManager()
+    self.vpnConfigurationManager = try await VPNConfigurationManager.create(
+      using: tunnelManagerFactory
     )
 
     try await manager().loadConfiguration(into: configuration, userDefaults: userDefaults)

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConfigurationTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConfigurationTests.swift
@@ -50,6 +50,7 @@ private final class MockTunnelProviderManager: TunnelProviderManager {
   var protocolConfiguration: NEVPNProtocol?
   let connection: NEVPNConnection = NETunnelProviderManager().connection
   var tunnelSession: (any TunnelSessionProtocol)? { nil }
+  let extensionBundleIdentifier = "dev.firezone.firezone.network-extension"
   var saveCount = 0
   var loadCount = 0
 


### PR DESCRIPTION
The extension's bundle identifier came from a static that force-unwraps the main bundle; it is now a requirement on `TunnelProviderManager`, so the real manager derives it from the app bundle and a mock answers with a fixed string. Creating a new VPN configuration also stops sharing an initializer shape with wrapping a loaded one: creation is a named `create(using:)` taking the factory, and only it stamps the `localizedDescription` that `load` selects by.

Related: #14772