### PR TITLE
refactor(apple): open the app's own windows in process

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -54,20 +54,16 @@ struct FirezoneApp: App {
       ) {
         AppView()
           .environmentObject(store)
+          .providingWindowOpener()
       }
-      .handlesExternalEvents(
-        matching: [AppView.WindowDefinition.main.externalEventMatchString]
-      )
       // macOS doesn't have Sheets, need to use another Window group to show settings
       WindowGroup(
         "Settings",
         id: AppView.WindowDefinition.settings.identifier
       ) {
         SettingsView(store: store)
+          .providingWindowOpener()
       }
-      .handlesExternalEvents(
-        matching: [AppView.WindowDefinition.settings.externalEventMatchString]
-      )
 
       MenuBarExtra {
         MenuBarView()
@@ -136,6 +132,21 @@ struct FirezoneApp: App {
     )!  // swiftlint:disable:this force_unwrapping
 
     var store: Store?
+
+    /// Opens the window a `firezone://<window>` URL names.
+    ///
+    /// `handlesExternalEvents` used to do this, at the cost of every window the app
+    /// showed itself going out to `NSWorkspace` and back.
+    func application(_ application: NSApplication, open urls: [URL]) {
+      for url in urls {
+        guard url.scheme == "firezone",
+          let host = url.host,
+          let window = AppView.WindowDefinition(rawValue: host)
+        else { continue }
+
+        window.openWindow()
+      }
+    }
 
     func applicationWillFinishLaunching(_ notification: Notification) {
       // Enforce single instance BEFORE the app fully launches

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
@@ -53,7 +53,6 @@ public struct AppView: View {
       case settings
 
       public var identifier: String { "firezone-\(rawValue)" }
-      public var externalEventMatchString: String { rawValue }
       // Simple custom scheme URL with known rawValue is guaranteed valid
       // swiftlint:disable:next force_unwrapping
       public var externalEventOpenURL: URL { URL(string: "firezone://\(rawValue)")! }
@@ -65,8 +64,12 @@ public struct AppView: View {
           // Order existing window front
           NSApp.activate(ignoringOtherApps: true)
           window.makeKeyAndOrderFront(self)
+        } else if let openWindow = WindowOpener.action {
+          NSApp.activate(ignoringOtherApps: true)
+          openWindow(id: identifier)
         } else {
-          // Open new window
+          // No scene has handed its action over yet. Asking the system to deliver
+          // the URL still works, at the risk of it starting a second copy.
           Task { await NSWorkspace.shared.openAsync(externalEventOpenURL) }
         }
       }
@@ -131,3 +134,30 @@ public struct AppView: View {
     #endif
   }
 }
+
+#if os(macOS)
+  /// Holds `openWindow` for the code that has to open a scene without a view to read
+  /// the environment from.
+  ///
+  /// Only SwiftUI can open one of its scenes, so a view that exists hands the action
+  /// over and everything else asks through here.
+  @MainActor
+  enum WindowOpener {
+    static var action: OpenWindowAction?
+  }
+
+  private struct WindowOpenerBridge: ViewModifier {
+    @Environment(\.openWindow) private var openWindow
+
+    func body(content: Content) -> some View {
+      content.onAppear { WindowOpener.action = openWindow }
+    }
+  }
+
+  extension View {
+    /// Lends this scene's `openWindow` action to the rest of the app.
+    public func providingWindowOpener() -> some View {
+      modifier(WindowOpenerBridge())
+    }
+  }
+#endif


### PR DESCRIPTION
`handlesExternalEvents` tied both macOS window groups to a `firezone://` URL, so every window the app showed itself left the process for LaunchServices and came back. LaunchServices is free to answer that by starting a second copy, which is where the duplicate instances, the retry loops and the single-instance guard all come from.

`openWindow(id:)` has been able to open a scene in process since macOS 13, which the app already targets. The window groups now open that way, and the app delegate handles `firezone://main` and `firezone://settings` so the URLs keep working for anything outside the app.

Untested: no Apple toolchain was available while writing this, so the launch behaviour and the deep links both need trying by hand.