### PR TITLE
refactor(apple): route diagnostic logs through the Store

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -215,6 +215,48 @@ public final class Log {
   }
 }
 
+extension FileManager {
+  enum FileManagerError: Error {
+    case invalidURL(URL, Error)
+
+    var localizedDescription: String {
+      switch self {
+      case .invalidURL(let url, let error):
+        return "Unable to get resource value for '\(url)': \(error)"
+      }
+    }
+  }
+
+  func forEachFileUnder(
+    _ dirURL: URL,
+    including resourceKeys: Set<URLResourceKey>,
+    handler: (URL, URLResourceValues) -> Void
+  ) {
+    // Deep-traverses the directory at dirURL
+    guard
+      let enumerator = self.enumerator(
+        at: dirURL,
+        includingPropertiesForKeys: [URLResourceKey](resourceKeys),
+        options: [],
+        errorHandler: nil
+      )
+    else {
+      return
+    }
+
+    for item in enumerator.enumerated() {
+      if Task.isCancelled { break }
+      guard let url = item.element as? URL else { continue }
+      do {
+        let resourceValues = try url.resourceValues(forKeys: resourceKeys)
+        handler(url, resourceValues)
+      } catch {
+        Log.error(FileManagerError.invalidURL(url, error))
+      }
+    }
+  }
+}
+
 /// Thread-safe: All mutable state access is serialised through workQueue.
 /// Log writes are queued asynchronously to avoid blocking the caller.
 final class LogWriter: @unchecked Sendable {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -153,6 +153,8 @@ public final class Log {
 
   // Returns the size in bytes of the provided directory, calculated by summing
   // the size of its contents recursively.
+  // @concurrent: walking a large log tree must not run on the caller's actor.
+  @concurrent
   public static func size(of directory: URL) async -> Int64 {
     let fileManager = FileManager.default
     var totalSize: Int64 = 0

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
@@ -29,13 +29,9 @@ import SystemPackage
     @MainActor
     static func export(
       to archiveURL: URL,
+      from logFolderURL: URL,
       session: any TunnelSessionProtocol
     ) async throws {
-      guard let logFolderURL = SharedAccess.logFolderURL
-      else {
-        throw ExportError.invalidSourceDirectory
-      }
-
       // 1. Create a temporary working directory to stage app and tunnel archives
       let sharedLogFolderURL = fileManager
         .temporaryDirectory
@@ -61,7 +57,23 @@ import SystemPackage
       // 3. Await tunnel log export from tunnel process
       try await IPCClient.exportLogs(session: session, fd: fd)
 
-      // 4. Create app log archive
+      // 4. Archive the app logs and join both into the final archive
+      try await archive(
+        appLogs: logFolderURL,
+        staging: sharedLogFolderURL,
+        tunnelArchive: tunnelLogURL,
+        to: archiveURL
+      )
+    }
+
+    // @concurrent: zipping a large log tree must not run on the main actor.
+    @concurrent
+    private static func archive(
+      appLogs logFolderURL: URL,
+      staging sharedLogFolderURL: URL,
+      tunnelArchive tunnelLogURL: URL,
+      to archiveURL: URL
+    ) async throws {
       let appLogURL = sharedLogFolderURL.appendingPathComponent("app.zip")
       try ZipService.createZip(
         source: logFolderURL,
@@ -91,12 +103,9 @@ import SystemPackage
       case documentDirectoryNotAvailable
     }
 
-    static func export(to archiveURL: URL) async throws {
-      guard let logFolderURL = SharedAccess.logFolderURL
-      else {
-        throw ExportError.invalidSourceDirectory
-      }
-
+    // @concurrent: zipping a large log tree must not run on the main actor.
+    @concurrent
+    static func export(to archiveURL: URL, from logFolderURL: URL) async throws {
       // Remove existing archive if it exists
       try? fileManager.removeItem(at: archiveURL)
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -19,21 +19,21 @@
   extension Store {
     /// A `Store` wired to mock dependencies for the `--mock-tunnel` demo.
     #if os(macOS)
-      public static func mock(logDirectory: URL = MockFixtures.makeLogDirectory()) -> Store {
+      public static func mock(logDirectory: URL? = nil) -> Store {
         Store(
           sessionNotification: MockSessionNotification(),
           systemExtensionManager: MockSystemExtensionManager(),
           updateChecker: MockUpdateChecker(),
           tunnelManagerFactory: MockTunnelProviderManagerFactory(),
-          logDirectory: logDirectory
+          logDirectory: logDirectory ?? MockFixtures.makeLogDirectory()
         )
       }
     #else
-      public static func mock(logDirectory: URL = MockFixtures.makeLogDirectory()) -> Store {
+      public static func mock(logDirectory: URL? = nil) -> Store {
         Store(
           sessionNotification: MockSessionNotification(),
           tunnelManagerFactory: MockTunnelProviderManagerFactory(),
-          logDirectory: logDirectory
+          logDirectory: logDirectory ?? MockFixtures.makeLogDirectory()
         )
       }
     #endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -45,7 +45,10 @@
 
     /// Drops to zero when a clear is acknowledged, so the settings screen shows
     /// the size a real provider would report afterwards.
-    private var providerLogFolderSize = MockFixtures.providerLogFolderSize
+    ///
+    /// nonisolated(unsafe): the session is Sendable, but the mock is only ever
+    /// driven from the main actor.
+    private nonisolated(unsafe) var providerLogFolderSize = MockFixtures.providerLogFolderSize
 
     // swiftlint:disable:next discouraged_optional_collection
     func startTunnel(options: [String: Any]?) throws {}
@@ -197,7 +200,9 @@
     /// The provider streams the bytes of a ZIP archive, so answer with the
     /// smallest valid one: an empty end-of-central-directory record. An export
     /// produced against the mock then unzips cleanly.
-    static let exportedTunnelLogs = Data([0x50, 0x4B, 0x05, 0x06] + [UInt8](repeating: 0, count: 18))
+    static let exportedTunnelLogs = Data(
+      [0x50, 0x4B, 0x05, 0x06] + [UInt8](repeating: 0, count: 18)
+    )
 
     /// A throwaway log directory seeded with two files of fixed contents, so
     /// the computed app-side log size is real and deterministic.

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -87,8 +87,26 @@
           Log.warning("MockTunnelSession: failed to encode state updates: \(error)")
           responseHandler(nil)
         }
-      case .setInternetResourceEnabled, .signOut, .clearLogs, .getLogFolderSize, .exportLogs,
-        .getEncodedFirezoneId, .drainFlowLogs:
+      case .getLogFolderSize:
+        // The provider answers with the raw bytes of an `Int64`.
+        responseHandler(withUnsafeBytes(of: MockFixtures.providerLogFolderSize) { Data($0) })
+      case .clearLogs:
+        // The provider answers a successful clear with an empty response.
+        responseHandler(nil)
+      case .exportLogs:
+        // The provider streams plist-encoded `LogChunk`s; everything fits in one
+        // final chunk here.
+        do {
+          responseHandler(
+            try PropertyListEncoder().encode(
+              LogChunk(done: true, data: MockFixtures.exportedTunnelLogs)
+            )
+          )
+        } catch {
+          Log.warning("MockTunnelSession: failed to encode the log chunk: \(error)")
+          responseHandler(nil)
+        }
+      case .setInternetResourceEnabled, .signOut, .getEncodedFirezoneId, .drainFlowLogs:
         responseHandler(nil)
       }
     }
@@ -168,6 +186,11 @@
   }
 
   private enum MockFixtures {
+    /// 30 MB, so the settings screen shows a believable provider-side log size.
+    static let providerLogFolderSize: Int64 = 30_000_000
+
+    static let exportedTunnelLogs = Data("Mock tunnel log archive\n".utf8)
+
     /// A throwaway log directory seeded with two files of fixed contents, so
     /// the computed app-side log size is real and deterministic.
     static func makeLogDirectory() -> URL {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -24,14 +24,16 @@
           sessionNotification: MockSessionNotification(),
           systemExtensionManager: MockSystemExtensionManager(),
           updateChecker: MockUpdateChecker(),
-          tunnelManagerFactory: MockTunnelProviderManagerFactory()
+          tunnelManagerFactory: MockTunnelProviderManagerFactory(),
+          logDirectory: MockFixtures.makeLogDirectory()
         )
       }
     #else
       public static func mock() -> Store {
         Store(
           sessionNotification: MockSessionNotification(),
-          tunnelManagerFactory: MockTunnelProviderManagerFactory()
+          tunnelManagerFactory: MockTunnelProviderManagerFactory(),
+          logDirectory: MockFixtures.makeLogDirectory()
         )
       }
     #endif
@@ -166,6 +168,26 @@
   }
 
   private enum MockFixtures {
+    /// A throwaway log directory seeded with two files of fixed contents, so
+    /// the computed app-side log size is real and deterministic.
+    static func makeLogDirectory() -> URL {
+      let fileManager = FileManager.default
+      let directory = fileManager.temporaryDirectory
+        .appendingPathComponent("firezone-mock-logs-\(UUID().uuidString)")
+
+      do {
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data("2026-01-01T00:00:00 INFO Connected to the portal\n".utf8)
+          .write(to: directory.appendingPathComponent("app.log"))
+        try Data("2026-01-01T00:00:00 DEBUG Tunnel interface is up\n".utf8)
+          .write(to: directory.appendingPathComponent("connlib.log"))
+      } catch {
+        Log.warning("MockFixtures: failed to seed the log directory: \(error)")
+      }
+
+      return directory
+    }
+
     static let resources: [Resource] = {
       let site = Site(id: "demo-site", name: "Demo Site")
       return [

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -19,21 +19,21 @@
   extension Store {
     /// A `Store` wired to mock dependencies for the `--mock-tunnel` demo.
     #if os(macOS)
-      public static func mock() -> Store {
+      public static func mock(logDirectory: URL = MockFixtures.makeLogDirectory()) -> Store {
         Store(
           sessionNotification: MockSessionNotification(),
           systemExtensionManager: MockSystemExtensionManager(),
           updateChecker: MockUpdateChecker(),
           tunnelManagerFactory: MockTunnelProviderManagerFactory(),
-          logDirectory: MockFixtures.makeLogDirectory()
+          logDirectory: logDirectory
         )
       }
     #else
-      public static func mock() -> Store {
+      public static func mock(logDirectory: URL = MockFixtures.makeLogDirectory()) -> Store {
         Store(
           sessionNotification: MockSessionNotification(),
           tunnelManagerFactory: MockTunnelProviderManagerFactory(),
-          logDirectory: MockFixtures.makeLogDirectory()
+          logDirectory: logDirectory
         )
       }
     #endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -43,6 +43,10 @@
   private final class MockTunnelSession: TunnelSessionProtocol {
     var status: NEVPNStatus { .connected }
 
+    /// Drops to zero when a clear is acknowledged, so the settings screen shows
+    /// the size a real provider would report afterwards.
+    private var providerLogFolderSize = MockFixtures.providerLogFolderSize
+
     // swiftlint:disable:next discouraged_optional_collection
     func startTunnel(options: [String: Any]?) throws {}
     func stopTunnel() {}
@@ -89,9 +93,10 @@
         }
       case .getLogFolderSize:
         // The provider answers with the raw bytes of an `Int64`.
-        responseHandler(withUnsafeBytes(of: MockFixtures.providerLogFolderSize) { Data($0) })
+        responseHandler(withUnsafeBytes(of: providerLogFolderSize) { Data($0) })
       case .clearLogs:
         // The provider answers a successful clear with an empty response.
+        providerLogFolderSize = 0
         responseHandler(nil)
       case .exportLogs:
         // The provider streams plist-encoded `LogChunk`s; everything fits in one
@@ -189,7 +194,10 @@
     /// 30 MB, so the settings screen shows a believable provider-side log size.
     static let providerLogFolderSize: Int64 = 30_000_000
 
-    static let exportedTunnelLogs = Data("Mock tunnel log archive\n".utf8)
+    /// The provider streams the bytes of a ZIP archive, so answer with the
+    /// smallest valid one: an empty end-of-central-directory record. An export
+    /// produced against the mock then unzips cleanly.
+    static let exportedTunnelLogs = Data([0x50, 0x4B, 0x05, 0x06] + [UInt8](repeating: 0, count: 18))
 
     /// A throwaway log directory seeded with two files of fixed contents, so
     /// the computed app-side log size is real and deterministic.

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -48,7 +48,7 @@
     ///
     /// nonisolated(unsafe): the session is Sendable, but the mock is only ever
     /// driven from the main actor.
-    private nonisolated(unsafe) var providerLogFolderSize = MockFixtures.providerLogFolderSize
+    nonisolated(unsafe) private var providerLogFolderSize = MockFixtures.providerLogFolderSize
 
     // swiftlint:disable:next discouraged_optional_collection
     func startTunnel(options: [String: Any]?) throws {}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -89,6 +89,15 @@ public final class Store: ObservableObject {
   /// UserDefaults instance for persisting GUI state.
   let userDefaults: UserDefaults
 
+  /// Overrides the app-side log directory; `SharedAccess.logFolderURL` applies when nil.
+  private let logDirectoryOverride: URL?
+
+  // Resolved lazily: the app group container behind `SharedAccess.logFolderURL` is
+  // unavailable outside a provisioned app bundle.
+  private var logDirectory: URL? {
+    logDirectoryOverride ?? SharedAccess.logFolderURL
+  }
+
   // Task consuming VPN status updates; its presence means observers are active.
   private var vpnStatusTask: CancellableTask?
 
@@ -99,6 +108,7 @@ public final class Store: ObservableObject {
       systemExtensionManager: (any SystemExtensionManagerProtocol)? = nil,
       updateChecker: (any UpdateCheckerProtocol)? = nil,
       tunnelManagerFactory: TunnelProviderManagerFactory = NETunnelProviderManagerFactory(),
+      logDirectory: URL? = nil,
       // swiftlint:disable:next no_userdefaults_standard
       userDefaults: UserDefaults = .standard
     ) {
@@ -108,6 +118,7 @@ public final class Store: ObservableObject {
       self.sessionNotification = sessionNotification
       self.systemExtensionManager = systemExtensionManager ?? SystemExtensionManager()
       self.tunnelManagerFactory = tunnelManagerFactory
+      self.logDirectoryOverride = logDirectory
       self.userDefaults = userDefaults
       self.favorites = Favorites(userDefaults: userDefaults)
       self.actorName = self.configuration.actorName
@@ -119,12 +130,14 @@ public final class Store: ObservableObject {
       configuration: Configuration? = nil,
       sessionNotification: SessionNotificationProtocol = SessionNotification(),
       tunnelManagerFactory: TunnelProviderManagerFactory = NETunnelProviderManagerFactory(),
+      logDirectory: URL? = nil,
       // swiftlint:disable:next no_userdefaults_standard
       userDefaults: UserDefaults = .standard
     ) {
       self.configuration = configuration ?? Configuration.shared
       self.sessionNotification = sessionNotification
       self.tunnelManagerFactory = tunnelManagerFactory
+      self.logDirectoryOverride = logDirectory
       self.userDefaults = userDefaults
       self.favorites = Favorites(userDefaults: userDefaults)
       self.actorName = self.configuration.actorName
@@ -622,12 +635,82 @@ public final class Store: ObservableObject {
     try await IPCClient.signOut(session: session)
   }
 
-  func clearLogs() async throws {
-    guard let session = try manager().session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-    try await IPCClient.clearLogs(session: session)
+  // Calculates the total size of our logs by summing the size of the
+  // app, tunnel, and connlib log directories.
+  //
+  // On iOS, the log directory is a single folder that contains all three
+  // directories, but on macOS, the app log directory lives in a different
+  // Group Container than tunnel and connlib directories, so we use IPC to make
+  // a call to sum both the tunnel and connlib directories.
+  //
+  // Unfortunately the IPC method doesn't work on iOS because the tunnel process
+  // is not started on demand, so the IPC calls hang. Thus, we use separate code
+  // paths for iOS and macOS.
+  func logDirectorySize() async -> UInt64? {
+    guard let logDirectory else { return nil }
+
+    let appLogSize = await Log.size(of: logDirectory)
+
+    #if os(macOS)
+      do {
+        guard let session = try manager().session() else {
+          throw VPNConfigurationManagerError.managerNotInitialized
+        }
+
+        let providerLogSize = try await IPCClient.getLogFolderSize(session: session)
+
+        return UInt64(clamping: appLogSize + providerLogSize)
+      } catch {
+        if let error = error as? IPCClient.Error,
+          case IPCClient.Error.noIPCData = error
+        {
+          // Will happen if the extension is not enabled
+          Log.warning("\(#function): Unable to count logs: \(error). Is the XPC service running?")
+        } else {
+          Log.error(error)
+        }
+
+        return nil
+      }
+    #else
+      return UInt64(clamping: appLogSize)
+    #endif
   }
+
+  // On iOS, all the logs are stored in one directory.
+  // On macOS, we clear logs from the app process, then call over IPC
+  // to clear the provider's log directory.
+  func clearLogs() async throws {
+    try Log.clear(in: logDirectory)
+
+    #if os(macOS)
+      guard let session = try manager().session() else {
+        throw VPNConfigurationManagerError.managerNotInitialized
+      }
+
+      try await IPCClient.clearLogs(session: session)
+    #endif
+  }
+
+  #if os(macOS)
+    func exportLogs(to destination: URL) async throws {
+      guard let session = try manager().session() else {
+        throw VPNConfigurationManagerError.managerNotInitialized
+      }
+
+      try await LogExporter.export(to: destination, session: session)
+    }
+  #endif
+
+  #if os(iOS)
+    /// Exports the logs to a temporary archive and returns its URL.
+    func exportLogs() async throws -> URL {
+      let archiveURL = try LogExporter.tempFile()
+      try await LogExporter.export(to: archiveURL)
+
+      return archiveURL
+    }
+  #endif
 
   // MARK: Private functions
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -89,14 +89,8 @@ public final class Store: ObservableObject {
   /// UserDefaults instance for persisting GUI state.
   let userDefaults: UserDefaults
 
-  /// Overrides the app-side log directory; `SharedAccess.logFolderURL` applies when nil.
-  private let logDirectoryOverride: URL?
-
-  // Resolved lazily: the app group container behind `SharedAccess.logFolderURL` is
-  // unavailable outside a provisioned app bundle.
-  private var logDirectory: URL? {
-    logDirectoryOverride ?? SharedAccess.logFolderURL
-  }
+  /// The app-side log directory; nil when the app group container is unavailable.
+  private let logDirectory: URL?
 
   // Task consuming VPN status updates; its presence means observers are active.
   private var vpnStatusTask: CancellableTask?
@@ -108,7 +102,7 @@ public final class Store: ObservableObject {
       systemExtensionManager: (any SystemExtensionManagerProtocol)? = nil,
       updateChecker: (any UpdateCheckerProtocol)? = nil,
       tunnelManagerFactory: TunnelProviderManagerFactory = NETunnelProviderManagerFactory(),
-      logDirectory: URL? = nil,
+      logDirectory: URL? = SharedAccess.logFolderURL,
       // swiftlint:disable:next no_userdefaults_standard
       userDefaults: UserDefaults = .standard
     ) {
@@ -118,7 +112,7 @@ public final class Store: ObservableObject {
       self.sessionNotification = sessionNotification
       self.systemExtensionManager = systemExtensionManager ?? SystemExtensionManager()
       self.tunnelManagerFactory = tunnelManagerFactory
-      self.logDirectoryOverride = logDirectory
+      self.logDirectory = logDirectory
       self.userDefaults = userDefaults
       self.favorites = Favorites(userDefaults: userDefaults)
       self.actorName = self.configuration.actorName
@@ -130,14 +124,14 @@ public final class Store: ObservableObject {
       configuration: Configuration? = nil,
       sessionNotification: SessionNotificationProtocol = SessionNotification(),
       tunnelManagerFactory: TunnelProviderManagerFactory = NETunnelProviderManagerFactory(),
-      logDirectory: URL? = nil,
+      logDirectory: URL? = SharedAccess.logFolderURL,
       // swiftlint:disable:next no_userdefaults_standard
       userDefaults: UserDefaults = .standard
     ) {
       self.configuration = configuration ?? Configuration.shared
       self.sessionNotification = sessionNotification
       self.tunnelManagerFactory = tunnelManagerFactory
-      self.logDirectoryOverride = logDirectory
+      self.logDirectory = logDirectory
       self.userDefaults = userDefaults
       self.favorites = Favorites(userDefaults: userDefaults)
       self.actorName = self.configuration.actorName

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -675,7 +675,12 @@ public final class Store: ObservableObject {
   // On macOS, we clear logs from the app process, then call over IPC
   // to clear the provider's log directory.
   func clearLogs() async throws {
-    try Log.clear(in: logDirectory)
+    // Deleting a large log tree is blocking filesystem work, so keep it off the
+    // main actor and hop back for the provider IPC.
+    let logDirectory = self.logDirectory
+    try await Task.detached {
+      try Log.clear(in: logDirectory)
+    }.value
 
     #if os(macOS)
       guard let session = try manager().session() else {
@@ -688,19 +693,26 @@ public final class Store: ObservableObject {
 
   #if os(macOS)
     func exportLogs(to destination: URL) async throws {
+      guard let logDirectory else {
+        throw LogExporter.ExportError.invalidSourceDirectory
+      }
       guard let session = try manager().session() else {
         throw VPNConfigurationManagerError.managerNotInitialized
       }
 
-      try await LogExporter.export(to: destination, session: session)
+      try await LogExporter.export(to: destination, from: logDirectory, session: session)
     }
   #endif
 
   #if os(iOS)
     /// Exports the logs to a temporary archive and returns its URL.
     func exportLogs() async throws -> URL {
+      guard let logDirectory else {
+        throw LogExporter.ExportError.invalidSourceDirectory
+      }
+
       let archiveURL = try LogExporter.tempFile()
-      try await LogExporter.export(to: archiveURL)
+      try await LogExporter.export(to: archiveURL, from: logDirectory)
 
       return archiveURL
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/ViewModels/SettingsViewModel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/ViewModels/SettingsViewModel.swift
@@ -10,7 +10,9 @@ import Foundation
 @MainActor
 class SettingsViewModel: ObservableObject {
   private let configuration: Configuration
+  private let store: Store?
   private var cancellables: Set<AnyCancellable> = []
+  private var logDirectorySizeTask: Task<Void, Never>?
 
   @Published private(set) var shouldDisableApplyButton = false
   @Published private(set) var shouldDisableResetButton = false
@@ -21,8 +23,27 @@ class SettingsViewModel: ObservableObject {
   @Published var connectOnStart: Bool
   @Published var startOnLogin: Bool
 
-  init(configuration: Configuration? = nil) {
-    self.configuration = configuration ?? Configuration.shared
+  /// Formatted size of the log directories; nil while a computation is running.
+  @Published private(set) var logDirectorySizeText: String?
+  @Published private(set) var isClearingLogs = false
+
+  // Spans the whole export interaction, so the presentation flows (save panel,
+  // share sheet) drive it from the view.
+  @Published var isExportingLogs = false
+
+  private static let logSizeFormatter: ByteCountFormatter = {
+    let formatter = ByteCountFormatter()
+    formatter.countStyle = .file
+    formatter.allowsNonnumericFormatting = false
+    formatter.allowedUnits = [.useKB, .useMB, .useGB, .useTB, .usePB]
+    return formatter
+  }()
+
+  /// `store` powers the diagnostic logs actions; without one they report an
+  /// unknown size and clear nothing.
+  init(configuration: Configuration? = nil, store: Store? = nil) {
+    self.configuration = configuration ?? store?.configuration ?? Configuration.shared
+    self.store = store
 
     authURL = self.configuration.authURL
     apiURL = self.configuration.apiURL
@@ -87,6 +108,46 @@ class SettingsViewModel: ObservableObject {
     if !configuration.isStartOnLoginForced { configuration.startOnLogin = startOnLogin }
 
     updateDerivedState()
+  }
+
+  func refreshLogDirectorySize() {
+    logDirectorySizeTask?.cancel()
+    logDirectorySizeText = nil
+
+    logDirectorySizeTask = Task {
+      let size = await store?.logDirectorySize()
+
+      guard !Task.isCancelled else { return }
+
+      logDirectorySizeText =
+        size.map { Self.logSizeFormatter.string(fromByteCount: Int64(clamping: $0)) } ?? "Unknown"
+    }
+  }
+
+  func cancelLogDirectorySizeRefresh() {
+    logDirectorySizeTask?.cancel()
+  }
+
+  func clearLogs() {
+    guard !isClearingLogs else { return }
+
+    isClearingLogs = true
+    logDirectorySizeTask?.cancel()
+
+    Task {
+      do {
+        try await store?.clearLogs()
+      } catch {
+        Log.error(error)
+      }
+
+      isClearingLogs = false
+      refreshLogDirectorySize()
+    }
+  }
+
+  func logArchiveFileName() -> String {
+    "firezone_logs_\(LogExporter.now()).zip"
   }
 
   func isAllForced() -> Bool {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -56,14 +56,8 @@ public struct SettingsView: View {
     }
   }
 
-  @State private var isCalculatingLogsSize = false
-  @State private var calculatedLogsSize = "Unknown"
-  @State private var isClearingLogs = false
-  @State private var isExportingLogs = false
   @State private var isShowingConfirmationAlert = false
   @State private var confirmationAlertContinueAction: ConfirmationAlertContinueAction = .none
-
-  @State private var calculateLogSizeTask: Task<(), Never>?
 
   @State private var selectedTab: Tab
 
@@ -98,7 +92,7 @@ public struct SettingsView: View {
   public init(store: Store, selectedTab: Tab = .general) {
     self.store = store
     self.configuration = store.configuration
-    _viewModel = StateObject(wrappedValue: SettingsViewModel())
+    _viewModel = StateObject(wrappedValue: SettingsViewModel(store: store))
     _selectedTab = State(initialValue: selectedTab)
   }
 
@@ -456,24 +450,21 @@ public struct SettingsView: View {
       VStack {
         Form {
           Section(header: Text("Logs")) {
-            LogDirectorySizeView(
-              isProcessing: $isCalculatingLogsSize,
-              sizeString: $calculatedLogsSize
-            )
-            .onAppear {
-              self.refreshLogSize()
-            }
-            .onDisappear {
-              self.cancelRefreshLogSize()
-            }
+            LogDirectorySizeView(sizeText: viewModel.logDirectorySizeText)
+              .onAppear {
+                viewModel.refreshLogDirectorySize()
+              }
+              .onDisappear {
+                viewModel.cancelLogDirectorySizeRefresh()
+              }
             HStack {
               Spacer()
               ButtonWithProgress(
                 systemImageName: "trash",
                 title: "Clear Log Directory",
-                isProcessing: $isClearingLogs,
+                isProcessing: viewModel.isClearingLogs,
                 action: {
-                  self.clearLogFiles()
+                  viewModel.clearLogs()
                 }
               )
               Spacer()
@@ -485,15 +476,17 @@ public struct SettingsView: View {
               ButtonWithProgress(
                 systemImageName: "arrow.up.doc",
                 title: "Export Logs",
-                isProcessing: $isExportingLogs,
+                isProcessing: viewModel.isExportingLogs,
                 action: {
-                  self.isExportingLogs = true
-                  Task.detached(priority: .background) {
-                    let archiveURL = try LogExporter.tempFile()
-                    try await LogExporter.export(to: archiveURL)
-                    await MainActor.run {
+                  viewModel.isExportingLogs = true
+                  Task {
+                    do {
+                      let archiveURL = try await store.exportLogs()
                       self.logTempZipFileURL = archiveURL
                       self.isPresentingExportLogShareSheet = true
+                    } catch {
+                      Log.error(error)
+                      viewModel.isExportingLogs = false
                     }
                   }
                 }
@@ -504,13 +497,13 @@ public struct SettingsView: View {
                     localFileURL: logfileURL,
                     completionHandler: {
                       self.isPresentingExportLogShareSheet = false
-                      self.isExportingLogs = false
+                      viewModel.isExportingLogs = false
                       self.logTempZipFileURL = nil
                     }
                   )
                   .onDisappear {
                     self.isPresentingExportLogShareSheet = false
-                    self.isExportingLogs = false
+                    viewModel.isExportingLogs = false
                     self.logTempZipFileURL = nil
                   }
                 }
@@ -523,29 +516,26 @@ public struct SettingsView: View {
     #elseif os(macOS)
       VStack {
         VStack(alignment: .leading, spacing: 10) {
-          LogDirectorySizeView(
-            isProcessing: $isCalculatingLogsSize,
-            sizeString: $calculatedLogsSize
-          )
-          .onAppear {
-            self.refreshLogSize()
-          }
-          .onDisappear {
-            self.cancelRefreshLogSize()
-          }
+          LogDirectorySizeView(sizeText: viewModel.logDirectorySizeText)
+            .onAppear {
+              viewModel.refreshLogDirectorySize()
+            }
+            .onDisappear {
+              viewModel.cancelLogDirectorySizeRefresh()
+            }
           HStack(spacing: 30) {
             ButtonWithProgress(
               systemImageName: "trash",
               title: "Clear Log Directory",
-              isProcessing: $isClearingLogs,
+              isProcessing: viewModel.isClearingLogs,
               action: {
-                self.clearLogFiles()
+                viewModel.clearLogs()
               }
             )
             ButtonWithProgress(
               systemImageName: "arrow.up.doc",
               title: "Export Logs",
-              isProcessing: $isExportingLogs,
+              isProcessing: viewModel.isExportingLogs,
               action: {
                 self.exportLogsWithSavePanelOnMac()
               }
@@ -565,44 +555,36 @@ public struct SettingsView: View {
 
   #if os(macOS)
     private func exportLogsWithSavePanelOnMac() {
-      self.isExportingLogs = true
+      viewModel.isExportingLogs = true
 
       let savePanel = NSSavePanel()
       savePanel.prompt = "Save"
       savePanel.nameFieldLabel = "Save log archive to:"
-      let fileName = "firezone_logs_\(LogExporter.now()).zip"
-
-      savePanel.nameFieldStringValue = fileName
+      savePanel.nameFieldStringValue = viewModel.logArchiveFileName()
 
       guard
         let window = NSApp.windows.first(where: {
           $0.identifier?.rawValue.hasPrefix("firezone-settings") ?? false
         })
       else {
-        self.isExportingLogs = false
+        viewModel.isExportingLogs = false
         Log.log("Settings window not found. Can't show save panel.")
         return
       }
 
       savePanel.beginSheetModal(for: window) { response in
         guard response == .OK else {
-          self.isExportingLogs = false
+          viewModel.isExportingLogs = false
           return
         }
         guard let destinationURL = savePanel.url else {
-          self.isExportingLogs = false
+          viewModel.isExportingLogs = false
           return
         }
 
         Task {
           do {
-            guard let session = try store.manager().session() else {
-              throw VPNConfigurationManagerError.managerNotInitialized
-            }
-            try await LogExporter.export(
-              to: destinationURL,
-              session: session
-            )
+            try await store.exportLogs(to: destinationURL)
 
             window.contentViewController?.presentingViewController?.dismiss(self)
           } catch {
@@ -618,113 +600,14 @@ public struct SettingsView: View {
             MacOSAlert.show(for: error)
           }
 
-          self.isExportingLogs = false
+          viewModel.isExportingLogs = false
         }
       }
     }
   #endif
 
-  private func refreshLogSize() {
-    guard !self.isCalculatingLogsSize else {
-      return
-    }
-    self.isCalculatingLogsSize = true
-    self.calculateLogSizeTask =
-      Task.detached(priority: .background) {
-        let calculatedLogsSize = await calculateLogDirSize()
-        await MainActor.run {
-          self.calculatedLogsSize = calculatedLogsSize
-          self.isCalculatingLogsSize = false
-          self.calculateLogSizeTask = nil
-        }
-      }
-  }
-
-  private func cancelRefreshLogSize() {
-    self.calculateLogSizeTask?.cancel()
-  }
-
-  private func clearLogFiles() {
-    self.isClearingLogs = true
-    self.cancelRefreshLogSize()
-    Task.detached(priority: .background) {
-      do { try await clearAllLogs() } catch { Log.error(error) }
-      await MainActor.run {
-        self.isClearingLogs = false
-        if !self.isCalculatingLogsSize {
-          self.refreshLogSize()
-        }
-      }
-    }
-  }
-
   private func saveSettings() async throws {
     try await viewModel.save()
-  }
-
-  // Calculates the total size of our logs by summing the size of the
-  // app, tunnel, and connlib log directories.
-  //
-  // On iOS, SharedAccess.logFolderURL is a single folder that contains all
-  // three directories, but on macOS, the app log directory lives in a different
-  // Group Container than tunnel and connlib directories, so we use IPC to make
-  // a call to sum both the tunnel and connlib directories.
-  //
-  // Unfortunately the IPC method doesn't work on iOS because the tunnel process
-  // is not started on demand, so the IPC calls hang. Thus, we use separate code
-  // paths for iOS and macOS.
-  private func calculateLogDirSize() async -> String {
-    Log.log("\(#function)")
-
-    guard let logFilesFolderURL = SharedAccess.logFolderURL else {
-      return "Unknown"
-    }
-
-    let logFolderSize = await Log.size(of: logFilesFolderURL)
-
-    do {
-      #if os(macOS)
-        guard let session = try store.manager().session() else {
-          throw VPNConfigurationManagerError.managerNotInitialized
-        }
-        let providerLogFolderSize = try await IPCClient.getLogFolderSize(session: session)
-        let totalSize = logFolderSize + providerLogFolderSize
-      #else
-        let totalSize = logFolderSize
-      #endif
-
-      let byteCountFormatter = ByteCountFormatter()
-      byteCountFormatter.countStyle = .file
-      byteCountFormatter.allowsNonnumericFormatting = false
-      byteCountFormatter.allowedUnits = [.useKB, .useMB, .useGB, .useTB, .usePB]
-
-      return byteCountFormatter.string(fromByteCount: Int64(totalSize))
-
-    } catch {
-      if let error = error as? IPCClient.Error,
-        case IPCClient.Error.noIPCData = error
-      {
-        // Will happen if the extension is not enabled
-        Log.warning("\(#function): Unable to count logs: \(error). Is the XPC service running?")
-      } else {
-        Log.error(error)
-      }
-
-      return "Unknown"
-    }
-  }
-
-  // On iOS, all the logs are stored in one directory.
-  // On macOS, we need to clear logs from the app process, then call over IPC
-  // to clear the provider's log directory.
-  private func clearAllLogs() async throws {
-    Log.log("\(#function)")
-
-    try Log.clear(in: SharedAccess.logFolderURL)
-
-    #if os(macOS)
-      try await store.clearLogs()
-    #endif
   }
 
   private func withErrorHandler(action: @escaping () async throws -> Void) {
@@ -746,7 +629,7 @@ public struct SettingsView: View {
 struct ButtonWithProgress: View {
   let systemImageName: String
   let title: String
-  @Binding var isProcessing: Bool
+  let isProcessing: Bool
   let action: () -> Void
 
   var body: some View {
@@ -774,8 +657,8 @@ struct ButtonWithProgress: View {
 }
 
 struct LogDirectorySizeView: View {
-  @Binding var isProcessing: Bool
-  @Binding var sizeString: String
+  /// nil while the size is being computed.
+  let sizeText: String?
 
   var body: some View {
     HStack(spacing: 10) {
@@ -794,14 +677,10 @@ struct LogDirectorySizeView: View {
       #endif
       Label(
         title: {
-          if isProcessing {
-            Text("")
-          } else {
-            Text(sizeString)
-          }
+          Text(sizeText ?? "")
         },
         icon: {
-          if isProcessing {
+          if sizeText == nil {
             ProgressView().controlSize(.small)
               .frame(maxWidth: 12, maxHeight: 12)
           }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -30,48 +30,6 @@ enum SettingsViewError: Error {
   }
 }
 
-extension FileManager {
-  enum FileManagerError: Error {
-    case invalidURL(URL, Error)
-
-    var localizedDescription: String {
-      switch self {
-      case .invalidURL(let url, let error):
-        return "Unable to get resource value for '\(url)': \(error)"
-      }
-    }
-  }
-
-  func forEachFileUnder(
-    _ dirURL: URL,
-    including resourceKeys: Set<URLResourceKey>,
-    handler: (URL, URLResourceValues) -> Void
-  ) {
-    // Deep-traverses the directory at dirURL
-    guard
-      let enumerator = self.enumerator(
-        at: dirURL,
-        includingPropertiesForKeys: [URLResourceKey](resourceKeys),
-        options: [],
-        errorHandler: nil
-      )
-    else {
-      return
-    }
-
-    for item in enumerator.enumerated() {
-      if Task.isCancelled { break }
-      guard let url = item.element as? URL else { continue }
-      do {
-        let resourceValues = try url.resourceValues(forKeys: resourceKeys)
-        handler(url, resourceValues)
-      } catch {
-        Log.error(FileManagerError.invalidURL(url, error))
-      }
-    }
-  }
-}
-
 // TODO: Move business logic to ViewModel to remove dependency on Store and fix body length
 public struct SettingsView: View {
   @StateObject private var viewModel: SettingsViewModel

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreDiagnosticLogsTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreDiagnosticLogsTests.swift
@@ -63,8 +63,8 @@
       let archive = try Data(contentsOf: destination)
       #expect(archive.prefix(4) == Data([0x50, 0x4B, 0x03, 0x04]))
       // ZIP entry names are stored uncompressed, so the members are findable as bytes.
-      #expect(archive.range(of: Data("tunnel.zip".utf8)) != nil)
-      #expect(archive.range(of: Data("app.zip".utf8)) != nil)
+      #expect(archive.firstRange(of: Data("tunnel.zip".utf8)) != nil)
+      #expect(archive.firstRange(of: Data("app.zip".utf8)) != nil)
     }
 
     @Test("the view model publishes the size and the clearing state")

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreDiagnosticLogsTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreDiagnosticLogsTests.swift
@@ -1,0 +1,114 @@
+//
+//  StoreDiagnosticLogsTests.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+#if os(macOS)
+  import Foundation
+  import Testing
+
+  @testable import FirezoneKit
+
+  /// Exercises the diagnostic-log operations end to end against the mocked extension:
+  /// through `Store`, `IPCClient`'s provider messages, and the mock session's answers.
+  ///
+  /// Serialised because every `Store` loads into the process-wide `Configuration`.
+  @MainActor
+  @Suite("Store diagnostic logs", .serialized)
+  struct StoreDiagnosticLogsTests {
+    /// The mock provider reports 30 MB; the mock log directory holds two 49-byte lines.
+    private static let mockLogBytes: UInt64 = 30_000_000 + 98
+
+    @Test("sums the app logs and the provider's report")
+    func sumsAppAndProviderSizes() async throws {
+      let store = Store.mock()
+      try await store.installVPNConfiguration()
+
+      let size = await store.logDirectorySize()
+
+      #expect(size == Self.mockLogBytes)
+    }
+
+    @Test("reports no size without a VPN configuration")
+    func reportsNoSizeWithoutConfiguration() async throws {
+      let store = Store.mock()
+
+      let size = await store.logDirectorySize()
+
+      #expect(size == nil)
+    }
+
+    @Test("clearing empties both sides")
+    func clearingEmptiesBothSides() async throws {
+      let store = Store.mock()
+      try await store.installVPNConfiguration()
+
+      try await store.clearLogs()
+
+      let size = await store.logDirectorySize()
+      #expect(size == 0)
+    }
+
+    @Test("exports an archive holding the app and tunnel logs")
+    func exportsAnArchive() async throws {
+      let store = Store.mock()
+      try await store.installVPNConfiguration()
+      let destination = FileManager.default.temporaryDirectory
+        .appendingPathComponent("firezone-export-\(UUID().uuidString).zip")
+      defer { try? FileManager.default.removeItem(at: destination) }
+
+      try await store.exportLogs(to: destination)
+
+      let archive = try Data(contentsOf: destination)
+      #expect(archive.prefix(4) == Data([0x50, 0x4B, 0x03, 0x04]))
+      // ZIP entry names are stored uncompressed, so the members are findable as bytes.
+      #expect(archive.range(of: Data("tunnel.zip".utf8)) != nil)
+      #expect(archive.range(of: Data("app.zip".utf8)) != nil)
+    }
+
+    @Test("the view model publishes the size and the clearing state")
+    func viewModelDrivesTheLogsState() async throws {
+      let store = Store.mock()
+      try await store.installVPNConfiguration()
+      let model = SettingsViewModel(store: store)
+
+      model.refreshLogDirectorySize()
+      try await waitUntil { model.logDirectorySizeText != nil }
+      let sizeBeforeClear = model.logDirectorySizeText
+      #expect(sizeBeforeClear != "Unknown")
+
+      model.clearLogs()
+      #expect(model.isClearingLogs)
+
+      try await waitUntil { !model.isClearingLogs }
+      try await waitUntil { model.logDirectorySizeText != nil }
+      #expect(model.logDirectorySizeText != sizeBeforeClear)
+    }
+
+    @Test("the view model reports an unknown size without a store")
+    func viewModelWithoutStoreReportsUnknown() async throws {
+      let model = SettingsViewModel(store: nil)
+
+      model.refreshLogDirectorySize()
+
+      try await waitUntil { model.logDirectorySizeText != nil }
+      #expect(model.logDirectorySizeText == "Unknown")
+    }
+
+    private func waitUntil(
+      timeout: Duration = .seconds(5),
+      _ condition: @MainActor () -> Bool
+    ) async throws {
+      let clock = ContinuousClock()
+      let deadline = clock.now.advanced(by: timeout)
+
+      while !condition() {
+        guard clock.now < deadline else { throw TimeoutError() }
+        try await Task.sleep(for: .milliseconds(10))
+      }
+    }
+
+    private struct TimeoutError: Error {}
+  }
+#endif

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreDiagnosticLogsTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreDiagnosticLogsTests.swift
@@ -17,17 +17,33 @@
   @MainActor
   @Suite("Store diagnostic logs", .serialized)
   struct StoreDiagnosticLogsTests {
-    /// The mock provider reports 30 MB; the mock log directory holds two 49-byte lines.
-    private static let mockLogBytes: UInt64 = 30_000_000 + 98
+    /// What the mock provider reports over IPC.
+    private static let providerLogBytes: UInt64 = 30_000_000
 
-    @Test("sums the app logs and the provider's report")
-    func sumsAppAndProviderSizes() async throws {
-      let store = Store.mock()
+    @Test("reports exactly the provider's size for an empty app log directory")
+    func reportsTheProviderSize() async throws {
+      let emptyDirectory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("firezone-empty-logs-\(UUID().uuidString)")
+      try FileManager.default.createDirectory(at: emptyDirectory, withIntermediateDirectories: true)
+      defer { try? FileManager.default.removeItem(at: emptyDirectory) }
+
+      let store = Store.mock(logDirectory: emptyDirectory)
       try await store.installVPNConfiguration()
 
       let size = await store.logDirectorySize()
 
-      #expect(size == Self.mockLogBytes)
+      #expect(size == Self.providerLogBytes)
+    }
+
+    @Test("counts the app logs into the total")
+    func countsAppLogsIntoTheTotal() async throws {
+      let store = Store.mock()
+      try await store.installVPNConfiguration()
+
+      // The exact app-side number depends on filesystem allocation, so only the
+      // provider baseline is pinned.
+      let size = try #require(await store.logDirectorySize())
+      #expect(size > Self.providerLogBytes)
     }
 
     @Test("reports no size without a VPN configuration")


### PR DESCRIPTION
The settings view reached `SharedAccess`, `LogExporter` and `IPCClient` directly and ran its own task juggling for the diagnostic logs. The orchestration now lives on `Store` (size, clear, export), the async state machine moves into `SettingsViewModel`, and the mock tunnel session answers the log provider messages the way a healthy extension would, so a test exercises the real path down to a mocked extension. The app-side log directory is an injected dependency, which lets the mock `Store` compute a genuine size over fixture files.

Related: #14772