### PR TITLE
fix(clients): tell the user why their session ended

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelNotification.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelNotification.kt
@@ -69,7 +69,10 @@ object TunnelNotification {
      * Shows a dismissable notification when the tunnel disconnects.
      * This notification can be dismissed by the user.
      */
-    fun showDisconnectedNotification(context: Context) {
+    fun showDisconnectedNotification(
+        context: Context,
+        message: String,
+    ) {
         ensureChannelExists(
             context,
             DISCONNECTED_CHANNEL_ID,
@@ -84,7 +87,8 @@ object TunnelNotification {
                 .setContentIntent(createMainActivityIntent(context))
                 .setSmallIcon(R.drawable.ic_firezone_logo)
                 .setContentTitle("Your Firezone session has ended")
-                .setContentText("Please sign in again to reconnect")
+                .setContentText(message)
+                .setStyle(NotificationCompat.BigTextStyle().bigText(message))
                 .setCategory(NotificationCompat.CATEGORY_STATUS)
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setAutoCancel(true)

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -359,8 +359,20 @@ class TunnelService : VpnService() {
 
                             Log.i(TAG, "Event-loop finished: $stopReason")
 
-                            if (startedByUser && stopReason is StopReason.Disconnected) {
-                                TunnelNotification.showDisconnectedNotification(context, stopReason.message)
+                            val message =
+                                when (stopReason) {
+                                    is StopReason.Disconnected -> stopReason.message
+
+                                    StopReason.Error -> UNRECOVERABLE_ERROR
+
+                                    StopReason.ExplicitDisconnect,
+                                    StopReason.EventChannelClosed,
+                                    StopReason.CommandChannelClosed,
+                                    -> null
+                                }
+
+                            if (startedByUser && message != null) {
+                                TunnelNotification.showDisconnectedNotification(context, message)
                             }
                         }
                 } catch (e: ConnlibException) {
@@ -785,6 +797,10 @@ class TunnelService : VpnService() {
         private const val SESSION_NAME: String = "Firezone Connection"
         private const val MTU: Int = 1280
         private const val TAG: String = "TunnelService"
+
+        // Whatever the event loop threw reads like a stack trace, so the user is told that the
+        // session ended rather than what raised it.
+        private const val UNRECOVERABLE_ERROR: String = "Firezone ran into an unrecoverable error."
         private const val FEATURE_FLAG_POLL_INTERVAL_MS: Long = 5_000
 
         fun logDir(context: Context): String {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -359,9 +359,8 @@ class TunnelService : VpnService() {
 
                             Log.i(TAG, "Event-loop finished: $stopReason")
 
-                            if (startedByUser && stopReason != StopReason.ExplicitDisconnect) {
-                                // Show dismissable disconnected notification
-                                TunnelNotification.showDisconnectedNotification(context)
+                            if (startedByUser && stopReason is StopReason.Disconnected) {
+                                TunnelNotification.showDisconnectedNotification(context, stopReason.message)
                             }
                         }
                 } catch (e: ConnlibException) {
@@ -554,12 +553,18 @@ class TunnelService : VpnService() {
         data object Reset : TunnelCommand()
     }
 
-    enum class StopReason {
-        ExplicitDisconnect,
-        Disconnected,
-        EventChannelClosed,
-        CommandChannelClosed,
-        Error,
+    sealed class StopReason {
+        data object ExplicitDisconnect : StopReason()
+
+        data class Disconnected(
+            val message: String,
+        ) : StopReason()
+
+        data object EventChannelClosed : StopReason()
+
+        data object CommandChannelClosed : StopReason()
+
+        data object Error : StopReason()
     }
 
     private fun resourceById(resourceId: String): Pair<Resource, Site>? {
@@ -664,11 +669,12 @@ class TunnelService : VpnService() {
                                 }
 
                                 is Event.Disconnected -> {
-                                    // Clear any user tokens and actorNames
-                                    repo.clearToken()
-                                    repo.clearActorName()
+                                    if (event.error.requiresSignIn()) {
+                                        repo.clearToken()
+                                        repo.clearActorName()
+                                    }
 
-                                    stopReason = StopReason.Disconnected
+                                    stopReason = StopReason.Disconnected(event.error.message())
                                 }
 
                                 is Event.GatewayVersionMismatch -> {

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -202,15 +202,6 @@ impl DisconnectError {
     pub fn requires_sign_in(&self) -> bool {
         self.0.requires_sign_in()
     }
-
-    /// Returns whether the X.509 client certificate is what failed.
-    ///
-    /// Lets a client word its error and choose what to offer from what actually went wrong,
-    /// rather than from how it happened to authenticate: a session that presented a certificate
-    /// can still fail for reasons that have nothing to do with it.
-    pub fn is_certificate_error(&self) -> bool {
-        self.0.is_certificate_error()
-    }
 }
 
 #[uniffi::export(with_foreign)]

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -675,18 +675,15 @@ impl<I: GuiIntegration> Controller<I> {
                 error_msg,
                 requires_sign_in,
             } => {
-                self.sign_out().await?;
-                if requires_sign_in {
-                    tracing::info!(?error_msg, "Auth error");
-                    self.integration.show_notification(
-                        "Firezone disconnected",
-                        "To access resources, sign in again.",
-                    )?;
-                } else {
-                    tracing::error!("Connlib disconnected: {error_msg}");
+                tracing::error!("Connlib disconnected: {error_msg}");
 
-                    dialog::error(&error_msg)?;
+                if requires_sign_in {
+                    self.sign_out().await?;
+                } else {
+                    self.disconnect().await?;
                 }
+
+                dialog::error(&error_msg)?;
             }
             service::ServerMsg::OnUpdateResources(resources) => {
                 if !self.status.needs_resource_updates() {
@@ -936,6 +933,25 @@ impl<I: GuiIntegration> Controller<I> {
     }
 
     /// Deletes the auth token, stops connlib, and refreshes the tray menu
+    /// Ends the session, leaving the stored token where it is.
+    async fn disconnect(&mut self) -> Result<()> {
+        match self.status {
+            Status::Quitting => return Ok(()),
+            Status::Disconnected
+            | Status::TunnelReady { .. }
+            | Status::WaitingForPortal
+            | Status::WaitingForTunnel => {}
+        }
+        self.status = Status::Disconnected;
+        tracing::debug!("disconnecting connlib");
+        // This is redundant if the token is expired, in that case
+        // connlib already disconnected itself.
+        self.send_ipc(&service::ClientMsg::Disconnect).await?;
+        self.refresh_ui_state();
+        Ok(())
+    }
+
+    /// Ends the session and discards the token, so the next one starts at sign-in.
     async fn sign_out(&mut self) -> Result<()> {
         match self.status {
             Status::Quitting => return Ok(()),
@@ -945,13 +961,8 @@ impl<I: GuiIntegration> Controller<I> {
             | Status::WaitingForTunnel => {}
         }
         self.auth.sign_out()?;
-        self.status = Status::Disconnected;
-        tracing::debug!("disconnecting connlib");
-        // This is redundant if the token is expired, in that case
-        // connlib already disconnected itself.
-        self.send_ipc(&service::ClientMsg::Disconnect).await?;
-        self.refresh_ui_state();
-        Ok(())
+
+        self.disconnect().await
     }
 
     fn resource_by_id(&self, resource_id: ResourceId) -> Result<(ResourceView, Site)> {

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -674,7 +674,6 @@ impl<I: GuiIntegration> Controller<I> {
             service::ServerMsg::OnDisconnect {
                 error_msg,
                 requires_sign_in,
-                is_certificate_error,
             } => {
                 self.sign_out().await?;
                 if requires_sign_in {
@@ -686,15 +685,7 @@ impl<I: GuiIntegration> Controller<I> {
                 } else {
                     tracing::error!("Connlib disconnected: {error_msg}");
 
-                    // A certificate the portal refused is not something the user can retry
-                    // their way out of, so point them at whoever installed it.
-                    let body = if is_certificate_error {
-                        format!("{error_msg}\n\nContact your administrator for support.")
-                    } else {
-                        error_msg
-                    };
-
-                    dialog::error(&body)?;
+                    dialog::error(&error_msg)?;
                 }
             }
             service::ServerMsg::OnUpdateResources(resources) => {

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -93,7 +93,6 @@ pub enum ServerMsg {
     OnDisconnect {
         error_msg: String,
         requires_sign_in: bool,
-        is_certificate_error: bool,
     },
     AllGatewaysOffline {
         resource_id: ResourceId,
@@ -599,7 +598,6 @@ impl<'a> Handler<'a> {
                 self.send_ipc(ServerMsg::OnDisconnect {
                     error_msg: error.to_string(),
                     requires_sign_in: error.requires_sign_in(),
-                    is_certificate_error: error.is_certificate_error(),
                 })
                 .await?
             }

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -129,19 +129,6 @@ impl DisconnectError {
 
         e.requires_sign_in()
     }
-
-    /// Returns whether the X.509 client certificate is what failed.
-    ///
-    /// Lets a client word its error and choose what to offer from what actually went wrong,
-    /// rather than from how it happened to authenticate: a session that presented a certificate
-    /// can still fail for reasons that have nothing to do with it.
-    pub fn is_certificate_error(&self) -> bool {
-        let Some(e) = self.0.any_downcast_ref::<phoenix_channel::Error>() else {
-            return false;
-        };
-
-        e.is_certificate_error()
-    }
 }
 
 impl Eventloop {

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -261,23 +261,6 @@ impl Error {
         }
     }
 
-    /// Returns whether the X.509 client certificate is what failed.
-    ///
-    /// Lets a client word its error and choose what to offer from what actually went wrong,
-    /// rather than from how it happened to authenticate: a session that presented a certificate
-    /// can still fail for reasons that have nothing to do with it.
-    pub fn is_certificate_error(&self) -> bool {
-        match self {
-            Error::CertificateRejected(_) => true,
-            Error::ClientCertificateSigningFailed(_) => true,
-            Error::InvalidToken => false,
-            Error::AuthenticationFailed(_) => false,
-            Error::MaxRetriesReached { .. } => false,
-            Error::LoginFailed(_) => false,
-            Error::FatalIo(_) => false,
-        }
-    }
-
     /// Classifies a rejected connection attempt by the reason the portal reported.
     ///
     /// Returns `None` when nothing in the response marks the failure as permanent, so the

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -213,25 +213,32 @@ const CERTIFICATE_REJECTION_CODES: &[&str] = &[
     "x509_user_type_not_allowed",
 ];
 
+/// Every variant's `Display` output is shown to the user verbatim: as a notification on mobile
+/// and as a dialog on desktop.
+///
+/// These are product copy, not log lines. Word them for someone who has never seen this code,
+/// and keep whatever diagnostic detail we have at the end so it never leads the sentence.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Authentication token invalid")]
+    #[error("Your Firezone sign-in has expired. Sign in again to reconnect.")]
     InvalidToken,
     /// The portal refused to authenticate us for a reason we cannot act on specifically.
-    #[error("Failed to authenticate with portal: {0}")]
+    #[error("The Firezone Portal rejected this device's sign-in: {0}")]
     AuthenticationFailed(String),
-    #[error("X.509 client certificate signing failed: {0}")]
+    #[error("This device could not sign in with its certificate: {0}")]
     ClientCertificateSigningFailed(String),
     /// The portal refused the X.509 client certificate we presented.
-    #[error("The portal rejected the client certificate: {0}")]
+    ///
+    /// It words its rejections for the user, so anything we wrap around one only repeats it.
+    #[error("{0}")]
     CertificateRejected(String),
     #[error(
-        "Got disconnected from portal and hit the max-retry limit. Last connection error: {final_error}"
+        "The connection to the Firezone Portal was lost and could not be restored: {final_error}"
     )]
     MaxRetriesReached { final_error: String },
-    #[error("Failed to login with portal: {0}")]
+    #[error("The Firezone Portal refused to start a session for this device: {0}")]
     LoginFailed(String),
-    #[error("Fatal IO error: {0}")]
+    #[error("Firezone ran into an unrecoverable error: {0}")]
     FatalIo(io::Error),
 }
 
@@ -1307,7 +1314,7 @@ mod tests {
         assert!(!error.requires_sign_in());
         assert_eq!(
             error.to_string(),
-            "Failed to authenticate with portal: Invalid token"
+            "The Firezone Portal rejected this device's sign-in: Invalid token"
         );
     }
 

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -350,18 +350,18 @@ async fn connect_with_zero_backoff_resets_reconnect_backoff() {
 
 // The portal names permanent rejections with a problem code; the HTTP status only decides
 // for a response that carries no code the client knows.
-#[test_case(r#"{"status":401,"detail":"Invalid token","code":"invalid_token"}"# => "Authentication token invalid"; "an unusable token")]
-#[test_case(r#"{"status":401,"detail":"No token","code":"missing_token"}"# => "Authentication token invalid"; "a missing token")]
-#[test_case(r#"{"status":403,"detail":"This device's certificate has been revoked.","code":"certificate_revoked"}"# => "The portal rejected the client certificate: This device's certificate has been revoked."; "a revoked certificate")]
-#[test_case(r#"{"status":403,"detail":"This device is not trusted.","code":"device_untrusted"}"# => "The portal rejected the client certificate: This device is not trusted."; "an untrusted device")]
-#[test_case(r#"{"status":409,"detail":"Different hardware.","code":"device_identity_conflict"}"# => "The portal rejected the client certificate: Different hardware."; "a conflicting device identity")]
-#[test_case(r#"{"status":403,"detail":"This device's certificate does not identify an active user authorized to access this Firezone account. Please contact your administrator.","code":"x509_user_not_authorized"}"# => "The portal rejected the client certificate: This device's certificate does not identify an active user authorized to access this Firezone account. Please contact your administrator."; "an unauthorized X.509 user")]
-#[test_case(r#"{"status":403,"detail":"Incomplete identity.","code":"invalid_x509_identity"}"# => "The portal rejected the client certificate: Incomplete identity."; "invalid X.509 identity claims")]
-#[test_case(r#"{"status":403,"detail":"Provider disabled.","code":"x509_authentication_disabled"}"# => "The portal rejected the client certificate: Provider disabled."; "a disabled X.509 provider")]
-#[test_case(r#"{"status":403,"detail":"No trust anchors.","code":"no_trust_anchors"}"# => "The portal rejected the client certificate: No trust anchors."; "missing X.509 trust anchors")]
-#[test_case(r#"{"status":403,"detail":"Unknown user.","code":"x509_user_not_found"}"# => "The portal rejected the client certificate: Unknown user."; "an unknown X.509 user")]
-#[test_case(r#"{"status":401,"detail":"Invalid token"}"# => "Failed to authenticate with portal: Invalid token"; "a 401 without a code")]
-#[test_case(r#"{"status":401}"# => "Failed to authenticate with portal: no reason provided"; "a 401 without a detail")]
+#[test_case(r#"{"status":401,"detail":"Invalid token","code":"invalid_token"}"# => "Your Firezone sign-in has expired. Sign in again to reconnect."; "an unusable token")]
+#[test_case(r#"{"status":401,"detail":"No token","code":"missing_token"}"# => "Your Firezone sign-in has expired. Sign in again to reconnect."; "a missing token")]
+#[test_case(r#"{"status":403,"detail":"This device's certificate has been revoked.","code":"certificate_revoked"}"# => "This device's certificate has been revoked."; "a revoked certificate")]
+#[test_case(r#"{"status":403,"detail":"This device is not trusted.","code":"device_untrusted"}"# => "This device is not trusted."; "an untrusted device")]
+#[test_case(r#"{"status":409,"detail":"Different hardware.","code":"device_identity_conflict"}"# => "Different hardware."; "a conflicting device identity")]
+#[test_case(r#"{"status":403,"detail":"This device's certificate does not identify an active user authorized to access this Firezone account. Please contact your administrator.","code":"x509_user_not_authorized"}"# => "This device's certificate does not identify an active user authorized to access this Firezone account. Please contact your administrator."; "an unauthorized X.509 user")]
+#[test_case(r#"{"status":403,"detail":"Incomplete identity.","code":"invalid_x509_identity"}"# => "Incomplete identity."; "invalid X.509 identity claims")]
+#[test_case(r#"{"status":403,"detail":"Provider disabled.","code":"x509_authentication_disabled"}"# => "Provider disabled."; "a disabled X.509 provider")]
+#[test_case(r#"{"status":403,"detail":"No trust anchors.","code":"no_trust_anchors"}"# => "No trust anchors."; "missing X.509 trust anchors")]
+#[test_case(r#"{"status":403,"detail":"Unknown user.","code":"x509_user_not_found"}"# => "Unknown user."; "an unknown X.509 user")]
+#[test_case(r#"{"status":401,"detail":"Invalid token"}"# => "The Firezone Portal rejected this device's sign-in: Invalid token"; "a 401 without a code")]
+#[test_case(r#"{"status":401}"# => "The Firezone Portal rejected this device's sign-in: no reason provided"; "a 401 without a detail")]
 #[tokio::test]
 async fn portal_rejection_is_terminal(problem_details: &str) -> String {
     let port = http_problem_details_server(problem_details).await;
@@ -403,7 +403,7 @@ async fn bare_401_is_terminal() {
 
     assert_eq!(
         error.to_string(),
-        "Failed to authenticate with portal: no reason provided"
+        "The Firezone Portal rejected this device's sign-in: no reason provided"
     );
 }
 

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -426,7 +426,6 @@ async fn rejected_certificate_does_not_require_sign_in(problem_details: &str) {
 
     let error = expect_error(first_event(port).await);
 
-    assert!(error.is_certificate_error());
     // A new token cannot replace the credential the portal refused.
     assert!(!error.requires_sign_in());
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
@@ -98,7 +98,7 @@ public class SessionNotification: NSObject, SessionNotificationProtocol {
   #if os(iOS)
     // In iOS, use User Notifications.
     // This gets called from the tunnel side.
-    nonisolated public static func showSignedOutNotificationiOS() {
+    nonisolated public static func showDisconnectedNotificationiOS(_ message: String) {
       UNUserNotificationCenter.current().getNotificationSettings { notificationSettings in
         if notificationSettings.authorizationStatus == .authorized {
           Log.log(
@@ -106,7 +106,7 @@ public class SessionNotification: NSObject, SessionNotificationProtocol {
           )
           let content = UNMutableNotificationContent()
           content.title = "Your Firezone session has ended"
-          content.body = "Please sign in again to reconnect"
+          content.body = message
           content.categoryIdentifier =
             NotificationIndentifier.sessionEndedNotificationCategory.rawValue
           let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/macOSAlert.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/macOSAlert.swift
@@ -312,11 +312,7 @@
     public static func showSignedOutAlert(_ message: String?) async -> Bool {
       let alert = NSAlert()
       alert.messageText = "Your Firezone session has ended"
-      alert.informativeText = """
-        Please sign in again to reconnect.
-
-        \(message ?? "")
-        """
+      alert.informativeText = message ?? "Please sign in again to reconnect."
       alert.addButton(withTitle: "Sign In")
       alert.addButton(withTitle: "Cancel")
       NSApp.activate(ignoringOtherApps: true)

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -494,9 +494,7 @@ actor Adapter {
       // iOS shows the notification from the tunnel process because the UI
       // process isn't guaranteed to be alive; macOS handles it from the UI.
       #if os(iOS)
-        if requiresSignIn {
-          SessionNotification.showSignedOutNotificationiOS()
-        }
+        SessionNotification.showDisconnectedNotificationiOS(errorMessage)
       #endif
 
       let sendableError = SendableError(errorMessage, requiresSignIn: requiresSignIn)


### PR DESCRIPTION
Right now, every Client has its own logic of what kind of error message they show to the user when a session ends. With the introduction of [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html) problem responses, we now get much more detailed error responses back from the portal when something goes wrong during the sign-in process.

This PR throws most of the Client-specific logic around error dialogs out the window and carries the `detail` response from the portal all the way through to the user. For non-portal triggered errors like giving up on the backoff, we re-word the error text on `phoenix_channel::Error` to be end-user friendly.