### PR TITLE
fix(gateway): create `/var/lib/firezone` via `StateDirectory`

### DIFF
--- a/rust/gateway/debian/firezone-gateway.service
+++ b/rust/gateway/debian/firezone-gateway.service
@@ -15,6 +15,12 @@ Group=firezone
 PermissionsStartOnly=true
 SyslogIdentifier=firezone-gateway
 
+# Creates /var/lib/firezone before the service starts, owned by the service
+# user, and fixes up ownership if it already exists. The Gateway stores its
+# device ID and the flow-log spool there.
+StateDirectory=firezone
+StateDirectoryMode=0700
+
 LoadCredential=FIREZONE_TOKEN:/etc/firezone/gateway-token
 EnvironmentFile=/etc/firezone/gateway-preset-env
 EnvironmentFile=/etc/firezone/gateway-env

--- a/scripts/gateway-systemd-install.sh
+++ b/scripts/gateway-systemd-install.sh
@@ -106,6 +106,12 @@ Group=firezone
 PermissionsStartOnly=true
 SyslogIdentifier=firezone-gateway
 
+# Creates /var/lib/firezone before the service starts, owned by the service
+# user, and fixes up ownership if it already exists. The Gateway stores its
+# device ID and the flow-log spool there.
+StateDirectory=firezone
+StateDirectoryMode=0700
+
 LoadCredential=FIREZONE_TOKEN:$TOKEN_FILE
 
 Environment="FIREZONE_NAME=$FIREZONE_NAME"

--- a/scripts/nix/modules/gateway.nix
+++ b/scripts/nix/modules/gateway.nix
@@ -151,10 +151,8 @@ in
       # when FIREZONE_TOKEN is unset, so the token never enters the
       # environment.
       # Derive the same deterministic ID the deb/rpm packages use and pass
-      # it explicitly. The binary can self-derive from /etc/machine-id, but
-      # only after create_dir_all("/var/lib/firezone"), which this hardened
-      # unit (DynamicUser, ProtectSystem = "strict", no StateDirectory)
-      # forbids, so it would fail to start. Precomputing keeps it stateless.
+      # it explicitly, so the Gateway keeps its identity across a wiped
+      # state directory instead of self-deriving into one.
       script = ''
         ${lib.optionalString (cfg.id == null) ''
           FIREZONE_ID="$(${pkgs.systemd}/bin/systemd-id128 --app-specific=753b38f9f96947ef8083802d5909a372 machine-id)"
@@ -170,6 +168,13 @@ in
         SyslogIdentifier = "firezone-gateway";
 
         LoadCredential = [ "FIREZONE_TOKEN:${cfg.tokenFile}" ];
+
+        # The Gateway stores its device ID and the flow-log spool here.
+        # ProtectSystem = "strict" leaves the rest of /var read-only, and
+        # under DynamicUser systemd bind-mounts /var/lib/private/firezone
+        # into place.
+        StateDirectory = "firezone";
+        StateDirectoryMode = "0700";
 
         TimeoutStartSec = "15s";
         TimeoutStopSec = "15s";

--- a/scripts/tests/bats/gateway_systemd_install.bats
+++ b/scripts/tests/bats/gateway_systemd_install.bats
@@ -167,6 +167,18 @@ refute_file_contains() {
     [ "$(file_mode "$(token_file)")" = "400" ]
 }
 
+@test "gateway-systemd-install: unit provisions the state directory" {
+    run env \
+        FIREZONE_ID="test-gateway-id" \
+        FIREZONE_TOKEN="test-secret-token" \
+        "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+
+    grep -q '^StateDirectory=firezone$' "$(service_file)"
+    grep -q '^StateDirectoryMode=0700$' "$(service_file)"
+}
+
 @test "gateway-systemd-install: generated init script uses hardcoded artifact URL and verifies checksums" {
     run env \
         FIREZONE_ID="test-gateway-id" \


### PR DESCRIPTION
The Gateway spools flow logs and stores its device ID under `/var/lib/firezone`, but nothing in the systemd packaging ever created that directory. The service runs as the unprivileged `firezone` user, which cannot create a subdirectory of root-owned `/var/lib`, so persisting a flow-log ingest token failed on every authorization. Reports for an authorization with no token on disk are skipped, so flow logs were then dropped silently and never reached the portal. The NixOS module was affected for the same reason, with `ProtectSystem = "strict"` making `/var` read-only outright.

Letting systemd own the directory also corrects ownership on hosts that grew a root-owned `/var/lib/firezone` under Docker.