### PR TITLE
fix(android): preserve external auth lifecycle

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
@@ -45,11 +45,7 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
     override fun onResume() {
         super.onResume()
 
-        when (browserState.resumeAction()) {
-            AuthBrowserState.ResumeAction.START_AUTH_FLOW -> viewModel.onActivityResume()
-            AuthBrowserState.ResumeAction.NAVIGATE_TO_SIGN_IN -> navigateToSignIn()
-            AuthBrowserState.ResumeAction.NONE -> Unit
-        }
+        handleAction(browserState.resumeAction())
     }
 
     private fun setupActionObservers() {
@@ -115,6 +111,14 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
         finish()
     }
 
+    private fun handleAction(action: AuthBrowserState.Action) {
+        when (action) {
+            AuthBrowserState.Action.START_AUTH_FLOW -> viewModel.onActivityResume()
+            AuthBrowserState.Action.NAVIGATE_TO_SIGN_IN -> navigateToSignIn()
+            AuthBrowserState.Action.NONE -> Unit
+        }
+    }
+
     private fun showBrowserRequiredError() {
         AlertDialog
             .Builder(this)
@@ -123,7 +127,7 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
             .setPositiveButton(
                 R.string.error_dialog_button_text,
             ) { _, _ ->
-                this@AuthActivity.finish()
+                handleAction(browserState.browserRequiredAcknowledgementAction())
             }.setIcon(R.drawable.ic_firezone_logo)
             .show()
     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
@@ -23,29 +23,32 @@ import kotlinx.coroutines.launch
 class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
     private lateinit var binding: ActivityAuthBinding
     private val viewModel: AuthViewModel by viewModels()
-    private var hasLaunchedBrowser = false
+    private var browserState = AuthBrowserState.NOT_STARTED
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityAuthBinding.inflate(layoutInflater)
-        hasLaunchedBrowser = savedInstanceState?.getBoolean(BROWSER_LAUNCHED_KEY) == true
+        browserState = AuthBrowserState.restore(savedInstanceState?.getString(BROWSER_STATE_KEY))
 
         setupActionObservers()
+
+        if (browserState == AuthBrowserState.UNAVAILABLE) {
+            showBrowserRequiredError()
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putBoolean(BROWSER_LAUNCHED_KEY, hasLaunchedBrowser)
+        outState.putString(BROWSER_STATE_KEY, browserState.name)
         super.onSaveInstanceState(outState)
     }
 
     override fun onResume() {
         super.onResume()
 
-        if (hasLaunchedBrowser) {
-            // User returned from Custom Tab without completing auth, navigate back to main app
-            navigateToSignIn()
-        } else {
-            viewModel.onActivityResume()
+        when (browserState.resumeAction()) {
+            AuthBrowserState.ResumeAction.START_AUTH_FLOW -> viewModel.onActivityResume()
+            AuthBrowserState.ResumeAction.NAVIGATE_TO_SIGN_IN -> navigateToSignIn()
+            AuthBrowserState.ResumeAction.NONE -> Unit
         }
     }
 
@@ -65,12 +68,16 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
     }
 
     private fun setupWebView(url: String) {
+        if (browserState != AuthBrowserState.NOT_STARTED) {
+            return
+        }
+
         val url = Uri.parse(url)
 
         // Try to use Custom Tabs with the default browser first
         try {
             launchCustomTabsIntent(url)
-            hasLaunchedBrowser = true
+            browserState = AuthBrowserState.LAUNCHED
             return
         } catch (e: ActivityNotFoundException) {
             Log.d(TAG, "CustomTabs don't appear to be available, falling back to ACTION_VIEW intent")
@@ -79,8 +86,9 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
         // Fallback to default browser if Custom Tabs unavailable
         try {
             launchActionViewIntent(url)
-            hasLaunchedBrowser = true
+            browserState = AuthBrowserState.LAUNCHED
         } catch (e: ActivityNotFoundException) {
+            browserState = AuthBrowserState.UNAVAILABLE
             showBrowserRequiredError()
         }
     }
@@ -121,7 +129,7 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
     }
 
     companion object {
-        private const val BROWSER_LAUNCHED_KEY = "browserLaunched"
+        private const val BROWSER_STATE_KEY = "browserState"
         private const val TAG = "AuthActivity"
     }
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
@@ -23,19 +23,25 @@ import kotlinx.coroutines.launch
 class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
     private lateinit var binding: ActivityAuthBinding
     private val viewModel: AuthViewModel by viewModels()
-    private var hasLaunchedCustomTab = false
+    private var hasLaunchedBrowser = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityAuthBinding.inflate(layoutInflater)
+        hasLaunchedBrowser = savedInstanceState?.getBoolean(BROWSER_LAUNCHED_KEY) == true
 
         setupActionObservers()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putBoolean(BROWSER_LAUNCHED_KEY, hasLaunchedBrowser)
+        super.onSaveInstanceState(outState)
     }
 
     override fun onResume() {
         super.onResume()
 
-        if (hasLaunchedCustomTab) {
+        if (hasLaunchedBrowser) {
             // User returned from Custom Tab without completing auth, navigate back to main app
             navigateToSignIn()
         } else {
@@ -59,13 +65,12 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
     }
 
     private fun setupWebView(url: String) {
-        hasLaunchedCustomTab = true
-
         val url = Uri.parse(url)
 
         // Try to use Custom Tabs with the default browser first
         try {
             launchCustomTabsIntent(url)
+            hasLaunchedBrowser = true
             return
         } catch (e: ActivityNotFoundException) {
             Log.d(TAG, "CustomTabs don't appear to be available, falling back to ACTION_VIEW intent")
@@ -74,6 +79,7 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
         // Fallback to default browser if Custom Tabs unavailable
         try {
             launchActionViewIntent(url)
+            hasLaunchedBrowser = true
         } catch (e: ActivityNotFoundException) {
             showBrowserRequiredError()
         }
@@ -115,6 +121,7 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
     }
 
     companion object {
+        private const val BROWSER_LAUNCHED_KEY = "browserLaunched"
         private const val TAG = "AuthActivity"
     }
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
@@ -50,7 +50,7 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
 
     private fun setupActionObservers() {
         lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
+            repeatOnLifecycle(authActionCollectionMinState) {
                 viewModel.actionStateFlow.collect { action ->
                     action?.let {
                         viewModel.clearAction()

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthBrowserState.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthBrowserState.kt
@@ -1,0 +1,26 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.features.auth.ui
+
+internal enum class AuthBrowserState {
+    NOT_STARTED,
+    LAUNCHED,
+    UNAVAILABLE,
+    ;
+
+    fun resumeAction(): ResumeAction =
+        when (this) {
+            NOT_STARTED -> ResumeAction.START_AUTH_FLOW
+            LAUNCHED -> ResumeAction.NAVIGATE_TO_SIGN_IN
+            UNAVAILABLE -> ResumeAction.NONE
+        }
+
+    enum class ResumeAction {
+        START_AUTH_FLOW,
+        NAVIGATE_TO_SIGN_IN,
+        NONE,
+    }
+
+    companion object {
+        fun restore(value: String?): AuthBrowserState = entries.firstOrNull { it.name == value } ?: NOT_STARTED
+    }
+}

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthBrowserState.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthBrowserState.kt
@@ -1,6 +1,10 @@
 // Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
 package dev.firezone.android.features.auth.ui
 
+import androidx.lifecycle.Lifecycle
+
+internal val authActionCollectionMinState = Lifecycle.State.RESUMED
+
 internal enum class AuthBrowserState {
     NOT_STARTED,
     LAUNCHED,

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthBrowserState.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthBrowserState.kt
@@ -7,14 +7,20 @@ internal enum class AuthBrowserState {
     UNAVAILABLE,
     ;
 
-    fun resumeAction(): ResumeAction =
+    fun resumeAction(): Action =
         when (this) {
-            NOT_STARTED -> ResumeAction.START_AUTH_FLOW
-            LAUNCHED -> ResumeAction.NAVIGATE_TO_SIGN_IN
-            UNAVAILABLE -> ResumeAction.NONE
+            NOT_STARTED -> Action.START_AUTH_FLOW
+            LAUNCHED -> Action.NAVIGATE_TO_SIGN_IN
+            UNAVAILABLE -> Action.NONE
         }
 
-    enum class ResumeAction {
+    fun browserRequiredAcknowledgementAction(): Action =
+        when (this) {
+            UNAVAILABLE -> Action.NAVIGATE_TO_SIGN_IN
+            NOT_STARTED, LAUNCHED -> Action.NONE
+        }
+
+    enum class Action {
         START_AUTH_FLOW,
         NAVIGATE_TO_SIGN_IN,
         NONE,

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthRequestState.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthRequestState.kt
@@ -1,0 +1,34 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.features.auth.ui
+
+import androidx.lifecycle.SavedStateHandle
+
+internal class AuthRequestState(
+    private val savedStateHandle: SavedStateHandle,
+) {
+    private var isGenerating = false
+
+    val issuedUrl: String?
+        get() = savedStateHandle[AUTH_REQUEST_URL_KEY]
+
+    fun claimGeneration(): Boolean {
+        if (isGenerating || issuedUrl != null) {
+            return false
+        }
+
+        isGenerating = true
+        return true
+    }
+
+    fun markIssued(url: String) {
+        savedStateHandle[AUTH_REQUEST_URL_KEY] = url
+    }
+
+    fun releaseGeneration() {
+        isGenerating = false
+    }
+
+    private companion object {
+        private const val AUTH_REQUEST_URL_KEY = "authRequestUrl"
+    }
+}

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
@@ -1,6 +1,7 @@
 // Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.auth.ui
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,22 +17,35 @@ internal class AuthViewModel
     @Inject
     constructor(
         private val repo: Repository,
+        savedStateHandle: SavedStateHandle,
     ) : ViewModel() {
-        private val actionMutableStateFlow = MutableStateFlow<ViewAction?>(null)
+        private val requestState = AuthRequestState(savedStateHandle)
+        private val actionMutableStateFlow =
+            MutableStateFlow<ViewAction?>(requestState.issuedUrl?.let(ViewAction::LaunchAuthFlow))
         val actionStateFlow: StateFlow<ViewAction?> = actionMutableStateFlow
 
-        fun onActivityResume() =
-            viewModelScope.launch {
-                val state = generateRandomString(NONCE_LENGTH)
-                val nonce = generateRandomString(NONCE_LENGTH)
-                repo.saveNonceSync(nonce)
-                repo.saveStateSync(state)
-                val config = repo.getConfigSync()
-                val authUrl = "${config.authUrl}/${config.accountSlug}?state=$state&nonce=$nonce&as=gui-client"
-
-                actionMutableStateFlow.value =
-                    ViewAction.LaunchAuthFlow(authUrl)
+        fun onActivityResume() {
+            if (!requestState.claimGeneration()) {
+                return
             }
+
+            viewModelScope.launch {
+                try {
+                    val state = generateRandomString(NONCE_LENGTH)
+                    val nonce = generateRandomString(NONCE_LENGTH)
+                    repo.saveNonceSync(nonce)
+                    repo.saveStateSync(state)
+                    val config = repo.getConfigSync()
+                    val authUrl = "${config.authUrl}/${config.accountSlug}?state=$state&nonce=$nonce&as=gui-client"
+
+                    requestState.markIssued(authUrl)
+                    actionMutableStateFlow.value =
+                        ViewAction.LaunchAuthFlow(authUrl)
+                } finally {
+                    requestState.releaseGeneration()
+                }
+            }
+        }
 
         fun clearAction() {
             actionMutableStateFlow.value = null

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/customuri/ui/CustomUriHandlerActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/customuri/ui/CustomUriHandlerActivity.kt
@@ -31,6 +31,12 @@ class CustomUriHandlerActivity : AppCompatActivity(R.layout.activity_custom_uri_
         viewModel.parseCustomUri(intent)
     }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        viewModel.parseCustomUri(intent)
+    }
+
     private fun setupActionObservers() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthBrowserStateTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthBrowserStateTest.kt
@@ -44,4 +44,24 @@ class AuthBrowserStateTest {
 
         assertEquals(AuthBrowserState.NOT_STARTED, restoredState)
     }
+
+    @Test
+    fun `unknown saved state starts a new authentication flow`() {
+        val restoredState = AuthBrowserState.restore("unknown")
+
+        assertEquals(AuthBrowserState.NOT_STARTED, restoredState)
+        assertEquals(AuthBrowserState.Action.START_AUTH_FLOW, restoredState.resumeAction())
+    }
+
+    @Test
+    fun `browser acknowledgement is ignored unless the browser is unavailable`() {
+        assertEquals(
+            AuthBrowserState.Action.NONE,
+            AuthBrowserState.NOT_STARTED.browserRequiredAcknowledgementAction(),
+        )
+        assertEquals(
+            AuthBrowserState.Action.NONE,
+            AuthBrowserState.LAUNCHED.browserRequiredAcknowledgementAction(),
+        )
+    }
 }

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthBrowserStateTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthBrowserStateTest.kt
@@ -1,10 +1,20 @@
 // Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
 package dev.firezone.android.features.auth.ui
 
+import androidx.lifecycle.Lifecycle
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AuthBrowserStateTest {
+    @Test
+    fun `auth actions wait until the activity is resumed`() {
+        assertFalse(Lifecycle.State.CREATED.isAtLeast(authActionCollectionMinState))
+        assertFalse(Lifecycle.State.STARTED.isAtLeast(authActionCollectionMinState))
+        assertTrue(Lifecycle.State.RESUMED.isAtLeast(authActionCollectionMinState))
+    }
+
     @Test
     fun `starts authentication before launching a browser`() {
         val action = AuthBrowserState.NOT_STARTED.resumeAction()

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthBrowserStateTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthBrowserStateTest.kt
@@ -9,7 +9,7 @@ class AuthBrowserStateTest {
     fun `starts authentication before launching a browser`() {
         val action = AuthBrowserState.NOT_STARTED.resumeAction()
 
-        assertEquals(AuthBrowserState.ResumeAction.START_AUTH_FLOW, action)
+        assertEquals(AuthBrowserState.Action.START_AUTH_FLOW, action)
     }
 
     @Test
@@ -17,7 +17,7 @@ class AuthBrowserStateTest {
         val restoredState = AuthBrowserState.restore(AuthBrowserState.LAUNCHED.name)
 
         assertEquals(AuthBrowserState.LAUNCHED, restoredState)
-        assertEquals(AuthBrowserState.ResumeAction.NAVIGATE_TO_SIGN_IN, restoredState.resumeAction())
+        assertEquals(AuthBrowserState.Action.NAVIGATE_TO_SIGN_IN, restoredState.resumeAction())
     }
 
     @Test
@@ -25,7 +25,17 @@ class AuthBrowserStateTest {
         val restoredState = AuthBrowserState.restore(AuthBrowserState.UNAVAILABLE.name)
 
         assertEquals(AuthBrowserState.UNAVAILABLE, restoredState)
-        assertEquals(AuthBrowserState.ResumeAction.NONE, restoredState.resumeAction())
+        assertEquals(AuthBrowserState.Action.NONE, restoredState.resumeAction())
+    }
+
+    @Test
+    fun `acknowledging browser unavailable returns to sign in`() {
+        val restoredState = AuthBrowserState.restore(AuthBrowserState.UNAVAILABLE.name)
+
+        assertEquals(
+            AuthBrowserState.Action.NAVIGATE_TO_SIGN_IN,
+            restoredState.browserRequiredAcknowledgementAction(),
+        )
     }
 
     @Test

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthBrowserStateTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthBrowserStateTest.kt
@@ -1,0 +1,37 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.features.auth.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AuthBrowserStateTest {
+    @Test
+    fun `starts authentication before launching a browser`() {
+        val action = AuthBrowserState.NOT_STARTED.resumeAction()
+
+        assertEquals(AuthBrowserState.ResumeAction.START_AUTH_FLOW, action)
+    }
+
+    @Test
+    fun `returns to sign in after restoring a launched browser`() {
+        val restoredState = AuthBrowserState.restore(AuthBrowserState.LAUNCHED.name)
+
+        assertEquals(AuthBrowserState.LAUNCHED, restoredState)
+        assertEquals(AuthBrowserState.ResumeAction.NAVIGATE_TO_SIGN_IN, restoredState.resumeAction())
+    }
+
+    @Test
+    fun `browser unavailable remains terminal after restoration`() {
+        val restoredState = AuthBrowserState.restore(AuthBrowserState.UNAVAILABLE.name)
+
+        assertEquals(AuthBrowserState.UNAVAILABLE, restoredState)
+        assertEquals(AuthBrowserState.ResumeAction.NONE, restoredState.resumeAction())
+    }
+
+    @Test
+    fun `missing saved state starts a new authentication flow`() {
+        val restoredState = AuthBrowserState.restore(null)
+
+        assertEquals(AuthBrowserState.NOT_STARTED, restoredState)
+    }
+}

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthRequestStateTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthRequestStateTest.kt
@@ -1,0 +1,36 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.features.auth.ui
+
+import androidx.lifecycle.SavedStateHandle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AuthRequestStateTest {
+    @Test
+    fun `claims request generation only once while in flight`() {
+        val state = AuthRequestState(SavedStateHandle())
+
+        assertTrue(state.claimGeneration())
+        assertFalse(state.claimGeneration())
+    }
+
+    @Test
+    fun `restores issued request without generating another`() {
+        val savedState = SavedStateHandle()
+        val state = AuthRequestState(savedState)
+        check(state.claimGeneration())
+        state.markIssued(AUTH_URL)
+        state.releaseGeneration()
+
+        val restoredState = AuthRequestState(savedState)
+
+        assertEquals(AUTH_URL, restoredState.issuedUrl)
+        assertFalse(restoredState.claimGeneration())
+    }
+
+    private companion object {
+        private const val AUTH_URL = "https://app.example.com/account?state=state&nonce=nonce"
+    }
+}

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthRequestStateTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthRequestStateTest.kt
@@ -30,6 +30,16 @@ class AuthRequestStateTest {
         assertFalse(restoredState.claimGeneration())
     }
 
+    @Test
+    fun `retries generation after an unsuccessful attempt`() {
+        val state = AuthRequestState(SavedStateHandle())
+        check(state.claimGeneration())
+
+        state.releaseGeneration()
+
+        assertTrue(state.claimGeneration())
+    }
+
     private companion object {
         private const val AUTH_URL = "https://app.example.com/account?state=state&nonce=nonce"
     }


### PR DESCRIPTION
Track the external authentication browser lifecycle across Activity recreation so the app neither launches a duplicate authorization flow nor retries a terminal browser-unavailable failure. Collect auth actions only while the Activity is resumed, preventing a restored authorization URL from launching before the first `onResume` and immediately being treated as a browser return. Acknowledging a browser-unavailable failure returns to sign-in even though the previous Activity was finished.

Also handle new callback intents delivered to the existing `singleTop` callback Activity instead of silently reusing the original intent.