### PR TITLE
chore: add tasks for removing the test certificates

### DIFF
--- a/mise-tasks/x509/uninstall-linux.sh
+++ b/mise-tasks/x509/uninstall-linux.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#MISE description="Remove the test X.509 client certificate from the system SoftHSM PKCS#11 token"
+set -euo pipefail
+
+# One task per platform, so running the wrong one is a mistake worth naming rather than a
+# confusing failure further down.
+host_os="$(uname -s)"
+if [ "$host_os" != "Linux" ]; then
+    echo "error: this task removes a PKCS#11 token, but this is ${host_os}." >&2
+    echo "'mise tasks' lists the task for this platform." >&2
+    exit 1
+fi
+
+# Both of these are what `//:x509:install-linux` wrote, and the only two things it left behind.
+SOFTHSM_CONF="/etc/softhsm/softhsm2.conf"
+if [ ! -f "$SOFTHSM_CONF" ] && [ -f /etc/softhsm2.conf ]; then
+    SOFTHSM_CONF="/etc/softhsm2.conf"
+fi
+PIN_PATH="/etc/firezone/pkcs11-pin"
+TOKEN_LABEL="Firezone"
+
+as_root() {
+    if [ "$(id -u)" -eq 0 ]; then
+        "$@"
+    else
+        sudo "$@"
+    fi
+}
+
+command -v softhsm2-util >/dev/null || {
+    echo "error: softhsm2-util is required (Debian: apt install softhsm2; Fedora: dnf install softhsm)" >&2
+    exit 1
+}
+
+if [ "$(id -u)" -ne 0 ] && ! command -v sudo >/dev/null; then
+    echo "error: removing the system SoftHSM token and ${PIN_PATH} needs root, and sudo is not" >&2
+    echo "installed; run this task as root instead" >&2
+    exit 1
+fi
+
+# SoftHSM prefers a per-user configuration over the system one, and `sudo` decides for itself
+# whose home directory it looks in, so the system one is named outright.
+system_softhsm=(env "SOFTHSM2_CONF=${SOFTHSM_CONF}")
+
+echo "==> Deleting the ${TOKEN_LABEL} token..."
+# A machine that never ran the install task has neither of these, and saying so beats failing.
+if as_root "${system_softhsm[@]}" softhsm2-util --delete-token --token "$TOKEN_LABEL" >/dev/null 2>&1; then
+    echo "    Deleted."
+else
+    echo "    No ${TOKEN_LABEL} token was in ${SOFTHSM_CONF}'s store."
+fi
+
+echo "==> Removing ${PIN_PATH}..."
+if as_root test -f "$PIN_PATH"; then
+    as_root rm -f "$PIN_PATH"
+    echo "    Removed."
+else
+    echo "    Not there."
+fi
+
+echo
+echo "The Client has no identity to find now. A connected Tunnel service holds its PKCS#11"
+echo "session until it restarts, so restart it to see the change."
+echo
+echo "'firezone-headless-client x509' prints what it makes of the store."

--- a/mise-tasks/x509/uninstall-linux.sh
+++ b/mise-tasks/x509/uninstall-linux.sh
@@ -32,10 +32,20 @@ command -v softhsm2-util >/dev/null || {
     exit 1
 }
 
-if [ "$(id -u)" -ne 0 ] && ! command -v sudo >/dev/null; then
-    echo "error: removing the system SoftHSM token and ${PIN_PATH} needs root, and sudo is not" >&2
-    echo "installed; run this task as root instead" >&2
-    exit 1
+if [ "$(id -u)" -ne 0 ]; then
+    if ! command -v sudo >/dev/null; then
+        echo "error: removing the system SoftHSM token and ${PIN_PATH} needs root, and sudo is" >&2
+        echo "not installed; run this task as root instead" >&2
+        exit 1
+    fi
+
+    # Elevating now means a refusal is its own error, rather than every check below reading
+    # as "there was nothing there".
+    if ! sudo true; then
+        echo "error: sudo could not elevate, and removing the system SoftHSM token and" >&2
+        echo "${PIN_PATH} needs root" >&2
+        exit 1
+    fi
 fi
 
 # SoftHSM prefers a per-user configuration over the system one, and `sudo` decides for itself
@@ -43,11 +53,20 @@ fi
 system_softhsm=(env "SOFTHSM2_CONF=${SOFTHSM_CONF}")
 
 echo "==> Deleting the ${TOKEN_LABEL} token..."
-# A machine that never ran the install task has neither of these, and saying so beats failing.
-if as_root "${system_softhsm[@]}" softhsm2-util --delete-token --token "$TOKEN_LABEL" >/dev/null 2>&1; then
+# A machine that never ran the install task has no token, which is not a failure. Anything
+# else softhsm2-util reports is one, and it says so on stderr rather than in its exit status.
+delete_status=0
+delete_output="$(as_root "${system_softhsm[@]}" softhsm2-util --delete-token \
+    --token "$TOKEN_LABEL" 2>&1)" || delete_status=$?
+
+if [ "$delete_status" -eq 0 ]; then
     echo "    Deleted."
-else
+elif printf '%s' "$delete_output" | grep -qi "could not be found\|not found"; then
     echo "    No ${TOKEN_LABEL} token was in ${SOFTHSM_CONF}'s store."
+else
+    echo "error: could not delete the ${TOKEN_LABEL} token:" >&2
+    printf '%s\n' "$delete_output" >&2
+    exit 1
 fi
 
 echo "==> Removing ${PIN_PATH}..."

--- a/mise-tasks/x509/uninstall-windows.ps1
+++ b/mise-tasks/x509/uninstall-windows.ps1
@@ -1,0 +1,58 @@
+#!/usr/bin/env pwsh
+#MISE description="Remove the test X.509 client certificate from the Windows certificate store"
+#USAGE flag "--alias <alias>" help="Name `//:x509:gen-certificate` stored the key under [default: firezone-client]"
+
+$ErrorActionPreference = 'Stop'
+
+# `$IsWindows` does not exist in Windows PowerShell, where the edition is the answer instead.
+$onWindows = $IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')
+
+# One task per platform, so running the wrong one is a mistake worth naming rather than a
+# confusing failure further down.
+if (-not $onWindows) {
+    [Console]::Error.WriteLine(
+        "error: this task removes from a Windows certificate store, but this is $([Environment]::OSVersion.Platform).")
+    [Console]::Error.WriteLine("'mise tasks' lists the task for this platform.")
+
+    exit 1
+}
+
+# `//:x509:gen-certificate` issues the certificate under this common name, which is how the
+# Client finds it and how this task knows which certificates it put there.
+$subjectCn = 'dev.firezone.device-trust'
+
+# The install task writes into the machine store, so that is where the removal happens, and
+# emptying it needs the same elevation filling it did.
+$principal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    [Console]::Error.WriteLine('error: removing from Cert:\LocalMachine\My needs an elevated shell.')
+    [Console]::Error.WriteLine('Re-run this task from a PowerShell started as Administrator.')
+
+    exit 1
+}
+
+Write-Output "==> Removing certificates for $subjectCn from Cert:\LocalMachine\My..."
+
+# Matched on the subject rather than a thumbprint, because a machine that ran the install task
+# more than once holds one certificate per run and all of them are throwaway test material.
+$certificates = @(
+    Get-ChildItem -Path 'Cert:\LocalMachine\My' |
+        Where-Object { $_.Subject -match [regex]::Escape($subjectCn) }
+)
+
+if ($certificates.Count -eq 0) {
+    Write-Output '    None were in the store.'
+} else {
+    foreach ($certificate in $certificates) {
+        # `-DeleteKey` takes the private key with the certificate, whichever provider holds it,
+        # so the key does not outlive the certificate it was imported with.
+        Remove-Item -Path $certificate.PSPath -Force -DeleteKey
+        Write-Output ('    Removed ' + $certificate.Thumbprint)
+    }
+}
+
+Write-Output ''
+Write-Output 'The Client has no identity to find now. A connected Tunnel service holds the'
+Write-Output 'certificate until it restarts, so restart it to see the change.'
+Write-Output ''
+Write-Output "'firezone-client-tunnel.exe x509' prints what the Client makes of the store."

--- a/mise-tasks/x509/uninstall-windows.ps1
+++ b/mise-tasks/x509/uninstall-windows.ps1
@@ -1,6 +1,5 @@
 #!/usr/bin/env pwsh
 #MISE description="Remove the test X.509 client certificate from the Windows certificate store"
-#USAGE flag "--alias <alias>" help="Name `//:x509:gen-certificate` stored the key under [default: firezone-client]"
 
 $ErrorActionPreference = 'Stop'
 
@@ -17,9 +16,10 @@ if (-not $onWindows) {
     exit 1
 }
 
-# `//:x509:gen-certificate` issues the certificate under this common name, which is how the
-# Client finds it and how this task knows which certificates it put there.
-$subjectCn = 'dev.firezone.device-trust'
+# `//:x509:gen-certificate` issues the certificate under the first of these common names and
+# `//:x509:create-ca` the CA under the second. `//:x509:install-windows` imports a PKCS#12 that
+# carries both, so both are in the store and both come out again.
+$commonNames = @('dev.firezone.device-trust', 'Firezone Test CA')
 
 # The install task writes into the machine store, so that is where the removal happens, and
 # emptying it needs the same elevation filling it did.
@@ -31,13 +31,18 @@ if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administra
     exit 1
 }
 
-Write-Output "==> Removing certificates for $subjectCn from Cert:\LocalMachine\My..."
+Write-Output ("==> Removing certificates for " + ($commonNames -join ', ') + " from Cert:\LocalMachine\My...")
 
-# Matched on the subject rather than a thumbprint, because a machine that ran the install task
-# more than once holds one certificate per run and all of them are throwaway test material.
+# Matched on the common name rather than a thumbprint, because a machine that ran the install
+# task more than once holds one certificate per run and all of them are throwaway test material.
+# `GetNameInfo` reads the CN out of the subject, so a certificate whose subject merely contains
+# one of these names somewhere is left alone: this task deletes private keys as an administrator.
 $certificates = @(
-    Get-ChildItem -Path 'Cert:\LocalMachine\My' |
-        Where-Object { $_.Subject -match [regex]::Escape($subjectCn) }
+    Get-ChildItem -Path 'Cert:\LocalMachine\My' | Where-Object {
+        $commonName = $_.GetNameInfo([Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false)
+
+        $commonNames -contains $commonName
+    }
 )
 
 if ($certificates.Count -eq 0) {

--- a/mise-tasks/x509/uninstall-windows.ps1
+++ b/mise-tasks/x509/uninstall-windows.ps1
@@ -16,10 +16,13 @@ if (-not $onWindows) {
     exit 1
 }
 
-# `//:x509:gen-certificate` issues the certificate under the first of these common names and
-# `//:x509:create-ca` the CA under the second. `//:x509:install-windows` imports a PKCS#12 that
-# carries both, so both are in the store and both come out again.
-$commonNames = @('dev.firezone.device-trust', 'Firezone Test CA')
+# `//:x509:gen-certificate` issues the certificate under this common name, which is how the
+# Client finds it and how this task knows which certificates it put there.
+#
+# The CA the certificate was issued from has its own tasks and its own lifetime, so it stays
+# where it is even though `//:x509:install-windows` carries it into the store alongside this
+# certificate.
+$commonName = 'dev.firezone.device-trust'
 
 # The install task writes into the machine store, so that is where the removal happens, and
 # emptying it needs the same elevation filling it did.
@@ -31,17 +34,15 @@ if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administra
     exit 1
 }
 
-Write-Output ("==> Removing certificates for " + ($commonNames -join ', ') + " from Cert:\LocalMachine\My...")
+Write-Output "==> Removing certificates for $commonName from Cert:\LocalMachine\My..."
 
 # Matched on the common name rather than a thumbprint, because a machine that ran the install
 # task more than once holds one certificate per run and all of them are throwaway test material.
 # `GetNameInfo` reads the CN out of the subject, so a certificate whose subject merely contains
-# one of these names somewhere is left alone: this task deletes private keys as an administrator.
+# that name somewhere is left alone: this task deletes private keys as an administrator.
 $certificates = @(
     Get-ChildItem -Path 'Cert:\LocalMachine\My' | Where-Object {
-        $commonName = $_.GetNameInfo([Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false)
-
-        $commonNames -contains $commonName
+        $_.GetNameInfo([Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false) -eq $commonName
     }
 )
 


### PR DESCRIPTION
The install tasks have no counterpart, so a test certificate stays on a machine until someone works out what was written where. Each of these removes what its install task left: the SoftHSM token and the PIN file on Linux, the machine-store certificates and their private keys on Windows.

Related: #14761