### PR TITLE
fix(portal): retry the DCR create and survive a deleted sink

### DIFF
--- a/elixir/lib/portal/log_sinks/delivery.ex
+++ b/elixir/lib/portal/log_sinks/delivery.ex
@@ -635,7 +635,9 @@ defmodule Portal.LogSinks.Delivery do
           :disabled_reason
         ])
 
-      {:ok, _sink} = changeset |> Safe.unscoped() |> Safe.update()
+      # An admin can delete a sink while its run is in flight, and recording a
+      # delivery outcome on a row that is gone is moot rather than an error.
+      {:ok, _sink} = Safe.update(Portal.Repo, changeset, allow_stale: true)
     end
 
     defp cursor_rows(sink, stream) do

--- a/elixir/lib/portal_web/live/settings/log_sinks.ex
+++ b/elixir/lib/portal_web/live/settings/log_sinks.ex
@@ -1927,9 +1927,26 @@ defmodule PortalWeb.Settings.LogSinks do
 
     DCR_ID=$(az monitor data-collection rule show \
       -g "$RG" -n firezone-logs --query id -o tsv 2>/dev/null)
-    if [ -z "$DCR_ID" ]; then
+
+    # A freshly created custom table is not accepted as a rule's output stream
+    # until Log Analytics finishes publishing it, so the first create can fail
+    # with InvalidOutputTable while that settles.
+    attempt=1
+    while [ -z "$DCR_ID" ] && [ "$attempt" -le 10 ]; do
       DCR_ID=$(az monitor data-collection rule create \
-        -g "$RG" -n firezone-logs --rule-file firezone-dcr.json --query id -o tsv)
+        -g "$RG" -n firezone-logs --rule-file firezone-dcr.json --query id -o tsv 2>/dev/null)
+
+      if [ -z "$DCR_ID" ]; then
+        echo "Waiting for table FirezoneLogs_CL to become available ($attempt/10)..." >&2
+        sleep 15
+      fi
+
+      attempt=$((attempt + 1))
+    done
+
+    if [ -z "$DCR_ID" ]; then
+      echo "Table FirezoneLogs_CL did not become available. Run this again." >&2
+      return 1
     fi
 
     SP_ID=$(az ad sp show --id FIREZONE_CLIENT_ID --query id -o tsv 2>/dev/null)

--- a/elixir/test/portal/sentinel/sync_test.exs
+++ b/elixir/test/portal/sentinel/sync_test.exs
@@ -6,6 +6,8 @@ defmodule Portal.Sentinel.SyncTest do
   import Portal.LogSinkFixtures
   import Portal.SessionLogFixtures
 
+  import Ecto.Query
+
   alias Portal.LogSinkCursor
   alias Portal.Sentinel
 
@@ -99,6 +101,30 @@ defmodule Portal.Sentinel.SyncTest do
       assert sink.disabled_reason == "Sync error"
       assert sink.error_message =~ "AADSTS700016"
       assert sink.error_message =~ "admin consent"
+    end
+
+    test "a sink deleted while its run is in flight does not raise", %{account: account} do
+      sink = sentinel_log_sink_fixture(account: account, enabled_streams: [:session])
+      assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
+      session_log_fixture(account: account)
+
+      Req.Test.stub(Sentinel.APIClient, fn conn ->
+        # Delete the row the run is about to record its outcome on.
+        Portal.Repo.delete_all(
+          from(s in Portal.Sentinel.LogSink,
+            where: s.account_id == ^sink.account_id and s.id == ^sink.id
+          )
+        )
+
+        Plug.Conn.send_resp(conn, 500, "")
+      end)
+
+      assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
+
+      refute Portal.Repo.get_by(Portal.Sentinel.LogSink,
+               account_id: sink.account_id,
+               id: sink.id
+             )
     end
 
     test "a 403 is transient while the role propagates and names it", %{account: account} do


### PR DESCRIPTION
Running the Azure CLI setup snippet for a Microsoft Sentinel log sink failed the first time and worked the second. Log Analytics does not accept a custom table as a data collection rule's output stream the instant the table is created, so the rule create came back with `InvalidOutputTable` while the table was still publishing. The failure then cascaded: the role assignment ran with an empty scope, and the snippet printed an empty DCR immutable ID. The snippet now waits for the table and retries the rule, and it stops with a message instead of carrying an empty rule id into the commands that follow.

Deleting a log sink while one of its delivery runs was in flight raised `Ecto.StaleEntryError` and discarded the job. The run finishes by writing its outcome back onto the sink row, and that row was already gone. Since the sink no longer exists, the outcome is moot, so that write now passes over a missing row rather than raising. This affects every sink type, not just Sentinel.
