### PR TITLE
fix(android): preserve managed config overlays

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -72,66 +72,14 @@ class Repository
             MutableStateFlow(Favorites(HashSet(sharedPreferences.getStringSet(FAVORITE_RESOURCES_KEY, null).orEmpty())))
         val favorites = _favorites.asStateFlow()
 
-        fun getConfigSync(): Config =
-            {
-                val authURL =
-                    sharedPreferences.getString(MANAGED_AUTH_URL_KEY, null)
-                        ?: sharedPreferences.getString(AUTH_URL_KEY, null)
-                        ?: BuildConfig.AUTH_URL
-
-                val apiURL =
-                    sharedPreferences.getString(MANAGED_API_URL_KEY, null)
-                        ?: sharedPreferences.getString(API_URL_KEY, null)
-                        ?: BuildConfig.API_URL
-
-                val logFilter =
-                    sharedPreferences.getString(MANAGED_LOG_FILTER_KEY, null)
-                        ?: sharedPreferences.getString(LOG_FILTER_KEY, null)
-                        ?: BuildConfig.LOG_FILTER
-
-                val accountSlug =
-                    sharedPreferences.getString(MANAGED_ACCOUNT_SLUG_KEY, null)
-                        ?: sharedPreferences.getString(ACCOUNT_SLUG_KEY, null)
-                        ?: ""
-
-                val startOnLogin =
-                    if (sharedPreferences.contains(MANAGED_START_ON_LOGIN_KEY)) {
-                        sharedPreferences.getBoolean(MANAGED_START_ON_LOGIN_KEY, false)
-                    } else {
-                        sharedPreferences.getBoolean(START_ON_LOGIN_KEY, false)
-                    }
-
-                val connectOnStart =
-                    if (sharedPreferences.contains(MANAGED_CONNECT_ON_START_KEY)) {
-                        sharedPreferences.getBoolean(MANAGED_CONNECT_ON_START_KEY, false)
-                    } else {
-                        sharedPreferences.getBoolean(CONNECT_ON_START_KEY, false)
-                    }
-
-                Config(
-                    authUrl = authURL,
-                    apiUrl = apiURL,
-                    logFilter = logFilter,
-                    accountSlug = accountSlug,
-                    startOnLogin = startOnLogin,
-                    connectOnStart = connectOnStart,
-                )
-            }()
+        fun getConfigSync(): Config = getUserConfigSync().withManagedOverrides()
 
         fun getConfig(): Flow<Config> =
             flow {
                 emit(getConfigSync())
             }.flowOn(coroutineDispatcher)
 
-        fun getDefaultConfigSync(): Config =
-            Config(
-                BuildConfig.AUTH_URL,
-                BuildConfig.API_URL,
-                BuildConfig.LOG_FILTER,
-                accountSlug = "",
-                startOnLogin = false,
-                connectOnStart = false,
-            )
+        fun getDefaultConfigSync(): Config = getBuildDefaultConfig().withManagedOverrides()
 
         fun getDefaultConfig(): Flow<Config> =
             flow {
@@ -140,17 +88,29 @@ class Repository
 
         fun saveSettings(value: Config): Flow<Unit> =
             flow {
-                emit(
-                    sharedPreferences
-                        .edit()
-                        .putString(AUTH_URL_KEY, value.authUrl)
-                        .putString(API_URL_KEY, value.apiUrl)
-                        .putString(LOG_FILTER_KEY, value.logFilter)
-                        .putString(ACCOUNT_SLUG_KEY, value.accountSlug)
-                        .putBoolean(START_ON_LOGIN_KEY, value.startOnLogin)
-                        .putBoolean(CONNECT_ON_START_KEY, value.connectOnStart)
-                        .apply(),
-                )
+                val managedStatus = getManagedStatus()
+                val editor = sharedPreferences.edit()
+
+                if (!managedStatus.isAuthUrlManaged) {
+                    editor.putString(AUTH_URL_KEY, value.authUrl)
+                }
+                if (!managedStatus.isApiUrlManaged) {
+                    editor.putString(API_URL_KEY, value.apiUrl)
+                }
+                if (!managedStatus.isLogFilterManaged) {
+                    editor.putString(LOG_FILTER_KEY, value.logFilter)
+                }
+                if (!managedStatus.isAccountSlugManaged) {
+                    editor.putString(ACCOUNT_SLUG_KEY, value.accountSlug)
+                }
+                if (!managedStatus.isStartOnLoginManaged) {
+                    editor.putBoolean(START_ON_LOGIN_KEY, value.startOnLogin)
+                }
+                if (!managedStatus.isConnectOnStartManaged) {
+                    editor.putBoolean(CONNECT_ON_START_KEY, value.connectOnStart)
+                }
+
+                emit(editor.apply())
             }.flowOn(coroutineDispatcher)
 
         // TODO: Consider adding support for the legacy managed configuration keys like token,
@@ -161,21 +121,33 @@ class Repository
 
                 if (bundle.containsKey(AUTH_URL_KEY)) {
                     editor.putString(MANAGED_AUTH_URL_KEY, bundle.getString(AUTH_URL_KEY))
+                } else {
+                    editor.remove(MANAGED_AUTH_URL_KEY)
                 }
                 if (bundle.containsKey(API_URL_KEY)) {
                     editor.putString(MANAGED_API_URL_KEY, bundle.getString(API_URL_KEY))
+                } else {
+                    editor.remove(MANAGED_API_URL_KEY)
                 }
                 if (bundle.containsKey(LOG_FILTER_KEY)) {
                     editor.putString(MANAGED_LOG_FILTER_KEY, bundle.getString(LOG_FILTER_KEY))
+                } else {
+                    editor.remove(MANAGED_LOG_FILTER_KEY)
                 }
                 if (bundle.containsKey(ACCOUNT_SLUG_KEY)) {
                     editor.putString(MANAGED_ACCOUNT_SLUG_KEY, bundle.getString(ACCOUNT_SLUG_KEY))
+                } else {
+                    editor.remove(MANAGED_ACCOUNT_SLUG_KEY)
                 }
                 if (bundle.containsKey(START_ON_LOGIN_KEY)) {
                     editor.putBoolean(MANAGED_START_ON_LOGIN_KEY, bundle.getBoolean(START_ON_LOGIN_KEY, false))
+                } else {
+                    editor.remove(MANAGED_START_ON_LOGIN_KEY)
                 }
                 if (bundle.containsKey(CONNECT_ON_START_KEY)) {
                     editor.putBoolean(MANAGED_CONNECT_ON_START_KEY, bundle.getBoolean(CONNECT_ON_START_KEY, false))
+                } else {
+                    editor.remove(MANAGED_CONNECT_ON_START_KEY)
                 }
 
                 emit(editor.apply())
@@ -357,6 +329,49 @@ class Repository
         fun setNotificationPermissionRequested() {
             sharedPreferences.edit().putBoolean(NOTIFICATION_PERMISSION_REQUESTED_KEY, true).apply()
         }
+
+        private fun getUserConfigSync(): Config {
+            val defaults = getBuildDefaultConfig()
+
+            return Config(
+                authUrl = sharedPreferences.getString(AUTH_URL_KEY, null) ?: defaults.authUrl,
+                apiUrl = sharedPreferences.getString(API_URL_KEY, null) ?: defaults.apiUrl,
+                logFilter = sharedPreferences.getString(LOG_FILTER_KEY, null) ?: defaults.logFilter,
+                accountSlug = sharedPreferences.getString(ACCOUNT_SLUG_KEY, null) ?: defaults.accountSlug,
+                startOnLogin = sharedPreferences.getBoolean(START_ON_LOGIN_KEY, defaults.startOnLogin),
+                connectOnStart = sharedPreferences.getBoolean(CONNECT_ON_START_KEY, defaults.connectOnStart),
+            )
+        }
+
+        private fun getBuildDefaultConfig(): Config =
+            Config(
+                authUrl = BuildConfig.AUTH_URL,
+                apiUrl = BuildConfig.API_URL,
+                logFilter = BuildConfig.LOG_FILTER,
+                accountSlug = "",
+                startOnLogin = false,
+                connectOnStart = false,
+            )
+
+        private fun Config.withManagedOverrides(): Config =
+            copy(
+                authUrl = sharedPreferences.getString(MANAGED_AUTH_URL_KEY, null) ?: authUrl,
+                apiUrl = sharedPreferences.getString(MANAGED_API_URL_KEY, null) ?: apiUrl,
+                logFilter = sharedPreferences.getString(MANAGED_LOG_FILTER_KEY, null) ?: logFilter,
+                accountSlug = sharedPreferences.getString(MANAGED_ACCOUNT_SLUG_KEY, null) ?: accountSlug,
+                startOnLogin =
+                    if (sharedPreferences.contains(MANAGED_START_ON_LOGIN_KEY)) {
+                        sharedPreferences.getBoolean(MANAGED_START_ON_LOGIN_KEY, false)
+                    } else {
+                        startOnLogin
+                    },
+                connectOnStart =
+                    if (sharedPreferences.contains(MANAGED_CONNECT_ON_START_KEY)) {
+                        sharedPreferences.getBoolean(MANAGED_CONNECT_ON_START_KEY, false)
+                    } else {
+                        connectOnStart
+                    },
+            )
 
         companion object {
             private const val AUTH_URL_KEY = "authUrl"

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
@@ -57,6 +57,8 @@ internal class SettingsViewModel
         private val _managedStatusStateFlow = MutableStateFlow<ManagedConfigStatus?>(null)
         val managedStatusStateFlow: StateFlow<ManagedConfigStatus?> = _managedStatusStateFlow
 
+        private var shouldResetFavoritesOnSave = false
+
         fun populateFieldsFromConfig() {
             viewModelScope.launch {
                 repo.getConfig().collect {
@@ -88,6 +90,10 @@ internal class SettingsViewModel
         fun onSaveSettingsCompleted() {
             viewModelScope.launch {
                 repo.saveSettings(config).collect {
+                    if (shouldResetFavoritesOnSave) {
+                        repo.resetFavorites()
+                        shouldResetFavoritesOnSave = false
+                    }
                     actionMutableStateFlow.value = ViewAction.NavigateBack
                 }
             }
@@ -180,7 +186,7 @@ internal class SettingsViewModel
 
         fun resetSettingsToDefaults() {
             config = repo.getDefaultConfigSync()
-            repo.resetFavorites()
+            shouldResetFavoritesOnSave = true
             _configStateFlow.value = config
             _managedStatusStateFlow.value = repo.getManagedStatus()
             onFieldUpdated()

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/data/RepositoryManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/data/RepositoryManagedConfigurationTest.kt
@@ -1,0 +1,169 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.core.data
+
+import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Bundle
+import dev.firezone.android.core.data.model.ManagedConfigStatus
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import dev.firezone.android.core.data.model.Config as FirezoneConfig
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class RepositoryManagedConfigurationTest {
+    private lateinit var sharedPreferences: SharedPreferences
+    private lateinit var repository: Repository
+
+    @Before
+    fun setUp() {
+        sharedPreferences =
+            RuntimeEnvironment
+                .getApplication()
+                .getSharedPreferences("managed-configuration-test", Context.MODE_PRIVATE)
+        sharedPreferences.edit().clear().commit()
+        repository = Repository(RuntimeEnvironment.getApplication(), Dispatchers.Unconfined, sharedPreferences)
+    }
+
+    @Test
+    fun `latest managed configuration replaces previous overlay`() =
+        runBlocking {
+            repository.saveSettings(userConfig).first()
+            repository.saveManagedConfiguration(allManagedConfig()).first()
+
+            repository
+                .saveManagedConfiguration(
+                    Bundle().apply {
+                        putString(API_URL_KEY, "wss://replacement.example.com")
+                        putBoolean(CONNECT_ON_START_KEY, false)
+                    },
+                ).first()
+
+            assertEquals(
+                userConfig.copy(
+                    apiUrl = "wss://replacement.example.com",
+                    connectOnStart = false,
+                ),
+                repository.getConfigSync(),
+            )
+            assertEquals(
+                ManagedConfigStatus(
+                    isAuthUrlManaged = false,
+                    isApiUrlManaged = true,
+                    isLogFilterManaged = false,
+                    isAccountSlugManaged = false,
+                    isStartOnLoginManaged = false,
+                    isConnectOnStartManaged = true,
+                ),
+                repository.getManagedStatus(),
+            )
+        }
+
+    @Test
+    fun `revoking managed configuration restores user values`() =
+        runBlocking {
+            repository.saveSettings(userConfig).first()
+            repository.saveManagedConfiguration(allManagedConfig()).first()
+
+            repository.saveManagedConfiguration(Bundle()).first()
+
+            assertEquals(userConfig, repository.getConfigSync())
+            assertEquals(unmanagedStatus, repository.getManagedStatus())
+        }
+
+    @Test
+    fun `saving settings preserves underlying values for managed fields`() =
+        runBlocking {
+            repository.saveSettings(userConfig).first()
+            repository
+                .saveManagedConfiguration(
+                    Bundle().apply {
+                        putString(AUTH_URL_KEY, "https://managed.example.com")
+                        putBoolean(CONNECT_ON_START_KEY, false)
+                    },
+                ).first()
+
+            repository
+                .saveSettings(
+                    repository.getConfigSync().copy(
+                        logFilter = "trace",
+                        accountSlug = "changed-account",
+                    ),
+                ).first()
+            repository.saveManagedConfiguration(Bundle()).first()
+
+            assertEquals(
+                userConfig.copy(
+                    logFilter = "trace",
+                    accountSlug = "changed-account",
+                ),
+                repository.getConfigSync(),
+            )
+        }
+
+    @Test
+    fun `default configuration keeps managed values`() =
+        runBlocking {
+            repository
+                .saveManagedConfiguration(
+                    Bundle().apply {
+                        putString(AUTH_URL_KEY, "https://managed.example.com")
+                        putBoolean(CONNECT_ON_START_KEY, true)
+                    },
+                ).first()
+
+            val defaults = repository.getDefaultConfigSync()
+
+            assertEquals("https://managed.example.com", defaults.authUrl)
+            assertTrue(defaults.connectOnStart)
+        }
+
+    private fun allManagedConfig(): Bundle =
+        Bundle().apply {
+            putString(AUTH_URL_KEY, "https://managed.example.com")
+            putString(API_URL_KEY, "wss://managed.example.com")
+            putString(LOG_FILTER_KEY, "debug")
+            putString(ACCOUNT_SLUG_KEY, "managed-account")
+            putBoolean(START_ON_LOGIN_KEY, true)
+            putBoolean(CONNECT_ON_START_KEY, false)
+        }
+
+    private companion object {
+        const val AUTH_URL_KEY = "authUrl"
+        const val API_URL_KEY = "apiUrl"
+        const val LOG_FILTER_KEY = "logFilter"
+        const val ACCOUNT_SLUG_KEY = "accountSlug"
+        const val START_ON_LOGIN_KEY = "startOnLogin"
+        const val CONNECT_ON_START_KEY = "connectOnStart"
+
+        val userConfig =
+            FirezoneConfig(
+                authUrl = "https://user.example.com",
+                apiUrl = "wss://user.example.com",
+                logFilter = "info",
+                accountSlug = "user-account",
+                startOnLogin = false,
+                connectOnStart = true,
+            )
+
+        val unmanagedStatus =
+            ManagedConfigStatus(
+                isAuthUrlManaged = false,
+                isApiUrlManaged = false,
+                isLogFilterManaged = false,
+                isAccountSlugManaged = false,
+                isStartOnLoginManaged = false,
+                isConnectOnStartManaged = false,
+            )
+    }
+}

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/data/RepositoryManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/data/RepositoryManagedConfigurationTest.kt
@@ -112,6 +112,28 @@ class RepositoryManagedConfigurationTest {
         }
 
     @Test
+    fun `saving cannot replace any managed underlying field`() =
+        runBlocking {
+            repository.saveSettings(userConfig).first()
+            repository.saveManagedConfiguration(allManagedConfig()).first()
+
+            repository
+                .saveSettings(
+                    FirezoneConfig(
+                        authUrl = "https://attempted.example.com",
+                        apiUrl = "wss://attempted.example.com",
+                        logFilter = "trace",
+                        accountSlug = "attempted-account",
+                        startOnLogin = true,
+                        connectOnStart = false,
+                    ),
+                ).first()
+            repository.saveManagedConfiguration(Bundle()).first()
+
+            assertEquals(userConfig, repository.getConfigSync())
+        }
+
+    @Test
     fun `default configuration keeps managed values`() =
         runBlocking {
             repository

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/data/RepositoryManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/data/RepositoryManagedConfigurationTest.kt
@@ -150,6 +150,25 @@ class RepositoryManagedConfigurationTest {
             assertTrue(defaults.connectOnStart)
         }
 
+    @Test
+    fun `revoking managed settings preserves the user certificate alias`() =
+        runBlocking {
+            repository.saveX509CertificateAliasSync("user-alias")
+            val managedRestrictions =
+                Bundle().apply {
+                    putString(AUTH_URL_KEY, "https://managed.example.com")
+                    putString(X509_CERTIFICATE_ALIAS_RESTRICTION, "managed-alias")
+                }
+            repository.saveManagedConfiguration(managedRestrictions).first()
+
+            assertEquals("managed-alias", repository.getX509CertificateAliasSync(managedRestrictions))
+
+            val revokedRestrictions = Bundle()
+            repository.saveManagedConfiguration(revokedRestrictions).first()
+
+            assertEquals("user-alias", repository.getX509CertificateAliasSync(revokedRestrictions))
+        }
+
     private fun allManagedConfig(): Bundle =
         Bundle().apply {
             putString(AUTH_URL_KEY, "https://managed.example.com")

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsViewModelTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsViewModelTest.kt
@@ -1,0 +1,76 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.features.settings.ui
+
+import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Bundle
+import android.os.Looper
+import dev.firezone.android.core.data.Repository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class SettingsViewModelTest {
+    private lateinit var sharedPreferences: SharedPreferences
+    private lateinit var repository: Repository
+    private lateinit var viewModel: SettingsViewModel
+
+    @Before
+    fun setUp() {
+        sharedPreferences =
+            RuntimeEnvironment
+                .getApplication()
+                .getSharedPreferences("settings-view-model-test", Context.MODE_PRIVATE)
+        sharedPreferences.edit().clear().commit()
+        repository = Repository(RuntimeEnvironment.getApplication(), Dispatchers.Unconfined, sharedPreferences)
+        viewModel = SettingsViewModel(repository)
+    }
+
+    @Test
+    fun `canceling a reset keeps favorites and managed values`() =
+        runBlocking {
+            repository.addFavoriteResource(FAVORITE_ID)
+            repository
+                .saveManagedConfiguration(
+                    Bundle().apply {
+                        putString("authUrl", "https://managed.example.com")
+                    },
+                ).first()
+
+            viewModel.resetSettingsToDefaults()
+            viewModel.onCancel()
+
+            assertTrue(FAVORITE_ID in repository.favorites.value.inner)
+            assertEquals("https://managed.example.com", viewModel.configStateFlow.value.authUrl)
+        }
+
+    @Test
+    fun `saving a reset clears favorites`() {
+        repository.addFavoriteResource(FAVORITE_ID)
+
+        viewModel.resetSettingsToDefaults()
+        viewModel.onSaveSettingsCompleted()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertTrue(
+            repository.favorites.value.inner
+                .isEmpty(),
+        )
+    }
+
+    private companion object {
+        const val FAVORITE_ID = "favorite-resource"
+    }
+}


### PR DESCRIPTION
Managed configuration is kept as an overlay on top of user preferences so policy removal restores user settings. Applying a new restrictions bundle replaces the previous managed state, and resetting settings only clears favorites after the reset is saved.

Managed X.509 aliases remain an independent device-trust and mTLS overlay. Policy removal restores the user-selected alias, and token authentication remains required.