### PR TITLE
fix(android): preserve connect on start through onboarding

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/x509/CertificateAccess.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/x509/CertificateAccess.kt
@@ -4,8 +4,9 @@ package dev.firezone.android.core.x509
 import android.os.Bundle
 import dev.firezone.android.core.Log
 import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.di.IoDispatcher
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -16,6 +17,7 @@ class CertificateAccess
         private val repository: Repository,
         private val applicationRestrictions: Bundle,
         private val keyChain: KeyChain,
+        @IoDispatcher private val coroutineDispatcher: CoroutineDispatcher,
     ) {
         /**
          * Whether this device has a configured alias whose certificate Android will not hand over.
@@ -26,7 +28,7 @@ class CertificateAccess
          * offering the chooser is more useful than failing later when the tunnel starts.
          */
         suspend fun needsSelection(): Boolean =
-            withContext(Dispatchers.IO) {
+            withContext(coroutineDispatcher) {
                 val alias =
                     repository.getX509CertificateAliasSync(applicationRestrictions)
                         ?: return@withContext false

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
@@ -36,6 +36,11 @@ internal class SplashFragment : Fragment(R.layout.fragment_splash) {
         viewModel.checkTunnelState(requireContext())
     }
 
+    override fun onPause() {
+        viewModel.cancelTunnelStateCheck()
+        super.onPause()
+    }
+
     private fun setupActionObservers() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.launch
 internal class SplashFragment : Fragment(R.layout.fragment_splash) {
     private lateinit var binding: FragmentSplashBinding
     private val viewModel: SplashViewModel by viewModels()
-    private var isInitialLaunch: Boolean = true
 
     override fun onViewCreated(
         view: View,
@@ -30,24 +29,11 @@ internal class SplashFragment : Fragment(R.layout.fragment_splash) {
         binding = FragmentSplashBinding.bind(view)
 
         setupActionObservers()
-
-        savedInstanceState?.let {
-            isInitialLaunch = it.getBoolean("isInitialLaunch", true)
-        }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-
-        // Save the initial launch state to handle edge cases where the fragment is recreated
-        outState.putBoolean("isInitialLaunch", isInitialLaunch)
     }
 
     override fun onResume() {
         super.onResume()
-        viewModel.checkTunnelState(requireContext(), isInitialLaunch)
-
-        isInitialLaunch = false
+        viewModel.checkTunnelState(requireContext())
     }
 
     private fun setupActionObservers() {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashLaunchFlow.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashLaunchFlow.kt
@@ -18,6 +18,7 @@ internal class SplashLaunchFlow(
         hasToken: Boolean,
         isTunnelRunning: Boolean,
         connectOnStart: Boolean,
+        hasCertificateIdentity: Boolean = false,
     ): Action {
         val initialLaunchConsumed: Boolean = savedStateHandle[INITIAL_LAUNCH_CONSUMED] ?: false
         val shouldConnect = !initialLaunchConsumed && connectOnStart

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashLaunchFlow.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashLaunchFlow.kt
@@ -1,9 +1,13 @@
 // Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
 package dev.firezone.android.features.splash.ui
 
-internal class SplashLaunchFlow {
-    private var isInitialLaunch = true
+import androidx.lifecycle.SavedStateHandle
 
+private const val INITIAL_LAUNCH_CONSUMED = "initialLaunchConsumed"
+
+internal class SplashLaunchFlow(
+    private val savedStateHandle: SavedStateHandle,
+) {
     fun vpnPermissionRequired(): Action = Action.REQUEST_VPN_PERMISSION
 
     fun notificationPermissionRequired(): Action = Action.REQUEST_NOTIFICATION_PERMISSION
@@ -15,8 +19,8 @@ internal class SplashLaunchFlow {
         isTunnelRunning: Boolean,
         connectOnStart: Boolean,
     ): Action {
-        val shouldConnect = isInitialLaunch && connectOnStart
-        isInitialLaunch = false
+        val shouldConnect = savedStateHandle[INITIAL_LAUNCH_CONSUMED] != true && connectOnStart
+        savedStateHandle[INITIAL_LAUNCH_CONSUMED] = true
 
         if (!hasToken) {
             return Action.SIGN_IN

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashLaunchFlow.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashLaunchFlow.kt
@@ -1,0 +1,44 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.features.splash.ui
+
+internal class SplashLaunchFlow {
+    private var isInitialLaunch = true
+
+    fun vpnPermissionRequired(): Action = Action.REQUEST_VPN_PERMISSION
+
+    fun notificationPermissionRequired(): Action = Action.REQUEST_NOTIFICATION_PERMISSION
+
+    fun certificatePermissionRequired(): Action = Action.REQUEST_CERTIFICATE_PERMISSION
+
+    fun permissionsReady(
+        hasToken: Boolean,
+        isTunnelRunning: Boolean,
+        connectOnStart: Boolean,
+    ): Action {
+        val shouldConnect = isInitialLaunch && connectOnStart
+        isInitialLaunch = false
+
+        if (!hasToken) {
+            return Action.SIGN_IN
+        }
+
+        if (isTunnelRunning) {
+            return Action.OPEN_SESSION
+        }
+
+        if (shouldConnect) {
+            return Action.CONNECT_AND_OPEN_SESSION
+        }
+
+        return Action.SIGN_IN
+    }
+
+    enum class Action {
+        REQUEST_VPN_PERMISSION,
+        REQUEST_NOTIFICATION_PERMISSION,
+        REQUEST_CERTIFICATE_PERMISSION,
+        SIGN_IN,
+        OPEN_SESSION,
+        CONNECT_AND_OPEN_SESSION,
+    }
+}

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashLaunchFlow.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashLaunchFlow.kt
@@ -18,7 +18,6 @@ internal class SplashLaunchFlow(
         hasToken: Boolean,
         isTunnelRunning: Boolean,
         connectOnStart: Boolean,
-        hasCertificateIdentity: Boolean = false,
     ): Action {
         val initialLaunchConsumed: Boolean = savedStateHandle[INITIAL_LAUNCH_CONSUMED] ?: false
         val shouldConnect = !initialLaunchConsumed && connectOnStart

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashLaunchFlow.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashLaunchFlow.kt
@@ -19,7 +19,8 @@ internal class SplashLaunchFlow(
         isTunnelRunning: Boolean,
         connectOnStart: Boolean,
     ): Action {
-        val shouldConnect = savedStateHandle[INITIAL_LAUNCH_CONSUMED] != true && connectOnStart
+        val initialLaunchConsumed: Boolean = savedStateHandle[INITIAL_LAUNCH_CONSUMED] ?: false
+        val shouldConnect = !initialLaunchConsumed && connectOnStart
         savedStateHandle[INITIAL_LAUNCH_CONSUMED] = true
 
         if (!hasToken) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
@@ -7,8 +7,6 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,6 +14,7 @@ import dev.firezone.android.core.ApplicationMode
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.x509.CertificateAccess
 import dev.firezone.android.tunnel.TunnelService
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -34,68 +33,88 @@ internal class SplashViewModel
         private val certificateAccess: CertificateAccess,
     ) : ViewModel() {
         private val actionMutableStateFlow = MutableStateFlow<ViewAction?>(null)
+        private val launchFlow = SplashLaunchFlow()
+        private var checkTunnelStateJob: Job? = null
         val actionStateFlow: StateFlow<ViewAction?> = actionMutableStateFlow
 
-        internal fun checkTunnelState(
-            context: Context,
-            isInitialLaunch: Boolean = false,
-        ) {
-            viewModelScope.launch {
-                // Stay a while and enjoy the logo
-                delay(REQUEST_DELAY)
+        internal fun checkTunnelState(context: Context) {
+            checkTunnelStateJob?.cancel()
+            checkTunnelStateJob =
+                viewModelScope.launch {
+                    // Stay a while and enjoy the logo
+                    delay(REQUEST_DELAY)
 
-                // If we don't have VPN permission, we can't continue.
-                if (!hasVpnPermissions(context) && applicationMode != ApplicationMode.TESTING) {
-                    actionMutableStateFlow.value = ViewAction.NavigateToVpnPermission
-                    return@launch
+                    // If we don't have VPN permission, we can't continue.
+                    if (!hasVpnPermissions(context) && applicationMode != ApplicationMode.TESTING) {
+                        publish(launchFlow.vpnPermissionRequired(), context)
+                        return@launch
+                    }
+
+                    // Check if we need to request notification permission (only once)
+                    if (shouldRequestNotificationPermission(context)) {
+                        publish(launchFlow.notificationPermissionRequired(), context)
+                        return@launch
+                    }
+
+                    // An administrator can configure a certificate that only the user can release, which
+                    // is what a work profile on a personally-owned device looks like. Ask once per
+                    // launch: pressing on without it only fails later, at the tunnel.
+                    if (!certificateSelectionOffered && certificateAccess.needsSelection()) {
+                        certificateSelectionOffered = true
+                        publish(launchFlow.certificatePermissionRequired(), context)
+                        return@launch
+                    }
+
+                    val token = applicationRestrictions.getString("token") ?: repo.getTokenSync()
+                    val isRunning = TunnelService.isRunning(context)
+                    val connectOnStart = repo.getConfigSync().connectOnStart
+
+                    publish(
+                        launchFlow.permissionsReady(
+                            hasToken = !token.isNullOrBlank(),
+                            isTunnelRunning = isRunning,
+                            connectOnStart = connectOnStart,
+                        ),
+                        context,
+                    )
                 }
-
-                // Check if we need to request notification permission (only once)
-                if (shouldRequestNotificationPermission(context)) {
-                    actionMutableStateFlow.value = ViewAction.NavigateToNotificationPermission
-                    return@launch
-                }
-
-                // An administrator can configure a certificate that only the user can release, which
-                // is what a work profile on a personally-owned device looks like. Ask once per
-                // launch: pressing on without it only fails later, at the tunnel.
-                if (!certificateSelectionOffered && certificateAccess.needsSelection()) {
-                    certificateSelectionOffered = true
-                    actionMutableStateFlow.value = ViewAction.NavigateToCertificatePermission
-                    return@launch
-                }
-
-                val token = applicationRestrictions.getString("token") ?: repo.getTokenSync()
-
-                if (token.isNullOrBlank()) {
-                    actionMutableStateFlow.value = ViewAction.NavigateToSignIn
-                    return@launch
-                }
-
-                val isRunning = TunnelService.isRunning(context)
-
-                // If the service is already running, we can go directly to the session.
-                if (isRunning) {
-                    actionMutableStateFlow.value = ViewAction.NavigateToSession
-                    return@launch
-                }
-
-                val connectOnStart = repo.getConfigSync().connectOnStart
-
-                // If this is the initial launch and connectOnStart is true, try to connect
-                if (isInitialLaunch && connectOnStart) {
-                    TunnelService.start(context)
-                    actionMutableStateFlow.value = ViewAction.NavigateToSession
-                    return@launch
-                }
-
-                // If we get here, we shouldn't start the tunnel, so show the sign in screen
-                actionMutableStateFlow.value = ViewAction.NavigateToSignIn
-            }
         }
 
         internal fun clearAction() {
             actionMutableStateFlow.value = null
+        }
+
+        private fun publish(
+            action: SplashLaunchFlow.Action,
+            context: Context,
+        ) {
+            actionMutableStateFlow.value =
+                when (action) {
+                    SplashLaunchFlow.Action.REQUEST_VPN_PERMISSION -> {
+                        ViewAction.NavigateToVpnPermission
+                    }
+
+                    SplashLaunchFlow.Action.REQUEST_NOTIFICATION_PERMISSION -> {
+                        ViewAction.NavigateToNotificationPermission
+                    }
+
+                    SplashLaunchFlow.Action.REQUEST_CERTIFICATE_PERMISSION -> {
+                        ViewAction.NavigateToCertificatePermission
+                    }
+
+                    SplashLaunchFlow.Action.SIGN_IN -> {
+                        ViewAction.NavigateToSignIn
+                    }
+
+                    SplashLaunchFlow.Action.OPEN_SESSION -> {
+                        ViewAction.NavigateToSession
+                    }
+
+                    SplashLaunchFlow.Action.CONNECT_AND_OPEN_SESSION -> {
+                        TunnelService.start(context)
+                        ViewAction.NavigateToSession
+                    }
+                }
         }
 
         private fun hasVpnPermissions(context: Context): Boolean = android.net.VpnService.prepare(context) == null

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
@@ -85,6 +85,7 @@ internal class SplashViewModel
         internal fun cancelTunnelStateCheck() {
             checkTunnelStateJob?.cancel()
             checkTunnelStateJob = null
+            actionMutableStateFlow.value = null
         }
 
         internal fun clearAction() {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -31,9 +32,10 @@ internal class SplashViewModel
         private val applicationRestrictions: Bundle,
         private val applicationMode: ApplicationMode,
         private val certificateAccess: CertificateAccess,
+        savedStateHandle: SavedStateHandle,
     ) : ViewModel() {
         private val actionMutableStateFlow = MutableStateFlow<ViewAction?>(null)
-        private val launchFlow = SplashLaunchFlow()
+        private val launchFlow = SplashLaunchFlow(savedStateHandle)
         private var checkTunnelStateJob: Job? = null
         val actionStateFlow: StateFlow<ViewAction?> = actionMutableStateFlow
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
@@ -82,6 +82,11 @@ internal class SplashViewModel
                 }
         }
 
+        internal fun cancelTunnelStateCheck() {
+            checkTunnelStateJob?.cancel()
+            checkTunnelStateJob = null
+        }
+
         internal fun clearAction() {
             actionMutableStateFlow.value = null
         }

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/x509/CertificateAccessTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/x509/CertificateAccessTest.kt
@@ -35,7 +35,7 @@ class CertificateAccessTest {
                 .getApplication()
                 .getSharedPreferences("certificate-access-test", Context.MODE_PRIVATE),
         )
-    private val certificateAccess = CertificateAccess(repository, restrictions, keyChain)
+    private val certificateAccess = CertificateAccess(repository, restrictions, keyChain, Dispatchers.Unconfined)
 
     @Test
     fun `no configured alias needs no selection`() {

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashLaunchFlowTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashLaunchFlowTest.kt
@@ -1,0 +1,97 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.features.splash.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SplashLaunchFlowTest {
+    @Test
+    fun `connects after granting VPN permission during initial launch`() {
+        val launchFlow = SplashLaunchFlow()
+
+        val permissionAction = launchFlow.vpnPermissionRequired()
+        val resumedAction = launchFlow.resumeSignedInAndStopped()
+
+        assertEquals(SplashLaunchFlow.Action.REQUEST_VPN_PERMISSION, permissionAction)
+        assertEquals(SplashLaunchFlow.Action.CONNECT_AND_OPEN_SESSION, resumedAction)
+    }
+
+    @Test
+    fun `connects after granting notification permission during initial launch`() {
+        val launchFlow = SplashLaunchFlow()
+
+        val permissionAction = launchFlow.notificationPermissionRequired()
+        val resumedAction = launchFlow.resumeSignedInAndStopped()
+
+        assertEquals(SplashLaunchFlow.Action.REQUEST_NOTIFICATION_PERMISSION, permissionAction)
+        assertEquals(SplashLaunchFlow.Action.CONNECT_AND_OPEN_SESSION, resumedAction)
+    }
+
+    @Test
+    fun `connects with a token after granting certificate permission during initial launch`() {
+        val launchFlow = SplashLaunchFlow()
+
+        val permissionAction = launchFlow.certificatePermissionRequired()
+        val resumedAction =
+            launchFlow.permissionsReady(
+                hasToken = true,
+                isTunnelRunning = false,
+                connectOnStart = true,
+            )
+
+        assertEquals(SplashLaunchFlow.Action.REQUEST_CERTIFICATE_PERMISSION, permissionAction)
+        assertEquals(SplashLaunchFlow.Action.CONNECT_AND_OPEN_SESSION, resumedAction)
+    }
+
+    @Test
+    fun `connects after skipping or denying notification permission during initial launch`() {
+        listOf("skipped", "denied").forEach { outcome ->
+            val launchFlow = SplashLaunchFlow()
+
+            val permissionAction = launchFlow.notificationPermissionRequired()
+            val resumedAction = launchFlow.resumeSignedInAndStopped()
+
+            assertEquals(
+                outcome,
+                SplashLaunchFlow.Action.REQUEST_NOTIFICATION_PERMISSION,
+                permissionAction,
+            )
+            assertEquals(
+                outcome,
+                SplashLaunchFlow.Action.CONNECT_AND_OPEN_SESSION,
+                resumedAction,
+            )
+        }
+    }
+
+    @Test
+    fun `connects after both permission detours during initial launch`() {
+        val launchFlow = SplashLaunchFlow()
+
+        val vpnPermissionAction = launchFlow.vpnPermissionRequired()
+        val notificationPermissionAction = launchFlow.notificationPermissionRequired()
+        val resumedAction = launchFlow.resumeSignedInAndStopped()
+
+        assertEquals(SplashLaunchFlow.Action.REQUEST_VPN_PERMISSION, vpnPermissionAction)
+        assertEquals(SplashLaunchFlow.Action.REQUEST_NOTIFICATION_PERMISSION, notificationPermissionAction)
+        assertEquals(SplashLaunchFlow.Action.CONNECT_AND_OPEN_SESSION, resumedAction)
+    }
+
+    @Test
+    fun `does not reconnect on a later ordinary resume`() {
+        val launchFlow = SplashLaunchFlow()
+
+        val initialAction = launchFlow.resumeSignedInAndStopped()
+        val laterAction = launchFlow.resumeSignedInAndStopped()
+
+        assertEquals(SplashLaunchFlow.Action.CONNECT_AND_OPEN_SESSION, initialAction)
+        assertEquals(SplashLaunchFlow.Action.SIGN_IN, laterAction)
+    }
+
+    private fun SplashLaunchFlow.resumeSignedInAndStopped(): SplashLaunchFlow.Action =
+        permissionsReady(
+            hasToken = true,
+            isTunnelRunning = false,
+            connectOnStart = true,
+        )
+}

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashLaunchFlowTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashLaunchFlowTest.kt
@@ -45,6 +45,22 @@ class SplashLaunchFlowTest {
     }
 
     @Test
+    fun `certificate permission does not replace a token`() {
+        val launchFlow = SplashLaunchFlow(SavedStateHandle())
+
+        val permissionAction = launchFlow.certificatePermissionRequired()
+        val resumedAction =
+            launchFlow.permissionsReady(
+                hasToken = false,
+                isTunnelRunning = false,
+                connectOnStart = true,
+            )
+
+        assertEquals(SplashLaunchFlow.Action.REQUEST_CERTIFICATE_PERMISSION, permissionAction)
+        assertEquals(SplashLaunchFlow.Action.SIGN_IN, resumedAction)
+    }
+
+    @Test
     fun `connects after skipping or denying notification permission during initial launch`() {
         listOf("skipped", "denied").forEach { outcome ->
             val launchFlow = SplashLaunchFlow(SavedStateHandle())

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashLaunchFlowTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashLaunchFlowTest.kt
@@ -90,6 +90,42 @@ class SplashLaunchFlowTest {
     }
 
     @Test
+    fun `does not connect when connect on start is disabled`() {
+        val action =
+            SplashLaunchFlow(SavedStateHandle()).permissionsReady(
+                hasToken = true,
+                isTunnelRunning = false,
+                connectOnStart = false,
+            )
+
+        assertEquals(SplashLaunchFlow.Action.SIGN_IN, action)
+    }
+
+    @Test
+    fun `does not connect without a token`() {
+        val action =
+            SplashLaunchFlow(SavedStateHandle()).permissionsReady(
+                hasToken = false,
+                isTunnelRunning = false,
+                connectOnStart = true,
+            )
+
+        assertEquals(SplashLaunchFlow.Action.SIGN_IN, action)
+    }
+
+    @Test
+    fun `opens an already running tunnel without reconnecting`() {
+        val action =
+            SplashLaunchFlow(SavedStateHandle()).permissionsReady(
+                hasToken = true,
+                isTunnelRunning = true,
+                connectOnStart = true,
+            )
+
+        assertEquals(SplashLaunchFlow.Action.OPEN_SESSION, action)
+    }
+
+    @Test
     fun `recreation before permissions are ready preserves the initial launch`() {
         val savedStateHandle = SavedStateHandle()
 

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashLaunchFlowTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashLaunchFlowTest.kt
@@ -1,13 +1,14 @@
 // Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
 package dev.firezone.android.features.splash.ui
 
+import androidx.lifecycle.SavedStateHandle
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SplashLaunchFlowTest {
     @Test
     fun `connects after granting VPN permission during initial launch`() {
-        val launchFlow = SplashLaunchFlow()
+        val launchFlow = SplashLaunchFlow(SavedStateHandle())
 
         val permissionAction = launchFlow.vpnPermissionRequired()
         val resumedAction = launchFlow.resumeSignedInAndStopped()
@@ -18,7 +19,7 @@ class SplashLaunchFlowTest {
 
     @Test
     fun `connects after granting notification permission during initial launch`() {
-        val launchFlow = SplashLaunchFlow()
+        val launchFlow = SplashLaunchFlow(SavedStateHandle())
 
         val permissionAction = launchFlow.notificationPermissionRequired()
         val resumedAction = launchFlow.resumeSignedInAndStopped()
@@ -28,12 +29,12 @@ class SplashLaunchFlowTest {
     }
 
     @Test
-    fun `connects with a token after granting certificate permission during initial launch`() {
-        val launchFlow = SplashLaunchFlow()
+    fun `certificate permission and recreation preserve token connect on start`() {
+        val savedStateHandle = SavedStateHandle()
 
-        val permissionAction = launchFlow.certificatePermissionRequired()
+        val permissionAction = SplashLaunchFlow(savedStateHandle).certificatePermissionRequired()
         val resumedAction =
-            launchFlow.permissionsReady(
+            SplashLaunchFlow(savedStateHandle).permissionsReady(
                 hasToken = true,
                 isTunnelRunning = false,
                 connectOnStart = true,
@@ -46,7 +47,7 @@ class SplashLaunchFlowTest {
     @Test
     fun `connects after skipping or denying notification permission during initial launch`() {
         listOf("skipped", "denied").forEach { outcome ->
-            val launchFlow = SplashLaunchFlow()
+            val launchFlow = SplashLaunchFlow(SavedStateHandle())
 
             val permissionAction = launchFlow.notificationPermissionRequired()
             val resumedAction = launchFlow.resumeSignedInAndStopped()
@@ -66,7 +67,7 @@ class SplashLaunchFlowTest {
 
     @Test
     fun `connects after both permission detours during initial launch`() {
-        val launchFlow = SplashLaunchFlow()
+        val launchFlow = SplashLaunchFlow(SavedStateHandle())
 
         val vpnPermissionAction = launchFlow.vpnPermissionRequired()
         val notificationPermissionAction = launchFlow.notificationPermissionRequired()
@@ -79,13 +80,33 @@ class SplashLaunchFlowTest {
 
     @Test
     fun `does not reconnect on a later ordinary resume`() {
-        val launchFlow = SplashLaunchFlow()
+        val launchFlow = SplashLaunchFlow(SavedStateHandle())
 
         val initialAction = launchFlow.resumeSignedInAndStopped()
         val laterAction = launchFlow.resumeSignedInAndStopped()
 
         assertEquals(SplashLaunchFlow.Action.CONNECT_AND_OPEN_SESSION, initialAction)
         assertEquals(SplashLaunchFlow.Action.SIGN_IN, laterAction)
+    }
+
+    @Test
+    fun `recreation before permissions are ready preserves the initial launch`() {
+        val savedStateHandle = SavedStateHandle()
+
+        SplashLaunchFlow(savedStateHandle).vpnPermissionRequired()
+        val restoredAction = SplashLaunchFlow(savedStateHandle).resumeSignedInAndStopped()
+
+        assertEquals(SplashLaunchFlow.Action.CONNECT_AND_OPEN_SESSION, restoredAction)
+    }
+
+    @Test
+    fun `recreation after consuming the initial launch does not reconnect`() {
+        val savedStateHandle = SavedStateHandle()
+
+        SplashLaunchFlow(savedStateHandle).resumeSignedInAndStopped()
+        val restoredAction = SplashLaunchFlow(savedStateHandle).resumeSignedInAndStopped()
+
+        assertEquals(SplashLaunchFlow.Action.SIGN_IN, restoredAction)
     }
 
     private fun SplashLaunchFlow.resumeSignedInAndStopped(): SplashLaunchFlow.Action =

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelTest.kt
@@ -8,7 +8,11 @@ import android.os.Looper
 import androidx.lifecycle.SavedStateHandle
 import dev.firezone.android.core.ApplicationMode
 import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.x509.CertificateUser
+import dev.firezone.android.core.x509.SystemKeyChain
+import dev.firezone.android.core.x509.X509Identity
 import kotlinx.coroutines.Dispatchers
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -29,24 +33,45 @@ class SplashViewModelTest {
     @Test
     fun `cancelling a tunnel state check prevents delayed navigation`() {
         val context = RuntimeEnvironment.getApplication()
-        val repository =
-            Repository(
-                context = context,
-                coroutineDispatcher = Dispatchers.Unconfined,
-                sharedPreferences = context.getSharedPreferences("splash-view-model-test", Context.MODE_PRIVATE),
-            )
-        val viewModel =
-            SplashViewModel(
-                repo = repository,
-                applicationRestrictions = Bundle(),
-                applicationMode = ApplicationMode.TESTING,
-                savedStateHandle = SavedStateHandle(),
-            )
+        val viewModel = newViewModel(context)
 
         viewModel.checkTunnelState(context)
         viewModel.cancelTunnelStateCheck()
         shadowOf(Looper.getMainLooper()).idleFor(2, TimeUnit.SECONDS)
 
         assertNull(viewModel.actionStateFlow.value)
+    }
+
+    @Test
+    fun `cancelling a tunnel state check clears delayed navigation`() {
+        val context = RuntimeEnvironment.getApplication()
+        val viewModel = newViewModel(context)
+
+        viewModel.checkTunnelState(context)
+        shadowOf(Looper.getMainLooper()).idleFor(2, TimeUnit.SECONDS)
+        assertNotNull(viewModel.actionStateFlow.value)
+
+        viewModel.cancelTunnelStateCheck()
+
+        assertNull(viewModel.actionStateFlow.value)
+    }
+
+    private fun newViewModel(context: Context): SplashViewModel {
+        val repository =
+            Repository(
+                context = context,
+                coroutineDispatcher = Dispatchers.Unconfined,
+                sharedPreferences = context.getSharedPreferences("splash-view-model-test", Context.MODE_PRIVATE),
+            )
+        val applicationRestrictions = Bundle()
+        val certificateUser = CertificateUser(repository, applicationRestrictions, X509Identity(SystemKeyChain(context)))
+
+        return SplashViewModel(
+            repo = repository,
+            applicationRestrictions = applicationRestrictions,
+            applicationMode = ApplicationMode.TESTING,
+            certificateUser = certificateUser,
+            savedStateHandle = SavedStateHandle(),
+        )
     }
 }

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelTest.kt
@@ -1,0 +1,52 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.features.splash.ui
+
+import android.app.Application
+import android.content.Context
+import android.os.Bundle
+import android.os.Looper
+import androidx.lifecycle.SavedStateHandle
+import dev.firezone.android.core.ApplicationMode
+import dev.firezone.android.core.data.Repository
+import kotlinx.coroutines.Dispatchers
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+@Config(
+    sdk = [34],
+    application = Application::class,
+)
+class SplashViewModelTest {
+    @Test
+    fun `cancelling a tunnel state check prevents delayed navigation`() {
+        val context = RuntimeEnvironment.getApplication()
+        val repository =
+            Repository(
+                context = context,
+                coroutineDispatcher = Dispatchers.Unconfined,
+                sharedPreferences = context.getSharedPreferences("splash-view-model-test", Context.MODE_PRIVATE),
+            )
+        val viewModel =
+            SplashViewModel(
+                repo = repository,
+                applicationRestrictions = Bundle(),
+                applicationMode = ApplicationMode.TESTING,
+                savedStateHandle = SavedStateHandle(),
+            )
+
+        viewModel.checkTunnelState(context)
+        viewModel.cancelTunnelStateCheck()
+        shadowOf(Looper.getMainLooper()).idleFor(2, TimeUnit.SECONDS)
+
+        assertNull(viewModel.actionStateFlow.value)
+    }
+}

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelTest.kt
@@ -8,9 +8,8 @@ import android.os.Looper
 import androidx.lifecycle.SavedStateHandle
 import dev.firezone.android.core.ApplicationMode
 import dev.firezone.android.core.data.Repository
-import dev.firezone.android.core.x509.CertificateUser
+import dev.firezone.android.core.x509.CertificateAccess
 import dev.firezone.android.core.x509.SystemKeyChain
-import dev.firezone.android.core.x509.X509Identity
 import kotlinx.coroutines.Dispatchers
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -64,13 +63,14 @@ class SplashViewModelTest {
                 sharedPreferences = context.getSharedPreferences("splash-view-model-test", Context.MODE_PRIVATE),
             )
         val applicationRestrictions = Bundle()
-        val certificateUser = CertificateUser(repository, applicationRestrictions, X509Identity(SystemKeyChain(context)))
+        val certificateAccess =
+            CertificateAccess(repository, applicationRestrictions, SystemKeyChain(context))
 
         return SplashViewModel(
             repo = repository,
             applicationRestrictions = applicationRestrictions,
             applicationMode = ApplicationMode.TESTING,
-            certificateUser = certificateUser,
+            certificateAccess = certificateAccess,
             savedStateHandle = SavedStateHandle(),
         )
     }

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelTest.kt
@@ -64,7 +64,12 @@ class SplashViewModelTest {
             )
         val applicationRestrictions = Bundle()
         val certificateAccess =
-            CertificateAccess(repository, applicationRestrictions, SystemKeyChain(context))
+            CertificateAccess(
+                repository,
+                applicationRestrictions,
+                SystemKeyChain(context),
+                Dispatchers.Unconfined,
+            )
 
         return SplashViewModel(
             repo = repository,


### PR DESCRIPTION
Keep the initial launch eligible for `connectOnStart` while the app sends the user through VPN and notification permission onboarding. Persist whether that launch has been consumed through Activity and process recreation, so restoration after an explicit disconnect cannot start the tunnel again. Cancel delayed splash checks and clear pending navigation when the splash Fragment pauses, preventing a stopped screen from starting the tunnel or replaying stale navigation.