### PR TITLE
fix(portal): verify the tenant that grants Sentinel consent

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -292,6 +292,8 @@ config :portal, Portal.Sentinel.APIClient,
   client_id: System.get_env("SENTINEL_SYNC_CLIENT_ID"),
   client_secret: System.get_env("SENTINEL_SYNC_CLIENT_SECRET"),
   token_base_url: "https://login.microsoftonline.com",
+  discovery_document_uri:
+    "https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration",
   req_opts: []
 
 config :portal, Portal.S3.APIClient,

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -170,7 +170,9 @@ if config_env() == :prod do
   # identity (Portal.Azure.ManagedIdentity).
   config :portal, Portal.Sentinel.APIClient,
     client_id: env_var_to_config!(:sentinel_sync_client_id),
-    token_base_url: "https://login.microsoftonline.com"
+    token_base_url: "https://login.microsoftonline.com",
+    discovery_document_uri:
+      "https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration"
 
   config :portal, Portal.Billing.Stripe.APIClient, endpoint: "https://api.stripe.com"
 

--- a/elixir/lib/portal_web/controllers/sentinel_consent_controller.ex
+++ b/elixir/lib/portal_web/controllers/sentinel_consent_controller.ex
@@ -4,21 +4,194 @@ defmodule PortalWeb.SentinelConsentController do
   registered reply address, and the consenting admin is often not a signed-in
   portal user, so the outcome renders as a standalone page that closes itself
   rather than a redirect into the authenticated app.
+
+  A returned admin consent proves nothing on its own: Entra reports it with
+  unsigned query parameters, and it can carry an error in the same redirect.
+  Consent is therefore followed by the same tenant proof the Entra auth
+  provider, directory sync, and Intune flows run. The `tenant` parameter only
+  picks the authority the proof is sent to; the tenant Firezone acts on is the
+  `tid` claim of a signature-verified ID token, which must match it, and the
+  `wids` claim of that token has to carry a tenant-wide admin role. The
+  verified tenant is sent back to the log sink form so nobody has to copy it by
+  hand.
   """
   use PortalWeb, :controller
+
+  alias PortalWeb.OIDC
+
+  require Logger
 
   plug :put_root_layout, html: {PortalWeb.Layouts, :verification}
   plug :put_layout, html: false
 
-  def callback(conn, %{"admin_consent" => "True"}) do
-    render(conn, :granted)
+  # An administrator can spend a while on the Microsoft consent screen signing
+  # in and completing MFA, so this state outlives the 5 minutes the OIDC
+  # verification flows allow.
+  @state_max_age 30 * 60
+
+  @verifier_session_key :sentinel_consent_verifier
+
+  @silent_sso_unavailable_errors ~w[consent_required interaction_required login_required]
+
+  @invalid_response_error "The consent response was missing or invalid."
+
+  @proof_failed_error "Firezone could not verify your Microsoft Entra tenant after consent. Please try again."
+
+  @session_lost_error "This browser lost the consent session before the tenant check finished. Please start the consent again."
+
+  @not_admin_error "Admin consent must be granted by a Global Administrator or a Privileged Role Administrator."
+
+  @tenant_mismatch_error "Firezone could not confirm which Microsoft Entra tenant granted consent. Please start the consent again."
+
+  def callback(conn, %{"state" => state} = params) do
+    case OIDC.verify_verification_state(state, max_age: @state_max_age) do
+      {:ok, %{type: "sentinel-log-sink"} = verification} ->
+        handle_admin_consent(conn, params, verification)
+
+      {:ok, %{type: "sentinel-log-sink-tenant-proof"} = verification} ->
+        handle_tenant_proof(conn, params, verification)
+
+      _ ->
+        render_declined(conn, error_message(params))
+    end
   end
 
-  def callback(conn, %{"error" => error} = params) do
-    render(conn, :declined, error: params["error_description"] || error)
+  def callback(conn, params) do
+    render_declined(conn, error_message(params))
   end
 
-  def callback(conn, _params) do
-    render(conn, :declined, error: "The consent response was missing or invalid.")
+  # Entra reports a failed consent with `admin_consent=True` and an `error` in
+  # the same redirect, so the error has to be matched first.
+  defp handle_admin_consent(conn, %{"error" => _error} = params, _verification) do
+    render_declined(conn, error_message(params))
+  end
+
+  defp handle_admin_consent(
+         conn,
+         %{"admin_consent" => "True", "tenant" => tenant_id},
+         verification
+       ) do
+    start_tenant_proof(conn, verification, tenant_id, true)
+  end
+
+  defp handle_admin_consent(conn, params, _verification) do
+    render_declined(conn, error_message(params))
+  end
+
+  defp handle_tenant_proof(conn, %{"code" => code}, verification) do
+    complete_tenant_proof(conn, code, verification)
+  end
+
+  # Entra rejects the silent request when it cannot reuse the session the
+  # consent screen created; retry once with an account picker.
+  defp handle_tenant_proof(conn, %{"error" => error}, %{silent: true} = verification)
+       when error in @silent_sso_unavailable_errors do
+    start_tenant_proof(conn, verification, verification.tenant_id, false)
+  end
+
+  defp handle_tenant_proof(conn, params, _verification) do
+    render_declined(conn, error_message(params))
+  end
+
+  defp start_tenant_proof(conn, verification, tenant_id, silent?) do
+    verifier = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+
+    state_token =
+      OIDC.sign_verification_state(verification.lv_pid, "sentinel-log-sink-tenant-proof", %{
+        verification_ref: verification.verification_ref,
+        tenant_id: tenant_id,
+        silent: silent?
+      })
+
+    with {:ok, %{config: config}} <- OIDC.setup_verification("sentinel_log_sink", []),
+         {:ok, uri} <-
+           OIDC.build_entra_tenant_authorization_uri(config, tenant_id, verifier, state_token,
+             prompt: tenant_proof_prompt(silent?),
+             redirect_uri: OIDC.sentinel_consent_url()
+           ) do
+      conn
+      |> put_session(@verifier_session_key, verifier)
+      |> redirect(external: uri)
+    else
+      error ->
+        log_tenant_proof_error(error)
+        render_declined(conn, @proof_failed_error)
+    end
+  end
+
+  defp complete_tenant_proof(conn, code, verification) do
+    verifier = get_session(conn, @verifier_session_key)
+    conn = delete_session(conn, @verifier_session_key)
+
+    case verify_tenant_proof(verifier, code, verification.tenant_id) do
+      {:ok, tenant_id} ->
+        notify_log_sink_form(verification, tenant_id)
+        render(conn, :granted, tenant_id: tenant_id)
+
+      {:error, message} ->
+        render_declined(conn, message)
+    end
+  end
+
+  defp verify_tenant_proof(verifier, code, tenant_id) when is_binary(verifier) do
+    with {:ok, %{config: config}} <- OIDC.setup_verification("sentinel_log_sink", []),
+         {:ok, %{tenant_id: verified_tenant_id, role_ids: role_ids}} <-
+           OIDC.verify_entra_callback(config, code, verifier, tenant_id,
+             redirect_uri: OIDC.sentinel_consent_url()
+           ) do
+      if OIDC.entra_setup_admin?(role_ids) do
+        {:ok, verified_tenant_id}
+      else
+        {:error, @not_admin_error}
+      end
+    else
+      {:error, {:invalid_entra_id_token, :tenant_mismatch}} ->
+        {:error, @tenant_mismatch_error}
+
+      error ->
+        log_tenant_proof_error(error)
+        {:error, @proof_failed_error}
+    end
+  end
+
+  defp verify_tenant_proof(_verifier, _code, _tenant_id), do: {:error, @session_lost_error}
+
+  # Best effort: the administrator who consents is often working in a different
+  # browser than the operator who opened the form, so the page also renders the
+  # verified tenant for them to copy.
+  defp notify_log_sink_form(%{lv_pid: lv_pid, verification_ref: verification_ref}, tenant_id)
+       when is_binary(verification_ref) do
+    case OIDC.deserialize_pid(lv_pid) do
+      pid when is_pid(pid) ->
+        send(pid, {:sentinel_log_sink_complete, tenant_id, verification_ref})
+        :ok
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp notify_log_sink_form(_verification, _tenant_id), do: :ok
+
+  defp tenant_proof_prompt(true), do: "none"
+  defp tenant_proof_prompt(false), do: nil
+
+  defp render_declined(conn, error) do
+    render(conn, :declined, error: error)
+  end
+
+  defp error_message(%{"error_description" => description})
+       when is_binary(description) and description != "" do
+    description
+  end
+
+  defp error_message(%{"error" => error}) when is_binary(error) and error != "" do
+    error
+  end
+
+  defp error_message(_params), do: @invalid_response_error
+
+  defp log_tenant_proof_error(error) do
+    Logger.warning("Sentinel tenant proof failed", reason: inspect(error))
   end
 end

--- a/elixir/lib/portal_web/controllers/sentinel_consent_html/granted.html.heex
+++ b/elixir/lib/portal_web/controllers/sentinel_consent_html/granted.html.heex
@@ -1,6 +1,7 @@
 <.result_page success title="Admin Consent Granted" auto_close_after_ms={1000}>
   <p class="mt-2 text-base text-gray-600">
-    The Firezone Sentinel Log Ingestion application has been added to your Microsoft
-    Entra tenant. If this window remains open, close it to return to the Firezone portal.
+    The Firezone Sentinel Log Ingestion application has been added to Microsoft Entra
+    tenant <span class="font-mono">{@tenant_id}</span>. If this window remains open,
+    close it to return to the Firezone portal.
   </p>
 </.result_page>

--- a/elixir/lib/portal_web/live/settings/log_sinks.ex
+++ b/elixir/lib/portal_web/live/settings/log_sinks.ex
@@ -72,6 +72,7 @@ defmodule PortalWeb.Settings.LogSinks do
       assign(socket,
         page_title: "Log Sinks",
         sentinel_setup_tab: "portal",
+        sentinel_verification_ref: nil,
         s3_setup_tab: "console",
         trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?(),
         device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
@@ -147,8 +148,28 @@ defmodule PortalWeb.Settings.LogSinks do
   end
 
   def handle_event("sentinel_admin_consent", _params, socket) do
-    url = sentinel_admin_consent_url(socket.assigns.form, socket.assigns.account)
-    {:noreply, push_event(socket, "open_url", %{url: url})}
+    verification_ref = Ecto.UUID.generate()
+
+    with {:ok, %{config: config}} <- PortalWeb.OIDC.setup_verification("sentinel_log_sink", []),
+         state_token =
+           PortalWeb.OIDC.sign_verification_state(
+             PortalWeb.OIDC.serialize_pid(self()),
+             PortalWeb.OIDC.verification_state_type("sentinel_log_sink"),
+             %{verification_ref: verification_ref}
+           ),
+         {:ok, url} <-
+           PortalWeb.OIDC.build_verification_uri("sentinel_log_sink", config, nil, state_token) do
+      {:noreply,
+       socket
+       |> assign(sentinel_verification_ref: verification_ref)
+       |> push_event("open_url", %{url: url})}
+    else
+      {:error, reason} ->
+        Logger.info("Failed to start Sentinel admin consent", reason: inspect(reason))
+
+        {:noreply,
+         put_flash(socket, :error, "Failed to start Microsoft admin consent. Please try again.")}
+    end
   end
 
   def handle_event("validate", %{"log_sink" => attrs}, socket) do
@@ -275,6 +296,25 @@ defmodule PortalWeb.Settings.LogSinks do
   def handle_event("close_sink_actions", _params, socket) do
     {:noreply, assign(socket, open_sink_actions_id: nil)}
   end
+
+  def handle_info({:sentinel_log_sink_complete, tenant_id, verification_ref}, socket) do
+    if socket.assigns[:sentinel_verification_ref] == verification_ref and socket.assigns[:form] do
+      changeset = socket.assigns.form.source
+      attrs = Map.put(changeset.changes, :tenant_id, tenant_id)
+
+      changeset =
+        changeset.data
+        |> changeset(attrs)
+        |> Map.put(:action, :validate)
+
+      {:noreply, assign(socket, form: to_form(changeset), sentinel_verification_ref: nil)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_info(message, socket),
+    do: PortalWeb.Live.Helpers.handle_info_fallback(message, socket)
 
   def render(assigns) do
     ~H"""
@@ -1050,12 +1090,13 @@ defmodule PortalWeb.Settings.LogSinks do
           <div class="mb-4 p-3 rounded border border-border bg-surface">
             <p class="text-xs font-medium text-heading mb-1.5">1. Grant admin consent</p>
             <p class="text-xs text-subtle mb-3">
-              Enter your Microsoft Entra tenant ID below, then have a tenant administrator grant
-              consent. This adds the <strong>Firezone Sentinel Log Ingestion</strong> application
-              to your tenant so you can assign it a role in the next step. It requests no API
-              permissions and cannot read your directory or data. It only becomes a service
-              principal you grant the Monitoring Metrics Publisher role to on a single data
-              collection rule.
+              Have a tenant administrator grant consent. This adds the
+              <strong>Firezone Sentinel Log Ingestion</strong>
+              application to your tenant so you can assign it a role in the next step. Firezone
+              verifies which tenant granted the consent and fills in the tenant ID below. The
+              application asks only to sign the administrator in and read their basic profile.
+              It cannot read your directory or your data. Log delivery is authorized only by the
+              Monitoring Metrics Publisher role you grant on a single data collection rule.
             </p>
             <.button
               type="button"
@@ -1143,9 +1184,10 @@ defmodule PortalWeb.Settings.LogSinks do
           </ol>
           <div :if={@sentinel_setup_tab == "cli"}>
             <p class="text-xs text-subtle mb-2">
-              Assumes an existing Log Analytics workspace. Set the variables for your
-              environment, then run the script with the Azure CLI logged into your
-              subscription. It prints the values for the fields below.
+              Creates the resource group, workspace, custom table, data collection endpoint,
+              and data collection rule if they do not exist yet, and leaves them alone if they
+              do. Set the variables for your environment, then run the script with the Azure
+              CLI logged into your subscription. It prints the values for the fields below.
             </p>
             <.code_block id="sentinel-setup-cli" class="rounded text-xs">{sentinel_cli_snippet()}</.code_block>
           </div>
@@ -1775,21 +1817,6 @@ defmodule PortalWeb.Settings.LogSinks do
     end
   end
 
-  defp sentinel_admin_consent_url(form, account) do
-    tenant =
-      case get_field(form.source, :tenant_id) do
-        tenant when is_binary(tenant) and tenant != "" -> String.trim(tenant)
-        _ -> "organizations"
-      end
-
-    "https://login.microsoftonline.com/#{tenant}/adminconsent?" <>
-      URI.encode_query(%{
-        "client_id" => sentinel_client_id(),
-        "redirect_uri" => url(~p"/auth/sentinel/consent"),
-        "state" => Phoenix.Param.to_param(account)
-      })
-  end
-
   defp sentinel_client_id do
     Portal.Config.fetch_env!(:portal, Portal.Sentinel.APIClient)
     |> Keyword.get(:client_id)
@@ -1797,30 +1824,39 @@ defmodule PortalWeb.Settings.LogSinks do
   end
 
   @sentinel_cli_snippet ~S"""
-  RG="my-resource-group"
-  WORKSPACE="my-workspace"
-  LOCATION="eastus"
+  firezone_sentinel_setup() {
+    RG="my-resource-group"
+    WORKSPACE="my-workspace"
+    LOCATION="eastus"
 
-  WORKSPACE_ID=$(az monitor log-analytics workspace show \
-    -g "$RG" -n "$WORKSPACE" --query id -o tsv)
+    if ! az group show -n "$RG" > /dev/null 2>&1; then
+      az group create -n "$RG" -l "$LOCATION" --output none
+    fi
 
-  if ! az monitor log-analytics workspace table show \
-       -g "$RG" --workspace-name "$WORKSPACE" -n FirezoneLogs_CL > /dev/null 2>&1; then
-    az monitor log-analytics workspace table create \
-      -g "$RG" --workspace-name "$WORKSPACE" -n FirezoneLogs_CL \
-      --columns TimeGenerated=datetime Message=string Stream=string Firezone=dynamic \
-      --output none
-  fi
+    WORKSPACE_ID=$(az monitor log-analytics workspace show \
+      -g "$RG" -n "$WORKSPACE" --query id -o tsv 2>/dev/null)
+    if [ -z "$WORKSPACE_ID" ]; then
+      WORKSPACE_ID=$(az monitor log-analytics workspace create \
+        -g "$RG" -n "$WORKSPACE" -l "$LOCATION" --query id -o tsv)
+    fi
 
-  DCE_ID=$(az monitor data-collection endpoint show \
-    -g "$RG" -n firezone-logs --query id -o tsv 2>/dev/null)
-  if [ -z "$DCE_ID" ]; then
-    DCE_ID=$(az monitor data-collection endpoint create \
-      -g "$RG" -n firezone-logs -l "$LOCATION" \
-      --public-network-access Enabled --query id -o tsv)
-  fi
+    if ! az monitor log-analytics workspace table show \
+         -g "$RG" --workspace-name "$WORKSPACE" -n FirezoneLogs_CL > /dev/null 2>&1; then
+      az monitor log-analytics workspace table create \
+        -g "$RG" --workspace-name "$WORKSPACE" -n FirezoneLogs_CL \
+        --columns TimeGenerated=datetime Message=string Stream=string Firezone=dynamic \
+        --output none
+    fi
 
-  cat > firezone-dcr.json <<EOF
+    DCE_ID=$(az monitor data-collection endpoint show \
+      -g "$RG" -n firezone-logs --query id -o tsv 2>/dev/null)
+    if [ -z "$DCE_ID" ]; then
+      DCE_ID=$(az monitor data-collection endpoint create \
+        -g "$RG" -n firezone-logs -l "$LOCATION" \
+        --public-network-access Enabled --query id -o tsv)
+    fi
+
+    cat > firezone-dcr.json <<EOF
   {
     "location": "$LOCATION",
     "properties": {
@@ -1852,29 +1888,37 @@ defmodule PortalWeb.Settings.LogSinks do
   }
   EOF
 
-  DCR_ID=$(az monitor data-collection rule show \
-    -g "$RG" -n firezone-logs --query id -o tsv 2>/dev/null)
-  if [ -z "$DCR_ID" ]; then
-    DCR_ID=$(az monitor data-collection rule create \
-      -g "$RG" -n firezone-logs --rule-file firezone-dcr.json --query id -o tsv)
-  fi
+    DCR_ID=$(az monitor data-collection rule show \
+      -g "$RG" -n firezone-logs --query id -o tsv 2>/dev/null)
+    if [ -z "$DCR_ID" ]; then
+      DCR_ID=$(az monitor data-collection rule create \
+        -g "$RG" -n firezone-logs --rule-file firezone-dcr.json --query id -o tsv)
+    fi
 
-  SP_ID=$(az ad sp show --id FIREZONE_CLIENT_ID --query id -o tsv)
+    SP_ID=$(az ad sp show --id FIREZONE_CLIENT_ID --query id -o tsv 2>/dev/null)
 
-  if ! az role assignment list --assignee "$SP_ID" --scope "$DCR_ID" \
-       --role "Monitoring Metrics Publisher" --query "[0].id" -o tsv 2>/dev/null | grep -q .; then
-    az role assignment create --assignee-object-id "$SP_ID" \
-      --assignee-principal-type ServicePrincipal \
-      --role "Monitoring Metrics Publisher" --scope "$DCR_ID" \
-      --output none
-  fi
+    if [ -z "$SP_ID" ]; then
+      echo "The Firezone application is not in this tenant. Grant admin consent first." >&2
+      return 1
+    fi
 
-  echo "Enter these in the Firezone form:"
-  echo "  Ingestion Endpoint: $(az monitor data-collection endpoint show \
-    -g "$RG" -n firezone-logs --query logsIngestion.endpoint -o tsv)"
-  echo "  DCR Immutable ID:   $(az monitor data-collection rule show \
-    -g "$RG" -n firezone-logs --query immutableId -o tsv)"
-  echo "  Stream Name:        Custom-FirezoneLogs_CL"
+    if ! az role assignment list --assignee "$SP_ID" --scope "$DCR_ID" \
+         --role "Monitoring Metrics Publisher" --query "[0].id" -o tsv 2>/dev/null | grep -q .; then
+      az role assignment create --assignee-object-id "$SP_ID" \
+        --assignee-principal-type ServicePrincipal \
+        --role "Monitoring Metrics Publisher" --scope "$DCR_ID" \
+        --output none
+    fi
+
+    echo "Enter these in the Firezone form:"
+    echo "  Ingestion Endpoint: $(az monitor data-collection endpoint show \
+      -g "$RG" -n firezone-logs --query logsIngestion.endpoint -o tsv)"
+    echo "  DCR Immutable ID:   $(az monitor data-collection rule show \
+      -g "$RG" -n firezone-logs --query immutableId -o tsv)"
+    echo "  Stream Name:        Custom-FirezoneLogs_CL"
+  }
+
+  firezone_sentinel_setup
   """
 
   @sentinel_terraform_snippet ~S"""

--- a/elixir/lib/portal_web/oidc.ex
+++ b/elixir/lib/portal_web/oidc.ex
@@ -197,17 +197,19 @@ defmodule PortalWeb.OIDC do
 
   @doc """
   Exchanges authorization code for tokens using a pre-built config.
-  Useful for legacy code paths where config is built manually.
+  Useful for legacy code paths where config is built manually. Pass
+  `:redirect_uri` for a flow whose authorization request replied somewhere
+  other than the OIDC callback; the two have to match.
   Returns {:ok, tokens} or {:error, reason}.
   """
-  def exchange_code_with_config(config, code, verifier) do
+  def exchange_code_with_config(config, code, verifier, opts \\ []) do
     with {:ok, credential} <- verification_client_credential(config) do
       params =
         %{
           grant_type: "authorization_code",
           code: code,
           code_verifier: verifier,
-          redirect_uri: callback_url()
+          redirect_uri: Keyword.get(opts, :redirect_uri, callback_url())
         }
         |> Map.merge(credential)
 
@@ -288,6 +290,7 @@ defmodule PortalWeb.OIDC do
   - "entra" — Entra auth_provider admin consent + silent authorization code/PKCE proof
   - "entra_directory_sync" — Entra directory_sync admin consent + user-bound PKCE proof
   - "intune_posture_provider" — Intune admin consent + user-bound PKCE proof
+  - "sentinel_log_sink" — Sentinel log sink admin consent + user-bound PKCE proof
 
   Options:
   - :okta_domain - Required for Okta providers
@@ -316,6 +319,21 @@ defmodule PortalWeb.OIDC do
     config =
       Portal.Microsoft.Graph.APIClient.verification_config(:intune)
       |> entra_verification_config("openid profile", "https://graph.microsoft.com/.default")
+
+    {:ok, %{config: config}}
+  end
+
+  def setup_verification("sentinel_log_sink", _opts) do
+    sentinel_config = Portal.Config.fetch_env!(:portal, Portal.Sentinel.APIClient)
+
+    config =
+      sentinel_config
+      |> Keyword.take([:client_id, :client_secret, :req_opts])
+      |> entra_verification_config(
+        "openid profile",
+        "https://graph.microsoft.com/.default",
+        Keyword.fetch!(sentinel_config, :discovery_document_uri)
+      )
 
     {:ok, %{config: config}}
   end
@@ -352,8 +370,10 @@ defmodule PortalWeb.OIDC do
   Verifies a signed verification state token.
   Returns {:ok, %{type: type, lv_pid: lv_pid}} or {:error, reason}.
   """
-  def verify_verification_state(state) do
-    Phoenix.Token.verify(PortalWeb.Endpoint, "oidc-verification-state", state, max_age: 5 * 60)
+  def verify_verification_state(state, opts \\ []) do
+    max_age = Keyword.get(opts, :max_age, 5 * 60)
+
+    Phoenix.Token.verify(PortalWeb.Endpoint, "oidc-verification-state", state, max_age: max_age)
   end
 
   @doc """
@@ -364,6 +384,7 @@ defmodule PortalWeb.OIDC do
   def verification_state_type("entra_directory_sync"), do: "entra-directory-sync"
   def verification_state_type("google_directory_sync"), do: "google-directory-sync"
   def verification_state_type("intune_posture_provider"), do: "intune-posture-provider"
+  def verification_state_type("sentinel_log_sink"), do: "sentinel-log-sink"
 
   def verification_state_type(type) when type in ["google", "okta", "oidc"],
     do: "oidc-auth-provider"
@@ -415,7 +436,7 @@ defmodule PortalWeb.OIDC do
   proof that binds the setup to the signed-in user's immutable tenant and object IDs.
   The state_token (from sign_verification_state/2) is passed through the IdP unchanged.
   Accepts types: "google", "okta", "oidc", "entra", "entra_directory_sync",
-  and "intune_posture_provider".
+  "intune_posture_provider", and "sentinel_log_sink".
   Returns {:ok, uri} or {:error, reason}.
   """
   def build_verification_uri(type, config, verifier, state_token)
@@ -467,6 +488,17 @@ defmodule PortalWeb.OIDC do
     {:ok, @entra_organizations_admin_consent_endpoint <> "?" <> URI.encode_query(params)}
   end
 
+  def build_verification_uri("sentinel_log_sink", config, _verifier, state_token) do
+    params = %{
+      client_id: config[:client_id],
+      redirect_uri: sentinel_consent_url(),
+      scope: config[:admin_consent_scope],
+      state: state_token
+    }
+
+    {:ok, @entra_organizations_admin_consent_endpoint <> "?" <> URI.encode_query(params)}
+  end
+
   def build_verification_uri(type, _config, _verifier, _state_token) do
     Logger.error("Unknown verification type", type: type)
     {:error, :unknown_verification_type}
@@ -476,7 +508,8 @@ defmodule PortalWeb.OIDC do
   Builds a tenant-specific Entra authorization-code request after admin consent.
   The initial request is silent so the Microsoft session created by admin consent
   can be reused without showing a second account picker. Set `prompt: nil` for the
-  interactive fallback when Entra reports that silent SSO is unavailable.
+  interactive fallback when Entra reports that silent SSO is unavailable, and
+  `:redirect_uri` for a flow that replies somewhere other than the OIDC callback.
   """
   def build_entra_tenant_authorization_uri(
         config,
@@ -490,7 +523,7 @@ defmodule PortalWeb.OIDC do
 
       params = %{
         client_id: config[:client_id],
-        redirect_uri: callback_url(),
+        redirect_uri: Keyword.get(opts, :redirect_uri, callback_url()),
         response_type: "code",
         response_mode: "query",
         scope: config[:scope],
@@ -519,6 +552,13 @@ defmodule PortalWeb.OIDC do
   def callback_url, do: url(~p"/auth/oidc/callback")
 
   @doc """
+  Returns the Sentinel admin consent callback URL. Both legs of the Sentinel
+  verification reply here, so the application registration needs a single
+  reply address.
+  """
+  def sentinel_consent_url, do: url(~p"/auth/sentinel/consent")
+
+  @doc """
   Performs the complete OIDC verification flow: exchange code for tokens and verify ID token.
   Returns {:ok, claims, userinfo_result} or {:error, reason}.
   """
@@ -540,9 +580,9 @@ defmodule PortalWeb.OIDC do
   from the cryptographically verified ID token after requiring it to match the
   tenant selected by the preceding admin-consent callback.
   """
-  def verify_entra_callback(config, code, verifier, expected_tenant_id) do
+  def verify_entra_callback(config, code, verifier, expected_tenant_id, opts \\ []) do
     with {:ok, expected_tenant_id} <- normalize_entra_tenant_id(expected_tenant_id),
-         {:ok, tokens} <- exchange_code_with_config(config, code, verifier),
+         {:ok, tokens} <- exchange_code_with_config(config, code, verifier, opts),
          id_token when is_binary(id_token) <- tokens["id_token"],
          {:ok, claims} <- verify_token_with_config(config, id_token),
          {:ok, tenant_id, issuer} <- verify_entra_tenant_claims(claims),
@@ -653,9 +693,14 @@ defmodule PortalWeb.OIDC do
     |> Enum.into(%{redirect_uri: callback_url()})
   end
 
-  defp entra_verification_config(config, scope, admin_consent_scope) do
+  defp entra_verification_config(
+         config,
+         scope,
+         admin_consent_scope,
+         discovery_document_uri \\ @entra_organizations_discovery_document_uri
+       ) do
     config
-    |> Keyword.put(:discovery_document_uri, @entra_organizations_discovery_document_uri)
+    |> Keyword.put(:discovery_document_uri, discovery_document_uri)
     |> Keyword.put(:response_type, "code")
     |> Keyword.put(:scope, scope)
     |> Keyword.put(:admin_consent_scope, admin_consent_scope)

--- a/elixir/test/portal_web/controllers/sentinel_consent_controller_test.exs
+++ b/elixir/test/portal_web/controllers/sentinel_consent_controller_test.exs
@@ -1,38 +1,306 @@
 defmodule PortalWeb.SentinelConsentControllerTest do
   use PortalWeb.ConnCase, async: true
 
-  test "renders the self-closing granted page", %{conn: conn} do
-    conn =
-      get(conn, ~p"/auth/sentinel/consent", %{
+  alias PortalWeb.Mocks
+
+  @client_id "test_sentinel_client_id"
+  @tenant_id "12345678-1234-1234-1234-123456789012"
+  @other_tenant_id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+  @global_administrator "62e90394-69f5-4237-9190-012177145e10"
+  @verifier_session_key :sentinel_consent_verifier
+  @verification_ref "b3d6f0a2-1c3e-4a5b-9d7f-2e4c6a8b0d1f"
+
+  setup do
+    Mocks.OIDC.stub_discovery_document()
+
+    Portal.Config.put_env_override(:portal, Portal.Sentinel.APIClient,
+      discovery_document_uri: Mocks.OIDC.discovery_document_uri(),
+      req_opts: [retry: false, plug: {Req.Test, PortalWeb.OIDC}]
+    )
+
+    :ok
+  end
+
+  describe "callback/2 admin consent" do
+    test "starts a silent tenant proof against the tenant Entra reports", %{conn: conn} do
+      conn = grant_admin_consent(conn)
+
+      params = redirect_params(conn)
+
+      assert redirect_uri(conn).host == "login.microsoftonline.com"
+      assert redirect_uri(conn).path == "/#{@tenant_id}/oauth2/v2.0/authorize"
+      assert params["client_id"] == @client_id
+      assert params["response_type"] == "code"
+      assert params["scope"] == "openid profile"
+      assert params["prompt"] == "none"
+      assert params["code_challenge_method"] == "S256"
+      assert params["redirect_uri"] == url(~p"/auth/sentinel/consent")
+      assert is_binary(Plug.Conn.get_session(conn, @verifier_session_key))
+    end
+
+    test "declines when Entra returns an error alongside admin_consent", %{conn: conn} do
+      conn =
+        grant_admin_consent(conn, %{
+          "error" => "access_denied",
+          "error_description" => "AADSTS650056: Misconfigured application."
+        })
+
+      html = html_response(conn, 200)
+      assert html =~ "Consent Was Not Granted"
+      assert html =~ "AADSTS650056"
+      refute html =~ "Admin Consent Granted"
+    end
+
+    test "declines a consent response with no tenant", %{conn: conn} do
+      conn =
+        get(conn, ~p"/auth/sentinel/consent", %{
+          "state" => consent_state(),
+          "admin_consent" => "True"
+        })
+
+      assert html_response(conn, 200) =~ "missing or invalid"
+    end
+
+    test "declines a malformed tenant", %{conn: conn} do
+      conn = grant_admin_consent(conn, %{"tenant" => "attacker-controlled-tenant"})
+
+      assert html_response(conn, 200) =~ "could not verify your Microsoft Entra tenant"
+    end
+
+    test "declines an unverifiable state", %{conn: conn} do
+      conn =
+        get(conn, ~p"/auth/sentinel/consent", %{
+          "state" => "acme",
+          "admin_consent" => "True"
+        })
+
+      assert html_response(conn, 200) =~ "missing or invalid"
+    end
+
+    test "keeps the Entra error when the state can no longer be verified", %{conn: conn} do
+      conn =
+        get(conn, ~p"/auth/sentinel/consent", %{
+          "state" => "acme",
+          "error" => "access_denied",
+          "error_description" => "AADSTS65004: User declined to consent."
+        })
+
+      html = html_response(conn, 200)
+      assert html =~ "Consent Was Not Granted"
+      assert html =~ "AADSTS65004"
+    end
+
+    test "declines a response with no state", %{conn: conn} do
+      conn = get(conn, ~p"/auth/sentinel/consent", %{})
+
+      assert html_response(conn, 200) =~ "missing or invalid"
+    end
+
+    test "declines an authorization code carrying the admin consent state", %{conn: conn} do
+      conn =
+        get(conn, ~p"/auth/sentinel/consent", %{
+          "state" => consent_state(),
+          "code" => "test-code"
+        })
+
+      assert html_response(conn, 200) =~ "missing or invalid"
+    end
+  end
+
+  describe "callback/2 tenant proof" do
+    test "renders the granted page for a verified tenant administrator", %{conn: conn} do
+      conn = grant_admin_consent(conn)
+      set_proof_token_response(conn)
+
+      conn = complete_tenant_proof(conn)
+
+      html = html_response(conn, 200)
+      assert html =~ "Admin Consent Granted"
+      assert html =~ @tenant_id
+      assert html =~ ~s(data-auto-close-window-after-ms="1000")
+
+      # Entra rejects the exchange unless it repeats the reply address the
+      # authorization request used.
+      assert token_request_params()["redirect_uri"] == url(~p"/auth/sentinel/consent")
+    end
+
+    test "sends the verified tenant back to the log sink form", %{conn: conn} do
+      conn = grant_admin_consent(conn)
+      set_proof_token_response(conn)
+
+      complete_tenant_proof(conn)
+
+      assert_received {:sentinel_log_sink_complete, @tenant_id, @verification_ref}
+    end
+
+    test "declines an ID token from a tenant other than the one that consented", %{conn: conn} do
+      conn = grant_admin_consent(conn, %{"tenant" => @other_tenant_id})
+      assert redirect_uri(conn).path == "/#{@other_tenant_id}/oauth2/v2.0/authorize"
+
+      set_proof_token_response(conn)
+      conn = complete_tenant_proof(conn)
+
+      html = html_response(conn, 200)
+      assert html =~ "Consent Was Not Granted"
+      assert html =~ "could not confirm which Microsoft Entra tenant"
+      refute_received {:sentinel_log_sink_complete, _tenant_id, _verification_ref}
+    end
+
+    test "declines an administrator without a tenant-wide admin role", %{conn: conn} do
+      conn = grant_admin_consent(conn)
+      set_proof_token_response(conn, %{"wids" => []})
+
+      conn = complete_tenant_proof(conn)
+
+      html = html_response(conn, 200)
+      assert html =~ "Consent Was Not Granted"
+      assert html =~ "Global Administrator"
+      refute_received {:sentinel_log_sink_complete, _tenant_id, _verification_ref}
+    end
+
+    test "retries with an account picker when silent SSO is unavailable", %{conn: conn} do
+      conn = grant_admin_consent(conn)
+      conn = complete_tenant_proof(conn, %{"error" => "interaction_required", "code" => nil})
+
+      params = redirect_params(conn)
+
+      assert redirect_uri(conn).path == "/#{@tenant_id}/oauth2/v2.0/authorize"
+      refute Map.has_key?(params, "prompt")
+    end
+
+    test "declines when the interactive retry also fails", %{conn: conn} do
+      conn = grant_admin_consent(conn)
+      conn = complete_tenant_proof(conn, %{"error" => "interaction_required", "code" => nil})
+      conn = complete_tenant_proof(conn, %{"error" => "interaction_required", "code" => nil})
+
+      html = html_response(conn, 200)
+      assert html =~ "Consent Was Not Granted"
+      assert html =~ "interaction_required"
+    end
+
+    test "declines an error the silent retry cannot recover from", %{conn: conn} do
+      conn = grant_admin_consent(conn)
+
+      conn =
+        complete_tenant_proof(conn, %{
+          "error" => "access_denied",
+          "error_description" => "AADSTS65004: User declined to consent.",
+          "code" => nil
+        })
+
+      html = html_response(conn, 200)
+      assert html =~ "Consent Was Not Granted"
+      assert html =~ "AADSTS65004"
+    end
+
+    test "declines when the browser no longer holds the code verifier", %{conn: conn} do
+      consent_conn = grant_admin_consent(conn)
+      set_proof_token_response(consent_conn)
+
+      conn =
+        get(build_conn(), ~p"/auth/sentinel/consent", %{
+          "state" => redirect_params(consent_conn) |> Map.fetch!("state"),
+          "code" => "test-code"
+        })
+
+      html = html_response(conn, 200)
+      assert html =~ "Consent Was Not Granted"
+      assert html =~ "lost the consent session"
+    end
+
+    test "declines when the token exchange fails", %{conn: conn} do
+      conn = grant_admin_consent(conn)
+      Mocks.OIDC.set_token_error(400, %{"error" => "invalid_grant"})
+
+      conn = complete_tenant_proof(conn)
+
+      html = html_response(conn, 200)
+      assert html =~ "Consent Was Not Granted"
+      assert html =~ "could not verify your Microsoft Entra tenant"
+    end
+  end
+
+  defp consent_state(verification_ref \\ @verification_ref) do
+    PortalWeb.OIDC.sign_verification_state(
+      PortalWeb.OIDC.serialize_pid(self()),
+      "sentinel-log-sink",
+      %{verification_ref: verification_ref}
+    )
+  end
+
+  defp grant_admin_consent(conn, extra_params \\ %{}) do
+    params =
+      %{
+        "state" => consent_state(),
         "admin_consent" => "True",
-        "tenant" => Ecto.UUID.generate(),
-        "state" => "acme"
-      })
+        "tenant" => @tenant_id
+      }
+      |> Map.merge(extra_params)
 
-    html = html_response(conn, 200)
-    assert html =~ "Admin Consent Granted"
-    assert html =~ ~s(data-auto-close-window-after-ms="1000")
+    get(conn, ~p"/auth/sentinel/consent", params)
   end
 
-  test "renders the Entra error when consent is declined", %{conn: conn} do
-    conn =
-      get(conn, ~p"/auth/sentinel/consent", %{
-        "error" => "access_denied",
-        "error_description" => "AADSTS65004: User declined to consent.",
-        "state" => "acme"
-      })
+  defp complete_tenant_proof(conn, extra_params \\ %{}) do
+    params =
+      %{
+        "state" => redirect_params(conn) |> Map.fetch!("state"),
+        "code" => "test-code"
+      }
+      |> Map.merge(extra_params)
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+      |> Map.new()
 
-    html = html_response(conn, 200)
-    assert html =~ "Consent Was Not Granted"
-    assert html =~ "AADSTS65004"
-    refute html =~ "data-auto-close-window-after-ms"
+    get(recycle(conn), ~p"/auth/sentinel/consent", params)
   end
 
-  test "renders the declined page for an invalid response", %{conn: conn} do
-    conn = get(conn, ~p"/auth/sentinel/consent", %{})
+  defp set_proof_token_response(conn, claim_overrides \\ %{}) do
+    verifier = Plug.Conn.get_session(conn, @verifier_session_key)
 
-    html = html_response(conn, 200)
-    assert html =~ "Consent Was Not Granted"
-    assert html =~ "missing or invalid"
+    claims =
+      Mocks.OIDC.default_claims()
+      |> Map.merge(%{
+        "aud" => @client_id,
+        "iss" => "https://login.microsoftonline.com/#{@tenant_id}/v2.0",
+        "nonce" => entra_nonce(verifier),
+        "oid" => "87654321-4321-4321-4321-210987654321",
+        "tid" => @tenant_id,
+        "wids" => [@global_administrator]
+      })
+      |> Map.merge(claim_overrides)
+
+    Mocks.OIDC.set_discovery_document_overrides(%{
+      "issuer" => "https://login.microsoftonline.com/{tenantid}/v2.0"
+    })
+
+    Mocks.OIDC.set_token_response(%{
+      "access_token" => "test-access-token",
+      "token_type" => "Bearer",
+      "id_token" => Mocks.OIDC.sign_openid_connect_token(claims)
+    })
+  end
+
+  defp entra_nonce(verifier) do
+    :crypto.hash(:sha256, "entra-verification-nonce:" <> verifier)
+    |> Base.url_encode64(padding: false)
+  end
+
+  defp token_request_params do
+    receive do
+      {:oidc_request, path, request_conn} ->
+        case String.ends_with?(path, "/oauth/token") do
+          true -> request_conn.body_params
+          false -> token_request_params()
+        end
+    after
+      0 -> flunk("the tenant proof made no token request")
+    end
+  end
+
+  defp redirect_uri(conn) do
+    conn |> redirected_to() |> URI.parse()
+  end
+
+  defp redirect_params(conn) do
+    conn |> redirect_uri() |> Map.fetch!(:query) |> URI.decode_query()
   end
 end

--- a/elixir/test/portal_web/live/settings/log_sinks_test.exs
+++ b/elixir/test/portal_web/live/settings/log_sinks_test.exs
@@ -398,24 +398,40 @@ defmodule PortalWeb.Settings.LogSinksTest do
       assert_push_event(lv, "open_url", %{url: consent_url})
 
       assert consent_url =~
-               "https://login.microsoftonline.com/organizations/adminconsent?client_id=test_sentinel_client_id"
+               "https://login.microsoftonline.com/organizations/v2.0/adminconsent?"
 
-      assert consent_url =~
-               "redirect_uri=#{URI.encode_www_form(url(~p"/auth/sentinel/consent"))}"
+      params = consent_url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
 
-      assert consent_url =~ "state=#{account.slug}"
+      assert params["client_id"] == "test_sentinel_client_id"
+      assert params["redirect_uri"] == url(~p"/auth/sentinel/consent")
+      assert params["scope"] == "https://graph.microsoft.com/.default"
+
+      assert {:ok, %{type: "sentinel-log-sink", verification_ref: verification_ref}} =
+               PortalWeb.OIDC.verify_verification_state(params["state"])
 
       tenant_id = Ecto.UUID.generate()
+      send(lv.pid, {:sentinel_log_sink_complete, tenant_id, verification_ref})
 
-      lv
-      |> form("#log-sink-form", log_sink: %{tenant_id: tenant_id})
-      |> render_change()
+      assert render(lv) =~ tenant_id
+    end
+
+    test "ignores a consent result for a stale verification", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/log_sinks/sentinel/new")
 
       lv |> element("#sentinel-consent-link") |> render_click()
-      assert_push_event(lv, "open_url", %{url: tenant_url})
+      assert_push_event(lv, "open_url", %{url: _consent_url})
 
-      assert tenant_url =~
-               "https://login.microsoftonline.com/#{tenant_id}/adminconsent?client_id=test_sentinel_client_id"
+      tenant_id = Ecto.UUID.generate()
+      send(lv.pid, {:sentinel_log_sink_complete, tenant_id, Ecto.UUID.generate()})
+
+      refute render(lv) =~ tenant_id
     end
 
     test "renders the Sentinel setup tabs with prefilled snippets", %{


### PR DESCRIPTION
Two fixes in this PR:

1. Updates the sentinel verification process to follow the same updated tenant-verification flow as the auth, dirsync, intune, and defender applications. This means adding `openid profile` scopes and setting the `DirectoryRole` group membership claim on the app so that we get the admin's `tid` (tenant id) and `wids` (role information) when they complete the OIDC flow. That allows us to securely assert the tenant the admin is granting consent for.
2. Updates the snippet to create missing resources in Azure if they're not found. Previously, we assumed the resource group and Log Analytics workspace already existed, so this improves UX there.

Related: #14658
Related: https://github.com/firezone/infra/pull/842
Related: https://app-na2.hubspot.com/live-messages/23723443/inbox/13061571272
