### PR TITLE
test(connlib): join the flow-log writer without a time bound

### DIFF
--- a/rust/libs/connlib/flow-tracker/tests/writer.rs
+++ b/rust/libs/connlib/flow-tracker/tests/writer.rs
@@ -532,7 +532,7 @@ impl SpoolObserver {
         let subscriber = tracing_subscriber::registry().with(layer);
 
         tracing::subscriber::with_default(subscriber, f);
-        drop(guard); // joins the writer thread, so the reports are on disk
+        guard.join(); // every emitted report is on disk once this returns
     }
 
     fn completed_flows(&self) -> Vec<serde_json::Value> {

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -193,6 +193,22 @@ impl Drop for Guard {
     }
 }
 
+impl Guard {
+    /// Drains the backlog and joins the writer thread, with no time bound.
+    ///
+    /// Production exits through [`Drop`], whose wait is bounded so a stalled
+    /// disk cannot hang the process. A test that reads the spool right after
+    /// emitting needs every report on disk instead, and a hung writer there
+    /// should hang the test into its own timeout, which names the culprit.
+    pub fn join(mut self) {
+        let _ = self.tx.send(Command::Shutdown);
+
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
 enum Command {
     Write(Report),
     /// Explicit shutdown signal; the layer's sender clone lives in the global
@@ -510,7 +526,7 @@ mod tests {
             emit_event(false);
             emit_event(true);
         });
-        drop(guard); // joins the writer thread, so everything is on disk
+        guard.join(); // every emitted report is on disk once this returns
 
         let authz_dir = dir.path().join("responder").join(AUTHZ_ID);
         let stems = std::fs::read_dir(&authz_dir)
@@ -548,7 +564,7 @@ mod tests {
         tracing::subscriber::with_default(subscriber, || {
             emit_event(true);
         });
-        drop(guard);
+        guard.join();
 
         assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
     }
@@ -567,7 +583,7 @@ mod tests {
                 "TCP flow started"
             );
         });
-        drop(guard);
+        guard.join();
 
         assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
     }


### PR DESCRIPTION
A test that reads the spool straight after emitting relied on dropping the writer's `Guard` to get the reports onto disk. That wait is deliberately bounded, so that a stalled disk cannot hang a client on exit, and on a slow runner the bound expires with a report still in the backlog. The test then counts what happens to be there rather than what it emitted, and fails on a machine that was merely busy.

`Guard::join` drains the backlog and joins the writer thread with no bound, and the tests use it instead. Production keeps exiting through `Drop`, so its wait stays bounded. A writer that really is stuck now hangs the test into its own timeout, which names the culprit rather than reporting a count that is short by one.