### PR TITLE
refactor(android): let TunnelService own the flows it produces

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
@@ -23,8 +23,10 @@ import dev.firezone.android.features.session.ui.compose.FirezoneTheme
 import dev.firezone.android.features.session.ui.compose.SessionScreen
 import dev.firezone.android.features.settings.ui.SettingsActivity
 import dev.firezone.android.tunnel.TunnelService
+import dev.firezone.android.tunnel.TunnelService.Companion.State
 import dev.firezone.android.tunnel.model.isInternetResource
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.emptyFlow
 
 @AndroidEntryPoint
 class SessionActivity : AppCompatActivity() {
@@ -40,13 +42,6 @@ class SessionActivity : AppCompatActivity() {
             ) {
                 val binder = service as TunnelService.LocalBinder
                 tunnelService = binder.getService()
-
-                tunnelService?.let {
-                    it.setServiceStateMutableStateFlow(viewModel.getServiceStatusMutableStateFlow())
-                    it.setResourcesMutableStateFlow(viewModel.getResourcesMutableStateFlow())
-                    it.setConnectedDevicesMutableStateFlow(viewModel.getConnectedDevicesMutableStateFlow())
-                    it.setActorNameMutableStateFlow(viewModel.getActorNameMutableStateFlow())
-                }
             }
 
             override fun onServiceDisconnected(name: ComponentName?) {
@@ -66,15 +61,15 @@ class SessionActivity : AppCompatActivity() {
 
         setContent {
             FirezoneTheme {
-                val resourcesState by viewModel.resourcesStateFlow.collectAsStateWithLifecycle()
-                val connectedDevicesState by viewModel.connectedDevicesStateFlow.collectAsStateWithLifecycle()
+                val resourcesState by (tunnelService?.resourcesState ?: emptyFlow()).collectAsStateWithLifecycle(emptyList())
+                val connectedDevicesState by (tunnelService?.connectedDevicesState ?: emptyFlow()).collectAsStateWithLifecycle(emptyList())
                 val favorites by viewModel.favorites.collectAsStateWithLifecycle()
-                val serviceStatus by viewModel.serviceStatusStateFlow.collectAsStateWithLifecycle()
-                val actorName by viewModel.actorNameStateFlow.collectAsStateWithLifecycle()
+                val serviceStatus by (tunnelService?.serviceState ?: emptyFlow()).collectAsStateWithLifecycle<State?>(null)
+                val actorName by (tunnelService?.actorNameState ?: emptyFlow()).collectAsStateWithLifecycle(null)
 
                 // Finish if the tunnel service dies.
                 LaunchedEffect(serviceStatus) {
-                    if (serviceStatus == TunnelService.Companion.State.DOWN) finish()
+                    if (serviceStatus == State.DOWN) finish()
                 }
 
                 var internetState by remember { mutableStateOf(ResourceState.UNSET) }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
@@ -5,10 +5,6 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.firezone.android.core.data.Favorites
 import dev.firezone.android.core.data.Repository
-import dev.firezone.android.tunnel.TunnelService.Companion.State
-import dev.firezone.android.tunnel.model.ConnectedDevice
-import dev.firezone.android.tunnel.model.Resource
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
@@ -19,28 +15,6 @@ internal class SessionViewModel
         // Must be `internal` because Dagger does not support injection into `private` fields
         @Inject
         internal lateinit var repo: Repository
-        private val _serviceStatusStateFlow = MutableStateFlow<State?>(null)
-        private val _resourcesStateFlow = MutableStateFlow<List<Resource>>(emptyList())
-        private val _connectedDevicesStateFlow = MutableStateFlow<List<ConnectedDevice>>(emptyList())
-        private val _actorNameStateFlow = MutableStateFlow<String?>(null)
-
-        val serviceStatusStateFlow: StateFlow<State?>
-            get() = _serviceStatusStateFlow
-        val resourcesStateFlow: StateFlow<List<Resource>>
-            get() = _resourcesStateFlow
-        val connectedDevicesStateFlow: StateFlow<List<ConnectedDevice>>
-            get() = _connectedDevicesStateFlow
-        val actorNameStateFlow: StateFlow<String?>
-            get() = _actorNameStateFlow
-
-        // Internal getters for TunnelService to update state
-        internal fun getServiceStatusMutableStateFlow(): MutableStateFlow<State?> = _serviceStatusStateFlow
-
-        internal fun getResourcesMutableStateFlow(): MutableStateFlow<List<Resource>> = _resourcesStateFlow
-
-        internal fun getConnectedDevicesMutableStateFlow(): MutableStateFlow<List<ConnectedDevice>> = _connectedDevicesStateFlow
-
-        internal fun getActorNameMutableStateFlow(): MutableStateFlow<String?> = _actorNameStateFlow
 
         val favorites: StateFlow<Favorites>
             get() = repo.favorites

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -44,6 +44,8 @@ import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
@@ -87,10 +89,6 @@ class TunnelService : VpnService() {
     private var tunnelDnsAddresses: MutableList<String> = mutableListOf()
     private var tunnelSearchDomain: String? = null
     private var tunnelRoutes: MutableList<Cidr> = mutableListOf()
-    private var _tunnelResources: List<Resource> = emptyList()
-    private var _tunnelConnectedDevices: List<ConnectedDevice> = emptyList()
-    private var _tunnelActorName: String? = null
-    private var _tunnelState: State = State.DOWN
     private var resourceState: ResourceState = ResourceState.UNSET
 
     // For reacting to changes to the network
@@ -103,36 +101,37 @@ class TunnelService : VpnService() {
     private var commandChannel: Channel<TunnelCommand>? = null
     private val serviceScope = CoroutineScope(SupervisorJob())
 
+    private val _serviceState = MutableStateFlow(State.DOWN)
+    private val _resourcesState = MutableStateFlow<List<Resource>>(emptyList())
+    private val _connectedDevicesState = MutableStateFlow<List<ConnectedDevice>>(emptyList())
+    private val _actorNameState = MutableStateFlow<String?>(null)
+
+    // A `StateFlow` replays its current value to every new collector, so a newly bound SessionActivity catches up on its own.
+    val serviceState: StateFlow<State> = _serviceState.asStateFlow()
+    val resourcesState: StateFlow<List<Resource>> = _resourcesState.asStateFlow()
+    val connectedDevicesState: StateFlow<List<ConnectedDevice>> = _connectedDevicesState.asStateFlow()
+    val actorNameState: StateFlow<String?> = _actorNameState.asStateFlow()
+
     var tunnelResources: List<Resource>
-        get() = _tunnelResources
+        get() = _resourcesState.value
         set(value) {
-            _tunnelResources = value
-            updateResourcesStateFlow(value)
+            _resourcesState.value = value
         }
     var tunnelConnectedDevices: List<ConnectedDevice>
-        get() = _tunnelConnectedDevices
+        get() = _connectedDevicesState.value
         set(value) {
-            _tunnelConnectedDevices = value
-            updateConnectedDevicesStateFlow(value)
+            _connectedDevicesState.value = value
         }
     var tunnelActorName: String?
-        get() = _tunnelActorName
+        get() = _actorNameState.value
         set(value) {
-            _tunnelActorName = value
-            updateActorNameStateFlow(value)
+            _actorNameState.value = value
         }
     var tunnelState: State
-        get() = _tunnelState
+        get() = _serviceState.value
         set(value) {
-            _tunnelState = value
-            updateServiceStateFlow(value)
+            _serviceState.value = value
         }
-
-    // Used to update the UI when the SessionActivity is bound to this service
-    private var serviceStateMutableStateFlow: MutableStateFlow<State?>? = null
-    private var resourcesMutableStateFlow: MutableStateFlow<List<Resource>>? = null
-    private var connectedDevicesMutableStateFlow: MutableStateFlow<List<ConnectedDevice>>? = null
-    private var actorNameMutableStateFlow: MutableStateFlow<String?>? = null
 
     // For binding the SessionActivity view to this service
     private val binder = LocalBinder()
@@ -491,50 +490,6 @@ class TunnelService : VpnService() {
         Log.setStreamingActive(false)
     }
 
-    fun setServiceStateMutableStateFlow(stateFlow: MutableStateFlow<State?>) {
-        serviceStateMutableStateFlow = stateFlow
-
-        // Update the newly bound SessionActivity with our current state
-        serviceStateMutableStateFlow?.value = tunnelState
-    }
-
-    fun setResourcesMutableStateFlow(stateFlow: MutableStateFlow<List<Resource>>) {
-        resourcesMutableStateFlow = stateFlow
-
-        // Update the newly bound SessionActivity with our current resources
-        resourcesMutableStateFlow?.value = tunnelResources
-    }
-
-    fun setConnectedDevicesMutableStateFlow(stateFlow: MutableStateFlow<List<ConnectedDevice>>) {
-        connectedDevicesMutableStateFlow = stateFlow
-
-        // Update the newly bound SessionActivity with our current connected devices
-        connectedDevicesMutableStateFlow?.value = tunnelConnectedDevices
-    }
-
-    fun setActorNameMutableStateFlow(stateFlow: MutableStateFlow<String?>) {
-        actorNameMutableStateFlow = stateFlow
-
-        // Update the newly bound SessionActivity with our current actor name
-        actorNameMutableStateFlow?.value = tunnelActorName
-    }
-
-    private fun updateServiceStateFlow(state: State) {
-        serviceStateMutableStateFlow?.value = state
-    }
-
-    private fun updateResourcesStateFlow(resources: List<Resource>) {
-        resourcesMutableStateFlow?.value = resources
-    }
-
-    private fun updateConnectedDevicesStateFlow(devices: List<ConnectedDevice>) {
-        connectedDevicesMutableStateFlow?.value = devices
-    }
-
-    private fun updateActorNameStateFlow(actorName: String?) {
-        actorNameMutableStateFlow?.value = actorName
-    }
-
     // `Tasks.await` throws when called on the main thread, which is the thread `onStartCommand`
     // runs `connect` on.
     private suspend fun firebaseInstallationId(): String? =
@@ -612,7 +567,7 @@ class TunnelService : VpnService() {
     }
 
     private fun resourceById(resourceId: String): Pair<Resource, Site>? {
-        val resource = _tunnelResources.find { it.id == resourceId } ?: return null
+        val resource = tunnelResources.find { it.id == resourceId } ?: return null
         val site = resource.sites?.firstOrNull() ?: return null
         return Pair(resource, site)
     }


### PR DESCRIPTION
`SessionViewModel` used to declare the `MutableStateFlow`s for the service's resources, connected devices and state, and hand them to `TunnelService` through setters on bind. The service then wrote to whichever flow it happened to be holding, keeping a second copy of each value in a plain field so it still had something to read before the setter arrived, and pushing that copy into the flow on every (re)bind to catch the collector up.

Ownership is inverted here: the service declares the flows, exposes them read-only, and the Activity collects them off the bound service. A `StateFlow` replays its current value to a new collector, which is what makes the catch-up pushes and the duplicate storage unnecessary.