### PR TITLE
docs: add AI contribution policy

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -46,6 +46,15 @@ the following general guidelines:
 1. For any security issues, please **do not** open a Github Issue. Please follow
    responsible disclosure practices laid out in [SECURITY.md](SECURITY.md)
 
+## AI policy
+
+Using AI (LLMs) as tools for coding is welcome.
+We hold a high bar for all contributions to this project, regardless of which tools have been used to create them.
+
+AI should not be used to generate comments when communicating with maintainers.
+Comments are expected to be written by humans.
+Comments, issues or pull requests from external contributors that are believed to be written by AI may be closed without notice.
+
 ## Quick Start
 
 The goal of the quick start guide is to get an environment up and running


### PR DESCRIPTION
I'd like to have something to point to when people open clearly AI generated issues. The suggested policy helps with that while staying true to the fact that we use AI ourselves extensively.