### PR TITLE
feat(clients): reset the session when waking from sleep

### DIFF
--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -8,7 +8,7 @@ use crate::{
 use anyhow::{Context as _, ErrorExt as _, Result, bail};
 use backoff::ExponentialBackoffBuilder;
 use bin_shared::{
-    DnsControlMethod, DnsController, TunDeviceManager,
+    DnsControlMethod, DnsController, ResumeNotifier, TunDeviceManager,
     device_id::{self, DeviceId},
     device_info,
     platform::{UdpSocketFactory, tcp_socket_factory},
@@ -231,6 +231,7 @@ struct Handler<'a> {
     tun_device: TunDeviceManager,
     dns_notifier: BoxStream<'static, Result<()>>,
     network_notifier: BoxStream<'static, Result<()>>,
+    resume_notifier: ResumeNotifier,
 }
 
 #[derive(Default, Debug)]
@@ -354,6 +355,7 @@ enum Event {
     Terminate,
     NetworkChanged(Result<()>),
     DnsChanged(Result<()>),
+    Resumed(Result<()>),
 }
 
 // Open to better names
@@ -399,6 +401,11 @@ impl<'a> Handler<'a> {
             .await
             .context("Failed to initialize network change monitor")?
             .boxed();
+        // Missing resumes only costs us a slower recovery, so don't fail the session over it.
+        let resume_notifier = bin_shared::new_resume_notifier()
+            .await
+            .inspect_err(|e| tracing::warn!("Failed to initialize resume monitor: {e:#}"))
+            .unwrap_or_default();
 
         let advanced_settings = load_advanced_settings()
             .inspect_err(|e| {
@@ -441,6 +448,7 @@ impl<'a> Handler<'a> {
             tun_device,
             dns_notifier,
             network_notifier,
+            resume_notifier,
         })
     }
 
@@ -494,37 +502,11 @@ impl<'a> Handler<'a> {
                 Event::DnsChanged(Err(e)) => {
                     tracing::warn!("Error while listening for DNS change events: {e:#}")
                 }
-                Event::NetworkChanged(Ok(())) => match &self.session {
-                    Session::Creating { .. } => {
-                        tracing::debug!("Ignoring network change since we're still signing in");
-                    }
-                    Session::Connected { connlib, .. } => {
-                        connlib.reset("network changed".to_owned());
-                    }
-                    Session::WaitingForNetwork {
-                        token,
-                        is_internet_resource_active,
-                    } => {
-                        tracing::info!("Attempting to re-connect upon network change");
-
-                        let token = token.clone();
-                        let is_internet_resource_active = *is_internet_resource_active;
-                        let result = self.try_connect(token, is_internet_resource_active);
-
-                        if let Some(e) = result
-                            .as_ref()
-                            .err()
-                            .and_then(|e| e.any_downcast_ref::<io::Error>())
-                        {
-                            tracing::debug!("Still cannot connect to Firezone: {e}");
-
-                            continue;
-                        }
-
-                        let _ = self.handle_connect_result(result).await;
-                    }
-                    Session::None => continue,
-                },
+                Event::Resumed(Err(e)) => {
+                    tracing::warn!("Error while listening for resume events: {e:#}")
+                }
+                Event::NetworkChanged(Ok(())) => self.reset_session("network changed").await,
+                Event::Resumed(Ok(())) => self.reset_session("resumed from sleep").await,
                 Event::DnsChanged(Ok(())) => {
                     let Session::Connected { connlib, .. } = &self.session else {
                         continue;
@@ -540,6 +522,42 @@ impl<'a> Handler<'a> {
         telemetry::stop(); // Flush telemetry as the service shuts down.
 
         ret
+    }
+
+    /// Tells connlib that the network underneath it has changed, or retries the connection if we
+    /// were waiting for a network in the first place.
+    async fn reset_session(&mut self, reason: &str) {
+        match &self.session {
+            Session::Creating { .. } => {
+                tracing::debug!(%reason, "Ignoring reset since we're still signing in");
+            }
+            Session::Connected { connlib, .. } => {
+                connlib.reset(reason.to_owned());
+            }
+            Session::WaitingForNetwork {
+                token,
+                is_internet_resource_active,
+            } => {
+                tracing::info!(%reason, "Attempting to re-connect");
+
+                let token = token.clone();
+                let is_internet_resource_active = *is_internet_resource_active;
+                let result = self.try_connect(token, is_internet_resource_active);
+
+                if let Some(e) = result
+                    .as_ref()
+                    .err()
+                    .and_then(|e| e.any_downcast_ref::<io::Error>())
+                {
+                    tracing::debug!("Still cannot connect to Firezone: {e}");
+
+                    return;
+                }
+
+                let _ = self.handle_connect_result(result).await;
+            }
+            Session::None => {}
+        }
     }
 
     fn next_event(
@@ -558,6 +576,10 @@ impl<'a> Handler<'a> {
 
         if let Poll::Ready(Some(result)) = self.dns_notifier.poll_next_unpin(cx) {
             return Poll::Ready(Event::DnsChanged(result));
+        }
+
+        if let Poll::Ready(Some(result)) = self.resume_notifier.poll_next_unpin(cx) {
+            return Poll::Ready(Event::Resumed(result));
         }
 
         // `FramedRead::next` is cancel-safe.

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::{Context as _, Result, anyhow};
 use backoff::ExponentialBackoffBuilder;
 use bin_shared::{
     DnsControlMethod, DnsController, TOKEN_ENV_KEY, TunDeviceManager, device_id, device_info,
-    new_dns_notifier, new_network_notifier,
+    new_dns_notifier, new_network_notifier, new_resume_notifier,
     platform::{UdpSocketFactory, tcp_socket_factory},
     signals,
 };
@@ -466,6 +466,10 @@ fn try_main() -> Result<()> {
             .await
             .inspect_err(|e| tracing::info!("Failed to initialize network change monitor: {e:#}"))
             .unwrap_or_default();
+        let mut resume_notifier = new_resume_notifier()
+            .await
+            .inspect_err(|e| tracing::info!("Failed to initialize resume monitor: {e:#}"))
+            .unwrap_or_default();
         drop(tokio_handle);
 
         let tun = tun_device.make_tun()?;
@@ -492,6 +496,11 @@ fn try_main() -> Result<()> {
                 result = network_notifier.next() => {
                     result.context("Network notifier stream ended")??;
                     session.reset("network changed".to_owned());
+                    continue;
+                },
+                result = resume_notifier.next() => {
+                    result.context("Resume notifier stream ended")??;
+                    session.reset("resumed from sleep".to_owned());
                     continue;
                 },
                 event = event_stream.next() => event.context("event stream unexpectedly ran empty")?,

--- a/rust/libs/bin-shared/Cargo.toml
+++ b/rust/libs/bin-shared/Cargo.toml
@@ -74,6 +74,9 @@ features = [
     "Win32_System_Com",
     # Needed to listen for system DNS changes
     "Win32_System_Registry",
+    # For listening for suspend / resume events
+    "Win32_System_Power",
+    "Win32_UI_WindowsAndMessaging",
     "Win32_System_Threading",
     "Win32_System_SystemInformation",
     # For uptime

--- a/rust/libs/bin-shared/src/dbus.rs
+++ b/rust/libs/bin-shared/src/dbus.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use futures::Stream;
+
+/// Subscribes to a DBus signal on the system bus.
+pub(crate) async fn signal_stream(
+    dest: &'static str,
+    path: &'static str,
+    interface: &'static str,
+    member: &'static str,
+) -> Result<impl Stream<Item = zbus::Message> + Unpin> {
+    let cxn = zbus::Connection::system().await?;
+    let proxy = zbus::Proxy::new_owned(cxn, dest, path, interface).await?;
+    let stream = proxy.receive_signal(member).await?;
+
+    Ok(stream)
+}

--- a/rust/libs/bin-shared/src/lib.rs
+++ b/rust/libs/bin-shared/src/lib.rs
@@ -4,7 +4,11 @@ pub mod http_health_check;
 
 mod dns_control;
 mod network_changes;
+mod power;
 mod tun_device_manager;
+
+#[cfg(target_os = "linux")]
+mod dbus;
 
 #[cfg(target_os = "linux")]
 pub mod linux;
@@ -39,4 +43,5 @@ pub const FIREZONE_MARK: u32 = 0xfd002021;
 
 pub use dns_control::{DnsControlMethod, DnsController};
 pub use network_changes::{new_dns_notifier, new_network_notifier};
+pub use power::{ResumeNotifier, new_resume_notifier};
 pub use tun_device_manager::{TunDeviceManager, TunIpStack};

--- a/rust/libs/bin-shared/src/network_changes/linux.rs
+++ b/rust/libs/bin-shared/src/network_changes/linux.rs
@@ -1,6 +1,6 @@
 //! Network change detection for Linux via DBus / NetworkManager
 
-use crate::DnsControlMethod;
+use crate::{DnsControlMethod, dbus};
 use anyhow::Result;
 use futures::stream::BoxStream;
 use futures::{Stream, StreamExt as _, stream};
@@ -24,7 +24,7 @@ pub async fn new_dns_notifier(
                 .map(|_| Ok(()))
                 .boxed()
         }
-        DnsControlMethod::SystemdResolved => dbus_stream(
+        DnsControlMethod::SystemdResolved => dbus::signal_stream(
             "org.freedesktop.resolve1",
             "/org/freedesktop/resolve1",
             "org.freedesktop.DBus.Properties",
@@ -58,7 +58,7 @@ pub async fn new_dns_notifier(
 /// stream, so callers can use `.unwrap_or_default()` to gracefully handle
 /// failure.
 pub async fn new_network_notifier() -> Result<impl Stream<Item = Result<()>> + Default + Unpin> {
-    let stream = dbus_stream(
+    let stream = dbus::signal_stream(
         "org.freedesktop.NetworkManager",
         "/org/freedesktop/NetworkManager",
         // Despite what the payload's first argument says, NM stamps
@@ -126,17 +126,4 @@ fn interval_stream(interval: Duration) -> impl Stream<Item = ()> + Unpin {
         Some(((), interval))
     })
     .boxed()
-}
-
-async fn dbus_stream(
-    dest: &'static str,
-    path: &'static str,
-    interface: &'static str,
-    member: &'static str,
-) -> Result<impl Stream<Item = zbus::Message> + Unpin> {
-    let cxn = zbus::Connection::system().await?;
-    let proxy = zbus::Proxy::new_owned(cxn, dest, path, interface).await?;
-    let stream = proxy.receive_signal(member).await?;
-
-    Ok(stream)
 }

--- a/rust/libs/bin-shared/src/power.rs
+++ b/rust/libs/bin-shared/src/power.rs
@@ -1,0 +1,55 @@
+//! Notifications about the system suspending and resuming.
+
+use anyhow::Result;
+use futures::{
+    Stream, StreamExt as _,
+    stream::{self, BoxStream},
+};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+#[cfg(target_os = "linux")]
+#[path = "power/linux.rs"]
+mod imp;
+
+#[cfg(target_os = "windows")]
+#[path = "power/windows.rs"]
+mod imp;
+
+#[cfg(target_os = "macos")]
+#[path = "power/macos.rs"]
+mod imp;
+
+/// Listens for the system resuming from sleep.
+///
+/// A resume invalidates most of what we know about the network: our peers have torn down their end
+/// of the connection, NAT bindings have expired and we may have come back on a different network.
+/// Callers are expected to reset their session upon notification.
+///
+/// Suspends are deliberately not reported. We have nothing to do before going to sleep and on most
+/// platforms we wouldn't reliably get the chance to do it anyway.
+pub async fn new_resume_notifier() -> Result<ResumeNotifier> {
+    Ok(ResumeNotifier(imp::resume_stream().await?))
+}
+
+/// A stream of "the system just resumed" notifications.
+///
+/// Implements [`Default`] as a no-op stream so callers can use `.unwrap_or_default()` to
+/// gracefully degrade when the notifier fails to initialise.
+pub struct ResumeNotifier(BoxStream<'static, Result<()>>);
+
+impl Default for ResumeNotifier {
+    fn default() -> Self {
+        Self(stream::pending().boxed())
+    }
+}
+
+impl Stream for ResumeNotifier {
+    type Item = Result<()>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.0.as_mut().poll_next(cx)
+    }
+}

--- a/rust/libs/bin-shared/src/power/linux.rs
+++ b/rust/libs/bin-shared/src/power/linux.rs
@@ -1,0 +1,54 @@
+//! Suspend / resume detection for Linux via systemd-logind.
+
+use crate::dbus;
+use anyhow::Result;
+use futures::{StreamExt as _, stream, stream::BoxStream};
+
+pub(crate) async fn resume_stream() -> Result<BoxStream<'static, Result<()>>> {
+    let stream = dbus::signal_stream(
+        "org.freedesktop.login1",
+        "/org/freedesktop/login1",
+        "org.freedesktop.login1.Manager",
+        "PrepareForSleep",
+    )
+    .await?
+    .filter(|msg| std::future::ready(is_resume(&msg.body())))
+    .inspect(|_| tracing::debug!("Received DBus notification for resume from sleep"))
+    .map(|_| Ok(()))
+    .chain(stream::pending()); // Ensure this never ends.
+
+    Ok(stream.boxed())
+}
+
+/// Returns `true` if the `PrepareForSleep` signal announces a resume rather than an impending
+/// suspend.
+///
+/// `logind` emits the signal twice per sleep cycle: `true` on the way down, `false` once the system
+/// is running again. Merely subscribing does not delay the suspend; that would require an inhibitor
+/// lock, which we deliberately don't take.
+fn is_resume(body: &zbus::message::Body) -> bool {
+    matches!(body.deserialize::<bool>(), Ok(false))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_the_second_half_of_a_sleep_cycle_is_a_resume() {
+        assert!(!is_resume(&prepare_for_sleep(true)));
+        assert!(is_resume(&prepare_for_sleep(false)));
+    }
+
+    fn prepare_for_sleep(start: bool) -> zbus::message::Body {
+        zbus::Message::signal(
+            "/org/freedesktop/login1",
+            "org.freedesktop.login1.Manager",
+            "PrepareForSleep",
+        )
+        .expect("Should be able to build a signal")
+        .build(&(start,))
+        .expect("Should be able to serialise a bool")
+        .body()
+    }
+}

--- a/rust/libs/bin-shared/src/power/macos.rs
+++ b/rust/libs/bin-shared/src/power/macos.rs
@@ -1,0 +1,12 @@
+//! The Apple clients handle this in `PacketTunnelProvider.wake`, not here.
+
+use anyhow::Result;
+use futures::stream::BoxStream;
+
+#[expect(
+    clippy::unused_async,
+    reason = "Must match the Linux implementation, which needs to connect to DBus."
+)]
+pub(crate) async fn resume_stream() -> Result<BoxStream<'static, Result<()>>> {
+    Err(anyhow::anyhow!("Not implemented"))
+}

--- a/rust/libs/bin-shared/src/power/windows.rs
+++ b/rust/libs/bin-shared/src/power/windows.rs
@@ -47,11 +47,11 @@ fn subscribe() -> Result<broadcast::Receiver<()>> {
     }
 
     let (tx, rx) = broadcast::channel(1);
-    let tx: &'static broadcast::Sender<()> = Box::leak(Box::new(tx));
+    let tx = Box::new(tx);
 
     let mut params = DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS {
         Callback: Some(suspend_resume_callback),
-        Context: std::ptr::from_ref(tx) as *mut c_void,
+        Context: std::ptr::from_ref(&*tx) as *mut c_void,
     };
     let mut registration = std::ptr::null_mut();
 
@@ -65,9 +65,9 @@ fn subscribe() -> Result<broadcast::Receiver<()>> {
         )
     }
     .ok()
-    .context("Failed to register for suspend / resume notifications")?;
+    .context("Failed to register for suspend / resume notifications")?; // On failure the OS never got our pointer, so `tx` is dropped here.
 
-    *registered = Some(tx);
+    *registered = Some(Box::leak(tx));
 
     Ok(rx)
 }

--- a/rust/libs/bin-shared/src/power/windows.rs
+++ b/rust/libs/bin-shared/src/power/windows.rs
@@ -1,0 +1,99 @@
+//! Suspend / resume detection for Windows.
+
+use anyhow::{Context as _, Result};
+use futures::{StreamExt as _, stream, stream::BoxStream};
+use std::{ffi::c_void, sync::Mutex};
+use tokio::sync::broadcast::{self, error::RecvError};
+use windows::Win32::{
+    Foundation::{ERROR_SUCCESS, HANDLE},
+    System::Power::{DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS, PowerRegisterSuspendResumeNotification},
+    UI::WindowsAndMessaging::{DEVICE_NOTIFY_CALLBACK, PBT_APMRESUMEAUTOMATIC},
+};
+
+/// The sender half of the process-wide resume notifications, once we have registered for them.
+static RESUME_TX: Mutex<Option<&'static broadcast::Sender<()>>> = Mutex::new(None);
+
+#[expect(
+    clippy::unused_async,
+    reason = "Must match the Linux implementation, which needs to connect to DBus."
+)]
+pub(crate) async fn resume_stream() -> Result<BoxStream<'static, Result<()>>> {
+    let rx = subscribe()?;
+
+    let stream = stream::unfold(rx, |mut rx| async move {
+        match rx.recv().await {
+            Ok(()) => Some((Ok(()), rx)),
+            // We only care that we resumed, not how many resumes we missed.
+            Err(RecvError::Lagged(_)) => Some((Ok(()), rx)),
+            Err(RecvError::Closed) => None,
+        }
+    })
+    .inspect(|_| tracing::debug!("Received power notification for resume from sleep"))
+    .chain(stream::pending()); // Ensure this never ends.
+
+    Ok(stream.boxed())
+}
+
+/// Registers for suspend / resume notifications on first use and subscribes to them.
+///
+/// The registration is process-wide and never cancelled. Unlike `CancelMibChangeNotify2`, which
+/// blocks until any in-flight callback has returned, `PowerUnregisterSuspendResumeNotification`
+/// makes no such promise, so the context we hand to the OS has to outlive the process.
+fn subscribe() -> Result<broadcast::Receiver<()>> {
+    let mut registered = RESUME_TX.lock().unwrap_or_else(|e| e.into_inner());
+
+    if let Some(tx) = *registered {
+        return Ok(tx.subscribe());
+    }
+
+    let (tx, rx) = broadcast::channel(1);
+    let tx: &'static broadcast::Sender<()> = Box::leak(Box::new(tx));
+
+    let mut params = DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS {
+        Callback: Some(suspend_resume_callback),
+        Context: std::ptr::from_ref(tx) as *mut c_void,
+    };
+    let mut registration = std::ptr::null_mut();
+
+    // SAFETY: `params` only needs to live for the duration of the call; the OS copies what it
+    // needs. `registration` is written by the call and unused afterwards, as we never unregister.
+    unsafe {
+        PowerRegisterSuspendResumeNotification(
+            DEVICE_NOTIFY_CALLBACK,
+            HANDLE(std::ptr::from_mut(&mut params).cast()),
+            &mut registration,
+        )
+    }
+    .ok()
+    .context("Failed to register for suspend / resume notifications")?;
+
+    *registered = Some(tx);
+
+    Ok(rx)
+}
+
+/// Runs on a Windows-managed thread, so keep it minimal: just wake the notifier.
+///
+/// This is a safe `extern "system" fn` (it coerces to the unsafe callback pointer the OS
+/// expects), keeping the only `unsafe` to the single pointer dereference below.
+extern "system" fn suspend_resume_callback(
+    ctx: *const c_void,
+    event_type: u32,
+    _setting: *const c_void,
+) -> u32 {
+    // `PBT_APMRESUMEAUTOMATIC` is delivered on every resume, whereas `PBT_APMRESUMESUSPEND` only
+    // follows it if the user is present. Matching just this one gives us exactly one notification
+    // per resume.
+    if event_type != PBT_APMRESUMEAUTOMATIC {
+        return ERROR_SUCCESS.0;
+    }
+
+    // SAFETY: `ctx` is the pointer we passed to `PowerRegisterSuspendResumeNotification`: a
+    // deliberately leaked `broadcast::Sender` that outlives the process.
+    let tx = unsafe { &*ctx.cast::<broadcast::Sender<()>>() };
+
+    // A failed send just means nobody is listening right now.
+    let _ = tx.send(());
+
+    ERROR_SUCCESS.0
+}

--- a/rust/libs/bin-shared/tests/network_notifiers.rs
+++ b/rust/libs/bin-shared/tests/network_notifiers.rs
@@ -1,19 +1,16 @@
 #![allow(clippy::unwrap_used)]
 
-use bin_shared::{DnsControlMethod, new_dns_notifier, new_network_notifier};
+use bin_shared::{DnsControlMethod, new_dns_notifier, new_network_notifier, new_resume_notifier};
 use futures::{StreamExt as _, future::FutureExt as _};
 use std::time::Duration;
 use tokio::time::timeout;
 
-/// Smoke test for the DNS and network change notifiers
+/// Smoke test for the DNS, network change and resume notifiers
 ///
 /// Turn them on, wait a second, turn them off.
 /// This tests that the threads quit gracefully when we call `close`, and they don't crash on startup.
 #[tokio::test]
-#[cfg_attr(
-    target_os = "macos",
-    ignore = "Network notifiers not implemented on macOS"
-)]
+#[cfg_attr(target_os = "macos", ignore = "Notifiers not implemented on macOS")]
 async fn notifiers() {
     logging::test_global("debug");
     let tokio_handle = tokio::runtime::Handle::current();
@@ -22,6 +19,7 @@ async fn notifiers() {
         .await
         .unwrap();
     let mut net = new_network_notifier().await.unwrap();
+    let mut resume = new_resume_notifier().await.unwrap();
 
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
@@ -34,6 +32,8 @@ async fn notifiers() {
 
     // After that first DNS notification, we shouldn't get any further notifications during a normal unit test.
     // The network notifier should never have fired, since nothing changed about the primary egress path.
+    // Likewise the resume notifier, since we never suspended.
     assert!(dns.next().now_or_never().is_none());
     assert!(net.next().now_or_never().is_none());
+    assert!(resume.next().now_or_never().is_none());
 }

--- a/rust/libs/bin-shared/tests/network_notifiers.rs
+++ b/rust/libs/bin-shared/tests/network_notifiers.rs
@@ -1,16 +1,19 @@
 #![allow(clippy::unwrap_used)]
 
-use bin_shared::{DnsControlMethod, new_dns_notifier, new_network_notifier, new_resume_notifier};
+use bin_shared::{DnsControlMethod, new_dns_notifier, new_network_notifier};
 use futures::{StreamExt as _, future::FutureExt as _};
 use std::time::Duration;
 use tokio::time::timeout;
 
-/// Smoke test for the DNS, network change and resume notifiers
+/// Smoke test for the DNS and network change notifiers
 ///
 /// Turn them on, wait a second, turn them off.
-/// This tests that the threads quit gracefully when the notifiers are dropped, and they don't crash on startup.
+/// This tests that the threads quit gracefully when we call `close`, and they don't crash on startup.
 #[tokio::test]
-#[cfg_attr(target_os = "macos", ignore = "Notifiers not implemented on macOS")]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "Network notifiers not implemented on macOS"
+)]
 async fn notifiers() {
     logging::test_global("debug");
     let tokio_handle = tokio::runtime::Handle::current();
@@ -19,7 +22,6 @@ async fn notifiers() {
         .await
         .unwrap();
     let mut net = new_network_notifier().await.unwrap();
-    let mut resume = new_resume_notifier().await.unwrap();
 
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
@@ -32,8 +34,6 @@ async fn notifiers() {
 
     // After that first DNS notification, we shouldn't get any further notifications during a normal unit test.
     // The network notifier should never have fired, since nothing changed about the primary egress path.
-    // Likewise the resume notifier, since we never suspended.
     assert!(dns.next().now_or_never().is_none());
     assert!(net.next().now_or_never().is_none());
-    assert!(resume.next().now_or_never().is_none());
 }

--- a/rust/libs/bin-shared/tests/network_notifiers.rs
+++ b/rust/libs/bin-shared/tests/network_notifiers.rs
@@ -8,7 +8,7 @@ use tokio::time::timeout;
 /// Smoke test for the DNS, network change and resume notifiers
 ///
 /// Turn them on, wait a second, turn them off.
-/// This tests that the threads quit gracefully when we call `close`, and they don't crash on startup.
+/// This tests that the threads quit gracefully when the notifiers are dropped, and they don't crash on startup.
 #[tokio::test]
 #[cfg_attr(target_os = "macos", ignore = "Notifiers not implemented on macOS")]
 async fn notifiers() {

--- a/rust/libs/bin-shared/tests/resume_notifier.rs
+++ b/rust/libs/bin-shared/tests/resume_notifier.rs
@@ -1,0 +1,27 @@
+#![allow(clippy::unwrap_used)]
+
+use bin_shared::new_resume_notifier;
+use futures::{StreamExt as _, future::FutureExt as _};
+
+/// Smoke test for the resume notifier.
+///
+/// Subscribing to the OS is the only part that can fail at runtime, so check that it succeeds and
+/// that we don't claim to have resumed when the system never slept.
+///
+/// Windows registers once per process and fans the notifications out, so the second notifier
+/// exercises a different path than the first. Both the Tunnel service and the headless client
+/// create one per connected client, meaning the second path is the common one in practice.
+#[tokio::test]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "Resume notifier not implemented on macOS"
+)]
+async fn resume_notifier() {
+    logging::test_global("debug");
+
+    let mut first = new_resume_notifier().await.unwrap();
+    let mut second = new_resume_notifier().await.unwrap();
+
+    assert!(first.next().now_or_never().is_none());
+    assert!(second.next().now_or_never().is_none());
+}


### PR DESCRIPTION
The Windows and Linux clients had no notion of waking up from sleep. They only recovered once a keepalive or heartbeat timed out, up to half a minute later, and on Windows a stale source-IP cache could keep the tunnel broken well past that, until an unrelated network change happened to clear it. The Apple clients have reset on wake for a while; this brings the other platforms in line.

Windows registers a `PowerRegisterSuspendResumeNotification` callback rather than handling `SERVICE_CONTROL_POWEREVENT`. The latter is not delivered on Modern Standby systems and would only ever reach the Tunnel service, never the headless client. Linux subscribes to logind's `PrepareForSleep`. Both sit behind a `ResumeNotifier` in `bin-shared`, alongside the existing DNS and network-change notifiers, and a platform that cannot register for the signal degrades to the timeout-based recovery we have today rather than failing the session.