### PR TITLE
fix: mount /var/lib/firezone for Docker Gateways

### DIFF
--- a/elixir/lib/portal_web/live/sites/components.ex
+++ b/elixir/lib/portal_web/live/sites/components.ex
@@ -1860,6 +1860,7 @@ defmodule PortalWeb.Sites.Components do
       "--sysctl net.ipv6.conf.all.forwarding=1",
       "--sysctl net.ipv6.conf.default.forwarding=1",
       "--device=\"/dev/net/tun:/dev/net/tun\"",
+      "--volume /var/lib/firezone:/var/lib/firezone",
       Enum.map(env, fn {key, value} -> "--env #{key}=\"#{value}\"" end),
       "--env RUST_LOG=info",
       "#{Portal.Config.fetch_env!(:portal, :docker_registry)}/gateway:1"

--- a/scripts/gateway-docker-upgrade.sh
+++ b/scripts/gateway-docker-upgrade.sh
@@ -43,6 +43,13 @@ for RUNNING_CONTAINER in $CURRENTLY_RUNNING; do
             fi
         fi
 
+        # The flow log spool lives in /var/lib/firezone and must survive re-creating the container.
+        # Keep whatever the running container mapped there; otherwise fall back to the documented host path.
+        FIREZONE_VOLUME=$(docker container inspect "$RUNNING_CONTAINER" --format '{{range .Mounts}}{{if eq .Destination "/var/lib/firezone"}}{{if eq .Type "volume"}}{{.Name}}{{else}}{{.Source}}{{end}}{{end}}{{end}}')
+        if [ -z "$FIREZONE_VOLUME" ]; then
+            FIREZONE_VOLUME="/var/lib/firezone"
+        fi
+
         docker stop "$RUNNING_CONTAINER" >/dev/null
         docker rm -f "$RUNNING_CONTAINER" >/dev/null
         docker run -d \
@@ -58,6 +65,7 @@ for RUNNING_CONTAINER in $CURRENTLY_RUNNING; do
             --sysctl net.ipv6.conf.all.forwarding=1 \
             --sysctl net.ipv6.conf.default.forwarding=1 \
             --device="/dev/net/tun:/dev/net/tun" \
+            --volume "$FIREZONE_VOLUME:/var/lib/firezone" \
             "$TARGET_IMAGE"
         rm variables.env
         echo "Container upgraded"


### PR DESCRIPTION
The Gateway keeps its flow log spool in `/var/lib/firezone`. In Docker that directory lived inside the container, so any flow that had not been uploaded yet was thrown away whenever the container was recreated.

The `docker run` command shown in the admin portal now mounts `/var/lib/firezone` from the host, matching the deployment docs. The Docker upgrade script mounts it too, and it reuses whatever the running container already had mapped there so a custom host path or a named volume is kept.
