### PR TITLE
ci: authenticate the bats library downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # v4.0.0
         id: setup-bats
+        with:
+          # The action downloads each library from GitHub and only authenticates
+          # when given this input, so without it the runner shares an anonymous
+          # rate limit and `tar` chokes on the error page it gets instead.
+          github-token: ${{ github.token }}
       - run: bats scripts/tests/bats
         env:
           BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
           # The action downloads each library from GitHub and only authenticates
           # when given this input, so without it the runner shares an anonymous
           # rate limit and `tar` chokes on the error page it gets instead.
-          github-token: ${{ github.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: bats scripts/tests/bats
         env:
           BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}


### PR DESCRIPTION
The `shell-tests` job has been failing intermittently for a while, several times a day recently, always in setup rather than in a test. The bats action downloads its helper libraries from GitHub anonymously unless it is given a token, so it shares the runner's per-IP rate limit; once that is exhausted it feeds an error document to `tar` instead of a tarball and the job dies before any test runs.

Passing the job's own token makes those downloads authenticated.