### PR TITLE
fix(portal): show log sink form errors and verify the tenant

### DIFF
--- a/elixir/lib/portal_web/live/settings/log_sinks.ex
+++ b/elixir/lib/portal_web/live/settings/log_sinks.ex
@@ -72,6 +72,7 @@ defmodule PortalWeb.Settings.LogSinks do
       assign(socket,
         page_title: "Log Sinks",
         sentinel_setup_tab: "portal",
+        submit_failed?: false,
         sentinel_verification_ref: nil,
         s3_setup_tab: "console",
         trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?(),
@@ -91,6 +92,7 @@ defmodule PortalWeb.Settings.LogSinks do
      assign(socket,
        type: type,
        form: to_form(changeset),
+       submit_failed?: false,
        open_sink_actions_id: nil
      )}
   end
@@ -112,6 +114,7 @@ defmodule PortalWeb.Settings.LogSinks do
        sink_name: sink.name,
        type: type,
        form: to_form(changeset),
+       submit_failed?: false,
        open_sink_actions_id: nil
      )}
   end
@@ -173,28 +176,12 @@ defmodule PortalWeb.Settings.LogSinks do
   end
 
   def handle_event("validate", %{"log_sink" => attrs}, socket) do
-    changeset = socket.assigns.form.source
-    attrs = normalize_attrs(attrs, changeset)
-
-    # EDIT: .data (original sink) so changes are relative to DB values.
-    # NEW: apply_changes() to capture all current values.
-    base =
-      if socket.assigns.live_action == :edit do
-        changeset.data
-      else
-        apply_changes(changeset)
-      end
-
-    changeset =
-      base
-      |> changeset(attrs)
-      |> Map.put(:action, :validate)
-
-    {:noreply, assign(socket, form: to_form(changeset))}
+    changeset = submitted_changeset(socket, attrs)
+    {:noreply, assign(socket, form: to_form(changeset), submit_failed?: false)}
   end
 
-  def handle_event("submit_sink", _params, socket) do
-    submit_sink(socket)
+  def handle_event("submit_sink", %{"log_sink" => attrs}, socket) do
+    submit_sink(socket, submitted_changeset(socket, attrs))
   end
 
   def handle_event("delete_sink", %{"id" => id}, socket) do
@@ -564,6 +551,9 @@ defmodule PortalWeb.Settings.LogSinks do
               <.sink_form form={@form} type={@type} live_action={@live_action} account={@account} sentinel_setup_tab={@sentinel_setup_tab} s3_setup_tab={@s3_setup_tab} />
             </div>
             <.panel_footer>
+              <p :if={@submit_failed?} class="mr-auto text-xs text-error">
+                Errors prevented this form from being saved
+              </p>
               <.panel_footer_button phx-click="close_panel">
                 Cancel
               </.panel_footer_button>
@@ -607,6 +597,9 @@ defmodule PortalWeb.Settings.LogSinks do
               <.sink_form form={@form} type={@type} live_action={@live_action} account={@account} sentinel_setup_tab={@sentinel_setup_tab} s3_setup_tab={@s3_setup_tab} />
             </div>
             <.panel_footer>
+              <p :if={@submit_failed?} class="mr-auto text-xs text-error">
+                Errors prevented this form from being saved
+              </p>
               <.panel_footer_button phx-click="close_panel">
                 Cancel
               </.panel_footer_button>
@@ -1087,27 +1080,35 @@ defmodule PortalWeb.Settings.LogSinks do
         <div :if={@type == "sentinel"} class="p-3 rounded border border-border bg-raised">
           <p class="text-xs font-medium text-heading mb-3">Setup</p>
 
-          <div class="mb-4 p-3 rounded border border-border bg-surface">
-            <p class="text-xs font-medium text-heading mb-1.5">1. Grant admin consent</p>
-            <p class="text-xs text-subtle mb-3">
-              Have a tenant administrator grant consent. This adds the
-              <strong>Firezone Sentinel Log Ingestion</strong>
-              application to your tenant so you can assign it a role in the next step. Firezone
-              verifies which tenant granted the consent and fills in the tenant ID below. The
-              application asks only to sign the administrator in and read their basic profile.
-              It cannot read your directory or your data. Log delivery is authorized only by the
-              Monitoring Metrics Publisher role you grant on a single data collection rule.
-            </p>
-            <.button
-              type="button"
-              style="primary"
-              icon="ri-external-link-line"
-              id="sentinel-consent-link"
-              phx-click="sentinel_admin_consent"
-              phx-hook="OpenURL"
-            >
-              Grant admin consent
-            </.button>
+          <p class="text-xs font-medium text-heading mb-1.5">1. Grant admin consent</p>
+          <p class="text-xs text-subtle mb-3">
+            Have a tenant administrator grant consent. This adds the
+            <strong>Firezone Sentinel Log Ingestion</strong>
+            application to your tenant so you can assign it a role in the next step. The
+            application asks only to sign the administrator in and read their basic profile,
+            which is how Firezone learns which tenant granted the consent. The tenant ID
+            cannot be typed in; it is only ever taken from that signed proof. The application
+            cannot read your directory or your data, and log delivery is authorized only by
+            the Monitoring Metrics Publisher role you grant on a single data collection rule.
+          </p>
+          <.button
+            type="button"
+            style="primary"
+            icon="ri-external-link-line"
+            id="sentinel-consent-link"
+            phx-click="sentinel_admin_consent"
+            phx-hook="OpenURL"
+          >
+            Grant admin consent
+          </.button>
+
+          <div class="mt-4 mb-4 flex justify-between items-center">
+            <label class="text-xs font-medium text-body">Tenant ID</label>
+            <div class="text-right">
+              <p id="sentinel-tenant-id" class="text-xs font-semibold text-heading">
+                {sentinel_tenant_id(@form)}
+              </p>
+            </div>
           </div>
 
           <p class="text-xs font-medium text-heading mb-1.5">2. Create the ingestion resources</p>
@@ -1200,23 +1201,6 @@ defmodule PortalWeb.Settings.LogSinks do
           </div>
         </div>
 
-        <div :if={@type == "sentinel"}>
-          <label for={@form[:tenant_id].id} class="block text-xs font-medium text-body mb-1.5">
-            Tenant ID <span class="text-error">*</span>
-          </label>
-          <.input
-            field={@form[:tenant_id]}
-            type="text"
-            autocomplete="off"
-            phx-debounce="300"
-            data-1p-ignore
-            required
-          />
-          <p class="mt-1 text-xs text-subtle">
-            Your Microsoft Entra directory (tenant) ID, e.g.
-            <code class="text-xs">00000000-0000-0000-0000-000000000000</code>.
-          </p>
-        </div>
 
         <div :if={@type == "sentinel"}>
           <label
@@ -1603,17 +1587,35 @@ defmodule PortalWeb.Settings.LogSinks do
     """
   end
 
-  defp submit_sink(%{assigns: %{live_action: :new, form: %{source: changeset}}} = socket) do
-    changeset = put_sink_assoc(changeset, socket)
+  # Every event rebuilds from the params it carries and from the pristine
+  # struct: an empty one for a new sink, the stored row for an edit.
+  #
+  # Reusing the previous event's changeset hid errors, because a change event
+  # marks the fields the operator never touched as unused and an input renders
+  # no error while its field carries that marker. Casting onto the previous
+  # event's applied values hid them too, because an unchanged field records no
+  # change and the validations that only run on changes stop running.
+  defp submitted_changeset(socket, attrs) do
+    changeset = socket.assigns.form.source
 
+    attrs =
+      attrs
+      |> normalize_attrs(changeset)
+      |> carry_verified_tenant_id(changeset)
+
+    changeset.data
+    |> changeset(attrs)
+    |> Map.put(:action, :validate)
+  end
+
+  defp submit_sink(%{assigns: %{live_action: :new}} = socket, changeset) do
     changeset
+    |> put_sink_assoc(socket)
     |> Database.insert_sink(socket.assigns.subject)
     |> handle_submit(socket, "created")
   end
 
-  defp submit_sink(
-         %{assigns: %{live_action: :edit, form: %{source: changeset}, sink: sink}} = socket
-       ) do
+  defp submit_sink(%{assigns: %{live_action: :edit, sink: sink}} = socket, changeset) do
     changeset
     |> maybe_clear_sync_error(sink)
     |> Database.update_sink(socket.assigns.subject)
@@ -1630,7 +1632,23 @@ defmodule PortalWeb.Settings.LogSinks do
          |> push_patch(to: ~p"/#{socket.assigns.account}/settings/log_sinks")}
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        {:noreply, assign(socket, form: to_form(changeset))}
+        changeset = hoist_base_row_errors(changeset)
+
+        {:noreply, assign(socket, form: to_form(changeset), submit_failed?: true)}
+    end
+  end
+
+  # The base row is written through the association, so an error on it comes
+  # back on that changeset, which the form does not render.
+  defp hoist_base_row_errors(%Ecto.Changeset{} = changeset) do
+    case changeset.changes[:log_sink] do
+      %Ecto.Changeset{errors: errors} ->
+        Enum.reduce(errors, changeset, fn {field, {message, opts}}, acc ->
+          add_error(acc, field, message, opts)
+        end)
+
+      _ ->
+        changeset
     end
   end
 
@@ -1713,6 +1731,25 @@ defmodule PortalWeb.Settings.LogSinks do
 
     cast(struct, attrs, Map.get(@fields, schema))
     |> schema.changeset()
+  end
+
+  # The tenant is proven by a signed Entra ID token, never typed, so the form
+  # has no input for it and anything the browser posts under that name is
+  # dropped in favour of what the verification put on the changeset.
+  defp carry_verified_tenant_id(attrs, %Ecto.Changeset{data: %Sentinel.LogSink{}} = changeset) do
+    case get_field(changeset, :tenant_id) do
+      nil -> Map.delete(attrs, "tenant_id")
+      tenant_id -> Map.put(attrs, "tenant_id", tenant_id)
+    end
+  end
+
+  defp carry_verified_tenant_id(attrs, _changeset), do: Map.delete(attrs, "tenant_id")
+
+  defp sentinel_tenant_id(form) do
+    case get_field(form.source, :tenant_id) do
+      tenant_id when is_binary(tenant_id) and tenant_id != "" -> tenant_id
+      _ -> "Awaiting verification..."
+    end
   end
 
   defp normalize_attrs(attrs, _changeset) do

--- a/elixir/test/portal_web/live/settings/device_posture_test.exs
+++ b/elixir/test/portal_web/live/settings/device_posture_test.exs
@@ -901,4 +901,61 @@ defmodule PortalWeb.Settings.DevicePostureTest do
     summary = lv |> element("#device-posture-summary") |> render()
     assert summary =~ ~r/1.*FileVault off/s
   end
+
+  describe "verified fields" do
+    test "ignores a tenant and a verified flag posted by the browser", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/device_posture/intune/new")
+
+      refute html =~ ~s(name="provider[tenant_id]")
+
+      lv
+      |> element("#device-posture-form")
+      |> render_change(%{
+        "provider" => %{
+          "name" => "Contoso",
+          "tenant_id" => "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          "is_verified" => "true"
+        }
+      })
+
+      lv |> element("#device-posture-form") |> render_submit()
+
+      refute Portal.Repo.get_by(Portal.Intune.PostureProvider, account_id: account.id)
+    end
+
+    test "keeps the verified tenant when a later change posts another", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/device_posture/intune/new")
+
+      verified = "11111111-1111-1111-1111-111111111111"
+      reverify(lv, verified)
+
+      lv
+      |> element("#device-posture-form")
+      |> render_change(%{
+        "provider" => %{
+          "name" => "Contoso",
+          "tenant_id" => "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        }
+      })
+
+      lv |> element("#device-posture-form") |> render_submit()
+
+      assert provider = Portal.Repo.get_by(Portal.Intune.PostureProvider, account_id: account.id)
+      assert provider.tenant_id == verified
+    end
+  end
 end

--- a/elixir/test/portal_web/live/settings/log_sinks_test.exs
+++ b/elixir/test/portal_web/live/settings/log_sinks_test.exs
@@ -20,6 +20,55 @@ defmodule PortalWeb.Settings.LogSinksTest do
     Repo.get_by!(Splunk.LogSink, account_id: sink.account_id, id: sink.id)
   end
 
+  # The Sentinel tenant has no input; it only ever arrives from the admin
+  # consent tenant proof.
+  defp verify_sentinel_tenant(lv, tenant_id) do
+    lv |> element("#sentinel-consent-link") |> render_click()
+    assert_push_event(lv, "open_url", %{url: consent_url})
+
+    {:ok, %{verification_ref: verification_ref}} =
+      consent_url
+      |> URI.parse()
+      |> Map.fetch!(:query)
+      |> URI.decode_query()
+      |> Map.fetch!("state")
+      |> PortalWeb.OIDC.verify_verification_state()
+
+    send(lv.pid, {:sentinel_log_sink_complete, tenant_id, verification_ref})
+    render(lv)
+
+    tenant_id
+  end
+
+  defp maybe_verify_tenant(lv, "sentinel"), do: verify_sentinel_tenant(lv, Ecto.UUID.generate())
+  defp maybe_verify_tenant(_lv, _type), do: :ok
+
+  defp sink_fixture(sink_type, attrs) do
+    apply(Portal.LogSinkFixtures, sink_type.fixture, [attrs])
+  end
+
+  defp name_field_error(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find(~s([data-validation-error-for="log_sink[name]"]))
+    |> Floki.text()
+  end
+
+  defp form_error_count(html, field) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find(~s([data-validation-error-for="log_sink[#{field}]"]))
+    |> length()
+  end
+
+  defp submit_button_disabled?(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("button[form=log-sink-form][type=submit]")
+    |> Floki.attribute("disabled")
+    |> Enum.any?()
+  end
+
   defp open_sink_actions(lv, sink_id) do
     lv
     |> element("button[phx-click='toggle_sink_actions'][phx-value-id='#{sink_id}']")
@@ -353,13 +402,12 @@ defmodule PortalWeb.Settings.LogSinksTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/log_sinks/sentinel/new")
 
-      tenant_id = Ecto.UUID.generate()
+      tenant_id = verify_sentinel_tenant(lv, Ecto.UUID.generate())
 
       form =
         form(lv, "#log-sink-form",
           log_sink: %{
             name: "SOC Sentinel",
-            tenant_id: tenant_id,
             ingestion_endpoint: "https://dce.eastus-1.ingest.monitor.azure.com/",
             dcr_immutable_id: "dcr-0123456789abcdef0123456789abcdef",
             stream_name: "Custom-FirezoneLogs_CL",
@@ -484,7 +532,6 @@ defmodule PortalWeb.Settings.LogSinksTest do
         |> form("#log-sink-form",
           log_sink: %{
             name: "SOC Sentinel",
-            tenant_id: Ecto.UUID.generate(),
             ingestion_endpoint: "https://dce.eastus-1.ingest.monitor.azure.com",
             dcr_immutable_id: "not-a-dcr-id"
           }
@@ -1074,6 +1121,357 @@ defmodule PortalWeb.Settings.LogSinksTest do
 
       assert html =~ "Failed to queue log sink delivery."
       refute_enqueued(worker: Splunk.Sync)
+    end
+  end
+
+  describe "submit errors" do
+    @sink_types [
+      %{
+        type: "splunk",
+        base_type: :splunk,
+        schema: Portal.Splunk.LogSink,
+        fixture: :splunk_log_sink_fixture,
+        label: "Splunk",
+        params: %{
+          collector_url: "https://http-inputs-acme.splunkcloud.com/services/collector/event",
+          hec_token: "test-hec-token",
+          enabled_streams: ["", "session"]
+        }
+      },
+      %{
+        type: "datadog",
+        base_type: :datadog,
+        schema: Portal.Datadog.LogSink,
+        fixture: :datadog_log_sink_fixture,
+        label: "Datadog",
+        params: %{
+          site: "datadoghq.eu",
+          api_key: "dd-test-key",
+          enabled_streams: ["", "change"]
+        }
+      },
+      %{
+        type: "newrelic",
+        base_type: :newrelic,
+        schema: Portal.NewRelic.LogSink,
+        fixture: :newrelic_log_sink_fixture,
+        label: "New Relic",
+        params: %{
+          region: "EU",
+          license_key: "nr-test-key",
+          enabled_streams: ["", "session"]
+        }
+      },
+      %{
+        type: "elastic",
+        base_type: :elastic,
+        schema: Portal.Elastic.LogSink,
+        fixture: :elastic_log_sink_fixture,
+        label: "Elastic",
+        params: %{
+          endpoint_url: "https://acme.es.us-east-1.aws.elastic-cloud.com/_bulk",
+          api_key: "es-test-key",
+          data_stream: "logs-firezone-default",
+          enabled_streams: ["", "session"]
+        }
+      },
+      %{
+        type: "sentinel",
+        base_type: :sentinel,
+        schema: Portal.Sentinel.LogSink,
+        fixture: :sentinel_log_sink_fixture,
+        label: "Microsoft Sentinel",
+        params: %{
+          ingestion_endpoint: "https://dce.eastus-1.ingest.monitor.azure.com/",
+          dcr_immutable_id: "dcr-0123456789abcdef0123456789abcdef",
+          stream_name: "Custom-FirezoneLogs_CL",
+          enabled_streams: ["", "session"]
+        }
+      },
+      %{
+        type: "s3",
+        base_type: :s3,
+        schema: Portal.S3.LogSink,
+        fixture: :s3_log_sink_fixture,
+        label: "S3",
+        params: %{
+          bucket: "acme-firezone-logs",
+          region: "us-west-2",
+          role_arn: "arn:aws:iam::123456789012:role/firezone-logs",
+          enabled_streams: ["", "session"]
+        }
+      },
+      %{
+        type: "qradar",
+        base_type: :qradar,
+        schema: Portal.QRadar.LogSink,
+        fixture: :qradar_log_sink_fixture,
+        label: "QRadar",
+        params: %{
+          endpoint_url: "https://qradar.example.com:12469/",
+          auth_header: "Bearer test-shared-secret",
+          enabled_streams: ["", "session"]
+        }
+      },
+      %{
+        type: "http",
+        base_type: :http,
+        schema: Portal.HTTP.LogSink,
+        fixture: :http_log_sink_fixture,
+        label: "HTTP",
+        params: %{
+          endpoint_url: "https://logs.acme.example/firezone/",
+          bearer_token: "http-secret-token",
+          batch_max_events: "250",
+          enabled_streams: ["", "session"]
+        }
+      }
+    ]
+
+    for sink_type <- @sink_types do
+      @sink_type sink_type
+
+      test "#{sink_type.label}: a duplicate name is reported on the form and in a flash", %{
+        conn: conn,
+        account: account,
+        actor: actor
+      } do
+        taken = "Taken #{@sink_type.label}"
+        sink_fixture(@sink_type, account: account, name: taken)
+
+        {:ok, lv, _html} =
+          conn
+          |> authorize_conn(actor)
+          |> live(~p"/#{account}/settings/log_sinks/#{@sink_type.type}/new")
+
+        maybe_verify_tenant(lv, @sink_type.type)
+
+        form = form(lv, "#log-sink-form", log_sink: Map.put(@sink_type.params, :name, taken))
+
+        render_change(form)
+        html = render_submit(form)
+
+        assert html =~ "with this name already exists"
+        assert form_error_count(html, "name") == 1
+        assert html =~ "Errors prevented this form from being saved"
+        assert submit_button_disabled?(html)
+        assert Repo.aggregate(@sink_type.schema, :count) == 1
+      end
+
+      test "#{sink_type.label}: renaming after a rejected submit saves the sink", %{
+        conn: conn,
+        account: account,
+        actor: actor
+      } do
+        taken = "Taken #{@sink_type.label}"
+        sink_fixture(@sink_type, account: account, name: taken)
+
+        {:ok, lv, _html} =
+          conn
+          |> authorize_conn(actor)
+          |> live(~p"/#{account}/settings/log_sinks/#{@sink_type.type}/new")
+
+        maybe_verify_tenant(lv, @sink_type.type)
+
+        form = form(lv, "#log-sink-form", log_sink: Map.put(@sink_type.params, :name, taken))
+        render_change(form)
+        render_submit(form)
+
+        free = "Free #{@sink_type.label}"
+        retry = form(lv, "#log-sink-form", log_sink: Map.put(@sink_type.params, :name, free))
+        render_change(retry)
+        render_submit(retry)
+
+        assert sink = Repo.get_by(@sink_type.schema, account_id: account.id, name: free)
+        assert base = Repo.get_by(Portal.LogSink, account_id: account.id, id: sink.id)
+        assert base.type == @sink_type.base_type
+      end
+
+      test "#{sink_type.label}: renaming an existing sink onto a taken name is reported", %{
+        conn: conn,
+        account: account,
+        actor: actor
+      } do
+        taken = "Taken #{@sink_type.label}"
+        sink_fixture(@sink_type, account: account, name: taken)
+        sink = sink_fixture(@sink_type, account: account, name: "Other #{@sink_type.label}")
+
+        {:ok, lv, _html} =
+          conn
+          |> authorize_conn(actor)
+          |> live(~p"/#{account}/settings/log_sinks/#{@sink_type.type}/#{sink.id}/edit")
+
+        form = form(lv, "#log-sink-form", log_sink: %{name: taken})
+        render_change(form)
+        html = render_submit(form)
+
+        assert html =~ "with this name already exists"
+        assert submit_button_disabled?(html)
+
+        renamed = "Renamed #{@sink_type.label}"
+        retry = form(lv, "#log-sink-form", log_sink: %{name: renamed})
+        render_change(retry)
+        render_submit(retry)
+
+        assert Repo.get_by(@sink_type.schema, account_id: account.id, id: sink.id).name == renamed
+      end
+    end
+  end
+
+  describe "Sentinel tenant" do
+    test "has no input and shows the tenant only once consent is verified", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/log_sinks/sentinel/new")
+
+      refute html =~ ~s(name="log_sink[tenant_id]")
+      assert html =~ "Awaiting verification"
+
+      tenant_id = verify_sentinel_tenant(lv, Ecto.UUID.generate())
+
+      html = render(lv)
+      refute html =~ ~s(name="log_sink[tenant_id]")
+      assert html =~ tenant_id
+      refute html =~ "Awaiting verification"
+    end
+
+    test "cannot be saved before the tenant is verified", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/log_sinks/sentinel/new")
+
+      form =
+        form(lv, "#log-sink-form",
+          log_sink: %{
+            name: "SOC Sentinel",
+            ingestion_endpoint: "https://dce.eastus-1.ingest.monitor.azure.com/",
+            dcr_immutable_id: "dcr-0123456789abcdef0123456789abcdef"
+          }
+        )
+
+      html = render_change(form)
+
+      assert submit_button_disabled?(html)
+      refute Repo.get_by(Portal.Sentinel.LogSink, account_id: account.id)
+    end
+
+    test "ignores a tenant posted by the browser", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/log_sinks/sentinel/new")
+
+      verified = verify_sentinel_tenant(lv, Ecto.UUID.generate())
+      forged = Ecto.UUID.generate()
+
+      lv
+      |> element("#log-sink-form")
+      |> render_change(%{
+        "log_sink" => %{
+          "name" => "SOC Sentinel",
+          "tenant_id" => forged,
+          "ingestion_endpoint" => "https://dce.eastus-1.ingest.monitor.azure.com/",
+          "dcr_immutable_id" => "dcr-0123456789abcdef0123456789abcdef",
+          "stream_name" => "Custom-FirezoneLogs_CL",
+          "enabled_streams" => ["", "session"]
+        }
+      })
+
+      lv |> element("#log-sink-form") |> render_submit()
+
+      assert sink = Repo.get_by(Portal.Sentinel.LogSink, account_id: account.id)
+      assert sink.tenant_id == verified
+      refute sink.tenant_id == forged
+    end
+  end
+
+  describe "untouched field errors" do
+    test "reports a duplicate name under the Name field", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      sentinel_log_sink_fixture(account: account, name: "Microsoft Sentinel")
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/log_sinks/sentinel/new")
+
+      verify_sentinel_tenant(lv, Ecto.UUID.generate())
+
+      # The operator never touches Name, so the browser marks it unused.
+      lv
+      |> element("#log-sink-form")
+      |> render_change(%{
+        "log_sink" => %{
+          "name" => "Microsoft Sentinel",
+          "_unused_name" => "",
+          "ingestion_endpoint" => "https://dce.eastus-1.ingest.monitor.azure.com/",
+          "dcr_immutable_id" => "dcr-0123456789abcdef0123456789abcdef",
+          "stream_name" => "Custom-FirezoneLogs_CL",
+          "enabled_streams" => ["", "session"]
+        }
+      })
+
+      html =
+        lv
+        |> element("#log-sink-form")
+        |> render_submit(%{
+          "log_sink" => %{
+            "name" => "Microsoft Sentinel",
+            "ingestion_endpoint" => "https://dce.eastus-1.ingest.monitor.azure.com/",
+            "dcr_immutable_id" => "dcr-0123456789abcdef0123456789abcdef",
+            "stream_name" => "Custom-FirezoneLogs_CL",
+            "enabled_streams" => ["", "session"]
+          }
+        })
+
+      assert form_error_count(html, "name") == 1
+      assert name_field_error(html) =~ "already exists"
+      assert html =~ "Errors prevented this form from being saved"
+    end
+
+    test "keeps a change-only validation error across repeated change events", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/log_sinks/datadog/new")
+
+      long_tags = Enum.map_join(1..11, ",", fn i -> "tag#{i}:#{String.duplicate("a", 190)}" end)
+
+      form =
+        form(lv, "#log-sink-form",
+          log_sink: %{
+            name: "SOC Datadog",
+            site: "datadoghq.eu",
+            api_key: "dd-test-key",
+            tags: long_tags,
+            enabled_streams: ["", "change"]
+          }
+        )
+
+      assert render_change(form) =~ "should be at most 2000 character"
+      assert render_change(form) =~ "should be at most 2000 character"
+      assert submit_button_disabled?(render_change(form))
     end
   end
 end


### PR DESCRIPTION
Saving a log sink could fail with nothing on screen to explain why. Two separate bugs did that.

Submitting the form threw away the values the browser sent and reused the ones from the last keystroke. Those carry a marker for every field the operator never typed into, and a field marked that way hides its own error, so a duplicate name landed on the Name field and stayed invisible. Submitting now uses the values it was given, and the error shows under the field.

Every event also built on top of the previous event's values. Ecto records a field as changed only when the value differs from what it started with, so once a value had been applied, the checks that run only on changed fields stopped running. A second keystroke made a validation error vanish while the value was still wrong, and re-enabled the save button. Each event now starts from an empty sink, or from the stored one when editing.

The panel footer says "Errors prevented this form from being saved" when a save is refused, so the disabled button next to it is no longer silent.

The Microsoft Sentinel tenant ID is no longer a text box. It comes only from the signed proof the admin consent flow returns, it renders read-only the same way the Intune provider renders its tenant, and anything the browser posts under that name is dropped.

Related: #14842
