### PR TITLE
chore(ci): stop non-release builds from reporting to Sentry

### DIFF
--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -11,6 +11,12 @@ permissions:
   contents: "read"
   id-token: "write" # OIDC auth
 
+# Stamped into every build below, so neither the emulator running the instrumented
+# tests nor a debug artifact someone installs later reports to Sentry. The release
+# build overrides it.
+env:
+  FIREZONE_NO_TELEMETRY: "true"
+
 jobs:
   static-analysis:
     # Android SDK tools hardware accel is available only on Linux runners
@@ -125,6 +131,7 @@ jobs:
           install_args: --cd kotlin/android
       - name: Build the release package
         env:
+          FIREZONE_NO_TELEMETRY: "false"
           KEYSTORE_BASE64: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_BASE64 }}
           KEYSTORE_PASSWORD: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_PASSWORD }}
           KEYSTORE_KEY_PASSWORD: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_KEY_PASSWORD }}

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -147,6 +147,7 @@ jobs:
           ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.artifact-file }}"
           PKG_ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.pkg-artifact-file }}"
           NOTARIZE: "${{ github.event_name == 'workflow_dispatch' }}"
+          FIREZONE_NO_TELEMETRY: "${{ github.event_name != 'workflow_dispatch' }}"
           ISSUER_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}"
           API_KEY_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY_ID }}"
           API_KEY: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY }}"

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -7,8 +7,11 @@ defaults:
   run:
     working-directory: ./rust/gui-client
 
+# Stamped into every build below, so the smoke test, the install test and any
+# artifact from a pull request stay silent. The release build overrides it.
 env:
   TSLINK_BUILD: true
+  FIREZONE_NO_TELEMETRY: "true"
 
 permissions:
   contents: "read"
@@ -171,6 +174,7 @@ jobs:
       - name: Build release exe and MSI / deb
         env:
           CARGO_PROFILE_RELEASE_LTO: thin # Fat LTO is getting too slow / RAM-hungry on Tauri builds
+          FIREZONE_NO_TELEMETRY: "${{ github.event_name != 'workflow_dispatch' || github.ref_name != 'main' }}"
         # `tauri build` signs Firezone.exe (after Tauri patches it) and the
         # MSI via `bundle.windows.signCommand`.
         run: pnpm build

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -61,6 +61,10 @@ android {
 
         val gitSha = System.getenv("GITHUB_SHA") ?: "unknown"
         resValue("string", "git_sha", "Build: \"${gitSha.take(8)}\"")
+
+        // CI sets this for every build that is not a release, so nothing it builds reports.
+        val noTelemetry = System.getenv("FIREZONE_NO_TELEMETRY") == "true"
+        buildConfigField("boolean", "NO_TELEMETRY", noTelemetry.toString())
     }
 
     signingConfigs {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/Telemetry.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/Telemetry.kt
@@ -13,6 +13,11 @@ object Telemetry {
     private var accountSlug: String? = null
 
     fun start(context: Context) {
+        if (BuildConfig.NO_TELEMETRY) {
+            Log.i("Telemetry", "Telemetry is switched off for this build")
+            return
+        }
+
         SentryAndroid.init(context) { options ->
             options.dsn =
                 "https://928a6ee1f6af9734100b8bc89b2dc87d@sentry.firezone.dev/4508175126233088"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7897,7 +7897,6 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "rand 0.10.2",
- "rustls",
  "sentry",
  "serde",
  "serde_json",

--- a/rust/gui-client/src-tauri/build.rs
+++ b/rust/gui-client/src-tauri/build.rs
@@ -71,6 +71,15 @@ fn main() -> Result<()> {
 
     println!("cargo:rerun-if-changed=../policy-templates/windows/firezone.admx");
 
+    // `FIREZONE_NO_TELEMETRY` is also a run-time flag, but the MSI runs
+    // `register-sparse.exe` with an environment we do not control, so CI stamps the
+    // build-time value in as well.
+    println!("cargo:rerun-if-env-changed=FIREZONE_NO_TELEMETRY");
+    println!("cargo:rustc-check-cfg=cfg(no_telemetry)");
+    if std::env::var("FIREZONE_NO_TELEMETRY").as_deref() == Ok("true") {
+        println!("cargo:rustc-cfg=no_telemetry");
+    }
+
     let pfn = format!("{PACKAGE_NAME}_{}", publisher_id(PUBLISHER_DN));
     println!("cargo:rustc-env=FIREZONE_PACKAGE_FAMILY_NAME={pfn}");
     write_wix_package_identity(&pfn)?;

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -345,7 +345,7 @@ impl Cli {
     }
 
     fn is_telemetry_allowed(&self) -> bool {
-        !self.no_telemetry
+        !self.no_telemetry && !firezone_gui_client::NO_TELEMETRY
     }
 }
 

--- a/rust/gui-client/src-tauri/src/bin/register-sparse.rs
+++ b/rust/gui-client/src-tauri/src/bin/register-sparse.rs
@@ -45,12 +45,14 @@ async fn main() -> ExitCode {
         .install_default()
         .expect("Failed to install default crypto provider");
 
-    telemetry::configure(std::sync::Arc::new(socket_factory::tcp));
-    telemetry::start(
-        "entrypoint",
-        firezone_gui_client::RELEASE,
-        telemetry::GUI_DSN,
-    );
+    if !firezone_gui_client::NO_TELEMETRY {
+        telemetry::configure(std::sync::Arc::new(socket_factory::tcp));
+        telemetry::start(
+            "entrypoint",
+            firezone_gui_client::RELEASE,
+            telemetry::GUI_DSN,
+        );
+    }
 
     let exit_code = run();
 

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -45,6 +45,13 @@ pub const BUNDLE_ID: &str = "dev.firezone.client";
 /// Hence, we have a single constant for Tunnel service and GUI client.
 pub const RELEASE: &str = concat!("gui-client@", env!("CARGO_PKG_VERSION"));
 
+/// Whether `FIREZONE_NO_TELEMETRY` was set when this binary was built.
+///
+/// CI stamps it into every build that is not a release, so the smoke test, the
+/// install test and any artifact from a pull request stay silent even where nothing
+/// sets the variable at run time.
+pub const NO_TELEMETRY: bool = cfg!(no_telemetry);
+
 pub const FIREZONE_CLIENT_GROUP: &str = "firezone-client";
 
 /// `Name_publisherId` for the sparse MSIX. Derived at build time

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -720,8 +720,8 @@ impl<'a> Handler<'a> {
                 // is cumbersome.
                 // Disabling telemetry for the service is mostly useful for our own testing and therefore
                 // doesn't need to be exposed publicly anyway.
-                let no_telemetry =
-                    std::env::var("FIREZONE_NO_TELEMETRY").is_ok_and(|s| s == "true");
+                let no_telemetry = crate::NO_TELEMETRY
+                    || std::env::var("FIREZONE_NO_TELEMETRY").is_ok_and(|s| s == "true");
 
                 if !no_telemetry {
                     self.telemetry_release = Some(release.clone());

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -29,8 +29,6 @@ tunnel-bypass-resolver = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-rustls = { workspace = true, features = ["ring"] }
-socket-factory = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 

--- a/rust/libs/telemetry/tests/attach_firezone_id.rs
+++ b/rust/libs/telemetry/tests/attach_firezone_id.rs
@@ -2,9 +2,8 @@ use telemetry::TESTING;
 
 #[tokio::test]
 async fn set_firezone_id_attaches_user_to_running_session() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-
-    telemetry::configure(std::sync::Arc::new(socket_factory::tcp));
+    // No socket factory is configured, so the ingest client can never connect and
+    // the tests report nothing to Sentry.
     telemetry::start("entrypoint", "1.0.0", TESTING);
 
     telemetry::set_firezone_id("device-abc".to_owned());

--- a/rust/libs/telemetry/tests/set_account_before_id.rs
+++ b/rust/libs/telemetry/tests/set_account_before_id.rs
@@ -2,9 +2,8 @@ use telemetry::TESTING;
 
 #[tokio::test]
 async fn set_account_slug_before_set_firezone_id_preserves_both() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-
-    telemetry::configure(std::sync::Arc::new(socket_factory::tcp));
+    // No socket factory is configured, so the ingest client can never connect and
+    // the tests report nothing to Sentry.
     telemetry::start("entrypoint", "1.0.0", TESTING);
 
     telemetry::set_account_slug("acme".to_owned());

--- a/rust/libs/telemetry/tests/stop_deactivates_session.rs
+++ b/rust/libs/telemetry/tests/stop_deactivates_session.rs
@@ -2,9 +2,8 @@ use telemetry::{Env, TESTING};
 
 #[tokio::test]
 async fn stop_deactivates_but_remembers_env() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-
-    telemetry::configure(std::sync::Arc::new(socket_factory::tcp));
+    // No socket factory is configured, so the ingest client can never connect and
+    // the tests report nothing to Sentry.
     telemetry::start("wss://api.firez.one", "1.0.0", TESTING);
     assert!(telemetry::is_active());
 

--- a/rust/libs/telemetry/tests/swap_env.rs
+++ b/rust/libs/telemetry/tests/swap_env.rs
@@ -2,9 +2,8 @@ use telemetry::{Env, TESTING};
 
 #[tokio::test]
 async fn entrypoint_then_real_env_swaps_running_session() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-
-    telemetry::configure(std::sync::Arc::new(socket_factory::tcp));
+    // No socket factory is configured, so the ingest client can never connect and
+    // the tests report nothing to Sentry.
     telemetry::start("entrypoint", "1.0.0", TESTING);
     assert_eq!(telemetry::current_env(), Some(Env::Entrypoint));
 

--- a/rust/libs/telemetry/tests/swap_env_across_threads.rs
+++ b/rust/libs/telemetry/tests/swap_env_across_threads.rs
@@ -2,9 +2,8 @@ use telemetry::{Env, TESTING};
 
 #[tokio::test]
 async fn start_on_other_thread_swaps_env_on_main_hub() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-
-    telemetry::configure(std::sync::Arc::new(socket_factory::tcp));
+    // No socket factory is configured, so the ingest client can never connect and
+    // the tests report nothing to Sentry.
     telemetry::start("entrypoint", "1.0.0", TESTING);
     assert_eq!(telemetry::current_env(), Some(Env::Entrypoint));
 

--- a/rust/libs/telemetry/tests/unsupported_disables_current.rs
+++ b/rust/libs/telemetry/tests/unsupported_disables_current.rs
@@ -2,9 +2,8 @@ use telemetry::TESTING;
 
 #[tokio::test]
 async fn starting_session_for_unsupported_env_disables_current_one() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-
-    telemetry::configure(std::sync::Arc::new(socket_factory::tcp));
+    // No socket factory is configured, so the ingest client can never connect and
+    // the tests report nothing to Sentry.
     telemetry::start("wss://api.firez.one", "1.0.0", TESTING);
     telemetry::start("wss://example.com", "1.0.0", TESTING);
 

--- a/scripts/build/ios-appstore.sh
+++ b/scripts/build/ios-appstore.sh
@@ -13,6 +13,8 @@ temp_dir="${TEMP_DIR:-$(mktemp -d)}"
 archive_path="$temp_dir/Firezone.xcarchive"
 export_options_plist_path="$temp_dir/ExportOptions.plist"
 git_sha=${GITHUB_SHA:-$(git rev-parse HEAD)}
+# CI sets this for every build that is not a release, so nothing it builds reports.
+no_telemetry=${FIREZONE_NO_TELEMETRY:-false}
 project_file=swift/apple/Firezone.xcodeproj
 code_sign_identity="Apple Distribution: Firezone, Inc. (47R2M6779T)"
 
@@ -30,6 +32,7 @@ echo "Building and signing app..."
 seconds_since_epoch=$(date +%s)
 xcodebuild archive \
     GIT_SHA="$git_sha" \
+    FIREZONE_NO_TELEMETRY="$no_telemetry" \
     CODE_SIGN_STYLE=Manual \
     CODE_SIGN_IDENTITY="$code_sign_identity" \
     APP_PROFILE_ID="$app_profile_id" \

--- a/scripts/build/macos-appstore.sh
+++ b/scripts/build/macos-appstore.sh
@@ -12,6 +12,8 @@ ne_profile_id=$(extract_uuid "$MACOS_NE_PROVISIONING_PROFILE")
 temp_dir="${TEMP_DIR:-$(mktemp -d)}"
 package_path="$temp_dir/Firezone.pkg"
 git_sha=${GITHUB_SHA:-$(git rev-parse HEAD)}
+# CI sets this for every build that is not a release, so nothing it builds reports.
+no_telemetry=${FIREZONE_NO_TELEMETRY:-false}
 project_file=swift/apple/Firezone.xcodeproj
 code_sign_identity="Apple Distribution: Firezone, Inc. (47R2M6779T)"
 installer_code_sign_identity="3rd Party Mac Developer Installer: Firezone, Inc. (47R2M6779T)"
@@ -30,6 +32,7 @@ echo "Building and signing app..."
 seconds_since_epoch=$(date +%s)
 xcodebuild build \
     GIT_SHA="$git_sha" \
+    FIREZONE_NO_TELEMETRY="$no_telemetry" \
     CODE_SIGN_STYLE=Manual \
     CODE_SIGN_IDENTITY="$code_sign_identity" \
     CONFIGURATION_BUILD_DIR="$temp_dir" \

--- a/scripts/build/macos-standalone.sh
+++ b/scripts/build/macos-standalone.sh
@@ -16,6 +16,8 @@ dmg_path="$temp_dir/Firezone.dmg"
 staging_dmg_path="$temp_dir/staging.dmg"
 staging_pkg_path="$temp_dir/staging.pkg"
 git_sha=${GITHUB_SHA:-$(git rev-parse HEAD)}
+# CI sets this for every build that is not a release, so nothing it builds reports.
+no_telemetry=${FIREZONE_NO_TELEMETRY:-false}
 project_file=swift/apple/Firezone.xcodeproj
 code_sign_identity="Developer ID Application: Firezone, Inc. (47R2M6779T)"
 installer_code_sign_identity="Developer ID Installer: Firezone, Inc. (47R2M6779T)"
@@ -34,6 +36,7 @@ echo "Building and signing app..."
 seconds_since_epoch=$(date +%s)
 xcodebuild build \
     GIT_SHA="$git_sha" \
+    FIREZONE_NO_TELEMETRY="$no_telemetry" \
     CODE_SIGN_STYLE=Manual \
     CODE_SIGN_IDENTITY="$code_sign_identity" \
     PACKET_TUNNEL_PROVIDER_SUFFIX=-systemextension \

--- a/swift/apple/Firezone/Info.plist
+++ b/swift/apple/Firezone/Info.plist
@@ -47,6 +47,8 @@
   <false/>
   <key>GitSha</key>
   <string>$(GIT_SHA)</string>
+  <key>NoTelemetry</key>
+  <string>$(FIREZONE_NO_TELEMETRY)</string>
 	<key>LSEnvironment</key>
 	<dict>
 		<key>SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL</key>

--- a/swift/apple/Firezone/xcconfig/config.xcconfig
+++ b/swift/apple/Firezone/xcconfig/config.xcconfig
@@ -19,3 +19,7 @@ CURRENT_PROJECT_VERSION = 0
 
 // mark:next-apple-version
 MARKETING_VERSION=1.5.20
+
+// CI stamps this into every build that is not a release, on the `xcodebuild`
+// command line, so nothing it builds reports to Sentry.
+FIREZONE_NO_TELEMETRY = false

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Bundle.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Bundle.swift
@@ -17,6 +17,12 @@ public enum BundleHelper {
     return false
   }
 
+  /// Whether telemetry was switched off when this bundle was built. CI stamps
+  /// `FIREZONE_NO_TELEMETRY` into every build that is not a release.
+  static var noTelemetry: Bool {
+    Bundle.main.object(forInfoDictionaryKey: "NoTelemetry") as? String == "true"
+  }
+
   static var gitSha: String {
     guard let gitSha = Bundle.main.object(forInfoDictionaryKey: "GitSha") as? String,
       !gitSha.isEmpty

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -19,6 +19,12 @@ public enum Telemetry {
   }
 
   public static func start(enableAppHangTracking: Bool = true) {
+    guard !BundleHelper.noTelemetry else {
+      Log.info("Telemetry is switched off for this build")
+
+      return
+    }
+
     SentrySDK.start { options in
       options.dsn =
         "https://66c71f83675f01abfffa8eb977bcbbf7@o4507971108339712.ingest.us.sentry.io/4508175177023488"

--- a/swift/apple/FirezoneNetworkExtension/Info.iOS.plist
+++ b/swift/apple/FirezoneNetworkExtension/Info.iOS.plist
@@ -11,6 +11,8 @@
 	</dict>
 	<key>AppGroupIdentifier</key>
 	<string>$(APP_GROUP_ID)</string>
+	<key>NoTelemetry</key>
+	<string>$(FIREZONE_NO_TELEMETRY)</string>
 	<key>LSEnvironment</key>
 	<dict>
 		<key>SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL</key>

--- a/swift/apple/FirezoneNetworkExtension/Info.macOS.plist
+++ b/swift/apple/FirezoneNetworkExtension/Info.macOS.plist
@@ -24,6 +24,8 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>AppGroupIdentifier</key>
 	<string>$(APP_GROUP_ID)</string>
+	<key>NoTelemetry</key>
+	<string>$(FIREZONE_NO_TELEMETRY)</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2025 Firezone, Inc. All rights reserved.</string>
 	<key>LSEnvironment</key>


### PR DESCRIPTION
CI runs were reporting issues to Sentry which creates lots of noise in the case of the Apple clients specifically.

This PR propagates our `FIREZONE_NO_TELEMETRY` flag to build time so it can be switched off for certain CI builds.

Fixes #14839 