### PR TITLE
test(connlib): reduce repetition in phoenix-channel tests

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5630,6 +5630,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "socket-factory",
+ "test-case",
  "thiserror 2.0.20",
  "tokio",
  "tokio-tungstenite",

--- a/rust/libs/connlib/phoenix-channel/Cargo.toml
+++ b/rust/libs/connlib/phoenix-channel/Cargo.toml
@@ -42,6 +42,7 @@ tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
 hostname = "0.4.2"
 
 [dev-dependencies]
+test-case = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "tracing"] }
 
 [lints]

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -1,41 +1,37 @@
 #![cfg(not(windows))] // For some reason, Windows doesn't like this test.
 #![allow(clippy::unwrap_used)]
 
+use std::future;
 use std::net::{IpAddr, Ipv4Addr};
-use std::sync::atomic::AtomicUsize;
-use std::{future, sync::Arc, time::Duration};
+use std::pin::pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
-use futures::SinkExt as _;
-use phoenix_channel::{DeviceInfo, Event, LoginUrl, PhoenixChannel, PublicKeyParam};
+use futures::future::Either;
+use futures::{SinkExt, StreamExt as _};
+use phoenix_channel::{DeviceInfo, Error, Event, LoginUrl, PhoenixChannel, PublicKeyParam};
 use secrecy::SecretString;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::TcpListener;
 use tokio::task::JoinError;
-use tokio_tungstenite::tungstenite::http;
+use tokio_tungstenite::tungstenite::{Message, http};
 
 #[tokio::test]
 async fn client_does_not_pipeline_messages() {
-    use std::time::Duration;
-
-    use futures::{SinkExt, StreamExt};
-    use phoenix_channel::PublicKeyParam;
-    use tokio::net::TcpListener;
-    use tokio_tungstenite::tungstenite::Message;
-
     let _guard = logging::test("debug,wire::api=trace");
 
     let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
-    let server_addr = listener.local_addr().unwrap();
+    let port = listener.local_addr().unwrap().port();
 
     let server = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
-
         let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
 
         loop {
             match ws.next().await {
                 Some(Ok(Message::Text(text))) => match text.as_str() {
-                    r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
+                    JOIN_REQUEST => {
                         // The real Elixir backend processes messages in parallel and therefore may drop messages if we pipeline them instead of waiting for the channel join.
                         // This is difficult to assert in a test because we need to mimic this behaviour of not processing messages sequentially.
                         // The way we assert this is by checking, whether any messages are pipelined.
@@ -46,54 +42,31 @@ async fn client_does_not_pipeline_messages() {
                             panic!("Did not yet expect another msg: {msg:?}")
                         }
 
-                        ws.send(Message::text(
-                            r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#,
-                        )).await.unwrap();
+                        ws.send(Message::text(JOIN_REPLY)).await.unwrap();
                     }
-                    r#"{"topic":"test","event":"bar","ref":1}"# => {
-                        ws.send(Message::text(
-                            r#"{"topic":"test","event":"foo","payload":null}"#,
-                        ))
-                        .await
-                        .unwrap();
+                    BAR_REQUEST => {
+                        ws.send(Message::text(FOO_MESSAGE)).await.unwrap();
                     }
                     other => panic!("Unexpected message: {other}"),
                 },
                 Some(Ok(Message::Close(_))) => continue,
-                Some(other) => {
-                    panic!("Unexpected message: {other:?}")
-                }
+                Some(other) => panic!("Unexpected message: {other:?}"),
                 None => break,
             }
         }
     });
 
-    let mut channel = make_test_channel("localhost", server_addr.port(), default_backoff);
+    let mut channel = make_test_channel("localhost", port, default_backoff);
 
     let client = async move {
-        channel.connect(
-            vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-            Duration::ZERO,
-            PublicKeyParam([0u8; 32]),
-        );
+        connect(&mut channel, Duration::ZERO);
+        poll_until_connected(&mut channel).await;
 
-        loop {
-            match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::Message {
-                    msg: InboundMsg::Foo,
-                    ..
-                } => {
-                    channel.close().unwrap();
-                }
-                phoenix_channel::Event::Hiccup { error, .. } => {
-                    panic!("Unexpected hiccup: {error:?}")
-                }
-                phoenix_channel::Event::Closed => break,
-                phoenix_channel::Event::Connected => {
-                    channel.send("test", OutboundMsg::Bar).unwrap();
-                }
-            }
-        }
+        channel.send("test", OutboundMsg::Bar).unwrap();
+        next_message(&mut channel).await;
+
+        channel.close().unwrap();
+        poll_until_closed(&mut channel).await;
     };
 
     let (join_res, _) = tokio::time::timeout(
@@ -107,56 +80,24 @@ async fn client_does_not_pipeline_messages() {
 
 #[tokio::test]
 async fn client_deduplicates_messages() {
-    use std::time::Duration;
-
-    use phoenix_channel::PublicKeyParam;
-
     let _guard = logging::test("debug,wire::api=trace");
 
-    let (server, port) = spawn_websocket_server(|text| {
-        match text {
-            r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
-                r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#
-            }
-            // We only handle the message with `ref: 1` and thus guarantee that not more than 1 is received
-            r#"{"topic":"test","event":"bar","ref":1}"# => {
-                r#"{"topic":"test","event":"foo","payload":null}"#
-            }
-            other => panic!("Unexpected message: {other}"),
-        }
-    })
-    .await;
-
+    let (server, port) = spawn_echo_server().await;
     let mut channel = make_test_channel("localhost", port, default_backoff);
 
     let mut num_responses = 0;
 
     let client = async {
-        channel.connect(
-            vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-            Duration::ZERO,
-            PublicKeyParam([0u8; 32]),
-        );
+        connect(&mut channel, Duration::ZERO);
+        poll_until_connected(&mut channel).await;
+
+        for _ in 0..4 {
+            channel.send("test", OutboundMsg::Bar).unwrap();
+        }
 
         loop {
-            match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::Message {
-                    msg: InboundMsg::Foo,
-                    ..
-                } => {
-                    num_responses += 1;
-                }
-                phoenix_channel::Event::Hiccup { error, .. } => {
-                    panic!("Unexpected hiccup: {error:?}")
-                }
-                phoenix_channel::Event::Closed => break,
-                phoenix_channel::Event::Connected => {
-                    channel.send("test", OutboundMsg::Bar).unwrap();
-                    channel.send("test", OutboundMsg::Bar).unwrap();
-                    channel.send("test", OutboundMsg::Bar).unwrap();
-                    channel.send("test", OutboundMsg::Bar).unwrap();
-                }
-            }
+            next_message(&mut channel).await;
+            num_responses += 1;
         }
     };
 
@@ -172,51 +113,24 @@ async fn client_deduplicates_messages() {
 
 #[tokio::test]
 async fn client_clears_local_message_on_connect() {
-    use phoenix_channel::PublicKeyParam;
-
     let _guard = logging::test("debug,wire::api=trace");
 
-    let (server, port) = spawn_websocket_server(|text| {
-        match text {
-            r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
-                r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#
-            }
-            // We only handle the message with `ref: 1` and thus guarantee that the first one is not received.
-            r#"{"topic":"test","event":"bar","ref":1}"# => {
-                r#"{"topic":"test","event":"foo","payload":null}"#
-            }
-            other => panic!("Unexpected message: {other}"),
-        }
-    })
-    .await;
-
+    let (server, port) = spawn_echo_server().await;
     let mut channel = make_test_channel("localhost", port, default_backoff);
 
     let client = async {
+        // A message sent while disconnected must not be buffered: the echo server only
+        // answers the `bar` with `ref: 1` and thus fails if this one is sent on connect.
         channel.send("test", OutboundMsg::Bar).unwrap_err();
-        channel.connect(
-            vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-            Duration::ZERO,
-            PublicKeyParam([0u8; 32]),
-        );
 
-        loop {
-            match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::Message {
-                    msg: InboundMsg::Foo,
-                    ..
-                } => {
-                    channel.close().unwrap();
-                }
-                phoenix_channel::Event::Hiccup { error, .. } => {
-                    panic!("Unexpected hiccup: {error:?}")
-                }
-                phoenix_channel::Event::Closed => break,
-                phoenix_channel::Event::Connected => {
-                    channel.send("test", OutboundMsg::Bar).unwrap();
-                }
-            }
-        }
+        connect(&mut channel, Duration::ZERO);
+        poll_until_connected(&mut channel).await;
+
+        channel.send("test", OutboundMsg::Bar).unwrap();
+        next_message(&mut channel).await;
+
+        channel.close().unwrap();
+        poll_until_closed(&mut channel).await;
     };
 
     client.await;
@@ -225,117 +139,63 @@ async fn client_clears_local_message_on_connect() {
 
 #[tokio::test]
 async fn replies_with_close_frame_upon_close() {
-    use phoenix_channel::PublicKeyParam;
-
     let _guard = logging::test("debug,wire::api=trace");
 
-    let (server, port) = spawn_websocket_server(|text| {
-        match text {
-            r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
-                r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#
-            }
-            other => panic!("Unexpected message: {other}"),
-        }
-    })
-    .await;
-
+    let (server, port) = spawn_joining_server().await;
     let mut channel = make_test_channel("localhost", port, default_backoff);
 
     let (mut connected_tx, mut connected_rx) = futures::channel::mpsc::channel(1);
 
     let client = tokio::spawn(async move {
-        channel.connect(
-            vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-            Duration::ZERO,
-            PublicKeyParam([0u8; 32]),
-        );
+        connect(&mut channel, Duration::ZERO);
+        poll_until_connected(&mut channel).await;
+        connected_tx.send(()).await.unwrap();
 
-        loop {
-            match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::Hiccup { error, .. } => break error,
-                phoenix_channel::Event::Closed => panic!("Should not close"),
-                phoenix_channel::Event::Message { .. } => {}
-                phoenix_channel::Event::Connected => connected_tx.send(()).await.unwrap(),
-            }
-        }
+        poll_until_hiccup(&mut channel).await.error
     });
 
     connected_rx.recv().await.unwrap(); // Wait for successful connection.
 
     let server_result = server.stop().await;
-    let client_result = client.await.unwrap();
+    let client_error = client.await.unwrap();
 
     server_result.unwrap(); // Server should shutdown cleanly.
 
     assert_eq!(
-        format!("{client_result:#}"),
+        client_error,
         "Connection hiccup: portal sent empty websocket close frame"
     );
 }
 
 #[tokio::test]
 async fn times_out_after_missed_heartbeats() {
-    use phoenix_channel::PublicKeyParam;
-
     let _guard = logging::test("debug,wire::api=trace");
 
-    let (server, port) = spawn_websocket_server(|text| {
-        match text {
-            r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
-                r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#
-            }
-            // We send a bogus reply (bad `ref`) to ensure the implementation matches those up correctly.
-            r#"{"topic":"phoenix","event":"heartbeat","payload":{},"ref":1}"# => {
-                r#"{"event":"phx_reply","ref":9999,"topic":"phoenix","payload":{"status":"ok","response":{}}}"#
-            }
-            r#"{"topic":"phoenix","event":"heartbeat","payload":{},"ref":2}"# => {
-                r#"{"event":"phx_reply","ref":9999,"topic":"phoenix","payload":{"status":"ok","response":{}}}"#
-            }
-            r#"{"topic":"phoenix","event":"heartbeat","payload":{},"ref":3}"# => {
-                r#"{"event":"phx_reply","ref":9999,"topic":"phoenix","payload":{"status":"ok","response":{}}}"#
-            }
-            r#"{"topic":"phoenix","event":"heartbeat","payload":{},"ref":4}"# => {
-                r#"{"event":"phx_reply","ref":9999,"topic":"phoenix","payload":{"status":"ok","response":{}}}"#
-            }
-            other => panic!("Unexpected message: {other}"),
-        }
+    let (server, port) = spawn_websocket_server(|text| match text {
+        JOIN_REQUEST => JOIN_REPLY,
+        // The channel gives up once more than three heartbeats are unanswered, so it never sends a fifth.
+        // Each reply carries a `ref` the channel never sent to ensure the implementation matches replies up correctly.
+        text if (1..=4).any(|reference| text == heartbeat_request(reference)) => UNMATCHED_REPLY,
+        other => panic!("Unexpected message: {other}"),
     })
     .await;
 
     let mut channel = make_test_channel("localhost", port, default_backoff);
 
-    let client = async {
-        channel.connect(
-            vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-            Duration::ZERO,
-            PublicKeyParam([0u8; 32]),
-        );
+    connect(&mut channel, Duration::ZERO);
+    poll_until_connected(&mut channel).await;
+    let error = poll_until_hiccup(&mut channel).await.error;
 
-        loop {
-            match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::Message { .. } => {}
-                phoenix_channel::Event::Hiccup { error, .. } => break error,
-                phoenix_channel::Event::Closed => {
-                    panic!("Channel closed")
-                }
-                phoenix_channel::Event::Connected => {}
-            }
-        }
-    };
-
-    let error = client.await;
     server.abort();
 
     assert_eq!(
-        format!("{error:#}"),
+        error,
         "Connection hiccup: too many heartbeats were unanswered"
     );
 }
 
 #[tokio::test]
 async fn sends_heartbeats_regardless_of_messages() {
-    use phoenix_channel::PublicKeyParam;
-
     let _guard = logging::test("debug,wire::api=trace");
 
     let num_heartbeats = Arc::new(AtomicUsize::default());
@@ -353,7 +213,7 @@ async fn sends_heartbeats_regardless_of_messages() {
                     format!(r#"{{"event":"phx_reply","ref":{reference},"topic":"{topic}","payload":{{"status":"ok","response":{{}}}}}}"#)
                 }
                 "heartbeat" => {
-                    num_heartbeats.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    num_heartbeats.fetch_add(1, Ordering::SeqCst);
 
                     format!(r#"{{"event":"phx_reply","ref":{reference},"topic":"phoenix","payload":{{"status":"ok","response":{{}}}}}}"#)
                 }
@@ -369,124 +229,129 @@ async fn sends_heartbeats_regardless_of_messages() {
     let mut channel = make_test_channel("localhost", port, default_backoff);
 
     let client = tokio::spawn(async move {
-        channel.connect(
-            vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-            Duration::ZERO,
-            PublicKeyParam([0u8; 32]),
-        );
+        connect(&mut channel, Duration::ZERO);
 
         let mut message_interval = tokio::time::interval(Duration::from_secs(3));
 
         loop {
-            tokio::select! {
-                event = std::future::poll_fn(|cx| channel.poll(cx)) => {
-                    match event.unwrap() {
-                        phoenix_channel::Event::Message { .. } => {}
-                        phoenix_channel::Event::Hiccup { error, .. } => panic!("Connection failed: {error}"),
-                        phoenix_channel::Event::Closed => {
-                            panic!("Channel closed")
-                        }
-                        phoenix_channel::Event::Connected => {}
-                    }
+            // Scoped so that the borrow of `channel` ends before we send on it.
+            let event = {
+                let event = pin!(future::poll_fn(|cx| channel.poll(cx)));
+                let tick = pin!(message_interval.tick());
+
+                match futures::future::select(event, tick).await {
+                    Either::Left((event, _)) => Some(event),
+                    Either::Right((_, _)) => None,
                 }
-                _ = message_interval.tick() => {
-                    let _ = channel.send("test", OutboundMsg::Bar);
-                }
+            };
+
+            let Some(event) = event else {
+                let _ = channel.send("test", OutboundMsg::Bar);
+                continue;
+            };
+
+            match event.unwrap() {
+                Event::Message { .. } => {}
+                Event::Connected => {}
+                Event::Closed => panic!("Channel closed"),
+                Event::Hiccup { error, .. } => panic!("Connection failed: {error:#}"),
             }
         }
     });
 
     tokio::time::sleep(Duration::from_secs(25)).await;
 
-    assert_eq!(num_heartbeats.load(std::sync::atomic::Ordering::SeqCst), 2);
+    assert_eq!(num_heartbeats.load(Ordering::SeqCst), 2);
 
     client.abort();
     server.abort();
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
-#[serde(rename_all = "snake_case", tag = "event", content = "payload")]
-enum InboundMsg {
-    Foo,
-}
+#[tokio::test]
+async fn includes_ip_from_hostname() {
+    let _guard = logging::test("debug,wire::api=trace");
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "snake_case", tag = "event", content = "payload")]
-enum OutboundMsg {
-    Bar,
+    let (server, port) = spawn_joining_server().await;
+    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
+
+    // Without any IPs, the channel has to resolve them from the URL's host itself.
+    channel.connect(vec![], Duration::ZERO, PublicKeyParam([0u8; 32]));
+    poll_until_connected(&mut channel).await;
+
+    server.abort();
 }
 
 #[tokio::test]
-async fn http_429_triggers_retry() {
-    let port = http_status_server(http::StatusCode::TOO_MANY_REQUESTS).await;
+async fn initial_connection_uses_constant_1s_backoff() {
+    let _guard = logging::test("debug");
 
-    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
-    channel.connect(
-        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-        Duration::ZERO,
-        PublicKeyParam([0u8; 32]),
-    );
+    let mut channel = make_test_channel("127.0.0.1", 1, default_backoff);
+    connect(&mut channel, Duration::ZERO);
 
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
-    })
-    .await
-    .expect("should not timeout");
+    let start = std::time::Instant::now();
 
-    // 429 should trigger a Hiccup (retry) not an Error::Client
+    loop {
+        match future::poll_fn(|cx| channel.poll(cx)).await {
+            Ok(Event::Hiccup {
+                backoff,
+                max_elapsed_time,
+                ..
+            }) => {
+                assert_eq!(max_elapsed_time, Some(Duration::from_secs(15)));
+                assert_eq!(backoff, Duration::from_secs(1));
+
+                connect(&mut channel, backoff);
+            }
+            Err(Error::MaxRetriesReached { .. }) => break,
+            other => panic!("Unexpected event: {other:?}"),
+        }
+    }
+
+    let elapsed = start.elapsed();
+
     assert!(
-        matches!(result, Ok(Event::Hiccup { .. })),
-        "expected Event::Hiccup for 429, got {result:?}"
+        elapsed < Duration::from_secs(20),
+        "Expected to complete within 20s, but took {elapsed:?}"
     );
 }
 
 #[tokio::test]
-async fn http_408_triggers_retry() {
-    let port = http_status_server(http::StatusCode::REQUEST_TIMEOUT).await;
+async fn connect_with_zero_backoff_resets_reconnect_backoff() {
+    let _guard = logging::test("debug");
 
-    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
+    let (server, port) = spawn_joining_server().await;
+    let mut channel = make_test_channel("127.0.0.1", port, fast_backoff);
 
-    channel.connect(
-        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-        Duration::ZERO,
-        PublicKeyParam([0u8; 32]),
-    );
+    tokio::time::timeout(Duration::from_secs(10), async {
+        // Connect once, then drop the server so every reconnect afterwards fails.
+        connect(&mut channel, Duration::ZERO);
+        poll_until_connected(&mut channel).await;
+        server.abort();
 
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
+        // Let the backoff grow by reconnecting with the suggested backoff.
+        let first = poll_until_hiccup(&mut channel).await.backoff;
+        connect(&mut channel, first);
+        let grown = poll_until_hiccup(&mut channel).await.backoff;
+        assert!(grown > first, "backoff should grow on consecutive hiccups");
+
+        // A zero-backoff `connect` resets the backoff, so the next hiccup starts
+        // over at the initial interval instead of continuing from `grown`.
+        connect(&mut channel, Duration::ZERO);
+        let reset = poll_until_hiccup(&mut channel).await.backoff;
+        assert_eq!(
+            reset, first,
+            "zero-backoff connect should reset the backoff"
+        );
     })
     .await
     .expect("should not timeout");
-
-    // 408 should trigger a Hiccup (retry) not an Error::Client
-    assert!(
-        matches!(result, Ok(Event::Hiccup { .. })),
-        "expected Event::Hiccup for 408, got {result:?}"
-    );
 }
 
 #[tokio::test]
 async fn http_400_returns_client_error() {
     let port = http_status_server(http::StatusCode::BAD_REQUEST).await;
 
-    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
-
-    channel.connect(
-        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-        Duration::ZERO,
-        PublicKeyParam([0u8; 32]),
-    );
-
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
-    })
-    .await
-    .expect("should not timeout");
-
-    assert!(
-        matches!(result, Ok(Event::Hiccup { .. })),
-        "expected Event::Hiccup for 400, got {result:?}"
-    );
+    expect_hiccup(first_event(port).await);
 }
 
 #[tokio::test]
@@ -497,141 +362,11 @@ async fn http_401_with_invalid_token_code_returns_invalid_token() {
     )
     .await;
 
-    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
-
-    channel.connect(
-        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-        Duration::ZERO,
-        PublicKeyParam([0u8; 32]),
-    );
-
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
-    })
-    .await
-    .expect("should not timeout");
+    let error = expect_error(first_event(port).await);
 
     assert!(
-        matches!(result, Err(phoenix_channel::Error::InvalidToken)),
-        "expected Error::InvalidToken for 401 with `invalid_token` code, got {result:?}"
-    );
-}
-
-#[tokio::test]
-async fn http_403_with_certificate_code_is_terminal() {
-    let port = http_problem_details_server(
-        http::StatusCode::FORBIDDEN,
-        r#"{"type":"about:blank","title":"Forbidden","status":403,"detail":"This device's certificate has been revoked.","code":"certificate_revoked"}"#,
-    )
-    .await;
-
-    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
-
-    channel.connect(
-        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-        Duration::ZERO,
-        PublicKeyParam([0u8; 32]),
-    );
-
-    // Without the terminal path this is an `Event::Hiccup` and the poll never resolves, so
-    // reaching the timeout is the failure this test is really guarding against.
-    let error = tokio::time::timeout(Duration::from_secs(5), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
-    })
-    .await
-    .expect("should not retry a rejected certificate")
-    .unwrap_err();
-
-    assert_eq!(
-        error.to_string(),
-        "The portal rejected the client certificate: This device's certificate has been revoked."
-    );
-    assert!(error.is_certificate_error());
-    // A new token cannot replace the credential the portal refused.
-    assert!(!error.requires_sign_in());
-}
-
-#[tokio::test]
-async fn http_409_with_certificate_code_is_terminal() {
-    let port = http_problem_details_server(
-        http::StatusCode::CONFLICT,
-        r#"{"type":"about:blank","title":"Conflict","status":409,"detail":"Different hardware.","code":"device_identity_conflict"}"#,
-    )
-    .await;
-
-    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
-
-    channel.connect(
-        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-        Duration::ZERO,
-        PublicKeyParam([0u8; 32]),
-    );
-
-    let error = tokio::time::timeout(Duration::from_secs(5), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
-    })
-    .await
-    .expect("should not retry a rejected certificate")
-    .unwrap_err();
-
-    assert_eq!(
-        error.to_string(),
-        "The portal rejected the client certificate: Different hardware."
-    );
-    assert!(error.is_certificate_error());
-    assert!(!error.requires_sign_in());
-}
-
-#[tokio::test]
-async fn http_403_with_another_code_triggers_retry() {
-    let port = http_problem_details_server(
-        http::StatusCode::FORBIDDEN,
-        r#"{"type":"about:blank","title":"Forbidden","status":403,"detail":"The account is disabled","code":"account_disabled"}"#,
-    )
-    .await;
-
-    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
-
-    channel.connect(
-        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-        Duration::ZERO,
-        PublicKeyParam([0u8; 32]),
-    );
-
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
-    })
-    .await
-    .expect("should not timeout");
-
-    // Only the codes that name the certificate are terminal; the rest stay retryable.
-    assert!(
-        matches!(result, Ok(Event::Hiccup { .. })),
-        "expected Event::Hiccup for a 403 whose code does not name the certificate, got {result:?}"
-    );
-}
-
-#[tokio::test]
-async fn http_403_without_problem_details_triggers_retry() {
-    let port = http_status_server(http::StatusCode::FORBIDDEN).await;
-
-    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
-
-    channel.connect(
-        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-        Duration::ZERO,
-        PublicKeyParam([0u8; 32]),
-    );
-
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
-    })
-    .await
-    .expect("should not timeout");
-
-    assert!(
-        matches!(result, Ok(Event::Hiccup { .. })),
-        "expected Event::Hiccup for a 403 an intermediary sent, got {result:?}"
+        matches!(error, Error::InvalidToken),
+        "expected Error::InvalidToken for 401 with `invalid_token` code, got {error:?}"
     );
 }
 
@@ -643,23 +378,11 @@ async fn http_401_without_code_returns_authentication_failed() {
     )
     .await;
 
-    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
-
-    channel.connect(
-        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-        Duration::ZERO,
-        PublicKeyParam([0u8; 32]),
-    );
-
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
-    })
-    .await
-    .expect("should not timeout");
+    let error = expect_error(first_event(port).await);
 
     assert!(
-        matches!(result, Err(phoenix_channel::Error::AuthenticationFailed(_))),
-        "expected Error::AuthenticationFailed for 401 without code, got {result:?}"
+        matches!(error, Error::AuthenticationFailed(_)),
+        "expected Error::AuthenticationFailed for 401 without code, got {error:?}"
     );
 }
 
@@ -667,129 +390,217 @@ async fn http_401_without_code_returns_authentication_failed() {
 async fn http_401_without_problem_details_returns_authentication_failed() {
     let port = http_status_server(http::StatusCode::UNAUTHORIZED).await;
 
-    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
-
-    channel.connect(
-        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-        Duration::ZERO,
-        PublicKeyParam([0u8; 32]),
-    );
-
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
-    })
-    .await
-    .expect("should not timeout");
+    let error = expect_error(first_event(port).await);
 
     assert!(
-        matches!(result, Err(phoenix_channel::Error::AuthenticationFailed(_))),
-        "expected Error::AuthenticationFailed for 401 without problem details, got {result:?}"
+        matches!(error, Error::AuthenticationFailed(_)),
+        "expected Error::AuthenticationFailed for 401 without problem details, got {error:?}"
     );
 }
 
 #[tokio::test]
-async fn includes_ip_from_hostname() {
-    use phoenix_channel::PublicKeyParam;
-
-    let _guard = logging::test("debug,wire::api=trace");
-
-    let (server, port) = spawn_websocket_server(|text| {
-        match text {
-            r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
-                r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#
-            }
-            other => panic!("Unexpected message: {other}"),
-        }
-    })
+async fn http_403_with_certificate_code_is_terminal() {
+    let port = http_problem_details_server(
+        http::StatusCode::FORBIDDEN,
+        r#"{"type":"about:blank","title":"Forbidden","status":403,"detail":"This device's certificate has been revoked.","code":"certificate_revoked"}"#,
+    )
     .await;
 
-    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
-    channel.connect(vec![], Duration::ZERO, PublicKeyParam([0u8; 32]));
+    // Without the terminal path this is an `Event::Hiccup` and the poll never resolves, so
+    // reaching the timeout is the failure this test is really guarding against.
+    let error = expect_error(first_event(port).await);
 
-    let client = async {
-        loop {
-            match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::Message { .. } => {}
-                phoenix_channel::Event::Hiccup { error, .. } => panic!("{error:#}"),
-                phoenix_channel::Event::Closed => {
-                    panic!("Channel closed")
-                }
-                phoenix_channel::Event::Connected => break,
-            }
-        }
-    };
-
-    client.await;
-    server.abort();
+    assert_eq!(
+        error.to_string(),
+        "The portal rejected the client certificate: This device's certificate has been revoked."
+    );
+    assert!(error.is_certificate_error());
+    // A new token cannot replace the credential the portal refused.
+    assert!(!error.requires_sign_in());
 }
 
-/// Spawns a WebSocket server that responds to requests using a handler function.
-/// Returns the server task handle and the port number.
-async fn spawn_websocket_server<F, R>(handler: F) -> (ServerHandle, u16)
-where
-    F: Fn(&str) -> R + Send + 'static,
-    R: Into<tokio_tungstenite::tungstenite::Utf8Bytes>,
-{
-    use futures::{SinkExt, StreamExt};
-    use tokio::net::TcpListener;
-    use tokio_tungstenite::tungstenite::Message;
-
-    let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
-    let port = listener.local_addr().unwrap().port();
-    let (close_tx, mut close_rx) = futures::channel::mpsc::channel(1);
-
-    let server = tokio::spawn(async move {
-        let (stream, _) = listener.accept().await.unwrap();
-        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
-
-        loop {
-            match futures::future::select(ws.next(), close_rx.recv()).await {
-                futures::future::Either::Left((Some(Ok(Message::Text(text))), _)) => {
-                    let response = handler(text.as_str());
-                    ws.send(Message::text(response)).await.unwrap();
-                }
-                futures::future::Either::Left((Some(Ok(Message::Close(_))), _)) => continue,
-                futures::future::Either::Left((Some(other), _)) => {
-                    panic!("Unexpected message: {other:?}")
-                }
-                futures::future::Either::Left((None, _)) => break,
-                futures::future::Either::Right((Err(_), _)) => continue,
-                futures::future::Either::Right((Ok(()), _)) => {
-                    ws.close(None).await.unwrap();
-                    ws.flush().await.unwrap();
-                    SinkExt::close(&mut ws).await.unwrap();
-                }
-            }
-        }
-    });
-
-    (
-        ServerHandle {
-            task: server,
-            close_tx,
-        },
-        port,
+#[tokio::test]
+async fn http_403_with_another_code_triggers_retry() {
+    let port = http_problem_details_server(
+        http::StatusCode::FORBIDDEN,
+        r#"{"type":"about:blank","title":"Forbidden","status":403,"detail":"The account is disabled","code":"account_disabled"}"#,
     )
+    .await;
+
+    // Only the codes that name the certificate are terminal; the rest stay retryable.
+    expect_hiccup(first_event(port).await);
 }
 
-struct ServerHandle {
-    task: tokio::task::JoinHandle<()>,
-    close_tx: futures::channel::mpsc::Sender<()>,
+#[tokio::test]
+async fn http_403_without_problem_details_triggers_retry() {
+    let port = http_status_server(http::StatusCode::FORBIDDEN).await;
+
+    expect_hiccup(first_event(port).await);
 }
 
-impl ServerHandle {
-    async fn stop(mut self) -> Result<(), JoinError> {
-        let _ = self.close_tx.send(()).await;
+#[tokio::test]
+async fn http_408_triggers_retry() {
+    let port = http_status_server(http::StatusCode::REQUEST_TIMEOUT).await;
 
-        self.task.await
+    expect_hiccup(first_event(port).await);
+}
+
+#[tokio::test]
+async fn http_409_with_certificate_code_is_terminal() {
+    let port = http_problem_details_server(
+        http::StatusCode::CONFLICT,
+        r#"{"type":"about:blank","title":"Conflict","status":409,"detail":"Different hardware.","code":"device_identity_conflict"}"#,
+    )
+    .await;
+
+    let error = expect_error(first_event(port).await);
+
+    assert_eq!(
+        error.to_string(),
+        "The portal rejected the client certificate: Different hardware."
+    );
+    assert!(error.is_certificate_error());
+    assert!(!error.requires_sign_in());
+}
+
+#[tokio::test]
+async fn http_429_triggers_retry() {
+    let port = http_status_server(http::StatusCode::TOO_MANY_REQUESTS).await;
+
+    expect_hiccup(first_event(port).await);
+}
+
+#[tokio::test]
+async fn http_429_with_retry_after_uses_header_value() {
+    let port = http_status_server_with_retry_after(
+        http::StatusCode::TOO_MANY_REQUESTS,
+        Duration::from_secs(30),
+    )
+    .await;
+
+    let backoff = expect_hiccup(first_event(port).await);
+
+    assert_eq!(backoff, Duration::from_secs(30));
+}
+
+#[tokio::test]
+async fn http_503_triggers_retry() {
+    let port = http_status_server(http::StatusCode::SERVICE_UNAVAILABLE).await;
+
+    expect_hiccup(first_event(port).await);
+}
+
+#[tokio::test]
+async fn http_503_with_retry_after_uses_header_value() {
+    let port = http_status_server_with_retry_after(
+        http::StatusCode::SERVICE_UNAVAILABLE,
+        Duration::from_secs(60),
+    )
+    .await;
+
+    let backoff = expect_hiccup(first_event(port).await);
+
+    assert_eq!(backoff, Duration::from_secs(60));
+}
+
+/// Connects the channel to localhost after waiting for `backoff`.
+fn connect(channel: &mut TestChannel, backoff: Duration) {
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        backoff,
+        PublicKeyParam([0u8; 32]),
+    );
+}
+
+/// Polls the channel until it is connected, panicking on any other event.
+async fn poll_until_connected(channel: &mut TestChannel) {
+    loop {
+        match future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
+            Event::Connected => return,
+            Event::Message { .. } => {}
+            Event::Closed => panic!("Channel closed"),
+            Event::Hiccup { error, .. } => panic!("Unexpected hiccup: {error:#}"),
+        }
     }
+}
 
-    async fn wait(self) {
-        self.task.await.unwrap()
+/// Polls the channel for the next message, panicking on any other event.
+async fn next_message(channel: &mut TestChannel) -> InboundMsg {
+    match future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
+        Event::Message { msg, .. } => msg,
+        Event::Connected => panic!("Channel re-connected"),
+        Event::Closed => panic!("Channel closed"),
+        Event::Hiccup { error, .. } => panic!("Unexpected hiccup: {error:#}"),
     }
+}
 
-    fn abort(self) {
-        self.task.abort();
+/// Polls the channel until it is closed, panicking on any other event.
+async fn poll_until_closed(channel: &mut TestChannel) {
+    loop {
+        match future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
+            Event::Closed => return,
+            Event::Message { .. } => {}
+            Event::Connected => panic!("Channel re-connected"),
+            Event::Hiccup { error, .. } => panic!("Unexpected hiccup: {error:#}"),
+        }
+    }
+}
+
+/// Polls the channel until the connection hiccups, panicking on any other event.
+async fn poll_until_hiccup(channel: &mut TestChannel) -> Hiccup {
+    loop {
+        match future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
+            Event::Hiccup { backoff, error, .. } => {
+                return Hiccup {
+                    backoff,
+                    error: format!("{error:#}"),
+                };
+            }
+            Event::Message { .. } => {}
+            Event::Connected => panic!("Channel re-connected"),
+            Event::Closed => panic!("Channel closed"),
+        }
+    }
+}
+
+struct Hiccup {
+    backoff: Duration,
+    /// The error's chain of causes, as rendered by its alternate `Display` representation.
+    error: String,
+}
+
+/// Connects a channel to `port` and returns the first event it emits.
+///
+/// # Panics
+///
+/// Panics if the channel does not emit an event within 5 seconds.
+async fn first_event(port: u16) -> Result<Event<InboundMsg>, Error> {
+    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
+    connect(&mut channel, Duration::ZERO);
+
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        future::poll_fn(|cx| channel.poll(cx)),
+    )
+    .await
+    .expect("should not timeout")
+}
+
+/// Asserts that the channel wants to retry and returns the backoff it suggests.
+#[track_caller]
+fn expect_hiccup(event: Result<Event<InboundMsg>, Error>) -> Duration {
+    match event {
+        Ok(Event::Hiccup { backoff, .. }) => backoff,
+        other => panic!("Expected `Event::Hiccup`, got {other:?}"),
+    }
+}
+
+/// Asserts that the channel failed terminally and returns the error.
+#[track_caller]
+fn expect_error(event: Result<Event<InboundMsg>, Error>) -> Error {
+    match event {
+        Err(error) => error,
+        Ok(other) => panic!("Expected an error, got {other:?}"),
     }
 }
 
@@ -838,6 +649,118 @@ fn fast_backoff() -> backoff::ExponentialBackoff {
         .build()
 }
 
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[serde(rename_all = "snake_case", tag = "event", content = "payload")]
+enum InboundMsg {
+    Foo,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "snake_case", tag = "event", content = "payload")]
+enum OutboundMsg {
+    Bar,
+}
+
+const JOIN_REQUEST: &str = r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"#;
+const JOIN_REPLY: &str =
+    r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#;
+const BAR_REQUEST: &str = r#"{"topic":"test","event":"bar","ref":1}"#;
+const FOO_MESSAGE: &str = r#"{"topic":"test","event":"foo","payload":null}"#;
+/// A reply carrying a reference the channel never sent.
+const UNMATCHED_REPLY: &str =
+    r#"{"event":"phx_reply","ref":9999,"topic":"phoenix","payload":{"status":"ok","response":{}}}"#;
+
+/// Formats the heartbeat a channel sends with the given reference.
+fn heartbeat_request(reference: u32) -> String {
+    format!(r#"{{"topic":"phoenix","event":"heartbeat","payload":{{}},"ref":{reference}}}"#)
+}
+
+/// Spawns a WebSocket server that only acknowledges the channel join.
+async fn spawn_joining_server() -> (ServerHandle, u16) {
+    spawn_websocket_server(|text| match text {
+        JOIN_REQUEST => JOIN_REPLY,
+        other => panic!("Unexpected message: {other}"),
+    })
+    .await
+}
+
+/// Spawns a WebSocket server that answers a single [`OutboundMsg::Bar`] with [`InboundMsg::Foo`].
+///
+/// Only the `bar` with `ref: 1` is answered, so any additional or earlier one fails the server.
+async fn spawn_echo_server() -> (ServerHandle, u16) {
+    spawn_websocket_server(|text| match text {
+        JOIN_REQUEST => JOIN_REPLY,
+        BAR_REQUEST => FOO_MESSAGE,
+        other => panic!("Unexpected message: {other}"),
+    })
+    .await
+}
+
+/// Spawns a WebSocket server that responds to requests using a handler function.
+/// Returns the server task handle and the port number.
+async fn spawn_websocket_server<F, R>(handler: F) -> (ServerHandle, u16)
+where
+    F: Fn(&str) -> R + Send + 'static,
+    R: Into<tokio_tungstenite::tungstenite::Utf8Bytes>,
+{
+    let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (close_tx, mut close_rx) = futures::channel::mpsc::channel(1);
+
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+        loop {
+            match futures::future::select(ws.next(), close_rx.recv()).await {
+                Either::Left((Some(Ok(Message::Text(text))), _)) => {
+                    let response = handler(text.as_str());
+                    ws.send(Message::text(response)).await.unwrap();
+                }
+                Either::Left((Some(Ok(Message::Close(_))), _)) => continue,
+                Either::Left((Some(other), _)) => panic!("Unexpected message: {other:?}"),
+                Either::Left((None, _)) => break,
+                Either::Right((Err(_), _)) => continue,
+                Either::Right((Ok(()), _)) => {
+                    ws.close(None).await.unwrap();
+                    ws.flush().await.unwrap();
+                    SinkExt::close(&mut ws).await.unwrap();
+                }
+            }
+        }
+    });
+
+    (
+        ServerHandle {
+            task: server,
+            close_tx,
+        },
+        port,
+    )
+}
+
+struct ServerHandle {
+    task: tokio::task::JoinHandle<()>,
+    close_tx: futures::channel::mpsc::Sender<()>,
+}
+
+impl ServerHandle {
+    async fn stop(mut self) -> Result<(), JoinError> {
+        let _ = self.close_tx.send(()).await;
+
+        self.task.await
+    }
+
+    async fn wait(self) {
+        self.task.await.unwrap()
+    }
+
+    fn abort(self) {
+        self.task.abort();
+    }
+}
+
+/// Spawns a server that rejects the WebSocket upgrade with the given status code.
 async fn http_status_server(code: http::StatusCode) -> u16 {
     http_response_server(format!(
         "HTTP/1.1 {status} {reason}\r\n\
@@ -845,7 +768,22 @@ async fn http_status_server(code: http::StatusCode) -> u16 {
          Content-Type: text/plain\r\n\
          Content-Length: 0\r\n\r\n",
         status = code.as_u16(),
-        reason = code.as_str()
+        reason = code.canonical_reason().unwrap_or_default()
+    ))
+    .await
+}
+
+/// Spawns a server that rejects the WebSocket upgrade and asks to retry after the given delay.
+async fn http_status_server_with_retry_after(code: http::StatusCode, retry_after: Duration) -> u16 {
+    http_response_server(format!(
+        "HTTP/1.1 {status} {reason}\r\n\
+         Connection: close\r\n\
+         Content-Type: text/plain\r\n\
+         Retry-After: {retry_after}\r\n\
+         Content-Length: 0\r\n\r\n",
+        status = code.as_u16(),
+        reason = code.canonical_reason().unwrap_or_default(),
+        retry_after = retry_after.as_secs()
     ))
     .await
 }
@@ -865,17 +803,7 @@ async fn http_problem_details_server(code: http::StatusCode, body: &str) -> u16 
     .await
 }
 
-async fn http_status_server_with_retry_after(status: u16, reason: &str, retry_after: u64) -> u16 {
-    http_response_server(format!(
-        "HTTP/1.1 {status} {reason}\r\n\
-         Connection: close\r\n\
-         Content-Type: text/plain\r\n\
-         Retry-After: {retry_after}\r\n\
-         Content-Length: 0\r\n\r\n"
-    ))
-    .await
-}
-
+/// Spawns a server that answers every request with the given raw HTTP response.
 async fn http_response_server(response: String) -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
@@ -889,7 +817,7 @@ async fn http_response_server(response: String) -> u16 {
                 loop {
                     match tokio::time::timeout(
                         Duration::from_millis(500),
-                        tokio::io::AsyncReadExt::read(&mut socket, &mut buf[total_read..]),
+                        socket.read(&mut buf[total_read..]),
                     )
                     .await
                     {
@@ -912,203 +840,4 @@ async fn http_response_server(response: String) -> u16 {
     });
 
     port
-}
-
-#[tokio::test]
-async fn http_503_triggers_retry() {
-    let port = http_status_server(http::StatusCode::SERVICE_UNAVAILABLE).await;
-
-    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
-
-    channel.connect(
-        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-        Duration::ZERO,
-        PublicKeyParam([0u8; 32]),
-    );
-
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
-    })
-    .await
-    .expect("should not timeout");
-
-    // 503 should trigger a Hiccup (retry) not an Error::Client
-    assert!(
-        matches!(result, Ok(Event::Hiccup { .. })),
-        "expected Event::Hiccup for 503, got {result:?}"
-    );
-}
-
-#[tokio::test]
-async fn http_429_with_retry_after_uses_header_value() {
-    let port = http_status_server_with_retry_after(429, "Too Many Requests", 30).await;
-
-    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
-
-    channel.connect(
-        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-        Duration::ZERO,
-        PublicKeyParam([0u8; 32]),
-    );
-
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
-    })
-    .await
-    .expect("should not timeout");
-
-    // 429 with Retry-After should use the header value for backoff
-    match result {
-        Ok(Event::Hiccup { backoff, .. }) => {
-            assert_eq!(backoff, Duration::from_secs(30));
-        }
-        other => {
-            panic!(
-                "expected Event::Hiccup with 30s backoff for 429 with Retry-After, got {other:?}"
-            )
-        }
-    }
-}
-
-#[tokio::test]
-async fn http_503_with_retry_after_uses_header_value() {
-    let port = http_status_server_with_retry_after(503, "Service Unavailable", 60).await;
-
-    let mut channel = make_test_channel("127.0.0.1", port, default_backoff);
-
-    channel.connect(
-        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-        Duration::ZERO,
-        PublicKeyParam([0u8; 32]),
-    );
-
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
-    })
-    .await
-    .expect("should not timeout");
-
-    // 503 with Retry-After should use the header value for backoff
-    match result {
-        Ok(Event::Hiccup { backoff, .. }) => {
-            assert_eq!(backoff, Duration::from_secs(60));
-        }
-        other => {
-            panic!(
-                "expected Event::Hiccup with 60s backoff for 503 with Retry-After, got {other:?}"
-            )
-        }
-    }
-}
-
-#[tokio::test]
-async fn initial_connection_uses_constant_1s_backoff() {
-    use phoenix_channel::{Error, PublicKeyParam};
-    use std::time::Duration;
-
-    let _guard = logging::test("debug");
-
-    let mut channel = make_test_channel("127.0.0.1", 1, default_backoff);
-    channel.connect(
-        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-        Duration::ZERO,
-        PublicKeyParam([0u8; 32]),
-    );
-
-    let start = std::time::Instant::now();
-
-    loop {
-        match std::future::poll_fn(|cx| channel.poll(cx)).await {
-            Ok(phoenix_channel::Event::Hiccup {
-                backoff,
-                max_elapsed_time,
-                ..
-            }) => {
-                assert_eq!(max_elapsed_time, Some(Duration::from_secs(15)));
-                assert_eq!(backoff, Duration::from_secs(1));
-
-                channel.connect(
-                    vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-                    backoff,
-                    PublicKeyParam([0u8; 32]),
-                );
-            }
-            Err(Error::MaxRetriesReached { .. }) => break,
-            other => panic!("Unexpected event: {other:?}"),
-        }
-    }
-
-    let elapsed = start.elapsed();
-
-    assert!(
-        elapsed < Duration::from_secs(20),
-        "Expected to complete within 20s, but took {elapsed:?}"
-    );
-}
-
-#[tokio::test]
-async fn connect_with_zero_backoff_resets_reconnect_backoff() {
-    let _guard = logging::test("debug");
-
-    let (server, port) = spawn_websocket_server(|text| match text {
-        r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
-            r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#
-        }
-        other => panic!("Unexpected message: {other}"),
-    })
-    .await;
-
-    let mut channel = make_test_channel("127.0.0.1", port, fast_backoff);
-    reconnect(&mut channel, Duration::ZERO);
-
-    tokio::time::timeout(Duration::from_secs(10), async {
-        // Connect once, then drop the server so every reconnect afterwards fails.
-        loop {
-            match future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                Event::Connected => break,
-                Event::Message { .. } => {}
-                other @ (Event::Closed | Event::Hiccup { .. }) => {
-                    panic!("Unexpected event: {other:?}")
-                }
-            }
-        }
-        server.abort();
-
-        // Let the backoff grow by reconnecting with the suggested backoff.
-        let first = poll_until_hiccup(&mut channel).await;
-        reconnect(&mut channel, first);
-        let grown = poll_until_hiccup(&mut channel).await;
-        assert!(grown > first, "backoff should grow on consecutive hiccups");
-
-        // A zero-backoff `connect` resets the backoff, so the next hiccup starts
-        // over at the initial interval instead of continuing from `grown`.
-        reconnect(&mut channel, Duration::ZERO);
-        let reset = poll_until_hiccup(&mut channel).await;
-        assert_eq!(
-            reset, first,
-            "zero-backoff connect should reset the backoff"
-        );
-    })
-    .await
-    .expect("should not timeout");
-}
-
-fn reconnect(channel: &mut TestChannel, backoff: Duration) {
-    channel.connect(
-        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
-        backoff,
-        PublicKeyParam([0u8; 32]),
-    );
-}
-
-async fn poll_until_hiccup(channel: &mut TestChannel) -> Duration {
-    loop {
-        match future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-            Event::Hiccup { backoff, .. } => return backoff,
-            Event::Message { .. } => {}
-            other @ (Event::Closed | Event::Connected) => {
-                panic!("Unexpected event: {other:?}")
-            }
-        }
-    }
 }

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -348,17 +348,18 @@ async fn connect_with_zero_backoff_resets_reconnect_backoff() {
     .expect("should not timeout");
 }
 
-#[test_case(http::StatusCode::UNAUTHORIZED, Some(INVALID_TOKEN) => "Authentication token invalid"; "401 naming the token")]
-#[test_case(http::StatusCode::UNAUTHORIZED, Some(UNAUTHORIZED) => "Failed to authenticate with portal: Invalid token"; "401 without a code")]
-#[test_case(http::StatusCode::UNAUTHORIZED, None => "Failed to authenticate with portal: no reason provided"; "401 without problem details")]
-#[test_case(http::StatusCode::FORBIDDEN, Some(REVOKED_CERTIFICATE) => "The portal rejected the client certificate: This device's certificate has been revoked."; "403 naming the certificate")]
-#[test_case(http::StatusCode::CONFLICT, Some(IDENTITY_CONFLICT) => "The portal rejected the client certificate: Different hardware."; "409 naming the certificate")]
+// The portal names permanent rejections with a problem code; the HTTP status only decides
+// for a response that carries no code the client knows.
+#[test_case(r#"{"status":401,"detail":"Invalid token","code":"invalid_token"}"# => "Authentication token invalid"; "an unusable token")]
+#[test_case(r#"{"status":401,"detail":"No token","code":"missing_token"}"# => "Authentication token invalid"; "a missing token")]
+#[test_case(r#"{"status":403,"detail":"This device's certificate has been revoked.","code":"certificate_revoked"}"# => "The portal rejected the client certificate: This device's certificate has been revoked."; "a revoked certificate")]
+#[test_case(r#"{"status":403,"detail":"This device is not trusted.","code":"device_untrusted"}"# => "The portal rejected the client certificate: This device is not trusted."; "an untrusted device")]
+#[test_case(r#"{"status":409,"detail":"Different hardware.","code":"device_identity_conflict"}"# => "The portal rejected the client certificate: Different hardware."; "a conflicting device identity")]
+#[test_case(r#"{"status":401,"detail":"Invalid token"}"# => "Failed to authenticate with portal: Invalid token"; "a 401 without a code")]
+#[test_case(r#"{"status":401}"# => "Failed to authenticate with portal: no reason provided"; "a 401 without a detail")]
 #[tokio::test]
-async fn rejected_upgrade_is_terminal(
-    code: http::StatusCode,
-    problem_details: Option<&str>,
-) -> String {
-    let port = rejecting_server(code, problem_details).await;
+async fn portal_rejection_is_terminal(problem_details: &str) -> String {
+    let port = http_problem_details_server(problem_details).await;
 
     // Without the terminal path these are an `Event::Hiccup` and the poll never resolves, so
     // reaching the timeout is the failure this test is really guarding against.
@@ -367,18 +368,38 @@ async fn rejected_upgrade_is_terminal(
     error.to_string()
 }
 
-// Only the codes that name the certificate are terminal; the rest stay retryable.
-#[test_case(http::StatusCode::BAD_REQUEST, None; "400")]
-#[test_case(http::StatusCode::FORBIDDEN, None; "403 without problem details")]
-#[test_case(http::StatusCode::FORBIDDEN, Some(ACCOUNT_DISABLED); "403 with a code that does not name the certificate")]
-#[test_case(http::StatusCode::REQUEST_TIMEOUT, None; "408")]
-#[test_case(http::StatusCode::TOO_MANY_REQUESTS, None; "429")]
-#[test_case(http::StatusCode::SERVICE_UNAVAILABLE, None; "503")]
+#[test_case(r#"{"status":403,"detail":"The account is disabled","code":"account_disabled"}"#; "a code that names neither the token nor the certificate")]
+#[test_case(r#"{"status":403,"detail":"Something new","code":"a_code_from_a_newer_portal"}"#; "a code the client does not know")]
 #[tokio::test]
-async fn rejected_upgrade_is_retried(code: http::StatusCode, problem_details: Option<&str>) {
-    let port = rejecting_server(code, problem_details).await;
+async fn portal_rejection_is_retried(problem_details: &str) {
+    let port = http_problem_details_server(problem_details).await;
 
     expect_hiccup(first_event(port).await);
+}
+
+// An intermediary rejects the upgrade without problem details, e.g. with an error page.
+#[test_case(http::StatusCode::BAD_REQUEST; "400")]
+#[test_case(http::StatusCode::FORBIDDEN; "403")]
+#[test_case(http::StatusCode::REQUEST_TIMEOUT; "408")]
+#[test_case(http::StatusCode::TOO_MANY_REQUESTS; "429")]
+#[test_case(http::StatusCode::SERVICE_UNAVAILABLE; "503")]
+#[tokio::test]
+async fn bare_rejection_is_retried(code: http::StatusCode) {
+    let port = http_status_server(code).await;
+
+    expect_hiccup(first_event(port).await);
+}
+
+#[tokio::test]
+async fn bare_401_is_terminal() {
+    let port = http_status_server(http::StatusCode::UNAUTHORIZED).await;
+
+    let error = expect_error(first_event(port).await);
+
+    assert_eq!(
+        error.to_string(),
+        "Failed to authenticate with portal: no reason provided"
+    );
 }
 
 #[test_case(http::StatusCode::TOO_MANY_REQUESTS, Duration::from_secs(30); "429")]
@@ -394,7 +415,10 @@ async fn retry_after_header_sets_the_backoff(code: http::StatusCode, retry_after
 
 #[tokio::test]
 async fn rejected_certificate_does_not_require_sign_in() {
-    let port = http_problem_details_server(http::StatusCode::FORBIDDEN, REVOKED_CERTIFICATE).await;
+    let port = http_problem_details_server(
+        r#"{"status":403,"detail":"This device's certificate has been revoked.","code":"certificate_revoked"}"#,
+    )
+    .await;
 
     let error = expect_error(first_event(port).await);
 
@@ -467,14 +491,6 @@ struct Hiccup {
     backoff: Duration,
     /// The error's chain of causes, as rendered by its alternate `Display` representation.
     error: String,
-}
-
-/// Spawns a server that rejects the WebSocket upgrade with `code`, optionally with problem details.
-async fn rejecting_server(code: http::StatusCode, problem_details: Option<&str>) -> u16 {
-    match problem_details {
-        Some(body) => http_problem_details_server(code, body).await,
-        None => http_status_server(code).await,
-    }
 }
 
 /// Connects a channel to `port` and returns the first event it emits.
@@ -574,13 +590,6 @@ const JOIN_REPLY: &str =
     r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#;
 const BAR_REQUEST: &str = r#"{"topic":"test","event":"bar","ref":1}"#;
 const FOO_MESSAGE: &str = r#"{"topic":"test","event":"foo","payload":null}"#;
-const INVALID_TOKEN: &str = r#"{"type":"about:blank","title":"Unauthorized","status":401,"detail":"Invalid token","code":"invalid_token"}"#;
-const UNAUTHORIZED: &str =
-    r#"{"type":"about:blank","title":"Unauthorized","status":401,"detail":"Invalid token"}"#;
-const REVOKED_CERTIFICATE: &str = r#"{"type":"about:blank","title":"Forbidden","status":403,"detail":"This device's certificate has been revoked.","code":"certificate_revoked"}"#;
-const IDENTITY_CONFLICT: &str = r#"{"type":"about:blank","title":"Conflict","status":409,"detail":"Different hardware.","code":"device_identity_conflict"}"#;
-const ACCOUNT_DISABLED: &str = r#"{"type":"about:blank","title":"Forbidden","status":403,"detail":"The account is disabled","code":"account_disabled"}"#;
-
 /// A reply carrying a reference the channel never sent.
 const UNMATCHED_REPLY: &str =
     r#"{"event":"phx_reply","ref":9999,"topic":"phoenix","payload":{"status":"ok","response":{}}}"#;
@@ -704,16 +713,24 @@ async fn http_status_server_with_retry_after(code: http::StatusCode, retry_after
 }
 
 /// Spawns a server that rejects the WebSocket upgrade with RFC 9457 problem details.
-async fn http_problem_details_server(code: http::StatusCode, body: &str) -> u16 {
+///
+/// The status line is taken from the body's `status` member, so a case cannot state one
+/// status in the response and another in the problem details.
+async fn http_problem_details_server(problem_details: &str) -> u16 {
+    let status = serde_json::from_str::<serde_json::Value>(problem_details).unwrap()["status"]
+        .as_u64()
+        .expect("problem details to carry a `status` member");
+    let code = http::StatusCode::from_u16(status.try_into().unwrap()).unwrap();
+
     http_response_server(format!(
         "HTTP/1.1 {status} {reason}\r\n\
          Connection: close\r\n\
          Content-Type: application/problem+json; charset=utf-8\r\n\
          Content-Length: {length}\r\n\r\n\
-         {body}",
+         {problem_details}",
         status = code.as_u16(),
         reason = code.canonical_reason().unwrap_or_default(),
-        length = body.len()
+        length = problem_details.len()
     ))
     .await
 }

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -12,6 +12,7 @@ use futures::future::Either;
 use futures::{SinkExt, StreamExt as _};
 use phoenix_channel::{DeviceInfo, Error, Event, LoginUrl, PhoenixChannel, PublicKeyParam};
 use secrecy::SecretString;
+use test_case::test_case;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::TcpListener;
 use tokio::task::JoinError;
@@ -347,160 +348,59 @@ async fn connect_with_zero_backoff_resets_reconnect_backoff() {
     .expect("should not timeout");
 }
 
+#[test_case(http::StatusCode::UNAUTHORIZED, Some(INVALID_TOKEN) => "Authentication token invalid"; "401 naming the token")]
+#[test_case(http::StatusCode::UNAUTHORIZED, Some(UNAUTHORIZED) => "Failed to authenticate with portal: Invalid token"; "401 without a code")]
+#[test_case(http::StatusCode::UNAUTHORIZED, None => "Failed to authenticate with portal: no reason provided"; "401 without problem details")]
+#[test_case(http::StatusCode::FORBIDDEN, Some(REVOKED_CERTIFICATE) => "The portal rejected the client certificate: This device's certificate has been revoked."; "403 naming the certificate")]
+#[test_case(http::StatusCode::CONFLICT, Some(IDENTITY_CONFLICT) => "The portal rejected the client certificate: Different hardware."; "409 naming the certificate")]
 #[tokio::test]
-async fn http_400_returns_client_error() {
-    let port = http_status_server(http::StatusCode::BAD_REQUEST).await;
+async fn rejected_upgrade_is_terminal(
+    code: http::StatusCode,
+    problem_details: Option<&str>,
+) -> String {
+    let port = rejecting_server(code, problem_details).await;
 
-    expect_hiccup(first_event(port).await);
-}
-
-#[tokio::test]
-async fn http_401_with_invalid_token_code_returns_invalid_token() {
-    let port = http_problem_details_server(
-        http::StatusCode::UNAUTHORIZED,
-        r#"{"type":"about:blank","title":"Unauthorized","status":401,"detail":"Invalid token","code":"invalid_token"}"#,
-    )
-    .await;
-
-    let error = expect_error(first_event(port).await);
-
-    assert!(
-        matches!(error, Error::InvalidToken),
-        "expected Error::InvalidToken for 401 with `invalid_token` code, got {error:?}"
-    );
-}
-
-#[tokio::test]
-async fn http_401_without_code_returns_authentication_failed() {
-    let port = http_problem_details_server(
-        http::StatusCode::UNAUTHORIZED,
-        r#"{"type":"about:blank","title":"Unauthorized","status":401,"detail":"Invalid token"}"#,
-    )
-    .await;
-
-    let error = expect_error(first_event(port).await);
-
-    assert!(
-        matches!(error, Error::AuthenticationFailed(_)),
-        "expected Error::AuthenticationFailed for 401 without code, got {error:?}"
-    );
-}
-
-#[tokio::test]
-async fn http_401_without_problem_details_returns_authentication_failed() {
-    let port = http_status_server(http::StatusCode::UNAUTHORIZED).await;
-
-    let error = expect_error(first_event(port).await);
-
-    assert!(
-        matches!(error, Error::AuthenticationFailed(_)),
-        "expected Error::AuthenticationFailed for 401 without problem details, got {error:?}"
-    );
-}
-
-#[tokio::test]
-async fn http_403_with_certificate_code_is_terminal() {
-    let port = http_problem_details_server(
-        http::StatusCode::FORBIDDEN,
-        r#"{"type":"about:blank","title":"Forbidden","status":403,"detail":"This device's certificate has been revoked.","code":"certificate_revoked"}"#,
-    )
-    .await;
-
-    // Without the terminal path this is an `Event::Hiccup` and the poll never resolves, so
+    // Without the terminal path these are an `Event::Hiccup` and the poll never resolves, so
     // reaching the timeout is the failure this test is really guarding against.
     let error = expect_error(first_event(port).await);
 
-    assert_eq!(
-        error.to_string(),
-        "The portal rejected the client certificate: This device's certificate has been revoked."
-    );
-    assert!(error.is_certificate_error());
-    // A new token cannot replace the credential the portal refused.
-    assert!(!error.requires_sign_in());
+    error.to_string()
 }
 
+// Only the codes that name the certificate are terminal; the rest stay retryable.
+#[test_case(http::StatusCode::BAD_REQUEST, None; "400")]
+#[test_case(http::StatusCode::FORBIDDEN, None; "403 without problem details")]
+#[test_case(http::StatusCode::FORBIDDEN, Some(ACCOUNT_DISABLED); "403 with a code that does not name the certificate")]
+#[test_case(http::StatusCode::REQUEST_TIMEOUT, None; "408")]
+#[test_case(http::StatusCode::TOO_MANY_REQUESTS, None; "429")]
+#[test_case(http::StatusCode::SERVICE_UNAVAILABLE, None; "503")]
 #[tokio::test]
-async fn http_403_with_another_code_triggers_retry() {
-    let port = http_problem_details_server(
-        http::StatusCode::FORBIDDEN,
-        r#"{"type":"about:blank","title":"Forbidden","status":403,"detail":"The account is disabled","code":"account_disabled"}"#,
-    )
-    .await;
-
-    // Only the codes that name the certificate are terminal; the rest stay retryable.
-    expect_hiccup(first_event(port).await);
-}
-
-#[tokio::test]
-async fn http_403_without_problem_details_triggers_retry() {
-    let port = http_status_server(http::StatusCode::FORBIDDEN).await;
+async fn rejected_upgrade_is_retried(code: http::StatusCode, problem_details: Option<&str>) {
+    let port = rejecting_server(code, problem_details).await;
 
     expect_hiccup(first_event(port).await);
 }
 
+#[test_case(http::StatusCode::TOO_MANY_REQUESTS, Duration::from_secs(30); "429")]
+#[test_case(http::StatusCode::SERVICE_UNAVAILABLE, Duration::from_secs(60); "503")]
 #[tokio::test]
-async fn http_408_triggers_retry() {
-    let port = http_status_server(http::StatusCode::REQUEST_TIMEOUT).await;
+async fn retry_after_header_sets_the_backoff(code: http::StatusCode, retry_after: Duration) {
+    let port = http_status_server_with_retry_after(code, retry_after).await;
 
-    expect_hiccup(first_event(port).await);
+    let backoff = expect_hiccup(first_event(port).await);
+
+    assert_eq!(backoff, retry_after);
 }
 
 #[tokio::test]
-async fn http_409_with_certificate_code_is_terminal() {
-    let port = http_problem_details_server(
-        http::StatusCode::CONFLICT,
-        r#"{"type":"about:blank","title":"Conflict","status":409,"detail":"Different hardware.","code":"device_identity_conflict"}"#,
-    )
-    .await;
+async fn rejected_certificate_does_not_require_sign_in() {
+    let port = http_problem_details_server(http::StatusCode::FORBIDDEN, REVOKED_CERTIFICATE).await;
 
     let error = expect_error(first_event(port).await);
 
-    assert_eq!(
-        error.to_string(),
-        "The portal rejected the client certificate: Different hardware."
-    );
     assert!(error.is_certificate_error());
+    // A new token cannot replace the credential the portal refused.
     assert!(!error.requires_sign_in());
-}
-
-#[tokio::test]
-async fn http_429_triggers_retry() {
-    let port = http_status_server(http::StatusCode::TOO_MANY_REQUESTS).await;
-
-    expect_hiccup(first_event(port).await);
-}
-
-#[tokio::test]
-async fn http_429_with_retry_after_uses_header_value() {
-    let port = http_status_server_with_retry_after(
-        http::StatusCode::TOO_MANY_REQUESTS,
-        Duration::from_secs(30),
-    )
-    .await;
-
-    let backoff = expect_hiccup(first_event(port).await);
-
-    assert_eq!(backoff, Duration::from_secs(30));
-}
-
-#[tokio::test]
-async fn http_503_triggers_retry() {
-    let port = http_status_server(http::StatusCode::SERVICE_UNAVAILABLE).await;
-
-    expect_hiccup(first_event(port).await);
-}
-
-#[tokio::test]
-async fn http_503_with_retry_after_uses_header_value() {
-    let port = http_status_server_with_retry_after(
-        http::StatusCode::SERVICE_UNAVAILABLE,
-        Duration::from_secs(60),
-    )
-    .await;
-
-    let backoff = expect_hiccup(first_event(port).await);
-
-    assert_eq!(backoff, Duration::from_secs(60));
 }
 
 /// Connects the channel to localhost after waiting for `backoff`.
@@ -567,6 +467,14 @@ struct Hiccup {
     backoff: Duration,
     /// The error's chain of causes, as rendered by its alternate `Display` representation.
     error: String,
+}
+
+/// Spawns a server that rejects the WebSocket upgrade with `code`, optionally with problem details.
+async fn rejecting_server(code: http::StatusCode, problem_details: Option<&str>) -> u16 {
+    match problem_details {
+        Some(body) => http_problem_details_server(code, body).await,
+        None => http_status_server(code).await,
+    }
 }
 
 /// Connects a channel to `port` and returns the first event it emits.
@@ -666,6 +574,13 @@ const JOIN_REPLY: &str =
     r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#;
 const BAR_REQUEST: &str = r#"{"topic":"test","event":"bar","ref":1}"#;
 const FOO_MESSAGE: &str = r#"{"topic":"test","event":"foo","payload":null}"#;
+const INVALID_TOKEN: &str = r#"{"type":"about:blank","title":"Unauthorized","status":401,"detail":"Invalid token","code":"invalid_token"}"#;
+const UNAUTHORIZED: &str =
+    r#"{"type":"about:blank","title":"Unauthorized","status":401,"detail":"Invalid token"}"#;
+const REVOKED_CERTIFICATE: &str = r#"{"type":"about:blank","title":"Forbidden","status":403,"detail":"This device's certificate has been revoked.","code":"certificate_revoked"}"#;
+const IDENTITY_CONFLICT: &str = r#"{"type":"about:blank","title":"Conflict","status":409,"detail":"Different hardware.","code":"device_identity_conflict"}"#;
+const ACCOUNT_DISABLED: &str = r#"{"type":"about:blank","title":"Forbidden","status":403,"detail":"The account is disabled","code":"account_disabled"}"#;
+
 /// A reply carrying a reference the channel never sent.
 const UNMATCHED_REPLY: &str =
     r#"{"event":"phx_reply","ref":9999,"topic":"phoenix","payload":{"status":"ok","response":{}}}"#;


### PR DESCRIPTION
The phoenix-channel integration tests had accumulated a lot of duplication. Every test spelled out its own connect call, poll loop and WebSocket server, and each way the portal can reject a WebSocket upgrade had its own near-identical test, which buried what any individual test was actually asserting.

Shared helpers now cover the recurring arrangements, and the rejections are expressed as `test_case` tables keyed on the problem+json the portal answers with, since the problem code is what marks a rejection permanent. The response takes its status from that body so a case cannot state one status in the response and another in the problem details.

Tabulating them surfaced two problem codes that `Error::from_rejection` handles but nothing exercised, `missing_token` and `device_untrusted`, as well as the message a bodyless 401 actually produces.