### PR TITLE
build(gui-client): pin the pnpm version for Dependabot

### DIFF
--- a/rust/gui-client/package.json
+++ b/rust/gui-client/package.json
@@ -2,6 +2,7 @@
   "name": "firezone-gui-client",
   "private": true,
   "version": "0.1.0",
+  "packageManager": "pnpm@10.33.0",
   "type": "module",
   "scripts": {
     "build": "run-script-os",


### PR DESCRIPTION
CI installs a pinned pnpm through the `setup-node` composite action, but Dependabot cannot see a version set in a workflow, so it regenerates the lockfile with whatever pnpm it ships. That pnpm is older and writes the `patchedDependencies` block in a shape the pinned pnpm refuses under a frozen install, which is why every Dependabot bump under `rust/gui-client` has been failing to install rather than failing on the dependency it bumped.

Declaring `packageManager` puts the version somewhere Dependabot reads, so both sides produce the same lockfile. The pin in the composite action stays, because it resolves before any package directory is known.

`elixir/assets` and `.github` carry no patches, so their lockfiles round-trip between the two versions and are left alone.

Related: #14782