### PR TITLE
feat(portal): name the connected session on the client init

### DIFF
--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -1760,6 +1760,7 @@ defmodule PortalAPI.Client.Channel.Shared do
     push(socket, "init", %{
       flow_logs: flow_logs_config(),
       account_slug: socket.assigns.subject.account.slug,
+      actor_name: socket.assigns.subject.actor.name,
       resources: Views.Resource.render_many(resources, socket.assigns.client),
       authorizations: Views.PolicyAuthorization.render_many(socket.assigns.authorizations_cache),
       relays:

--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -1759,6 +1759,7 @@ defmodule PortalAPI.Client.Channel.Shared do
   defp init(socket, resources, relays) do
     push(socket, "init", %{
       flow_logs: flow_logs_config(),
+      account_slug: socket.assigns.subject.account.slug,
       resources: Views.Resource.render_many(resources, socket.assigns.client),
       authorizations: Views.PolicyAuthorization.render_many(socket.assigns.authorizations_cache),
       relays:

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -476,6 +476,17 @@ defmodule PortalAPI.Client.ChannelTest do
       assert account_slug == account.slug
     end
 
+    test "sends actor name in init message", %{
+      actor: actor,
+      client: client,
+      subject: subject
+    } do
+      join_channel(client, subject)
+
+      assert_push "init", %{actor_name: actor_name}
+      assert actor_name == actor.name
+    end
+
     test "sends list of available resources after join", %{
       client: client,
       subject: subject,

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -465,6 +465,17 @@ defmodule PortalAPI.Client.ChannelTest do
       assert_receive {:EXIT, _pid, :shutdown}
     end
 
+    test "sends account slug in init message", %{
+      account: account,
+      client: client,
+      subject: subject
+    } do
+      join_channel(client, subject)
+
+      assert_push "init", %{account_slug: account_slug}
+      assert account_slug == account.slug
+    end
+
     test "sends list of available resources after join", %{
       client: client,
       subject: subject,


### PR DESCRIPTION
The `init` message the portal pushes to a Client says what the session can reach but not who it belongs to, so each Client has had to work that out for itself: the account slug and the actor's name are parsed out of the browser sign-in callback and cached on disk. That leaves nothing to fall back on for a session authenticated by a client certificate, where there is no browser round trip at all.

The portal already holds both facts on the subject it authenticated, and already sends the equivalent to Gateways. This adds them to the client `init` payload so the Clients can take the account and actor they actually reached from the portal that decided it.

Clients ignore unknown fields on `init`, so this can land ahead of the Client changes that consume it.