### PR TITLE
fix(apple): report a real error when no utun fd is found

### DIFF
--- a/rust/client-ffi/src/platform/apple/tun.rs
+++ b/rust/client-ffi/src/platform/apple/tun.rs
@@ -314,7 +314,13 @@ fn search_for_tun_fd() -> io::Result<RawFd> {
         }
     }
 
-    Err(get_last_error())
+    // Not `get_last_error`: every miss above leaves `errno` set by the probe that
+    // rejected the descriptor, so the final one describes whatever fd the scan
+    // happened to end on rather than the search itself.
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        "No utun file descriptor found",
+    ))
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]


### PR DESCRIPTION
The scan for the NetworkExtension's utun descriptor surfaced `errno` from whichever probe rejected the last descriptor it looked at, so an exhausted search was reported as "Bad file descriptor" or "Socket operation on non-socket" depending on what happened to occupy the end of the range. Neither describes the actual condition, which is that no utun descriptor was found at all.