### PR TITLE
test(apple): wait for cancellation instead of sleeping past it

### DIFF
--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/CancellableTaskTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/CancellableTaskTests.swift
@@ -10,8 +10,24 @@ private actor Flag {
     value = newValue
   }
 
-  func get() -> Bool {
-    value
+  /// The flag once it is set, or its value at `timeout`.
+  ///
+  /// What these tests wait on is a task noticing cancellation, which takes as
+  /// long as the scheduler needs. A fixed sleep either gives that away or, on a
+  /// loaded machine, ends first and reports a failure that says nothing about
+  /// the code under test.
+  func waitUntilSet(timeout: Duration = .seconds(5)) async -> Bool {
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+
+    while ContinuousClock.now < deadline {
+      if value {
+        return true
+      }
+
+      try? await Task.sleep(for: .milliseconds(5))
+    }
+
+    return value
   }
 }
 
@@ -26,10 +42,7 @@ struct CancellableTaskTests {
       await executed.set(true)
     }
 
-    // Give the task time to execute
-    try? await Task.sleep(for: .milliseconds(50))
-
-    let wasExecuted = await executed.get()
+    let wasExecuted = await executed.waitUntilSet()
     #expect(wasExecuted == true)
 
     // Keep task alive until assertion
@@ -51,10 +64,7 @@ struct CancellableTaskTests {
       // CancellableTask goes out of scope here, triggering deinit -> cancel
     }
 
-    // Give the cancelled task time to handle the cancellation
-    try? await Task.sleep(for: .milliseconds(50))
-
-    let taskWasCancelled = await wasCancelled.get()
+    let taskWasCancelled = await wasCancelled.waitUntilSet()
     #expect(taskWasCancelled == true)
   }
 
@@ -73,10 +83,7 @@ struct CancellableTaskTests {
     // Set to nil, triggering cancellation
     task = nil
 
-    // Give the cancelled task time to handle the cancellation
-    try? await Task.sleep(for: .milliseconds(50))
-
-    let taskWasCancelled = await wasCancelled.get()
+    let taskWasCancelled = await wasCancelled.waitUntilSet()
     #expect(taskWasCancelled == true)
 
     // Silence unused variable warning

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/CancellableTaskTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/CancellableTaskTests.swift
@@ -10,24 +10,8 @@ private actor Flag {
     value = newValue
   }
 
-  /// The flag once it is set, or its value at `timeout`.
-  ///
-  /// What these tests wait on is a task noticing cancellation, which takes as
-  /// long as the scheduler needs. A fixed sleep either gives that away or, on a
-  /// loaded machine, ends first and reports a failure that says nothing about
-  /// the code under test.
-  func waitUntilSet(timeout: Duration = .seconds(5)) async -> Bool {
-    let deadline = ContinuousClock.now.advanced(by: timeout)
-
-    while ContinuousClock.now < deadline {
-      if value {
-        return true
-      }
-
-      try? await Task.sleep(for: .milliseconds(5))
-    }
-
-    return value
+  func get() -> Bool {
+    value
   }
 }
 
@@ -35,22 +19,21 @@ private actor Flag {
 struct CancellableTaskTests {
 
   @Test("Task executes its operation")
-  func taskExecutesOperation() async {
+  func taskExecutesOperation() async throws {
     let executed = Flag()
 
     let task = CancellableTask {
       await executed.set(true)
     }
 
-    let wasExecuted = await executed.waitUntilSet()
-    #expect(wasExecuted == true)
+    try await waitUntil { await executed.get() }
 
     // Keep task alive until assertion
     _ = task
   }
 
   @Test("Task is cancelled when CancellableTask is deallocated")
-  func taskCancelledOnDealloc() async {
+  func taskCancelledOnDealloc() async throws {
     let wasCancelled = Flag()
 
     do {
@@ -64,12 +47,11 @@ struct CancellableTaskTests {
       // CancellableTask goes out of scope here, triggering deinit -> cancel
     }
 
-    let taskWasCancelled = await wasCancelled.waitUntilSet()
-    #expect(taskWasCancelled == true)
+    try await waitUntil { await wasCancelled.get() }
   }
 
   @Test("Setting to nil cancels the task")
-  func settingToNilCancelsTask() async {
+  func settingToNilCancelsTask() async throws {
     let wasCancelled = Flag()
 
     var task: CancellableTask? = CancellableTask {
@@ -83,8 +65,7 @@ struct CancellableTaskTests {
     // Set to nil, triggering cancellation
     task = nil
 
-    let taskWasCancelled = await wasCancelled.waitUntilSet()
-    #expect(taskWasCancelled == true)
+    try await waitUntil { await wasCancelled.get() }
 
     // Silence unused variable warning
     _ = task

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreDiagnosticLogsTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreDiagnosticLogsTests.swift
@@ -111,20 +111,5 @@
       try await waitUntil { model.logDirectorySizeText != nil }
       #expect(model.logDirectorySizeText == "Unknown")
     }
-
-    private func waitUntil(
-      timeout: Duration = .seconds(5),
-      _ condition: @MainActor () -> Bool
-    ) async throws {
-      let clock = ContinuousClock()
-      let deadline = clock.now.advanced(by: timeout)
-
-      while !condition() {
-        guard clock.now < deadline else { throw TimeoutError() }
-        try await Task.sleep(for: .milliseconds(10))
-      }
-    }
-
-    private struct TimeoutError: Error {}
   }
 #endif

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/TestSupport/WaitUntil.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/TestSupport/WaitUntil.swift
@@ -14,8 +14,12 @@ struct TimeoutError: Error {}
 /// as the scheduler needs. A fixed sleep either gives that time away or, on a
 /// loaded machine, ends first and reports a failure that says nothing about the
 /// code under test.
+///
+/// The loop stays in the caller's isolation domain, so a condition that reads
+/// actor-isolated state is not sent across a boundary.
 func waitUntil(
   timeout: Duration = .seconds(5),
+  isolation: isolated (any Actor)? = #isolation,
   _ condition: () async -> Bool
 ) async throws {
   let clock = ContinuousClock()

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/TestSupport/WaitUntil.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/TestSupport/WaitUntil.swift
@@ -1,0 +1,29 @@
+//
+//  WaitUntil.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Foundation
+
+struct TimeoutError: Error {}
+
+/// Waits for `condition` to hold, giving up after `timeout`.
+///
+/// What tests wait on here is other tasks reaching a point, which takes as long
+/// as the scheduler needs. A fixed sleep either gives that time away or, on a
+/// loaded machine, ends first and reports a failure that says nothing about the
+/// code under test.
+func waitUntil(
+  timeout: Duration = .seconds(5),
+  _ condition: () async -> Bool
+) async throws {
+  let clock = ContinuousClock()
+  let deadline = clock.now.advanced(by: timeout)
+
+  while await !condition() {
+    guard clock.now < deadline else { throw TimeoutError() }
+
+    try await Task.sleep(for: .milliseconds(10))
+  }
+}


### PR DESCRIPTION
The `CancellableTask` tests wait on an asynchronous cancellation by sleeping a fixed 50 milliseconds and then asserting. That is a bet on the scheduler rather than a wait: on a loaded machine the sleep ends before the cancelled task has run, and the test reports a failure that says nothing about the code under test. All three tests in the file share the pattern; one of them lost the bet in CI.

The flag they observe now offers a bounded wait instead. A passing run finishes as soon as the work is done rather than always costing 50 milliseconds, and a real regression fails on substance rather than on timing.