### PR TITLE
fix(portal): demote WebSocket TLS alerts to info

### DIFF
--- a/elixir/lib/portal/logger_filters.ex
+++ b/elixir/lib/portal/logger_filters.ex
@@ -39,11 +39,11 @@ defmodule Portal.LoggerFilters do
            {:report,
             %{
               label: {:gen_server, :terminate},
-              process_label: {:thousand_island, :connection, _connection},
+              process_label: process_label,
               reason: reason
             }}
        }) do
-    expected_reason?(reason)
+    client_connection_process?(process_label) and expected_reason?(reason)
   end
 
   defp expected_client_error?(%{meta: %{domain: domain, crash_reason: crash_reason}})
@@ -52,6 +52,14 @@ defmodule Portal.LoggerFilters do
   end
 
   defp expected_client_error?(_event), do: false
+
+  # Phoenix relabels the transport process, so a WebSocket connection terminates as
+  # {Phoenix.Socket, _, _} instead of {:thousand_island, :connection, _}, and its
+  # channels exit with the same reason.
+  defp client_connection_process?({:thousand_island, :connection, _connection}), do: true
+  defp client_connection_process?({Phoenix.Socket, _handler, _id}), do: true
+  defp client_connection_process?({Phoenix.Channel, _channel, _topic}), do: true
+  defp client_connection_process?(_process_label), do: false
 
   defp expected_reason?({:tls_alert, {alert, _description}}), do: alert in @client_tls_alerts
 

--- a/elixir/test/portal/logger_filters_test.exs
+++ b/elixir/test/portal/logger_filters_test.exs
@@ -73,6 +73,31 @@ defmodule Portal.LoggerFiltersTest do
       assert LoggerFilters.relevel_expected_client_errors(transport_error, nil) == :ignore
     end
 
+    test "relevels client TLS alerts on WebSocket sockets and channels to info" do
+      for process_label <- [
+            {Phoenix.Socket, PortalAPI.Client.Socket, "socket:16365c49-6446-4de9-be3b-1840db805315"},
+            {Phoenix.Channel, PortalAPI.Client.Channel, "client"}
+          ] do
+        event =
+          termination_event(
+            process_label,
+            {:tls_alert, {:bad_record_mac, ~c"TLS server: Bad Record MAC"}}
+          )
+
+        assert %{level: :info} = LoggerFilters.relevel_expected_client_errors(event, nil)
+      end
+    end
+
+    test "leaves terminations of other labeled processes at error" do
+      event =
+        termination_event(
+          {:gen_statem, Portal.Replication.SlotPoller},
+          {:tls_alert, {:bad_record_mac, ~c"TLS server: Bad Record MAC"}}
+        )
+
+      assert LoggerFilters.relevel_expected_client_errors(event, nil) == :ignore
+    end
+
     test "leaves other TLS alerts at error" do
       for alert <- [:handshake_failure, :internal_error, :unrecognized_name] do
         event = thousand_island_termination_event({:tls_alert, {alert, ~c"TLS server: #{alert}"}})
@@ -119,14 +144,20 @@ defmodule Portal.LoggerFiltersTest do
   end
 
   defp thousand_island_termination_event(reason) do
+    termination_event(
+      {:thousand_island, :connection, {Bandit.DelegatingHandler, {{127, 0, 0, 1}, 443}}},
+      reason
+    )
+  end
+
+  defp termination_event(process_label, reason) do
     %{
       level: :error,
       msg:
         {:report,
          %{
            label: {:gen_server, :terminate},
-           process_label:
-             {:thousand_island, :connection, {Bandit.DelegatingHandler, {{127, 0, 0, 1}, 443}}},
+           process_label: process_label,
            reason: reason
          }},
       meta: %{domain: [:otp]}


### PR DESCRIPTION
Clients sometimes drop a WebSocket connection in a way that makes the TLS stack raise a `bad_record_mac` alert. These alerts paged us at error level in production, even though there is nothing the portal can do about them.

We already relevel this kind of client noise to info, but only for processes that still carry a Thousand Island label. Phoenix renames the connection process, so a WebSocket socket and its channels did not match the filter and stayed at error.

The filter now also matches Phoenix socket and channel processes. The list of accepted reasons does not change, so real server faults and other TLS alerts still log at error.
