### PR TITLE
test(portal): stop the X.509 rate limit test crossing seconds

### DIFF
--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -1041,8 +1041,15 @@ defmodule PortalAPI.Client.SocketTest do
           client_cert: x509_identity_cert(untrusted_pki, account, actor)
         )
 
-      assert connect(Socket, connect_attrs([]), connect_info: connect_info_with_bogus_token) ==
-               {:error, :rate_limit}
+      # Use Enum.any? to avoid flakiness from crossing second boundaries with the
+      # slow (1/s) refill rate.
+      rate_limited =
+        Enum.any?(1..3, fn _ ->
+          connect(Socket, connect_attrs([]), connect_info: connect_info_with_bogus_token) ==
+            {:error, :rate_limit}
+        end)
+
+      assert rate_limited, "Expected the repeated X.509 failure to be rate limited"
     end
   end
 


### PR DESCRIPTION
`PortalAPI.Client.SocketTest` "rate limits failed X.509 authentication before repeating validation" fails intermittently, for example here: https://github.com/firezone/firezone/actions/runs/33148396459/job/98774513409?pr=14883

Other tests in this file already work around this by using `Enum.any` instead: https://github.com/firezone/firezone/blob/9c86ea69c811d9b48e8fce91b26dd7f3a4947ed2/elixir/test/portal_api/client/socket_test.exs#L333-L340

This PR applies the same pattern to the x509 rate limiter test.