### PR TITLE
test(portal): scope captured log sink events

### DIFF
--- a/elixir/test/portal/elastic/sync_test.exs
+++ b/elixir/test/portal/elastic/sync_test.exs
@@ -236,7 +236,7 @@ defmodule Portal.Elastic.SyncTest do
       stub_with_poison(self(), "document_parsing_exception")
 
       log_output =
-        ExUnit.CaptureLog.capture_log([level: :error], fn ->
+        capture_log_for_sink(sink, [level: :error], fn ->
           assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 
@@ -288,7 +288,7 @@ defmodule Portal.Elastic.SyncTest do
       stub_with_poison(self(), "cluster_block_exception")
 
       log_output =
-        ExUnit.CaptureLog.capture_log([level: :error], fn ->
+        capture_log_for_sink(sink, [level: :error], fn ->
           assert :ok = perform_job(Elastic.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 

--- a/elixir/test/portal/sentinel/sync_test.exs
+++ b/elixir/test/portal/sentinel/sync_test.exs
@@ -191,7 +191,7 @@ defmodule Portal.Sentinel.SyncTest do
       })
 
       log_output =
-        ExUnit.CaptureLog.capture_log([level: :error], fn ->
+        capture_log_for_sink(sink, [level: :error], fn ->
           assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 
@@ -224,7 +224,7 @@ defmodule Portal.Sentinel.SyncTest do
       })
 
       log_output =
-        ExUnit.CaptureLog.capture_log([level: :error], fn ->
+        capture_log_for_sink(sink, [level: :error], fn ->
           assert :ok = perform_job(Sentinel.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 

--- a/elixir/test/portal/splunk/sync_test.exs
+++ b/elixir/test/portal/splunk/sync_test.exs
@@ -349,7 +349,7 @@ defmodule Portal.Splunk.SyncTest do
       end)
 
       log_output =
-        ExUnit.CaptureLog.capture_log([level: :error], fn ->
+        capture_log_for_sink(sink, [level: :error], fn ->
           assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 
@@ -393,7 +393,7 @@ defmodule Portal.Splunk.SyncTest do
       end)
 
       log_output =
-        ExUnit.CaptureLog.capture_log([level: :error], fn ->
+        capture_log_for_sink(sink, [level: :error], fn ->
           assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 
@@ -448,7 +448,7 @@ defmodule Portal.Splunk.SyncTest do
       end)
 
       log_output =
-        ExUnit.CaptureLog.capture_log(fn ->
+        capture_log_for_sink(sink, [], fn ->
           assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 
@@ -500,7 +500,7 @@ defmodule Portal.Splunk.SyncTest do
       end)
 
       log_output =
-        ExUnit.CaptureLog.capture_log([level: :error], fn ->
+        capture_log_for_sink(sink, [level: :error], fn ->
           assert :ok = perform_job(Splunk.Sync, %{account_id: sink.account_id, log_sink_id: sink.id})
         end)
 

--- a/elixir/test/support/fixtures/log_sink_fixtures.ex
+++ b/elixir/test/support/fixtures/log_sink_fixtures.ex
@@ -8,6 +8,19 @@ defmodule Portal.LogSinkFixtures do
 
   import Portal.AccountFixtures
 
+  # capture_log/2 includes events from concurrent async tests, so only return
+  # events emitted for this test's sink.
+  def capture_log_for_sink(%{id: log_sink_id}, opts, callback) do
+    opts = Keyword.put(opts, :metadata, [:log_sink_id])
+    log_sink_metadata = "log_sink_id=#{log_sink_id}"
+
+    opts
+    |> ExUnit.CaptureLog.capture_log(callback)
+    |> String.split("\n", trim: true)
+    |> Enum.filter(&String.contains?(&1, log_sink_metadata))
+    |> Enum.join("\n")
+  end
+
   def valid_splunk_log_sink_attrs(attrs \\ %{}) do
     unique_num = System.unique_integer([:positive, :monotonic])
 


### PR DESCRIPTION
## Summary

- scope captured log-sink events by their unique log_sink_id metadata
- update every Elastic, Sentinel, and Splunk assertion on the shared undeliverable-event message
- keep the provider test modules async without allowing unrelated workers to satisfy or fail log assertions
