### PR TITLE
fix(ci): default Apple builds to no telemetry

### DIFF
--- a/swift/apple/Firezone/xcconfig/config.xcconfig
+++ b/swift/apple/Firezone/xcconfig/config.xcconfig
@@ -20,6 +20,6 @@ CURRENT_PROJECT_VERSION = 0
 // mark:next-apple-version
 MARKETING_VERSION=1.5.20
 
-// CI stamps this into every build that is not a release, on the `xcodebuild`
-// command line, so nothing it builds reports to Sentry.
-FIREZONE_NO_TELEMETRY = false
+// Keep telemetry off unless an official release build explicitly opts in. This
+// also covers CI jobs that invoke `xcodebuild` directly instead of a release script.
+FIREZONE_NO_TELEMETRY = true

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Bundle.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Bundle.swift
@@ -17,8 +17,8 @@ public enum BundleHelper {
     return false
   }
 
-  /// Whether telemetry was switched off when this bundle was built. CI stamps
-  /// `FIREZONE_NO_TELEMETRY` into every build that is not a release.
+  /// Whether telemetry was switched off when this bundle was built. Apple builds
+  /// default to no telemetry; official release scripts explicitly opt in.
   static var noTelemetry: Bool {
     Bundle.main.object(forInfoDictionaryKey: "NoTelemetry") as? String == "true"
   }


### PR DESCRIPTION
The Apple project now defaults FIREZONE_NO_TELEMETRY to true, so direct xcodebuild callers such as UI screenshot jobs cannot accidentally report simulator events to Sentry. The official release scripts already pass false explicitly, preserving telemetry in shipped builds.

Validated with:

- xcodebuild build settings for a Debug iOS simulator target: telemetry disabled
- xcodebuild build settings for a Release iOS target with the release override: telemetry enabled
- mise run //swift/apple:check

---

Fixes #14860