### PR TITLE
fix(apple): find the TUN device before starting a session

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -269,6 +269,11 @@ impl Session {
         let tcp_socket_factory = Arc::new(socket_factory::tcp);
         let udp_socket_factory = Arc::new(socket_factory::udp);
 
+        // Locate the TUN device before `connect` spawns anything: every failed
+        // search used to leave a Tokio runtime and its threads behind, and the
+        // NetworkExtension process outlives the session that owns them.
+        let tun_fd = find_tun_fd()?;
+
         let session = connect(
             api_url,
             token,
@@ -281,7 +286,7 @@ impl Session {
             udp_socket_factory,
         )?;
 
-        set_tun_from_search(&session)?;
+        session.set_tun(tun_fd)?;
 
         Ok(session)
     }
@@ -321,25 +326,22 @@ impl Session {
     }
 }
 
-/// Set up TUN device with retry logic.
+/// Find the TUN device with retry logic.
 ///
 /// Retries a few times with a small delay, as the NetworkExtension
 /// might still be setting up the TUN interface.
 #[cfg(any(target_os = "ios", target_os = "macos"))]
-fn set_tun_from_search(session: &Session) -> Result<(), ConnlibError> {
+fn find_tun_fd() -> Result<RawFd, ConnlibError> {
     const MAX_TUN_SETUP_ATTEMPTS: u32 = 5;
     const TUN_SETUP_RETRY_DELAY_MS: u64 = 100;
-
-    let runtime = session.runtime.as_ref().context("No runtime")?;
 
     let mut last_error = None;
     for attempt in 1..=MAX_TUN_SETUP_ATTEMPTS {
         tracing::debug!(attempt, "Attempting to find TUN device");
-        match platform::Tun::new(runtime.handle()) {
-            Ok(tun) => {
-                tracing::debug!("Successfully found and set TUN device");
-                session.inner.set_tun(Box::new(tun));
-                return Ok(());
+        match platform::search_fd() {
+            Ok(fd) => {
+                tracing::debug!("Successfully found TUN device");
+                return Ok(fd);
             }
             Err(e) => {
                 tracing::debug!(attempt, error = %e, "Failed to find TUN device");

--- a/rust/client-ffi/src/platform/apple.rs
+++ b/rust/client-ffi/src/platform/apple.rs
@@ -25,4 +25,4 @@ pub const MAX_PARTITION_TIME: Duration = Duration::from_secs(60 * 60 * 24);
 pub const DSN: Dsn = telemetry::APPLE_DSN;
 
 pub(crate) use make_writer::MakeWriter;
-pub(crate) use tun::Tun;
+pub(crate) use tun::{Tun, search_fd};

--- a/rust/client-ffi/src/platform/apple/tun.rs
+++ b/rust/client-ffi/src/platform/apple/tun.rs
@@ -35,7 +35,9 @@ pub struct Tun {
 /// Finds the `utun` descriptor the NetworkExtension opened for this process.
 ///
 /// Separate from [`Tun::from_fd`] so a caller can establish that the descriptor
-/// exists before committing any resources to the session that will own it.
+/// exists before committing any resources to the session that will own it. Leaves
+/// the descriptor untouched: it belongs to the NetworkExtension, and a caller that
+/// gets this far may still give up before there is a [`Tun`] to own it.
 pub fn search_fd() -> io::Result<RawFd> {
     search_for_tun_fd()
 }
@@ -310,8 +312,6 @@ fn search_for_tun_fd() -> io::Result<RawFd> {
         }
 
         if addr.sc_id == info.ctl_id {
-            set_non_blocking(fd)?;
-
             return Ok(fd);
         }
     }

--- a/rust/client-ffi/src/platform/apple/tun.rs
+++ b/rust/client-ffi/src/platform/apple/tun.rs
@@ -32,13 +32,15 @@ pub struct Tun {
     inbound_rx: tun::InboundRx,
 }
 
-impl Tun {
-    pub fn new(runtime: &tokio::runtime::Handle) -> io::Result<Self> {
-        let fd = search_for_tun_fd()?;
-        set_non_blocking(fd)?;
-        Self::from_fd_inner(fd, runtime)
-    }
+/// Finds the `utun` descriptor the NetworkExtension opened for this process.
+///
+/// Separate from [`Tun::from_fd`] so a caller can establish that the descriptor
+/// exists before committing any resources to the session that will own it.
+pub fn search_fd() -> io::Result<RawFd> {
+    search_for_tun_fd()
+}
 
+impl Tun {
     /// Create a new [`Tun`] from a raw file descriptor.
     ///
     /// # Safety


### PR DESCRIPTION
`Session::new_apple` built the whole session and only then looked for the NetworkExtension's utun descriptor, so a failed search still left a Tokio runtime, an uploader thread and a Sentry meter provider behind. The extension process outlives the session that owns those and the OS keeps retrying `startTunnel`, so a machine that cannot find its descriptor accumulates them until it runs out of memory or threads.

Looking the descriptor up first makes a failed search free.