### PR TITLE
fix(portal): say "Enable" instead of "Re-enable"

### DIFF
--- a/elixir/lib/portal/mailer/log_sink_email/log_sink_error.html.eex
+++ b/elixir/lib/portal/mailer/log_sink_email/log_sink_error.html.eex
@@ -137,11 +137,11 @@
 											<li style="margin-bottom: 8px;">
 												<strong>Edit and Save</strong> the log sink in your
 												<a href="<%= @settings_url %>" style="color: #5e00d6; text-decoration: underline;">log sink settings</a>
-												to re-enable it. Delivery resumes from where it left off; no events are skipped while
+												to enable it. Delivery resumes from where it left off; no events are skipped while
 												the sink is disabled.
 											</li>
 											<li>
-												Re-enable promptly: logs continue to accumulate while the sink is disabled, but logs
+												Enable promptly: logs continue to accumulate while the sink is disabled, but logs
 												that age out of your retention window before delivery resumes cannot be recovered.
 											</li>
 										</ol>

--- a/elixir/lib/portal/mailer/log_sink_email/log_sink_error.text.eex
+++ b/elixir/lib/portal/mailer/log_sink_email/log_sink_error.text.eex
@@ -23,13 +23,13 @@ How to fix it:
 
   1. <%= @provider_hint %>
 
-  2. Edit and Save the log sink in your Firezone settings to re-enable it:
+  2. Edit and Save the log sink in your Firezone settings to enable it:
      <%= @settings_url %>
 
      Delivery resumes from where it left off; no events are skipped while the
      sink is disabled.
 
-  3. Re-enable promptly: logs continue to accumulate while the sink is
+  3. Enable promptly: logs continue to accumulate while the sink is
      disabled, but logs that age out of your retention window before delivery
      resumes cannot be recovered.
 

--- a/elixir/lib/portal_web/controllers/sign_in_html.ex
+++ b/elixir/lib/portal_web/controllers/sign_in_html.ex
@@ -188,7 +188,7 @@ defmodule PortalWeb.SignInHTML do
             has been disabled.
           </p>
           <p class="mt-4 text-xs text-muted">
-            Please contact your Firezone administrator to re-enable this account.
+            Please contact your Firezone administrator to enable this account.
           </p>
         </div>
       </body>

--- a/elixir/lib/portal_web/live/settings/api_clients/index.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/index.ex
@@ -394,7 +394,7 @@ defmodule PortalWeb.Settings.ApiClients.Index do
               <span class="text-xs text-warning">
                 {if !@actor.is_disabled,
                   do: "Disable this API Token? It will no longer be able to authenticate.",
-                  else: "Re-enable this API Token?"}
+                  else: "Enable this API Token?"}
               </span>
               <div class="flex items-center gap-2 ml-auto shrink-0">
                 <.button

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -978,7 +978,7 @@ defmodule PortalWeb.Settings.Authentication do
             <div class="flex items-center gap-4">
               <span class="text-xs text-warning">
                 {if @provider.is_disabled,
-                  do: "Re-enable this provider?",
+                  do: "Enable this provider?",
                   else:
                     "Disable this provider? Users will not be able to sign in while it is disabled."}
               </span>

--- a/elixir/lib/portal_web/live/settings/log_sinks.ex
+++ b/elixir/lib/portal_web/live/settings/log_sinks.ex
@@ -209,7 +209,7 @@ defmodule PortalWeb.Settings.LogSinks do
     cond do
       new_disabled_state == false && sink.disabled_reason == "Sync error" ->
         {:noreply,
-         put_flash(socket, :error, "Edit and save this log sink to re-enable it.")}
+         put_flash(socket, :error, "Edit and save this log sink to enable it.")}
 
       new_disabled_state == false && not account.features.log_sinks ->
         {:noreply,
@@ -835,7 +835,7 @@ defmodule PortalWeb.Settings.LogSinks do
         <.status_popover id={"sink-status-#{@sink.id}"} label="Error" color="red">
           <p class="text-xs text-body break-words">{@sink.error_message}</p>
           <p class="mt-2 text-xs text-subtle">
-            Delivery is stopped. Edit and Save this log sink to re-enable it.
+            Delivery is stopped. Edit and Save this log sink to enable it.
           </p>
         </.status_popover>
       <% @sink.is_disabled -> %>

--- a/elixir/test/portal_web/live/settings/log_sinks_test.exs
+++ b/elixir/test/portal_web/live/settings/log_sinks_test.exs
@@ -176,7 +176,7 @@ defmodule PortalWeb.Settings.LogSinksTest do
 
       assert html =~ "Error"
       assert html =~ "Invalid token"
-      assert html =~ "Edit and Save this log sink to re-enable it."
+      assert html =~ "Edit and Save this log sink to enable it."
     end
 
     test "shows upgrade prompt when the feature is disabled", %{conn: conn} do


### PR DESCRIPTION
Updates product "Re-enable" wording to always be "Enable". The latter consistently applies under all cases while the former assumes it was previously enabled, which is not always true (i.e. X.509 auth provider).
