### PR TITLE
fix(android): react to managed config changes

### DIFF
--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/di/TestDataModule.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/di/TestDataModule.kt
@@ -3,12 +3,12 @@ package dev.firezone.android.core.di
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.os.Bundle
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
+import dev.firezone.android.core.data.ManagedConfigurationReader
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.tunnel.TestRestrictions
 import kotlinx.coroutines.CoroutineDispatcher
@@ -20,10 +20,9 @@ import javax.inject.Singleton
     replaces = [DataModule::class],
 )
 object TestDataModule {
-    // The real restrictions come from `RestrictionsManager`, which stays empty until a device
-    // owner sets them. Tests write into this bundle instead to stand in for a managed config.
     @Provides
-    internal fun provideApplicationRestrictions(): Bundle = TestRestrictions.bundle
+    internal fun provideManagedConfigurationReader(): ManagedConfigurationReader =
+        ManagedConfigurationReader { TestRestrictions.snapshot() }
 
     @Provides
     @Singleton

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/DeviceTrustE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/DeviceTrustE2eTest.kt
@@ -11,6 +11,7 @@ import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
 import androidx.test.runner.lifecycle.Stage
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.data.TokenStore
 import dev.firezone.android.core.data.X509_CERTIFICATE_ALIAS_RESTRICTION
@@ -60,6 +61,9 @@ class DeviceTrustE2eTest {
     @Inject
     lateinit var preferences: SharedPreferences
 
+    @Inject
+    internal lateinit var managedConfigurationSource: ManagedConfigurationSource
+
     @Before
     fun setUp() {
         hiltRule.inject()
@@ -71,6 +75,7 @@ class DeviceTrustE2eTest {
         stopTunnelService()
         preferences.edit().clear().commit()
         TestRestrictions.bundle.clear()
+        refreshManagedConfiguration()
     }
 
     @Test
@@ -131,13 +136,105 @@ class DeviceTrustE2eTest {
         awaitText("Select your client certificate")
     }
 
+    @Test
+    fun anAvailableManagedCertificateWithoutATokenDoesNotConnectOnStart() {
+        val identity = testIdentity(SERIAL_CLAIM)
+        FakeKeyChain.install(ALIAS, identity, granted = true)
+        TestRestrictions.bundle.putString(X509_CERTIFICATE_ALIAS_RESTRICTION, ALIAS)
+        TestRestrictions.bundle.putBoolean("connectOnStart", true)
+        refreshManagedConfiguration()
+
+        launchApp()
+
+        awaitText("Sign In")
+        assertEquals("a session was opened without a token", 0, FakeSessionFactory.opened)
+    }
+
+    @Test
+    fun managedTokenAndCertificateConnectOnStart() {
+        val identity = testIdentity(SERIAL_CLAIM)
+        FakeKeyChain.install(ALIAS, identity, granted = true)
+        TestRestrictions.bundle.putString(X509_CERTIFICATE_ALIAS_RESTRICTION, ALIAS)
+        TestRestrictions.bundle.putString("token", TOKEN)
+        TestRestrictions.bundle.putBoolean("connectOnStart", true)
+        refreshManagedConfiguration()
+
+        launchApp()
+
+        val session = awaitSession()
+        assertArrayEquals(identity.chain.first().encoded, session.tlsIdentity?.certificateChain()?.first())
+        assertEquals(TOKEN, session.config.token)
+        awaitText("Resources")
+    }
+
+    @Test
+    fun managedCertificateChangesReconnectAndRestoreTheUserSelection() {
+        val userIdentity = testIdentity(SERIAL_CLAIM)
+        val firstManagedIdentity = testIdentity(SERIAL_CLAIM)
+        val secondManagedIdentity = testIdentity(SERIAL_CLAIM)
+        givenTheUserPicked(userIdentity)
+        tokenStore.save(TOKEN)
+        FakeKeyChain.install(FIRST_MANAGED_ALIAS, firstManagedIdentity, granted = true)
+        FakeKeyChain.install(SECOND_MANAGED_ALIAS, secondManagedIdentity, granted = true)
+
+        TestRestrictions.bundle.putString(X509_CERTIFICATE_ALIAS_RESTRICTION, FIRST_MANAGED_ALIAS)
+        refreshManagedConfiguration()
+        startTunnelService()
+
+        val firstSession = awaitSession()
+        assertArrayEquals(
+            firstManagedIdentity.chain.first().encoded,
+            firstSession.tlsIdentity?.certificateChain()?.first(),
+        )
+        assertEquals(TOKEN, firstSession.config.token)
+
+        TestRestrictions.bundle.putString(X509_CERTIFICATE_ALIAS_RESTRICTION, SECOND_MANAGED_ALIAS)
+        refreshManagedConfiguration()
+        runBlocking { withTimeout(TIMEOUT_MS) { firstSession.awaitCommand("disconnect") } }
+
+        val secondSession = awaitSession()
+        assertArrayEquals(
+            secondManagedIdentity.chain.first().encoded,
+            secondSession.tlsIdentity?.certificateChain()?.first(),
+        )
+        assertEquals(TOKEN, secondSession.config.token)
+
+        TestRestrictions.bundle.putString(X509_CERTIFICATE_ALIAS_RESTRICTION, "")
+        refreshManagedConfiguration()
+        runBlocking { withTimeout(TIMEOUT_MS) { secondSession.awaitCommand("disconnect") } }
+
+        val tokenOnlySession = awaitSession()
+        assertNull(tokenOnlySession.tlsIdentity)
+        assertEquals(TOKEN, tokenOnlySession.config.token)
+
+        TestRestrictions.bundle.remove(X509_CERTIFICATE_ALIAS_RESTRICTION)
+        refreshManagedConfiguration()
+        runBlocking { withTimeout(TIMEOUT_MS) { tokenOnlySession.awaitCommand("disconnect") } }
+
+        val restoredSession = awaitSession()
+        assertArrayEquals(
+            userIdentity.chain.first().encoded,
+            restoredSession.tlsIdentity?.certificateChain()?.first(),
+        )
+        assertEquals(TOKEN, restoredSession.config.token)
+        assertEquals(ALIAS, repo.getUserX509CertificateAliasSync())
+    }
+
     /** Installs [certificate] as granted and records its alias the way settings would. */
     private fun givenCertificate(certificate: TestIdentity) {
         FakeKeyChain.install(ALIAS, certificate, granted = true)
         repo.saveX509CertificateAliasSync(ALIAS)
     }
 
+    /** Installs [identity] as granted and records its alias the way the settings screen would. */
+    private fun givenTheUserPicked(identity: TestIdentity) {
+        FakeKeyChain.install(ALIAS, identity, granted = true)
+        repo.saveX509CertificateAliasSync(ALIAS)
+    }
+
     private fun awaitSession(): FakeSession = runBlocking { withTimeout(TIMEOUT_MS) { FakeSessionFactory.awaitSession() } }
+
+    private fun refreshManagedConfiguration() = runBlocking { managedConfigurationSource.refresh() }
 
     private fun authActivityExists(): Boolean {
         var exists = false
@@ -180,6 +277,8 @@ class DeviceTrustE2eTest {
 
     private companion object {
         const val ALIAS = "firezone-e2e"
+        const val FIRST_MANAGED_ALIAS = "firezone-managed-first"
+        const val SECOND_MANAGED_ALIAS = "firezone-managed-second"
         const val TOKEN = "browser-token"
         const val TIMEOUT_MS = 20_000L
 

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.data.TokenStore
 import dev.firezone.android.tunnel.ACCOUNT_SLUG
@@ -66,6 +67,9 @@ class TunnelE2eTest {
     @Inject
     lateinit var preferences: SharedPreferences
 
+    @Inject
+    internal lateinit var managedConfigurationSource: ManagedConfigurationSource
+
     @Before
     fun setUp() {
         hiltRule.inject()
@@ -79,6 +83,7 @@ class TunnelE2eTest {
         notificationManager().cancelAll()
         preferences.edit().clear().commit()
         TestRestrictions.bundle.clear()
+        refreshManagedConfiguration()
     }
 
     @Test
@@ -222,12 +227,54 @@ class TunnelE2eTest {
         signIn()
         TestRestrictions.bundle.putString("token", "managed-token")
         TestRestrictions.bundle.putString("deviceName", "Managed Pixel")
+        refreshManagedConfiguration()
 
         startTunnelService()
         val session = awaitSession()
 
         assertEquals("managed-token", session.config.token)
         assertEquals("Managed Pixel", session.config.deviceName)
+    }
+
+    @Test
+    fun managedTokenUpdatesReconnectAndRevocationRestoresTheSavedToken() {
+        signIn()
+        TestRestrictions.bundle.putString("token", "first-managed-token")
+        refreshManagedConfiguration()
+        startTunnelService()
+
+        val firstSession = awaitSession()
+        assertEquals("first-managed-token", firstSession.config.token)
+
+        TestRestrictions.bundle.putString("token", "second-managed-token")
+        refreshManagedConfiguration()
+        runBlocking { withTimeout(TIMEOUT_MS) { firstSession.awaitCommand("disconnect") } }
+
+        val secondSession = awaitSession()
+        assertEquals("second-managed-token", secondSession.config.token)
+
+        TestRestrictions.bundle.remove("token")
+        refreshManagedConfiguration()
+        runBlocking { withTimeout(TIMEOUT_MS) { secondSession.awaitCommand("disconnect") } }
+
+        val restoredSession = awaitSession()
+        assertEquals(TOKEN, restoredSession.config.token)
+        assertEquals(TOKEN, repo.getTokenSync())
+    }
+
+    @Test
+    fun managedAuthenticationFailurePreservesTheSavedUserToken() {
+        signIn()
+        TestRestrictions.bundle.putString("token", "managed-token")
+        refreshManagedConfiguration()
+        startTunnelService()
+
+        val session = awaitSession()
+        assertEquals("managed-token", session.config.token)
+        session.emit(Event.Disconnected(FakeDisconnectError(signInRequired = true, text = "managed session expired")))
+
+        assertEquals("managed session expired", awaitDisconnectedNotification())
+        assertEquals(TOKEN, repo.getTokenSync())
     }
 
     private fun signInAndConnect(): FakeSession {
@@ -238,6 +285,8 @@ class TunnelE2eTest {
     }
 
     private fun signIn() = tokenStore.save(TOKEN)
+
+    private fun refreshManagedConfiguration() = runBlocking { managedConfigurationSource.refresh() }
 
     private fun awaitSession(): FakeSession = runBlocking { withTimeout(TIMEOUT_MS) { FakeSessionFactory.awaitSession() } }
 

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
@@ -259,7 +259,7 @@ class TunnelE2eTest {
 
         val restoredSession = awaitSession()
         assertEquals(TOKEN, restoredSession.config.token)
-        assertEquals(TOKEN, repo.getTokenSync())
+        assertEquals(TOKEN, tokenStore.get())
     }
 
     @Test
@@ -274,7 +274,7 @@ class TunnelE2eTest {
         session.emit(Event.Disconnected(FakeDisconnectError(signInRequired = true, text = "managed session expired")))
 
         assertEquals("managed session expired", awaitDisconnectedNotification())
-        assertEquals(TOKEN, repo.getTokenSync())
+        assertEquals(TOKEN, tokenStore.get())
     }
 
     private fun signInAndConnect(): FakeSession {

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/TestRestrictions.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/TestRestrictions.kt
@@ -7,4 +7,6 @@ import android.os.Bundle
 // reason as the session factory: the service reading it may predate the test writing it.
 object TestRestrictions {
     val bundle = Bundle()
+
+    fun snapshot(): Bundle = Bundle(bundle)
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/BootReceiver.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/BootReceiver.kt
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import dagger.hilt.android.AndroidEntryPoint
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.di.ApplicationScope
 import dev.firezone.android.tunnel.TunnelService
@@ -19,6 +20,9 @@ class BootReceiver : BroadcastReceiver() {
     lateinit var repo: Repository
 
     @Inject
+    internal lateinit var managedConfigurationSource: ManagedConfigurationSource
+
+    @Inject
     @ApplicationScope
     lateinit var applicationScope: CoroutineScope
 
@@ -27,11 +31,17 @@ class BootReceiver : BroadcastReceiver() {
         intent: Intent,
     ) {
         if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            val pendingResult = goAsync()
             applicationScope.launch(Dispatchers.IO) {
-                val userConfig = repo.getConfigSync()
-                if (userConfig.startOnLogin) {
-                    val serviceIntent = Intent(context, TunnelService::class.java)
-                    context.startService(serviceIntent)
+                try {
+                    managedConfigurationSource.refresh()
+                    val userConfig = repo.getConfigSync()
+                    if (userConfig.startOnLogin) {
+                        val serviceIntent = Intent(context, TunnelService::class.java)
+                        context.startService(serviceIntent)
+                    }
+                } finally {
+                    pendingResult.finish()
                 }
             }
         }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/BootReceiver.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/BootReceiver.kt
@@ -34,9 +34,9 @@ class BootReceiver : BroadcastReceiver() {
             val pendingResult = goAsync()
             applicationScope.launch(Dispatchers.IO) {
                 try {
-                    managedConfigurationSource.refresh()
-                    val userConfig = repo.getConfigSync()
-                    if (userConfig.startOnLogin) {
+                    val managedConfiguration = managedConfigurationSource.refresh()
+                    val config = repo.getEffectiveConfig(repo.getUserConfigSync(), managedConfiguration)
+                    if (config.startOnLogin) {
                         val serviceIntent = Intent(context, TunnelService::class.java)
                         context.startService(serviceIntent)
                     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
@@ -10,17 +10,24 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.HiltAndroidApp
 import dev.firezone.android.BuildConfig
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.tunnel.TunnelService
 import uniffi.connlib.ConnlibException
 import uniffi.connlib.configureLogger
 import uniffi.connlib.drainFlowLogs
 import java.io.IOException
+import javax.inject.Inject
 import kotlin.concurrent.thread
 
 @HiltAndroidApp
 class FirezoneApp : Application() {
+    @Inject
+    internal lateinit var managedConfigurationSource: ManagedConfigurationSource
+
     override fun onCreate() {
         super.onCreate()
+
+        managedConfigurationSource.start()
 
         // Initialize Telemetry as early as possible
         Telemetry.start(this)

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/ManagedConfigurationSource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/ManagedConfigurationSource.kt
@@ -21,6 +21,11 @@ import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 
+internal data class ManagedConfigurationUpdate(
+    val revision: Long,
+    val configuration: ManagedConfiguration,
+)
+
 @Singleton
 internal class ManagedConfigurationSource
     @Inject
@@ -33,8 +38,11 @@ internal class ManagedConfigurationSource
         private val refreshMutex = Mutex()
         private val _configuration = MutableStateFlow<ManagedConfiguration?>(null)
         val configuration = _configuration.asStateFlow()
+        private val _updates = MutableStateFlow<ManagedConfigurationUpdate?>(null)
+        val updates = _updates.asStateFlow()
 
         private var started = false
+        private var revision = 0L
 
         private val restrictionsReceiver =
             object : BroadcastReceiver() {
@@ -69,14 +77,30 @@ internal class ManagedConfigurationSource
             applicationScope.launch { refresh() }
         }
 
-        suspend fun refresh(): ManagedConfiguration = applyRestrictions(restrictionsManager.applicationRestrictions)
+        suspend fun refresh(): ManagedConfiguration = refreshUpdate().configuration
+
+        internal suspend fun refreshUpdate(): ManagedConfigurationUpdate =
+            refreshMutex.withLock {
+                applyRestrictionsLocked(restrictionsManager.applicationRestrictions)
+            }
+
+        internal suspend fun refresh(readRestrictions: suspend () -> Bundle): ManagedConfiguration =
+            refreshMutex.withLock {
+                applyRestrictionsLocked(readRestrictions()).configuration
+            }
 
         internal suspend fun applyRestrictions(bundle: Bundle): ManagedConfiguration =
             refreshMutex.withLock {
-                repository.saveManagedConfiguration(bundle).first()
-
-                val configuration = ManagedConfiguration.from(bundle)
-                _configuration.value = configuration
-                configuration
+                applyRestrictionsLocked(bundle).configuration
             }
+
+        private suspend fun applyRestrictionsLocked(bundle: Bundle): ManagedConfigurationUpdate {
+            repository.saveManagedConfiguration(bundle).first()
+
+            val configuration = ManagedConfiguration.from(bundle)
+            val update = ManagedConfigurationUpdate(++revision, configuration)
+            _configuration.value = configuration
+            _updates.value = update
+            return update
+        }
     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/ManagedConfigurationSource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/ManagedConfigurationSource.kt
@@ -1,0 +1,82 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.core.data
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.RestrictionsManager
+import android.os.Bundle
+import androidx.core.content.ContextCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.firezone.android.core.data.model.ManagedConfiguration
+import dev.firezone.android.core.di.ApplicationScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class ManagedConfigurationSource
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+        private val restrictionsManager: RestrictionsManager,
+        private val repository: Repository,
+        @ApplicationScope private val applicationScope: CoroutineScope,
+    ) {
+        private val refreshMutex = Mutex()
+        private val _configuration = MutableStateFlow<ManagedConfiguration?>(null)
+        val configuration = _configuration.asStateFlow()
+
+        private var started = false
+
+        private val restrictionsReceiver =
+            object : BroadcastReceiver() {
+                override fun onReceive(
+                    context: Context,
+                    intent: Intent,
+                ) {
+                    val pendingResult = goAsync()
+                    applicationScope.launch {
+                        try {
+                            refresh()
+                        } finally {
+                            pendingResult.finish()
+                        }
+                    }
+                }
+            }
+
+        @Synchronized
+        fun start() {
+            if (started) {
+                return
+            }
+            started = true
+
+            ContextCompat.registerReceiver(
+                context,
+                restrictionsReceiver,
+                IntentFilter(Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED),
+                ContextCompat.RECEIVER_EXPORTED,
+            )
+            applicationScope.launch { refresh() }
+        }
+
+        suspend fun refresh(): ManagedConfiguration = applyRestrictions(restrictionsManager.applicationRestrictions)
+
+        internal suspend fun applyRestrictions(bundle: Bundle): ManagedConfiguration =
+            refreshMutex.withLock {
+                repository.saveManagedConfiguration(bundle).first()
+
+                val configuration = ManagedConfiguration.from(bundle)
+                _configuration.value = configuration
+                configuration
+            }
+    }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/ManagedConfigurationSource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/ManagedConfigurationSource.kt
@@ -5,7 +5,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.content.RestrictionsManager
 import android.os.Bundle
 import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -26,12 +25,16 @@ internal data class ManagedConfigurationUpdate(
     val configuration: ManagedConfiguration,
 )
 
+internal fun interface ManagedConfigurationReader {
+    fun read(): Bundle
+}
+
 @Singleton
 internal class ManagedConfigurationSource
     @Inject
     constructor(
         @ApplicationContext private val context: Context,
-        private val restrictionsManager: RestrictionsManager,
+        private val managedConfigurationReader: ManagedConfigurationReader,
         private val repository: Repository,
         @ApplicationScope private val applicationScope: CoroutineScope,
     ) {
@@ -81,7 +84,7 @@ internal class ManagedConfigurationSource
 
         internal suspend fun refreshUpdate(): ManagedConfigurationUpdate =
             refreshMutex.withLock {
-                applyRestrictionsLocked(restrictionsManager.applicationRestrictions)
+                applyRestrictionsLocked(managedConfigurationReader.read())
             }
 
         internal suspend fun refresh(readRestrictions: suspend () -> Bundle): ManagedConfiguration =

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -94,7 +94,7 @@ class Repository
 
         internal fun getEffectiveConfigFromPersistedManaged(userConfig: Config): Config = userConfig.withManagedOverrides()
 
-        fun mergeUnmanagedConfig(
+        private fun mergeUnmanagedConfig(
             userConfig: Config,
             editedConfig: Config,
             managedStatus: ManagedConfigStatus,

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -189,25 +189,11 @@ class Repository
                 emit(editor.apply())
             }.flowOn(coroutineDispatcher)
 
-        /**
-         * The KeyChain alias of the client certificate to present to the portal.
-         *
-         * A managed configuration overrides whatever the user picked, and one that sets the alias to
-         * an empty value turns certificate-based device attestation off entirely.
-         */
-        fun getX509CertificateAliasSync(applicationRestrictions: Bundle): String? =
-            if (isX509CertificateAliasManaged(applicationRestrictions)) {
-                applicationRestrictions
-                    .getString(X509_CERTIFICATE_ALIAS_RESTRICTION)
-                    ?.takeUnless(String::isBlank)
-            } else {
-                sharedPreferences
-                    .getString(X509_CERTIFICATE_ALIAS_KEY, null)
-                    ?.takeUnless(String::isBlank)
-            }
-
-        fun isX509CertificateAliasManaged(applicationRestrictions: Bundle): Boolean =
-            applicationRestrictions.containsKey(X509_CERTIFICATE_ALIAS_RESTRICTION)
+        /** The user-selected KeyChain alias, before a managed configuration is applied. */
+        fun getUserX509CertificateAliasSync(): String? =
+            sharedPreferences
+                .getString(X509_CERTIFICATE_ALIAS_KEY, null)
+                ?.takeUnless(String::isBlank)
 
         fun saveX509CertificateAliasSync(alias: String?) {
             sharedPreferences.edit().apply {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -10,6 +10,7 @@ import com.google.gson.reflect.TypeToken
 import dev.firezone.android.BuildConfig
 import dev.firezone.android.core.data.model.Config
 import dev.firezone.android.core.data.model.ManagedConfigStatus
+import dev.firezone.android.core.data.model.ManagedConfiguration
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -71,7 +72,7 @@ class Repository
             MutableStateFlow(Favorites(HashSet(sharedPreferences.getStringSet(FAVORITE_RESOURCES_KEY, null).orEmpty())))
         val favorites = _favorites.asStateFlow()
 
-        fun getConfigSync(): Config = getEffectiveConfig(getUserConfigSync())
+        fun getConfigSync(): Config = getUserConfigSync().withManagedOverrides()
 
         fun getUserConfigSync(): Config {
             val defaults = getDefaultUserConfigSync()
@@ -86,7 +87,10 @@ class Repository
             )
         }
 
-        fun getEffectiveConfig(userConfig: Config): Config = userConfig.withManagedOverrides()
+        internal fun getEffectiveConfig(
+            userConfig: Config,
+            managedConfiguration: ManagedConfiguration,
+        ): Config = managedConfiguration.applyTo(userConfig)
 
         fun mergeUnmanagedConfig(
             userConfig: Config,
@@ -115,7 +119,7 @@ class Repository
                 emit(getConfigSync())
             }.flowOn(coroutineDispatcher)
 
-        fun getDefaultConfigSync(): Config = getEffectiveConfig(getDefaultUserConfigSync())
+        fun getDefaultConfigSync(): Config = getDefaultUserConfigSync().withManagedOverrides()
 
         fun getDefaultUserConfigSync(): Config =
             Config(
@@ -135,17 +139,12 @@ class Repository
         fun saveSettings(value: Config): Flow<Unit> =
             flow {
                 val userConfig = mergeUnmanagedConfig(getUserConfigSync(), value, getManagedStatus())
-                emit(
-                    sharedPreferences
-                        .edit()
-                        .putString(AUTH_URL_KEY, userConfig.authUrl)
-                        .putString(API_URL_KEY, userConfig.apiUrl)
-                        .putString(LOG_FILTER_KEY, userConfig.logFilter)
-                        .putString(ACCOUNT_SLUG_KEY, userConfig.accountSlug)
-                        .putBoolean(START_ON_LOGIN_KEY, userConfig.startOnLogin)
-                        .putBoolean(CONNECT_ON_START_KEY, userConfig.connectOnStart)
-                        .apply(),
-                )
+                emit(saveUserConfigSync(userConfig))
+            }.flowOn(coroutineDispatcher)
+
+        fun saveUserConfig(value: Config): Flow<Unit> =
+            flow {
+                emit(saveUserConfigSync(value))
             }.flowOn(coroutineDispatcher)
 
         // TODO: Consider adding support for the legacy managed configuration keys like token,
@@ -301,6 +300,17 @@ class Repository
         fun setNotificationPermissionRequested() {
             sharedPreferences.edit().putBoolean(NOTIFICATION_PERMISSION_REQUESTED_KEY, true).apply()
         }
+
+        private fun saveUserConfigSync(value: Config) =
+            sharedPreferences
+                .edit()
+                .putString(AUTH_URL_KEY, value.authUrl)
+                .putString(API_URL_KEY, value.apiUrl)
+                .putString(LOG_FILTER_KEY, value.logFilter)
+                .putString(ACCOUNT_SLUG_KEY, value.accountSlug)
+                .putBoolean(START_ON_LOGIN_KEY, value.startOnLogin)
+                .putBoolean(CONNECT_ON_START_KEY, value.connectOnStart)
+                .apply()
 
         private fun Config.withManagedOverrides(): Config =
             copy(

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -92,6 +92,8 @@ class Repository
             managedConfiguration: ManagedConfiguration,
         ): Config = managedConfiguration.applyTo(userConfig)
 
+        internal fun getEffectiveConfigFromPersistedManaged(userConfig: Config): Config = userConfig.withManagedOverrides()
+
         fun mergeUnmanagedConfig(
             userConfig: Config,
             editedConfig: Config,

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -71,14 +71,61 @@ class Repository
             MutableStateFlow(Favorites(HashSet(sharedPreferences.getStringSet(FAVORITE_RESOURCES_KEY, null).orEmpty())))
         val favorites = _favorites.asStateFlow()
 
-        fun getConfigSync(): Config = getUserConfigSync().withManagedOverrides()
+        fun getConfigSync(): Config = getEffectiveConfig(getUserConfigSync())
+
+        fun getUserConfigSync(): Config {
+            val defaults = getDefaultUserConfigSync()
+
+            return Config(
+                authUrl = sharedPreferences.getString(AUTH_URL_KEY, null) ?: defaults.authUrl,
+                apiUrl = sharedPreferences.getString(API_URL_KEY, null) ?: defaults.apiUrl,
+                logFilter = sharedPreferences.getString(LOG_FILTER_KEY, null) ?: defaults.logFilter,
+                accountSlug = sharedPreferences.getString(ACCOUNT_SLUG_KEY, null) ?: defaults.accountSlug,
+                startOnLogin = sharedPreferences.getBoolean(START_ON_LOGIN_KEY, defaults.startOnLogin),
+                connectOnStart = sharedPreferences.getBoolean(CONNECT_ON_START_KEY, defaults.connectOnStart),
+            )
+        }
+
+        fun getEffectiveConfig(userConfig: Config): Config = userConfig.withManagedOverrides()
+
+        fun mergeUnmanagedConfig(
+            userConfig: Config,
+            editedConfig: Config,
+            managedStatus: ManagedConfigStatus,
+        ): Config =
+            userConfig.copy(
+                authUrl = editedConfig.authUrl.takeUnless { managedStatus.isAuthUrlManaged } ?: userConfig.authUrl,
+                apiUrl = editedConfig.apiUrl.takeUnless { managedStatus.isApiUrlManaged } ?: userConfig.apiUrl,
+                logFilter =
+                    editedConfig.logFilter.takeUnless { managedStatus.isLogFilterManaged }
+                        ?: userConfig.logFilter,
+                accountSlug =
+                    editedConfig.accountSlug.takeUnless { managedStatus.isAccountSlugManaged }
+                        ?: userConfig.accountSlug,
+                startOnLogin =
+                    editedConfig.startOnLogin.takeUnless { managedStatus.isStartOnLoginManaged }
+                        ?: userConfig.startOnLogin,
+                connectOnStart =
+                    editedConfig.connectOnStart.takeUnless { managedStatus.isConnectOnStartManaged }
+                        ?: userConfig.connectOnStart,
+            )
 
         fun getConfig(): Flow<Config> =
             flow {
                 emit(getConfigSync())
             }.flowOn(coroutineDispatcher)
 
-        fun getDefaultConfigSync(): Config = getBuildDefaultConfig().withManagedOverrides()
+        fun getDefaultConfigSync(): Config = getEffectiveConfig(getDefaultUserConfigSync())
+
+        fun getDefaultUserConfigSync(): Config =
+            Config(
+                authUrl = BuildConfig.AUTH_URL,
+                apiUrl = BuildConfig.API_URL,
+                logFilter = BuildConfig.LOG_FILTER,
+                accountSlug = "",
+                startOnLogin = false,
+                connectOnStart = false,
+            )
 
         fun getDefaultConfig(): Flow<Config> =
             flow {
@@ -87,29 +134,18 @@ class Repository
 
         fun saveSettings(value: Config): Flow<Unit> =
             flow {
-                val managedStatus = getManagedStatus()
-                val editor = sharedPreferences.edit()
-
-                if (!managedStatus.isAuthUrlManaged) {
-                    editor.putString(AUTH_URL_KEY, value.authUrl)
-                }
-                if (!managedStatus.isApiUrlManaged) {
-                    editor.putString(API_URL_KEY, value.apiUrl)
-                }
-                if (!managedStatus.isLogFilterManaged) {
-                    editor.putString(LOG_FILTER_KEY, value.logFilter)
-                }
-                if (!managedStatus.isAccountSlugManaged) {
-                    editor.putString(ACCOUNT_SLUG_KEY, value.accountSlug)
-                }
-                if (!managedStatus.isStartOnLoginManaged) {
-                    editor.putBoolean(START_ON_LOGIN_KEY, value.startOnLogin)
-                }
-                if (!managedStatus.isConnectOnStartManaged) {
-                    editor.putBoolean(CONNECT_ON_START_KEY, value.connectOnStart)
-                }
-
-                emit(editor.apply())
+                val userConfig = mergeUnmanagedConfig(getUserConfigSync(), value, getManagedStatus())
+                emit(
+                    sharedPreferences
+                        .edit()
+                        .putString(AUTH_URL_KEY, userConfig.authUrl)
+                        .putString(API_URL_KEY, userConfig.apiUrl)
+                        .putString(LOG_FILTER_KEY, userConfig.logFilter)
+                        .putString(ACCOUNT_SLUG_KEY, userConfig.accountSlug)
+                        .putBoolean(START_ON_LOGIN_KEY, userConfig.startOnLogin)
+                        .putBoolean(CONNECT_ON_START_KEY, userConfig.connectOnStart)
+                        .apply(),
+                )
             }.flowOn(coroutineDispatcher)
 
         // TODO: Consider adding support for the legacy managed configuration keys like token,
@@ -265,29 +301,6 @@ class Repository
         fun setNotificationPermissionRequested() {
             sharedPreferences.edit().putBoolean(NOTIFICATION_PERMISSION_REQUESTED_KEY, true).apply()
         }
-
-        private fun getUserConfigSync(): Config {
-            val defaults = getBuildDefaultConfig()
-
-            return Config(
-                authUrl = sharedPreferences.getString(AUTH_URL_KEY, null) ?: defaults.authUrl,
-                apiUrl = sharedPreferences.getString(API_URL_KEY, null) ?: defaults.apiUrl,
-                logFilter = sharedPreferences.getString(LOG_FILTER_KEY, null) ?: defaults.logFilter,
-                accountSlug = sharedPreferences.getString(ACCOUNT_SLUG_KEY, null) ?: defaults.accountSlug,
-                startOnLogin = sharedPreferences.getBoolean(START_ON_LOGIN_KEY, defaults.startOnLogin),
-                connectOnStart = sharedPreferences.getBoolean(CONNECT_ON_START_KEY, defaults.connectOnStart),
-            )
-        }
-
-        private fun getBuildDefaultConfig(): Config =
-            Config(
-                authUrl = BuildConfig.AUTH_URL,
-                apiUrl = BuildConfig.API_URL,
-                logFilter = BuildConfig.LOG_FILTER,
-                accountSlug = "",
-                startOnLogin = false,
-                connectOnStart = false,
-            )
 
         private fun Config.withManagedOverrides(): Config =
             copy(

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/ManagedConfiguration.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/ManagedConfiguration.kt
@@ -1,0 +1,61 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.core.data.model
+
+import android.os.Bundle
+
+internal data class ManagedConfiguration(
+    val token: String? = null,
+    val allowedApplications: String? = null,
+    val disallowedApplications: String? = null,
+    val deviceName: String? = null,
+    val authUrl: String? = null,
+    val apiUrl: String? = null,
+    val logFilter: String? = null,
+    val accountSlug: String? = null,
+    val startOnLogin: Boolean? = null,
+    val connectOnStart: Boolean? = null,
+) {
+    fun requiresSessionReconnect(previous: ManagedConfiguration): Boolean =
+        token != previous.token ||
+            deviceName != previous.deviceName ||
+            apiUrl != previous.apiUrl ||
+            accountSlug != previous.accountSlug
+
+    fun requiresVpnRebuild(previous: ManagedConfiguration): Boolean =
+        allowedApplications != previous.allowedApplications ||
+            disallowedApplications != previous.disallowedApplications
+
+    companion object {
+        fun from(bundle: Bundle): ManagedConfiguration =
+            ManagedConfiguration(
+                token = bundle.getString(TOKEN_KEY),
+                allowedApplications = bundle.getString(ALLOWED_APPLICATIONS_KEY),
+                disallowedApplications = bundle.getString(DISALLOWED_APPLICATIONS_KEY),
+                deviceName = bundle.getString(DEVICE_NAME_KEY),
+                authUrl = bundle.getString(AUTH_URL_KEY),
+                apiUrl = bundle.getString(API_URL_KEY),
+                logFilter = bundle.getString(LOG_FILTER_KEY),
+                accountSlug = bundle.getString(ACCOUNT_SLUG_KEY),
+                startOnLogin = bundle.getBooleanOrNull(START_ON_LOGIN_KEY),
+                connectOnStart = bundle.getBooleanOrNull(CONNECT_ON_START_KEY),
+            )
+
+        private fun Bundle.getBooleanOrNull(key: String): Boolean? =
+            if (containsKey(key)) {
+                getBoolean(key)
+            } else {
+                null
+            }
+
+        private const val TOKEN_KEY = "token"
+        private const val ALLOWED_APPLICATIONS_KEY = "allowedApplications"
+        private const val DISALLOWED_APPLICATIONS_KEY = "disallowedApplications"
+        private const val DEVICE_NAME_KEY = "deviceName"
+        private const val AUTH_URL_KEY = "authUrl"
+        private const val API_URL_KEY = "apiUrl"
+        private const val LOG_FILTER_KEY = "logFilter"
+        private const val ACCOUNT_SLUG_KEY = "accountSlug"
+        private const val START_ON_LOGIN_KEY = "startOnLogin"
+        private const val CONNECT_ON_START_KEY = "connectOnStart"
+    }
+}

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/ManagedConfiguration.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/ManagedConfiguration.kt
@@ -3,6 +3,19 @@ package dev.firezone.android.core.data.model
 
 import android.os.Bundle
 
+internal enum class CredentialOrigin {
+    MANAGED,
+    USER,
+}
+
+internal fun CredentialOrigin.shouldClearSavedCredentials(requiresSignIn: Boolean): Boolean =
+    requiresSignIn && this == CredentialOrigin.USER
+
+internal data class SessionCredential(
+    val token: String,
+    val origin: CredentialOrigin,
+)
+
 internal data class ManagedConfiguration(
     val token: String? = null,
     val allowedApplications: String? = null,
@@ -24,6 +37,14 @@ internal data class ManagedConfiguration(
     fun requiresVpnRebuild(previous: ManagedConfiguration): Boolean =
         allowedApplications != previous.allowedApplications ||
             disallowedApplications != previous.disallowedApplications
+
+    fun resolveSessionCredential(userToken: String?): SessionCredential? {
+        val origin = if (token != null) CredentialOrigin.MANAGED else CredentialOrigin.USER
+        val resolvedToken = token ?: userToken
+
+        // A present but blank managed token explicitly disables the saved user-token fallback.
+        return resolvedToken?.takeIf { it.isNotBlank() }?.let { SessionCredential(it, origin) }
+    }
 
     companion object {
         fun from(bundle: Bundle): ManagedConfiguration =

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/ManagedConfiguration.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/ManagedConfiguration.kt
@@ -2,6 +2,7 @@
 package dev.firezone.android.core.data.model
 
 import android.os.Bundle
+import dev.firezone.android.core.data.X509_CERTIFICATE_ALIAS_RESTRICTION
 
 internal enum class CredentialOrigin {
     MANAGED,
@@ -27,11 +28,16 @@ internal data class ManagedConfiguration(
     val accountSlug: String? = null,
     val startOnLogin: Boolean? = null,
     val connectOnStart: Boolean? = null,
+    /** Raw alias value; [x509CertificateAliasManaged] preserves whether the key was present. */
+    val x509CertificateAlias: String? = null,
+    val x509CertificateAliasManaged: Boolean = x509CertificateAlias != null,
 ) {
     fun requiresSessionReconnect(previous: ManagedConfiguration): Boolean =
         token != previous.token ||
             deviceName != previous.deviceName ||
-            apiUrl != previous.apiUrl
+            apiUrl != previous.apiUrl ||
+            x509CertificateAlias != previous.x509CertificateAlias ||
+            x509CertificateAliasManaged != previous.x509CertificateAliasManaged
 
     fun requiresVpnRebuild(previous: ManagedConfiguration): Boolean =
         allowedApplications != previous.allowedApplications ||
@@ -65,6 +71,15 @@ internal data class ManagedConfiguration(
         return resolvedToken?.takeIf { it.isNotBlank() }?.let { SessionCredential(it, origin) }
     }
 
+    fun resolveX509CertificateAlias(userAlias: String?): String? =
+        if (x509CertificateAliasManaged) {
+            x509CertificateAlias?.takeUnless(String::isBlank)
+        } else {
+            userAlias?.takeUnless(String::isBlank)
+        }
+
+    fun isX509CertificateAliasManaged(): Boolean = x509CertificateAliasManaged
+
     companion object {
         fun from(bundle: Bundle): ManagedConfiguration =
             ManagedConfiguration(
@@ -78,6 +93,8 @@ internal data class ManagedConfiguration(
                 accountSlug = bundle.getString(ACCOUNT_SLUG_KEY),
                 startOnLogin = bundle.getBooleanOrNull(START_ON_LOGIN_KEY),
                 connectOnStart = bundle.getBooleanOrNull(CONNECT_ON_START_KEY),
+                x509CertificateAlias = bundle.getString(X509_CERTIFICATE_ALIAS_RESTRICTION),
+                x509CertificateAliasManaged = bundle.containsKey(X509_CERTIFICATE_ALIAS_RESTRICTION),
             )
 
         private fun Bundle.getBooleanOrNull(key: String): Boolean? =

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/ManagedConfiguration.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/ManagedConfiguration.kt
@@ -38,6 +38,26 @@ internal data class ManagedConfiguration(
         allowedApplications != previous.allowedApplications ||
             disallowedApplications != previous.disallowedApplications
 
+    fun applyTo(userConfig: Config): Config =
+        userConfig.copy(
+            authUrl = authUrl ?: userConfig.authUrl,
+            apiUrl = apiUrl ?: userConfig.apiUrl,
+            logFilter = logFilter ?: userConfig.logFilter,
+            accountSlug = accountSlug ?: userConfig.accountSlug,
+            startOnLogin = startOnLogin ?: userConfig.startOnLogin,
+            connectOnStart = connectOnStart ?: userConfig.connectOnStart,
+        )
+
+    fun managedStatus(): ManagedConfigStatus =
+        ManagedConfigStatus(
+            isAuthUrlManaged = authUrl != null,
+            isApiUrlManaged = apiUrl != null,
+            isLogFilterManaged = logFilter != null,
+            isAccountSlugManaged = accountSlug != null,
+            isStartOnLoginManaged = startOnLogin != null,
+            isConnectOnStartManaged = connectOnStart != null,
+        )
+
     fun resolveSessionCredential(userToken: String?): SessionCredential? {
         val origin = if (token != null) CredentialOrigin.MANAGED else CredentialOrigin.USER
         val resolvedToken = token ?: userToken

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/ManagedConfiguration.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/ManagedConfiguration.kt
@@ -31,8 +31,7 @@ internal data class ManagedConfiguration(
     fun requiresSessionReconnect(previous: ManagedConfiguration): Boolean =
         token != previous.token ||
             deviceName != previous.deviceName ||
-            apiUrl != previous.apiUrl ||
-            accountSlug != previous.accountSlug
+            apiUrl != previous.apiUrl
 
     fun requiresVpnRebuild(previous: ManagedConfiguration): Boolean =
         allowedApplications != previous.allowedApplications ||

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/di/DataModule.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/di/DataModule.kt
@@ -10,6 +10,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import dev.firezone.android.core.data.ManagedConfigurationReader
 import dev.firezone.android.core.data.Repository
 import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Singleton
@@ -18,9 +19,12 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 class DataModule {
     @Provides
-    internal fun provideRestrictionsManager(
+    internal fun provideManagedConfigurationReader(
         @ApplicationContext context: Context,
-    ): RestrictionsManager = context.getSystemService()!!
+    ): ManagedConfigurationReader =
+        ManagedConfigurationReader {
+            context.getSystemService<RestrictionsManager>()!!.applicationRestrictions
+        }
 
     @Singleton
     @Provides

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/di/DataModule.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/di/DataModule.kt
@@ -2,8 +2,8 @@
 package dev.firezone.android.core.di
 
 import android.content.Context
+import android.content.RestrictionsManager
 import android.content.SharedPreferences
-import android.os.Bundle
 import androidx.core.content.getSystemService
 import dagger.Module
 import dagger.Provides
@@ -18,9 +18,9 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 class DataModule {
     @Provides
-    internal fun provideApplicationRestrictions(
+    internal fun provideRestrictionsManager(
         @ApplicationContext context: Context,
-    ): Bundle = (context.getSystemService(Context.RESTRICTIONS_SERVICE) as android.content.RestrictionsManager).applicationRestrictions
+    ): RestrictionsManager = context.getSystemService()!!
 
     @Singleton
     @Provides

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/presentation/MainActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/presentation/MainActivity.kt
@@ -1,35 +1,22 @@
 // Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core.presentation
 
-import android.content.Context
-import android.content.RestrictionsManager
-import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.lifecycleScope // For launching coroutines
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import dev.firezone.android.R
-import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
 internal class MainActivity : AppCompatActivity(R.layout.activity_main) {
     @Inject
-    lateinit var repository: Repository
+    internal lateinit var managedConfigurationSource: ManagedConfigurationSource
 
     override fun onResume() {
         super.onResume()
 
-        // Apply managed configurations when the app resumes since it's not guaranteed
-        // the TunnelService is running when the app starts or is backgrounded.
-        applyManagedConfigurations()
-    }
-
-    private fun applyManagedConfigurations() {
-        val restrictionsManager = getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager
-        val appRestrictions: Bundle = restrictionsManager.applicationRestrictions
-        lifecycleScope.launch {
-            repository.saveManagedConfiguration(appRestrictions).collect {}
-        }
+        lifecycleScope.launch { managedConfigurationSource.refresh() }
     }
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/x509/CertificateAccess.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/x509/CertificateAccess.kt
@@ -1,21 +1,24 @@
 // Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
 package dev.firezone.android.core.x509
 
-import android.os.Bundle
 import dev.firezone.android.core.Log
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.data.model.ManagedConfiguration
+import dev.firezone.android.core.di.IoDispatcher
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 /** Answers whether Android must grant Firezone access to the configured certificate. */
-class CertificateAccess
+internal class CertificateAccess
     @Inject
     constructor(
         private val repository: Repository,
-        private val applicationRestrictions: Bundle,
+        private val managedConfigurationSource: ManagedConfigurationSource,
         private val keyChain: KeyChain,
+        @IoDispatcher private val coroutineDispatcher: CoroutineDispatcher,
     ) {
         /**
          * Whether this device has a configured alias whose certificate Android will not hand over.
@@ -25,10 +28,14 @@ class CertificateAccess
          * A grant that is later revoked, or a certificate that is removed, lands here too, because
          * offering the chooser is more useful than failing later when the tunnel starts.
          */
-        suspend fun needsSelection(): Boolean =
-            withContext(Dispatchers.IO) {
+        suspend fun needsSelection(): Boolean = needsSelection(managedConfigurationSource.refresh())
+
+        internal suspend fun needsSelection(managedConfiguration: ManagedConfiguration): Boolean =
+            withContext(coroutineDispatcher) {
                 val alias =
-                    repository.getX509CertificateAliasSync(applicationRestrictions)
+                    managedConfiguration.resolveX509CertificateAlias(
+                        repository.getUserX509CertificateAliasSync(),
+                    )
                         ?: return@withContext false
 
                 try {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
@@ -37,12 +37,12 @@ internal class AuthViewModel
             hasStartedAuthFlow = true
 
             viewModelScope.launch {
-                managedConfigurationSource.refresh()
+                val managedConfiguration = managedConfigurationSource.refresh()
                 val state = generateRandomString(NONCE_LENGTH)
                 val nonce = generateRandomString(NONCE_LENGTH)
                 authState = state
                 pendingAuthSession.begin(nonce = nonce, state = state)
-                val config = repo.getConfigSync()
+                val config = repo.getEffectiveConfig(repo.getUserConfigSync(), managedConfiguration)
                 val authUrl = "${config.authUrl}/${config.accountSlug}?state=$state&nonce=$nonce&as=gui-client"
 
                 actionMutableStateFlow.value =

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
@@ -3,13 +3,16 @@ package dev.firezone.android.features.auth.ui
 
 import android.net.Uri
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.features.auth.AuthCallbackHandler
 import dev.firezone.android.features.auth.AuthCallbackOutcome
 import dev.firezone.android.features.auth.PendingAuthSession
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import java.security.SecureRandom
 import javax.inject.Inject
 
@@ -20,6 +23,7 @@ internal class AuthViewModel
         private val repo: Repository,
         private val pendingAuthSession: PendingAuthSession,
         private val authCallbackHandler: AuthCallbackHandler,
+        private val managedConfigurationSource: ManagedConfigurationSource,
     ) : ViewModel() {
         private val actionMutableStateFlow = MutableStateFlow<ViewAction?>(null)
         val actionStateFlow: StateFlow<ViewAction?> = actionMutableStateFlow
@@ -32,15 +36,18 @@ internal class AuthViewModel
             }
             hasStartedAuthFlow = true
 
-            val state = generateRandomString(NONCE_LENGTH)
-            val nonce = generateRandomString(NONCE_LENGTH)
-            authState = state
-            pendingAuthSession.begin(nonce = nonce, state = state)
-            val config = repo.getConfigSync()
-            val authUrl = "${config.authUrl}/${config.accountSlug}?state=$state&nonce=$nonce&as=gui-client"
+            viewModelScope.launch {
+                managedConfigurationSource.refresh()
+                val state = generateRandomString(NONCE_LENGTH)
+                val nonce = generateRandomString(NONCE_LENGTH)
+                authState = state
+                pendingAuthSession.begin(nonce = nonce, state = state)
+                val config = repo.getConfigSync()
+                val authUrl = "${config.authUrl}/${config.accountSlug}?state=$state&nonce=$nonce&as=gui-client"
 
-            actionMutableStateFlow.value =
-                ViewAction.LaunchAuthFlow(authUrl)
+                actionMutableStateFlow.value =
+                    ViewAction.LaunchAuthFlow(authUrl)
+            }
         }
 
         fun processAuthCallback(uri: Uri?) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/permission/certificate/ui/CertificatePermissionActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/permission/certificate/ui/CertificatePermissionActivity.kt
@@ -6,12 +6,15 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import dev.firezone.android.R
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.x509.KeyChain
 import dev.firezone.android.features.permission.certificate.ui.compose.CertificatePermissionScreen
 import dev.firezone.android.features.session.ui.compose.FirezoneTheme
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -28,7 +31,7 @@ class CertificatePermissionActivity : AppCompatActivity() {
     lateinit var repository: Repository
 
     @Inject
-    lateinit var applicationRestrictions: Bundle
+    internal lateinit var managedConfigurationSource: ManagedConfigurationSource
 
     @Inject
     lateinit var keyChain: KeyChain
@@ -47,19 +50,32 @@ class CertificatePermissionActivity : AppCompatActivity() {
     }
 
     private fun chooseCertificate() {
-        val configuredAlias = repository.getX509CertificateAliasSync(applicationRestrictions)
+        lifecycleScope.launch {
+            val managedConfiguration = managedConfigurationSource.refresh()
+            val configuredAlias =
+                managedConfiguration.resolveX509CertificateAlias(
+                    repository.getUserX509CertificateAliasSync(),
+                )
 
-        // Android answers on a binder thread, so anything touching the UI hops back itself.
-        keyChain.choosePrivateKeyAlias(this, requestUri(), configuredAlias) { alias ->
-            // KeyChain takes the configured alias as a pre-selection only, so the user can
-            // hand back a different one, which leaves the configured certificate still refused.
-            if (alias != null && alias == configuredAlias) {
-                finish()
-            } else {
-                runOnUiThread {
-                    Toast
-                        .makeText(this, R.string.device_trust_no_certificate_selected, Toast.LENGTH_LONG)
-                        .show()
+            // Android answers on a binder thread, so anything touching the UI hops back itself.
+            keyChain.choosePrivateKeyAlias(
+                this@CertificatePermissionActivity,
+                requestUri(),
+                configuredAlias,
+            ) { alias ->
+                // KeyChain takes the configured alias as a pre-selection only, so the user can
+                // hand back a different one, which leaves the configured certificate still refused.
+                if (alias != null && alias == configuredAlias) {
+                    finish()
+                } else {
+                    runOnUiThread {
+                        Toast
+                            .makeText(
+                                this@CertificatePermissionActivity,
+                                R.string.device_trust_no_certificate_selected,
+                                Toast.LENGTH_LONG,
+                            ).show()
+                    }
                 }
             }
         }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/DeviceTrustSettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/DeviceTrustSettingsViewModel.kt
@@ -2,18 +2,22 @@
 package dev.firezone.android.features.settings.ui
 
 import android.net.Uri
-import android.os.Bundle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.firezone.android.core.Log
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.data.model.ManagedConfiguration
+import dev.firezone.android.core.di.IoDispatcher
 import dev.firezone.android.core.x509.KeyChain
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import uniffi.x509claims.DetailField
@@ -25,16 +29,61 @@ internal class DeviceTrustSettingsViewModel
     @Inject
     constructor(
         private val repository: Repository,
-        private val applicationRestrictions: Bundle,
+        private val managedConfigurationSource: ManagedConfigurationSource,
         private val keyChain: KeyChain,
+        @IoDispatcher private val coroutineDispatcher: CoroutineDispatcher,
     ) : ViewModel() {
         private val uiMutableStateFlow = MutableStateFlow(UiState())
         val uiStateFlow: StateFlow<UiState> = uiMutableStateFlow
+        private var refreshJob: Job? = null
         private var loadJob: Job? = null
 
-        fun loadDetails() {
-            val alias = repository.getX509CertificateAliasSync(applicationRestrictions)
-            val isManaged = repository.isX509CertificateAliasManaged(applicationRestrictions)
+        init {
+            viewModelScope.launch {
+                managedConfigurationSource.configuration.filterNotNull().collect(::showDetails)
+            }
+        }
+
+        fun loadDetails() = refreshAndApply()
+
+        /** Records the alias the user picked, unless the administrator dictates one. */
+        fun onAliasSelected(alias: String) =
+            refreshAndApply { managedConfiguration ->
+                if (managedConfiguration.isX509CertificateAliasManaged()) {
+                    // The administrator chooses the alias; what the prompt achieves is the KeyChain
+                    // grant that lets us read the key behind it.
+                    Log.d(TAG, "Keeping the managed alias after the user answered the KeyChain prompt")
+                } else {
+                    repository.saveX509CertificateAliasSync(alias)
+                }
+            }
+
+        fun forgetSelection() =
+            refreshAndApply { managedConfiguration ->
+                if (!managedConfiguration.isX509CertificateAliasManaged()) {
+                    repository.saveX509CertificateAliasSync(null)
+                }
+            }
+
+        private fun refreshAndApply(action: ((ManagedConfiguration) -> Unit)? = null) {
+            refreshJob?.cancel()
+            refreshJob =
+                viewModelScope.launch {
+                    val previousConfiguration = managedConfigurationSource.configuration.value
+                    val managedConfiguration = managedConfigurationSource.refresh()
+                    action?.invoke(managedConfiguration)
+                    if (action != null || managedConfiguration == previousConfiguration) {
+                        showDetails(managedConfiguration)
+                    }
+                }
+        }
+
+        private fun showDetails(managedConfiguration: ManagedConfiguration) {
+            val alias =
+                managedConfiguration.resolveX509CertificateAlias(
+                    repository.getUserX509CertificateAliasSync(),
+                )
+            val isManaged = managedConfiguration.isX509CertificateAliasManaged()
 
             uiMutableStateFlow.value =
                 UiState(alias = alias, isManaged = isManaged, isLoading = alias != null)
@@ -49,7 +98,7 @@ internal class DeviceTrustSettingsViewModel
                 viewModelScope.launch {
                     val chain =
                         try {
-                            withContext(Dispatchers.IO) {
+                            withContext(coroutineDispatcher) {
                                 try {
                                     keyChain.certificateChain(alias)
                                 } catch (exception: InterruptedException) {
@@ -97,28 +146,6 @@ internal class DeviceTrustSettingsViewModel
                             details = certificate?.detailFields.orEmpty(),
                         )
                 }
-        }
-
-        /** Records the alias the user picked, unless the administrator dictates one. */
-        fun onAliasSelected(alias: String) {
-            if (repository.isX509CertificateAliasManaged(applicationRestrictions)) {
-                // The administrator chooses the alias; what the prompt achieves is the KeyChain
-                // grant that lets us read the key behind it.
-                Log.d(TAG, "Keeping the managed alias after the user answered the KeyChain prompt")
-            } else {
-                repository.saveX509CertificateAliasSync(alias)
-            }
-
-            loadDetails()
-        }
-
-        fun forgetSelection() {
-            if (repository.isX509CertificateAliasManaged(applicationRestrictions)) {
-                return
-            }
-
-            repository.saveX509CertificateAliasSync(null)
-            loadDetails()
         }
 
         /** The portal the certificate is meant for, shown by Android in the chooser dialog. */

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
@@ -161,6 +161,7 @@ internal class SettingsActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
+        viewModel.populateFieldsFromConfig()
         viewModel.onViewResume(this@SettingsActivity)
     }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
@@ -16,10 +16,8 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import dagger.hilt.android.AndroidEntryPoint
 import dev.firezone.android.R
-import dev.firezone.android.core.data.Repository
 import dev.firezone.android.databinding.ActivitySettingsBinding
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 /** The navigation item and the page it shows, in order. */
 internal fun settingsPages(hasConfiguredCertificateAlias: Boolean): List<Pair<Int, () -> Fragment>> =
@@ -38,20 +36,9 @@ internal fun settingsPages(hasConfiguredCertificateAlias: Boolean): List<Pair<In
 internal class SettingsActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySettingsBinding
     private val viewModel: SettingsViewModel by viewModels()
-    private val pages: List<Pair<Int, () -> Fragment>> by lazy {
-        settingsPages(
-            hasConfiguredCertificateAlias =
-                repository.getX509CertificateAliasSync(applicationRestrictions) != null,
-        )
-    }
+    private lateinit var pages: List<Pair<Int, () -> Fragment>>
     private var lastFocusedView: View? = null
     private var lastSelectedPage = -1
-
-    @Inject
-    lateinit var repository: Repository
-
-    @Inject
-    lateinit var applicationRestrictions: Bundle
 
     private val navigationSelectionSync =
         object : ViewPager2.OnPageChangeCallback() {
@@ -89,8 +76,12 @@ internal class SettingsActivity : AppCompatActivity() {
         binding = ActivitySettingsBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        setupViews()
         setupStateObservers()
+
+        lifecycleScope.launch {
+            pages = settingsPages(viewModel.hasConfiguredCertificateAlias())
+            setupViews()
+        }
 
         viewModel.deleteLogZip(this@SettingsActivity)
     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
@@ -92,7 +92,6 @@ internal class SettingsActivity : AppCompatActivity() {
         setupViews()
         setupStateObservers()
 
-        viewModel.populateFieldsFromConfig()
         viewModel.deleteLogZip(this@SettingsActivity)
     }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
@@ -249,7 +249,7 @@ internal class SettingsViewModel
 
         private fun getEffectiveConfig(): Config =
             managedConfiguration?.let { repo.getEffectiveConfig(userConfig, it) }
-                ?: repo.getConfigSync()
+                ?: repo.getEffectiveConfigFromPersistedManaged(userConfig)
 
         private fun areFieldsValid(): Boolean =
             URLUtil.isValidUrl(config.authUrl) &&

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
@@ -42,16 +42,8 @@ internal class SettingsViewModel
         private val actionMutableStateFlow = MutableStateFlow<ViewAction?>(null)
         val actionStateFlow: StateFlow<ViewAction?> = actionMutableStateFlow
 
-        // Working config that gets modified during editing using immutable copy
-        private var config =
-            Config(
-                authUrl = "",
-                apiUrl = "",
-                logFilter = "",
-                accountSlug = "",
-                startOnLogin = false,
-                connectOnStart = false,
-            )
+        private var userConfig = repo.getUserConfigSync()
+        private var config = repo.getEffectiveConfig(userConfig)
 
         // StateFlow that emits config only on load/reset, not during editing
         private val _configStateFlow = MutableStateFlow(config)
@@ -65,15 +57,9 @@ internal class SettingsViewModel
         init {
             viewModelScope.launch {
                 managedConfigurationSource.configuration.filterNotNull().collect {
-                    val effectiveConfig = repo.getConfigSync()
                     val managedStatus = repo.getManagedStatus()
-                    config =
-                        _managedStatusStateFlow.value?.let { previousManagedStatus ->
-                            config.withManagedUpdates(effectiveConfig, previousManagedStatus, managedStatus)
-                        } ?: effectiveConfig
-                    _configStateFlow.value = config
                     _managedStatusStateFlow.value = managedStatus
-                    onFieldUpdated()
+                    publishEffectiveConfig()
                 }
             }
         }
@@ -101,7 +87,7 @@ internal class SettingsViewModel
 
         fun onSaveSettingsCompleted() {
             viewModelScope.launch {
-                repo.saveSettings(config).collect {
+                repo.saveSettings(userConfig).collect {
                     if (shouldResetFavoritesOnSave) {
                         repo.resetFavorites()
                         shouldResetFavoritesOnSave = false
@@ -116,33 +102,27 @@ internal class SettingsViewModel
         }
 
         fun onValidateAuthUrl(authUrl: String) {
-            config = config.copy(authUrl = authUrl)
-            onFieldUpdated()
+            updateUserConfig(config.copy(authUrl = authUrl))
         }
 
         fun onValidateApiUrl(apiUrl: String) {
-            config = config.copy(apiUrl = apiUrl)
-            onFieldUpdated()
+            updateUserConfig(config.copy(apiUrl = apiUrl))
         }
 
         fun onValidateLogFilter(logFilter: String) {
-            config = config.copy(logFilter = logFilter)
-            onFieldUpdated()
+            updateUserConfig(config.copy(logFilter = logFilter))
         }
 
         fun onValidateAccountSlug(accountSlug: String) {
-            config = config.copy(accountSlug = accountSlug)
-            onFieldUpdated()
+            updateUserConfig(config.copy(accountSlug = accountSlug))
         }
 
         fun onStartOnLoginChanged(isChecked: Boolean) {
-            config = config.copy(startOnLogin = isChecked)
-            onFieldUpdated()
+            updateUserConfig(config.copy(startOnLogin = isChecked))
         }
 
         fun onConnectOnStartChanged(isChecked: Boolean) {
-            config = config.copy(connectOnStart = isChecked)
-            onFieldUpdated()
+            updateUserConfig(config.copy(connectOnStart = isChecked))
         }
 
         fun deleteLogDirectory(context: Context) {
@@ -197,11 +177,10 @@ internal class SettingsViewModel
         }
 
         fun resetSettingsToDefaults() {
-            config = repo.getDefaultConfigSync()
+            userConfig = repo.getDefaultUserConfigSync()
             shouldResetFavoritesOnSave = true
-            _configStateFlow.value = config
             _managedStatusStateFlow.value = repo.getManagedStatus()
-            onFieldUpdated()
+            publishEffectiveConfig()
         }
 
         fun clearAction() {
@@ -248,41 +227,17 @@ internal class SettingsViewModel
                 )
         }
 
-        private fun Config.withManagedUpdates(
-            effectiveConfig: Config,
-            previousStatus: ManagedConfigStatus,
-            currentStatus: ManagedConfigStatus,
-        ): Config =
-            copy(
-                authUrl =
-                    effectiveConfig.authUrl.takeIf {
-                        previousStatus.isAuthUrlManaged || currentStatus.isAuthUrlManaged
-                    } ?: authUrl,
-                apiUrl =
-                    effectiveConfig.apiUrl.takeIf {
-                        previousStatus.isApiUrlManaged || currentStatus.isApiUrlManaged
-                    } ?: apiUrl,
-                logFilter =
-                    effectiveConfig.logFilter.takeIf {
-                        previousStatus.isLogFilterManaged || currentStatus.isLogFilterManaged
-                    } ?: logFilter,
-                accountSlug =
-                    effectiveConfig.accountSlug.takeIf {
-                        previousStatus.isAccountSlugManaged || currentStatus.isAccountSlugManaged
-                    } ?: accountSlug,
-                startOnLogin =
-                    if (previousStatus.isStartOnLoginManaged || currentStatus.isStartOnLoginManaged) {
-                        effectiveConfig.startOnLogin
-                    } else {
-                        startOnLogin
-                    },
-                connectOnStart =
-                    if (previousStatus.isConnectOnStartManaged || currentStatus.isConnectOnStartManaged) {
-                        effectiveConfig.connectOnStart
-                    } else {
-                        connectOnStart
-                    },
-            )
+        private fun updateUserConfig(editedConfig: Config) {
+            val managedStatus = _managedStatusStateFlow.value ?: repo.getManagedStatus()
+            userConfig = repo.mergeUnmanagedConfig(userConfig, editedConfig, managedStatus)
+            publishEffectiveConfig()
+        }
+
+        private fun publishEffectiveConfig() {
+            config = repo.getEffectiveConfig(userConfig)
+            _configStateFlow.value = config
+            onFieldUpdated()
+        }
 
         private fun areFieldsValid(): Boolean =
             URLUtil.isValidUrl(config.authUrl) &&

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
@@ -74,7 +74,7 @@ internal class SettingsViewModel
         }
 
         suspend fun hasConfiguredCertificateAlias(): Boolean {
-            val configuration = managedConfigurationSource.configuration.value ?: managedConfigurationSource.refresh()
+            val configuration = managedConfigurationSource.refresh()
 
             return configuration.resolveX509CertificateAlias(repo.getUserX509CertificateAliasSync()) != null
         }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
@@ -12,6 +12,7 @@ import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.data.model.Config
 import dev.firezone.android.core.data.model.ManagedConfigStatus
+import dev.firezone.android.core.data.model.ManagedConfiguration
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -43,22 +44,26 @@ internal class SettingsViewModel
         val actionStateFlow: StateFlow<ViewAction?> = actionMutableStateFlow
 
         private var userConfig = repo.getUserConfigSync()
-        private var config = repo.getEffectiveConfig(userConfig)
+        private var managedConfiguration: ManagedConfiguration? = managedConfigurationSource.configuration.value
+        private var config = getEffectiveConfig()
 
         // StateFlow that emits config only on load/reset, not during editing
         private val _configStateFlow = MutableStateFlow(config)
         val configStateFlow: StateFlow<Config> = _configStateFlow
 
-        private val _managedStatusStateFlow = MutableStateFlow<ManagedConfigStatus?>(null)
+        private val _managedStatusStateFlow =
+            MutableStateFlow<ManagedConfigStatus?>(
+                managedConfiguration?.managedStatus() ?: repo.getManagedStatus(),
+            )
         val managedStatusStateFlow: StateFlow<ManagedConfigStatus?> = _managedStatusStateFlow
 
         private var shouldResetFavoritesOnSave = false
 
         init {
             viewModelScope.launch {
-                managedConfigurationSource.configuration.filterNotNull().collect {
-                    val managedStatus = repo.getManagedStatus()
-                    _managedStatusStateFlow.value = managedStatus
+                managedConfigurationSource.configuration.filterNotNull().collect { configuration ->
+                    managedConfiguration = configuration
+                    _managedStatusStateFlow.value = configuration.managedStatus()
                     publishEffectiveConfig()
                 }
             }
@@ -87,7 +92,7 @@ internal class SettingsViewModel
 
         fun onSaveSettingsCompleted() {
             viewModelScope.launch {
-                repo.saveSettings(userConfig).collect {
+                repo.saveUserConfig(userConfig).collect {
                     if (shouldResetFavoritesOnSave) {
                         repo.resetFavorites()
                         shouldResetFavoritesOnSave = false
@@ -179,7 +184,7 @@ internal class SettingsViewModel
         fun resetSettingsToDefaults() {
             userConfig = repo.getDefaultUserConfigSync()
             shouldResetFavoritesOnSave = true
-            _managedStatusStateFlow.value = repo.getManagedStatus()
+            _managedStatusStateFlow.value = managedConfiguration?.managedStatus() ?: repo.getManagedStatus()
             publishEffectiveConfig()
         }
 
@@ -228,16 +233,23 @@ internal class SettingsViewModel
         }
 
         private fun updateUserConfig(editedConfig: Config) {
-            val managedStatus = _managedStatusStateFlow.value ?: repo.getManagedStatus()
+            val managedStatus =
+                _managedStatusStateFlow.value
+                    ?: managedConfiguration?.managedStatus()
+                    ?: repo.getManagedStatus()
             userConfig = repo.mergeUnmanagedConfig(userConfig, editedConfig, managedStatus)
             publishEffectiveConfig()
         }
 
         private fun publishEffectiveConfig() {
-            config = repo.getEffectiveConfig(userConfig)
+            config = getEffectiveConfig()
             _configStateFlow.value = config
             onFieldUpdated()
         }
+
+        private fun getEffectiveConfig(): Config =
+            managedConfiguration?.let { repo.getEffectiveConfig(userConfig, it) }
+                ?: repo.getConfigSync()
 
         private fun areFieldsValid(): Boolean =
             URLUtil.isValidUrl(config.authUrl) &&

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
@@ -107,27 +107,45 @@ internal class SettingsViewModel
         }
 
         fun onValidateAuthUrl(authUrl: String) {
-            updateUserConfig(config.copy(authUrl = authUrl))
+            updateUserConfig(
+                isManaged = { it.isAuthUrlManaged },
+                update = { copy(authUrl = authUrl) },
+            )
         }
 
         fun onValidateApiUrl(apiUrl: String) {
-            updateUserConfig(config.copy(apiUrl = apiUrl))
+            updateUserConfig(
+                isManaged = { it.isApiUrlManaged },
+                update = { copy(apiUrl = apiUrl) },
+            )
         }
 
         fun onValidateLogFilter(logFilter: String) {
-            updateUserConfig(config.copy(logFilter = logFilter))
+            updateUserConfig(
+                isManaged = { it.isLogFilterManaged },
+                update = { copy(logFilter = logFilter) },
+            )
         }
 
         fun onValidateAccountSlug(accountSlug: String) {
-            updateUserConfig(config.copy(accountSlug = accountSlug))
+            updateUserConfig(
+                isManaged = { it.isAccountSlugManaged },
+                update = { copy(accountSlug = accountSlug) },
+            )
         }
 
         fun onStartOnLoginChanged(isChecked: Boolean) {
-            updateUserConfig(config.copy(startOnLogin = isChecked))
+            updateUserConfig(
+                isManaged = { it.isStartOnLoginManaged },
+                update = { copy(startOnLogin = isChecked) },
+            )
         }
 
         fun onConnectOnStartChanged(isChecked: Boolean) {
-            updateUserConfig(config.copy(connectOnStart = isChecked))
+            updateUserConfig(
+                isManaged = { it.isConnectOnStartManaged },
+                update = { copy(connectOnStart = isChecked) },
+            )
         }
 
         fun deleteLogDirectory(context: Context) {
@@ -232,12 +250,17 @@ internal class SettingsViewModel
                 )
         }
 
-        private fun updateUserConfig(editedConfig: Config) {
+        private fun updateUserConfig(
+            isManaged: (ManagedConfigStatus) -> Boolean,
+            update: Config.() -> Config,
+        ) {
             val managedStatus =
                 _managedStatusStateFlow.value
                     ?: managedConfiguration?.managedStatus()
                     ?: repo.getManagedStatus()
-            userConfig = repo.mergeUnmanagedConfig(userConfig, editedConfig, managedStatus)
+            if (!isManaged(managedStatus)) {
+                userConfig = userConfig.update()
+            }
             publishEffectiveConfig()
         }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
@@ -8,6 +8,7 @@ import androidx.core.content.FileProvider
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.data.model.Config
 import dev.firezone.android.core.data.model.ManagedConfigStatus
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
@@ -32,6 +34,7 @@ internal class SettingsViewModel
     @Inject
     constructor(
         private val repo: Repository,
+        private val managedConfigurationSource: ManagedConfigurationSource,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(UiState())
         val uiState: StateFlow<UiState> = _uiState
@@ -59,15 +62,24 @@ internal class SettingsViewModel
 
         private var shouldResetFavoritesOnSave = false
 
-        fun populateFieldsFromConfig() {
+        init {
             viewModelScope.launch {
-                repo.getConfig().collect {
-                    config = it
-                    _configStateFlow.value = it
-                    _managedStatusStateFlow.value = repo.getManagedStatus()
+                managedConfigurationSource.configuration.filterNotNull().collect {
+                    val effectiveConfig = repo.getConfigSync()
+                    val managedStatus = repo.getManagedStatus()
+                    config =
+                        _managedStatusStateFlow.value?.let { previousManagedStatus ->
+                            config.withManagedUpdates(effectiveConfig, previousManagedStatus, managedStatus)
+                        } ?: effectiveConfig
+                    _configStateFlow.value = config
+                    _managedStatusStateFlow.value = managedStatus
                     onFieldUpdated()
                 }
             }
+        }
+
+        fun populateFieldsFromConfig() {
+            viewModelScope.launch { managedConfigurationSource.refresh() }
         }
 
         fun onViewResume(context: Context) {
@@ -235,6 +247,42 @@ internal class SettingsViewModel
                     isSaveButtonEnabled = areFieldsValid(),
                 )
         }
+
+        private fun Config.withManagedUpdates(
+            effectiveConfig: Config,
+            previousStatus: ManagedConfigStatus,
+            currentStatus: ManagedConfigStatus,
+        ): Config =
+            copy(
+                authUrl =
+                    effectiveConfig.authUrl.takeIf {
+                        previousStatus.isAuthUrlManaged || currentStatus.isAuthUrlManaged
+                    } ?: authUrl,
+                apiUrl =
+                    effectiveConfig.apiUrl.takeIf {
+                        previousStatus.isApiUrlManaged || currentStatus.isApiUrlManaged
+                    } ?: apiUrl,
+                logFilter =
+                    effectiveConfig.logFilter.takeIf {
+                        previousStatus.isLogFilterManaged || currentStatus.isLogFilterManaged
+                    } ?: logFilter,
+                accountSlug =
+                    effectiveConfig.accountSlug.takeIf {
+                        previousStatus.isAccountSlugManaged || currentStatus.isAccountSlugManaged
+                    } ?: accountSlug,
+                startOnLogin =
+                    if (previousStatus.isStartOnLoginManaged || currentStatus.isStartOnLoginManaged) {
+                        effectiveConfig.startOnLogin
+                    } else {
+                        startOnLogin
+                    },
+                connectOnStart =
+                    if (previousStatus.isConnectOnStartManaged || currentStatus.isConnectOnStartManaged) {
+                        effectiveConfig.connectOnStart
+                    } else {
+                        connectOnStart
+                    },
+            )
 
         private fun areFieldsValid(): Boolean =
             URLUtil.isValidUrl(config.authUrl) &&

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
@@ -73,6 +73,12 @@ internal class SettingsViewModel
             viewModelScope.launch { managedConfigurationSource.refresh() }
         }
 
+        suspend fun hasConfiguredCertificateAlias(): Boolean {
+            val configuration = managedConfigurationSource.configuration.value ?: managedConfigurationSource.refresh()
+
+            return configuration.resolveX509CertificateAlias(repo.getUserX509CertificateAliasSync()) != null
+        }
+
         fun onViewResume(context: Context) {
             val directory = File(context.cacheDir.absolutePath + "/logs")
             viewModelScope.launch(Dispatchers.IO) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
@@ -58,16 +58,17 @@ internal class SplashViewModel
                     return@launch
                 }
 
+                val managedConfiguration = managedConfigurationSource.refresh()
+
                 // An administrator can configure a certificate that only the user can release, which
                 // is what a work profile on a personally-owned device looks like. Ask once per
                 // launch: pressing on without it only fails later, at the tunnel.
-                if (!certificateSelectionOffered && certificateAccess.needsSelection()) {
+                if (!certificateSelectionOffered && certificateAccess.needsSelection(managedConfiguration)) {
                     certificateSelectionOffered = true
                     actionMutableStateFlow.value = ViewAction.NavigateToCertificatePermission
                     return@launch
                 }
 
-                val managedConfiguration = managedConfigurationSource.refresh()
                 val credential = managedConfiguration.resolveSessionCredential(tokenStore.get())
 
                 if (credential == null) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
@@ -5,7 +5,6 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
-import android.os.Bundle
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -13,6 +12,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.firezone.android.core.ApplicationMode
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.data.TokenStore
 import dev.firezone.android.core.x509.CertificateAccess
@@ -31,7 +31,7 @@ internal class SplashViewModel
     constructor(
         private val repo: Repository,
         private val tokenStore: TokenStore,
-        private val applicationRestrictions: Bundle,
+        private val managedConfigurationSource: ManagedConfigurationSource,
         private val applicationMode: ApplicationMode,
         private val certificateAccess: CertificateAccess,
     ) : ViewModel() {
@@ -67,7 +67,8 @@ internal class SplashViewModel
                     return@launch
                 }
 
-                val token = applicationRestrictions.getString("token") ?: tokenStore.get()
+                val managedConfiguration = managedConfigurationSource.refresh()
+                val token = managedConfiguration.token ?: tokenStore.get()
 
                 if (token.isNullOrBlank()) {
                     actionMutableStateFlow.value = ViewAction.NavigateToSignIn

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
@@ -68,9 +68,9 @@ internal class SplashViewModel
                 }
 
                 val managedConfiguration = managedConfigurationSource.refresh()
-                val token = managedConfiguration.token ?: tokenStore.get()
+                val credential = managedConfiguration.resolveSessionCredential(tokenStore.get())
 
-                if (token.isNullOrBlank()) {
+                if (credential == null) {
                     actionMutableStateFlow.value = ViewAction.NavigateToSignIn
                     return@launch
                 }
@@ -83,7 +83,10 @@ internal class SplashViewModel
                     return@launch
                 }
 
-                val connectOnStart = repo.getConfigSync().connectOnStart
+                val connectOnStart =
+                    repo
+                        .getEffectiveConfig(repo.getUserConfigSync(), managedConfiguration)
+                        .connectOnStart
 
                 // If this is the initial launch and connectOnStart is true, try to connect
                 if (isInitialLaunch && connectOnStart) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/ApplicationRoutingPolicy.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/ApplicationRoutingPolicy.kt
@@ -1,0 +1,70 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.tunnel
+
+import dev.firezone.android.core.data.model.ManagedConfiguration
+
+internal enum class ApplicationRoutingMode {
+    ALLOW,
+    DISALLOW,
+}
+
+internal data class ApplicationRoutingPolicy(
+    val mode: ApplicationRoutingMode,
+    val packageNames: List<String>,
+    val hasConflict: Boolean,
+)
+
+internal fun ManagedConfiguration.applicationRoutingPolicy(): ApplicationRoutingPolicy {
+    val allowed = allowedApplications.toPackageNames()
+    val disallowed = disallowedApplications.toPackageNames()
+
+    return if (allowed.isNotEmpty()) {
+        ApplicationRoutingPolicy(
+            mode = ApplicationRoutingMode.ALLOW,
+            packageNames = allowed.filterNot { it in NEVER_TUNNEL_APPLICATIONS },
+            hasConflict = disallowed.isNotEmpty(),
+        )
+    } else {
+        ApplicationRoutingPolicy(
+            mode = ApplicationRoutingMode.DISALLOW,
+            packageNames = (disallowed + NEVER_TUNNEL_APPLICATIONS).distinct(),
+            hasConflict = false,
+        )
+    }
+}
+
+internal fun ApplicationRoutingPolicy.apply(
+    addAllowed: (String) -> Boolean,
+    addDisallowed: (String) -> Boolean,
+): Boolean =
+    when (mode) {
+        ApplicationRoutingMode.ALLOW -> {
+            var applied = 0
+            packageNames.forEach { packageName ->
+                if (addAllowed(packageName)) {
+                    applied += 1
+                }
+            }
+            applied > 0
+        }
+
+        ApplicationRoutingMode.DISALLOW -> {
+            packageNames.forEach { packageName -> addDisallowed(packageName) }
+            true
+        }
+    }
+
+private fun String?.toPackageNames(): List<String> =
+    this
+        ?.split(",")
+        ?.map(String::trim)
+        ?.filter(String::isNotEmpty)
+        ?.distinct()
+        .orEmpty()
+
+private val NEVER_TUNNEL_APPLICATIONS =
+    listOf(
+        "com.google.android.gms",
+        "com.google.firebase.messaging",
+        "com.google.android.gsf",
+    )

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/ManagedConnectionState.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/ManagedConnectionState.kt
@@ -1,0 +1,162 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.tunnel
+
+import dev.firezone.android.core.data.model.ManagedConfiguration
+
+internal sealed interface ConnectionClaim<out T> {
+    data object Unavailable : ConnectionClaim<Nothing>
+
+    data class Existing<T>(
+        val owner: T,
+    ) : ConnectionClaim<T>
+
+    data class Started<T>(
+        val owner: T,
+    ) : ConnectionClaim<T>
+}
+
+internal sealed interface ConnectionCompletion<out T> {
+    data object Stale : ConnectionCompletion<Nothing>
+
+    data object Stopped : ConnectionCompletion<Nothing>
+
+    data class Restarted<T>(
+        val owner: T,
+    ) : ConnectionCompletion<T>
+}
+
+internal data class ManagedConnectionUpdate<T>(
+    val owner: T,
+    val requiresReconnect: Boolean,
+    val updateLogFilter: Boolean,
+    val rebuildVpn: Boolean,
+)
+
+internal class ManagedConnectionState<T : Any> {
+    private val lock = Any()
+    private var managedConfiguration = ManagedConfiguration()
+    private var owner: T? = null
+    private var desiredRunning = false
+    private var reconnectRequested = false
+    private var finishing = false
+    private var latestStartRequest = 0L
+
+    fun apply(configuration: ManagedConfiguration): ManagedConnectionUpdate<T>? =
+        synchronized(lock) {
+            val previous = managedConfiguration
+            managedConfiguration = configuration
+
+            val currentOwner = owner ?: return@synchronized null
+            if (configuration == previous || !desiredRunning) {
+                return@synchronized null
+            }
+
+            val requiresReconnect = configuration.requiresSessionReconnect(previous)
+            if (requiresReconnect) {
+                reconnectRequested = true
+            }
+
+            ManagedConnectionUpdate(
+                owner = currentOwner,
+                requiresReconnect = requiresReconnect,
+                updateLogFilter = configuration.logFilter != previous.logFilter,
+                rebuildVpn = configuration.requiresVpnRebuild(previous),
+            )
+        }
+
+    fun claim(
+        startRequest: Long,
+        create: (ManagedConfiguration) -> T?,
+    ): ConnectionClaim<T> =
+        synchronized(lock) {
+            owner?.let {
+                if (!desiredRunning) {
+                    reconnectRequested = true
+                }
+                desiredRunning = true
+                return@synchronized ConnectionClaim.Existing(it)
+            }
+
+            val newOwner = create(managedConfiguration)
+            if (newOwner == null) {
+                if (startRequest == latestStartRequest) {
+                    desiredRunning = false
+                    reconnectRequested = false
+                }
+                return@synchronized ConnectionClaim.Unavailable
+            }
+            desiredRunning = true
+            owner = newOwner
+            finishing = false
+            ConnectionClaim.Started(newOwner)
+        }
+
+    fun requestStart(): Long =
+        synchronized(lock) {
+            latestStartRequest += 1
+            if (owner != null && (finishing || !desiredRunning)) {
+                reconnectRequested = true
+            }
+            desiredRunning = true
+            latestStartRequest
+        }
+
+    fun disconnect(): T? =
+        synchronized(lock) {
+            desiredRunning = false
+            reconnectRequested = false
+            owner
+        }
+
+    fun beginCompletion(expectedOwner: T) {
+        synchronized(lock) {
+            if (owner === expectedOwner) {
+                finishing = true
+            }
+        }
+    }
+
+    fun complete(
+        expectedOwner: T,
+        create: (ManagedConfiguration) -> T?,
+    ): ConnectionCompletion<T> =
+        synchronized(lock) {
+            if (owner !== expectedOwner) {
+                return@synchronized ConnectionCompletion.Stale
+            }
+
+            owner = null
+            finishing = false
+            if (!desiredRunning || !reconnectRequested) {
+                desiredRunning = false
+                reconnectRequested = false
+                return@synchronized ConnectionCompletion.Stopped
+            }
+
+            reconnectRequested = false
+            val newOwner = create(managedConfiguration)
+            if (newOwner == null) {
+                desiredRunning = false
+                return@synchronized ConnectionCompletion.Stopped
+            }
+
+            owner = newOwner
+            ConnectionCompletion.Restarted(newOwner)
+        }
+
+    fun stopIfIdle(stop: () -> Unit): Boolean =
+        synchronized(lock) {
+            if (owner != null || desiredRunning) {
+                return@synchronized false
+            }
+
+            stop()
+            true
+        }
+
+    fun owner(): T? = synchronized(lock) { owner }
+
+    fun isCurrent(expectedOwner: T): Boolean = synchronized(lock) { owner === expectedOwner }
+
+    fun managedConfiguration(): ManagedConfiguration = synchronized(lock) { managedConfiguration }
+}

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/ManagedConnectionState.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/ManagedConnectionState.kt
@@ -69,11 +69,11 @@ internal class ManagedConnectionState<T : Any> {
         create: (ManagedConfiguration) -> T?,
     ): ConnectionClaim<T> =
         synchronized(lock) {
+            if (!desiredRunning || startRequest != latestStartRequest) {
+                return@synchronized ConnectionClaim.Unavailable
+            }
+
             owner?.let {
-                if (!desiredRunning) {
-                    reconnectRequested = true
-                }
-                desiredRunning = true
                 return@synchronized ConnectionClaim.Existing(it)
             }
 
@@ -103,6 +103,7 @@ internal class ManagedConnectionState<T : Any> {
 
     fun disconnect(): T? =
         synchronized(lock) {
+            latestStartRequest += 1
             desiredRunning = false
             reconnectRequested = false
             owner

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/ManagedConnectionState.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/ManagedConnectionState.kt
@@ -159,5 +159,20 @@ internal class ManagedConnectionState<T : Any> {
 
     fun isCurrent(expectedOwner: T): Boolean = synchronized(lock) { owner === expectedOwner }
 
+    fun isActive(expectedOwner: T): Boolean = synchronized(lock) { owner === expectedOwner && desiredRunning && !finishing }
+
+    fun runIfActive(
+        expectedOwner: T,
+        action: () -> Unit,
+    ): Boolean =
+        synchronized(lock) {
+            if (owner !== expectedOwner || !desiredRunning || finishing) {
+                return@synchronized false
+            }
+
+            action()
+            true
+        }
+
     fun managedConfiguration(): ManagedConfiguration = synchronized(lock) { managedConfiguration }
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/OwnedTunFileDescriptor.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/OwnedTunFileDescriptor.kt
@@ -1,0 +1,32 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.tunnel
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class OwnedTunFileDescriptor(
+    private val fd: Int,
+    private val closeFd: (Int) -> Unit,
+) : AutoCloseable {
+    private val owned = AtomicBoolean(true)
+
+    fun transferTo(consumer: (Int) -> Unit) {
+        check(owned.compareAndSet(true, false)) { "TUN file descriptor ownership was already released" }
+
+        try {
+            consumer(fd)
+        } catch (error: Throwable) {
+            try {
+                closeFd(fd)
+            } catch (closeError: Throwable) {
+                error.addSuppressed(closeError)
+            }
+            throw error
+        }
+    }
+
+    override fun close() {
+        if (owned.compareAndSet(true, false)) {
+            closeFd(fd)
+        }
+    }
+}

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -25,7 +25,10 @@ import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.data.ResourceState
 import dev.firezone.android.core.data.TokenStore
 import dev.firezone.android.core.data.isEnabled
+import dev.firezone.android.core.data.model.Config
 import dev.firezone.android.core.data.model.ManagedConfiguration
+import dev.firezone.android.core.data.model.SessionCredential
+import dev.firezone.android.core.data.model.shouldClearSavedCredentials
 import dev.firezone.android.core.x509.X509Identity
 import dev.firezone.android.tunnel.model.Cidr
 import dev.firezone.android.tunnel.model.ConnectedDevice
@@ -50,6 +53,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
@@ -108,7 +112,6 @@ class TunnelService : VpnService() {
     private var featureFlagPollJob: Job? = null
 
     var startedByUser: Boolean = false
-    private var commandChannel: Channel<TunnelCommand>? = null
 
     // A `SupervisorJob` keeps one failed child from cancelling its siblings, but an exception it
     // does not handle still reaches the thread's default handler and takes the process with it.
@@ -131,11 +134,9 @@ class TunnelService : VpnService() {
     val connectedDevicesState: StateFlow<List<ConnectedDevice>> = _connectedDevicesState.asStateFlow()
     val actorNameState: StateFlow<String?> = _actorNameState.asStateFlow()
 
-    @Volatile
-    private var managedConfiguration = ManagedConfiguration()
-
-    @Volatile
-    private var reconnectAfterDisconnect = false
+    private val connectionState = ManagedConnectionState<ConnectionParameters>()
+    private val appliedManagedConfigurationRevision = MutableStateFlow(0L)
+    private val tunnelConfigurationLock = Any()
 
     var tunnelResources: List<Resource>
         get() = _resourcesState.value
@@ -174,96 +175,95 @@ class TunnelService : VpnService() {
             binder
         }
 
-    private fun buildVpnService() {
-        fun handleApplications(
-            applications: String?,
-            action: (String) -> Unit,
-        ) {
-            applications?.takeIf { it.isNotBlank() }?.split(",")?.forEach { p ->
-                p.trim().takeIf { it.isNotBlank() }?.let(action)
+    private fun buildVpnService(connection: ConnectionParameters) {
+        synchronized(tunnelConfigurationLock) {
+            if (!connectionState.isCurrent(connection)) {
+                return
             }
+
+            val managedConfiguration = connectionState.managedConfiguration()
+            val ipv4Address = tunnelIpv4Address ?: return
+            val ipv6Address = tunnelIpv6Address ?: return
+
+            fun handleApplications(
+                applications: String?,
+                action: (String) -> Unit,
+            ) {
+                applications?.takeIf { it.isNotBlank() }?.split(",")?.forEach { p ->
+                    p.trim().takeIf { it.isNotBlank() }?.let(action)
+                }
+            }
+
+            Builder()
+                .apply {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        setMetered(false) // Inherit the metered status from the underlying networks.
+                    }
+
+                    if (tunnelRoutes.all { it.prefix != 0 }) {
+                        // Allow traffic to bypass the VPN interface when Always-on VPN is enabled only
+                        // if full-route is not enabled.
+                        allowBypass()
+                    }
+
+                    setUnderlyingNetworks(null) // Use all available networks.
+
+                    setSession(SESSION_NAME)
+                    setMtu(MTU)
+
+                    handleApplications(managedConfiguration.allowedApplications) { addAllowedApplication(it) }
+                    handleApplications(
+                        managedConfiguration.disallowedApplications,
+                    ) { addDisallowedApplication(it) }
+
+                    // Never route GCM notifications through the tunnel.
+                    addDisallowedApplication("com.google.android.gms") // Google Mobile Services
+                    addDisallowedApplication("com.google.firebase.messaging") // Firebase Cloud Messaging
+                    addDisallowedApplication("com.google.android.gsf") // Google Services Framework
+
+                    tunnelRoutes.forEach {
+                        addRoute(it.address, it.prefix)
+                    }
+
+                    tunnelDnsAddresses.forEach { dns ->
+                        addDnsServer(dns)
+                    }
+
+                    tunnelSearchDomain?.let {
+                        addSearchDomain(it)
+                    }
+
+                    addAddress(ipv4Address, 32)
+                    addAddress(ipv6Address, 128)
+                }.runCatching { establish() }
+                .onFailure { Log.e(TAG, "Error establishing VPN service", it) }
+                .onSuccess { fd ->
+                    if (fd == null) {
+                        Log.d(TAG, "VpnService.Builder.establish() returned null")
+                        return@onSuccess
+                    }
+
+                    sendTunnelCommand(connection.commandChannel, TunnelCommand.SetTun(fd.detachFd()))
+                }
         }
-
-        Builder()
-            .apply {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    setMetered(false) // Inherit the metered status from the underlying networks.
-                }
-
-                if (tunnelRoutes.all { it.prefix != 0 }) {
-                    // Allow traffic to bypass the VPN interface when Always-on VPN is enabled only
-                    // if full-route is not enabled.
-                    allowBypass()
-                }
-
-                setUnderlyingNetworks(null) // Use all available networks.
-
-                setSession(SESSION_NAME)
-                setMtu(MTU)
-
-                handleApplications(managedConfiguration.allowedApplications) { addAllowedApplication(it) }
-                handleApplications(
-                    managedConfiguration.disallowedApplications,
-                ) { addDisallowedApplication(it) }
-
-                // Never route GCM notifications through the tunnel.
-                addDisallowedApplication("com.google.android.gms") // Google Mobile Services
-                addDisallowedApplication("com.google.firebase.messaging") // Firebase Cloud Messaging
-                addDisallowedApplication("com.google.android.gsf") // Google Services Framework
-
-                tunnelRoutes.forEach {
-                    addRoute(it.address, it.prefix)
-                }
-
-                tunnelDnsAddresses.forEach { dns ->
-                    addDnsServer(dns)
-                }
-
-                tunnelSearchDomain?.let {
-                    addSearchDomain(it)
-                }
-
-                addAddress(tunnelIpv4Address!!, 32)
-                addAddress(tunnelIpv6Address!!, 128)
-            }.runCatching { establish() }
-            .onFailure { Log.e(TAG, "Error establishing VPN service", it) }
-            .onSuccess { fd ->
-                if (fd == null) {
-                    Log.d(TAG, "VpnService.Builder.establish() returned null")
-                    return@onSuccess
-                }
-
-                sendTunnelCommand(TunnelCommand.SetTun(fd.detachFd()))
-            }
     }
 
     private fun applyManagedConfiguration(configuration: ManagedConfiguration) {
-        val previous = managedConfiguration
-        managedConfiguration = configuration
-
-        if (configuration == previous || commandChannel == null) {
+        val update = connectionState.apply(configuration) ?: return
+        if (update.requiresReconnect) {
+            Log.i(TAG, "Reconnecting to apply managed configuration")
+            sendTunnelCommand(update.owner.commandChannel, TunnelCommand.Disconnect)
             return
         }
-        if (configuration.requiresSessionReconnect(previous)) {
-            reconnect()
-            return
+        if (update.updateLogFilter) {
+            sendTunnelCommand(
+                update.owner.commandChannel,
+                TunnelCommand.SetLogDirectives(repo.getConfigSync().logFilter),
+            )
         }
-        if (configuration.logFilter != previous.logFilter) {
-            sendTunnelCommand(TunnelCommand.SetLogDirectives(repo.getConfigSync().logFilter))
+        if (update.rebuildVpn) {
+            buildVpnService(update.owner)
         }
-        if (
-            configuration.requiresVpnRebuild(previous) &&
-            tunnelIpv4Address != null &&
-            tunnelIpv6Address != null
-        ) {
-            buildVpnService()
-        }
-    }
-
-    private fun reconnect() {
-        Log.i(TAG, "Reconnecting to apply managed configuration")
-        reconnectAfterDisconnect = true
-        sendTunnelCommand(TunnelCommand.Disconnect)
     }
 
     // Primary callback used to start and stop the VPN service
@@ -277,10 +277,12 @@ class TunnelService : VpnService() {
         if (intent?.getBooleanExtra("startedByUser", false) == true) {
             startedByUser = true
         }
+        val startRequest = connectionState.requestStart()
         serviceScope.launch {
-            applyManagedConfiguration(managedConfigurationSource.refresh())
-            if (!connect()) {
-                stopSelf(startId)
+            val update = managedConfigurationSource.refreshUpdate()
+            appliedManagedConfigurationRevision.first { it >= update.revision }
+            if (!connect(startRequest)) {
+                connectionState.stopIfIdle { stopSelf(startId) }
             }
         }
         return START_STICKY
@@ -291,8 +293,9 @@ class TunnelService : VpnService() {
         activeService = this
 
         serviceScope.launch {
-            managedConfigurationSource.configuration.filterNotNull().collect {
-                applyManagedConfiguration(it)
+            managedConfigurationSource.updates.filterNotNull().collect { update ->
+                applyManagedConfiguration(update.configuration)
+                appliedManagedConfigurationRevision.value = update.revision
             }
         }
 
@@ -339,8 +342,13 @@ class TunnelService : VpnService() {
 
     // Call this to stop the tunnel and shutdown the service, leaving the token intact.
     fun disconnect() {
-        reconnectAfterDisconnect = false
-        sendTunnelCommand(TunnelCommand.Disconnect)
+        val connection = connectionState.disconnect()
+        if (connection == null) {
+            Log.d(TAG, "Cannot send ${TunnelCommand.Disconnect.javaClass.name}: No active connlib session")
+            return
+        }
+
+        sendTunnelCommand(connection.commandChannel, TunnelCommand.Disconnect)
     }
 
     fun setDns(dnsList: List<String>) {
@@ -351,19 +359,31 @@ class TunnelService : VpnService() {
         sendTunnelCommand(TunnelCommand.Reset)
     }
 
-    private fun connect(): Boolean {
-        if (commandChannel != null) {
-            return true
+    private fun connect(startRequest: Long): Boolean {
+        return when (val claim = connectionState.claim(startRequest, ::createConnection)) {
+            ConnectionClaim.Unavailable -> false
+            is ConnectionClaim.Existing -> true
+            is ConnectionClaim.Started -> {
+                startConnection(claim.owner)
+                true
+            }
         }
+    }
 
-        val token =
-            (managedConfiguration.token ?: tokenStore.get())
-                ?.takeUnless(String::isBlank)
-        if (token == null) {
-            return false
-        }
-        val config = repo.getConfigSync()
-        resourceState = repo.getInternetResourceStateSync()
+    private fun createConnection(managedConfiguration: ManagedConfiguration): ConnectionParameters? {
+        val credential = managedConfiguration.resolveSessionCredential(tokenStore.get()) ?: return null
+
+        return ConnectionParameters(
+            commandChannel = Channel(Channel.UNLIMITED),
+            credential = credential,
+            config = repo.getConfigSync(),
+            resourceState = repo.getInternetResourceStateSync(),
+            managedConfiguration = managedConfiguration,
+        )
+    }
+
+    private fun startConnection(connection: ConnectionParameters) {
+        resourceState = connection.resourceState
 
         tunnelState = State.CONNECTING
         // Dismiss any previous disconnected notifications
@@ -384,21 +404,19 @@ class TunnelService : VpnService() {
                 identifierForVendor = null,
             )
 
-        commandChannel = Channel<TunnelCommand>(Channel.UNLIMITED)
-
         val context = this
 
         serviceScope.launch {
             try {
                 // Set telemetry environment and user context
                 val deviceIdValue = deviceId()
-                Telemetry.setEnvironmentOrClose(config.apiUrl)
+                Telemetry.setEnvironmentOrClose(connection.config.apiUrl)
                 Telemetry.setFirezoneId(deviceIdValue)
-                Telemetry.setAccountSlug(config.accountSlug)
+                Telemetry.setAccountSlug(connection.config.accountSlug)
 
                 configureLogger(
                     logDir(this@TunnelService),
-                    config.logFilter,
+                    connection.config.logFilter,
                     flowLogsDir(this@TunnelService),
                 )
 
@@ -406,11 +424,11 @@ class TunnelService : VpnService() {
                     .newAndroid(
                         config =
                             AndroidSessionConfig(
-                                apiUrl = config.apiUrl,
-                                token = token,
-                                accountSlug = config.accountSlug,
+                                apiUrl = connection.config.apiUrl,
+                                token = connection.credential.token,
+                                accountSlug = connection.config.accountSlug,
                                 deviceId = deviceIdValue,
-                                deviceName = getDeviceName(),
+                                deviceName = getDeviceName(connection.managedConfiguration),
                                 isInternetResourceActive = resourceState.isEnabled(),
                                 deviceInfo = deviceInfo,
                             ),
@@ -421,7 +439,7 @@ class TunnelService : VpnService() {
                         startLogCleanup()
                         startFeatureFlagPoll()
 
-                        val stopReason = eventLoop(session, commandChannel!!)
+                        val stopReason = eventLoop(session, connection)
 
                         Log.i(TAG, "Event-loop finished: $stopReason")
 
@@ -445,35 +463,67 @@ class TunnelService : VpnService() {
                 Log.e(TAG, "Failed to start session", e)
                 e.close()
             } finally {
-                commandChannel = null
-                tunnelState = State.DOWN
-
+                connectionState.beginCompletion(connection)
                 stopNetworkMonitoring()
                 stopFeatureFlagPoll()
                 stopLogCleanup()
+                clearTunnelConfiguration(connection)
+                completeConnection(connection)
+            }
+        }
+    }
 
-                val shouldReconnect = reconnectAfterDisconnect
-                reconnectAfterDisconnect = false
-                if (!shouldReconnect || !connect()) {
+    private fun completeConnection(connection: ConnectionParameters) {
+        when (val completion = connectionState.complete(connection, ::createConnection)) {
+            ConnectionCompletion.Stale -> Unit
+            ConnectionCompletion.Stopped -> {
+                connectionState.stopIfIdle {
+                    tunnelState = State.DOWN
                     stopForeground(STOP_FOREGROUND_REMOVE)
                     stopSelf()
                 }
             }
-        }
 
-        return true
+            is ConnectionCompletion.Restarted -> {
+                startConnection(completion.owner)
+            }
+        }
+    }
+
+    private fun clearTunnelConfiguration(connection: ConnectionParameters) {
+        synchronized(tunnelConfigurationLock) {
+            if (!connectionState.isCurrent(connection)) {
+                return
+            }
+
+            tunnelIpv4Address = null
+            tunnelIpv6Address = null
+            tunnelDnsAddresses.clear()
+            tunnelSearchDomain = null
+            tunnelRoutes.clear()
+            tunnelResources = emptyList()
+            tunnelConnectedDevices = emptyList()
+        }
     }
 
     private fun sendTunnelCommand(command: TunnelCommand) {
-        val commandName = command.javaClass.name
-
-        if (commandChannel == null) {
-            Log.d(TAG, "Cannot send $commandName: No active connlib session")
+        val connection = connectionState.owner()
+        if (connection == null) {
+            Log.d(TAG, "Cannot send ${command.javaClass.name}: No active connlib session")
             return
         }
 
+        sendTunnelCommand(connection.commandChannel, command)
+    }
+
+    private fun sendTunnelCommand(
+        commandChannel: Channel<TunnelCommand>,
+        command: TunnelCommand,
+    ) {
+        val commandName = command.javaClass.name
+
         try {
-            commandChannel?.trySend(command)?.getOrThrow()
+            commandChannel.trySend(command).getOrThrow()
         } catch (e: Exception) {
             Log.w(TAG, "Cannot send $commandName: ${e.message}")
         }
@@ -582,7 +632,7 @@ class TunnelService : VpnService() {
         startForeground(TunnelNotification.CONNECTED_NOTIFICATION_ID, notification)
     }
 
-    private fun getDeviceName(): String {
+    private fun getDeviceName(managedConfiguration: ManagedConfiguration): String {
         val deviceName = managedConfiguration.deviceName
         return if (deviceName.isNullOrBlank() || deviceName == "null") {
             Build.MODEL
@@ -627,6 +677,14 @@ class TunnelService : VpnService() {
         data object Error : StopReason()
     }
 
+    private data class ConnectionParameters(
+        val commandChannel: Channel<TunnelCommand>,
+        val credential: SessionCredential,
+        val config: Config,
+        val resourceState: ResourceState,
+        val managedConfiguration: ManagedConfiguration,
+    )
+
     private fun resourceById(resourceId: String): Pair<Resource, Site>? {
         val resource = tunnelResources.find { it.id == resourceId } ?: return null
         val site = resource.sites?.firstOrNull() ?: return null
@@ -640,10 +698,45 @@ class TunnelService : VpnService() {
         TunnelNotification.showErrorNotification(this, title, message)
     }
 
+    private fun updateTunnelConfiguration(
+        connection: ConnectionParameters,
+        event: Event.TunInterfaceUpdated,
+    ) {
+        synchronized(tunnelConfigurationLock) {
+            if (!connectionState.isCurrent(connection)) {
+                return
+            }
+
+            tunnelDnsAddresses = event.dns.toMutableList()
+            tunnelSearchDomain = event.searchDomain
+            tunnelIpv4Address = event.ipv4
+            tunnelIpv6Address = event.ipv6
+            tunnelRoutes.clear()
+            tunnelRoutes.addAll(
+                event.ipv4Routes.map { cidr ->
+                    Cidr(
+                        address = cidr.address,
+                        prefix = cidr.prefix.toInt(),
+                    )
+                },
+            )
+            tunnelRoutes.addAll(
+                event.ipv6Routes.map { cidr ->
+                    Cidr(
+                        address = cidr.address,
+                        prefix = cidr.prefix.toInt(),
+                    )
+                },
+            )
+            buildVpnService(connection)
+        }
+    }
+
     private suspend fun eventLoop(
         session: SessionInterface,
-        commandChannel: Channel<TunnelCommand>,
+        connection: ConnectionParameters,
     ): StopReason {
+        val commandChannel = connection.commandChannel
         @OptIn(ExperimentalCoroutinesApi::class)
         val eventChannel =
             serviceScope.produce {
@@ -704,28 +797,7 @@ class TunnelService : VpnService() {
                                 }
 
                                 is Event.TunInterfaceUpdated -> {
-                                    tunnelDnsAddresses = event.dns.toMutableList()
-                                    tunnelSearchDomain = event.searchDomain
-                                    tunnelIpv4Address = event.ipv4
-                                    tunnelIpv6Address = event.ipv6
-                                    tunnelRoutes.clear()
-                                    tunnelRoutes.addAll(
-                                        event.ipv4Routes.map { cidr ->
-                                            Cidr(
-                                                address = cidr.address,
-                                                prefix = cidr.prefix.toInt(),
-                                            )
-                                        },
-                                    )
-                                    tunnelRoutes.addAll(
-                                        event.ipv6Routes.map { cidr ->
-                                            Cidr(
-                                                address = cidr.address,
-                                                prefix = cidr.prefix.toInt(),
-                                            )
-                                        },
-                                    )
-                                    buildVpnService()
+                                    updateTunnelConfiguration(connection, event)
                                 }
 
                                 is Event.ConnectedToPortal -> {
@@ -743,7 +815,11 @@ class TunnelService : VpnService() {
                                 is Event.Disconnected -> {
                                     Log.i(TAG, "Disconnected by connlib: ${event.error.logMessage()}")
 
-                                    if (event.error.requiresSignIn()) {
+                                    if (
+                                        connection.credential.origin.shouldClearSavedCredentials(
+                                            event.error.requiresSignIn(),
+                                        )
+                                    ) {
                                         tokenStore.clear()
                                     }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -5,6 +5,7 @@ import NetworkMonitor
 import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
@@ -12,6 +13,7 @@ import android.net.VpnService
 import android.os.Binder
 import android.os.Build
 import android.os.IBinder
+import android.os.ParcelFileDescriptor
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.installations.FirebaseInstallations
 import com.squareup.moshi.Moshi
@@ -180,7 +182,7 @@ class TunnelService : VpnService() {
 
     private fun buildVpnService(connection: ConnectionParameters) {
         synchronized(tunnelConfigurationLock) {
-            if (!connectionState.isCurrent(connection)) {
+            if (!connectionState.isActive(connection)) {
                 return
             }
 
@@ -188,42 +190,45 @@ class TunnelService : VpnService() {
             val ipv4Address = tunnelIpv4Address ?: return
             val ipv6Address = tunnelIpv6Address ?: return
 
-            fun handleApplications(
-                applications: String?,
-                action: (String) -> Unit,
-            ) {
-                applications?.takeIf { it.isNotBlank() }?.split(",")?.forEach { p ->
-                    p.trim().takeIf { it.isNotBlank() }?.let(action)
-                }
+            val builder =
+                Builder()
+                    .apply {
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                            setMetered(false) // Inherit the metered status from the underlying networks.
+                        }
+
+                        if (tunnelRoutes.all { it.prefix != 0 }) {
+                            // Allow traffic to bypass the VPN interface when Always-on VPN is enabled only
+                            // if full-route is not enabled.
+                            allowBypass()
+                        }
+
+                        setUnderlyingNetworks(null) // Use all available networks.
+
+                        setSession(SESSION_NAME)
+                        setMtu(MTU)
+                    }
+
+            val applicationRoutingPolicy = managedConfiguration.applicationRoutingPolicy()
+            if (applicationRoutingPolicy.hasConflict) {
+                Log.w(TAG, "Both managed application lists are set; using the allow list")
+            }
+            val hasValidApplicationRouting =
+                applicationRoutingPolicy.apply(
+                    addAllowed = { packageName ->
+                        tryAddApplication(packageName) { builder.addAllowedApplication(packageName) }
+                    },
+                    addDisallowed = { packageName ->
+                        tryAddApplication(packageName) { builder.addDisallowedApplication(packageName) }
+                    },
+                )
+            if (!hasValidApplicationRouting) {
+                Log.e(TAG, "Managed VPN allow list has no installed applications; keeping the current interface")
+                return
             }
 
-            Builder()
+            builder
                 .apply {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        setMetered(false) // Inherit the metered status from the underlying networks.
-                    }
-
-                    if (tunnelRoutes.all { it.prefix != 0 }) {
-                        // Allow traffic to bypass the VPN interface when Always-on VPN is enabled only
-                        // if full-route is not enabled.
-                        allowBypass()
-                    }
-
-                    setUnderlyingNetworks(null) // Use all available networks.
-
-                    setSession(SESSION_NAME)
-                    setMtu(MTU)
-
-                    handleApplications(managedConfiguration.allowedApplications) { addAllowedApplication(it) }
-                    handleApplications(
-                        managedConfiguration.disallowedApplications,
-                    ) { addDisallowedApplication(it) }
-
-                    // Never route GCM notifications through the tunnel.
-                    addDisallowedApplication("com.google.android.gms") // Google Mobile Services
-                    addDisallowedApplication("com.google.firebase.messaging") // Firebase Cloud Messaging
-                    addDisallowedApplication("com.google.android.gsf") // Google Services Framework
-
                     tunnelRoutes.forEach {
                         addRoute(it.address, it.prefix)
                     }
@@ -246,10 +251,34 @@ class TunnelService : VpnService() {
                         return@onSuccess
                     }
 
-                    sendTunnelCommand(connection.commandChannel, TunnelCommand.SetTun(fd.detachFd()))
+                    val ownedFd = OwnedTunFileDescriptor(fd.detachFd(), ::closeTunFileDescriptor)
+                    if (
+                        !connectionState.runIfActive(connection) {
+                            sendTunnelCommand(connection.commandChannel, TunnelCommand.SetTun(ownedFd))
+                        }
+                    ) {
+                        ownedFd.close()
+                    }
                 }
         }
     }
+
+    private fun closeTunFileDescriptor(fd: Int) {
+        runCatching { ParcelFileDescriptor.adoptFd(fd).close() }
+            .onFailure { Log.w(TAG, "Failed to close an undelivered TUN file descriptor", it) }
+    }
+
+    private fun tryAddApplication(
+        packageName: String,
+        addApplication: () -> Unit,
+    ): Boolean =
+        try {
+            addApplication()
+            true
+        } catch (_: PackageManager.NameNotFoundException) {
+            Log.w(TAG, "Ignoring unavailable application in managed VPN policy: $packageName")
+            false
+        }
 
     private fun applyManagedConfiguration(configuration: ManagedConfiguration) {
         val update = connectionState.apply(configuration) ?: return
@@ -300,8 +329,13 @@ class TunnelService : VpnService() {
 
         serviceScope.launch {
             managedConfigurationSource.updates.filterNotNull().collect { update ->
-                applyManagedConfiguration(update.configuration)
-                appliedManagedConfigurationRevision.value = update.revision
+                try {
+                    applyManagedConfiguration(update.configuration)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to apply managed configuration", e)
+                } finally {
+                    appliedManagedConfigurationRevision.value = update.revision
+                }
             }
         }
 
@@ -385,7 +419,11 @@ class TunnelService : VpnService() {
         val credential = managedConfiguration.resolveSessionCredential(tokenStore.get()) ?: return null
 
         return ConnectionParameters(
-            commandChannel = Channel(Channel.UNLIMITED),
+            commandChannel =
+                Channel(
+                    capacity = Channel.UNLIMITED,
+                    onUndeliveredElement = { command -> command.closeOwnedResources() },
+                ),
             credential = credential,
             config = repo.getEffectiveConfig(repo.getUserConfigSync(), managedConfiguration),
             resourceState = repo.getInternetResourceStateSync(),
@@ -474,7 +512,7 @@ class TunnelService : VpnService() {
                 Log.e(TAG, "Failed to start session", e)
                 e.close()
             } finally {
-                connectionState.beginCompletion(connection)
+                beginConnectionCompletion(connection)
                 stopNetworkMonitoring()
                 stopFeatureFlagPoll()
                 stopLogCleanup()
@@ -482,6 +520,11 @@ class TunnelService : VpnService() {
                 completeConnection(connection)
             }
         }
+    }
+
+    private fun beginConnectionCompletion(connection: ConnectionParameters) {
+        connectionState.beginCompletion(connection)
+        connection.commandChannel.cancel()
     }
 
     private fun completeConnection(connection: ConnectionParameters) {
@@ -525,6 +568,7 @@ class TunnelService : VpnService() {
         val connection = connectionState.owner()
         if (connection == null) {
             Log.d(TAG, "Cannot send ${command.javaClass.name}: No active connlib session")
+            command.closeOwnedResources()
             return
         }
 
@@ -534,13 +578,21 @@ class TunnelService : VpnService() {
     private fun sendTunnelCommand(
         commandChannel: Channel<TunnelCommand>,
         command: TunnelCommand,
-    ) {
+    ): Boolean {
         val commandName = command.javaClass.name
+        val result = commandChannel.trySend(command)
+        if (result.isSuccess) {
+            return true
+        }
 
-        try {
-            commandChannel.trySend(command).getOrThrow()
-        } catch (e: Exception) {
-            Log.w(TAG, "Cannot send $commandName: ${e.message}")
+        command.closeOwnedResources()
+        Log.w(TAG, "Cannot send $commandName: ${result.exceptionOrNull()?.message}")
+        return false
+    }
+
+    private fun TunnelCommand.closeOwnedResources() {
+        if (this is TunnelCommand.SetTun) {
+            fd.close()
         }
     }
 
@@ -656,7 +708,7 @@ class TunnelService : VpnService() {
         }
     }
 
-    sealed class TunnelCommand {
+    internal sealed class TunnelCommand {
         data object Disconnect : TunnelCommand()
 
         data class SetInternetResourceState(
@@ -672,7 +724,7 @@ class TunnelService : VpnService() {
         ) : TunnelCommand()
 
         data class SetTun(
-            val fd: Int,
+            val fd: OwnedTunFileDescriptor,
         ) : TunnelCommand()
 
         data object Reset : TunnelCommand()
@@ -751,6 +803,17 @@ class TunnelService : VpnService() {
         session: SessionInterface,
         connection: ConnectionParameters,
     ): StopReason {
+        try {
+            return runEventLoop(session, connection)
+        } finally {
+            beginConnectionCompletion(connection)
+        }
+    }
+
+    private suspend fun runEventLoop(
+        session: SessionInterface,
+        connection: ConnectionParameters,
+    ): StopReason {
         val commandChannel = connection.commandChannel
 
         @OptIn(ExperimentalCoroutinesApi::class)
@@ -768,38 +831,42 @@ class TunnelService : VpnService() {
             try {
                 select<Unit> {
                     commandChannel.onReceive { command ->
-                        when (command) {
-                            is TunnelCommand.Disconnect -> {
-                                explicitDisconnect = true
-                                session.disconnect()
+                        try {
+                            when (command) {
+                                is TunnelCommand.Disconnect -> {
+                                    explicitDisconnect = true
+                                    session.disconnect()
 
-                                // Sending disconnect will close the event-stream which will exit this loop.
-                                // We don't want to bail out here right away to allow connlib to clean up after itself.
-                            }
+                                    // Sending disconnect will close the event-stream which will exit this loop.
+                                    // We don't want to bail out here right away to allow connlib to clean up after itself.
+                                }
 
-                            is TunnelCommand.SetInternetResourceState -> {
-                                session.setInternetResourceState(command.active)
-                            }
+                                is TunnelCommand.SetInternetResourceState -> {
+                                    session.setInternetResourceState(command.active)
+                                }
 
-                            is TunnelCommand.SetDns -> {
-                                session.setDns(command.dnsServers)
-                            }
+                                is TunnelCommand.SetDns -> {
+                                    session.setDns(command.dnsServers)
+                                }
 
-                            is TunnelCommand.SetLogDirectives -> {
-                                configureLogger(
-                                    logDir(this@TunnelService),
-                                    command.directives,
-                                    flowLogsDir(this@TunnelService),
-                                )
-                            }
+                                is TunnelCommand.SetLogDirectives -> {
+                                    configureLogger(
+                                        logDir(this@TunnelService),
+                                        command.directives,
+                                        flowLogsDir(this@TunnelService),
+                                    )
+                                }
 
-                            is TunnelCommand.SetTun -> {
-                                session.setTun(command.fd)
-                            }
+                                is TunnelCommand.SetTun -> {
+                                    command.fd.transferTo(session::setTun)
+                                }
 
-                            is TunnelCommand.Reset -> {
-                                session.reset("roam")
+                                is TunnelCommand.Reset -> {
+                                    session.reset("roam")
+                                }
                             }
+                        } finally {
+                            command.closeOwnedResources()
                         }
                     }
                     eventChannel.onReceive { event ->

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -138,6 +138,9 @@ class TunnelService : VpnService() {
     private val appliedManagedConfigurationRevision = MutableStateFlow(0L)
     private val tunnelConfigurationLock = Any()
 
+    @Volatile
+    private var latestStartId = 0
+
     var tunnelResources: List<Resource>
         get() = _resourcesState.value
         set(value) {
@@ -258,7 +261,9 @@ class TunnelService : VpnService() {
         if (update.updateLogFilter) {
             sendTunnelCommand(
                 update.owner.commandChannel,
-                TunnelCommand.SetLogDirectives(repo.getConfigSync().logFilter),
+                TunnelCommand.SetLogDirectives(
+                    repo.getEffectiveConfig(repo.getUserConfigSync(), configuration).logFilter,
+                ),
             )
         }
         if (update.rebuildVpn) {
@@ -278,11 +283,12 @@ class TunnelService : VpnService() {
             startedByUser = true
         }
         val startRequest = connectionState.requestStart()
+        latestStartId = startId
         serviceScope.launch {
             val update = managedConfigurationSource.refreshUpdate()
             appliedManagedConfigurationRevision.first { it >= update.revision }
             if (!connect(startRequest)) {
-                connectionState.stopIfIdle { stopSelf(startId) }
+                connectionState.stopIfIdle { stopSelfResult(startId) }
             }
         }
         return START_STICKY
@@ -359,16 +365,21 @@ class TunnelService : VpnService() {
         sendTunnelCommand(TunnelCommand.Reset)
     }
 
-    private fun connect(startRequest: Long): Boolean {
-        return when (val claim = connectionState.claim(startRequest, ::createConnection)) {
-            ConnectionClaim.Unavailable -> false
-            is ConnectionClaim.Existing -> true
+    private fun connect(startRequest: Long): Boolean =
+        when (val claim = connectionState.claim(startRequest, ::createConnection)) {
+            ConnectionClaim.Unavailable -> {
+                false
+            }
+
+            is ConnectionClaim.Existing -> {
+                true
+            }
+
             is ConnectionClaim.Started -> {
                 startConnection(claim.owner)
                 true
             }
         }
-    }
 
     private fun createConnection(managedConfiguration: ManagedConfiguration): ConnectionParameters? {
         val credential = managedConfiguration.resolveSessionCredential(tokenStore.get()) ?: return null
@@ -376,7 +387,7 @@ class TunnelService : VpnService() {
         return ConnectionParameters(
             commandChannel = Channel(Channel.UNLIMITED),
             credential = credential,
-            config = repo.getConfigSync(),
+            config = repo.getEffectiveConfig(repo.getUserConfigSync(), managedConfiguration),
             resourceState = repo.getInternetResourceStateSync(),
             managedConfiguration = managedConfiguration,
         )
@@ -475,12 +486,16 @@ class TunnelService : VpnService() {
 
     private fun completeConnection(connection: ConnectionParameters) {
         when (val completion = connectionState.complete(connection, ::createConnection)) {
-            ConnectionCompletion.Stale -> Unit
+            ConnectionCompletion.Stale -> {
+                Unit
+            }
+
             ConnectionCompletion.Stopped -> {
                 connectionState.stopIfIdle {
-                    tunnelState = State.DOWN
-                    stopForeground(STOP_FOREGROUND_REMOVE)
-                    stopSelf()
+                    if (stopSelfResult(latestStartId)) {
+                        tunnelState = State.DOWN
+                        stopForeground(STOP_FOREGROUND_REMOVE)
+                    }
                 }
             }
 
@@ -737,6 +752,7 @@ class TunnelService : VpnService() {
         connection: ConnectionParameters,
     ): StopReason {
         val commandChannel = connection.commandChannel
+
         @OptIn(ExperimentalCoroutinesApi::class)
         val eventChannel =
             serviceScope.produce {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -3,17 +3,14 @@ package dev.firezone.android.tunnel
 
 import NetworkMonitor
 import android.app.ActivityManager
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.content.IntentFilter
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.net.VpnService
 import android.os.Binder
 import android.os.Build
-import android.os.Bundle
 import android.os.IBinder
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.installations.FirebaseInstallations
@@ -23,12 +20,13 @@ import dagger.hilt.android.AndroidEntryPoint
 import dev.firezone.android.BuildConfig
 import dev.firezone.android.core.Log
 import dev.firezone.android.core.Telemetry
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.data.ResourceState
 import dev.firezone.android.core.data.TokenStore
 import dev.firezone.android.core.data.isEnabled
+import dev.firezone.android.core.data.model.ManagedConfiguration
 import dev.firezone.android.core.x509.X509Identity
-import dev.firezone.android.core.x509.X509IdentityException
 import dev.firezone.android.tunnel.model.Cidr
 import dev.firezone.android.tunnel.model.ConnectedDevice
 import dev.firezone.android.tunnel.model.Resource
@@ -50,6 +48,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
@@ -83,7 +83,7 @@ class TunnelService : VpnService() {
     internal lateinit var tokenStore: TokenStore
 
     @Inject
-    internal lateinit var appRestrictions: Bundle
+    internal lateinit var managedConfigurationSource: ManagedConfigurationSource
 
     @Inject
     internal lateinit var moshi: Moshi
@@ -131,6 +131,12 @@ class TunnelService : VpnService() {
     val connectedDevicesState: StateFlow<List<ConnectedDevice>> = _connectedDevicesState.asStateFlow()
     val actorNameState: StateFlow<String?> = _actorNameState.asStateFlow()
 
+    @Volatile
+    private var managedConfiguration = ManagedConfiguration()
+
+    @Volatile
+    private var reconnectAfterDisconnect = false
+
     var tunnelResources: List<Resource>
         get() = _resourcesState.value
         set(value) {
@@ -170,11 +176,10 @@ class TunnelService : VpnService() {
 
     private fun buildVpnService() {
         fun handleApplications(
-            appRestrictions: Bundle,
-            key: String,
+            applications: String?,
             action: (String) -> Unit,
         ) {
-            appRestrictions.getString(key)?.takeIf { it.isNotBlank() }?.split(",")?.forEach { p ->
+            applications?.takeIf { it.isNotBlank() }?.split(",")?.forEach { p ->
                 p.trim().takeIf { it.isNotBlank() }?.let(action)
             }
         }
@@ -196,10 +201,9 @@ class TunnelService : VpnService() {
                 setSession(SESSION_NAME)
                 setMtu(MTU)
 
-                handleApplications(appRestrictions, "allowedApplications") { addAllowedApplication(it) }
+                handleApplications(managedConfiguration.allowedApplications) { addAllowedApplication(it) }
                 handleApplications(
-                    appRestrictions,
-                    "disallowedApplications",
+                    managedConfiguration.disallowedApplications,
                 ) { addDisallowedApplication(it) }
 
                 // Never route GCM notifications through the tunnel.
@@ -233,29 +237,34 @@ class TunnelService : VpnService() {
             }
     }
 
-    private val restrictionsFilter = IntentFilter(Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED)
+    private fun applyManagedConfiguration(configuration: ManagedConfiguration) {
+        val previous = managedConfiguration
+        managedConfiguration = configuration
 
-    private val restrictionsReceiver =
-        object : BroadcastReceiver() {
-            override fun onReceive(
-                context: Context,
-                intent: Intent,
-            ) {
-                // Only change VPN if appRestrictions have changed
-                val restrictionsManager = context.getSystemService(Context.RESTRICTIONS_SERVICE) as android.content.RestrictionsManager
-                val newAppRestrictions = restrictionsManager.applicationRestrictions
-                serviceScope.launch { repo.saveManagedConfiguration(newAppRestrictions).collect {} }
-                val changed = MANAGED_CONFIGURATIONS.any { newAppRestrictions.getString(it) != appRestrictions.getString(it) }
-                // The next `connect()` reads the token and the certificate alias off this bundle,
-                // so refresh it even when the tunnel itself stays as it is.
-                appRestrictions = newAppRestrictions
-                if (!changed) {
-                    return
-                }
-
-                buildVpnService()
-            }
+        if (configuration == previous || commandChannel == null) {
+            return
         }
+        if (configuration.requiresSessionReconnect(previous)) {
+            reconnect()
+            return
+        }
+        if (configuration.logFilter != previous.logFilter) {
+            sendTunnelCommand(TunnelCommand.SetLogDirectives(repo.getConfigSync().logFilter))
+        }
+        if (
+            configuration.requiresVpnRebuild(previous) &&
+            tunnelIpv4Address != null &&
+            tunnelIpv6Address != null
+        ) {
+            buildVpnService()
+        }
+    }
+
+    private fun reconnect() {
+        Log.i(TAG, "Reconnecting to apply managed configuration")
+        reconnectAfterDisconnect = true
+        sendTunnelCommand(TunnelCommand.Disconnect)
+    }
 
     // Primary callback used to start and stop the VPN service
     // This can be called either from the UI or from the system
@@ -268,14 +277,24 @@ class TunnelService : VpnService() {
         if (intent?.getBooleanExtra("startedByUser", false) == true) {
             startedByUser = true
         }
-        connect()
+        serviceScope.launch {
+            applyManagedConfiguration(managedConfigurationSource.refresh())
+            if (!connect()) {
+                stopSelf(startId)
+            }
+        }
         return START_STICKY
     }
 
     override fun onCreate() {
         super.onCreate()
         activeService = this
-        registerReceiver(restrictionsReceiver, restrictionsFilter)
+
+        serviceScope.launch {
+            managedConfigurationSource.configuration.filterNotNull().collect {
+                applyManagedConfiguration(it)
+            }
+        }
 
         // `Telemetry.start` honours this for the Kotlin side; connlib's telemetry is a separate
         // client, so without this a build stamped as not reporting still reports.
@@ -286,7 +305,6 @@ class TunnelService : VpnService() {
 
     override fun onDestroy() {
         activeService = null
-        unregisterReceiver(restrictionsReceiver)
         serviceScope.cancel()
 
         if (!BuildConfig.NO_TELEMETRY) {
@@ -321,6 +339,7 @@ class TunnelService : VpnService() {
 
     // Call this to stop the tunnel and shutdown the service, leaving the token intact.
     fun disconnect() {
+        reconnectAfterDisconnect = false
         sendTunnelCommand(TunnelCommand.Disconnect)
     }
 
@@ -332,113 +351,117 @@ class TunnelService : VpnService() {
         sendTunnelCommand(TunnelCommand.Reset)
     }
 
-    private fun connect() {
+    private fun connect(): Boolean {
+        if (commandChannel != null) {
+            return true
+        }
+
         val token =
-            (appRestrictions.getString("token") ?: tokenStore.get())
+            (managedConfiguration.token ?: tokenStore.get())
                 ?.takeUnless(String::isBlank)
-        val certificateAlias = repo.getX509CertificateAliasSync(appRestrictions)
+        if (token == null) {
+            return false
+        }
         val config = repo.getConfigSync()
         resourceState = repo.getInternetResourceStateSync()
 
-        if (token != null) {
-            tunnelState = State.CONNECTING
-            // Dismiss any previous disconnected notifications
-            TunnelNotification.dismissDisconnectedNotification(this)
+        tunnelState = State.CONNECTING
+        // Dismiss any previous disconnected notifications
+        TunnelNotification.dismissDisconnectedNotification(this)
 
-            commandChannel = Channel<TunnelCommand>(Channel.UNLIMITED)
+        val firebaseInstallationId =
+            runCatching { Tasks.await(FirebaseInstallations.getInstance().id) }
+                .getOrElse { exception ->
+                    Log.d(TAG, "Failed to obtain firebase installation id: $exception")
+                    null
+                }
 
-            val context = this
+        val deviceInfo =
+            DeviceInfo(
+                firebaseInstallationId = firebaseInstallationId,
+                deviceUuid = null,
+                deviceSerial = null,
+                identifierForVendor = null,
+            )
 
-            serviceScope.launch {
-                try {
-                    // Set telemetry environment and user context
-                    val deviceIdValue = deviceId()
-                    Telemetry.setEnvironmentOrClose(config.apiUrl)
-                    Telemetry.setFirezoneId(deviceIdValue)
-                    // The portal names the account in `init`; until then this session has none.
-                    Telemetry.setAccountSlug(null)
+        commandChannel = Channel<TunnelCommand>(Channel.UNLIMITED)
 
-                    configureLogger(
-                        logDir(this@TunnelService),
-                        config.logFilter,
-                        flowLogsDir(this@TunnelService),
-                    )
+        val context = this
 
-                    val deviceInfo =
-                        DeviceInfo(
-                            firebaseInstallationId = firebaseInstallationId(),
-                            deviceUuid = null,
-                            deviceSerial = null,
-                            identifierForVendor = null,
-                        )
+        serviceScope.launch {
+            try {
+                // Set telemetry environment and user context
+                val deviceIdValue = deviceId()
+                Telemetry.setEnvironmentOrClose(config.apiUrl)
+                Telemetry.setFirezoneId(deviceIdValue)
+                Telemetry.setAccountSlug(config.accountSlug)
 
-                    // The KeyChain blocks on a system service and connlib reads the identity while
-                    // it constructs the session, so load it before we get there.
-                    val certificate =
-                        withContext(Dispatchers.IO) { x509Identity.load(certificateAlias) }
+                configureLogger(
+                    logDir(this@TunnelService),
+                    config.logFilter,
+                    flowLogsDir(this@TunnelService),
+                )
 
-                    sessionFactory
-                        .open(
+                Session
+                    .newAndroid(
+                        config =
                             AndroidSessionConfig(
                                 apiUrl = config.apiUrl,
                                 token = token,
+                                accountSlug = config.accountSlug,
                                 deviceId = deviceIdValue,
                                 deviceName = getDeviceName(),
                                 isInternetResourceActive = resourceState.isEnabled(),
                                 deviceInfo = deviceInfo,
                             ),
-                            // The token authenticates the user. A configured certificate attests
-                            // the device, and the portal decides whether to accept it.
-                            tlsIdentity = certificate?.tlsIdentity,
-                        ).use { session ->
-                            startNetworkMonitoring()
-                            startLogCleanup()
-                            startFeatureFlagPoll()
+                        protectSocket = protectSocketCallback,
+                        tlsIdentity = null,
+                    ).use { session ->
+                        startNetworkMonitoring()
+                        startLogCleanup()
+                        startFeatureFlagPoll()
 
-                            val stopReason = eventLoop(session, commandChannel!!)
+                        val stopReason = eventLoop(session, commandChannel!!)
 
-                            Log.i(TAG, "Event-loop finished: $stopReason")
+                        Log.i(TAG, "Event-loop finished: $stopReason")
 
-                            val message =
-                                when (stopReason) {
-                                    is StopReason.Disconnected -> stopReason.message
+                        val message =
+                            when (stopReason) {
+                                is StopReason.Disconnected -> stopReason.message
 
-                                    StopReason.Error -> UNRECOVERABLE_ERROR
+                                StopReason.Error -> UNRECOVERABLE_ERROR
 
-                                    StopReason.ExplicitDisconnect,
-                                    StopReason.EventChannelClosed,
-                                    StopReason.CommandChannelClosed,
-                                    -> null
-                                }
-
-                            if (startedByUser && message != null) {
-                                TunnelNotification.showDisconnectedNotification(context, message)
+                                StopReason.ExplicitDisconnect,
+                                StopReason.EventChannelClosed,
+                                StopReason.CommandChannelClosed,
+                                -> null
                             }
+
+                        if (startedByUser && message != null) {
+                            TunnelNotification.showDisconnectedNotification(context, message)
                         }
-                } catch (e: ConnlibException) {
-                    Log.e(TAG, "Failed to start session", e)
-                    e.close()
-                } catch (e: X509IdentityException) {
-                    Log.e(TAG, "Failed to load the client certificate", e)
-                    val advice = "Contact your administrator for support."
-                    showErrorNotification(
-                        "Client certificate unavailable",
-                        e.message?.takeUnless(String::isBlank)?.let { "$it $advice" } ?: advice,
-                    )
-                } finally {
-                    commandChannel = null
-                    tunnelState = State.DOWN
+                    }
+            } catch (e: ConnlibException) {
+                Log.e(TAG, "Failed to start session", e)
+                e.close()
+            } finally {
+                commandChannel = null
+                tunnelState = State.DOWN
 
-                    stopNetworkMonitoring()
-                    stopFeatureFlagPoll()
+                stopNetworkMonitoring()
+                stopFeatureFlagPoll()
+                stopLogCleanup()
 
-                    // Stop the foreground notification
+                val shouldReconnect = reconnectAfterDisconnect
+                reconnectAfterDisconnect = false
+                if (!shouldReconnect || !connect()) {
                     stopForeground(STOP_FOREGROUND_REMOVE)
-                    stopLogCleanup()
                     stopSelf()
                 }
             }
         }
+
+        return true
     }
 
     private fun sendTunnelCommand(command: TunnelCommand) {
@@ -560,7 +583,7 @@ class TunnelService : VpnService() {
     }
 
     private fun getDeviceName(): String {
-        val deviceName = appRestrictions.getString("deviceName")
+        val deviceName = managedConfiguration.deviceName
         return if (deviceName.isNullOrBlank() || deviceName == "null") {
             Build.MODEL
         } else {
@@ -854,9 +877,6 @@ class TunnelService : VpnService() {
             Files.createDirectories(Paths.get(flowLogsDir))
             return flowLogsDir
         }
-
-        private val MANAGED_CONFIGURATIONS =
-            arrayOf("token", "allowedApplications", "disallowedApplications", "deviceName")
 
         @Volatile
         private var activeService: TunnelService? = null

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -32,6 +32,7 @@ import dev.firezone.android.core.data.model.ManagedConfiguration
 import dev.firezone.android.core.data.model.SessionCredential
 import dev.firezone.android.core.data.model.shouldClearSavedCredentials
 import dev.firezone.android.core.x509.X509Identity
+import dev.firezone.android.core.x509.X509IdentityException
 import dev.firezone.android.tunnel.model.Cidr
 import dev.firezone.android.tunnel.model.ConnectedDevice
 import dev.firezone.android.tunnel.model.Resource
@@ -417,6 +418,10 @@ class TunnelService : VpnService() {
 
     private fun createConnection(managedConfiguration: ManagedConfiguration): ConnectionParameters? {
         val credential = managedConfiguration.resolveSessionCredential(tokenStore.get()) ?: return null
+        val certificateAlias =
+            managedConfiguration.resolveX509CertificateAlias(
+                repo.getUserX509CertificateAliasSync(),
+            )
 
         return ConnectionParameters(
             commandChannel =
@@ -425,6 +430,7 @@ class TunnelService : VpnService() {
                     onUndeliveredElement = { command -> command.closeOwnedResources() },
                 ),
             credential = credential,
+            certificateAlias = certificateAlias,
             config = repo.getEffectiveConfig(repo.getUserConfigSync(), managedConfiguration),
             resourceState = repo.getInternetResourceStateSync(),
             managedConfiguration = managedConfiguration,
@@ -438,21 +444,6 @@ class TunnelService : VpnService() {
         // Dismiss any previous disconnected notifications
         TunnelNotification.dismissDisconnectedNotification(this)
 
-        val firebaseInstallationId =
-            runCatching { Tasks.await(FirebaseInstallations.getInstance().id) }
-                .getOrElse { exception ->
-                    Log.d(TAG, "Failed to obtain firebase installation id: $exception")
-                    null
-                }
-
-        val deviceInfo =
-            DeviceInfo(
-                firebaseInstallationId = firebaseInstallationId,
-                deviceUuid = null,
-                deviceSerial = null,
-                identifierForVendor = null,
-            )
-
         val context = this
 
         serviceScope.launch {
@@ -461,7 +452,8 @@ class TunnelService : VpnService() {
                 val deviceIdValue = deviceId()
                 Telemetry.setEnvironmentOrClose(connection.config.apiUrl)
                 Telemetry.setFirezoneId(deviceIdValue)
-                Telemetry.setAccountSlug(connection.config.accountSlug)
+                // The portal names the account in `init`; until then this session has none.
+                Telemetry.setAccountSlug(null)
 
                 configureLogger(
                     logDir(this@TunnelService),
@@ -469,20 +461,32 @@ class TunnelService : VpnService() {
                     flowLogsDir(this@TunnelService),
                 )
 
-                Session
-                    .newAndroid(
-                        config =
-                            AndroidSessionConfig(
-                                apiUrl = connection.config.apiUrl,
-                                token = connection.credential.token,
-                                accountSlug = connection.config.accountSlug,
-                                deviceId = deviceIdValue,
-                                deviceName = getDeviceName(connection.managedConfiguration),
-                                isInternetResourceActive = resourceState.isEnabled(),
-                                deviceInfo = deviceInfo,
-                            ),
-                        protectSocket = protectSocketCallback,
-                        tlsIdentity = null,
+                val deviceInfo =
+                    DeviceInfo(
+                        firebaseInstallationId = firebaseInstallationId(),
+                        deviceUuid = null,
+                        deviceSerial = null,
+                        identifierForVendor = null,
+                    )
+
+                // The KeyChain blocks on a system service and connlib reads the identity while
+                // it constructs the session, so load it before we get there.
+                val identity =
+                    withContext(Dispatchers.IO) { x509Identity.load(connection.certificateAlias) }
+
+                sessionFactory
+                    .open(
+                        AndroidSessionConfig(
+                            apiUrl = connection.config.apiUrl,
+                            token = connection.credential.token,
+                            deviceId = deviceIdValue,
+                            deviceName = getDeviceName(connection.managedConfiguration),
+                            isInternetResourceActive = resourceState.isEnabled(),
+                            deviceInfo = deviceInfo,
+                        ),
+                        // The token authenticates the user. A configured certificate attests
+                        // the device, and the portal decides whether to accept it.
+                        tlsIdentity = identity?.tlsIdentity,
                     ).use { session ->
                         startNetworkMonitoring()
                         startLogCleanup()
@@ -511,6 +515,13 @@ class TunnelService : VpnService() {
             } catch (e: ConnlibException) {
                 Log.e(TAG, "Failed to start session", e)
                 e.close()
+            } catch (e: X509IdentityException) {
+                Log.e(TAG, "Failed to load the client certificate", e)
+                val advice = "Contact your administrator for support."
+                showErrorNotification(
+                    "Client certificate unavailable",
+                    e.message?.takeUnless(String::isBlank)?.let { "$it $advice" } ?: advice,
+                )
             } finally {
                 beginConnectionCompletion(connection)
                 stopNetworkMonitoring()
@@ -747,6 +758,7 @@ class TunnelService : VpnService() {
     private data class ConnectionParameters(
         val commandChannel: Channel<TunnelCommand>,
         val credential: SessionCredential,
+        val certificateAlias: String?,
         val config: Config,
         val resourceState: ResourceState,
         val managedConfiguration: ManagedConfiguration,

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/data/ManagedConfigurationSourceTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/data/ManagedConfigurationSourceTest.kt
@@ -7,9 +7,12 @@ import android.content.RestrictionsManager
 import android.content.SharedPreferences
 import android.os.Bundle
 import dev.firezone.android.core.data.model.Config
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -32,7 +35,7 @@ class ManagedConfigurationSourceTest {
 
     @Before
     fun setUp() {
-        val context = RuntimeEnvironment.getApplication<Application>()
+        val context: Application = RuntimeEnvironment.getApplication()
         sharedPreferences = context.getSharedPreferences("managed-configuration-source-test", Context.MODE_PRIVATE)
         sharedPreferences.edit().clear().commit()
         repository = Repository(context, Dispatchers.Unconfined, sharedPreferences)
@@ -63,6 +66,13 @@ class ManagedConfigurationSourceTest {
             assertTrue(repository.getManagedStatus().isAuthUrlManaged)
             assertTrue(repository.getManagedStatus().isConnectOnStartManaged)
 
+            repository
+                .saveSettings(
+                    repository.getConfigSync().copy(
+                        logFilter = "trace",
+                    ),
+                ).first()
+
             source.applyRestrictions(
                 Bundle().apply {
                     putString("token", "second-token")
@@ -80,8 +90,66 @@ class ManagedConfigurationSourceTest {
             source.applyRestrictions(Bundle())
 
             assertNull(source.configuration.value?.token)
-            assertEquals(userConfig, repository.getConfigSync())
+            assertEquals(userConfig.copy(logFilter = "trace"), repository.getConfigSync())
             assertFalse(repository.getManagedStatus().isApiUrlManaged)
+        }
+
+    @Test
+    fun `refresh reads restrictions after acquiring the serialization lock`() =
+        runBlocking {
+            val releaseFirstRead = CompletableDeferred<Unit>()
+            var secondReadStarted = false
+
+            val firstRefresh =
+                async(start = CoroutineStart.UNDISPATCHED) {
+                    source.refresh {
+                        releaseFirstRead.await()
+                        Bundle().apply { putString("token", "old-token") }
+                    }
+                }
+            val secondRefresh =
+                async(start = CoroutineStart.UNDISPATCHED) {
+                    source.refresh {
+                        secondReadStarted = true
+                        Bundle().apply { putString("token", "new-token") }
+                    }
+                }
+
+            assertFalse(secondReadStarted)
+            releaseFirstRead.complete(Unit)
+            firstRefresh.await()
+            secondRefresh.await()
+
+            assertEquals("new-token", source.configuration.value?.token)
+        }
+
+    @Test
+    fun `user draft survives policy removal across recreation`() =
+        runBlocking {
+            repository.saveSettings(userConfig).first()
+            source.applyRestrictions(
+                Bundle().apply {
+                    putString("authUrl", "https://managed.example.com")
+                },
+            )
+
+            val userDraft = repository.getUserConfigSync()
+            val managedStatus = repository.getManagedStatus()
+            val editedEffectiveConfig = repository.getEffectiveConfig(userDraft).copy(logFilter = "trace")
+            val retainedUserDraft =
+                repository.mergeUnmanagedConfig(userDraft, editedEffectiveConfig, managedStatus)
+            assertEquals(userConfig.copy(logFilter = "trace"), retainedUserDraft)
+            assertEquals(
+                "https://managed.example.com",
+                repository.getEffectiveConfig(retainedUserDraft).authUrl,
+            )
+
+            source.applyRestrictions(Bundle())
+
+            assertEquals(
+                userConfig.copy(logFilter = "trace"),
+                repository.getEffectiveConfig(retainedUserDraft),
+            )
         }
 
     private companion object {

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/data/ManagedConfigurationSourceTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/data/ManagedConfigurationSourceTest.kt
@@ -1,0 +1,98 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.core.data
+
+import android.app.Application
+import android.content.Context
+import android.content.RestrictionsManager
+import android.content.SharedPreferences
+import android.os.Bundle
+import dev.firezone.android.core.data.model.Config
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config as RobolectricConfig
+
+@RunWith(RobolectricTestRunner::class)
+@RobolectricConfig(application = Application::class)
+class ManagedConfigurationSourceTest {
+    private lateinit var sharedPreferences: SharedPreferences
+    private lateinit var repository: Repository
+    private lateinit var source: ManagedConfigurationSource
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication<Application>()
+        sharedPreferences = context.getSharedPreferences("managed-configuration-source-test", Context.MODE_PRIVATE)
+        sharedPreferences.edit().clear().commit()
+        repository = Repository(context, Dispatchers.Unconfined, sharedPreferences)
+        source =
+            ManagedConfigurationSource(
+                context,
+                context.getSystemService(RestrictionsManager::class.java)!!,
+                repository,
+                CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
+            )
+    }
+
+    @Test
+    fun `updates and revokes token and managed settings`() =
+        runBlocking {
+            repository.saveSettings(userConfig).first()
+
+            source.applyRestrictions(
+                Bundle().apply {
+                    putString("token", "first-token")
+                    putString("authUrl", "https://managed.example.com")
+                    putBoolean("connectOnStart", true)
+                },
+            )
+
+            assertEquals("first-token", source.configuration.value?.token)
+            assertEquals("https://managed.example.com", repository.getConfigSync().authUrl)
+            assertTrue(repository.getManagedStatus().isAuthUrlManaged)
+            assertTrue(repository.getManagedStatus().isConnectOnStartManaged)
+
+            source.applyRestrictions(
+                Bundle().apply {
+                    putString("token", "second-token")
+                    putString("apiUrl", "wss://managed.example.com")
+                },
+            )
+
+            assertEquals("second-token", source.configuration.value?.token)
+            assertEquals(userConfig.authUrl, repository.getConfigSync().authUrl)
+            assertEquals("wss://managed.example.com", repository.getConfigSync().apiUrl)
+            assertFalse(repository.getManagedStatus().isAuthUrlManaged)
+            assertFalse(repository.getManagedStatus().isConnectOnStartManaged)
+            assertTrue(repository.getManagedStatus().isApiUrlManaged)
+
+            source.applyRestrictions(Bundle())
+
+            assertNull(source.configuration.value?.token)
+            assertEquals(userConfig, repository.getConfigSync())
+            assertFalse(repository.getManagedStatus().isApiUrlManaged)
+        }
+
+    private companion object {
+        val userConfig =
+            Config(
+                authUrl = "https://user.example.com",
+                apiUrl = "wss://user.example.com",
+                logFilter = "info",
+                accountSlug = "user-account",
+                startOnLogin = false,
+                connectOnStart = false,
+            )
+    }
+}

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/data/ManagedConfigurationSourceTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/data/ManagedConfigurationSourceTest.kt
@@ -135,11 +135,9 @@ class ManagedConfigurationSourceTest {
                 )
 
             val userDraft = repository.getUserConfigSync()
-            val managedStatus = managedConfiguration.managedStatus()
             val editedEffectiveConfig =
                 repository.getEffectiveConfig(userDraft, managedConfiguration).copy(logFilter = "trace")
-            val retainedUserDraft =
-                repository.mergeUnmanagedConfig(userDraft, editedEffectiveConfig, managedStatus)
+            val retainedUserDraft = userDraft.copy(logFilter = editedEffectiveConfig.logFilter)
             assertEquals(userConfig.copy(logFilter = "trace"), retainedUserDraft)
             assertEquals(
                 "https://managed.example.com",

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/data/ManagedConfigurationSourceTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/data/ManagedConfigurationSourceTest.kt
@@ -3,7 +3,6 @@ package dev.firezone.android.core.data
 
 import android.app.Application
 import android.content.Context
-import android.content.RestrictionsManager
 import android.content.SharedPreferences
 import android.os.Bundle
 import dev.firezone.android.core.data.model.Config
@@ -42,7 +41,7 @@ class ManagedConfigurationSourceTest {
         source =
             ManagedConfigurationSource(
                 context,
-                context.getSystemService(RestrictionsManager::class.java)!!,
+                ManagedConfigurationReader { Bundle() },
                 repository,
                 CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
             )

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/data/ManagedConfigurationSourceTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/data/ManagedConfigurationSourceTest.kt
@@ -8,8 +8,8 @@ import android.content.SharedPreferences
 import android.os.Bundle
 import dev.firezone.android.core.data.model.Config
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
@@ -127,28 +127,30 @@ class ManagedConfigurationSourceTest {
     fun `user draft survives policy removal across recreation`() =
         runBlocking {
             repository.saveSettings(userConfig).first()
-            source.applyRestrictions(
-                Bundle().apply {
-                    putString("authUrl", "https://managed.example.com")
-                },
-            )
+            val managedConfiguration =
+                source.applyRestrictions(
+                    Bundle().apply {
+                        putString("authUrl", "https://managed.example.com")
+                    },
+                )
 
             val userDraft = repository.getUserConfigSync()
-            val managedStatus = repository.getManagedStatus()
-            val editedEffectiveConfig = repository.getEffectiveConfig(userDraft).copy(logFilter = "trace")
+            val managedStatus = managedConfiguration.managedStatus()
+            val editedEffectiveConfig =
+                repository.getEffectiveConfig(userDraft, managedConfiguration).copy(logFilter = "trace")
             val retainedUserDraft =
                 repository.mergeUnmanagedConfig(userDraft, editedEffectiveConfig, managedStatus)
             assertEquals(userConfig.copy(logFilter = "trace"), retainedUserDraft)
             assertEquals(
                 "https://managed.example.com",
-                repository.getEffectiveConfig(retainedUserDraft).authUrl,
+                repository.getEffectiveConfig(retainedUserDraft, managedConfiguration).authUrl,
             )
 
-            source.applyRestrictions(Bundle())
+            val revokedConfiguration = source.applyRestrictions(Bundle())
 
             assertEquals(
                 userConfig.copy(logFilter = "trace"),
-                repository.getEffectiveConfig(retainedUserDraft),
+                repository.getEffectiveConfig(retainedUserDraft, revokedConfiguration),
             )
         }
 

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/data/RepositoryManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/data/RepositoryManagedConfigurationTest.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.os.Bundle
 import dev.firezone.android.core.data.model.ManagedConfigStatus
+import dev.firezone.android.core.data.model.ManagedConfiguration
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -161,12 +162,22 @@ class RepositoryManagedConfigurationTest {
                 }
             repository.saveManagedConfiguration(managedRestrictions).first()
 
-            assertEquals("managed-alias", repository.getX509CertificateAliasSync(managedRestrictions))
+            assertEquals(
+                "managed-alias",
+                ManagedConfiguration
+                    .from(managedRestrictions)
+                    .resolveX509CertificateAlias(repository.getUserX509CertificateAliasSync()),
+            )
 
             val revokedRestrictions = Bundle()
             repository.saveManagedConfiguration(revokedRestrictions).first()
 
-            assertEquals("user-alias", repository.getX509CertificateAliasSync(revokedRestrictions))
+            assertEquals(
+                "user-alias",
+                ManagedConfiguration
+                    .from(revokedRestrictions)
+                    .resolveX509CertificateAlias(repository.getUserX509CertificateAliasSync()),
+            )
         }
 
     private fun allManagedConfig(): Bundle =

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/data/model/ManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/data/model/ManagedConfigurationTest.kt
@@ -10,10 +10,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.robolectric.annotation.Config as RobolectricConfig
 
 @RunWith(RobolectricTestRunner::class)
-@Config(application = Application::class)
+@RobolectricConfig(application = Application::class)
 class ManagedConfigurationTest {
     @Test
     fun `parsing preserves absent and explicit boolean values`() {
@@ -77,5 +77,44 @@ class ManagedConfigurationTest {
     fun `managed authentication failure preserves saved user credentials`() {
         assertFalse(CredentialOrigin.MANAGED.shouldClearSavedCredentials(requiresSignIn = true))
         assertTrue(CredentialOrigin.USER.shouldClearSavedCredentials(requiresSignIn = true))
+    }
+
+    @Test
+    fun `effective config and mask come from one managed snapshot`() {
+        val userConfig =
+            Config(
+                authUrl = "https://user.example.com",
+                apiUrl = "wss://user.example.com",
+                logFilter = "info",
+                accountSlug = "user-account",
+                startOnLogin = false,
+                connectOnStart = false,
+            )
+        val snapshot =
+            ManagedConfiguration(
+                authUrl = "https://managed.example.com",
+                apiUrl = "wss://managed.example.com",
+                connectOnStart = true,
+            )
+
+        assertEquals(
+            userConfig.copy(
+                authUrl = "https://managed.example.com",
+                apiUrl = "wss://managed.example.com",
+                connectOnStart = true,
+            ),
+            snapshot.applyTo(userConfig),
+        )
+        assertEquals(
+            ManagedConfigStatus(
+                isAuthUrlManaged = true,
+                isApiUrlManaged = true,
+                isLogFilterManaged = false,
+                isAccountSlugManaged = false,
+                isStartOnLoginManaged = false,
+                isConnectOnStartManaged = true,
+            ),
+            snapshot.managedStatus(),
+        )
     }
 }

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/data/model/ManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/data/model/ManagedConfigurationTest.kt
@@ -3,6 +3,7 @@ package dev.firezone.android.core.data.model
 
 import android.app.Application
 import android.os.Bundle
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -49,5 +50,32 @@ class ManagedConfigurationTest {
         assertTrue(ManagedConfiguration(allowedApplications = "com.example.allowed").requiresVpnRebuild(previous))
         assertTrue(ManagedConfiguration(disallowedApplications = "com.example.blocked").requiresVpnRebuild(previous))
         assertFalse(ManagedConfiguration(token = "token").requiresVpnRebuild(previous))
+    }
+
+    @Test
+    fun `absent managed token uses the saved user token`() {
+        assertEquals(
+            SessionCredential("user-token", CredentialOrigin.USER),
+            ManagedConfiguration().resolveSessionCredential("user-token"),
+        )
+    }
+
+    @Test
+    fun `blank managed token explicitly disables the saved user token`() {
+        assertNull(ManagedConfiguration(token = "").resolveSessionCredential("user-token"))
+    }
+
+    @Test
+    fun `managed token records its credential origin`() {
+        assertEquals(
+            SessionCredential("managed-token", CredentialOrigin.MANAGED),
+            ManagedConfiguration(token = "managed-token").resolveSessionCredential("user-token"),
+        )
+    }
+
+    @Test
+    fun `managed authentication failure preserves saved user credentials`() {
+        assertFalse(CredentialOrigin.MANAGED.shouldClearSavedCredentials(requiresSignIn = true))
+        assertTrue(CredentialOrigin.USER.shouldClearSavedCredentials(requiresSignIn = true))
     }
 }

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/data/model/ManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/data/model/ManagedConfigurationTest.kt
@@ -1,0 +1,53 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.core.data.model
+
+import android.app.Application
+import android.os.Bundle
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class ManagedConfigurationTest {
+    @Test
+    fun `parsing preserves absent and explicit boolean values`() {
+        val configuration =
+            ManagedConfiguration.from(
+                Bundle().apply {
+                    putBoolean("connectOnStart", false)
+                },
+            )
+
+        assertFalse(configuration.connectOnStart!!)
+        assertNull(configuration.startOnLogin)
+    }
+
+    @Test
+    fun `session settings require reconnect`() {
+        val previous = ManagedConfiguration()
+
+        assertTrue(ManagedConfiguration(token = "token").requiresSessionReconnect(previous))
+        assertTrue(ManagedConfiguration().requiresSessionReconnect(ManagedConfiguration(token = "token")))
+        assertTrue(ManagedConfiguration(deviceName = "managed-device").requiresSessionReconnect(previous))
+        assertTrue(ManagedConfiguration(apiUrl = "wss://api.example.com").requiresSessionReconnect(previous))
+        assertTrue(ManagedConfiguration(accountSlug = "example").requiresSessionReconnect(previous))
+        assertFalse(ManagedConfiguration(authUrl = "https://app.example.com").requiresSessionReconnect(previous))
+        assertFalse(ManagedConfiguration(logFilter = "debug").requiresSessionReconnect(previous))
+        assertFalse(ManagedConfiguration(startOnLogin = true).requiresSessionReconnect(previous))
+        assertFalse(ManagedConfiguration(connectOnStart = true).requiresSessionReconnect(previous))
+    }
+
+    @Test
+    fun `application routing settings require VPN rebuild`() {
+        val previous = ManagedConfiguration()
+
+        assertTrue(ManagedConfiguration(allowedApplications = "com.example.allowed").requiresVpnRebuild(previous))
+        assertTrue(ManagedConfiguration(disallowedApplications = "com.example.blocked").requiresVpnRebuild(previous))
+        assertFalse(ManagedConfiguration(token = "token").requiresVpnRebuild(previous))
+    }
+}

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/data/model/ManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/data/model/ManagedConfigurationTest.kt
@@ -36,7 +36,7 @@ class ManagedConfigurationTest {
         assertTrue(ManagedConfiguration().requiresSessionReconnect(ManagedConfiguration(token = "token")))
         assertTrue(ManagedConfiguration(deviceName = "managed-device").requiresSessionReconnect(previous))
         assertTrue(ManagedConfiguration(apiUrl = "wss://api.example.com").requiresSessionReconnect(previous))
-        assertTrue(ManagedConfiguration(accountSlug = "example").requiresSessionReconnect(previous))
+        assertFalse(ManagedConfiguration(accountSlug = "example").requiresSessionReconnect(previous))
         assertFalse(ManagedConfiguration(authUrl = "https://app.example.com").requiresSessionReconnect(previous))
         assertFalse(ManagedConfiguration(logFilter = "debug").requiresSessionReconnect(previous))
         assertFalse(ManagedConfiguration(startOnLogin = true).requiresSessionReconnect(previous))

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/data/model/ManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/data/model/ManagedConfigurationTest.kt
@@ -26,6 +26,28 @@ class ManagedConfigurationTest {
 
         assertFalse(configuration.connectOnStart!!)
         assertNull(configuration.startOnLogin)
+        assertNull(configuration.x509CertificateAlias)
+
+        val blankAlias =
+            ManagedConfiguration.from(
+                Bundle().apply {
+                    putString("x509CertificateAlias", "")
+                },
+            )
+
+        assertEquals("", blankAlias.x509CertificateAlias)
+        assertTrue(blankAlias.isX509CertificateAliasManaged())
+
+        val nullAlias =
+            ManagedConfiguration.from(
+                Bundle().apply {
+                    putString("x509CertificateAlias", null)
+                },
+            )
+
+        assertNull(nullAlias.x509CertificateAlias)
+        assertTrue(nullAlias.isX509CertificateAliasManaged())
+        assertNull(nullAlias.resolveX509CertificateAlias("user-alias"))
     }
 
     @Test
@@ -36,6 +58,13 @@ class ManagedConfigurationTest {
         assertTrue(ManagedConfiguration().requiresSessionReconnect(ManagedConfiguration(token = "token")))
         assertTrue(ManagedConfiguration(deviceName = "managed-device").requiresSessionReconnect(previous))
         assertTrue(ManagedConfiguration(apiUrl = "wss://api.example.com").requiresSessionReconnect(previous))
+        assertTrue(ManagedConfiguration(x509CertificateAlias = "managed-alias").requiresSessionReconnect(previous))
+        assertTrue(ManagedConfiguration(x509CertificateAliasManaged = true).requiresSessionReconnect(previous))
+        assertTrue(
+            ManagedConfiguration().requiresSessionReconnect(
+                ManagedConfiguration(x509CertificateAlias = "managed-alias"),
+            ),
+        )
         assertFalse(ManagedConfiguration(accountSlug = "example").requiresSessionReconnect(previous))
         assertFalse(ManagedConfiguration(authUrl = "https://app.example.com").requiresSessionReconnect(previous))
         assertFalse(ManagedConfiguration(logFilter = "debug").requiresSessionReconnect(previous))
@@ -77,6 +106,23 @@ class ManagedConfigurationTest {
     fun `managed authentication failure preserves saved user credentials`() {
         assertFalse(CredentialOrigin.MANAGED.shouldClearSavedCredentials(requiresSignIn = true))
         assertTrue(CredentialOrigin.USER.shouldClearSavedCredentials(requiresSignIn = true))
+    }
+
+    @Test
+    fun `managed certificate alias overrides disables and restores the user selection`() {
+        val userAlias = "user-alias"
+
+        assertEquals(userAlias, ManagedConfiguration().resolveX509CertificateAlias(userAlias))
+        assertEquals(
+            "managed-alias",
+            ManagedConfiguration(x509CertificateAlias = "managed-alias")
+                .resolveX509CertificateAlias(userAlias),
+        )
+        assertNull(
+            ManagedConfiguration(x509CertificateAlias = "")
+                .resolveX509CertificateAlias(userAlias),
+        )
+        assertEquals(userAlias, ManagedConfiguration().resolveX509CertificateAlias(userAlias))
     }
 
     @Test

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/x509/CertificateAccessTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/x509/CertificateAccessTest.kt
@@ -6,13 +6,18 @@ import android.app.Application
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
+import dev.firezone.android.core.data.ManagedConfigurationReader
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.data.X509_CERTIFICATE_ALIAS_RESTRICTION
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -27,15 +32,31 @@ import java.security.cert.X509Certificate
 class CertificateAccessTest {
     private val keyChain = WithholdingKeyChain()
     private val restrictions = Bundle()
-    private val repository =
-        Repository(
-            RuntimeEnvironment.getApplication(),
-            Dispatchers.Unconfined,
-            RuntimeEnvironment
-                .getApplication()
-                .getSharedPreferences("certificate-access-test", Context.MODE_PRIVATE),
-        )
-    private val certificateAccess = CertificateAccess(repository, restrictions, keyChain)
+    private lateinit var repository: Repository
+    private lateinit var certificateAccess: CertificateAccess
+
+    @Before
+    fun setUp() {
+        val application: Application = RuntimeEnvironment.getApplication()
+        val preferences = application.getSharedPreferences("certificate-access-test", Context.MODE_PRIVATE)
+        preferences.edit().clear().commit()
+        restrictions.clear()
+        repository = Repository(application, Dispatchers.Unconfined, preferences)
+        val managedConfigurationSource =
+            ManagedConfigurationSource(
+                application,
+                ManagedConfigurationReader { Bundle(restrictions) },
+                repository,
+                CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
+            )
+        certificateAccess =
+            CertificateAccess(
+                repository = repository,
+                managedConfigurationSource = managedConfigurationSource,
+                keyChain = keyChain,
+                coroutineDispatcher = Dispatchers.Unconfined,
+            )
+    }
 
     @Test
     fun `no configured alias needs no selection`() {

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthViewModelManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthViewModelManagedConfigurationTest.kt
@@ -1,0 +1,63 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.features.auth.ui
+
+import android.app.Application
+import android.content.Context
+import android.os.Bundle
+import android.os.Looper
+import dev.firezone.android.core.data.ManagedConfigurationReader
+import dev.firezone.android.core.data.ManagedConfigurationSource
+import dev.firezone.android.core.data.Repository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class AuthViewModelManagedConfigurationTest {
+    private lateinit var repository: Repository
+    private lateinit var viewModel: AuthViewModel
+
+    @Before
+    fun setUp() {
+        val context: Application = RuntimeEnvironment.getApplication()
+        val sharedPreferences =
+            context.getSharedPreferences("auth-managed-configuration-test", Context.MODE_PRIVATE)
+        sharedPreferences.edit().clear().commit()
+        repository = Repository(context, Dispatchers.Unconfined, sharedPreferences)
+        val restrictions =
+            Bundle().apply {
+                putString("authUrl", "https://managed.example.com")
+                putString("accountSlug", "managed-account")
+            }
+        val source =
+            ManagedConfigurationSource(
+                context,
+                ManagedConfigurationReader { Bundle(restrictions) },
+                repository,
+                CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
+            )
+        viewModel = AuthViewModel(repository, source)
+    }
+
+    @Test
+    fun `authentication uses the latest managed URL and account`() {
+        viewModel.onActivityResume()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        val action = viewModel.actionStateFlow.value as AuthViewModel.ViewAction.LaunchAuthFlow
+        assertEquals(
+            "https://managed.example.com/managed-account" +
+                "?state=${repository.getStateSync()}&nonce=${repository.getNonceSync()}&as=gui-client",
+            action.url,
+        )
+    }
+}

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthViewModelManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/auth/ui/AuthViewModelManagedConfigurationTest.kt
@@ -3,15 +3,20 @@ package dev.firezone.android.features.auth.ui
 
 import android.app.Application
 import android.content.Context
+import android.net.Uri
 import android.os.Bundle
 import android.os.Looper
 import dev.firezone.android.core.data.ManagedConfigurationReader
 import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.data.TokenStore
+import dev.firezone.android.features.auth.AuthCallbackHandler
+import dev.firezone.android.features.auth.PendingAuthSession
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -45,19 +50,28 @@ class AuthViewModelManagedConfigurationTest {
                 repository,
                 CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
             )
-        viewModel = AuthViewModel(repository, source)
+        val pendingAuthSession = PendingAuthSession()
+        viewModel =
+            AuthViewModel(
+                repository,
+                pendingAuthSession,
+                AuthCallbackHandler(pendingAuthSession, TokenStore(sharedPreferences)),
+                source,
+            )
     }
 
     @Test
     fun `authentication uses the latest managed URL and account`() {
-        viewModel.onActivityResume()
+        viewModel.startAuthFlow()
         shadowOf(Looper.getMainLooper()).idle()
 
         val action = viewModel.actionStateFlow.value as AuthViewModel.ViewAction.LaunchAuthFlow
-        assertEquals(
-            "https://managed.example.com/managed-account" +
-                "?state=${repository.getStateSync()}&nonce=${repository.getNonceSync()}&as=gui-client",
-            action.url,
-        )
+        val uri = Uri.parse(action.url)
+        assertEquals("https", uri.scheme)
+        assertEquals("managed.example.com", uri.host)
+        assertEquals("/managed-account", uri.path)
+        assertFalse(uri.getQueryParameter("state").isNullOrBlank())
+        assertFalse(uri.getQueryParameter("nonce").isNullOrBlank())
+        assertEquals("gui-client", uri.getQueryParameter("as"))
     }
 }

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/DeviceTrustSettingsViewModelTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/DeviceTrustSettingsViewModelTest.kt
@@ -12,7 +12,6 @@ import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.data.X509_CERTIFICATE_ALIAS_RESTRICTION
 import dev.firezone.android.core.x509.KeyChain
-import dev.firezone.android.core.x509.X509Identity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -33,16 +32,16 @@ import java.security.cert.X509Certificate
 
 @RunWith(RobolectricTestRunner::class)
 @Config(application = Application::class)
-class X509SettingsViewModelTest {
+class DeviceTrustSettingsViewModelTest {
     private val restrictions = Bundle()
     private lateinit var repository: Repository
     private lateinit var source: ManagedConfigurationSource
-    private lateinit var viewModel: X509SettingsViewModel
+    private lateinit var viewModel: DeviceTrustSettingsViewModel
 
     @Before
     fun setUp() {
         val application: Application = RuntimeEnvironment.getApplication()
-        val preferences = application.getSharedPreferences("x509-settings-view-model-test", Context.MODE_PRIVATE)
+        val preferences = application.getSharedPreferences("device-trust-settings-test", Context.MODE_PRIVATE)
         preferences.edit().clear().commit()
         restrictions.clear()
         repository = Repository(application, Dispatchers.Unconfined, preferences)
@@ -53,7 +52,13 @@ class X509SettingsViewModelTest {
                 repository,
                 CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
             )
-        viewModel = X509SettingsViewModel(repository, source, X509Identity(WithholdingKeyChain()))
+        viewModel =
+            DeviceTrustSettingsViewModel(
+                repository = repository,
+                managedConfigurationSource = source,
+                keyChain = WithholdingKeyChain(),
+                coroutineDispatcher = Dispatchers.Unconfined,
+            )
     }
 
     @Test

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
@@ -8,6 +8,7 @@ import android.os.Looper
 import dev.firezone.android.core.data.ManagedConfigurationReader
 import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.data.X509_CERTIFICATE_ALIAS_RESTRICTION
 import dev.firezone.android.core.data.model.Config
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -84,7 +85,7 @@ class SettingsManagedConfigurationTest {
 
             source.applyRestrictions(
                 Bundle().apply {
-                    putString("x509CertificateAlias", "")
+                    putString(X509_CERTIFICATE_ALIAS_RESTRICTION, "")
                 },
             )
             assertFalse(viewModel.hasConfiguredCertificateAlias())

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
@@ -3,10 +3,10 @@ package dev.firezone.android.features.settings.ui
 
 import android.app.Application
 import android.content.Context
-import android.content.RestrictionsManager
 import android.os.Bundle
 import android.os.Looper
 import dev.firezone.android.core.data.ManagedConfigurationSource
+import dev.firezone.android.core.data.ManagedConfigurationReader
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.data.model.Config
 import kotlinx.coroutines.CoroutineScope
@@ -42,7 +42,7 @@ class SettingsManagedConfigurationTest {
         source =
             ManagedConfigurationSource(
                 context,
-                context.getSystemService(RestrictionsManager::class.java)!!,
+                ManagedConfigurationReader { Bundle() },
                 repository,
                 CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
             )
@@ -174,6 +174,26 @@ class SettingsManagedConfigurationTest {
             shadowOf(Looper.getMainLooper()).idle()
 
             assertEquals(userConfig.copy(logFilter = "trace"), repository.getUserConfigSync())
+        }
+
+    @Test
+    fun `sequential field callbacks preserve earlier draft edits`() =
+        runBlocking {
+            source.applyRestrictions(Bundle())
+            shadowOf(Looper.getMainLooper()).idle()
+
+            viewModel.onValidateAuthUrl("https://edited.example.com")
+            viewModel.onValidateLogFilter("trace")
+            viewModel.onConnectOnStartChanged(true)
+
+            assertEquals(
+                userConfig.copy(
+                    authUrl = "https://edited.example.com",
+                    logFilter = "trace",
+                    connectOnStart = true,
+                ),
+                viewModel.configStateFlow.value,
+            )
         }
 
     @Test

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
@@ -29,6 +29,7 @@ import org.robolectric.annotation.Config as RobolectricConfig
 @RunWith(RobolectricTestRunner::class)
 @RobolectricConfig(application = Application::class)
 class SettingsManagedConfigurationTest {
+    private val restrictions = Bundle()
     private lateinit var repository: Repository
     private lateinit var source: ManagedConfigurationSource
     private lateinit var viewModel: SettingsViewModel
@@ -39,11 +40,12 @@ class SettingsManagedConfigurationTest {
         val sharedPreferences =
             context.getSharedPreferences("settings-managed-configuration-test", Context.MODE_PRIVATE)
         sharedPreferences.edit().clear().commit()
+        restrictions.clear()
         repository = Repository(context, Dispatchers.Unconfined, sharedPreferences)
         source =
             ManagedConfigurationSource(
                 context,
-                ManagedConfigurationReader { Bundle() },
+                ManagedConfigurationReader { Bundle(restrictions) },
                 repository,
                 CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
             )
@@ -83,14 +85,10 @@ class SettingsManagedConfigurationTest {
         runBlocking {
             repository.saveX509CertificateAliasSync("user-alias")
 
-            source.applyRestrictions(
-                Bundle().apply {
-                    putString(X509_CERTIFICATE_ALIAS_RESTRICTION, "")
-                },
-            )
+            restrictions.putString(X509_CERTIFICATE_ALIAS_RESTRICTION, "")
             assertFalse(viewModel.hasConfiguredCertificateAlias())
 
-            source.applyRestrictions(Bundle())
+            restrictions.clear()
             assertTrue(viewModel.hasConfiguredCertificateAlias())
 
             repository.saveX509CertificateAliasSync(null)

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
@@ -46,6 +46,7 @@ class SettingsManagedConfigurationTest {
                 repository,
                 CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
             )
+        runBlocking { repository.saveSettings(userConfig).first() }
         viewModel = SettingsViewModel(repository, source)
     }
 
@@ -117,6 +118,28 @@ class SettingsManagedConfigurationTest {
         }
 
     @Test
+    fun `saving after policy arrival preserves the prior user edit`() =
+        runBlocking {
+            source.applyRestrictions(Bundle())
+            shadowOf(Looper.getMainLooper()).idle()
+            viewModel.onValidateAuthUrl("https://unsaved.example.com")
+
+            source.applyRestrictions(
+                Bundle().apply {
+                    putString("authUrl", "https://managed.example.com")
+                },
+            )
+            shadowOf(Looper.getMainLooper()).idle()
+            viewModel.onSaveSettingsCompleted()
+            shadowOf(Looper.getMainLooper()).idle()
+
+            source.applyRestrictions(Bundle())
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertEquals("https://unsaved.example.com", repository.getConfigSync().authUrl)
+        }
+
+    @Test
     fun `saving a reset clears favorites`() {
         repository.addFavoriteResource(FAVORITE_ID)
 
@@ -124,7 +147,10 @@ class SettingsManagedConfigurationTest {
         viewModel.onSaveSettingsCompleted()
         shadowOf(Looper.getMainLooper()).idle()
 
-        assertTrue(repository.favorites.value.inner.isEmpty())
+        assertTrue(
+            repository.favorites.value.inner
+                .isEmpty(),
+        )
     }
 
     private companion object {

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
@@ -1,0 +1,89 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.features.settings.ui
+
+import android.app.Application
+import android.content.Context
+import android.content.RestrictionsManager
+import android.os.Bundle
+import android.os.Looper
+import dev.firezone.android.core.data.ManagedConfigurationSource
+import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.data.model.Config
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config as RobolectricConfig
+
+@RunWith(RobolectricTestRunner::class)
+@RobolectricConfig(application = Application::class)
+class SettingsManagedConfigurationTest {
+    private lateinit var repository: Repository
+    private lateinit var source: ManagedConfigurationSource
+    private lateinit var viewModel: SettingsViewModel
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication<Application>()
+        val sharedPreferences = context.getSharedPreferences("settings-managed-configuration-test", Context.MODE_PRIVATE)
+        sharedPreferences.edit().clear().commit()
+        repository = Repository(context, Dispatchers.Unconfined, sharedPreferences)
+        source =
+            ManagedConfigurationSource(
+                context,
+                context.getSystemService(RestrictionsManager::class.java)!!,
+                repository,
+                CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
+            )
+        viewModel = SettingsViewModel(repository, source)
+    }
+
+    @Test
+    fun `open settings follow managed configuration changes`() =
+        runBlocking {
+            repository.saveSettings(userConfig).first()
+
+            source.applyRestrictions(
+                Bundle().apply {
+                    putString("authUrl", "https://managed.example.com")
+                    putBoolean("connectOnStart", true)
+                },
+            )
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertEquals("https://managed.example.com", viewModel.configStateFlow.value.authUrl)
+            assertTrue(viewModel.configStateFlow.value.connectOnStart)
+            assertTrue(viewModel.managedStatusStateFlow.value!!.isAuthUrlManaged)
+            assertTrue(viewModel.managedStatusStateFlow.value!!.isConnectOnStartManaged)
+
+            viewModel.onValidateLogFilter("trace")
+            source.applyRestrictions(Bundle())
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertEquals(userConfig.copy(logFilter = "trace"), viewModel.configStateFlow.value)
+            assertFalse(viewModel.managedStatusStateFlow.value!!.isAuthUrlManaged)
+            assertFalse(viewModel.managedStatusStateFlow.value!!.isConnectOnStartManaged)
+        }
+
+    private companion object {
+        val userConfig =
+            Config(
+                authUrl = "https://user.example.com",
+                apiUrl = "wss://user.example.com",
+                logFilter = "info",
+                accountSlug = "user-account",
+                startOnLogin = false,
+                connectOnStart = false,
+            )
+    }
+}

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
@@ -34,8 +34,9 @@ class SettingsManagedConfigurationTest {
 
     @Before
     fun setUp() {
-        val context = RuntimeEnvironment.getApplication<Application>()
-        val sharedPreferences = context.getSharedPreferences("settings-managed-configuration-test", Context.MODE_PRIVATE)
+        val context: Application = RuntimeEnvironment.getApplication()
+        val sharedPreferences =
+            context.getSharedPreferences("settings-managed-configuration-test", Context.MODE_PRIVATE)
         sharedPreferences.edit().clear().commit()
         repository = Repository(context, Dispatchers.Unconfined, sharedPreferences)
         source =
@@ -75,7 +76,60 @@ class SettingsManagedConfigurationTest {
             assertFalse(viewModel.managedStatusStateFlow.value!!.isConnectOnStartManaged)
         }
 
+    @Test
+    fun `canceling a reset keeps favorites and managed values`() =
+        runBlocking {
+            repository.addFavoriteResource(FAVORITE_ID)
+            source.applyRestrictions(
+                Bundle().apply {
+                    putString("authUrl", "https://managed.example.com")
+                },
+            )
+            shadowOf(Looper.getMainLooper()).idle()
+
+            viewModel.resetSettingsToDefaults()
+            viewModel.onCancel()
+
+            assertTrue(FAVORITE_ID in repository.favorites.value.inner)
+            assertEquals("https://managed.example.com", viewModel.configStateFlow.value.authUrl)
+        }
+
+    @Test
+    fun `managed field restores its unsaved user edit after revocation`() =
+        runBlocking {
+            repository.saveSettings(userConfig).first()
+            source.applyRestrictions(Bundle())
+            shadowOf(Looper.getMainLooper()).idle()
+
+            viewModel.onValidateAuthUrl("https://unsaved.example.com")
+            source.applyRestrictions(
+                Bundle().apply {
+                    putString("authUrl", "https://managed.example.com")
+                },
+            )
+            shadowOf(Looper.getMainLooper()).idle()
+            assertEquals("https://managed.example.com", viewModel.configStateFlow.value.authUrl)
+
+            source.applyRestrictions(Bundle())
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertEquals("https://unsaved.example.com", viewModel.configStateFlow.value.authUrl)
+        }
+
+    @Test
+    fun `saving a reset clears favorites`() {
+        repository.addFavoriteResource(FAVORITE_ID)
+
+        viewModel.resetSettingsToDefaults()
+        viewModel.onSaveSettingsCompleted()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertTrue(repository.favorites.value.inner.isEmpty())
+    }
+
     private companion object {
+        const val FAVORITE_ID = "favorite-resource"
+
         val userConfig =
             Config(
                 authUrl = "https://user.example.com",

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
@@ -157,6 +157,26 @@ class SettingsManagedConfigurationTest {
         }
 
     @Test
+    fun `editing another field after policy removal preserves the raw user value`() =
+        runBlocking {
+            source.applyRestrictions(
+                Bundle().apply {
+                    putString("authUrl", "https://managed.example.com")
+                },
+            )
+            shadowOf(Looper.getMainLooper()).idle()
+            assertEquals("https://managed.example.com", viewModel.configStateFlow.value.authUrl)
+
+            source.applyRestrictions(Bundle())
+            shadowOf(Looper.getMainLooper()).idle()
+            viewModel.onValidateLogFilter("trace")
+            viewModel.onSaveSettingsCompleted()
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertEquals(userConfig.copy(logFilter = "trace"), repository.getUserConfigSync())
+        }
+
+    @Test
     fun `saving a reset clears favorites`() {
         repository.addFavoriteResource(FAVORITE_ID)
 

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
@@ -78,6 +78,25 @@ class SettingsManagedConfigurationTest {
         }
 
     @Test
+    fun `device trust availability follows the managed alias overlay`() =
+        runBlocking {
+            repository.saveX509CertificateAliasSync("user-alias")
+
+            source.applyRestrictions(
+                Bundle().apply {
+                    putString("x509CertificateAlias", "")
+                },
+            )
+            assertFalse(viewModel.hasConfiguredCertificateAlias())
+
+            source.applyRestrictions(Bundle())
+            assertTrue(viewModel.hasConfiguredCertificateAlias())
+
+            repository.saveX509CertificateAliasSync(null)
+            assertFalse(viewModel.hasConfiguredCertificateAlias())
+        }
+
+    @Test
     fun `canceling a reset keeps favorites and managed values`() =
         runBlocking {
             repository.addFavoriteResource(FAVORITE_ID)

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
@@ -5,8 +5,8 @@ import android.app.Application
 import android.content.Context
 import android.os.Bundle
 import android.os.Looper
-import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.ManagedConfigurationReader
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.data.model.Config
 import kotlinx.coroutines.CoroutineScope

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsManagedConfigurationTest.kt
@@ -118,6 +118,23 @@ class SettingsManagedConfigurationTest {
         }
 
     @Test
+    fun `edit before the first managed snapshot updates the overlaid user draft`() =
+        runBlocking {
+            repository
+                .saveManagedConfiguration(
+                    Bundle().apply {
+                        putString("authUrl", "https://managed.example.com")
+                    },
+                ).first()
+            val preSnapshotViewModel = SettingsViewModel(repository, source)
+
+            preSnapshotViewModel.onValidateLogFilter("trace")
+
+            assertEquals("https://managed.example.com", preSnapshotViewModel.configStateFlow.value.authUrl)
+            assertEquals("trace", preSnapshotViewModel.configStateFlow.value.logFilter)
+        }
+
+    @Test
     fun `saving after policy arrival preserves the prior user edit`() =
         runBlocking {
             source.applyRestrictions(Bundle())

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsScreenshotTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsScreenshotTest.kt
@@ -2,6 +2,7 @@
 package dev.firezone.android.features.settings.ui
 
 import android.app.Application
+import android.content.RestrictionsManager
 import android.os.Bundle
 import android.os.Looper
 import android.view.LayoutInflater
@@ -30,11 +31,14 @@ import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.captureRoboImage
 import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
 import dev.firezone.android.R
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.databinding.ActivitySettingsBinding
 import dev.firezone.android.features.session.ui.compose.FirezoneTheme
 import dev.firezone.android.features.settings.ui.compose.DeviceTrustSettingsScreen
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -277,7 +281,14 @@ internal class SettingsScreenshotActivity : AppCompatActivity() {
                         getSharedPreferences("settings-screenshot", MODE_PRIVATE),
                     )
                 runBlocking { repository.saveSettings(sampleConfig).first() }
-                SettingsViewModel(repository)
+                val managedConfigurationSource =
+                    ManagedConfigurationSource(
+                        applicationContext,
+                        getSystemService(RestrictionsManager::class.java)!!,
+                        repository,
+                        CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
+                    )
+                SettingsViewModel(repository, managedConfigurationSource)
             }
         }
 

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsScreenshotTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsScreenshotTest.kt
@@ -2,7 +2,6 @@
 package dev.firezone.android.features.settings.ui
 
 import android.app.Application
-import android.content.RestrictionsManager
 import android.os.Bundle
 import android.os.Looper
 import android.view.LayoutInflater
@@ -32,6 +31,7 @@ import com.github.takahirom.roborazzi.captureRoboImage
 import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
 import dev.firezone.android.R
 import dev.firezone.android.core.data.ManagedConfigurationSource
+import dev.firezone.android.core.data.ManagedConfigurationReader
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.databinding.ActivitySettingsBinding
 import dev.firezone.android.features.session.ui.compose.FirezoneTheme
@@ -284,7 +284,7 @@ internal class SettingsScreenshotActivity : AppCompatActivity() {
                 val managedConfigurationSource =
                     ManagedConfigurationSource(
                         applicationContext,
-                        getSystemService(RestrictionsManager::class.java)!!,
+                        ManagedConfigurationReader { Bundle() },
                         repository,
                         CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
                     )

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsScreenshotTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsScreenshotTest.kt
@@ -30,8 +30,8 @@ import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.captureRoboImage
 import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
 import dev.firezone.android.R
-import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.ManagedConfigurationReader
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.databinding.ActivitySettingsBinding
 import dev.firezone.android.features.session.ui.compose.FirezoneTheme

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsViewModelTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/SettingsViewModelTest.kt
@@ -6,8 +6,12 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.os.Looper
+import dev.firezone.android.core.data.ManagedConfigurationReader
+import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -35,7 +39,14 @@ class SettingsViewModelTest {
                 .getSharedPreferences("settings-view-model-test", Context.MODE_PRIVATE)
         sharedPreferences.edit().clear().commit()
         repository = Repository(RuntimeEnvironment.getApplication(), Dispatchers.Unconfined, sharedPreferences)
-        viewModel = SettingsViewModel(repository)
+        val managedConfigurationSource =
+            ManagedConfigurationSource(
+                RuntimeEnvironment.getApplication(),
+                ManagedConfigurationReader { Bundle() },
+                repository,
+                CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
+            )
+        viewModel = SettingsViewModel(repository, managedConfigurationSource)
     }
 
     @Test

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/X509SettingsViewModelTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/settings/ui/X509SettingsViewModelTest.kt
@@ -1,0 +1,137 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.features.settings.ui
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.net.Uri
+import android.os.Bundle
+import android.os.Looper
+import dev.firezone.android.core.data.ManagedConfigurationReader
+import dev.firezone.android.core.data.ManagedConfigurationSource
+import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.data.X509_CERTIFICATE_ALIAS_RESTRICTION
+import dev.firezone.android.core.x509.KeyChain
+import dev.firezone.android.core.x509.X509Identity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class X509SettingsViewModelTest {
+    private val restrictions = Bundle()
+    private lateinit var repository: Repository
+    private lateinit var source: ManagedConfigurationSource
+    private lateinit var viewModel: X509SettingsViewModel
+
+    @Before
+    fun setUp() {
+        val application: Application = RuntimeEnvironment.getApplication()
+        val preferences = application.getSharedPreferences("x509-settings-view-model-test", Context.MODE_PRIVATE)
+        preferences.edit().clear().commit()
+        restrictions.clear()
+        repository = Repository(application, Dispatchers.Unconfined, preferences)
+        source =
+            ManagedConfigurationSource(
+                application,
+                ManagedConfigurationReader { Bundle(restrictions) },
+                repository,
+                CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
+            )
+        viewModel = X509SettingsViewModel(repository, source, X509Identity(WithholdingKeyChain()))
+    }
+
+    @Test
+    fun `live managed alias changes disable and restore the user selection`() {
+        repository.saveX509CertificateAliasSync("user-alias")
+
+        applyRestrictions(
+            Bundle().apply {
+                putString(X509_CERTIFICATE_ALIAS_RESTRICTION, "managed-alias")
+            },
+        )
+
+        assertEquals("managed-alias", viewModel.uiStateFlow.value.alias)
+        assertTrue(viewModel.uiStateFlow.value.isManaged)
+
+        applyRestrictions(
+            Bundle().apply {
+                putString(X509_CERTIFICATE_ALIAS_RESTRICTION, "")
+            },
+        )
+
+        assertNull(viewModel.uiStateFlow.value.alias)
+        assertTrue(viewModel.uiStateFlow.value.isManaged)
+
+        applyRestrictions(Bundle())
+
+        assertEquals("user-alias", viewModel.uiStateFlow.value.alias)
+        assertFalse(viewModel.uiStateFlow.value.isManaged)
+    }
+
+    @Test
+    fun `managed alias cannot be replaced or forgotten by the settings screen`() {
+        repository.saveX509CertificateAliasSync("user-alias")
+        restrictions.putString(X509_CERTIFICATE_ALIAS_RESTRICTION, "managed-alias")
+        applyRestrictions(Bundle(restrictions))
+
+        viewModel.onAliasSelected("attempted-alias")
+        drainMainLooper()
+        viewModel.forgetSelection()
+        drainMainLooper()
+
+        assertEquals("user-alias", repository.getUserX509CertificateAliasSync())
+        assertEquals("managed-alias", viewModel.uiStateFlow.value.alias)
+        assertTrue(viewModel.uiStateFlow.value.isManaged)
+    }
+
+    @Test
+    fun `unmanaged alias can be replaced and forgotten`() {
+        applyRestrictions(Bundle())
+
+        viewModel.onAliasSelected("selected-alias")
+        drainMainLooper()
+        assertEquals("selected-alias", repository.getUserX509CertificateAliasSync())
+
+        viewModel.forgetSelection()
+        drainMainLooper()
+        assertNull(repository.getUserX509CertificateAliasSync())
+    }
+
+    private fun applyRestrictions(bundle: Bundle) {
+        runBlocking { source.applyRestrictions(bundle) }
+        drainMainLooper()
+    }
+
+    private fun drainMainLooper() {
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private class WithholdingKeyChain : KeyChain {
+        override fun certificateChain(alias: String): List<X509Certificate>? = null
+
+        override fun privateKey(alias: String): PrivateKey? = null
+
+        override fun choosePrivateKeyAlias(
+            activity: Activity,
+            requestUri: Uri?,
+            preselectedAlias: String?,
+            onChosen: (String?) -> Unit,
+        ): Unit = error("The settings ViewModel never opens the chooser itself")
+    }
+}

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelManagedConfigurationTest.kt
@@ -25,7 +25,6 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
-import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 @Config(application = Application::class, sdk = [Build.VERSION_CODES.TIRAMISU])
@@ -66,7 +65,7 @@ class SplashViewModelManagedConfigurationTest {
     @Test
     fun `managed token and connect on start launch the tunnel`() {
         viewModel.checkTunnelState(context, isInitialLaunch = true)
-        shadowOf(Looper.getMainLooper()).idleFor(1, TimeUnit.SECONDS)
+        shadowOf(Looper.getMainLooper()).runToEndOfTasks()
 
         assertEquals(SplashViewModel.ViewAction.NavigateToSession, viewModel.actionStateFlow.value)
         val serviceIntent = shadowOf(context).nextStartedService

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelManagedConfigurationTest.kt
@@ -10,6 +10,7 @@ import dev.firezone.android.core.ApplicationMode
 import dev.firezone.android.core.data.ManagedConfigurationReader
 import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.data.TokenStore
 import dev.firezone.android.core.x509.CertificateAccess
 import dev.firezone.android.core.x509.SystemKeyChain
 import dev.firezone.android.tunnel.TunnelService
@@ -59,7 +60,14 @@ class SplashViewModelManagedConfigurationTest {
                 keyChain = SystemKeyChain(context),
                 coroutineDispatcher = Dispatchers.Unconfined,
             )
-        viewModel = SplashViewModel(repository, source, ApplicationMode.TESTING, certificateAccess)
+        viewModel =
+            SplashViewModel(
+                repository,
+                TokenStore(sharedPreferences),
+                source,
+                ApplicationMode.TESTING,
+                certificateAccess,
+            )
     }
 
     @Test

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelManagedConfigurationTest.kt
@@ -10,6 +10,8 @@ import dev.firezone.android.core.ApplicationMode
 import dev.firezone.android.core.data.ManagedConfigurationReader
 import dev.firezone.android.core.data.ManagedConfigurationSource
 import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.x509.CertificateAccess
+import dev.firezone.android.core.x509.SystemKeyChain
 import dev.firezone.android.tunnel.TunnelService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -51,7 +53,14 @@ class SplashViewModelManagedConfigurationTest {
                 repository,
                 CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
             )
-        viewModel = SplashViewModel(repository, source, ApplicationMode.TESTING)
+        val certificateAccess =
+            CertificateAccess(
+                repository = repository,
+                managedConfigurationSource = source,
+                keyChain = SystemKeyChain(context),
+                coroutineDispatcher = Dispatchers.Unconfined,
+            )
+        viewModel = SplashViewModel(repository, source, ApplicationMode.TESTING, certificateAccess)
     }
 
     @Test

--- a/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelManagedConfigurationTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/features/splash/ui/SplashViewModelManagedConfigurationTest.kt
@@ -1,0 +1,67 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.features.splash.ui
+
+import android.app.Application
+import android.content.Context
+import android.os.Build
+import android.os.Bundle
+import android.os.Looper
+import dev.firezone.android.core.ApplicationMode
+import dev.firezone.android.core.data.ManagedConfigurationReader
+import dev.firezone.android.core.data.ManagedConfigurationSource
+import dev.firezone.android.core.data.Repository
+import dev.firezone.android.tunnel.TunnelService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [Build.VERSION_CODES.TIRAMISU])
+class SplashViewModelManagedConfigurationTest {
+    private lateinit var context: Application
+    private lateinit var viewModel: SplashViewModel
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        val sharedPreferences =
+            context.getSharedPreferences("splash-managed-configuration-test", Context.MODE_PRIVATE)
+        sharedPreferences.edit().clear().commit()
+        val repository = Repository(context, Dispatchers.Unconfined, sharedPreferences)
+        repository.setNotificationPermissionRequested()
+        val restrictions =
+            Bundle().apply {
+                putString("token", "managed-token")
+                putBoolean("connectOnStart", true)
+            }
+        val source =
+            ManagedConfigurationSource(
+                context,
+                ManagedConfigurationReader { Bundle(restrictions) },
+                repository,
+                CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
+            )
+        viewModel = SplashViewModel(repository, source, ApplicationMode.TESTING)
+    }
+
+    @Test
+    fun `managed token and connect on start launch the tunnel`() {
+        viewModel.checkTunnelState(context, isInitialLaunch = true)
+        shadowOf(Looper.getMainLooper()).idleFor(1, TimeUnit.SECONDS)
+
+        assertEquals(SplashViewModel.ViewAction.NavigateToSession, viewModel.actionStateFlow.value)
+        val serviceIntent = shadowOf(context).nextStartedService
+        assertEquals(TunnelService::class.java.name, serviceIntent.component?.className)
+        assertTrue(serviceIntent.getBooleanExtra("startedByUser", false))
+    }
+}

--- a/kotlin/android/app/src/test/java/dev/firezone/android/tunnel/ApplicationRoutingPolicyTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/tunnel/ApplicationRoutingPolicyTest.kt
@@ -1,0 +1,111 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.tunnel
+
+import dev.firezone.android.core.data.model.ManagedConfiguration
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ApplicationRoutingPolicyTest {
+    @Test
+    fun `allow mode excludes notification packages`() {
+        val policy =
+            ManagedConfiguration(
+                allowedApplications =
+                    "com.example.allowed, com.google.android.gms, com.google.android.gsf, com.example.allowed",
+            ).applicationRoutingPolicy()
+
+        assertEquals(ApplicationRoutingMode.ALLOW, policy.mode)
+        assertEquals(listOf("com.example.allowed"), policy.packageNames)
+        assertFalse(policy.hasConflict)
+    }
+
+    @Test
+    fun `disallow mode appends notification packages`() {
+        val policy =
+            ManagedConfiguration(
+                disallowedApplications = "com.example.blocked, com.google.android.gms",
+            ).applicationRoutingPolicy()
+
+        assertEquals(ApplicationRoutingMode.DISALLOW, policy.mode)
+        assertEquals(
+            listOf(
+                "com.example.blocked",
+                "com.google.android.gms",
+                "com.google.firebase.messaging",
+                "com.google.android.gsf",
+            ),
+            policy.packageNames,
+        )
+    }
+
+    @Test
+    fun `conflicting lists use restrictive allow mode`() {
+        val policy =
+            ManagedConfiguration(
+                allowedApplications = "com.example.allowed",
+                disallowedApplications = "com.example.blocked",
+            ).applicationRoutingPolicy()
+
+        assertEquals(ApplicationRoutingMode.ALLOW, policy.mode)
+        assertEquals(listOf("com.example.allowed"), policy.packageNames)
+        assertTrue(policy.hasConflict)
+    }
+
+    @Test
+    fun `allow mode requires at least one installed package`() {
+        val attempted = mutableListOf<String>()
+        val policy =
+            ManagedConfiguration(
+                allowedApplications = "com.example.missing, com.example.installed",
+            ).applicationRoutingPolicy()
+
+        val valid =
+            policy.apply(
+                addAllowed = { packageName ->
+                    attempted += packageName
+                    packageName == "com.example.installed"
+                },
+                addDisallowed = { error("Unexpected disallow application") },
+            )
+
+        assertTrue(valid)
+        assertEquals(listOf("com.example.missing", "com.example.installed"), attempted)
+        assertFalse(
+            ManagedConfiguration(allowedApplications = "com.example.missing")
+                .applicationRoutingPolicy()
+                .apply(
+                    addAllowed = { false },
+                    addDisallowed = { error("Unexpected disallow application") },
+                ),
+        )
+        assertFalse(
+            ManagedConfiguration(allowedApplications = "com.google.android.gms")
+                .applicationRoutingPolicy()
+                .apply(
+                    addAllowed = { error("Notification packages must not be allowed") },
+                    addDisallowed = { error("Unexpected disallow application") },
+                ),
+        )
+    }
+
+    @Test
+    fun `disallow mode tolerates unavailable packages`() {
+        val attempted = mutableListOf<String>()
+        val policy =
+            ManagedConfiguration(disallowedApplications = "com.example.missing")
+                .applicationRoutingPolicy()
+
+        assertTrue(
+            policy.apply(
+                addAllowed = { error("Unexpected allow application") },
+                addDisallowed = { packageName ->
+                    attempted += packageName
+                    false
+                },
+            ),
+        )
+        assertEquals(policy.packageNames, attempted)
+    }
+}

--- a/kotlin/android/app/src/test/java/dev/firezone/android/tunnel/ManagedConnectionStateTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/tunnel/ManagedConnectionStateTest.kt
@@ -86,14 +86,19 @@ class ManagedConnectionStateTest {
     }
 
     @Test
-    fun `new start request during completion starts a replacement owner`() {
+    fun `start claimed after completion begins starts a replacement owner`() {
         val state = ManagedConnectionState<Any>()
         val firstOwner = Any()
         val replacementOwner = Any()
 
         state.claim(state.requestStart()) { firstOwner }
         state.beginCompletion(firstOwner)
-        state.requestStart()
+        val startRequest = state.requestStart()
+
+        assertEquals(
+            ConnectionClaim.Existing(firstOwner),
+            state.claim(startRequest) { Any() },
+        )
 
         assertEquals(
             ConnectionCompletion.Restarted(replacementOwner),
@@ -125,5 +130,22 @@ class ManagedConnectionStateTest {
         )
         assertTrue(state.stopIfIdle {})
         assertNull(state.owner())
+    }
+
+    @Test
+    fun `completion rejects new work for the old owner`() {
+        val state = ManagedConnectionState<Any>()
+        val owner = Any()
+        var ran = false
+
+        state.claim(state.requestStart()) { owner }
+        assertTrue(state.runIfActive(owner) { ran = true })
+        assertTrue(ran)
+
+        state.beginCompletion(owner)
+        ran = false
+
+        assertFalse(state.runIfActive(owner) { ran = true })
+        assertFalse(ran)
     }
 }

--- a/kotlin/android/app/src/test/java/dev/firezone/android/tunnel/ManagedConnectionStateTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/tunnel/ManagedConnectionStateTest.kt
@@ -111,4 +111,19 @@ class ManagedConnectionStateTest {
         assertFalse(state.stopIfIdle {})
         assertTrue(state.claim(secondRequest) { Any() } is ConnectionClaim.Started)
     }
+
+    @Test
+    fun `disconnect invalidates a pending start`() {
+        val state = ManagedConnectionState<Any>()
+        val pendingStart = state.requestStart()
+
+        state.disconnect()
+
+        assertEquals(
+            ConnectionClaim.Unavailable,
+            state.claim(pendingStart) { Any() },
+        )
+        assertTrue(state.stopIfIdle {})
+        assertNull(state.owner())
+    }
 }

--- a/kotlin/android/app/src/test/java/dev/firezone/android/tunnel/ManagedConnectionStateTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/tunnel/ManagedConnectionStateTest.kt
@@ -1,0 +1,114 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.tunnel
+
+import dev.firezone.android.core.data.model.ManagedConfiguration
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ManagedConnectionStateTest {
+    @Test
+    fun `only one connection owns session setup`() {
+        val state = ManagedConnectionState<Any>()
+        val firstOwner = Any()
+        val startRequest = state.requestStart()
+
+        assertEquals(ConnectionClaim.Started(firstOwner), state.claim(startRequest) { firstOwner })
+        assertEquals(ConnectionClaim.Existing(firstOwner), state.claim(startRequest) { Any() })
+    }
+
+    @Test
+    fun `managed identity change during setup restarts with latest configuration`() {
+        val state = ManagedConnectionState<Any>()
+        val firstOwner = Any()
+        val secondOwner = Any()
+        val initialConfiguration = ManagedConfiguration(token = "first-token")
+        val replacementConfiguration = ManagedConfiguration(token = "second-token")
+
+        state.apply(initialConfiguration)
+        state.claim(state.requestStart()) { firstOwner }
+
+        val update = state.apply(replacementConfiguration)!!
+        assertTrue(update.requiresReconnect)
+        assertSame(firstOwner, update.owner)
+
+        var restartedWith: ManagedConfiguration? = null
+        val completion =
+            state.complete(firstOwner) { configuration ->
+                restartedWith = configuration
+                secondOwner
+            }
+
+        assertEquals(ConnectionCompletion.Restarted(secondOwner), completion)
+        assertEquals(replacementConfiguration, restartedWith)
+        assertSame(secondOwner, state.owner())
+    }
+
+    @Test
+    fun `explicit disconnect wins over subsequent managed changes`() {
+        val state = ManagedConnectionState<Any>()
+        val owner = Any()
+
+        state.apply(ManagedConfiguration(token = "first-token"))
+        state.claim(state.requestStart()) { owner }
+        state.apply(ManagedConfiguration(token = "second-token"))
+        state.disconnect()
+        state.apply(ManagedConfiguration(token = "third-token"))
+
+        assertEquals(
+            ConnectionCompletion.Stopped,
+            state.complete(owner) { Any() },
+        )
+        assertNull(state.owner())
+    }
+
+    @Test
+    fun `new start request prevents an old completion from stopping the service`() {
+        val state = ManagedConnectionState<Any>()
+        val firstOwner = Any()
+
+        state.claim(state.requestStart()) { firstOwner }
+        state.beginCompletion(firstOwner)
+        assertEquals(
+            ConnectionCompletion.Stopped,
+            state.complete(firstOwner) { Any() },
+        )
+
+        val startRequest = state.requestStart()
+        var stopped = false
+
+        assertFalse(state.stopIfIdle { stopped = true })
+        assertFalse(stopped)
+        assertTrue(state.claim(startRequest) { Any() } is ConnectionClaim.Started)
+    }
+
+    @Test
+    fun `new start request during completion starts a replacement owner`() {
+        val state = ManagedConnectionState<Any>()
+        val firstOwner = Any()
+        val replacementOwner = Any()
+
+        state.claim(state.requestStart()) { firstOwner }
+        state.beginCompletion(firstOwner)
+        state.requestStart()
+
+        assertEquals(
+            ConnectionCompletion.Restarted(replacementOwner),
+            state.complete(firstOwner) { replacementOwner },
+        )
+    }
+
+    @Test
+    fun `older failed start cannot cancel a newer request`() {
+        val state = ManagedConnectionState<Any>()
+        val firstRequest = state.requestStart()
+        val secondRequest = state.requestStart()
+
+        assertEquals(ConnectionClaim.Unavailable, state.claim(firstRequest) { null })
+        assertFalse(state.stopIfIdle {})
+        assertTrue(state.claim(secondRequest) { Any() } is ConnectionClaim.Started)
+    }
+}

--- a/kotlin/android/app/src/test/java/dev/firezone/android/tunnel/OwnedTunFileDescriptorTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/tunnel/OwnedTunFileDescriptorTest.kt
@@ -1,0 +1,44 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.tunnel
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class OwnedTunFileDescriptorTest {
+    @Test
+    fun `closing an undelivered descriptor releases it exactly once`() {
+        val closed = mutableListOf<Int>()
+        val descriptor = OwnedTunFileDescriptor(42) { fd -> closed += fd }
+
+        descriptor.close()
+        descriptor.close()
+
+        assertEquals(listOf(42), closed)
+    }
+
+    @Test
+    fun `successful transfer releases ownership to the consumer`() {
+        val consumed = mutableListOf<Int>()
+        val closed = mutableListOf<Int>()
+        val descriptor = OwnedTunFileDescriptor(42) { fd -> closed += fd }
+
+        descriptor.transferTo { fd -> consumed += fd }
+        descriptor.close()
+
+        assertEquals(listOf(42), consumed)
+        assertEquals(emptyList<Int>(), closed)
+    }
+
+    @Test
+    fun `failed transfer closes the descriptor`() {
+        val closed = mutableListOf<Int>()
+        val descriptor = OwnedTunFileDescriptor(42) { fd -> closed += fd }
+
+        assertThrows(IllegalStateException::class.java) {
+            descriptor.transferTo { error("Consumer failed") }
+        }
+
+        assertEquals(listOf(42), closed)
+    }
+}


### PR DESCRIPTION
Managed configuration now flows through a single application-scoped source so policy changes reach startup, authentication, Settings, and an active tunnel consistently.

Each policy revision is applied as one snapshot. Settings keeps a separate user draft beneath the managed overlay, and a present but blank managed token explicitly disables the saved-token fallback. Runtime-safe changes are applied in place, while token, device-trust, and connection policy changes disconnect and restart the tunnel with the latest policy.

Managed X.509 aliases remain optional device-trust and mTLS configuration. Alias changes reconnect live sessions, blank or null values disable device trust, policy removal restores the user selection, and every session still requires a token.

Tunnel ownership is serialized across concurrent starts, teardown, and policy refreshes. Managed application routing keeps allow and disallow modes separate, treats invalid allowlists as fail-closed, and safely releases undelivered TUN file descriptors.

Tests cover policy replacement and revocation, raw user-value restoration, concurrent refresh/start/stop ordering, credential origin, reconnect and VPN rebuild classification, application routing modes, descriptor ownership, live Settings and device-trust changes, mandatory token startup, and reset/cancel behavior.