### PR TITLE
fix(clients): make certificate rejections terminal

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -194,6 +194,15 @@ impl DisconnectError {
     pub fn requires_sign_in(&self) -> bool {
         self.0.requires_sign_in()
     }
+
+    /// Returns whether the X.509 client certificate is what failed.
+    ///
+    /// Lets a client word its error and choose what to offer from what actually went wrong,
+    /// rather than from how it happened to authenticate: a session that presented a certificate
+    /// can still fail for reasons that have nothing to do with it.
+    pub fn is_certificate_error(&self) -> bool {
+        self.0.is_certificate_error()
+    }
 }
 
 #[uniffi::export(with_foreign)]

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -674,6 +674,7 @@ impl<I: GuiIntegration> Controller<I> {
             service::ServerMsg::OnDisconnect {
                 error_msg,
                 requires_sign_in,
+                is_certificate_error,
             } => {
                 self.sign_out().await?;
                 if requires_sign_in {
@@ -685,7 +686,15 @@ impl<I: GuiIntegration> Controller<I> {
                 } else {
                     tracing::error!("Connlib disconnected: {error_msg}");
 
-                    dialog::error(&error_msg)?;
+                    // A certificate the portal refused is not something the user can retry
+                    // their way out of, so point them at whoever installed it.
+                    let body = if is_certificate_error {
+                        format!("{error_msg}\n\nContact your administrator for support.")
+                    } else {
+                        error_msg
+                    };
+
+                    dialog::error(&body)?;
                 }
             }
             service::ServerMsg::OnUpdateResources(resources) => {

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -93,6 +93,7 @@ pub enum ServerMsg {
     OnDisconnect {
         error_msg: String,
         requires_sign_in: bool,
+        is_certificate_error: bool,
     },
     AllGatewaysOffline {
         resource_id: ResourceId,
@@ -598,6 +599,7 @@ impl<'a> Handler<'a> {
                 self.send_ipc(ServerMsg::OnDisconnect {
                     error_msg: error.to_string(),
                     requires_sign_in: error.requires_sign_in(),
+                    is_certificate_error: error.is_certificate_error(),
                 })
                 .await?
             }

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -129,6 +129,19 @@ impl DisconnectError {
 
         e.requires_sign_in()
     }
+
+    /// Returns whether the X.509 client certificate is what failed.
+    ///
+    /// Lets a client word its error and choose what to offer from what actually went wrong,
+    /// rather than from how it happened to authenticate: a session that presented a certificate
+    /// can still fail for reasons that have nothing to do with it.
+    pub fn is_certificate_error(&self) -> bool {
+        let Some(e) = self.0.any_downcast_ref::<phoenix_channel::Error>() else {
+            return false;
+        };
+
+        e.is_certificate_error()
+    }
 }
 
 impl Eventloop {

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -185,6 +185,16 @@ async fn connect(
     Err(InternalError::SocketConnection(errors))
 }
 
+/// The problem codes the portal reports when it refuses the certificate we presented.
+///
+/// None of them can be retried into success: the certificate has to be replaced, or the portal
+/// reconfigured, before another attempt means anything.
+const CERTIFICATE_REJECTION_CODES: &[&str] = &[
+    "device_untrusted",
+    "certificate_revoked",
+    "device_identity_conflict",
+];
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Authentication token invalid")]
@@ -194,6 +204,12 @@ pub enum Error {
     AuthenticationFailed(String),
     #[error("X.509 client certificate signing failed: {0}")]
     ClientCertificateSigningFailed(String),
+    /// The portal refused the X.509 client certificate we presented.
+    ///
+    /// `code` is the portal's machine-readable reason, kept so the clients can tell a revoked
+    /// certificate from an untrusted one without matching on prose.
+    #[error("The portal rejected the client certificate: {detail}")]
+    CertificateRejected { code: String, detail: String },
     #[error(
         "Got disconnected from portal and hit the max-retry limit. Last connection error: {final_error}"
     )]
@@ -215,10 +231,35 @@ impl Error {
             // The portal rejected us without naming the token, so a new one is not known to help.
             Error::AuthenticationFailed(_) => false,
             Error::ClientCertificateSigningFailed(_) => false,
+            // The certificate is the credential the portal refused, so a new token cannot help.
+            Error::CertificateRejected { .. } => false,
             Error::MaxRetriesReached { .. } => false,
             Error::LoginFailed(_) => false,
             Error::FatalIo(_) => false,
         }
+    }
+
+    /// Classifies a refusal of the certificate we presented, if that is what the portal reported.
+    ///
+    /// The portal answers these with 403 and 409 rather than 401, so without this they would be
+    /// indistinguishable from a transient failure and retried until the backoff gave up, long
+    /// after the portal had said something the user could act on.
+    fn from_certificate_rejection(
+        response: &tungstenite::handshake::client::Response,
+    ) -> Option<Self> {
+        let problem = ProblemDetails::from_response(response)?;
+        let code = problem.code?;
+
+        if !CERTIFICATE_REJECTION_CODES.contains(&code.as_str()) {
+            return None;
+        }
+
+        Some(Error::CertificateRejected {
+            code,
+            detail: problem
+                .detail
+                .unwrap_or_else(|| "no reason provided".to_owned()),
+        })
     }
 
     /// Classifies a rejected connection attempt by the reason the portal reported.
@@ -651,6 +692,12 @@ where
                     {
                         self.state = State::Closed;
                         return Poll::Ready(Err(Error::from_unauthorized(&r)));
+                    }
+                    Poll::Ready(Err(InternalError::WebSocket(tungstenite::Error::Http(ref r))))
+                        if let Some(error) = Error::from_certificate_rejection(r) =>
+                    {
+                        self.state = State::Closed;
+                        return Poll::Ready(Err(error));
                     }
                     Poll::Ready(Err(e))
                         if let Some(message) = e.client_certificate_signing_error() =>
@@ -1217,6 +1264,64 @@ mod tests {
         let error = anyhow::Error::msg("some other failure").context("Connection hiccup");
 
         assert_eq!(http_error_body(&error), None);
+    }
+
+    #[test]
+    fn forbidden_with_a_certificate_code_is_terminal() {
+        let response = tungstenite::http::Response::builder()
+            .status(StatusCode::FORBIDDEN)
+            .header("content-type", "application/problem+json")
+            .body(Some(
+                br#"{"title":"Forbidden","status":403,"detail":"This device's certificate has been revoked.","code":"certificate_revoked"}"#.to_vec(),
+            ))
+            .unwrap();
+
+        let error = Error::from_certificate_rejection(&response)
+            .expect("a certificate code should be recognised");
+
+        let Error::CertificateRejected { code, detail } = &error else {
+            panic!("expected `CertificateRejected`, got {error:?}");
+        };
+        assert_eq!(code, "certificate_revoked");
+        assert_eq!(detail, "This device's certificate has been revoked.");
+        // A new token cannot replace the credential the portal refused.
+        assert!(!error.requires_sign_in());
+    }
+
+    #[test]
+    fn a_conflict_naming_the_device_identity_is_terminal() {
+        let response = tungstenite::http::Response::builder()
+            .status(StatusCode::CONFLICT)
+            .header("content-type", "application/problem+json")
+            .body(Some(
+                br#"{"title":"Conflict","status":409,"detail":"Different hardware.","code":"device_identity_conflict"}"#.to_vec(),
+            ))
+            .unwrap();
+
+        assert!(Error::from_certificate_rejection(&response).is_some());
+    }
+
+    #[test]
+    fn other_rejections_keep_retrying() {
+        let response = tungstenite::http::Response::builder()
+            .status(StatusCode::FORBIDDEN)
+            .header("content-type", "application/problem+json")
+            .body(Some(
+                br#"{"title":"Forbidden","status":403,"detail":"The account is disabled","code":"account_disabled"}"#.to_vec(),
+            ))
+            .unwrap();
+
+        assert!(Error::from_certificate_rejection(&response).is_none());
+    }
+
+    #[test]
+    fn a_rejection_without_problem_details_keeps_retrying() {
+        let response = tungstenite::http::Response::builder()
+            .status(StatusCode::FORBIDDEN)
+            .body(Some(b"<html>Forbidden</html>".to_vec()))
+            .unwrap();
+
+        assert!(Error::from_certificate_rejection(&response).is_none());
     }
 
     #[test]

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -205,11 +205,8 @@ pub enum Error {
     #[error("X.509 client certificate signing failed: {0}")]
     ClientCertificateSigningFailed(String),
     /// The portal refused the X.509 client certificate we presented.
-    ///
-    /// `code` is the portal's machine-readable reason, kept so the clients can tell a revoked
-    /// certificate from an untrusted one without matching on prose.
-    #[error("The portal rejected the client certificate: {detail}")]
-    CertificateRejected { code: String, detail: String },
+    #[error("The portal rejected the client certificate: {0}")]
+    CertificateRejected(String),
     #[error(
         "Got disconnected from portal and hit the max-retry limit. Last connection error: {final_error}"
     )]
@@ -232,7 +229,24 @@ impl Error {
             Error::AuthenticationFailed(_) => false,
             Error::ClientCertificateSigningFailed(_) => false,
             // The certificate is the credential the portal refused, so a new token cannot help.
-            Error::CertificateRejected { .. } => false,
+            Error::CertificateRejected(_) => false,
+            Error::MaxRetriesReached { .. } => false,
+            Error::LoginFailed(_) => false,
+            Error::FatalIo(_) => false,
+        }
+    }
+
+    /// Returns whether the X.509 client certificate is what failed.
+    ///
+    /// Lets a client word its error and choose what to offer from what actually went wrong,
+    /// rather than from how it happened to authenticate: a session that presented a certificate
+    /// can still fail for reasons that have nothing to do with it.
+    pub fn is_certificate_error(&self) -> bool {
+        match self {
+            Error::CertificateRejected(_) => true,
+            Error::ClientCertificateSigningFailed(_) => true,
+            Error::InvalidToken => false,
+            Error::AuthenticationFailed(_) => false,
             Error::MaxRetriesReached { .. } => false,
             Error::LoginFailed(_) => false,
             Error::FatalIo(_) => false,
@@ -254,12 +268,11 @@ impl Error {
             return None;
         }
 
-        Some(Error::CertificateRejected {
-            code,
-            detail: problem
+        Some(Error::CertificateRejected(
+            problem
                 .detail
                 .unwrap_or_else(|| "no reason provided".to_owned()),
-        })
+        ))
     }
 
     /// Classifies a rejected connection attempt by the reason the portal reported.
@@ -1279,13 +1292,13 @@ mod tests {
         let error = Error::from_certificate_rejection(&response)
             .expect("a certificate code should be recognised");
 
-        let Error::CertificateRejected { code, detail } = &error else {
+        let Error::CertificateRejected(detail) = &error else {
             panic!("expected `CertificateRejected`, got {error:?}");
         };
-        assert_eq!(code, "certificate_revoked");
         assert_eq!(detail, "This device's certificate has been revoked.");
         // A new token cannot replace the credential the portal refused.
         assert!(!error.requires_sign_in());
+        assert!(error.is_certificate_error());
     }
 
     #[test]

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -1280,64 +1280,6 @@ mod tests {
     }
 
     #[test]
-    fn forbidden_with_a_certificate_code_is_terminal() {
-        let response = tungstenite::http::Response::builder()
-            .status(StatusCode::FORBIDDEN)
-            .header("content-type", "application/problem+json")
-            .body(Some(
-                br#"{"title":"Forbidden","status":403,"detail":"This device's certificate has been revoked.","code":"certificate_revoked"}"#.to_vec(),
-            ))
-            .unwrap();
-
-        let error = Error::from_certificate_rejection(&response)
-            .expect("a certificate code should be recognised");
-
-        let Error::CertificateRejected(detail) = &error else {
-            panic!("expected `CertificateRejected`, got {error:?}");
-        };
-        assert_eq!(detail, "This device's certificate has been revoked.");
-        // A new token cannot replace the credential the portal refused.
-        assert!(!error.requires_sign_in());
-        assert!(error.is_certificate_error());
-    }
-
-    #[test]
-    fn a_conflict_naming_the_device_identity_is_terminal() {
-        let response = tungstenite::http::Response::builder()
-            .status(StatusCode::CONFLICT)
-            .header("content-type", "application/problem+json")
-            .body(Some(
-                br#"{"title":"Conflict","status":409,"detail":"Different hardware.","code":"device_identity_conflict"}"#.to_vec(),
-            ))
-            .unwrap();
-
-        assert!(Error::from_certificate_rejection(&response).is_some());
-    }
-
-    #[test]
-    fn other_rejections_keep_retrying() {
-        let response = tungstenite::http::Response::builder()
-            .status(StatusCode::FORBIDDEN)
-            .header("content-type", "application/problem+json")
-            .body(Some(
-                br#"{"title":"Forbidden","status":403,"detail":"The account is disabled","code":"account_disabled"}"#.to_vec(),
-            ))
-            .unwrap();
-
-        assert!(Error::from_certificate_rejection(&response).is_none());
-    }
-
-    #[test]
-    fn a_rejection_without_problem_details_keeps_retrying() {
-        let response = tungstenite::http::Response::builder()
-            .status(StatusCode::FORBIDDEN)
-            .body(Some(b"<html>Forbidden</html>".to_vec()))
-            .unwrap();
-
-        assert!(Error::from_certificate_rejection(&response).is_none());
-    }
-
-    #[test]
     fn unauthorized_with_invalid_token_code_blames_the_token() {
         let response = tungstenite::http::Response::builder()
             .status(StatusCode::UNAUTHORIZED)

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -253,43 +253,29 @@ impl Error {
         }
     }
 
-    /// Classifies a refusal of the certificate we presented, if that is what the portal reported.
-    ///
-    /// The portal answers these with 403 and 409 rather than 401, so without this they would be
-    /// indistinguishable from a transient failure and retried until the backoff gave up, long
-    /// after the portal had said something the user could act on.
-    fn from_certificate_rejection(
-        response: &tungstenite::handshake::client::Response,
-    ) -> Option<Self> {
-        let problem = ProblemDetails::from_response(response)?;
-        let code = problem.code?;
-
-        if !CERTIFICATE_REJECTION_CODES.contains(&code.as_str()) {
-            return None;
-        }
-
-        Some(Error::CertificateRejected(
-            problem
-                .detail
-                .unwrap_or_else(|| "no reason provided".to_owned()),
-        ))
-    }
-
     /// Classifies a rejected connection attempt by the reason the portal reported.
     ///
-    /// Reasons the client cannot act on specifically map to [`Error::AuthenticationFailed`],
-    /// as do responses without problem details, e.g. an error page from an intermediary proxy.
-    fn from_unauthorized(response: &tungstenite::handshake::client::Response) -> Self {
+    /// Returns `None` when nothing in the response marks the failure as permanent, so the
+    /// caller keeps retrying. The portal names permanent rejections with a problem code:
+    /// an unusable token, or a refused client certificate, which it answers with 403 and
+    /// 409 rather than 401. A 401 without a specific code maps to
+    /// [`Error::AuthenticationFailed`], as does one without problem details at all,
+    /// e.g. an error page from an intermediary proxy.
+    fn from_rejection(response: &tungstenite::handshake::client::Response) -> Option<Self> {
         let problem = ProblemDetails::from_response(response).unwrap_or_default();
+        let detail = problem
+            .detail
+            .unwrap_or_else(|| "no reason provided".to_owned());
 
         match problem.code.as_deref() {
-            Some("invalid_token") => Error::InvalidToken,
-            Some("missing_token") => Error::InvalidToken,
-            _ => Error::AuthenticationFailed(
-                problem
-                    .detail
-                    .unwrap_or_else(|| "no reason provided".to_owned()),
-            ),
+            Some("invalid_token" | "missing_token") => Some(Error::InvalidToken),
+            Some(code) if CERTIFICATE_REJECTION_CODES.contains(&code) => {
+                Some(Error::CertificateRejected(detail))
+            }
+            _ if response.status() == StatusCode::UNAUTHORIZED => {
+                Some(Error::AuthenticationFailed(detail))
+            }
+            _ => None,
         }
     }
 }
@@ -700,14 +686,8 @@ where
 
                         continue;
                     }
-                    Poll::Ready(Err(InternalError::WebSocket(tungstenite::Error::Http(r))))
-                        if r.status() == StatusCode::UNAUTHORIZED =>
-                    {
-                        self.state = State::Closed;
-                        return Poll::Ready(Err(Error::from_unauthorized(&r)));
-                    }
                     Poll::Ready(Err(InternalError::WebSocket(tungstenite::Error::Http(ref r))))
-                        if let Some(error) = Error::from_certificate_rejection(r) =>
+                        if let Some(error) = Error::from_rejection(r) =>
                     {
                         self.state = State::Closed;
                         return Poll::Ready(Err(error));
@@ -1289,7 +1269,7 @@ mod tests {
             ))
             .unwrap();
 
-        let error = Error::from_unauthorized(&response);
+        let error = Error::from_rejection(&response).expect("a 401 naming the token is terminal");
 
         assert!(matches!(error, Error::InvalidToken), "got {error:?}");
     }
@@ -1304,7 +1284,7 @@ mod tests {
             ))
             .unwrap();
 
-        let error = Error::from_unauthorized(&response);
+        let error = Error::from_rejection(&response).expect("a plain 401 is terminal");
 
         assert!(!error.requires_sign_in());
         assert_eq!(

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -607,7 +607,7 @@ async fn http_403_with_another_code_triggers_retry() {
     // Only the codes that name the certificate are terminal; the rest stay retryable.
     assert!(
         matches!(result, Ok(Event::Hiccup { .. })),
-        "expected Event::Hiccup for a 403 without a certificate code, got {result:?}"
+        "expected Event::Hiccup for a 403 whose code does not name the certificate, got {result:?}"
     );
 }
 

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -535,22 +535,20 @@ async fn http_403_with_certificate_code_is_terminal() {
 
     // Without the terminal path this is an `Event::Hiccup` and the poll never resolves, so
     // reaching the timeout is the failure this test is really guarding against.
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
+    let error = tokio::time::timeout(Duration::from_secs(5), async {
         future::poll_fn(|cx| channel.poll(cx)).await
     })
     .await
-    .expect("should not retry a rejected certificate");
+    .expect("should not retry a rejected certificate")
+    .unwrap_err();
 
-    let Err(error) = result else {
-        panic!(
-            "expected Error::CertificateRejected for 403 with a certificate code, got {result:?}"
-        )
-    };
-    let phoenix_channel::Error::CertificateRejected(detail) = &error else {
-        panic!("expected Error::CertificateRejected for 403 with a certificate code, got {error:?}")
-    };
-    assert_eq!(detail, "This device's certificate has been revoked.");
+    assert_eq!(
+        error.to_string(),
+        "The portal rejected the client certificate: This device's certificate has been revoked."
+    );
     assert!(error.is_certificate_error());
+    // A new token cannot replace the credential the portal refused.
+    assert!(!error.requires_sign_in());
 }
 
 #[tokio::test]
@@ -569,15 +567,71 @@ async fn http_409_with_certificate_code_is_terminal() {
         PublicKeyParam([0u8; 32]),
     );
 
+    let error = tokio::time::timeout(Duration::from_secs(5), async {
+        future::poll_fn(|cx| channel.poll(cx)).await
+    })
+    .await
+    .expect("should not retry a rejected certificate")
+    .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "The portal rejected the client certificate: Different hardware."
+    );
+    assert!(error.is_certificate_error());
+    assert!(!error.requires_sign_in());
+}
+
+#[tokio::test]
+async fn http_403_with_another_code_triggers_retry() {
+    let port = http_problem_details_server(
+        http::StatusCode::FORBIDDEN,
+        r#"{"type":"about:blank","title":"Forbidden","status":403,"detail":"The account is disabled","code":"account_disabled"}"#,
+    )
+    .await;
+
+    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
+
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
+
     let result = tokio::time::timeout(Duration::from_secs(5), async {
         future::poll_fn(|cx| channel.poll(cx)).await
     })
     .await
-    .expect("should not retry a rejected certificate");
+    .expect("should not timeout");
+
+    // Only the codes that name the certificate are terminal; the rest stay retryable.
+    assert!(
+        matches!(result, Ok(Event::Hiccup { .. })),
+        "expected Event::Hiccup for a 403 without a certificate code, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn http_403_without_problem_details_triggers_retry() {
+    let port = http_status_server(http::StatusCode::FORBIDDEN).await;
+
+    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
+
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        future::poll_fn(|cx| channel.poll(cx)).await
+    })
+    .await
+    .expect("should not timeout");
 
     assert!(
-        matches!(result, Err(phoenix_channel::Error::CertificateRejected(_))),
-        "expected Error::CertificateRejected for 409 with a certificate code, got {result:?}"
+        matches!(result, Ok(Event::Hiccup { .. })),
+        "expected Event::Hiccup for a 403 an intermediary sent, got {result:?}"
     );
 }
 

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -541,13 +541,16 @@ async fn http_403_with_certificate_code_is_terminal() {
     .await
     .expect("should not retry a rejected certificate");
 
-    let Err(phoenix_channel::Error::CertificateRejected { code, detail }) = result else {
+    let Err(error) = result else {
         panic!(
             "expected Error::CertificateRejected for 403 with a certificate code, got {result:?}"
         )
     };
-    assert_eq!(code, "certificate_revoked");
+    let phoenix_channel::Error::CertificateRejected(detail) = &error else {
+        panic!("expected Error::CertificateRejected for 403 with a certificate code, got {error:?}")
+    };
     assert_eq!(detail, "This device's certificate has been revoked.");
+    assert!(error.is_certificate_error());
 }
 
 #[tokio::test]
@@ -573,10 +576,7 @@ async fn http_409_with_certificate_code_is_terminal() {
     .expect("should not retry a rejected certificate");
 
     assert!(
-        matches!(
-            result,
-            Err(phoenix_channel::Error::CertificateRejected { .. })
-        ),
+        matches!(result, Err(phoenix_channel::Error::CertificateRejected(_))),
         "expected Error::CertificateRejected for 409 with a certificate code, got {result:?}"
     );
 }

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -518,6 +518,70 @@ async fn http_401_with_invalid_token_code_returns_invalid_token() {
 }
 
 #[tokio::test]
+async fn http_403_with_certificate_code_is_terminal() {
+    let port = http_problem_details_server(
+        http::StatusCode::FORBIDDEN,
+        r#"{"type":"about:blank","title":"Forbidden","status":403,"detail":"This device's certificate has been revoked.","code":"certificate_revoked"}"#,
+    )
+    .await;
+
+    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
+
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
+
+    // Without the terminal path this is an `Event::Hiccup` and the poll never resolves, so
+    // reaching the timeout is the failure this test is really guarding against.
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        future::poll_fn(|cx| channel.poll(cx)).await
+    })
+    .await
+    .expect("should not retry a rejected certificate");
+
+    let Err(phoenix_channel::Error::CertificateRejected { code, detail }) = result else {
+        panic!(
+            "expected Error::CertificateRejected for 403 with a certificate code, got {result:?}"
+        )
+    };
+    assert_eq!(code, "certificate_revoked");
+    assert_eq!(detail, "This device's certificate has been revoked.");
+}
+
+#[tokio::test]
+async fn http_409_with_certificate_code_is_terminal() {
+    let port = http_problem_details_server(
+        http::StatusCode::CONFLICT,
+        r#"{"type":"about:blank","title":"Conflict","status":409,"detail":"Different hardware.","code":"device_identity_conflict"}"#,
+    )
+    .await;
+
+    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
+
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        future::poll_fn(|cx| channel.poll(cx)).await
+    })
+    .await
+    .expect("should not retry a rejected certificate");
+
+    assert!(
+        matches!(
+            result,
+            Err(phoenix_channel::Error::CertificateRejected { .. })
+        ),
+        "expected Error::CertificateRejected for 409 with a certificate code, got {result:?}"
+    );
+}
+
+#[tokio::test]
 async fn http_401_without_code_returns_authentication_failed() {
     let port = http_problem_details_server(
         http::StatusCode::UNAUTHORIZED,


### PR DESCRIPTION
The portal answers a refused client certificate with 403, or with 409 when the certificate reports different hardware than the device already registered under the same MDM device id. Only 401 was terminal, so those rejections went into the reconnect backoff and, on a client that had connected once, kept retrying for up to thirty days before surfacing as a generic websocket failure.

None of them can be retried into success: the certificate has to be replaced, or the portal reconfigured, before another attempt means anything. A rejection is recognised by the portal's machine-readable problem code rather than by matching on the response text, and the error carries the portal's stated reason so a client can surface it.

Rejections the client cannot act on specifically, such as a disabled account or exceeded billing limits, keep retrying as before.

Related: #14712