### PR TITLE
refactor(apple): make Store.requestStop synchronous

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -155,16 +155,11 @@ struct FirezoneApp: App {
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-      guard let store else {
-        return .terminateNow
-      }
+      // Stopping is a request rather than an operation to wait on, so there is
+      // nothing left for the app to defer its termination for once it is made.
+      do { try store?.stop() } catch { Log.error(error) }
 
-      Task {
-        do { try await store.stop() } catch { Log.error(error) }
-        await MainActor.run { NSApp.reply(toApplicationShouldTerminate: true) }
-      }
-
-      return .terminateLater
+      return .terminateNow
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -157,7 +157,7 @@ struct FirezoneApp: App {
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
       // Stopping is a request rather than an operation to wait on, so there is
       // nothing left for the app to defer its termination for once it is made.
-      do { try store?.stop() } catch { Log.error(error) }
+      do { try store?.requestStop() } catch { Log.error(error) }
 
       return .terminateNow
     }

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -157,7 +157,7 @@ struct FirezoneApp: App {
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
       // Stopping is a request rather than an operation to wait on, so there is
       // nothing left for the app to defer its termination for once it is made.
-      do { try store?.requestStop() } catch { Log.error(error) }
+      store?.requestStop()
 
       return .terminateNow
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -215,7 +215,7 @@ public final class Store: ObservableObject {
 
     public func quitApp() {
       SharedAccess.clearAppRunning()
-      do { try requestStop() } catch { Log.error(error) }
+      requestStop()
       NSApp.terminate(nil)
     }
 
@@ -588,10 +588,9 @@ public final class Store: ObservableObject {
     self.decision = try await sessionNotification.askUserForNotificationPermissions()
   }
 
-  public func requestStop() throws {
-    guard let session = try manager().session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
+  public func requestStop() {
+    // No manager or no session is no tunnel, which is where stopping was headed anyway.
+    guard let session = try? manager().session() else { return }
 
     session.stopTunnel()
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -215,10 +215,8 @@ public final class Store: ObservableObject {
 
     public func quitApp() {
       SharedAccess.clearAppRunning()
-      Task {
-        do { try await stop() } catch { Log.error(error) }
-        NSApp.terminate(nil)
-      }
+      do { try stop() } catch { Log.error(error) }
+      NSApp.terminate(nil)
     }
 
     /// Returns the appropriate icon name from asset catalog for the given state
@@ -590,7 +588,11 @@ public final class Store: ObservableObject {
     self.decision = try await sessionNotification.askUserForNotificationPermissions()
   }
 
-  public func stop() async throws {
+  /// Asks the tunnel to stop.
+  ///
+  /// Asking is all this does: the session reports having stopped through
+  /// `NEVPNStatusDidChange`, not by returning from here.
+  public func stop() throws {
     guard let session = try manager().session() else {
       throw VPNConfigurationManagerError.managerNotInitialized
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -215,7 +215,7 @@ public final class Store: ObservableObject {
 
     public func quitApp() {
       SharedAccess.clearAppRunning()
-      do { try stop() } catch { Log.error(error) }
+      do { try requestStop() } catch { Log.error(error) }
       NSApp.terminate(nil)
     }
 
@@ -588,11 +588,7 @@ public final class Store: ObservableObject {
     self.decision = try await sessionNotification.askUserForNotificationPermissions()
   }
 
-  /// Asks the tunnel to stop.
-  ///
-  /// Asking is all this does: the session reports having stopped through
-  /// `NEVPNStatusDidChange`, not by returning from here.
-  public func stop() throws {
+  public func requestStop() throws {
     guard let session = try manager().session() else {
       throw VPNConfigurationManagerError.managerNotInitialized
     }


### PR DESCRIPTION
`Store.stop()` never suspended: resolving the manager and the session are both synchronous, and `stopTunnel()` only makes a request, reporting the outcome through `NEVPNStatusDidChange` rather than by returning. It is `requestStop()` now, so every call site says which of the two it is.

Making it synchronous lets `applicationShouldTerminate` request the stop inline and answer `.terminateNow`, so the app no longer defers its termination on a reply that can go missing when terminate arrives close to launch.