### PR TITLE
fix(portal): stop iru syncs deleting devices they paged past

### DIFF
--- a/elixir/lib/portal/iru/sync.ex
+++ b/elixir/lib/portal/iru/sync.ex
@@ -5,6 +5,20 @@ defmodule Portal.Iru.Sync do
   The device list is one endpoint and each posture signal is another, so a run
   reads `/api/v1/devices` first and then folds every per-device Prism category
   into the rows it just wrote.
+
+  That list is walked with `limit` and `offset` over a collection that keeps
+  changing, so a page boundary can step over a device that was there the whole
+  time: anything removed at the source mid-walk pulls the devices after it back
+  by one, into a page already read. There is no cursor to follow instead.
+
+  So a device missing from one run is not evidence that it is gone. A run
+  deletes a device only once no run has seen it for `@stale_after_seconds`, and
+  only if the run before this one did not see it either.
+
+  The first bound rides out a skip, because the run two hours later picks the
+  device up again. The second bound covers a sync that has been failing for
+  longer than the window: every row is past the clock by then, so without it
+  the first run to succeed again could delete most of a tenant on one walk.
   """
 
   use Oban.Worker,
@@ -17,6 +31,11 @@ defmodule Portal.Iru.Sync do
   alias Portal.Iru
   alias Portal.Iru.APIClient
   alias __MODULE__.Database
+
+  # Twelve runs at the current two-hour schedule. Long enough that a device has
+  # to be skipped over and over to be deleted, short enough that a device really
+  # removed from the tenant stops counting as known within a day.
+  @stale_after_seconds 24 * 60 * 60
 
   # Postgres binds at most 65535 parameters per statement, so a full page of 300
   # devices has to fit within that. Derived from the field count so adding a
@@ -61,7 +80,7 @@ defmodule Portal.Iru.Sync do
     synced_ids = sync_devices(provider, client, started_at)
     sync_prism_categories(provider, client, synced_ids)
 
-    Database.delete_stale_devices(provider, started_at)
+    delete_stale_devices(provider, started_at)
     Database.mark_succeeded(provider, started_at)
 
     Logger.info("Finished Iru device inventory sync",
@@ -71,6 +90,18 @@ defmodule Portal.Iru.Sync do
     )
 
     :ok
+  end
+
+  # `synced_at` on the provider is the run before this one, so the earlier of the
+  # two bounds is the one to delete against. Nothing has synced yet on a first
+  # run, which leaves no earlier run to measure from and nothing to delete.
+  defp delete_stale_devices(%Iru.PostureProvider{synced_at: nil}, _started_at), do: :ok
+
+  defp delete_stale_devices(provider, started_at) do
+    cutoff =
+      Enum.min([provider.synced_at, DateTime.add(started_at, -@stale_after_seconds)], DateTime)
+
+    Database.delete_stale_devices(provider, cutoff)
   end
 
   # Every property of the `/api/v1/devices` record. `user` is an object on a
@@ -498,11 +529,11 @@ defmodule Portal.Iru.Sync do
       Enum.map(fields, &{&1, nil}) ++ [updated_at: now]
     end
 
-    def delete_stale_devices(provider, synced_at) do
+    def delete_stale_devices(provider, cutoff) do
       from(d in Iru.Device,
         where: d.account_id == ^provider.account_id,
         where: d.posture_provider_id == ^provider.id,
-        where: d.synced_at < ^synced_at
+        where: d.synced_at < ^cutoff
       )
       |> Safe.unscoped()
       |> Safe.delete_all()

--- a/elixir/test/portal/iru/sync_test.exs
+++ b/elixir/test/portal/iru/sync_test.exs
@@ -308,9 +308,9 @@ defmodule Portal.Iru.SyncTest do
     assert_raise Portal.Iru.SyncError, fn -> perform_job(Sync, sync_args(provider)) end
   end
 
-  test "deletes devices the tenant no longer reports" do
-    provider = iru_posture_provider_fixture()
-    stale = iru_device_fixture(provider: provider, iru_id: "stale-device")
+  test "deletes devices no run has seen for a day" do
+    provider = iru_posture_provider_fixture(synced_at: ago(2, :hour))
+    stale = iru_device_fixture(provider: provider, iru_id: "stale-device", synced_at: ago(2, :day))
 
     stub_api([device(%{"device_id" => "device-1"})])
 
@@ -318,6 +318,47 @@ defmodule Portal.Iru.SyncTest do
 
     refute Repo.get_by(Device, account_id: provider.account_id, iru_id: stale.iru_id)
     assert Repo.get_by(Device, account_id: provider.account_id, iru_id: "device-1")
+  end
+
+  # `offset` steps over a device whenever the tenant loses one mid-walk, so one
+  # run missing a device has to leave it alone. Deleting it here would drop the
+  # row on one run and write it back on the next, every couple of hours.
+  test "keeps a device a single run skipped over" do
+    provider = iru_posture_provider_fixture(synced_at: ago(2, :hour))
+
+    skipped =
+      iru_device_fixture(provider: provider, iru_id: "skipped-device", synced_at: ago(3, :hour))
+
+    stub_api([device(%{"device_id" => "device-1"})])
+
+    assert :ok = perform_job(Sync, sync_args(provider))
+
+    assert Repo.get_by(Device, account_id: provider.account_id, iru_id: skipped.iru_id)
+  end
+
+  # Once syncing has been broken for longer than the window, every row is past
+  # the clock, and measuring from it alone would let one walk empty the tenant.
+  test "keeps a device skipped by the first run after a long outage" do
+    outage = ago(30, :day)
+    provider = iru_posture_provider_fixture(synced_at: outage)
+    skipped = iru_device_fixture(provider: provider, iru_id: "skipped-device", synced_at: outage)
+
+    stub_api([device(%{"device_id" => "device-1"})])
+
+    assert :ok = perform_job(Sync, sync_args(provider))
+
+    assert Repo.get_by(Device, account_id: provider.account_id, iru_id: skipped.iru_id)
+  end
+
+  test "deletes nothing on the first run of a provider" do
+    provider = iru_posture_provider_fixture(synced_at: nil)
+    ancient = iru_device_fixture(provider: provider, iru_id: "old-device", synced_at: ago(30, :day))
+
+    stub_api([device(%{"device_id" => "device-1"})])
+
+    assert :ok = perform_job(Sync, sync_args(provider))
+
+    assert Repo.get_by(Device, account_id: provider.account_id, iru_id: ancient.iru_id)
   end
 
   test "records the sync and clears earlier errors on the provider" do
@@ -379,6 +420,10 @@ defmodule Portal.Iru.SyncTest do
 
     assert :ok = perform_job(Sync, sync_args(provider))
     assert Repo.aggregate(Device, :count) == 0
+  end
+
+  defp ago(amount, unit) do
+    DateTime.utc_now() |> DateTime.add(-amount, unit) |> DateTime.truncate(:microsecond)
   end
 
   defp sync_args(provider) do


### PR DESCRIPTION
The Iru device list is read a page at a time with `limit` and `offset`. When a device is removed from the tenant while a run is walking those pages, every device after it shifts back one place, into a page the run already read. That device is never returned, so the run never sees it.

A run then deleted every device it had not seen, so one device removed mid-walk meant a different device wrongly deleted. The next run put it back two hours later, so a row could disappear and reappear for no reason.

Now a run deletes a device only after a full day of runs have all missed it, and only when the run before it missed the device too. That second check matters once syncing has been broken for longer than a day, because every row is stale by the clock at that point, and one bad walk could otherwise empty a whole tenant.

The Defender sync pages the same way and takes the same fix.

Related: #14768
