### PR TITLE
fix(apple): surface connlib's error message to the Swift side

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -371,7 +371,7 @@ fn set_tun_from_search(session: &Session) -> Result<(), ConnlibError> {
                 return Ok(());
             }
             Err(e) => {
-                tracing::debug!(attempt, "Failed to find TUN device: {e}");
+                tracing::debug!(attempt, error = %e, "Failed to find TUN device");
                 last_error = Some(e);
                 if attempt < MAX_TUN_SETUP_ATTEMPTS {
                     std::thread::sleep(std::time::Duration::from_millis(TUN_SETUP_RETRY_DELAY_MS));

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -363,7 +363,7 @@ fn set_tun_from_search(session: &Session) -> Result<(), ConnlibError> {
 
     let mut last_error = None;
     for attempt in 1..=MAX_TUN_SETUP_ATTEMPTS {
-        tracing::debug!("Attempting to find TUN device (attempt {})", attempt);
+        tracing::debug!(attempt, "Attempting to find TUN device");
         match platform::Tun::new(runtime.handle()) {
             Ok(tun) => {
                 tracing::debug!("Successfully found and set TUN device");
@@ -371,7 +371,7 @@ fn set_tun_from_search(session: &Session) -> Result<(), ConnlibError> {
                 return Ok(());
             }
             Err(e) => {
-                tracing::debug!("Attempt {} failed: {}", attempt, e);
+                tracing::debug!(attempt, "Failed to find TUN device: {e}");
                 last_error = Some(e);
                 if attempt < MAX_TUN_SETUP_ATTEMPTS {
                     std::thread::sleep(std::time::Duration::from_millis(TUN_SETUP_RETRY_DELAY_MS));

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -182,6 +182,17 @@ pub enum Event {
 }
 
 #[uniffi::export]
+impl ConnlibError {
+    /// Renders the error and its source chain.
+    ///
+    /// UniFFI maps this type to an opaque foreign class, so the `Display` impl is
+    /// not otherwise reachable from the bindings.
+    pub fn message(&self) -> String {
+        self.to_string()
+    }
+}
+
+#[uniffi::export]
 impl DisconnectError {
     pub fn message(&self) -> String {
         self.0.to_string()
@@ -360,7 +371,7 @@ fn set_tun_from_search(session: &Session) -> Result<(), ConnlibError> {
                 return Ok(());
             }
             Err(e) => {
-                tracing::warn!("Attempt {} failed: {}", attempt, e);
+                tracing::debug!("Attempt {} failed: {}", attempt, e);
                 last_error = Some(e);
                 if attempt < MAX_TUN_SETUP_ATTEMPTS {
                     std::thread::sleep(std::time::Duration::from_millis(TUN_SETUP_RETRY_DELAY_MS));

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -11,14 +11,16 @@ import Foundation
 import NetworkExtension
 import OSLog
 
-enum AdapterError: Error {
+/// `LocalizedError` is what makes `description` reachable through an `any Error`
+/// existential, which is the only way `Log.error(_:)` ever sees us.
+enum AdapterError: Error, CustomStringConvertible, LocalizedError {
   /// Failure to perform an operation in such state.
   case invalidSession(Session?)
 
   /// connlib failed to start
   case connlibConnectError(String)
 
-  var localizedDescription: String {
+  var description: String {
     switch self {
     case .invalidSession(let session):
       let message = session == nil ? "Session is disconnected" : "Session is still connected"
@@ -27,6 +29,8 @@ enum AdapterError: Error {
       return "connlib failed to start: \(error)"
     }
   }
+
+  var errorDescription: String? { description }
 }
 
 // Loosely inspired from WireGuardAdapter from WireGuardKit
@@ -206,6 +210,8 @@ actor Adapter {
         deviceInfo: deviceInfo,
         isInternetResourceActive: internetResourceEnabled
       )
+    } catch let error as ConnlibError {
+      throw AdapterError.connlibConnectError(error.message())
     } catch {
       throw AdapterError.connlibConnectError(String(describing: error))
     }

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -11,8 +11,9 @@ import Foundation
 import NetworkExtension
 import OSLog
 
-/// `LocalizedError` is what makes `description` reachable through an `any Error`
-/// existential, which is the only way `Log.error(_:)` ever sees us.
+/// `LocalizedError` feeds `errorDescription` into `localizedDescription`, which is
+/// what `Log.error(_:)` reads off an `any Error`. `CustomStringConvertible` makes
+/// string interpolation render the same text.
 enum AdapterError: Error, CustomStringConvertible, LocalizedError {
   /// Failure to perform an operation in such state.
   case invalidSession(Session?)


### PR DESCRIPTION
The Apple client reported every connlib start failure as the bare string "ConnlibError" because UniFFI maps the error to an opaque Swift class whose `Display` impl the bindings never expose. The `anyhow` chain that says what actually went wrong was lost at the FFI boundary.

`AdapterError` also carried `localizedDescription` as a plain property, which the `Error` protocol extension shadows whenever the value is held as `any Error`, so even the wrapper text never reached the logs.

The per-attempt TUN lookup failures are already summarised in the error that `Session::new_apple` returns, so they no longer warrant a warning each.