### PR TITLE
fix(connlib): race addresses when opening an HTTP connection

### DIFF
--- a/rust/libs/http-client/Cargo.toml
+++ b/rust/libs/http-client/Cargo.toml
@@ -10,6 +10,7 @@ path = "lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 bytes = { workspace = true }
+futures = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["client", "http1", "http2"] }

--- a/rust/libs/http-client/lib.rs
+++ b/rust/libs/http-client/lib.rs
@@ -187,8 +187,8 @@ async fn connect(
     tracing::debug!(?addresses, %domain, "Creating new HTTP connection");
 
     // Race the addresses instead of walking them in order. A blackholed address
-    // never errors, so trying them one at a time waits out the OS' TCP timeout
-    // before moving on, and a working address behind it is never reached.
+    // fails only once the OS gives up on the TCP connect, over a minute later,
+    // so in order a working address behind one is not reached until then.
     let mut attempts = addresses
         .into_iter()
         .map(|address| {
@@ -201,9 +201,8 @@ async fn connect(
         })
         .collect::<FuturesUnordered<_>>();
 
-    // Ends once every attempt has resolved, so an address that hangs rather than
-    // failing keeps this pending; the caller bounds the wait. Returning early
-    // drops the losing attempts, which cancels them.
+    // Ends once every attempt has resolved. Returning early drops the losing
+    // attempts, which cancels them.
     while let Some((socket, attempt)) = attempts.next().await {
         match attempt {
             Ok(connection) => {

--- a/rust/libs/http-client/lib.rs
+++ b/rust/libs/http-client/lib.rs
@@ -9,6 +9,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
+use futures::{StreamExt as _, stream::FuturesUnordered};
 use http_body_util::{BodyExt, Full};
 use rustls::ClientConfig;
 use socket_factory::{SocketFactory, TcpSocket};
@@ -185,36 +186,36 @@ async fn connect(
 ) -> Result<(Sender, ConnectionDriver)> {
     tracing::debug!(?addresses, %domain, "Creating new HTTP connection");
 
-    anyhow::ensure!(!addresses.is_empty(), "No addresses for '{domain}'");
-
     // Race the addresses instead of walking them in order. A blackholed address
     // never errors, so trying them one at a time waits out the OS' TCP timeout
-    // before moving on, and a working address behind one is never reached.
-    // Whichever connects first wins; dropping the rest cancels them.
-    let attempts = addresses.into_iter().map(|address| {
-        let socket = SocketAddr::new(address, port);
-        let domain = domain.clone();
-        let tls_config = tls_config.clone();
-        let sf = sf.clone();
+    // before moving on, and a working address behind it is never reached.
+    let mut attempts = addresses
+        .into_iter()
+        .map(|address| {
+            let socket = SocketAddr::new(address, port);
+            let domain = domain.clone();
+            let tls_config = tls_config.clone();
+            let sf = sf.clone();
 
-        Box::pin(async move {
-            let connection = connect_one(socket, domain.clone(), tls_config, sf)
-                .await
-                .inspect_err(
-                    |e| tracing::debug!(%socket, %domain, "Failed to create HTTP client: {e:#}"),
-                )?;
-
-            tracing::debug!(%socket, %domain, "Created new HTTP connection");
-
-            anyhow::Ok(connection)
+            async move { (socket, connect_one(socket, domain, tls_config, sf).await) }
         })
-    });
+        .collect::<FuturesUnordered<_>>();
 
-    let (connection, _cancelled) = futures::future::select_ok(attempts)
-        .await
-        .with_context(|| format!("Failed to connect to '{domain}' on port {port}"))?;
+    // Ends once every attempt has resolved, so an address that hangs rather than
+    // failing keeps this pending; the caller bounds the wait. Returning early
+    // drops the losing attempts, which cancels them.
+    while let Some((socket, attempt)) = attempts.next().await {
+        match attempt {
+            Ok(connection) => {
+                tracing::debug!(%socket, %domain, "Created new HTTP connection");
 
-    Ok(connection)
+                return Ok(connection);
+            }
+            Err(e) => tracing::debug!(%socket, %domain, "Failed to create HTTP client: {e:#}"),
+        }
+    }
+
+    anyhow::bail!("Failed to connect to '{domain}' on port {port}");
 }
 
 async fn connect_one(

--- a/rust/libs/http-client/lib.rs
+++ b/rust/libs/http-client/lib.rs
@@ -185,23 +185,36 @@ async fn connect(
 ) -> Result<(Sender, ConnectionDriver)> {
     tracing::debug!(?addresses, %domain, "Creating new HTTP connection");
 
-    for address in addresses {
+    anyhow::ensure!(!addresses.is_empty(), "No addresses for '{domain}'");
+
+    // Race the addresses instead of walking them in order. A blackholed address
+    // never errors, so trying them one at a time waits out the OS' TCP timeout
+    // before moving on, and a working address behind one is never reached.
+    // Whichever connects first wins; dropping the rest cancels them.
+    let attempts = addresses.into_iter().map(|address| {
         let socket = SocketAddr::new(address, port);
+        let domain = domain.clone();
+        let tls_config = tls_config.clone();
+        let sf = sf.clone();
 
-        match connect_one(socket, domain.clone(), tls_config.clone(), sf.clone()).await {
-            Ok((sender, driver)) => {
-                tracing::debug!(%socket, %domain, "Created new HTTP connection");
+        Box::pin(async move {
+            let connection = connect_one(socket, domain.clone(), tls_config, sf)
+                .await
+                .inspect_err(
+                    |e| tracing::debug!(%socket, %domain, "Failed to create HTTP client: {e:#}"),
+                )?;
 
-                return Ok((sender, driver));
-            }
-            Err(e) => {
-                tracing::debug!(%socket, %domain, "Failed to create HTTP client: {e:#}");
-                continue;
-            }
-        }
-    }
+            tracing::debug!(%socket, %domain, "Created new HTTP connection");
 
-    anyhow::bail!("Failed to connect to '{domain}' on port {port}");
+            anyhow::Ok(connection)
+        })
+    });
+
+    let (connection, _cancelled) = futures::future::select_ok(attempts)
+        .await
+        .with_context(|| format!("Failed to connect to '{domain}' on port {port}"))?;
+
+    Ok(connection)
 }
 
 async fn connect_one(


### PR DESCRIPTION
Opening a connection walked the resolved addresses in order, which only works while a bad address fails quickly. When a host's IPv6 address is blackholed the attempt instead sits there until the OS gives up on the TCP connect, 75 seconds on macOS, and the working IPv4 address behind it is not tried until then.

That reaches further than the connection itself. The Apple client drains flow logs at launch and waits for the result, so a blackholed address for the ingest host surfaces as ten seconds of "Loading VPN configurations from system settings" on every launch, until the drain's own budget expires.

Every address is now attempted at once and the first to connect wins; the rest are cancelled.