### PR TITLE
fix(ci): allow Tauri jobs to upload Trivy results

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -100,6 +100,7 @@ jobs:
     permissions:
       contents: write # for attaching the build artifacts to the release
       id-token: write # OIDC auth
+      security-events: write # for Trivy SARIF upload in setup-mise
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:


### PR DESCRIPTION
## Summary

- grant `security-events: write` to the Tauri build job
- allow the `setup-mise` Trivy scan to upload its SARIF results
- unblock all GUI release matrix builds before compilation