### PR TITLE
fix(portal): hide portal sessions for X.509 provider

### DIFF
--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -1042,13 +1042,13 @@ defmodule PortalWeb.Settings.Authentication do
             </td>
             <td class="px-6 py-3">
               <div class="flex items-center gap-2.5 text-xs text-body tabular-nums">
-                <span>
+                <span :if={@type != "x509"}>
                   <span class="font-medium text-heading">
                     {@provider.portal_sessions_count}
                   </span>
                   portal
                 </span>
-                <span class="w-px h-3 bg-border-strong shrink-0"></span>
+                <span :if={@type != "x509"} class="w-px h-3 bg-border-strong shrink-0"></span>
                 <span>
                   <span class="font-medium text-heading">
                     {@provider.client_tokens_count}

--- a/elixir/test/portal_web/live/settings/authentication_test.exs
+++ b/elixir/test/portal_web/live/settings/authentication_test.exs
@@ -187,6 +187,10 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       assert html =~ "X.509"
       assert html =~ "No devices will be able to use this authentication provider"
 
+      row_text = provider_row_text(html, provider.id)
+      assert row_text =~ "0 client"
+      refute row_text =~ "0 portal"
+
       assert has_element?(
                lv,
                "a[href='/#{account.slug}/settings/trust_anchors']",


### PR DESCRIPTION
Hide the portal session count and divider from the X.509 authentication provider row. X.509 authentication is client-only, so portal session information does not apply.

Adds a regression assertion that the X.509 row renders the client session count without a portal session count.

Tested with:

- mix test test/portal_web/live/settings/authentication_test.exs (190 tests passed)

---