### PR TITLE
fix(gateway): persist reported device metadata

### DIFF
--- a/elixir/lib/portal/device.ex
+++ b/elixir/lib/portal/device.ex
@@ -86,12 +86,16 @@ defmodule Portal.Device do
     field :ipv4, Portal.Types.IP, read_after_writes: true
     field :ipv6, Portal.Types.IP, read_after_writes: true
 
-    # Client-only
-    belongs_to :actor, Portal.Actor
+    # Self-reported hardware metadata
     field :device_serial, :string
     field :device_uuid, :string
+
+    # Mobile client-only
     field :identifier_for_vendor, :string
     field :firebase_installation_id, :string
+
+    # Client-only
+    belongs_to :actor, Portal.Actor
     field :hostname, :string
 
     # Device trust. Enforced client-only today, but gateways may adopt
@@ -229,6 +233,8 @@ defmodule Portal.Device do
       :gateway ->
         changeset
         |> validate_required([:site_id])
+        |> validate_length(:device_serial, max: 255)
+        |> validate_length(:device_uuid, max: 255)
         |> validate_gateway_verification()
 
       _ ->

--- a/elixir/lib/portal_api/gateway/socket.ex
+++ b/elixir/lib/portal_api/gateway/socket.ex
@@ -11,6 +11,12 @@ defmodule PortalAPI.Gateway.Socket do
   import Ecto.Changeset
   import Portal.Changeset
 
+  @reported_metadata_fields ~w[
+    name
+    device_serial
+    device_uuid
+  ]a
+
   ## Channels
 
   channel "gateway", PortalAPI.Gateway.Channel
@@ -54,7 +60,9 @@ defmodule PortalAPI.Gateway.Socket do
     with {:ok, gateway_token} <- Authentication.verify_gateway_token(encoded_token),
          {:ok, public_key} <- validate_public_key(attrs),
          {:ok, site, gateway} <- resolve_gateway(gateway_token, attrs),
-         :ok <- ensure_gateway_not_connected(gateway) do
+         :ok <- ensure_gateway_not_connected(gateway),
+         {:ok, gateway} <- put_reported_metadata(gateway, attrs),
+         {:ok, gateway} <- maybe_put_firezone_id(gateway, attrs) do
       version = derive_version(context.user_agent)
       {context, version} = PortalAPI.Sockets.truncate_session_fields(context, version)
       gateway = apply_session(gateway, gateway_token.id, public_key, context, version)
@@ -119,11 +127,26 @@ defmodule PortalAPI.Gateway.Socket do
 
   # Single-owner token: the token identifies the gateway directly; the
   # reported firezone_id is kept in sync as a telemetry hint
-  defp resolve_gateway(%Portal.GatewayToken{} = gateway_token, attrs) do
+  defp resolve_gateway(%Portal.GatewayToken{} = gateway_token, _attrs) do
     with {:ok, gateway} <-
-           Database.fetch_gateway(gateway_token.account_id, gateway_token.device_id),
-         {:ok, gateway} <- maybe_put_firezone_id(gateway, attrs) do
+           Database.fetch_gateway(gateway_token.account_id, gateway_token.device_id) do
       {:ok, gateway.site, gateway}
+    end
+  end
+
+  # Device metadata is self-reported on every connection. Only fields present
+  # in the socket params are cast, so an older gateway that omits a field keeps
+  # the value already stored on its device row.
+  defp put_reported_metadata(%Device{} = gateway, attrs) do
+    changeset =
+      gateway
+      |> cast(attrs, @reported_metadata_fields)
+      |> Device.changeset()
+
+    if changeset.changes == %{} do
+      {:ok, gateway}
+    else
+      Database.update_gateway(changeset)
     end
   end
 
@@ -161,7 +184,7 @@ defmodule PortalAPI.Gateway.Socket do
   defp maybe_put_firezone_id(%Device{} = gateway, _attrs), do: {:ok, gateway}
 
   defp insert_changeset(site, attrs) do
-    insert_fields = ~w[firezone_id name]a
+    insert_fields = [:firezone_id | @reported_metadata_fields]
     required_fields = ~w[firezone_id name]a
 
     %Device{}

--- a/elixir/lib/portal_api/gateway/socket.ex
+++ b/elixir/lib/portal_api/gateway/socket.ex
@@ -12,7 +12,6 @@ defmodule PortalAPI.Gateway.Socket do
   import Portal.Changeset
 
   @reported_metadata_fields ~w[
-    name
     device_serial
     device_uuid
   ]a
@@ -134,7 +133,7 @@ defmodule PortalAPI.Gateway.Socket do
     end
   end
 
-  # Device metadata is self-reported on every connection. Only fields present
+  # Hardware metadata is self-reported on every connection. Only fields present
   # in the socket params are cast, so an older gateway that omits a field keeps
   # the value already stored on its device row.
   defp put_reported_metadata(%Device{} = gateway, attrs) do
@@ -184,7 +183,7 @@ defmodule PortalAPI.Gateway.Socket do
   defp maybe_put_firezone_id(%Device{} = gateway, _attrs), do: {:ok, gateway}
 
   defp insert_changeset(site, attrs) do
-    insert_fields = [:firezone_id | @reported_metadata_fields]
+    insert_fields = [:firezone_id, :name | @reported_metadata_fields]
     required_fields = ~w[firezone_id name]a
 
     %Device{}

--- a/elixir/test/portal_api/gateway/socket_test.exs
+++ b/elixir/test/portal_api/gateway/socket_test.exs
@@ -178,7 +178,7 @@ defmodule PortalAPI.Gateway.SocketTest do
       assert connected_gateway.last_seen_remote_ip_location_lon == 30.5167
     end
 
-    test "updates an existing multi-owner gateway with its reported metadata" do
+    test "updates an existing multi-owner gateway's hardware metadata without changing its name" do
       account = account_fixture()
       site = site_fixture(account: account)
 
@@ -204,12 +204,12 @@ defmodule PortalAPI.Gateway.SocketTest do
 
       assert {:ok, socket} = connect(Socket, attrs, connect_info: build_connect_info())
       assert socket.assigns.gateway.id == gateway.id
-      assert socket.assigns.gateway.name == "new-name"
+      assert socket.assigns.gateway.name == "old-name"
       assert socket.assigns.gateway.device_serial == "new-serial"
       assert socket.assigns.gateway.device_uuid == "new-uuid"
 
       persisted = Portal.Repo.get_by!(Portal.Device, account_id: account.id, id: gateway.id)
-      assert persisted.name == "new-name"
+      assert persisted.name == "old-name"
       assert persisted.device_serial == "new-serial"
       assert persisted.device_uuid == "new-uuid"
     end
@@ -289,7 +289,7 @@ defmodule PortalAPI.Gateway.SocketTest do
       assert socket.assigns.gateway.firezone_id == "reported-id"
     end
 
-    test "single-owner connect updates the reported firezone_id and metadata" do
+    test "single-owner connect updates the reported firezone_id and hardware metadata without changing its name" do
       account = account_fixture()
       site = site_fixture(account: account)
 
@@ -315,13 +315,13 @@ defmodule PortalAPI.Gateway.SocketTest do
 
       assert {:ok, socket} = connect(Socket, attrs, connect_info: build_connect_info())
       assert socket.assigns.gateway.firezone_id == "different-id"
-      assert socket.assigns.gateway.name == "new-name"
+      assert socket.assigns.gateway.name == "old-name"
       assert socket.assigns.gateway.device_serial == "new-serial"
       assert socket.assigns.gateway.device_uuid == "new-uuid"
 
       persisted = Portal.Repo.get_by!(Portal.Device, account_id: account.id, id: gateway.id)
       assert persisted.firezone_id == "different-id"
-      assert persisted.name == "new-name"
+      assert persisted.name == "old-name"
       assert persisted.device_serial == "new-serial"
       assert persisted.device_uuid == "new-uuid"
     end

--- a/elixir/test/portal_api/gateway/socket_test.exs
+++ b/elixir/test/portal_api/gateway/socket_test.exs
@@ -81,7 +81,15 @@ defmodule PortalAPI.Gateway.SocketTest do
       token = gateway_token_fixture()
       encrypted_secret = encode_gateway_token(token)
 
-      attrs = connect_attrs(token: encrypted_secret)
+      attrs =
+        connect_attrs(
+          token: encrypted_secret,
+          name: "reported-name",
+          device_serial: "reported-serial",
+          device_uuid: "reported-uuid",
+          identifier_for_vendor: "mobile-only-ifv",
+          firebase_installation_id: "mobile-only-firebase-id"
+        )
 
       connect_info =
         build_connect_info(user_agent: "iOS/12.7 (iPhone) connlib/#{@connlib_version}")
@@ -90,6 +98,18 @@ defmodule PortalAPI.Gateway.SocketTest do
       assert gateway = Map.fetch!(socket.assigns, :gateway)
 
       assert gateway.firezone_id == attrs["external_id"]
+      assert gateway.name == "reported-name"
+      assert gateway.device_serial == "reported-serial"
+      assert gateway.device_uuid == "reported-uuid"
+      assert is_nil(gateway.identifier_for_vendor)
+      assert is_nil(gateway.firebase_installation_id)
+
+      persisted = Portal.Repo.get_by!(Portal.Device, account_id: gateway.account_id, id: gateway.id)
+      assert persisted.name == "reported-name"
+      assert persisted.device_serial == "reported-serial"
+      assert persisted.device_uuid == "reported-uuid"
+      assert is_nil(persisted.identifier_for_vendor)
+      assert is_nil(persisted.firebase_installation_id)
 
       assert is_reference(Map.fetch!(socket.assigns, :session_ref))
       assert gateway.public_key == attrs["public_key"]
@@ -156,6 +176,42 @@ defmodule PortalAPI.Gateway.SocketTest do
       assert connected_gateway.last_seen_remote_ip_location_city == "Kyiv"
       assert connected_gateway.last_seen_remote_ip_location_lat == 50.4333
       assert connected_gateway.last_seen_remote_ip_location_lon == 30.5167
+    end
+
+    test "updates an existing multi-owner gateway with its reported metadata" do
+      account = account_fixture()
+      site = site_fixture(account: account)
+
+      gateway =
+        gateway_fixture(
+          account: account,
+          site: site,
+          name: "old-name",
+          device_serial: "old-serial",
+          device_uuid: "old-uuid"
+        )
+
+      token = gateway_token_fixture(account: account, site: site)
+
+      attrs =
+        connect_attrs(
+          token: encode_gateway_token(token),
+          external_id: gateway.firezone_id,
+          name: "new-name",
+          device_serial: "new-serial",
+          device_uuid: "new-uuid"
+        )
+
+      assert {:ok, socket} = connect(Socket, attrs, connect_info: build_connect_info())
+      assert socket.assigns.gateway.id == gateway.id
+      assert socket.assigns.gateway.name == "new-name"
+      assert socket.assigns.gateway.device_serial == "new-serial"
+      assert socket.assigns.gateway.device_uuid == "new-uuid"
+
+      persisted = Portal.Repo.get_by!(Portal.Device, account_id: account.id, id: gateway.id)
+      assert persisted.name == "new-name"
+      assert persisted.device_serial == "new-serial"
+      assert persisted.device_uuid == "new-uuid"
     end
 
     test "preserves ipv4 and ipv6 addresses on reconnection" do
@@ -233,19 +289,63 @@ defmodule PortalAPI.Gateway.SocketTest do
       assert socket.assigns.gateway.firezone_id == "reported-id"
     end
 
-    test "single-owner connect updates a changed firezone_id" do
+    test "single-owner connect updates the reported firezone_id and metadata" do
       account = account_fixture()
       site = site_fixture(account: account)
-      gateway = gateway_fixture(account: account, site: site)
+
+      gateway =
+        gateway_fixture(
+          account: account,
+          site: site,
+          name: "old-name",
+          device_serial: "old-serial",
+          device_uuid: "old-uuid"
+        )
+
       token = gateway_token_fixture(gateway: gateway)
 
-      attrs = connect_attrs(token: encode_gateway_token(token), external_id: "different-id")
+      attrs =
+        connect_attrs(
+          token: encode_gateway_token(token),
+          external_id: "different-id",
+          name: "new-name",
+          device_serial: "new-serial",
+          device_uuid: "new-uuid"
+        )
 
       assert {:ok, socket} = connect(Socket, attrs, connect_info: build_connect_info())
       assert socket.assigns.gateway.firezone_id == "different-id"
+      assert socket.assigns.gateway.name == "new-name"
+      assert socket.assigns.gateway.device_serial == "new-serial"
+      assert socket.assigns.gateway.device_uuid == "new-uuid"
 
       persisted = Portal.Repo.get_by!(Portal.Device, account_id: account.id, id: gateway.id)
       assert persisted.firezone_id == "different-id"
+      assert persisted.name == "new-name"
+      assert persisted.device_serial == "new-serial"
+      assert persisted.device_uuid == "new-uuid"
+    end
+
+    test "single-owner connect preserves metadata the gateway omits" do
+      account = account_fixture()
+      site = site_fixture(account: account)
+
+      gateway =
+        gateway_fixture(
+          account: account,
+          site: site,
+          name: "stored-name",
+          device_serial: "stored-serial",
+          device_uuid: "stored-uuid"
+        )
+
+      token = gateway_token_fixture(gateway: gateway)
+      attrs = connect_attrs(token: encode_gateway_token(token), external_id: gateway.firezone_id)
+
+      assert {:ok, socket} = connect(Socket, attrs, connect_info: build_connect_info())
+      assert socket.assigns.gateway.name == "stored-name"
+      assert socket.assigns.gateway.device_serial == "stored-serial"
+      assert socket.assigns.gateway.device_uuid == "stored-uuid"
     end
 
     test "single-owner connect keeps the firezone_id when none is reported" do

--- a/elixir/test/support/fixtures/device_fixtures.ex
+++ b/elixir/test/support/fixtures/device_fixtures.ex
@@ -314,7 +314,9 @@ defmodule Portal.DeviceFixtures do
       %Portal.Device{}
       |> Ecto.Changeset.cast(device_attrs, [
         :name,
-        :firezone_id
+        :firezone_id,
+        :device_serial,
+        :device_uuid
       ])
       |> Ecto.Changeset.put_change(:type, :gateway)
       |> Ecto.Changeset.put_change(:account_id, account.id)

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -7,7 +7,7 @@ use crate::eventloop::{Eventloop, PHOENIX_TOPIC};
 use anyhow::{Context, ErrorExt, Result, bail};
 use backoff::ExponentialBackoffBuilder;
 use bin_shared::{
-    TunDeviceManager, device_id, http_health_check,
+    TunDeviceManager, device_id, device_info, http_health_check,
     platform::{UdpSocketFactory, tcp_socket_factory},
 };
 use clap::Parser;
@@ -192,8 +192,14 @@ async fn try_main(cli: Cli) -> Result<()> {
         }
     }
 
-    let login = LoginUrl::gateway(cli.api_url, firezone_id, cli.firezone_name)
-        .context("Failed to construct URL for logging into portal")?;
+    let login = LoginUrl::gateway(
+        cli.api_url,
+        firezone_id,
+        cli.firezone_name,
+        device_info::serial(),
+        device_info::uuid(),
+    )
+    .context("Failed to construct URL for logging into portal")?;
 
     let resolv_conf = resolv_conf::Config::parse(
         std::fs::read_to_string("/etc/resolv.conf").context("Failed to read /etc/resolv.conf")?,

--- a/rust/libs/connlib/phoenix-channel/src/login_url.rs
+++ b/rust/libs/connlib/phoenix-channel/src/login_url.rs
@@ -132,6 +132,8 @@ impl LoginUrl<PublicKeyParam> {
         url: impl TryInto<Url, Error = E>,
         device_id: String,
         device_name: Option<String>,
+        device_serial: Option<String>,
+        device_uuid: Option<String>,
     ) -> Result<Self, LoginUrlError<E>> {
         let external_id = if uuid::Uuid::from_str(&device_id).is_ok() {
             hex::encode(sha2::Sha256::digest(device_id))
@@ -151,7 +153,11 @@ impl LoginUrl<PublicKeyParam> {
             None,
             None,
             None,
-            Default::default(),
+            DeviceInfo {
+                device_serial,
+                device_uuid,
+                ..Default::default()
+            },
         )?;
 
         let (host, port) = parse_host(&url)?;
@@ -575,13 +581,28 @@ mod tests {
             "wss://api.firez.one",
             "some-id".to_owned(),
             Some("some-name".to_owned()),
+            Some("serial".to_owned()),
+            Some("uuid".to_owned()),
         )
         .unwrap();
 
+        let url = login_url.to_url(PublicKeyParam([0; 32]));
+
+        assert_eq!(url.path(), "/gateway/v2/websocket");
         assert_eq!(
-            login_url.to_url(PublicKeyParam([0; 32])).path(),
-            "/gateway/v2/websocket"
-        )
+            url.query_pairs()
+                .collect::<std::collections::HashMap<_, _>>(),
+            std::collections::HashMap::from([
+                (Cow::Borrowed("external_id"), Cow::Borrowed("some-id")),
+                (Cow::Borrowed("name"), Cow::Borrowed("some-name")),
+                (Cow::Borrowed("device_serial"), Cow::Borrowed("serial")),
+                (Cow::Borrowed("device_uuid"), Cow::Borrowed("uuid")),
+                (
+                    Cow::Borrowed("public_key"),
+                    Cow::Borrowed("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+                ),
+            ])
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The gateway did not include host hardware identifiers in its connect URL, and the portal did not persist those identifiers when a gateway connected. Gateway names are intentionally managed separately and remain unchanged on reconnect.

- report the gateway host device serial and UUID alongside its name
- persist reported device serial and device UUID for both multi-owner and single-owner gateway connections
- preserve the configured gateway name on reconnect while still using the reported name for initial legacy gateway registration
- preserve stored hardware metadata when an older gateway omits a field
- keep identifier-for-vendor and Firebase installation ID client/mobile-only
- validate gateway serials and UUIDs to the database column limit

## Testing

- `MIX_TEST_PARTITION=codex_gateway_pr_name_20260828 mix test test/portal_api/gateway/socket_test.exs` (27 passed)
- `cargo test -p phoenix-channel gateway_uses_v2_endpoint`
- `cargo check -p firezone-gateway`
- `MIX_ENV=test mix compile --warnings-as-errors`
- formatting checks for Rust and Elixir

---
