### PR TITLE
refactor(relay): extract parsing into a turn-message crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6171,20 +6171,18 @@ dependencies = [
  "base64 0.23.1",
  "bimap",
  "bytecodec",
- "derive_more",
  "hex",
  "logging",
  "once_cell",
  "opentelemetry",
- "proptest",
  "rand 0.10.2",
  "secrecy",
  "sha2 0.11.0",
  "smallvec",
  "stun_codec",
- "test-strategy",
  "thiserror 2.0.20",
  "tracing",
+ "turn-message",
  "uuid",
 ]
 
@@ -8679,6 +8677,18 @@ dependencies = [
  "test-case",
  "test-strategy",
  "thiserror 2.0.20",
+ "tracing",
+]
+
+[[package]]
+name = "turn-message"
+version = "0.1.0"
+dependencies = [
+ "bytecodec",
+ "derive_more",
+ "proptest",
+ "stun_codec",
+ "test-strategy",
  "tracing",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -50,6 +50,7 @@ members = [
     "relay/ebpf-turn-router",
     "relay/proto",
     "relay/server",
+    "relay/turn-message",
     "tests/fuzz",
     "tests/gui-smoke-test",
     "tests/http-test-server",
@@ -244,6 +245,7 @@ tracing-macros = { git = "https://github.com/tokio-rs/tracing", branch = "main" 
 tracing-opentelemetry = "0.33.0"
 tracing-subscriber = { version = "0.3.23", features = ["parking_lot"] }
 tun = { path = "libs/connlib/tun" }
+turn-message = { path = "relay/turn-message" }
 tunnel = { path = "libs/connlib/tunnel" }
 tunnel-bypass-resolver = { path = "libs/tunnel-bypass-resolver" }
 tunnel-proto = { path = "libs/connlib/tunnel-proto" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -245,10 +245,10 @@ tracing-macros = { git = "https://github.com/tokio-rs/tracing", branch = "main" 
 tracing-opentelemetry = "0.33.0"
 tracing-subscriber = { version = "0.3.23", features = ["parking_lot"] }
 tun = { path = "libs/connlib/tun" }
-turn-message = { path = "relay/turn-message" }
 tunnel = { path = "libs/connlib/tunnel" }
 tunnel-bypass-resolver = { path = "libs/tunnel-bypass-resolver" }
 tunnel-proto = { path = "libs/connlib/tunnel-proto" }
+turn-message = { path = "relay/turn-message" }
 uniffi = "0.31.1"
 url = "2.5.2"
 uuid = "1.23.2"

--- a/rust/relay/proto/Cargo.toml
+++ b/rust/relay/proto/Cargo.toml
@@ -9,12 +9,10 @@ anyhow = { workspace = true }
 base64 = { workspace = true, features = ["std"] }
 bimap = { workspace = true }
 bytecodec = { workspace = true }
-derive_more = { workspace = true, features = ["from"] }
 hex = { workspace = true }
 logging = { workspace = true }
 once_cell = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
-proptest = { workspace = true, optional = true }
 rand = { workspace = true }
 secrecy = { workspace = true }
 sha2 = { workspace = true }
@@ -22,10 +20,8 @@ smallvec = { workspace = true }
 stun_codec = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+turn-message = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
-
-[dev-dependencies]
-test-strategy = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/relay/proto/src/server.rs
+++ b/rust/relay/proto/src/server.rs
@@ -1,9 +1,6 @@
-mod channel_data;
-mod client_message;
-
-pub use crate::server::channel_data::ChannelData;
-pub use crate::server::client_message::{
-    Allocate, Binding, ChannelBind, ClientMessage, CreatePermission, Refresh,
+pub use turn_message::{
+    Allocate, Attribute, Binding, ChannelBind, ChannelData, ClientMessage, CreatePermission,
+    Refresh,
 };
 
 use crate::auth::{self, AuthenticatedMessage, FIREZONE, MessageIntegrityExt, Nonces};
@@ -25,13 +22,11 @@ use std::net::{IpAddr, SocketAddr};
 use std::ops::RangeInclusive;
 use std::time::{Duration, Instant, SystemTime};
 use stun_codec::rfc5389::attributes::{
-    ErrorCode, MessageIntegrity, Nonce, Realm, Software, Username, XorMappedAddress,
+    ErrorCode, MessageIntegrity, Nonce, Software, Username, XorMappedAddress,
 };
 use stun_codec::rfc5389::errors::{BadRequest, ServerError, StaleNonce, Unauthorized};
 use stun_codec::rfc5389::methods::BINDING;
-use stun_codec::rfc5766::attributes::{
-    ChannelNumber, Lifetime, RequestedTransport, XorPeerAddress, XorRelayAddress,
-};
+use stun_codec::rfc5766::attributes::{ChannelNumber, Lifetime, XorRelayAddress};
 use stun_codec::rfc5766::errors::{AllocationMismatch, InsufficientCapacity};
 use stun_codec::rfc5766::methods::{ALLOCATE, CHANNEL_BIND, CREATE_PERMISSION, REFRESH};
 use stun_codec::rfc8656::attributes::{
@@ -266,30 +261,34 @@ where
             return None;
         }
 
-        match client_message::decode(bytes) {
+        match turn_message::decode(bytes) {
             Ok(Ok(message)) => {
                 return self.handle_client_message(message, sender, now);
             }
             // Could parse the bytes but message was semantically invalid (like missing attribute).
-            Ok(Err(error_response)) => {
-                tracing::warn!(target: "relay", %sender, method = %error_response.method(), "Failed to decode message");
+            Ok(Err(rejection)) => {
+                tracing::warn!(target: "relay", %sender, method = %rejection.method(), "Failed to decode message");
 
                 // This is fine, the original message failed to parse to we cannot respond with an authenticated reply.
-                let message = AuthenticatedMessage::new_dangerous_unauthenticated(error_response);
+                let message = AuthenticatedMessage::new_dangerous_unauthenticated(error_response(
+                    rejection.method(),
+                    rejection.transaction_id(),
+                    rejection.error_code().clone(),
+                ));
 
                 self.send_message(message, sender);
             }
             // Parsing the bytes failed.
-            Err(client_message::Error::BadChannelData(ref error)) => {
+            Err(turn_message::DecodeError::BadChannelData(ref error)) => {
                 tracing::debug!(target: "relay", %error, "failed to decode channel data")
             }
-            Err(client_message::Error::DecodeStun(ref error)) => {
+            Err(turn_message::DecodeError::DecodeStun(ref error)) => {
                 tracing::debug!(target: "relay", %error, "failed to decode stun packet")
             }
-            Err(client_message::Error::UnknownMessageType(t)) => {
+            Err(turn_message::DecodeError::UnknownMessageType(t)) => {
                 tracing::debug!(target: "relay", r#type = %t, "unknown STUN message type")
             }
-            Err(client_message::Error::Eof) => {
+            Err(turn_message::DecodeError::Eof) => {
                 tracing::debug!(target: "relay", "unexpected EOF while parsing message")
             }
         };
@@ -1346,28 +1345,6 @@ impl_protected_request_for!(CreatePermission);
 impl_protected_request_for!(Refresh);
 
 // Define an enum of all attributes that we care about for our server.
-stun_codec::define_attribute_enums!(
-    Attribute,
-    AttributeDecoder,
-    AttributeEncoder,
-    [
-        MessageIntegrity,
-        XorMappedAddress,
-        ErrorCode,
-        RequestedTransport,
-        XorRelayAddress,
-        Lifetime,
-        ChannelNumber,
-        XorPeerAddress,
-        Nonce,
-        Realm,
-        Username,
-        RequestedAddressFamily,
-        AdditionalAddressFamily,
-        Software
-    ]
-);
-
 fn success_response(method: Method, id: TransactionId) -> Message<Attribute> {
     let mut message = Message::new(MessageClass::SuccessResponse, method, id);
     message.add_attribute(SOFTWARE.clone());

--- a/rust/relay/proto/src/server.rs
+++ b/rust/relay/proto/src/server.rs
@@ -269,7 +269,7 @@ where
             Ok(Err(rejection)) => {
                 tracing::warn!(target: "relay", %sender, method = %rejection.method(), "Failed to decode message");
 
-                // This is fine, the original message failed to parse to we cannot respond with an authenticated reply.
+                // This is fine, the original message failed to parse so we cannot respond with an authenticated reply.
                 let message = AuthenticatedMessage::new_dangerous_unauthenticated(error_response(
                     rejection.method(),
                     rejection.transaction_id(),

--- a/rust/relay/turn-message/Cargo.toml
+++ b/rust/relay/turn-message/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "turn-message"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+bytecodec = { workspace = true }
+derive_more = { workspace = true, features = ["from"] }
+stun_codec = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+test-strategy = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/relay/turn-message/src/channel_data.rs
+++ b/rust/relay/turn-message/src/channel_data.rs
@@ -77,7 +77,7 @@ impl<'a> ChannelData<'a> {
     }
 }
 
-#[cfg(all(test, feature = "proptest"))]
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/rust/relay/turn-message/src/client_message.rs
+++ b/rust/relay/turn-message/src/client_message.rs
@@ -1,10 +1,6 @@
-use crate::Attribute;
-use crate::auth::{FIREZONE, generate_password, split_username};
-use crate::server::channel_data::ChannelData;
-use crate::server::{UDP_TRANSPORT, error_response};
-use anyhow::{Context, Result};
+use crate::channel_data::ChannelData;
+use crate::{Attribute, Rejection};
 use bytecodec::DecodeExt;
-use secrecy::SecretString;
 use std::io;
 use std::time::Duration;
 use stun_codec::rfc5389::attributes::{ErrorCode, MessageIntegrity, Nonce, Software, Username};
@@ -14,11 +10,8 @@ use stun_codec::rfc5766::attributes::{
     ChannelNumber, Lifetime, RequestedTransport, XorPeerAddress,
 };
 use stun_codec::rfc5766::methods::{ALLOCATE, CHANNEL_BIND, CREATE_PERMISSION, REFRESH};
-use stun_codec::rfc8656::attributes::{
-    AdditionalAddressFamily, AddressFamily, RequestedAddressFamily,
-};
+use stun_codec::rfc8656::attributes::{AdditionalAddressFamily, RequestedAddressFamily};
 use stun_codec::{Message, MessageClass, TransactionId};
-use uuid::Uuid;
 
 /// The maximum lifetime of an allocation.
 const MAX_ALLOCATION_LIFETIME: Duration = Duration::from_secs(3600);
@@ -28,7 +21,7 @@ const MAX_ALLOCATION_LIFETIME: Duration = Duration::from_secs(3600);
 /// See <https://www.rfc-editor.org/rfc/rfc8656#name-allocations-2>.
 const DEFAULT_ALLOCATION_LIFETIME: Duration = Duration::from_secs(600);
 
-pub fn decode(input: &[u8]) -> Result<Result<ClientMessage<'_>, Message<Attribute>>, Error> {
+pub fn decode(input: &[u8]) -> Result<Result<ClientMessage<'_>, Rejection>, DecodeError> {
     let mut decoder = stun_codec::MessageDecoder::default();
 
     // De-multiplex as per <https://www.rfc-editor.org/rfc/rfc8656#name-channels-2>.
@@ -45,7 +38,7 @@ pub fn decode(input: &[u8]) -> Result<Result<ClientMessage<'_>, Message<Attribut
 
                     let error_code = ErrorCode::from(error);
 
-                    return Ok(Err(error_response(method, transaction_id, error_code)));
+                    return Ok(Err(Rejection::new(method, transaction_id, error_code)));
                 }
             };
 
@@ -61,18 +54,20 @@ pub fn decode(input: &[u8]) -> Result<Result<ClientMessage<'_>, Message<Attribut
                     CreatePermission::parse(&message),
                 ))),
                 (_, Request) => Ok(Err(bad_request(&message))),
-                (method, class) => Err(Error::DecodeStun(bytecodec::Error::from(io::Error::new(
-                    io::ErrorKind::Unsupported,
-                    format!(
-                        "handling method {} and {class:?} is not implemented",
-                        method.as_u16()
+                (method, class) => Err(DecodeError::DecodeStun(bytecodec::Error::from(
+                    io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        format!(
+                            "handling method {} and {class:?} is not implemented",
+                            method.as_u16()
+                        ),
                     ),
-                )))),
+                ))),
             }
         }
         Some(64..=79) => Ok(Ok(ClientMessage::ChannelData(ChannelData::parse(input)?))),
-        Some(other) => Err(Error::UnknownMessageType(*other)),
-        None => Err(Error::Eof),
+        Some(other) => Err(DecodeError::UnknownMessageType(*other)),
+        None => Err(DecodeError::Eof),
     }
 }
 
@@ -116,13 +111,6 @@ pub struct Binding {
 }
 
 impl Binding {
-    pub fn new(transaction_id: TransactionId) -> Self {
-        Self {
-            transaction_id,
-            software: None,
-        }
-    }
-
     pub fn parse(message: &Message<Attribute>) -> Self {
         let transaction_id = message.transaction_id();
         let software = message.get_attribute::<Software>().cloned();
@@ -156,129 +144,7 @@ pub struct Allocate {
 }
 
 impl Allocate {
-    pub fn new_authenticated_udp_implicit_ip4(
-        transaction_id: TransactionId,
-        lifetime: Option<Lifetime>,
-        username: Username,
-        relay_secret: &SecretString,
-        nonce: Uuid,
-    ) -> Result<Self> {
-        let (requested_transport, nonce, message_integrity) = Self::make_attributes(
-            transaction_id,
-            &lifetime,
-            &username,
-            relay_secret,
-            nonce,
-            None,
-        )?;
-
-        Ok(Self {
-            transaction_id,
-            message_integrity: Some(message_integrity),
-            requested_transport,
-            lifetime,
-            username: Some(username),
-            nonce: Some(nonce),
-            requested_address_family: None, // IPv4 is the default.
-            additional_address_family: None,
-            software: None,
-        })
-    }
-
-    pub fn new_authenticated_udp_ip6(
-        transaction_id: TransactionId,
-        lifetime: Option<Lifetime>,
-        username: Username,
-        relay_secret: &SecretString,
-        nonce: Uuid,
-    ) -> Result<Self> {
-        let requested_address_family = RequestedAddressFamily::new(AddressFamily::V6);
-
-        let (requested_transport, nonce, message_integrity) = Self::make_attributes(
-            transaction_id,
-            &lifetime,
-            &username,
-            relay_secret,
-            nonce,
-            Some(requested_address_family.clone()),
-        )?;
-
-        Ok(Self {
-            transaction_id,
-            message_integrity: Some(message_integrity),
-            requested_transport,
-            lifetime,
-            username: Some(username),
-            nonce: Some(nonce),
-            requested_address_family: Some(requested_address_family),
-            additional_address_family: None,
-            software: None,
-        })
-    }
-
-    pub fn new_unauthenticated_udp(
-        transaction_id: TransactionId,
-        lifetime: Option<Lifetime>,
-    ) -> Self {
-        let requested_transport = RequestedTransport::new(UDP_TRANSPORT);
-
-        let mut message =
-            Message::<Attribute>::new(MessageClass::Request, ALLOCATE, transaction_id);
-        message.add_attribute(requested_transport.clone());
-
-        if let Some(lifetime) = &lifetime {
-            message.add_attribute(lifetime.clone());
-        }
-
-        Self {
-            transaction_id,
-            message_integrity: None,
-            requested_transport,
-            lifetime,
-            username: None,
-            nonce: None,
-            requested_address_family: None,
-            additional_address_family: None,
-            software: None,
-        }
-    }
-
-    fn make_attributes(
-        transaction_id: TransactionId,
-        lifetime: &Option<Lifetime>,
-        username: &Username,
-        relay_secret: &SecretString,
-        nonce: Uuid,
-        requested_address_family: Option<RequestedAddressFamily>,
-    ) -> Result<(RequestedTransport, Nonce, MessageIntegrity)> {
-        let requested_transport = RequestedTransport::new(UDP_TRANSPORT);
-        let nonce = Nonce::new(nonce.as_hyphenated().to_string()).context("Invalid nonce")?;
-
-        let mut message =
-            Message::<Attribute>::new(MessageClass::Request, ALLOCATE, transaction_id);
-        message.add_attribute(requested_transport.clone());
-        message.add_attribute(username.clone());
-        message.add_attribute(nonce.clone());
-
-        if let Some(requested_address_family) = requested_address_family {
-            message.add_attribute(requested_address_family);
-        }
-
-        if let Some(lifetime) = &lifetime {
-            message.add_attribute(lifetime.clone());
-        }
-
-        let (expiry, salt) = split_username(username.name())?;
-
-        let password = generate_password(relay_secret, expiry, salt);
-
-        let message_integrity =
-            MessageIntegrity::new_long_term_credential(&message, username, &FIREZONE, &password)?;
-
-        Ok((requested_transport, nonce, message_integrity))
-    }
-
-    pub fn parse(message: &Message<Attribute>) -> Result<Self, Message<Attribute>> {
+    pub fn parse(message: &Message<Attribute>) -> Result<Self, Rejection> {
         let transaction_id = message.transaction_id();
         let message_integrity = message.get_attribute::<MessageIntegrity>().cloned();
         let nonce = message.get_attribute::<Nonce>().cloned();
@@ -353,40 +219,6 @@ pub struct Refresh {
 }
 
 impl Refresh {
-    pub fn new(
-        transaction_id: TransactionId,
-        lifetime: Option<Lifetime>,
-        username: Username,
-        relay_secret: &SecretString,
-        nonce: Uuid,
-    ) -> Result<Self> {
-        let nonce = Nonce::new(nonce.as_hyphenated().to_string()).context("Invalid nonce")?;
-
-        let mut message = Message::<Attribute>::new(MessageClass::Request, REFRESH, transaction_id);
-        message.add_attribute(username.clone());
-        message.add_attribute(nonce.clone());
-
-        if let Some(lifetime) = &lifetime {
-            message.add_attribute(lifetime.clone());
-        }
-
-        let (expiry, salt) = split_username(username.name())?;
-
-        let password = generate_password(relay_secret, expiry, salt);
-
-        let message_integrity =
-            MessageIntegrity::new_long_term_credential(&message, &username, &FIREZONE, &password)?;
-
-        Ok(Self {
-            transaction_id,
-            message_integrity: Some(message_integrity),
-            lifetime,
-            username: Some(username),
-            nonce: Some(nonce),
-            software: None,
-        })
-    }
-
     pub fn parse(message: &Message<Attribute>) -> Self {
         let transaction_id = message.transaction_id();
         let message_integrity = message.get_attribute::<MessageIntegrity>().cloned();
@@ -442,42 +274,7 @@ pub struct ChannelBind {
 }
 
 impl ChannelBind {
-    pub fn new(
-        transaction_id: TransactionId,
-        channel_number: ChannelNumber,
-        xor_peer_address: XorPeerAddress,
-        username: Username,
-        relay_secret: &SecretString,
-        nonce: Uuid,
-    ) -> Result<Self> {
-        let nonce = Nonce::new(nonce.as_hyphenated().to_string()).context("Invalid nonce")?;
-
-        let mut message =
-            Message::<Attribute>::new(MessageClass::Request, CHANNEL_BIND, transaction_id);
-        message.add_attribute(username.clone());
-        message.add_attribute(channel_number);
-        message.add_attribute(xor_peer_address.clone());
-        message.add_attribute(nonce.clone());
-
-        let (expiry, salt) = split_username(username.name())?;
-
-        let password = generate_password(relay_secret, expiry, salt);
-
-        let message_integrity =
-            MessageIntegrity::new_long_term_credential(&message, &username, &FIREZONE, &password)?;
-
-        Ok(Self {
-            transaction_id,
-            channel_number,
-            message_integrity: Some(message_integrity),
-            xor_peer_address,
-            username: Some(username),
-            nonce: Some(nonce),
-            software: None,
-        })
-    }
-
-    pub fn parse(message: &Message<Attribute>) -> Result<Self, Message<Attribute>> {
+    pub fn parse(message: &Message<Attribute>) -> Result<Self, Rejection> {
         let transaction_id = message.transaction_id();
         let channel_number = message
             .get_attribute::<ChannelNumber>()
@@ -592,31 +389,27 @@ fn compute_effective_lifetime(requested_lifetime: Option<&Lifetime>) -> Lifetime
         .expect("lifetime is at most MAX_ALLOCATION_LIFETIME which is less than 0xFFFF_FFFF")
 }
 
-fn bad_request(message: &Message<Attribute>) -> Message<Attribute> {
-    error_response(
-        message.method(),
-        message.transaction_id(),
-        ErrorCode::from(BadRequest),
-    )
+fn bad_request(message: &Message<Attribute>) -> Rejection {
+    Rejection::new(message.method(), message.transaction_id(), BadRequest)
 }
 
 #[derive(Debug)]
-pub enum Error {
+pub enum DecodeError {
     BadChannelData(io::Error),
     DecodeStun(bytecodec::Error),
     UnknownMessageType(u8),
     Eof,
 }
 
-impl From<bytecodec::Error> for Error {
+impl From<bytecodec::Error> for DecodeError {
     fn from(error: bytecodec::Error) -> Self {
-        Error::DecodeStun(error)
+        DecodeError::DecodeStun(error)
     }
 }
 
-impl From<io::Error> for Error {
+impl From<io::Error> for DecodeError {
     fn from(error: io::Error) -> Self {
-        Error::BadChannelData(error)
+        DecodeError::BadChannelData(error)
     }
 }
 

--- a/rust/relay/turn-message/src/lib.rs
+++ b/rust/relay/turn-message/src/lib.rs
@@ -1,0 +1,83 @@
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+//! Parsing of the STUN & TURN messages a TURN client sends to a server.
+//!
+//! This crate only decodes; it holds no server state and performs no
+//! authentication. A message that decodes but is not a valid request comes back
+//! as a [`Rejection`], leaving it to the server to render an error response.
+
+mod channel_data;
+mod client_message;
+
+pub use channel_data::ChannelData;
+pub use client_message::{
+    Allocate, Binding, ChannelBind, ClientMessage, CreatePermission, DecodeError, Refresh, decode,
+};
+
+use stun_codec::rfc5389::attributes::{
+    ErrorCode, MessageIntegrity, Nonce, Realm, Software, Username, XorMappedAddress,
+};
+use stun_codec::rfc5766::attributes::{
+    ChannelNumber, Lifetime, RequestedTransport, XorPeerAddress, XorRelayAddress,
+};
+use stun_codec::rfc8656::attributes::{AdditionalAddressFamily, RequestedAddressFamily};
+use stun_codec::{Method, TransactionId};
+
+stun_codec::define_attribute_enums!(
+    Attribute,
+    AttributeDecoder,
+    AttributeEncoder,
+    [
+        MessageIntegrity,
+        XorMappedAddress,
+        ErrorCode,
+        RequestedTransport,
+        XorRelayAddress,
+        Lifetime,
+        ChannelNumber,
+        XorPeerAddress,
+        Nonce,
+        Realm,
+        Username,
+        RequestedAddressFamily,
+        AdditionalAddressFamily,
+        Software
+    ]
+);
+
+/// A message that decoded but is not a request we can serve.
+///
+/// Carries what an error response needs, so the server can render one with its
+/// own `SOFTWARE` attribute.
+#[derive(Debug)]
+pub struct Rejection {
+    method: Method,
+    transaction_id: TransactionId,
+    error_code: ErrorCode,
+}
+
+impl Rejection {
+    pub fn new(
+        method: Method,
+        transaction_id: TransactionId,
+        error_code: impl Into<ErrorCode>,
+    ) -> Self {
+        Self {
+            method,
+            transaction_id,
+            error_code: error_code.into(),
+        }
+    }
+
+    pub fn method(&self) -> Method {
+        self.method
+    }
+
+    pub fn transaction_id(&self) -> TransactionId {
+        self.transaction_id
+    }
+
+    pub fn error_code(&self) -> &ErrorCode {
+        &self.error_code
+    }
+}

--- a/rust/relay/turn-message/src/lib.rs
+++ b/rust/relay/turn-message/src/lib.rs
@@ -3,8 +3,12 @@
 //! Parsing of the STUN & TURN messages a TURN client sends to a server.
 //!
 //! This crate only decodes; it holds no server state and performs no
-//! authentication. A message that decodes but is not a valid request comes back
-//! as a [`Rejection`], leaving it to the server to render an error response.
+//! authentication. A request that decodes but cannot be served comes back as a
+//! [`Rejection`], leaving it to the server to render an error response.
+//!
+//! A message of any other class is a [`DecodeError`] instead. Answering an
+//! indication or a response would make the relay a reflector, so there is
+//! deliberately nothing for the server to render.
 
 mod channel_data;
 mod client_message;
@@ -45,7 +49,7 @@ stun_codec::define_attribute_enums!(
     ]
 );
 
-/// A message that decoded but is not a request we can serve.
+/// A request that decoded but that we cannot serve.
 ///
 /// Carries what an error response needs, so the server can render one with its
 /// own `SOFTWARE` attribute.


### PR DESCRIPTION
Decoding a client message needs no server state, so it does not belong next to the allocation state machine. The new crate decodes only: a request that decodes but cannot be served comes back as a `Rejection`, and the server renders it into a response carrying its own `SOFTWARE` attribute. A message of any other class stays a `DecodeError` with nothing to render, since answering an indication or a response would make the relay a reflector.

Dropping the client-side message constructors is what makes the split possible. They existed only to build requests for the proptests that have since been removed, and they were what tied parsing to `auth` and to the relay's own credential format.

This also gives a parsing fuzz target a dependency graph containing only the code it exercises, so its uncovered-region ceiling stops moving with unrelated changes elsewhere in the relay.