### PR TITLE
feat(gui): build Windows ARM64 release

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -151,6 +151,7 @@ jobs:
         # Installing new packages can take time
         timeout-minutes: 15
       - uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2.0.0
+        if: ${{ !(runner.os == 'Windows' && matrix.arch == 'aarch64') }}
         with:
           token: ${{ secrets.SENTRY_AUTH_TOKEN }}
           organization: firezone-inc
@@ -234,7 +235,8 @@ jobs:
         run: cat 'C:/ProgramData/dev.firezone.client/data/logs/register-sparse.latest' || true
 
       - name: Upload debug symbols to Sentry
-        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
+        # setup-sentry-cli does not provide a win32/arm64 binary.
+        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && !(runner.os == 'Windows' && matrix.arch == 'aarch64') }}"
         shell: bash
         run: ${{ env.SYMBOLS_SCRIPT }}
 

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -114,6 +114,10 @@ jobs:
             arch: x86_64
             os: windows
             pkg-extension: msi
+          - runs-on: windows-11-arm
+            arch: aarch64
+            os: windows
+            pkg-extension: msi
     env:
       # mark:next-gui-version
       ARTIFACT_SRC: ./rust/gui-client/firezone-client-gui-${{ matrix.os }}_1.5.17_${{ matrix.arch }}


### PR DESCRIPTION
## Summary

- add a native Windows ARM64 runner to the GUI release matrix
- build, sign, test, and upload the ARM64 MSI through the existing release pipeline
- skip Sentry CLI setup and symbol upload on Windows ARM64 because the setup action does not support that platform