### PR TITLE
feat(connlib): configure the logger outside a session

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
@@ -3,6 +3,7 @@ package dev.firezone.android.core
 
 import android.app.Application
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
@@ -10,6 +11,8 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.HiltAndroidApp
 import dev.firezone.android.BuildConfig
 import dev.firezone.android.tunnel.TunnelService
+import uniffi.connlib.ConnlibException
+import uniffi.connlib.configureLogger
 import uniffi.connlib.drainFlowLogs
 import kotlin.concurrent.thread
 
@@ -31,6 +34,19 @@ class FirezoneApp : Application() {
         // Wires connlib's TLS stack (rustls) to Android's trust store; required before any TLS handshake.
         initRustlsPlatformVerifier(this)
 
+        // The drain below runs without a session, so it never reaches `connect`.
+        // Configure the logger here so that work is not silent.
+        try {
+            configureLogger(
+                TunnelService.logDir(this),
+                BuildConfig.LOG_FILTER,
+                TunnelService.flowLogsDir(this),
+            )
+        } catch (e: ConnlibException) {
+            Log.e(TAG, "Failed to configure connlib's logger", e)
+            e.close()
+        }
+
         // Drain flow logs whenever the app comes to the foreground (including this
         // launch): pokes the session's uploader while connected, or runs a bounded
         // one-shot pass to sweep up spool a previous session left behind. Off the
@@ -48,6 +64,8 @@ class FirezoneApp : Application() {
     }
 
     companion object {
+        private const val TAG: String = "FirezoneApp"
+
         @JvmStatic
         external fun initRustlsPlatformVerifier(context: Context)
     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
@@ -14,6 +14,7 @@ import dev.firezone.android.tunnel.TunnelService
 import uniffi.connlib.ConnlibException
 import uniffi.connlib.configureLogger
 import uniffi.connlib.drainFlowLogs
+import java.io.IOException
 import kotlin.concurrent.thread
 
 @HiltAndroidApp
@@ -34,24 +35,24 @@ class FirezoneApp : Application() {
         // Wires connlib's TLS stack (rustls) to Android's trust store; required before any TLS handshake.
         initRustlsPlatformVerifier(this)
 
+        val flowLogsDir = TunnelService.flowLogsDir(this)
+
         // The drain below runs without a session, so it never reaches `connect`.
-        // Configure the logger here so that work is not silent.
+        // Configure the logger here so that work is not silent. Best-effort: a
+        // failure costs connlib's logs, not startup.
         try {
-            configureLogger(
-                TunnelService.logDir(this),
-                BuildConfig.LOG_FILTER,
-                TunnelService.flowLogsDir(this),
-            )
+            configureLogger(TunnelService.logDir(this), BuildConfig.LOG_FILTER, flowLogsDir)
         } catch (e: ConnlibException) {
             Log.e(TAG, "Failed to configure connlib's logger", e)
             e.close()
+        } catch (e: IOException) {
+            Log.e(TAG, "Failed to configure connlib's logger", e)
         }
 
         // Drain flow logs whenever the app comes to the foreground (including this
         // launch): pokes the session's uploader while connected, or runs a bounded
         // one-shot pass to sweep up spool a previous session left behind. Off the
         // main thread because the one-shot case blocks for up to ten seconds.
-        val flowLogsDir = TunnelService.flowLogsDir(this)
         ProcessLifecycleOwner.get().lifecycle.addObserver(
             object : DefaultLifecycleObserver {
                 override fun onStart(owner: LifecycleOwner) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -339,7 +339,7 @@ class TunnelService : VpnService() {
                                     accountSlug = config.accountSlug,
                                     deviceId = deviceIdValue,
                                     deviceName = getDeviceName(),
-                                    logDir = getLogDir(),
+                                    logDir = logDir(this@TunnelService),
                                     logFilter = config.logFilter,
                                     flowLogsDir = flowLogsDir(this@TunnelService),
                                     isInternetResourceActive = resourceState.isEnabled(),
@@ -420,12 +420,12 @@ class TunnelService : VpnService() {
         logCleanupJob =
             serviceScope.launch(Dispatchers.IO) {
                 try {
-                    val logDir = getLogDir()
+                    val dir = logDir(this@TunnelService)
                     val maxSizeMb = logCleanupDefaultMaxSizeMb()
                     val intervalMs = logCleanupDefaultIntervalSecs().toLong() * 1000
                     while (isActive) {
                         try {
-                            val bytesDeleted = enforceLogSizeCap(listOf(logDir), maxSizeMb)
+                            val bytesDeleted = enforceLogSizeCap(listOf(dir), maxSizeMb)
                             if (bytesDeleted > 0u) {
                                 Log.d(TAG, "Log cleanup deleted $bytesDeleted bytes")
                             }
@@ -512,13 +512,6 @@ class TunnelService : VpnService() {
             }
 
         return deviceId
-    }
-
-    private fun getLogDir(): String {
-        // Create log directory if it doesn't exist
-        val logDir = cacheDir.absolutePath + "/logs"
-        Files.createDirectories(Paths.get(logDir))
-        return logDir
     }
 
     fun startConnectedNotification() {
@@ -779,6 +772,12 @@ class TunnelService : VpnService() {
         private const val MTU: Int = 1280
         private const val TAG: String = "TunnelService"
         private const val FEATURE_FLAG_POLL_INTERVAL_MS: Long = 5_000
+
+        fun logDir(context: Context): String {
+            val logDir = context.cacheDir.absolutePath + "/logs"
+            Files.createDirectories(Paths.get(logDir))
+            return logDir
+        }
 
         // Under `filesDir` (persistent) and outside the log directory so exported
         // log bundles never sweep the spool up.

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -53,6 +53,7 @@ import uniffi.connlib.Event
 import uniffi.connlib.ProtectSocket
 import uniffi.connlib.Session
 import uniffi.connlib.SessionInterface
+import uniffi.connlib.configureLogger
 import uniffi.connlib.enforceLogSizeCap
 import uniffi.connlib.isLogStreamingActive
 import uniffi.connlib.logCleanupDefaultIntervalSecs
@@ -330,6 +331,12 @@ class TunnelService : VpnService() {
                     Telemetry.setFirezoneId(deviceIdValue)
                     Telemetry.setAccountSlug(config.accountSlug)
 
+                    configureLogger(
+                        logDir(this@TunnelService),
+                        config.logFilter,
+                        flowLogsDir(this@TunnelService),
+                    )
+
                     Session
                         .newAndroid(
                             config =
@@ -339,9 +346,6 @@ class TunnelService : VpnService() {
                                     accountSlug = config.accountSlug,
                                     deviceId = deviceIdValue,
                                     deviceName = getDeviceName(),
-                                    logDir = logDir(this@TunnelService),
-                                    logFilter = config.logFilter,
-                                    flowLogsDir = flowLogsDir(this@TunnelService),
                                     isInternetResourceActive = resourceState.isEnabled(),
                                     deviceInfo = deviceInfo,
                                 ),
@@ -608,7 +612,11 @@ class TunnelService : VpnService() {
                             }
 
                             is TunnelCommand.SetLogDirectives -> {
-                                session.setLogDirectives(command.directives)
+                                configureLogger(
+                                    logDir(this@TunnelService),
+                                    command.directives,
+                                    flowLogsDir(this@TunnelService),
+                                )
                             }
 
                             is TunnelCommand.SetTun -> {

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -562,7 +562,7 @@ fn connect(
         .filter(|dir| !dir.is_empty())
         .map(PathBuf::from);
 
-    init_logging(&PathBuf::from(log_dir), log_filter, flow_logs_dir.clone())?;
+    install_logger(&PathBuf::from(log_dir), log_filter, flow_logs_dir.clone())?;
 
     tunnel_bypass_resolver::configure(tcp_socket_factory.clone(), udp_socket_factory.clone());
 
@@ -661,7 +661,39 @@ static LOGGER_STATE: OnceLock<(
     Option<flow_log_writer::Guard>,
 )> = OnceLock::new();
 
-fn init_logging(log_dir: &Path, log_filter: String, flow_logs_dir: Option<PathBuf>) -> Result<()> {
+/// Installs the logger without starting a session.
+///
+/// [`connect`] installs it as part of session setup, but the network extension
+/// also runs without a session: a cycle start wakes it only to drain flow logs.
+/// Until this is called, those paths have no subscriber and every event they
+/// emit is dropped.
+///
+/// A later call re-applies `log_filter` to the running subscriber, so calling
+/// this before connecting costs the session nothing. The directories are not
+/// re-applied: they are whichever the first call passed, so callers must agree
+/// on them.
+#[uniffi::export]
+pub fn init_logging(
+    log_dir: String,
+    log_filter: String,
+    flow_logs_dir: Option<String>,
+) -> Result<(), ConnlibError> {
+    install_logger(
+        &PathBuf::from(log_dir),
+        log_filter,
+        flow_logs_dir
+            .filter(|dir| !dir.is_empty())
+            .map(PathBuf::from),
+    )?;
+
+    Ok(())
+}
+
+fn install_logger(
+    log_dir: &Path,
+    log_filter: String,
+    flow_logs_dir: Option<PathBuf>,
+) -> Result<()> {
     if let Some((_, reload_handle, _)) = LOGGER_STATE.get() {
         reload_handle
             .reload(&log_filter)

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -80,9 +80,6 @@ pub struct AndroidSessionConfig {
     pub device_id: String,
     pub account_slug: String,
     pub device_name: String,
-    pub log_dir: String,
-    pub log_filter: String,
-    pub flow_logs_dir: Option<String>,
     pub device_info: DeviceInfo,
     pub is_internet_resource_active: bool,
 }
@@ -224,9 +221,6 @@ impl Session {
             device_id,
             account_slug,
             device_name,
-            log_dir,
-            log_filter,
-            flow_logs_dir,
             device_info,
             is_internet_resource_active,
         } = config;
@@ -239,9 +233,6 @@ impl Session {
             device_id,
             account_slug,
             Some(device_name),
-            log_dir,
-            log_filter,
-            flow_logs_dir,
             device_info,
             is_internet_resource_active,
             tcp_socket_factory,
@@ -254,19 +245,12 @@ impl Session {
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 impl Session {
     #[uniffi::constructor]
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "This is the API we want to expose over FFI."
-    )]
     pub fn new_apple(
         api_url: String,
         token: String,
         device_id: String,
         account_slug: String,
         device_name: Option<String>,
-        log_dir: String,
-        log_filter: String,
-        flow_logs_dir: Option<String>,
         device_info: DeviceInfo,
         is_internet_resource_active: bool,
     ) -> Result<Self, ConnlibError> {
@@ -280,9 +264,6 @@ impl Session {
             device_id,
             account_slug,
             device_name,
-            log_dir,
-            log_filter,
-            flow_logs_dir,
             device_info,
             is_internet_resource_active,
             tcp_socket_factory,
@@ -298,10 +279,6 @@ impl Session {
 #[uniffi::export]
 impl Session {
     #[uniffi::constructor]
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "This is the API we want to expose over FFI."
-    )]
     /// Dummy constructor that isn't feature-gated by an OS.
     ///
     /// This only exists to make working on the FFI module from Linux/Windows more convenient without many "unused code" warnings.
@@ -311,9 +288,6 @@ impl Session {
         device_id: String,
         account_slug: String,
         device_name: Option<String>,
-        log_dir: String,
-        log_filter: String,
-        flow_logs_dir: Option<String>,
         device_info: DeviceInfo,
         is_internet_resource_active: bool,
     ) -> Result<Self, ConnlibError> {
@@ -326,9 +300,6 @@ impl Session {
             device_id,
             account_slug,
             device_name,
-            log_dir,
-            log_filter,
-            flow_logs_dir,
             device_info,
             is_internet_resource_active,
             tcp_socket_factory,
@@ -403,16 +374,6 @@ impl Session {
 
     pub fn reset(&self, reason: String) {
         self.inner.reset(reason)
-    }
-
-    pub fn set_log_directives(&self, directives: String) -> Result<(), ConnlibError> {
-        let (_, reload_handle, _) = LOGGER_STATE.get().context("Logger not yet initialised")?;
-
-        reload_handle
-            .reload(&directives)
-            .context("Failed to apply new directives")?;
-
-        Ok(())
     }
 
     pub fn set_tun(&self, fd: RawFd) -> Result<(), ConnlibError> {
@@ -532,9 +493,6 @@ fn connect(
     device_id: String,
     account_slug: String,
     device_name: Option<String>,
-    log_dir: String,
-    log_filter: String,
-    flow_logs_dir: Option<String>,
     device_info: DeviceInfo,
     is_internet_resource_active: bool,
     tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
@@ -558,11 +516,13 @@ fn connect(
 
     install_rustls_crypto_provider();
 
-    configure_logger(log_dir, log_filter, flow_logs_dir.clone())?;
-
-    let flow_logs_dir = flow_logs_dir
-        .filter(|dir| !dir.is_empty())
-        .map(PathBuf::from);
+    // Fail loudly rather than run a session with no logs and no flow-log spool.
+    let flow_logs_dir = LOGGER
+        .get()
+        .context("Logger must be configured before connecting")?
+        .flow_log_guard
+        .as_ref()
+        .map(|guard| guard.spool_root().to_path_buf());
 
     tunnel_bypass_resolver::configure(tcp_socket_factory.clone(), udp_socket_factory.clone());
 
@@ -655,18 +615,24 @@ pub fn stop_telemetry() {
     telemetry::stop();
 }
 
-static LOGGER_STATE: OnceLock<(
-    logging::file::Handle,
-    logging::FilterReloadHandle,
-    Option<flow_log_writer::Guard>,
-)> = OnceLock::new();
+/// The process-wide logger, installed once by [`configure_logger`].
+struct Logger {
+    reload_handle: logging::FilterReloadHandle,
+    /// Owns the flow-log spool root, so the uploader can be pointed at the same
+    /// place the writer uses rather than told separately.
+    flow_log_guard: Option<flow_log_writer::Guard>,
+    _file_handle: logging::file::Handle,
+}
+
+static LOGGER: OnceLock<Logger> = OnceLock::new();
 
 /// Installs the logger, or re-applies `log_filter` when it is already installed.
 ///
 /// A session is not the only thing that logs: the network extension is woken
 /// without one to drain flow logs, and every event emitted before this runs is
-/// dropped. So callers configure the logger themselves rather than relying on
-/// [`connect`] to do it, and [`connect`] calls this too.
+/// dropped. So every entry point configures the logger itself, and [`connect`]
+/// requires that to have happened already: it reads the flow-log spool root back
+/// off the installed logger rather than being told it a second time.
 ///
 /// Only `log_filter` is re-applied. The directories stay whichever the first
 /// call passed, so callers must agree on them.
@@ -676,8 +642,9 @@ pub fn configure_logger(
     log_filter: String,
     flow_logs_dir: Option<String>,
 ) -> Result<(), ConnlibError> {
-    if let Some((_, reload_handle, _)) = LOGGER_STATE.get() {
-        reload_handle
+    if let Some(logger) = LOGGER.get() {
+        logger
+            .reload_handle
             .reload(&log_filter)
             .context("Failed to apply new log-filter")?;
         return Ok(());
@@ -711,8 +678,12 @@ pub fn configure_logger(
 
     logging::init(subscriber)?;
 
-    LOGGER_STATE
-        .set((handle, reload_handle, flow_log_guard))
+    LOGGER
+        .set(Logger {
+            reload_handle,
+            flow_log_guard,
+            _file_handle: handle,
+        })
         .map_err(|_| anyhow!("Logging guard should never be initialized twice"))?;
 
     Ok(())

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -11,7 +11,7 @@ use crate::fd::RawFd;
 
 use std::{
     fmt,
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{Arc, OnceLock},
     time::Duration,
 };
@@ -558,11 +558,11 @@ fn connect(
 
     install_rustls_crypto_provider();
 
+    configure_logger(log_dir, log_filter, flow_logs_dir.clone())?;
+
     let flow_logs_dir = flow_logs_dir
         .filter(|dir| !dir.is_empty())
         .map(PathBuf::from);
-
-    install_logger(&PathBuf::from(log_dir), log_filter, flow_logs_dir.clone())?;
 
     tunnel_bypass_resolver::configure(tcp_socket_factory.clone(), udp_socket_factory.clone());
 
@@ -661,39 +661,21 @@ static LOGGER_STATE: OnceLock<(
     Option<flow_log_writer::Guard>,
 )> = OnceLock::new();
 
-/// Installs the logger without starting a session.
+/// Installs the logger, or re-applies `log_filter` when it is already installed.
 ///
-/// [`connect`] installs it as part of session setup, but the network extension
-/// also runs without a session: a cycle start wakes it only to drain flow logs.
-/// Until this is called, those paths have no subscriber and every event they
-/// emit is dropped.
+/// A session is not the only thing that logs: the network extension is woken
+/// without one to drain flow logs, and every event emitted before this runs is
+/// dropped. So callers configure the logger themselves rather than relying on
+/// [`connect`] to do it, and [`connect`] calls this too.
 ///
-/// A later call re-applies `log_filter` to the running subscriber, so calling
-/// this before connecting costs the session nothing. The directories are not
-/// re-applied: they are whichever the first call passed, so callers must agree
-/// on them.
+/// Only `log_filter` is re-applied. The directories stay whichever the first
+/// call passed, so callers must agree on them.
 #[uniffi::export]
-pub fn init_logging(
+pub fn configure_logger(
     log_dir: String,
     log_filter: String,
     flow_logs_dir: Option<String>,
 ) -> Result<(), ConnlibError> {
-    install_logger(
-        &PathBuf::from(log_dir),
-        log_filter,
-        flow_logs_dir
-            .filter(|dir| !dir.is_empty())
-            .map(PathBuf::from),
-    )?;
-
-    Ok(())
-}
-
-fn install_logger(
-    log_dir: &Path,
-    log_filter: String,
-    flow_logs_dir: Option<PathBuf>,
-) -> Result<()> {
     if let Some((_, reload_handle, _)) = LOGGER_STATE.get() {
         reload_handle
             .reload(&log_filter)
@@ -701,11 +683,17 @@ fn install_logger(
         return Ok(());
     }
 
-    let (file_log_filter, file_reload_handle) = logging::try_filter(&log_filter)?;
-    let (platform_log_filter, platform_reload_handle) = logging::try_filter(&log_filter)?;
-    let (file_layer, handle) = logging::file::layer(log_dir, "connlib");
+    let (file_log_filter, file_reload_handle) =
+        logging::try_filter(&log_filter).context("Failed to parse log filter")?;
+    let (platform_log_filter, platform_reload_handle) =
+        logging::try_filter(&log_filter).context("Failed to parse log filter")?;
+    let (file_layer, handle) = logging::file::layer(&PathBuf::from(log_dir), "connlib");
     // Spools flow-log reports for the uploader, like the desktop entrypoints do.
-    let (flow_log_layer, flow_log_guard) = flow_logs_dir.map(flow_log_writer::layer).unzip();
+    let (flow_log_layer, flow_log_guard) = flow_logs_dir
+        .filter(|dir| !dir.is_empty())
+        .map(PathBuf::from)
+        .map(flow_log_writer::layer)
+        .unzip();
 
     let subscriber = tracing_subscriber::registry()
         .with(file_layer.with_filter(file_log_filter))

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -97,7 +97,11 @@ where
     let (tx, rx) = mpsc::sync_channel::<Command>(CHANNEL_CAPACITY);
     let handle = std::thread::Builder::new()
         .name("flow-log-writer".to_owned())
-        .spawn(move || writer_loop(&spool_root, &rx))
+        .spawn({
+            let spool_root = spool_root.clone();
+
+            move || writer_loop(&spool_root, &rx)
+        })
         .expect("Failed to spawn flow-log writer thread");
 
     let layer = FlowLogLayer {
@@ -112,6 +116,7 @@ where
         layer,
         Guard {
             tx,
+            spool_root,
             handle: Some(handle),
         },
     )
@@ -163,7 +168,16 @@ pub fn write_token(spool_root: &Path, token: &str) -> anyhow::Result<()> {
 /// cannot hang process exit.
 pub struct Guard {
     tx: mpsc::SyncSender<Command>,
+    spool_root: PathBuf,
     handle: Option<JoinHandle<()>>,
+}
+
+impl Guard {
+    /// Where this writer spools its reports, so an uploader can be pointed at
+    /// the same place rather than told separately.
+    pub fn spool_root(&self) -> &Path {
+        &self.spool_root
+    }
 }
 
 impl Drop for Guard {

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -172,8 +172,13 @@ actor Adapter {
       }
     #endif
 
-    let logDir = SharedAccess.connlibLogFolderURL?.path ?? "/tmp/firezone"
-    let flowLogsDir = SharedAccess.flowLogsFolderURL?.path
+    // Applies the configured filter to the logger the extension installed at
+    // startup; connlib reads the flow-log spool back off it when connecting.
+    try configureLogger(
+      logDir: SharedAccess.connlibLogFolderURL?.path ?? "/tmp/firezone",
+      logFilter: logFilter,
+      flowLogsDir: SharedAccess.flowLogsFolderURL?.path
+    )
 
     #if os(iOS)
       let deviceInfo = DeviceInfo(
@@ -200,9 +205,6 @@ actor Adapter {
         deviceId: deviceId,
         accountSlug: accountSlug,
         deviceName: deviceName,
-        logDir: logDir,
-        logFilter: logFilter,
-        flowLogsDir: flowLogsDir,
         deviceInfo: deviceInfo,
         isInternetResourceActive: internetResourceEnabled
       )

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -34,6 +34,19 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     startTelemetry()
 
+    // connlib installs its logger from `connect`, which a cycle start never
+    // reaches: it wakes this process only to drain flow logs. Install it here so
+    // that work is not silent.
+    do {
+      try initLogging(
+        logDir: SharedAccess.connlibLogFolderURL?.path ?? "/tmp/firezone",
+        logFilter: ConfigurationDefaults.logFilter,
+        flowLogsDir: SharedAccess.flowLogsFolderURL?.path
+      )
+    } catch {
+      Log.error(error)
+    }
+
     super.init()
 
     // Log version information immediately on startup

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -34,11 +34,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     startTelemetry()
 
-    // connlib installs its logger from `connect`, which a cycle start never
-    // reaches: it wakes this process only to drain flow logs. Install it here so
-    // that work is not silent.
+    // A cycle start wakes this process only to drain flow logs, so it never
+    // reaches `connect`. Configure the logger here so that work is not silent.
     do {
-      try initLogging(
+      try configureLogger(
         logDir: SharedAccess.connlibLogFolderURL?.path ?? "/tmp/firezone",
         logFilter: ConfigurationDefaults.logFilter,
         flowLogsDir: SharedAccess.flowLogsFolderURL?.path


### PR DESCRIPTION
connlib installed its logger as part of `connect`, so it only existed once a session did. Both clients also run code without one: the Apple network extension is woken by a cycle start purely to drain flow logs, and Android drains from `Application.onCreate`. Those paths emitted every event into a process with no subscriber, which left the drain that blocks Apple's launch for ten seconds impossible to diagnose from logs.

Installing the logger and re-applying a filter were already the same idempotent call behind two names, so they fold into one exported `configure_logger` that both clients call at startup. `connect` becomes just another caller rather than the entry point every other path has to work around.