### PR TITLE
feat(portal): show MDM and EDR posture on a Client

### DIFF
--- a/elixir/assets/js/hooks.js
+++ b/elixir/assets/js/hooks.js
@@ -230,28 +230,6 @@ Hooks.OpenURL = {
   },
 };
 
-Hooks.FormatJSON = {
-  mounted() {
-    this.formatJSON();
-  },
-
-  updated() {
-    this.formatJSON();
-  },
-
-  formatJSON() {
-    const code = this.el.querySelector("code");
-    if (code && code.textContent.trim()) {
-      try {
-        const json = JSON.parse(code.textContent);
-        code.textContent = JSON.stringify(json, null, 2);
-      } catch (e) {
-        // If parsing fails, leave the content as is
-      }
-    }
-  },
-};
-
 Hooks.Toast = {
   mounted() {
     this.flashKey = this.el.className.match(/flash-(\w+)/)?.[1];

--- a/elixir/lib/portal/posture_provider.ex
+++ b/elixir/lib/portal/posture_provider.ex
@@ -5,6 +5,13 @@ defmodule Portal.PostureProvider do
   @primary_key false
   @foreign_key_type :binary_id
 
+  @type t :: %__MODULE__{
+          account_id: Ecto.UUID.t(),
+          id: Ecto.UUID.t(),
+          type: :intune | :iru | :defender | :santa | :sentinelone,
+          name: String.t()
+        }
+
   schema "posture_providers" do
     belongs_to :account, Portal.Account, primary_key: true
     field :id, :binary_id, primary_key: true

--- a/elixir/lib/portal_api/client/device_trust.ex
+++ b/elixir/lib/portal_api/client/device_trust.ex
@@ -55,7 +55,6 @@ defmodule PortalAPI.Client.DeviceTrust do
     "apple-udid" => :last_attested_device_uuid,
     "smbios-uuid" => :last_attested_device_uuid,
     "intune-id" => :last_attested_mdm_device_id,
-    "entra-id" => :last_attested_mdm_device_id,
     "ws1-uuid" => :last_attested_mdm_device_id,
     "jamf-id" => :last_attested_mdm_device_id,
     "kandji-id" => :last_attested_mdm_device_id

--- a/elixir/lib/portal_web.ex
+++ b/elixir/lib/portal_web.ex
@@ -153,6 +153,7 @@ defmodule PortalWeb do
       import PortalWeb.FormComponents
       import PortalWeb.TableComponents
       import PortalWeb.PageComponents
+      import PortalWeb.JSONComponents
     end
   end
 

--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -784,6 +784,7 @@ defmodule PortalWeb.CoreComponents do
   """
   attr :placement, :string, default: "top"
   attr :trigger, :string, default: "hover"
+  attr :class, :string, default: nil, doc: "Classes for the element wrapping the target"
   slot :target, required: true
   slot :content, required: true
 
@@ -801,6 +802,7 @@ defmodule PortalWeb.CoreComponents do
     <span
       phx-hook="Popover"
       id={@target_id <> "-trigger"}
+      class={@class}
       data-popover-target-id={@target_id}
       data-popover-placement={@placement}
       data-popover-trigger={@trigger}

--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -817,9 +817,9 @@ defmodule PortalWeb.CoreComponents do
       id={@target_id}
       role={if @menu?, do: "menu", else: "tooltip"}
       class={~w[
-        fixed z-10 invisible inline-block
-        text-xs text-body transition-opacity
-        duration-50 bg-elevated border border-border
+        fixed z-10 invisible inline-block max-w-xs
+        text-xs font-normal normal-case tracking-normal text-body
+        transition-opacity duration-50 bg-elevated border border-border
         rounded-md shadow-xs opacity-0
       ]}
     >

--- a/elixir/lib/portal_web/components/json_components.ex
+++ b/elixir/lib/portal_web/components/json_components.ex
@@ -18,10 +18,13 @@ defmodule PortalWeb.JSONComponents do
 
   `value` must already hold JSON-encodable terms; see `encodable/1` for turning
   an Ecto struct into one.
+
+  A blob rendered under a heading of its own needs no `label`; without one the
+  header row is dropped rather than left blank.
   """
   attr :id, :string, required: true
   attr :value, :any, required: true
-  attr :label, :string, required: true
+  attr :label, :string, default: nil
   attr :hint, :string, default: nil
 
   def json_view(assigns) do
@@ -31,7 +34,7 @@ defmodule PortalWeb.JSONComponents do
 
     ~H"""
     <section id={@id} phx-hook="CopyClipboard">
-      <div class="mb-3 flex items-center justify-between gap-3">
+      <div :if={@label || @hint} class="mb-3 flex items-center justify-between gap-3">
         <h3 class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
           {@label}
         </h3>

--- a/elixir/lib/portal_web/components/json_components.ex
+++ b/elixir/lib/portal_web/components/json_components.ex
@@ -1,0 +1,135 @@
+defmodule PortalWeb.JSONComponents do
+  @moduledoc """
+  Read-only JSON rendering for show panels.
+
+  Syntax highlighting is done here rather than in JavaScript so the markup a
+  panel renders is the markup the clipboard button copies.
+  """
+  use Phoenix.Component
+
+  import PortalWeb.CoreComponents
+
+  alias PortalWeb.Logs.JSONDiff
+
+  @token_regex ~r/"(?:\\.|[^"\\])*"|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?|\b(?:true|false|null)\b/
+
+  @doc """
+  Renders a pretty-printed, syntax-highlighted JSON blob with a copy button.
+
+  `value` must already hold JSON-encodable terms; see `encodable/1` for turning
+  an Ecto struct into one.
+  """
+  attr :id, :string, required: true
+  attr :value, :any, required: true
+  attr :label, :string, required: true
+  attr :hint, :string, default: nil
+
+  def json_view(assigns) do
+    encoded = JSONDiff.pretty(assigns.value)
+
+    assigns = assign(assigns, :tokens, tokens(encoded))
+
+    ~H"""
+    <section id={@id} phx-hook="CopyClipboard">
+      <div class="mb-3 flex items-center justify-between gap-3">
+        <h3 class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
+          {@label}
+        </h3>
+        <span :if={@hint} class="text-[10px] text-[var(--text-tertiary)]">{@hint}</span>
+      </div>
+      <div class="relative">
+        <pre class="max-h-96 overflow-auto rounded border border-[var(--border)] bg-[var(--surface-raised)] p-4 pr-24 text-xs leading-5"><code id={"#{@id}-code"} class="block min-w-max" phx-no-format><span :for={token <- @tokens} class={token_class(token.kind)}><%= token.text %></span></code></pre>
+        <button
+          type="button"
+          data-copy-to-clipboard-target={"#{@id}-code"}
+          title="Copy JSON to clipboard"
+          class="absolute end-2 top-2 inline-flex h-8 items-center gap-1.5 rounded border border-[var(--control-border)] bg-[var(--surface)] px-2.5 text-xs text-[var(--text-secondary)] shadow-sm hover:text-[var(--text-primary)]"
+        >
+          <span id={"#{@id}-default-message"} class="inline-flex items-center gap-1.5">
+            <.icon name="ri-clipboard-line" data-icon class="h-3.5 w-3.5" /> Copy
+          </span>
+          <span id={"#{@id}-success-message"} class="hidden items-center gap-1.5">
+            <.icon name="ri-check-line" data-icon class="h-3.5 w-3.5 text-emerald-600" /> Copied
+          </span>
+        </button>
+      </div>
+    </section>
+    """
+  end
+
+  @doc """
+  Turns an Ecto struct into a map `json_view/1` can render.
+
+  Associations and `__meta__` are dropped, and the types Postgres hands back
+  that carry no JSON representation of their own are rendered the way the rest
+  of the portal renders them.
+  """
+  def encodable(%_{} = struct) do
+    struct
+    |> Map.from_struct()
+    |> Map.drop([:__meta__])
+    |> Enum.reject(fn {_key, value} -> match?(%Ecto.Association.NotLoaded{}, value) end)
+    |> Map.new(fn {key, value} -> {Atom.to_string(key), encodable_value(value)} end)
+  end
+
+  defp encodable_value(%DateTime{} = value), do: DateTime.to_iso8601(value)
+  defp encodable_value(%Date{} = value), do: Date.to_iso8601(value)
+  defp encodable_value(%NaiveDateTime{} = value), do: NaiveDateTime.to_iso8601(value)
+  defp encodable_value(%Postgrex.INET{} = value), do: Portal.Types.INET.to_string(value)
+  defp encodable_value(value) when is_list(value), do: Enum.map(value, &encodable_value/1)
+
+  defp encodable_value(value) when is_map(value) and not is_struct(value) do
+    Map.new(value, fn {key, nested} -> {to_string(key), encodable_value(nested)} end)
+  end
+
+  defp encodable_value(value) when is_atom(value) and not is_nil(value) and not is_boolean(value),
+    do: Atom.to_string(value)
+
+  defp encodable_value(value) when is_binary(value) do
+    if String.valid?(value), do: value, else: Base.encode16(value, case: :lower)
+  end
+
+  defp encodable_value(value), do: value
+
+  defp tokens(json) do
+    {groups, cursor} =
+      @token_regex
+      |> Regex.scan(json, return: :index, capture: :first)
+      |> Enum.map_reduce(0, fn [{start, length}], cursor ->
+        token_end = start + length
+        leading = binary_part(json, cursor, start - cursor)
+        token = binary_part(json, start, length)
+
+        {[
+           %{kind: :plain, text: leading},
+           %{kind: token_kind(token, json, token_end), text: token}
+         ], token_end}
+      end)
+
+    trailing = binary_part(json, cursor, byte_size(json) - cursor)
+
+    groups
+    |> List.flatten()
+    |> Kernel.++([%{kind: :plain, text: trailing}])
+    |> Enum.reject(&(&1.text == ""))
+  end
+
+  defp token_kind(<<"\"", _::binary>>, json, token_end) do
+    remainder = binary_part(json, token_end, byte_size(json) - token_end)
+
+    if remainder |> String.trim_leading() |> String.starts_with?(":"),
+      do: :key,
+      else: :string
+  end
+
+  defp token_kind(token, _json, _token_end) when token in ["true", "false"], do: :boolean
+  defp token_kind("null", _json, _token_end), do: :null
+  defp token_kind(_token, _json, _token_end), do: :number
+
+  defp token_class(:key), do: "json-key text-sky-700 dark:text-sky-300"
+  defp token_class(:string), do: "json-string text-emerald-700 dark:text-emerald-300"
+  defp token_class(:number), do: "json-number text-violet-700 dark:text-violet-300"
+  defp token_class(:boolean), do: "json-boolean text-amber-700 dark:text-amber-300"
+  defp token_class(:null), do: "json-null text-[var(--text-tertiary)]"
+  defp token_class(:plain), do: nil
+end

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -30,7 +30,8 @@ defmodule PortalWeb.Clients do
         policy_authorizations_expanded_id: nil,
         client_posture: [],
         client_certificate: nil,
-        posture_types_by_client: %{}
+        posture_providers_connected?: false,
+        posture_by_client: %{}
       )
       |> assign(base_client_assigns())
       |> assign_live_table("clients",
@@ -73,7 +74,9 @@ defmodule PortalWeb.Clients do
            policy_authorizations_has_next: has_next,
            policy_authorizations_expanded_id: nil,
            client_posture: Database.list_posture_for_client(client, socket.assigns.subject),
-           client_certificate: Database.certificate_status(client, socket.assigns.subject)
+           client_certificate: Database.certificate_status(client, socket.assigns.subject),
+           posture_providers_connected?:
+             Database.posture_providers_connected?(socket.assigns.subject)
          )}
     end
   end
@@ -117,7 +120,7 @@ defmodule PortalWeb.Clients do
        assign(socket,
          clients: clients,
          clients_metadata: metadata,
-         posture_types_by_client: Database.posture_types_by_client(clients, socket.assigns.subject)
+         posture_by_client: Database.posture_index(clients, socket.assigns.subject)
        )}
     end
   end
@@ -186,6 +189,12 @@ defmodule PortalWeb.Clients do
               return_to={@return_to}
             />
           </:col>
+          <:col :let={client} label="Serial" class="w-44">
+            <.client_serial_badge
+              account={@account}
+              serial={row_posture(@posture_by_client, client).serial}
+            />
+          </:col>
           <:col :let={client} field={{:devices, :last_seen_version}} label="Version" class="w-32">
             <.version
               current={client.last_seen_version}
@@ -196,7 +205,7 @@ defmodule PortalWeb.Clients do
             <.client_verified_status client={client} />
           </:col>
           <:col :let={client} label="Posture" class="w-28">
-            <.client_posture_icons types={Map.get(@posture_types_by_client, client.id, [])} />
+            <.client_posture_icons types={row_posture(@posture_by_client, client).types} />
           </:col>
           <:col :let={client} label="Status" class="w-28">
             <.client_status_badge online?={client.online?} />
@@ -245,6 +254,7 @@ defmodule PortalWeb.Clients do
         query_params={@query_params}
         device_pools={@client_device_pools}
         posture={@client_posture}
+        posture_providers_connected?={@posture_providers_connected?}
         certificate={@client_certificate}
         policy_authorizations={@policy_authorizations}
         policy_authorizations_page={@policy_authorizations_page}
@@ -253,6 +263,10 @@ defmodule PortalWeb.Clients do
       />
     </div>
     """
+  end
+
+  defp row_posture(posture_by_client, client) do
+    Map.get(posture_by_client, client.id, %{types: [], serial: nil})
   end
 
   defp client_panel_state(assigns) do
@@ -906,6 +920,7 @@ defmodule PortalWeb.Clients do
           {Enum.take(rows, @page_size), has_next}
       end
     end
+
     @doc """
     Records from the account's posture providers that describe this device.
 
@@ -918,6 +933,12 @@ defmodule PortalWeb.Clients do
     Only the first two prove anything. The third is whatever the Client said
     about itself, so the panel cautions about rows matched that way.
 
+    Defender for Endpoint issues no device id of its own for a certificate to
+    attest and its machines report no hardware serial, so a Defender row is
+    reached through the Intune row already matched to this device: both carry
+    the same Entra device id. A row reached that way is only as well matched as
+    the Intune row that led to it.
+
     One row per configured provider rather than per provider type, so an
     account running two Intune tenants sees the device in both.
     """
@@ -926,7 +947,8 @@ defmodule PortalWeb.Clients do
               type: atom(),
               provider: PostureProvider.t(),
               device: struct(),
-              matched_on: :mdm_device_id | :attested_serial | :device_serial
+              matched_on: :mdm_device_id | :attested_serial | :device_serial,
+              via: :intune | nil
             }
           ]
     def list_posture_for_client(%Device{type: :client} = device, subject) do
@@ -936,11 +958,12 @@ defmodule PortalWeb.Clients do
       if keys == [] or providers == [] do
         []
       else
-        providers
-        |> Enum.map(& &1.type)
-        |> Enum.uniq()
-        |> Enum.flat_map(&match_posture(&1, keys, subject))
-        |> Enum.flat_map(&posture_entry(&1, Map.new(providers, fn p -> {p.id, p} end)))
+        types = providers |> Enum.map(& &1.type) |> Enum.uniq()
+        matched = Enum.flat_map(types, &match_posture(&1, keys, subject))
+        providers_by_id = Map.new(providers, &{&1.id, &1})
+
+        (matched ++ link_defender_posture(types, matched, subject))
+        |> Enum.flat_map(&posture_entry(&1, providers_by_id))
         |> Enum.group_by(& &1.provider.id)
         |> Enum.map(fn {_provider_id, entries} -> best_posture_entry(entries) end)
         |> Enum.sort_by(&{provider_type_rank(&1.type), String.downcase(&1.provider.name)})
@@ -949,45 +972,202 @@ defmodule PortalWeb.Clients do
 
     def list_posture_for_client(_client, _subject), do: []
 
-    defp posture_entry({type, device, matched_on}, providers_by_id) do
+    defp posture_entry({type, device, matched_on, via}, providers_by_id) do
       case Map.fetch(providers_by_id, device.posture_provider_id) do
-        {:ok, provider} -> [%{type: type, provider: provider, device: device, matched_on: matched_on}]
-        :error -> []
+        {:ok, provider} ->
+          [%{type: type, provider: provider, device: device, matched_on: matched_on, via: via}]
+
+        :error ->
+          []
       end
     end
 
     defp best_posture_entry(entries), do: Enum.min_by(entries, &rung_rank(&1.matched_on))
 
     @doc """
-    Which posture providers hold a record for each device in a list.
+    Whether the account has connected a posture provider at all.
 
-    One query per configured provider type for the whole page, so the Clients
-    list can badge every row without a lookup per Client.
+    The panel offers its Posture tab to every Client, so it has to tell a
+    device no provider holds a record for apart from an account that has no
+    provider to hold one.
     """
-    @spec posture_types_by_client([Device.t()], Portal.Authentication.Subject.t()) ::
-            %{Ecto.UUID.t() => [atom()]}
-    def posture_types_by_client(devices, subject) do
-      keys_by_client =
-        for device <- devices, keys = match_keys(device), keys != [], do: {device.id, keys}
+    @spec posture_providers_connected?(Portal.Authentication.Subject.t()) :: boolean()
+    def posture_providers_connected?(subject) do
+      from(p in PostureProvider)
+      |> Safe.scoped(subject)
+      |> Safe.exists?()
+      |> case do
+        connected? when is_boolean(connected?) -> connected?
+        _refused -> false
+      end
+    end
+
+    @doc """
+    What the Clients list badges each row with.
+
+    Returns the posture provider types that hold a record for the Client, and
+    the serial number to show for it alongside how well that serial is proven.
+
+    One query per configured provider type for the whole page, so the list can
+    badge every row without a lookup per Client.
+    """
+    @spec posture_index([Device.t()], Portal.Authentication.Subject.t()) ::
+            %{
+              Ecto.UUID.t() => %{
+                types: [atom()],
+                serial: %{value: String.t(), source: :attested | :mdm | :reported} | nil
+              }
+            }
+    def posture_index(devices, subject) do
+      keys_by_device =
+        for device <- devices, keys = match_keys(device), keys != [], into: %{} do
+          {device.id, keys}
+        end
 
       types = subject |> list_posture_providers() |> Enum.map(& &1.type) |> Enum.uniq()
+      loaded = load_posture_rows(types, keys_by_device, subject)
 
-      if keys_by_client == [] or types == [] do
-        %{}
-      else
-        Enum.reduce(types, %{}, &credit_posture_type(&1, &2, keys_by_client, subject))
+      Map.new(devices, fn device ->
+        matches = posture_matches(Map.get(keys_by_device, device.id, []), loaded)
+
+        {device.id,
+         %{
+           types: Enum.sort_by(matches.types, &provider_type_rank/1),
+           serial: serial_badge(device, matches.mdm_serial)
+         }}
+      end)
+    end
+
+    defp load_posture_rows(types, keys_by_device, subject) do
+      values =
+        keys_by_device
+        |> Enum.flat_map(fn {_device_id, keys} -> Keyword.values(keys) end)
+        |> Enum.uniq()
+
+      rows_by_type =
+        for type <- types, type != :defender, into: %{} do
+          {type, posture_rows(type, values, subject)}
+        end
+
+      defender_entra_ids =
+        if :defender in types do
+          defender_entra_ids(Map.get(rows_by_type, :intune, []), subject)
+        else
+          MapSet.new()
+        end
+
+      %{rows_by_type: rows_by_type, defender_entra_ids: defender_entra_ids}
+    end
+
+    defp posture_rows(_type, [], _subject), do: []
+
+    defp posture_rows(type, values, subject) do
+      conditions =
+        for field_name <- posture_match_fields(type),
+            do: dynamic([d], field(d, ^field_name) in ^values)
+
+      case conditions do
+        [] ->
+          []
+
+        conditions ->
+          from(d in posture_schema(type),
+            where: ^Enum.reduce(conditions, &dynamic(^&1 or ^&2)),
+            select: map(d, ^posture_index_fields(type))
+          )
+          |> Safe.scoped(subject)
+          |> Safe.all()
+          |> case do
+            rows when is_list(rows) -> rows
+            _refused -> []
+          end
       end
     end
 
-    defp credit_posture_type(type, acc, keys_by_client, subject) do
-      known = known_posture_values(type, keys_by_client, subject)
+    defp defender_entra_ids([], _subject), do: MapSet.new()
 
-      for {client_id, keys} <- keys_by_client,
-          posture_known?(type, keys, known),
-          reduce: acc do
-        acc -> Map.update(acc, client_id, [type], &(&1 ++ [type]))
+    defp defender_entra_ids(intune_rows, subject) do
+      entra_ids =
+        intune_rows
+        |> Enum.map(& &1.entra_device_id)
+        |> Enum.reject(&is_nil/1)
+        |> Enum.uniq()
+
+      case entra_ids do
+        [] ->
+          MapSet.new()
+
+        entra_ids ->
+          from(d in Defender.Device,
+            where: d.entra_device_id in ^entra_ids,
+            select: d.entra_device_id
+          )
+          |> Safe.scoped(subject)
+          |> Safe.all()
+          |> case do
+            ids when is_list(ids) -> MapSet.new(ids)
+            _refused -> MapSet.new()
+          end
       end
     end
+
+    defp posture_matches([], _loaded), do: %{types: [], mdm_serial: nil}
+
+    defp posture_matches(keys, loaded) do
+      matched =
+        for {type, rows} <- loaded.rows_by_type, into: %{} do
+          {type, matching_posture_rows(type, keys, rows)}
+        end
+
+      types = for {type, [_ | _]} <- matched, do: type
+
+      types =
+        if defender_linked?(Map.get(matched, :intune, []), loaded.defender_entra_ids) do
+          [:defender | types]
+        else
+          types
+        end
+
+      %{types: types, mdm_serial: mdm_serial(matched)}
+    end
+
+    defp matching_posture_rows(type, keys, rows) do
+      for row <- rows, rung = matched_rung(type, keys, row), do: {row, rung}
+    end
+
+    defp defender_linked?(intune_matches, entra_ids) do
+      Enum.any?(intune_matches, fn {row, _rung} ->
+        MapSet.member?(entra_ids, row.entra_device_id)
+      end)
+    end
+
+    # The serial an MDM holds for the device id a certificate attested is as
+    # well proven as that id, so it beats the one the Client reports about
+    # itself.
+    defp mdm_serial(matched) do
+      [:intune, :iru]
+      |> Enum.flat_map(&Map.get(matched, &1, []))
+      |> Enum.find_value(fn
+        {%{serial_number: serial}, :mdm_device_id} when is_binary(serial) -> serial
+        _other -> nil
+      end)
+    end
+
+    defp serial_badge(%Device{last_attested_device_serial: serial}, _mdm_serial)
+         when is_binary(serial) do
+      %{value: serial, source: :attested}
+    end
+
+    defp serial_badge(%Device{last_attested_mdm_device_id: mdm_id}, mdm_serial)
+         when is_binary(mdm_id) and is_binary(mdm_serial) do
+      %{value: mdm_serial, source: :mdm}
+    end
+
+    defp serial_badge(%Device{device_serial: serial}, _mdm_serial) when is_binary(serial) do
+      %{value: serial, source: :reported}
+    end
+
+    defp serial_badge(_device, _mdm_serial), do: nil
 
     @doc """
     What the account knows about the certificate this Client last attested with.
@@ -1112,11 +1292,48 @@ defmodule PortalWeb.Clients do
           |> Safe.all()
           |> case do
             rows when is_list(rows) ->
-              Enum.map(rows, &{type, &1, matched_rung(type, keys, &1)})
+              Enum.map(rows, &{type, &1, matched_rung(type, keys, &1), nil})
 
             _refused ->
               []
           end
+      end
+    end
+
+    defp link_defender_posture(types, matched, subject) do
+      if :defender in types do
+        matched
+        |> Enum.flat_map(fn
+          {:intune, %{entra_device_id: entra_id}, rung, _via} when is_binary(entra_id) ->
+            [{entra_id, rung}]
+
+          _other ->
+            []
+        end)
+        |> Enum.sort_by(fn {_entra_id, rung} -> rung_rank(rung) end)
+        |> Enum.uniq_by(fn {entra_id, _rung} -> entra_id end)
+        |> match_defender_by_entra_id(subject)
+      else
+        []
+      end
+    end
+
+    defp match_defender_by_entra_id([], _subject), do: []
+
+    defp match_defender_by_entra_id(entra_ids, subject) do
+      rung_by_entra_id = Map.new(entra_ids)
+
+      from(d in Defender.Device, where: d.entra_device_id in ^Map.keys(rung_by_entra_id))
+      |> Safe.scoped(subject)
+      |> Safe.all()
+      |> case do
+        rows when is_list(rows) ->
+          for row <- rows, rung = Map.get(rung_by_entra_id, row.entra_device_id) do
+            {:defender, row, rung, :intune}
+          end
+
+        _refused ->
+          []
       end
     end
 
@@ -1132,49 +1349,16 @@ defmodule PortalWeb.Clients do
       end)
     end
 
-    defp known_posture_values(type, keys_by_client, subject) do
-      fields = type |> posture_match_fields() |> Enum.uniq()
-
-      values =
-        keys_by_client
-        |> Enum.flat_map(fn {_client_id, keys} -> Keyword.values(keys) end)
-        |> Enum.uniq()
-
-      conditions = for field_name <- fields, do: dynamic([d], field(d, ^field_name) in ^values)
-
-      case conditions do
-        [] ->
-          MapSet.new()
-
-        conditions ->
-          from(d in posture_schema(type),
-            where: ^Enum.reduce(conditions, &dynamic(^&1 or ^&2)),
-            select: map(d, ^fields)
-          )
-          |> Safe.scoped(subject)
-          |> Safe.all()
-          |> index_posture_values()
-      end
-    end
-
-    defp index_posture_values(rows) when is_list(rows) do
-      for row <- rows, {field_name, value} <- row, not is_nil(value), into: MapSet.new() do
-        {field_name, value}
-      end
-    end
-
-    # A refused read leaves the list with no badges rather than with wrong ones.
-    defp index_posture_values(_refused), do: MapSet.new()
-
-    defp posture_known?(type, keys, known) do
-      Enum.any?(keys, fn {rung, value} ->
-        Enum.any?(rung_fields(type, rung), &MapSet.member?(known, {&1, value}))
-      end)
-    end
-
     defp posture_match_fields(type) do
-      Enum.flat_map([:mdm_device_id, :attested_serial, :device_serial], &rung_fields(type, &1))
+      [:mdm_device_id, :attested_serial, :device_serial]
+      |> Enum.flat_map(&rung_fields(type, &1))
+      |> Enum.uniq()
     end
+
+    # The list also needs the serial Intune holds and the Entra device id that
+    # reaches a Defender machine, neither of which it matches on.
+    defp posture_index_fields(:intune), do: posture_match_fields(:intune) ++ [:entra_device_id]
+    defp posture_index_fields(type), do: posture_match_fields(type)
 
     defp posture_schema(:intune), do: Intune.Device
     defp posture_schema(:iru), do: Iru.Device
@@ -1186,16 +1370,15 @@ defmodule PortalWeb.Clients do
     # against. Both the query and the credit given to a row it returns are
     # built from this, so they can never disagree.
     #
-    # Intune and Defender both carry the Entra device id, which is the value a
-    # certificate issued through Entra attests. Defender's machine entity
-    # reports no hardware serial at all, and neither of the two EDRs carries an
-    # MDM device id, so each of those has one rung it cannot answer.
-    defp rung_fields(:intune, :mdm_device_id), do: [:intune_id, :entra_device_id]
+    # Only an MDM issues a device id a certificate attests, so neither EDR
+    # answers that rung. Defender answers none of them: its machine entity
+    # carries no hardware serial either, which is why it is reached through
+    # Intune instead.
+    defp rung_fields(:intune, :mdm_device_id), do: [:intune_id]
     defp rung_fields(:intune, _serial_rung), do: [:serial_number]
     defp rung_fields(:iru, :mdm_device_id), do: [:iru_id]
     defp rung_fields(:iru, _serial_rung), do: [:serial_number]
-    defp rung_fields(:defender, :mdm_device_id), do: [:defender_id, :entra_device_id]
-    defp rung_fields(:defender, _serial_rung), do: []
+    defp rung_fields(:defender, _rung), do: []
     defp rung_fields(:santa, :mdm_device_id), do: []
     defp rung_fields(:santa, _serial_rung), do: [:serial_number]
     defp rung_fields(:sentinelone, :mdm_device_id), do: []

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -931,10 +931,11 @@ defmodule PortalWeb.Clients do
 
       1. the MDM device id the Client's certificate attested,
       2. the hardware serial that certificate attested,
-      3. the hardware serial the Client reports about itself.
+      3. the self-reported hardware serial.
 
-    Only the first two prove anything. The third is whatever the Client said
-    about itself, so the panel cautions about rows matched that way.
+    Only the first two prove anything. The third is only as trustworthy as the
+    actor and the device running the Client, so the panel labels rows matched
+    that way.
 
     Defender for Endpoint issues no device id of its own for a certificate to
     attest and its machines report no hardware serial, so a Defender row is
@@ -1010,8 +1011,8 @@ defmodule PortalWeb.Clients do
 
     A Client that attested a serial shows that one. Failing that, the serial the
     account's MDM holds for the device id the Client did attest, which is as
-    well proven as that id. Failing both, the serial the Client reports about
-    itself, which nothing vouches for.
+    well proven as that id. Failing both, the self-reported serial, which
+    nothing vouches for.
 
     One query per MDM the account has connected, for the whole page.
     """

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -787,7 +787,7 @@ defmodule PortalWeb.Clients do
         },
         %Portal.Repo.Filter{
           name: :attestation,
-          title: "Attestation level",
+          title: "Trust level",
           type: {:string, :select},
           values: [
             {"Verified", "verified"},

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -27,7 +27,10 @@ defmodule PortalWeb.Clients do
         policy_authorizations: [],
         policy_authorizations_page: 1,
         policy_authorizations_has_next: false,
-        policy_authorizations_expanded_id: nil
+        policy_authorizations_expanded_id: nil,
+        client_posture: [],
+        client_certificate: nil,
+        posture_types_by_client: %{}
       )
       |> assign(base_client_assigns())
       |> assign_live_table("clients",
@@ -68,7 +71,9 @@ defmodule PortalWeb.Clients do
            policy_authorizations: policy_authorizations,
            policy_authorizations_page: page,
            policy_authorizations_has_next: has_next,
-           policy_authorizations_expanded_id: nil
+           policy_authorizations_expanded_id: nil,
+           client_posture: Database.list_posture_for_client(client, socket.assigns.subject),
+           client_certificate: Database.certificate_status(client, socket.assigns.subject)
          )}
     end
   end
@@ -95,7 +100,12 @@ defmodule PortalWeb.Clients do
 
     {:noreply,
      socket
-     |> assign(selected_client: nil, client_device_pools: [])
+     |> assign(
+       selected_client: nil,
+       client_device_pools: [],
+       client_posture: [],
+       client_certificate: nil
+     )
      |> assign(base_client_assigns())}
   end
 
@@ -106,7 +116,8 @@ defmodule PortalWeb.Clients do
       {:ok,
        assign(socket,
          clients: clients,
-         clients_metadata: metadata
+         clients_metadata: metadata,
+         posture_types_by_client: Database.posture_types_by_client(clients, socket.assigns.subject)
        )}
     end
   end
@@ -184,6 +195,9 @@ defmodule PortalWeb.Clients do
           <:col :let={client} label="Trust" class="w-28">
             <.client_verified_status client={client} />
           </:col>
+          <:col :let={client} label="Posture" class="w-28">
+            <.client_posture_icons types={Map.get(@posture_types_by_client, client.id, [])} />
+          </:col>
           <:col :let={client} label="Status" class="w-28">
             <.client_status_badge online?={client.online?} />
           </:col>
@@ -230,6 +244,8 @@ defmodule PortalWeb.Clients do
         confirm_state={client_confirm_state(assigns)}
         query_params={@query_params}
         device_pools={@client_device_pools}
+        posture={@client_posture}
+        certificate={@client_certificate}
         policy_authorizations={@policy_authorizations}
         policy_authorizations_page={@policy_authorizations_page}
         policy_authorizations_has_next={@policy_authorizations_has_next}
@@ -476,6 +492,7 @@ defmodule PortalWeb.Clients do
   end
 
   defp parse_client_tab("authorizations"), do: :authorizations
+  defp parse_client_tab("posture"), do: :posture
   defp parse_client_tab("overview"), do: :overview
   defp parse_client_tab(_), do: :overview
 
@@ -558,6 +575,8 @@ defmodule PortalWeb.Clients do
     alias Portal.StaticDevicePoolMember
     alias Portal.Repo.Filter
     alias Portal.Repo.OffsetPaginator
+    alias Portal.PostureProvider
+    alias Portal.{Defender, Intune, Iru, Santa, SentinelOne}
 
     def count_clients(subject) do
       from(d in Device, as: :devices)
@@ -887,5 +906,310 @@ defmodule PortalWeb.Clients do
           {Enum.take(rows, @page_size), has_next}
       end
     end
+    @doc """
+    Records from the account's posture providers that describe this device.
+
+    A row is matched on the strongest identifier it shares with the Client:
+
+      1. the MDM device id the Client's certificate attested,
+      2. the hardware serial that certificate attested,
+      3. the hardware serial the Client reports about itself.
+
+    Only the first two prove anything. The third is whatever the Client said
+    about itself, so the panel cautions about rows matched that way.
+
+    One row per configured provider rather than per provider type, so an
+    account running two Intune tenants sees the device in both.
+    """
+    @spec list_posture_for_client(Device.t(), Portal.Authentication.Subject.t()) :: [
+            %{
+              type: atom(),
+              provider: PostureProvider.t(),
+              device: struct(),
+              matched_on: :mdm_device_id | :attested_serial | :device_serial
+            }
+          ]
+    def list_posture_for_client(%Device{type: :client} = device, subject) do
+      keys = match_keys(device)
+      providers = list_posture_providers(subject)
+
+      if keys == [] or providers == [] do
+        []
+      else
+        providers
+        |> Enum.map(& &1.type)
+        |> Enum.uniq()
+        |> Enum.flat_map(&match_posture(&1, keys, subject))
+        |> Enum.flat_map(&posture_entry(&1, Map.new(providers, fn p -> {p.id, p} end)))
+        |> Enum.group_by(& &1.provider.id)
+        |> Enum.map(fn {_provider_id, entries} -> best_posture_entry(entries) end)
+        |> Enum.sort_by(&{provider_type_rank(&1.type), String.downcase(&1.provider.name)})
+      end
+    end
+
+    def list_posture_for_client(_client, _subject), do: []
+
+    defp posture_entry({type, device, matched_on}, providers_by_id) do
+      case Map.fetch(providers_by_id, device.posture_provider_id) do
+        {:ok, provider} -> [%{type: type, provider: provider, device: device, matched_on: matched_on}]
+        :error -> []
+      end
+    end
+
+    defp best_posture_entry(entries), do: Enum.min_by(entries, &rung_rank(&1.matched_on))
+
+    @doc """
+    Which posture providers hold a record for each device in a list.
+
+    One query per configured provider type for the whole page, so the Clients
+    list can badge every row without a lookup per Client.
+    """
+    @spec posture_types_by_client([Device.t()], Portal.Authentication.Subject.t()) ::
+            %{Ecto.UUID.t() => [atom()]}
+    def posture_types_by_client(devices, subject) do
+      keys_by_client =
+        for device <- devices, keys = match_keys(device), keys != [], do: {device.id, keys}
+
+      types = subject |> list_posture_providers() |> Enum.map(& &1.type) |> Enum.uniq()
+
+      if keys_by_client == [] or types == [] do
+        %{}
+      else
+        Enum.reduce(types, %{}, &credit_posture_type(&1, &2, keys_by_client, subject))
+      end
+    end
+
+    defp credit_posture_type(type, acc, keys_by_client, subject) do
+      known = known_posture_values(type, keys_by_client, subject)
+
+      for {client_id, keys} <- keys_by_client,
+          posture_known?(type, keys, known),
+          reduce: acc do
+        acc -> Map.update(acc, client_id, [type], &(&1 ++ [type]))
+      end
+    end
+
+    @doc """
+    What the account knows about the certificate this Client last attested with.
+
+    Both mechanisms are read in one round trip because they answer the same
+    question and an admin looking at the panel wants whichever of them has an
+    answer. A published list beats a responder: a serial on a CRL is revoked
+    whatever a stale responder still says about it.
+
+    Returns `nil` when the Client has never attested a certificate.
+    """
+    @spec certificate_status(Device.t(), Portal.Authentication.Subject.t()) ::
+            %{
+              state: :revoked | :good | :unknown,
+              source: :crl | :ocsp | nil,
+              revoked_at: DateTime.t() | nil,
+              reason: String.t() | nil,
+              next_update: DateTime.t() | nil
+            }
+            | nil
+    def certificate_status(%Device{} = device, subject)
+        when is_binary(device.last_attested_cert_issuer) and
+               is_binary(device.last_attested_cert_serial) do
+      issuer = device.last_attested_cert_issuer
+      serial = device.last_attested_cert_serial
+
+      from(a in Portal.Account,
+        left_join: r in Portal.CrlRevocation,
+        on: r.account_id == a.id and r.issuer == ^issuer and r.serial == ^serial,
+        left_join: s in Portal.OcspStatus,
+        on: s.account_id == a.id and s.issuer == ^issuer and s.serial == ^serial,
+        # A CA that partitions its list holds the same serial in more than one
+        # partition, and any one of them revokes it.
+        order_by: [asc: r.revoked_at],
+        limit: 1,
+        select: %{
+          crl_revoked_at: r.revoked_at,
+          crl_reason: r.reason,
+          ocsp_status: s.status,
+          ocsp_revoked_at: s.revoked_at,
+          ocsp_reason: s.reason,
+          ocsp_next_update: s.next_update
+        }
+      )
+      |> Safe.scoped(subject)
+      |> Safe.one()
+      |> normalize_certificate_status()
+    end
+
+    def certificate_status(_client, _subject), do: nil
+
+    defp normalize_certificate_status(%{crl_revoked_at: revoked_at} = row)
+         when not is_nil(revoked_at) do
+      %{
+        state: :revoked,
+        source: :crl,
+        revoked_at: revoked_at,
+        reason: row.crl_reason,
+        next_update: row.ocsp_next_update
+      }
+    end
+
+    defp normalize_certificate_status(%{ocsp_status: "revoked"} = row) do
+      %{
+        state: :revoked,
+        source: :ocsp,
+        revoked_at: row.ocsp_revoked_at,
+        reason: row.ocsp_reason,
+        next_update: row.ocsp_next_update
+      }
+    end
+
+    defp normalize_certificate_status(%{ocsp_status: "good"} = row) do
+      %{
+        state: :good,
+        source: :ocsp,
+        revoked_at: nil,
+        reason: nil,
+        next_update: row.ocsp_next_update
+      }
+    end
+
+    defp normalize_certificate_status(%{}) do
+      %{state: :unknown, source: nil, revoked_at: nil, reason: nil, next_update: nil}
+    end
+
+    # Anything else means the read was refused, which leaves the panel with no
+    # facts rather than with false ones.
+    defp normalize_certificate_status(_other), do: nil
+
+    # Ordered strongest first: the head of this list is what a matched row is
+    # credited to.
+    defp match_keys(%Device{} = device) do
+      Enum.reject(
+        [
+          mdm_device_id: device.last_attested_mdm_device_id,
+          attested_serial: device.last_attested_device_serial,
+          device_serial: device.device_serial
+        ],
+        fn {_rung, value} -> is_nil(value) end
+      )
+    end
+
+    defp list_posture_providers(subject) do
+      from(p in PostureProvider, order_by: [asc: p.name])
+      |> Safe.scoped(subject)
+      |> Safe.all()
+      |> case do
+        providers when is_list(providers) -> providers
+        _refused -> []
+      end
+    end
+
+    defp match_posture(type, keys, subject) do
+      case rung_conditions(type, keys) do
+        [] ->
+          []
+
+        conditions ->
+          from(d in posture_schema(type), where: ^Enum.reduce(conditions, &dynamic(^&1 or ^&2)))
+          |> Safe.scoped(subject)
+          |> Safe.all()
+          |> case do
+            rows when is_list(rows) ->
+              Enum.map(rows, &{type, &1, matched_rung(type, keys, &1)})
+
+            _refused ->
+              []
+          end
+      end
+    end
+
+    defp rung_conditions(type, keys) do
+      for {rung, value} <- keys,
+          field_name <- rung_fields(type, rung),
+          do: dynamic([d], field(d, ^field_name) == ^value)
+    end
+
+    defp matched_rung(type, keys, row) do
+      Enum.find_value(keys, fn {rung, value} ->
+        if Enum.any?(rung_fields(type, rung), &(Map.fetch!(row, &1) == value)), do: rung
+      end)
+    end
+
+    defp known_posture_values(type, keys_by_client, subject) do
+      fields = type |> posture_match_fields() |> Enum.uniq()
+
+      values =
+        keys_by_client
+        |> Enum.flat_map(fn {_client_id, keys} -> Keyword.values(keys) end)
+        |> Enum.uniq()
+
+      conditions = for field_name <- fields, do: dynamic([d], field(d, ^field_name) in ^values)
+
+      case conditions do
+        [] ->
+          MapSet.new()
+
+        conditions ->
+          from(d in posture_schema(type),
+            where: ^Enum.reduce(conditions, &dynamic(^&1 or ^&2)),
+            select: map(d, ^fields)
+          )
+          |> Safe.scoped(subject)
+          |> Safe.all()
+          |> index_posture_values()
+      end
+    end
+
+    defp index_posture_values(rows) when is_list(rows) do
+      for row <- rows, {field_name, value} <- row, not is_nil(value), into: MapSet.new() do
+        {field_name, value}
+      end
+    end
+
+    # A refused read leaves the list with no badges rather than with wrong ones.
+    defp index_posture_values(_refused), do: MapSet.new()
+
+    defp posture_known?(type, keys, known) do
+      Enum.any?(keys, fn {rung, value} ->
+        Enum.any?(rung_fields(type, rung), &MapSet.member?(known, {&1, value}))
+      end)
+    end
+
+    defp posture_match_fields(type) do
+      Enum.flat_map([:mdm_device_id, :attested_serial, :device_serial], &rung_fields(type, &1))
+    end
+
+    defp posture_schema(:intune), do: Intune.Device
+    defp posture_schema(:iru), do: Iru.Device
+    defp posture_schema(:defender), do: Defender.Device
+    defp posture_schema(:santa), do: Santa.Device
+    defp posture_schema(:sentinelone), do: SentinelOne.Device
+
+    # Which columns of a provider's posture row each rung is compared
+    # against. Both the query and the credit given to a row it returns are
+    # built from this, so they can never disagree.
+    #
+    # Intune and Defender both carry the Entra device id, which is the value a
+    # certificate issued through Entra attests. Defender's machine entity
+    # reports no hardware serial at all, and neither of the two EDRs carries an
+    # MDM device id, so each of those has one rung it cannot answer.
+    defp rung_fields(:intune, :mdm_device_id), do: [:intune_id, :entra_device_id]
+    defp rung_fields(:intune, _serial_rung), do: [:serial_number]
+    defp rung_fields(:iru, :mdm_device_id), do: [:iru_id]
+    defp rung_fields(:iru, _serial_rung), do: [:serial_number]
+    defp rung_fields(:defender, :mdm_device_id), do: [:defender_id, :entra_device_id]
+    defp rung_fields(:defender, _serial_rung), do: []
+    defp rung_fields(:santa, :mdm_device_id), do: []
+    defp rung_fields(:santa, _serial_rung), do: [:serial_number]
+    defp rung_fields(:sentinelone, :mdm_device_id), do: []
+    defp rung_fields(:sentinelone, _serial_rung), do: [:serial_number]
+
+    defp rung_rank(:mdm_device_id), do: 0
+    defp rung_rank(:attested_serial), do: 1
+    defp rung_rank(:device_serial), do: 2
+
+    defp provider_type_rank(:intune), do: 0
+    defp provider_type_rank(:iru), do: 1
+    defp provider_type_rank(:defender), do: 2
+    defp provider_type_rank(:santa), do: 3
+    defp provider_type_rank(:sentinelone), do: 4
+
   end
 end

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -31,7 +31,7 @@ defmodule PortalWeb.Clients do
         client_posture: [],
         client_certificate: nil,
         posture_providers_connected?: false,
-        posture_by_client: %{}
+        serials_by_client: %{}
       )
       |> assign(base_client_assigns())
       |> assign_live_table("clients",
@@ -120,7 +120,7 @@ defmodule PortalWeb.Clients do
        assign(socket,
          clients: clients,
          clients_metadata: metadata,
-         posture_by_client: Database.posture_index(clients, socket.assigns.subject)
+         serials_by_client: Database.serial_index(clients, socket.assigns.subject)
        )}
     end
   end
@@ -190,22 +190,13 @@ defmodule PortalWeb.Clients do
             />
           </:col>
           <:col :let={client} label="Serial" class="w-44">
-            <.client_serial_badge
-              account={@account}
-              serial={row_posture(@posture_by_client, client).serial}
-            />
+            <.client_serial serial={Map.get(@serials_by_client, client.id)} />
           </:col>
           <:col :let={client} field={{:devices, :last_seen_version}} label="Version" class="w-32">
             <.version
               current={client.last_seen_version}
               latest={ComponentVersions.client_version(client)}
             />
-          </:col>
-          <:col :let={client} label="Trust" class="w-28">
-            <.client_verified_status client={client} />
-          </:col>
-          <:col :let={client} label="Posture" class="w-28">
-            <.client_posture_icons types={row_posture(@posture_by_client, client).types} />
           </:col>
           <:col :let={client} label="Status" class="w-28">
             <.client_status_badge online?={client.online?} />
@@ -263,10 +254,6 @@ defmodule PortalWeb.Clients do
       />
     </div>
     """
-  end
-
-  defp row_posture(posture_by_client, client) do
-    Map.get(posture_by_client, client.id, %{types: [], serial: nil})
   end
 
   defp client_panel_state(assigns) do
@@ -799,14 +786,15 @@ defmodule PortalWeb.Clients do
           fun: &filter_by_search_fts/2
         },
         %Portal.Repo.Filter{
-          name: :verification,
-          title: "Verification Status",
-          type: :string,
+          name: :attestation,
+          title: "Attestation level",
+          type: {:string, :select},
           values: [
             {"Verified", "verified"},
-            {"Not Verified", "not_verified"}
+            {"Attested", "attested"},
+            {"None", "none"}
           ],
-          fun: &filter_by_verification/2
+          fun: &filter_by_attestation/2
         },
         %Portal.Repo.Filter{
           name: :presence,
@@ -841,12 +829,27 @@ defmodule PortalWeb.Clients do
        )}
     end
 
-    def filter_by_verification(queryable, "verified") do
-      {queryable, dynamic([devices: devices], not is_nil(devices.verified_at))}
+    # A device that attested is badged "Attested" rather than "Verified" however
+    # its verified_at reads, so the two options have to be exclusive here too or
+    # the filter would disagree with the panel.
+    def filter_by_attestation(queryable, "verified") do
+      {queryable,
+       dynamic(
+         [devices: devices],
+         not is_nil(devices.verified_at) and is_nil(devices.last_attested_at)
+       )}
     end
 
-    def filter_by_verification(queryable, "not_verified") do
-      {queryable, dynamic([devices: devices], is_nil(devices.verified_at))}
+    def filter_by_attestation(queryable, "attested") do
+      {queryable, dynamic([devices: devices], not is_nil(devices.last_attested_at))}
+    end
+
+    def filter_by_attestation(queryable, "none") do
+      {queryable,
+       dynamic(
+         [devices: devices],
+         is_nil(devices.verified_at) and is_nil(devices.last_attested_at)
+       )}
     end
 
     def filter_by_presence(queryable, _presence) do
@@ -1003,171 +1006,81 @@ defmodule PortalWeb.Clients do
     end
 
     @doc """
-    What the Clients list badges each row with.
+    The serial number the Clients list shows for each row, and where it came from.
 
-    Returns the posture provider types that hold a record for the Client, and
-    the serial number to show for it alongside how well that serial is proven.
+    A Client that attested a serial shows that one. Failing that, the serial the
+    account's MDM holds for the device id the Client did attest, which is as
+    well proven as that id. Failing both, the serial the Client reports about
+    itself, which nothing vouches for.
 
-    One query per configured provider type for the whole page, so the list can
-    badge every row without a lookup per Client.
+    One query per MDM the account has connected, for the whole page.
     """
-    @spec posture_index([Device.t()], Portal.Authentication.Subject.t()) ::
+    @spec serial_index([Device.t()], Portal.Authentication.Subject.t()) ::
             %{
               Ecto.UUID.t() => %{
-                types: [atom()],
-                serial: %{value: String.t(), source: :attested | :mdm | :reported} | nil
+                value: String.t(),
+                source: :attested | :mdm | :reported,
+                provider: atom() | nil
               }
             }
-    def posture_index(devices, subject) do
-      keys_by_device =
-        for device <- devices, keys = match_keys(device), keys != [], into: %{} do
-          {device.id, keys}
-        end
+    def serial_index(devices, subject) do
+      mdm_device_ids =
+        for device <- devices,
+            is_nil(device.last_attested_device_serial),
+            is_binary(device.last_attested_mdm_device_id),
+            uniq: true,
+            do: device.last_attested_mdm_device_id
 
-      types = subject |> list_posture_providers() |> Enum.map(& &1.type) |> Enum.uniq()
-      loaded = load_posture_rows(types, keys_by_device, subject)
+      by_mdm_device_id = mdm_serials(mdm_device_ids, subject)
 
-      Map.new(devices, fn device ->
-        matches = posture_matches(Map.get(keys_by_device, device.id, []), loaded)
-
+      for device <- devices, into: %{} do
         {device.id,
-         %{
-           types: Enum.sort_by(matches.types, &provider_type_rank/1),
-           serial: serial_badge(device, matches.mdm_serial)
-         }}
-      end)
-    end
-
-    defp load_posture_rows(types, keys_by_device, subject) do
-      values =
-        keys_by_device
-        |> Enum.flat_map(fn {_device_id, keys} -> Keyword.values(keys) end)
-        |> Enum.uniq()
-
-      rows_by_type =
-        for type <- types, type != :defender, into: %{} do
-          {type, posture_rows(type, values, subject)}
-        end
-
-      defender_entra_ids =
-        if :defender in types do
-          defender_entra_ids(Map.get(rows_by_type, :intune, []), subject)
-        else
-          MapSet.new()
-        end
-
-      %{rows_by_type: rows_by_type, defender_entra_ids: defender_entra_ids}
-    end
-
-    defp posture_rows(_type, [], _subject), do: []
-
-    defp posture_rows(type, values, subject) do
-      conditions =
-        for field_name <- posture_match_fields(type),
-            do: dynamic([d], field(d, ^field_name) in ^values)
-
-      case conditions do
-        [] ->
-          []
-
-        conditions ->
-          from(d in posture_schema(type),
-            where: ^Enum.reduce(conditions, &dynamic(^&1 or ^&2)),
-            select: map(d, ^posture_index_fields(type))
-          )
-          |> Safe.scoped(subject)
-          |> Safe.all()
-          |> case do
-            rows when is_list(rows) -> rows
-            _refused -> []
-          end
+         serial_badge(device, Map.get(by_mdm_device_id, device.last_attested_mdm_device_id))}
       end
     end
 
-    defp defender_entra_ids([], _subject), do: MapSet.new()
+    defp mdm_serials([], _subject), do: %{}
 
-    defp defender_entra_ids(intune_rows, subject) do
-      entra_ids =
-        intune_rows
-        |> Enum.map(& &1.entra_device_id)
-        |> Enum.reject(&is_nil/1)
-        |> Enum.uniq()
+    defp mdm_serials(mdm_device_ids, subject) do
+      connected = subject |> list_posture_providers() |> Enum.map(& &1.type) |> Enum.uniq()
 
-      case entra_ids do
-        [] ->
-          MapSet.new()
-
-        entra_ids ->
-          from(d in Defender.Device,
-            where: d.entra_device_id in ^entra_ids,
-            select: d.entra_device_id
-          )
-          |> Safe.scoped(subject)
-          |> Safe.all()
-          |> case do
-            ids when is_list(ids) -> MapSet.new(ids)
-            _refused -> MapSet.new()
-          end
+      # Reversed so that the first type to answer for a device id is the one
+      # left in the map, since a later merge keeps what is already there.
+      for type <- [:iru, :intune], type in connected, reduce: %{} do
+        acc -> Map.merge(acc, mdm_serial_rows(type, mdm_device_ids, subject))
       end
     end
 
-    defp posture_matches([], _loaded), do: %{types: [], mdm_serial: nil}
+    defp mdm_serial_rows(type, mdm_device_ids, subject) do
+      [field_name] = rung_fields(type, :mdm_device_id)
 
-    defp posture_matches(keys, loaded) do
-      matched =
-        for {type, rows} <- loaded.rows_by_type, into: %{} do
-          {type, matching_posture_rows(type, keys, rows)}
-        end
-
-      types = for {type, [_ | _]} <- matched, do: type
-
-      types =
-        if defender_linked?(Map.get(matched, :intune, []), loaded.defender_entra_ids) do
-          [:defender | types]
-        else
-          types
-        end
-
-      %{types: types, mdm_serial: mdm_serial(matched)}
+      from(d in posture_schema(type),
+        where: field(d, ^field_name) in ^mdm_device_ids and not is_nil(d.serial_number),
+        select: {field(d, ^field_name), d.serial_number}
+      )
+      |> Safe.scoped(subject)
+      |> Safe.all()
+      |> case do
+        rows when is_list(rows) -> Map.new(rows, fn {id, serial} -> {id, {type, serial}} end)
+        _refused -> %{}
+      end
     end
 
-    defp matching_posture_rows(type, keys, rows) do
-      for row <- rows, rung = matched_rung(type, keys, row), do: {row, rung}
-    end
-
-    defp defender_linked?(intune_matches, entra_ids) do
-      Enum.any?(intune_matches, fn {row, _rung} ->
-        MapSet.member?(entra_ids, row.entra_device_id)
-      end)
-    end
-
-    # The serial an MDM holds for the device id a certificate attested is as
-    # well proven as that id, so it beats the one the Client reports about
-    # itself.
-    defp mdm_serial(matched) do
-      [:intune, :iru]
-      |> Enum.flat_map(&Map.get(matched, &1, []))
-      |> Enum.find_value(fn
-        {%{serial_number: serial}, :mdm_device_id} when is_binary(serial) -> serial
-        _other -> nil
-      end)
-    end
-
-    defp serial_badge(%Device{last_attested_device_serial: serial}, _mdm_serial)
+    defp serial_badge(%Device{last_attested_device_serial: serial}, _mdm)
          when is_binary(serial) do
-      %{value: serial, source: :attested}
+      %{value: serial, source: :attested, provider: nil}
     end
 
-    defp serial_badge(%Device{last_attested_mdm_device_id: mdm_id}, mdm_serial)
-         when is_binary(mdm_id) and is_binary(mdm_serial) do
-      %{value: mdm_serial, source: :mdm}
+    defp serial_badge(%Device{last_attested_mdm_device_id: mdm_id}, {type, serial})
+         when is_binary(mdm_id) and is_binary(serial) do
+      %{value: serial, source: :mdm, provider: type}
     end
 
-    defp serial_badge(%Device{device_serial: serial}, _mdm_serial) when is_binary(serial) do
-      %{value: serial, source: :reported}
+    defp serial_badge(%Device{device_serial: serial}, _mdm) when is_binary(serial) do
+      %{value: serial, source: :reported, provider: nil}
     end
 
-    defp serial_badge(_device, _mdm_serial), do: nil
+    defp serial_badge(_device, _mdm), do: nil
 
     @doc """
     What the account knows about the certificate this Client last attested with.
@@ -1348,17 +1261,6 @@ defmodule PortalWeb.Clients do
         if Enum.any?(rung_fields(type, rung), &(Map.fetch!(row, &1) == value)), do: rung
       end)
     end
-
-    defp posture_match_fields(type) do
-      [:mdm_device_id, :attested_serial, :device_serial]
-      |> Enum.flat_map(&rung_fields(type, &1))
-      |> Enum.uniq()
-    end
-
-    # The list also needs the serial Intune holds and the Entra device id that
-    # reaches a Defender machine, neither of which it matches on.
-    defp posture_index_fields(:intune), do: posture_match_fields(:intune) ++ [:entra_device_id]
-    defp posture_index_fields(type), do: posture_match_fields(type)
 
     defp posture_schema(:intune), do: Intune.Device
     defp posture_schema(:iru), do: Iru.Device

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -891,11 +891,11 @@ defmodule PortalWeb.Clients.Components do
     <div class="flex items-center gap-1.5">
       <.popover :if={@serial.source != :reported} placement="right">
         <:target>
-          <.provider_icon :if={@serial.provider} provider={to_string(@serial.provider)} size="xs" />
+          <.provider_icon :if={@serial.provider} provider={to_string(@serial.provider)} size="sm" />
           <.icon
             :if={is_nil(@serial.provider)}
             name="ri-shield-keyhole-line"
-            class="w-3 h-3 shrink-0 text-success"
+            class="w-4 h-4 shrink-0 text-success"
           />
         </:target>
         <:content>{serial_source_hint(@serial)}</:content>

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -621,10 +621,10 @@ defmodule PortalWeb.Clients.Components do
   def client_device_section(assigns) do
     ~H"""
     <div class="px-5 pt-4 pb-3 border-b border-border">
-      <.section_heading title="Reported by this Client" />
+      <.section_heading title="Self-Reported" />
       <p class="mb-3 text-xs text-subtle">
-        The Firezone Client reports these fields about itself, so a malicious actor could spoof
-        them.
+        The Firezone Client supplies these values, so they are only as trustworthy as the actor
+        and the device it runs on.
         <span :if={is_nil(@client.last_attested_at)}>
           Set up
           <.link
@@ -798,13 +798,13 @@ defmodule PortalWeb.Clients.Components do
     <.popover placement="left">
       <:target>
         <span class="inline-flex shrink-0 items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-warning bg-warning-light">
-          <.icon name="ri-error-warning-line" class="w-2.5 h-2.5" /> Reported serial
+          <.icon name="ri-error-warning-line" class="w-2.5 h-2.5" /> Self-reported serial
         </span>
       </:target>
       <:content>
         <p>
-          Matched on the serial number the device reports about itself. This field could be
-          spoofed by a malicious actor.
+          Matched on a self-reported serial number, which is only as trustworthy as the actor
+          and the device running the Client.
         </p>
         <p :if={@via == :intune} class="mt-1">
           Reached through the Microsoft Intune record that serial matched, which holds the same
@@ -1378,12 +1378,12 @@ defmodule PortalWeb.Clients.Components do
   end
 
   defp serial_source_hint(%{source: :attested}) do
-    "The serial number this device proved with an MDM-issued device certificate."
+    "This serial is attested directly through an X.509 certificate."
   end
 
   defp serial_source_hint(%{source: :mdm, provider: provider}) do
-    "#{posture_provider_label(provider)} holds this serial number for the device ID " <>
-      "this device proved with its certificate."
+    "This serial is reported by #{posture_provider_label(provider)} and matches " <>
+      "the attested device ID from an X.509 certificate."
   end
 
   defp posture_provider_label(:intune), do: "Microsoft Intune"

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -621,21 +621,31 @@ defmodule PortalWeb.Clients.Components do
   def client_device_section(assigns) do
     ~H"""
     <div class="px-5 pt-4 pb-3 border-b border-border">
-      <.section_heading title="Self-Reported" />
-      <p class="mb-3 text-xs text-subtle">
-        The Firezone Client supplies these values, so they are only as trustworthy as the actor
-        and the device it runs on.
-        <span :if={is_nil(@client.last_attested_at)}>
-          Set up
-          <.link
-            navigate={~p"/#{@account}/settings/trust_anchors"}
-            class="text-brand hover:underline"
-          >
-            X.509 Device Trust
-          </.link>
-          to strongly identify this device and associate it with posture data.
-        </span>
-      </p>
+      <.section_heading title="Reported by Client">
+        <:info>
+          <.popover placement="right">
+            <:target>
+              <.icon name="ri-information-line" class="w-3 h-3" />
+            </:target>
+            <:content>
+              <p>
+                The Firezone Client reads and reports these values. Only trust them if you trust
+                the actor and device.
+              </p>
+              <p :if={is_nil(@client.last_attested_at)} class="mt-1">
+                Set up
+                <.link
+                  navigate={~p"/#{@account}/settings/trust_anchors"}
+                  class="text-brand hover:underline"
+                >
+                  X.509 Device Trust
+                </.link>
+                to strongly identify this device and associate it with posture data.
+              </p>
+            </:content>
+          </.popover>
+        </:info>
+      </.section_heading>
       <dl class="space-y-3">
         <.client_detail_row :if={@client.last_seen_at} label="Operating System">
           <.client_os client={@client} />
@@ -1045,7 +1055,7 @@ defmodule PortalWeb.Clients.Components do
             <.relative_datetime datetime={@client.last_attested_at} />
           </span>
         </.client_detail_row>
-        <.client_detail_row label="Verification">
+        <.client_detail_row label="Trust Status">
           <.client_verified_status client={@client} />
         </.client_detail_row>
         <.client_detail_row label="Version">
@@ -1090,7 +1100,7 @@ defmodule PortalWeb.Clients.Components do
             </.action_button>
           </:target>
           <:content>
-            This device is already attested through X.509 Device Trust.
+            This device is already attested through an X.509 certificate.
           </:content>
         </.popover>
         <.action_button
@@ -1215,11 +1225,13 @@ defmodule PortalWeb.Clients.Components do
   end
 
   attr :title, :string, required: true
+  slot :info, doc: "Rendered beside the title, for a popover explaining the section"
 
   def section_heading(assigns) do
     ~H"""
-    <h3 class="text-[10px] font-semibold tracking-widest uppercase text-subtle mb-3">
+    <h3 class="flex items-center gap-1 text-[10px] font-semibold tracking-widest uppercase text-subtle mb-3">
       {@title}
+      {render_slot(@info)}
     </h3>
     """
   end

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -868,71 +868,30 @@ defmodule PortalWeb.Clients.Components do
     """
   end
 
-  attr :account, :any, required: true
   attr :serial, :map, default: nil
 
-  def client_serial_badge(%{serial: nil} = assigns) do
+  def client_serial(%{serial: nil} = assigns) do
     ~H"""
     <span class="text-xs text-muted">—</span>
     """
   end
 
-  def client_serial_badge(%{serial: %{source: :reported}} = assigns) do
+  def client_serial(assigns) do
     ~H"""
-    <.popover placement="right">
-      <:target>
-        <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-[10px] font-medium text-warning bg-warning-light">
-          <.icon name="ri-lock-unlock-line" class="w-2.5 h-2.5 shrink-0" />{@serial.value}
-        </span>
-      </:target>
-      <:content>
-        <p>
-          The serial number this Client reports about itself. This field could be spoofed by a
-          malicious actor.
-        </p>
-        <p class="mt-1">
-          Set up
-          <.link
-            navigate={~p"/#{@account}/settings/trust_anchors"}
-            class="text-brand hover:underline"
-          >
-            X.509 Device Trust
-          </.link>
-          so devices prove their serial with an MDM-issued certificate instead.
-        </p>
-      </:content>
-    </.popover>
-    """
-  end
-
-  def client_serial_badge(assigns) do
-    ~H"""
-    <.popover placement="right">
-      <:target>
-        <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-[10px] font-medium text-success bg-success-light">
-          <.icon name="ri-shield-keyhole-line" class="w-2.5 h-2.5 shrink-0" />{@serial.value}
-        </span>
-      </:target>
-      <:content>{serial_source_hint(@serial.source)}</:content>
-    </.popover>
-    """
-  end
-
-  attr :types, :list, required: true
-
-  def client_posture_icons(assigns) do
-    ~H"""
-    <div :if={@types != []} class="flex items-center gap-1.5">
-      <.popover :for={type <- @types} placement="right">
+    <div class="flex items-center gap-1.5">
+      <.popover :if={@serial.source != :reported} placement="right">
         <:target>
-          <.provider_icon provider={to_string(type)} size="xs" />
+          <.provider_icon :if={@serial.provider} provider={to_string(@serial.provider)} size="xs" />
+          <.icon
+            :if={is_nil(@serial.provider)}
+            name="ri-shield-keyhole-line"
+            class="w-3 h-3 shrink-0 text-success"
+          />
         </:target>
-        <:content>
-          {posture_provider_label(type)} holds posture for this Client.
-        </:content>
+        <:content>{serial_source_hint(@serial)}</:content>
       </.popover>
+      <span class="font-mono text-xs text-body truncate">{@serial.value}</span>
     </div>
-    <span :if={@types == []} class="text-xs text-muted">—</span>
     """
   end
 
@@ -1114,26 +1073,42 @@ defmodule PortalWeb.Clients.Components do
   attr :confirm_unverify_client, :boolean, default: false
 
   def client_actions(assigns) do
+    assigns = assign(assigns, :action, client_action(assigns))
+
     ~H"""
     <section>
       <.section_heading title="Actions" />
       <div class="space-y-1.5">
+        <.popover :if={@action in [:attested_verify, :attested_unverify]} class="block" placement="left">
+          <:target>
+            <.action_button
+              icon={attested_action_icon(@action)}
+              disabled
+              class="opacity-50 cursor-not-allowed"
+            >
+              {attested_action_label(@action)}
+            </.action_button>
+          </:target>
+          <:content>
+            This device is already attested through X.509 Device Trust.
+          </:content>
+        </.popover>
         <.action_button
-          :if={is_nil(@client.verified_at)}
+          :if={@action == :verify}
           icon="ri-shield-check-line"
           phx-click="verify_client"
         >
           Verify
         </.action_button>
         <.action_button
-          :if={not is_nil(@client.verified_at) and not @confirm_unverify_client}
+          :if={@action == :unverify}
           icon="ri-prohibited-line"
           phx-click="confirm_unverify_client"
         >
           Revoke verification
         </.action_button>
         <div
-          :if={not is_nil(@client.verified_at) and @confirm_unverify_client}
+          :if={@action == :confirm_unverify}
           class="px-3 py-2.5 rounded border border-border bg-raised"
         >
           <p class="text-xs font-medium text-heading mb-1">
@@ -1350,6 +1325,24 @@ defmodule PortalWeb.Clients.Components do
     """
   end
 
+  # Attestation supersedes manual verification, so an attested device offers the
+  # button it would otherwise offer, disabled, rather than hiding it.
+  defp client_action(%{client: %{last_attested_at: at, verified_at: nil}}) when not is_nil(at),
+    do: :attested_verify
+
+  defp client_action(%{client: %{last_attested_at: at}}) when not is_nil(at),
+    do: :attested_unverify
+
+  defp client_action(%{client: %{verified_at: nil}}), do: :verify
+  defp client_action(%{confirm_unverify_client: true}), do: :confirm_unverify
+  defp client_action(_assigns), do: :unverify
+
+  defp attested_action_icon(:attested_verify), do: "ri-shield-check-line"
+  defp attested_action_icon(_action), do: "ri-prohibited-line"
+
+  defp attested_action_label(:attested_verify), do: "Verify"
+  defp attested_action_label(_action), do: "Revoke verification"
+
   defp posture_tab_state(assigns) do
     cond do
       not Portal.Account.device_posture_enabled?(assigns.account) -> :locked
@@ -1384,12 +1377,13 @@ defmodule PortalWeb.Clients.Components do
     ]
   end
 
-  defp serial_source_hint(:attested) do
+  defp serial_source_hint(%{source: :attested}) do
     "The serial number this device proved with an MDM-issued device certificate."
   end
 
-  defp serial_source_hint(:mdm) do
-    "The serial number your MDM holds for the device ID this device proved with its certificate."
+  defp serial_source_hint(%{source: :mdm, provider: provider}) do
+    "#{posture_provider_label(provider)} holds this serial number for the device ID " <>
+      "this device proved with its certificate."
   end
 
   defp posture_provider_label(:intune), do: "Microsoft Intune"

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -200,6 +200,8 @@ defmodule PortalWeb.Clients.Components do
   attr :confirm_state, :map, required: true
   attr :query_params, :map, default: %{}
   attr :device_pools, :list, default: []
+  attr :posture, :list, default: []
+  attr :certificate, :map, default: nil
   attr :policy_authorizations, :list, default: []
   attr :policy_authorizations_page, :integer, default: 1
   attr :policy_authorizations_has_next, :boolean, default: false
@@ -238,6 +240,8 @@ defmodule PortalWeb.Clients.Components do
           confirm_delete_client={@confirm_delete_client}
           confirm_unverify_client={@confirm_unverify_client}
           device_pools={@device_pools}
+          posture={@posture}
+          certificate={@certificate}
           policy_authorizations={@policy_authorizations}
           policy_authorizations_page={@policy_authorizations_page}
           policy_authorizations_has_next={@policy_authorizations_has_next}
@@ -312,12 +316,16 @@ defmodule PortalWeb.Clients.Components do
   attr :confirm_delete_client, :boolean, default: false
   attr :confirm_unverify_client, :boolean, default: false
   attr :device_pools, :list, default: []
+  attr :posture, :list, default: []
+  attr :certificate, :map, default: nil
   attr :policy_authorizations, :list, default: []
   attr :policy_authorizations_page, :integer, default: 1
   attr :policy_authorizations_has_next, :boolean, default: false
   attr :policy_authorizations_expanded_id, :string, default: nil
 
   def client_details_view(assigns) do
+    assigns = assign(assigns, :tab, visible_client_tab(assigns.tab, assigns.posture))
+
     ~H"""
     <div class="flex flex-col h-full overflow-hidden">
       <.client_details_header client={@client} />
@@ -327,36 +335,18 @@ defmodule PortalWeb.Clients.Components do
             role="tablist"
             class="flex items-end gap-0 px-5 border-b border-border bg-raised shrink-0"
           >
-            <button
-              role="tab"
-              aria-selected={@tab == :overview}
-              phx-click="switch_client_tab"
-              phx-value-tab="overview"
-              class={[
-                "flex items-center gap-1.5 px-1 py-2.5 mr-5 text-xs font-medium border-b-2 transition-colors",
-                if(@tab == :overview,
-                  do: "border-brand text-brand",
-                  else: "border-transparent text-body hover:text-heading"
-                )
-              ]}
-            >
-              Overview
-            </button>
-            <button
-              role="tab"
-              aria-selected={@tab == :authorizations}
-              phx-click="switch_client_tab"
-              phx-value-tab="authorizations"
-              class={[
-                "flex items-center gap-1.5 px-1 py-2.5 mr-5 text-xs font-medium border-b-2 transition-colors",
-                if(@tab == :authorizations,
-                  do: "border-brand text-brand",
-                  else: "border-transparent text-body hover:text-heading"
-                )
-              ]}
-            >
-              Authorizations
-            </button>
+            <.client_tab tab="overview" label="Overview" selected={@tab == :overview} />
+            <.client_tab
+              tab="authorizations"
+              label="Authorizations"
+              selected={@tab == :authorizations}
+            />
+            <.client_tab
+              :if={@posture != []}
+              tab="posture"
+              label="Posture"
+              selected={@tab == :posture}
+            />
           </div>
           <div :if={@tab == :overview} class="flex-1 overflow-y-auto">
             <.client_owner_section account={@account} client={@client} />
@@ -366,8 +356,14 @@ defmodule PortalWeb.Clients.Components do
               device_pools={@device_pools}
             />
             <.client_device_section client={@client} />
+            <.client_certificate_section
+              :if={@client.last_attested_cert_fingerprint}
+              client={@client}
+              certificate={@certificate}
+            />
             <.client_network_section client={@client} />
           </div>
+          <.client_posture_tab :if={@tab == :posture} account={@account} posture={@posture} />
           <.client_policy_authorizations_tab
             :if={@tab == :authorizations}
             account={@account}
@@ -680,6 +676,267 @@ defmodule PortalWeb.Clients.Components do
     """
   end
 
+  attr :tab, :string, required: true
+  attr :label, :string, required: true
+  attr :selected, :boolean, required: true
+
+  def client_tab(assigns) do
+    ~H"""
+    <button
+      role="tab"
+      aria-selected={@selected}
+      phx-click="switch_client_tab"
+      phx-value-tab={@tab}
+      class={[
+        "flex items-center gap-1.5 px-1 py-2.5 mr-5 text-xs font-medium border-b-2 transition-colors",
+        if(@selected,
+          do: "border-brand text-brand",
+          else: "border-transparent text-body hover:text-heading"
+        )
+      ]}
+    >
+      {@label}
+    </button>
+    """
+  end
+
+  attr :account, :any, required: true
+  attr :posture, :list, required: true
+
+  def client_posture_tab(assigns) do
+    ~H"""
+    <div class="flex-1 overflow-y-auto">
+      <.client_posture_section
+        :for={entry <- @posture}
+        account={@account}
+        entry={entry}
+      />
+    </div>
+    """
+  end
+
+  attr :account, :any, required: true
+  attr :entry, :map, required: true
+
+  def client_posture_section(assigns) do
+    assigns =
+      assigns
+      |> assign(:attributes, posture_attributes(assigns.entry.type, assigns.entry.device))
+      |> assign(:dom_id, "posture-#{assigns.entry.type}-#{assigns.entry.provider.id}")
+
+    ~H"""
+    <div class="px-5 pt-4 pb-3 border-b border-border">
+      <div class="flex items-center justify-between gap-3 mb-3">
+        <div class="flex items-center gap-2 min-w-0">
+          <.provider_icon provider={to_string(@entry.type)} size="sm" />
+          <span class="text-sm font-medium text-heading truncate">{@entry.provider.name}</span>
+          <span class="text-xs text-subtle shrink-0">
+            {posture_provider_label(@entry.type)}
+          </span>
+        </div>
+        <.posture_match_badge account={@account} matched_on={@entry.matched_on} />
+      </div>
+
+      <dl class="grid grid-cols-2 gap-x-6 gap-y-3 mb-4">
+        <.client_detail_row :for={{label, value} <- @attributes} label={label}>
+          <.posture_value value={value} />
+        </.client_detail_row>
+      </dl>
+
+      <.json_view
+        id={@dom_id}
+        value={posture_record(@entry.device)}
+        label="Provider record"
+        hint="Empty fields omitted"
+      />
+    </div>
+    """
+  end
+
+  attr :account, :any, required: true
+  attr :matched_on, :atom, required: true
+
+  def posture_match_badge(%{matched_on: :device_serial} = assigns) do
+    ~H"""
+    <.popover placement="left">
+      <:target>
+        <span class="inline-flex shrink-0 items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-warning bg-warning-light">
+          <.icon name="ri-error-warning-line" class="w-2.5 h-2.5" /> Reported serial
+        </span>
+      </:target>
+      <:content>
+        <p>
+          Matched on the serial number the device reports about itself. This field could be
+          spoofed by a malicious actor.
+        </p>
+        <p class="mt-1">
+          Set up
+          <.link
+            navigate={~p"/#{@account}/settings/trust_anchors"}
+            class="text-brand hover:underline"
+          >
+            X.509 Device Trust
+          </.link>
+          so devices prove their identity with an MDM-issued certificate instead.
+        </p>
+      </:content>
+    </.popover>
+    """
+  end
+
+  def posture_match_badge(assigns) do
+    assigns = assign(assigns, :label, posture_match_label(assigns.matched_on))
+
+    ~H"""
+    <.popover placement="left">
+      <:target>
+        <span class="inline-flex shrink-0 items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-success bg-success-light">
+          <.icon name="ri-shield-keyhole-line" class="w-2.5 h-2.5" />{@label}
+        </span>
+      </:target>
+      <:content>
+        Matched on an identifier this device proved with an MDM-issued device certificate.
+      </:content>
+    </.popover>
+    """
+  end
+
+  attr :value, :any, required: true
+
+  def posture_value(%{value: value} = assigns) when is_struct(value, DateTime) do
+    ~H"""
+    <span class="text-xs text-body">
+      <.relative_datetime datetime={@value} />
+    </span>
+    """
+  end
+
+  def posture_value(%{value: value} = assigns) when is_boolean(value) do
+    ~H"""
+    <span class="text-xs text-body">{if @value, do: "Yes", else: "No"}</span>
+    """
+  end
+
+  def posture_value(assigns) do
+    ~H"""
+    <span class="font-mono text-xs text-body break-all">{@value}</span>
+    """
+  end
+
+  attr :types, :list, required: true
+
+  def client_posture_icons(assigns) do
+    ~H"""
+    <div :if={@types != []} class="flex items-center gap-1.5">
+      <.popover :for={type <- @types} placement="right">
+        <:target>
+          <.provider_icon provider={to_string(type)} size="xs" />
+        </:target>
+        <:content>
+          {posture_provider_label(type)} holds posture for this Client.
+        </:content>
+      </.popover>
+    </div>
+    <span :if={@types == []} class="text-xs text-muted">—</span>
+    """
+  end
+
+  attr :client, :any, required: true
+  attr :certificate, :map, default: nil
+
+  def client_certificate_section(assigns) do
+    assigns = assign(assigns, :issuer, describe_issuer(assigns.client.last_attested_cert_issuer))
+
+    ~H"""
+    <div class="px-5 pt-4 pb-3 border-b border-border">
+      <.section_heading title="Certificate" />
+      <dl class="space-y-3">
+        <.client_detail_row label="Status">
+          <.certificate_status_badge certificate={@certificate} />
+        </.client_detail_row>
+        <.client_detail_row :if={@issuer} label="Issuer">
+          <span class="text-xs text-body break-all">{@issuer}</span>
+        </.client_detail_row>
+        <.client_detail_row :if={@client.last_attested_cert_serial} label="Serial">
+          <span class="font-mono text-xs text-body break-all">
+            {@client.last_attested_cert_serial}
+          </span>
+        </.client_detail_row>
+        <.client_detail_row :if={@client.last_attested_cert_fingerprint} label="SHA-256 Fingerprint">
+          <span class="font-mono text-xs text-body break-all">
+            {@client.last_attested_cert_fingerprint}
+          </span>
+        </.client_detail_row>
+        <.client_detail_row :if={@certificate && @certificate.revoked_at} label="Revoked">
+          <span class="text-xs text-body">
+            <.relative_datetime datetime={@certificate.revoked_at} />
+          </span>
+        </.client_detail_row>
+        <.client_detail_row :if={@certificate && @certificate.reason} label="Revocation Reason">
+          <span class="text-xs text-body">{@certificate.reason}</span>
+        </.client_detail_row>
+        <.client_detail_row :if={@client.last_attested_at} label="Last Attested">
+          <span class="text-xs text-body">
+            <.relative_datetime datetime={@client.last_attested_at} />
+          </span>
+        </.client_detail_row>
+      </dl>
+    </div>
+    """
+  end
+
+  attr :certificate, :map, default: nil
+
+  def certificate_status_badge(%{certificate: %{state: :revoked}} = assigns) do
+    ~H"""
+    <.popover>
+      <:target>
+        <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-error bg-error-light">
+          <.icon name="ri-close-circle-line" class="w-2.5 h-2.5" /> Revoked
+        </span>
+      </:target>
+      <:content>
+        {certificate_source_label(@certificate.source)} reports this certificate as revoked.
+      </:content>
+    </.popover>
+    """
+  end
+
+  def certificate_status_badge(%{certificate: %{state: :good}} = assigns) do
+    ~H"""
+    <.popover>
+      <:target>
+        <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-success bg-success-light">
+          <.icon name="ri-check-line" class="w-2.5 h-2.5" /> Valid
+        </span>
+      </:target>
+      <:content>
+        <p>The issuer's OCSP responder reports this certificate as good.</p>
+        <p :if={@certificate.next_update} class="mt-1">
+          That answer stands until
+          <.relative_datetime datetime={@certificate.next_update} popover={false} />.
+        </p>
+      </:content>
+    </.popover>
+    """
+  end
+
+  def certificate_status_badge(assigns) do
+    ~H"""
+    <.popover>
+      <:target>
+        <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-muted bg-raised">
+          <.icon name="ri-question-line" class="w-2.5 h-2.5" /> Unknown
+        </span>
+      </:target>
+      <:content>
+        Neither a published revocation list nor an OCSP responder has said anything about this
+        certificate.
+      </:content>
+    </.popover>
+    """
+  end
+
   attr :client, :any, required: true
   attr :confirm_delete_client, :boolean, default: false
   attr :confirm_unverify_client, :boolean, default: false
@@ -956,4 +1213,137 @@ defmodule PortalWeb.Clients.Components do
   end
 
   defp trust_state(_client), do: nil
+
+  # The tab is only offered when a provider has a record to put in it, so a
+  # link into it for a device with none lands on the overview rather than on
+  # blank space.
+  defp visible_client_tab(:posture, []), do: :overview
+  defp visible_client_tab(tab, _posture), do: tab
+
+  defp posture_provider_label(:intune), do: "Microsoft Intune"
+  defp posture_provider_label(:iru), do: "Iru"
+  defp posture_provider_label(:defender), do: "Microsoft Defender"
+  defp posture_provider_label(:santa), do: "Santa"
+  defp posture_provider_label(:sentinelone), do: "SentinelOne"
+
+  defp posture_match_label(:mdm_device_id), do: "Attested device ID"
+  defp posture_match_label(:attested_serial), do: "Attested serial"
+
+  defp certificate_source_label(:crl), do: "The issuer's revocation list"
+  defp certificate_source_label(:ocsp), do: "The issuer's OCSP responder"
+
+  defp describe_issuer(nil), do: nil
+  defp describe_issuer(issuer_der), do: Portal.Crypto.X509.describe_name(issuer_der)
+
+  # The handful of columns worth reading at a glance. Everything the provider
+  # reported is in the JSON blob underneath, so this list stays short and is
+  # ordered identity first, posture second.
+  defp posture_attributes(:intune, device) do
+    drop_empty([
+      {"Device name", device.device_name},
+      {"Serial number", device.serial_number},
+      {"Compliance", device.compliance_state},
+      {"Operating system", join_present([device.operating_system, device.os_version])},
+      {"Model", join_present([device.manufacturer, device.model])},
+      {"Primary user", device.user_principal_name},
+      {"Ownership", device.managed_device_owner_type},
+      {"Encrypted", device.is_encrypted},
+      {"Intune ID", device.intune_id},
+      {"Entra device ID", device.entra_device_id},
+      {"Last check-in", device.last_sync_at},
+      {"Last synced", device.synced_at}
+    ])
+  end
+
+  defp posture_attributes(:iru, device) do
+    drop_empty([
+      {"Device name", device.device_name},
+      {"Serial number", device.serial_number},
+      {"Model", device.model_name || device.model},
+      {"Operating system", join_present([device.os_name || device.platform, device.os_version])},
+      {"User", device.user_email || device.user_name},
+      {"Blueprint", device.blueprint_name},
+      {"MDM enrolled", device.mdm_enabled},
+      {"FileVault", device.filevault_enabled},
+      {"Agent version", device.agent_version},
+      {"Iru ID", device.iru_id},
+      {"Last check-in", device.last_check_in_at},
+      {"Last synced", device.synced_at}
+    ])
+  end
+
+  defp posture_attributes(:defender, device) do
+    drop_empty([
+      {"DNS name", device.computer_dns_name},
+      {"Operating system", join_present([device.os_platform, device.version])},
+      {"Sensor health", device.health_status},
+      {"Onboarding", device.onboarding_status},
+      {"Risk score", device.risk_score},
+      {"Exposure level", device.exposure_level},
+      {"Managed by", device.managed_by},
+      {"Agent version", device.agent_version},
+      {"Defender ID", device.defender_id},
+      {"Entra device ID", device.entra_device_id},
+      {"Last seen", device.last_seen_at},
+      {"Last synced", device.synced_at}
+    ])
+  end
+
+  defp posture_attributes(:santa, device) do
+    drop_empty([
+      {"Hostname", device.hostname},
+      {"Serial number", device.serial_number},
+      {"Model", device.machine_model},
+      {"Operating system", join_present([device.os_type, device.os_version])},
+      {"Client mode", device.last_seen_client_mode || device.configured_client_mode},
+      {"Primary user", device.primary_user},
+      {"Santa version", device.santa_version},
+      {"Santa ID", device.santa_id},
+      {"Last sync", device.last_sync_at},
+      {"Last synced", device.synced_at}
+    ])
+  end
+
+  defp posture_attributes(:sentinelone, device) do
+    drop_empty([
+      {"Computer name", device.computer_name},
+      {"Serial number", device.serial_number},
+      {"Model", device.model_name},
+      {"Operating system", join_present([device.os_name, device.os_revision])},
+      {"Agent version", device.agent_version},
+      {"Network status", device.network_status},
+      {"Infected", device.infected},
+      {"Active threats", device.active_threats},
+      {"Last logged in user", device.last_logged_in_user_name},
+      {"Site", device.site_name},
+      {"SentinelOne UUID", device.uuid},
+      {"Last active", device.last_active_at},
+      {"Last synced", device.synced_at}
+    ])
+  end
+
+  # Everything the provider reported about the device, for copying into a
+  # ticket. Columns it left empty are dropped rather than rendered as a wall of
+  # nulls above the ones it filled in, and the two keys that are Firezone's own
+  # bookkeeping rather than the provider's data go with them.
+  defp posture_record(device) do
+    device
+    |> PortalWeb.JSONComponents.encodable()
+    |> Map.drop(["account_id", "posture_provider_id"])
+    |> Map.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp drop_empty(attributes) do
+    Enum.reject(attributes, fn {_label, value} -> value in [nil, ""] end)
+  end
+
+  defp join_present(values) do
+    values
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join(" ")
+    |> case do
+      "" -> nil
+      joined -> joined
+    end
+  end
 end

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -327,6 +327,13 @@ defmodule PortalWeb.Clients.Components do
   attr :policy_authorizations_expanded_id, :string, default: nil
 
   def client_details_view(assigns) do
+    posture_tab? = device_posture_enabled?()
+
+    assigns =
+      assigns
+      |> assign(:posture_tab?, posture_tab?)
+      |> assign(:tab, visible_client_tab(assigns.tab, posture_tab?))
+
     ~H"""
     <div class="flex flex-col h-full overflow-hidden">
       <.client_details_header client={@client} />
@@ -342,7 +349,12 @@ defmodule PortalWeb.Clients.Components do
               label="Authorizations"
               selected={@tab == :authorizations}
             />
-            <.client_tab tab="posture" label="Posture" selected={@tab == :posture} />
+            <.client_tab
+              :if={@posture_tab?}
+              tab="posture"
+              label="Posture"
+              selected={@tab == :posture}
+            />
           </div>
           <div :if={@tab == :overview} class="flex-1 overflow-y-auto">
             <.client_owner_section account={@account} client={@client} />
@@ -1373,6 +1385,12 @@ defmodule PortalWeb.Clients.Components do
 
   defp attested_action_label(:attested_verify), do: "Verify"
   defp attested_action_label(_action), do: "Revoke verification"
+
+  # The Posture tab is hidden while the feature is off for the whole
+  # deployment, so a link into it lands on the overview rather than on blank
+  # space.
+  defp visible_client_tab(:posture, false), do: :overview
+  defp visible_client_tab(tab, _posture_tab?), do: tab
 
   defp posture_tab_state(assigns) do
     cond do

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -201,6 +201,7 @@ defmodule PortalWeb.Clients.Components do
   attr :query_params, :map, default: %{}
   attr :device_pools, :list, default: []
   attr :posture, :list, default: []
+  attr :posture_providers_connected?, :boolean, default: false
   attr :certificate, :map, default: nil
   attr :policy_authorizations, :list, default: []
   attr :policy_authorizations_page, :integer, default: 1
@@ -241,6 +242,7 @@ defmodule PortalWeb.Clients.Components do
           confirm_unverify_client={@confirm_unverify_client}
           device_pools={@device_pools}
           posture={@posture}
+          posture_providers_connected?={@posture_providers_connected?}
           certificate={@certificate}
           policy_authorizations={@policy_authorizations}
           policy_authorizations_page={@policy_authorizations_page}
@@ -317,6 +319,7 @@ defmodule PortalWeb.Clients.Components do
   attr :confirm_unverify_client, :boolean, default: false
   attr :device_pools, :list, default: []
   attr :posture, :list, default: []
+  attr :posture_providers_connected?, :boolean, default: false
   attr :certificate, :map, default: nil
   attr :policy_authorizations, :list, default: []
   attr :policy_authorizations_page, :integer, default: 1
@@ -324,8 +327,6 @@ defmodule PortalWeb.Clients.Components do
   attr :policy_authorizations_expanded_id, :string, default: nil
 
   def client_details_view(assigns) do
-    assigns = assign(assigns, :tab, visible_client_tab(assigns.tab, assigns.posture))
-
     ~H"""
     <div class="flex flex-col h-full overflow-hidden">
       <.client_details_header client={@client} />
@@ -341,12 +342,7 @@ defmodule PortalWeb.Clients.Components do
               label="Authorizations"
               selected={@tab == :authorizations}
             />
-            <.client_tab
-              :if={@posture != []}
-              tab="posture"
-              label="Posture"
-              selected={@tab == :posture}
-            />
+            <.client_tab tab="posture" label="Posture" selected={@tab == :posture} />
           </div>
           <div :if={@tab == :overview} class="flex-1 overflow-y-auto">
             <.client_owner_section account={@account} client={@client} />
@@ -355,7 +351,7 @@ defmodule PortalWeb.Clients.Components do
               account={@account}
               device_pools={@device_pools}
             />
-            <.client_device_section client={@client} />
+            <.client_device_section account={@account} client={@client} />
             <.client_certificate_section
               :if={@client.last_attested_cert_fingerprint}
               client={@client}
@@ -363,7 +359,12 @@ defmodule PortalWeb.Clients.Components do
             />
             <.client_network_section client={@client} />
           </div>
-          <.client_posture_tab :if={@tab == :posture} account={@account} posture={@posture} />
+          <.client_posture_tab
+            :if={@tab == :posture}
+            account={@account}
+            posture={@posture}
+            providers_connected?={@posture_providers_connected?}
+          />
           <.client_policy_authorizations_tab
             :if={@tab == :authorizations}
             account={@account}
@@ -614,12 +615,27 @@ defmodule PortalWeb.Clients.Components do
     """
   end
 
+  attr :account, :any, required: true
   attr :client, :any, required: true
 
   def client_device_section(assigns) do
     ~H"""
     <div class="px-5 pt-4 pb-3 border-b border-border">
-      <.section_heading title="Device" />
+      <.section_heading title="Reported by this Client" />
+      <p class="mb-3 text-xs text-subtle">
+        The Firezone Client reports these fields about itself, so a malicious actor could spoof
+        them.
+        <span :if={is_nil(@client.last_attested_at)}>
+          Set up
+          <.link
+            navigate={~p"/#{@account}/settings/trust_anchors"}
+            class="text-brand hover:underline"
+          >
+            X.509 Device Trust
+          </.link>
+          to strongly identify this device and associate it with posture data.
+        </span>
+      </p>
       <dl class="space-y-3">
         <.client_detail_row :if={@client.last_seen_at} label="Operating System">
           <.client_os client={@client} />
@@ -702,15 +718,35 @@ defmodule PortalWeb.Clients.Components do
 
   attr :account, :any, required: true
   attr :posture, :list, required: true
+  attr :providers_connected?, :boolean, default: false
 
   def client_posture_tab(assigns) do
+    assigns = assign(assigns, :state, posture_tab_state(assigns))
+
     ~H"""
     <div class="flex-1 overflow-y-auto">
-      <.client_posture_section
-        :for={entry <- @posture}
-        account={@account}
-        entry={entry}
-      />
+      <div :if={@state == :records}>
+        <.client_posture_section :for={entry <- @posture} account={@account} entry={entry} />
+      </div>
+      <.posture_locked :if={@state == :locked} account={@account} />
+      <div
+        :if={@state in [:no_records, :no_providers]}
+        class="flex flex-col items-center justify-center gap-2 px-5 py-16 text-center text-subtle"
+      >
+        <.icon name="ri-shield-star-line" class="w-8 h-8" />
+        <p :if={@state == :no_records} class="text-xs">
+          No posture data was found for this device.
+        </p>
+        <p :if={@state == :no_providers} class="text-xs">
+          <.link
+            navigate={~p"/#{@account}/settings/device_posture/new"}
+            class="text-brand hover:underline"
+          >
+            Connect a posture provider
+          </.link>
+          to view posture data for this device.
+        </p>
+      </div>
     </div>
     """
   end
@@ -734,7 +770,7 @@ defmodule PortalWeb.Clients.Components do
             {posture_provider_label(@entry.type)}
           </span>
         </div>
-        <.posture_match_badge account={@account} matched_on={@entry.matched_on} />
+        <.posture_match_badge account={@account} matched_on={@entry.matched_on} via={@entry.via} />
       </div>
 
       <dl class="grid grid-cols-2 gap-x-6 gap-y-3 mb-4">
@@ -755,6 +791,7 @@ defmodule PortalWeb.Clients.Components do
 
   attr :account, :any, required: true
   attr :matched_on, :atom, required: true
+  attr :via, :atom, default: nil
 
   def posture_match_badge(%{matched_on: :device_serial} = assigns) do
     ~H"""
@@ -768,6 +805,10 @@ defmodule PortalWeb.Clients.Components do
         <p>
           Matched on the serial number the device reports about itself. This field could be
           spoofed by a malicious actor.
+        </p>
+        <p :if={@via == :intune} class="mt-1">
+          Reached through the Microsoft Intune record that serial matched, which holds the same
+          Entra device ID as this machine.
         </p>
         <p class="mt-1">
           Set up
@@ -795,7 +836,11 @@ defmodule PortalWeb.Clients.Components do
         </span>
       </:target>
       <:content>
-        Matched on an identifier this device proved with an MDM-issued device certificate.
+        <p>Matched on an identifier this device proved with an MDM-issued device certificate.</p>
+        <p :if={@via == :intune} class="mt-1">
+          Reached through the Microsoft Intune record for that identifier, which holds the same
+          Entra device ID as this machine.
+        </p>
       </:content>
     </.popover>
     """
@@ -820,6 +865,56 @@ defmodule PortalWeb.Clients.Components do
   def posture_value(assigns) do
     ~H"""
     <span class="font-mono text-xs text-body break-all">{@value}</span>
+    """
+  end
+
+  attr :account, :any, required: true
+  attr :serial, :map, default: nil
+
+  def client_serial_badge(%{serial: nil} = assigns) do
+    ~H"""
+    <span class="text-xs text-muted">—</span>
+    """
+  end
+
+  def client_serial_badge(%{serial: %{source: :reported}} = assigns) do
+    ~H"""
+    <.popover placement="right">
+      <:target>
+        <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-[10px] font-medium text-warning bg-warning-light">
+          <.icon name="ri-lock-unlock-line" class="w-2.5 h-2.5 shrink-0" />{@serial.value}
+        </span>
+      </:target>
+      <:content>
+        <p>
+          The serial number this Client reports about itself. This field could be spoofed by a
+          malicious actor.
+        </p>
+        <p class="mt-1">
+          Set up
+          <.link
+            navigate={~p"/#{@account}/settings/trust_anchors"}
+            class="text-brand hover:underline"
+          >
+            X.509 Device Trust
+          </.link>
+          so devices prove their serial with an MDM-issued certificate instead.
+        </p>
+      </:content>
+    </.popover>
+    """
+  end
+
+  def client_serial_badge(assigns) do
+    ~H"""
+    <.popover placement="right">
+      <:target>
+        <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-[10px] font-medium text-success bg-success-light">
+          <.icon name="ri-shield-keyhole-line" class="w-2.5 h-2.5 shrink-0" />{@serial.value}
+        </span>
+      </:target>
+      <:content>{serial_source_hint(@serial.source)}</:content>
+    </.popover>
     """
   end
 
@@ -1214,11 +1309,88 @@ defmodule PortalWeb.Clients.Components do
 
   defp trust_state(_client), do: nil
 
-  # The tab is only offered when a provider has a record to put in it, so a
-  # link into it for a device with none lands on the overview rather than on
-  # blank space.
-  defp visible_client_tab(:posture, []), do: :overview
-  defp visible_client_tab(tab, _posture), do: tab
+  attr :account, :any, required: true
+
+  defp posture_locked(assigns) do
+    ~H"""
+    <div class="px-5 py-4">
+      <.upgrade_locked_section
+        account={@account}
+        message="Upgrade to unlock Device Posture"
+        description="See what your MDM and EDR hold for this device, matched to the identity its certificate proved."
+      >
+        <.posture_preview />
+      </.upgrade_locked_section>
+    </div>
+    """
+  end
+
+  defp posture_preview(assigns) do
+    assigns = assign(assigns, :samples, posture_preview_samples())
+
+    ~H"""
+    <div class="space-y-4">
+      <div :for={sample <- @samples}>
+        <div class="flex items-center justify-between gap-3 mb-3">
+          <div class="flex items-center gap-2">
+            <.provider_icon provider={sample.provider} size="sm" />
+            <span class="text-sm font-medium text-heading">{sample.name}</span>
+          </div>
+          <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-success bg-success-light">
+            <.icon name="ri-shield-keyhole-line" class="w-2.5 h-2.5" /> Attested device ID
+          </span>
+        </div>
+        <dl class="grid grid-cols-2 gap-x-6 gap-y-3">
+          <.client_detail_row :for={{label, value} <- sample.attributes} label={label}>
+            <span class="font-mono text-xs text-body">{value}</span>
+          </.client_detail_row>
+        </dl>
+      </div>
+    </div>
+    """
+  end
+
+  defp posture_tab_state(assigns) do
+    cond do
+      not Portal.Account.device_posture_enabled?(assigns.account) -> :locked
+      assigns.posture != [] -> :records
+      assigns.providers_connected? -> :no_records
+      true -> :no_providers
+    end
+  end
+
+  defp posture_preview_samples do
+    [
+      %{
+        provider: "intune",
+        name: "Microsoft Intune",
+        attributes: [
+          {"Device name", "DESKTOP-4KJ21"},
+          {"Serial number", "5CD2419T7K"},
+          {"Compliance", "compliant"},
+          {"Encrypted", "Yes"}
+        ]
+      },
+      %{
+        provider: "defender",
+        name: "Microsoft Defender",
+        attributes: [
+          {"Sensor health", "Active"},
+          {"Risk score", "Low"},
+          {"Exposure level", "Low"},
+          {"Agent version", "10.8760.19041"}
+        ]
+      }
+    ]
+  end
+
+  defp serial_source_hint(:attested) do
+    "The serial number this device proved with an MDM-issued device certificate."
+  end
+
+  defp serial_source_hint(:mdm) do
+    "The serial number your MDM holds for the device ID this device proved with its certificate."
+  end
 
   defp posture_provider_label(:intune), do: "Microsoft Intune"
   defp posture_provider_label(:iru), do: "Iru"

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -1055,7 +1055,15 @@ defmodule PortalWeb.Clients.Components do
             <.relative_datetime datetime={@client.last_attested_at} />
           </span>
         </.client_detail_row>
-        <.client_detail_row label="Trust Status">
+        <.client_detail_row label="Trust level">
+          <:info>
+            <.popover placement="left">
+              <:target>
+                <.icon name="ri-information-line" class="w-3 h-3" />
+              </:target>
+              <:content>{trust_hint(@client)}</:content>
+            </.popover>
+          </:info>
           <.client_verified_status client={@client} />
         </.client_detail_row>
         <.client_detail_row label="Version">
@@ -1238,11 +1246,15 @@ defmodule PortalWeb.Clients.Components do
 
   slot :inner_block, required: true
   attr :label, :string, required: true
+  slot :info, doc: "Rendered beside the label, for a popover explaining the row"
 
   def client_detail_row(assigns) do
     ~H"""
     <div>
-      <dt class="text-[10px] text-subtle mb-0.5">{@label}</dt>
+      <dt class="flex items-center gap-1 text-[10px] text-subtle mb-0.5">
+        {@label}
+        {render_slot(@info)}
+      </dt>
       <dd>{render_slot(@inner_block)}</dd>
     </div>
     """
@@ -1281,7 +1293,7 @@ defmodule PortalWeb.Clients.Components do
       label: "Attested",
       icon: "ri-shield-keyhole-line",
       class: "text-success bg-success-light",
-      title: "This device proved possession of an MDM-issued client certificate"
+      title: "This device is attested through an X.509 certificate."
     }
   end
 
@@ -1290,11 +1302,18 @@ defmodule PortalWeb.Clients.Components do
       label: "Verified",
       icon: "ri-shield-check-line",
       class: "text-success bg-success-light",
-      title: "Device attributes of this client are manually verified"
+      title: "An admin vouched for the values this Client reports."
     }
   end
 
   defp trust_state(_client), do: nil
+
+  defp trust_hint(client) do
+    case trust_state(client) do
+      %{title: title} -> title
+      nil -> "No certificate or admin has vouched for the values this Client reports."
+    end
+  end
 
   attr :account, :any, required: true
 

--- a/elixir/lib/portal_web/live/logs/flow_logs.ex
+++ b/elixir/lib/portal_web/live/logs/flow_logs.ex
@@ -4,11 +4,9 @@ defmodule PortalWeb.Logs.FlowLogs do
   import PortalWeb.Logs.Components
 
   alias __MODULE__.Database
-  alias PortalWeb.Logs.JSONDiff
 
   @table_id "flow_logs"
   @filter_key "flow_logs_filter"
-  @json_token_regex ~r/"(?:\\.|[^"\\])*"|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?|\b(?:true|false|null)\b/
 
   def mount(_params, _session, socket) do
     browser_tz = browser_tz_from_connect(socket)
@@ -152,7 +150,7 @@ defmodule PortalWeb.Logs.FlowLogs do
           </:col>
           <:col :let={row} label="Client" class="w-52">
             <.flow_client_cell
-              device_name={device_name(row.initiator_device, "Deleted client")}
+              device_name={device_name(row.initiator_device, "Deleted device")}
               ip={first_outer_src_ip(row.log)}
             />
           </:col>
@@ -377,7 +375,7 @@ defmodule PortalWeb.Logs.FlowLogs do
             </div>
           </section>
 
-          <.json_view id="flow-log-json" value={@selected_report_json} />
+          <.json_view id="flow-log-json" value={@selected_report_json} label="Flow log JSON" />
         </div>
 
         <.show_panel_sidebar :if={@selected_report}>
@@ -425,7 +423,7 @@ defmodule PortalWeb.Logs.FlowLogs do
               </.detail_row>
               <.detail_row label="Initiator device">
                 <div class="text-xs text-[var(--text-secondary)]">
-                  {device_name(@selected_report.initiator_device, "Deleted client")}
+                  {device_name(@selected_report.initiator_device, "Deleted device")}
                 </div>
                 <.identifier value={@selected_report.log.initiator_device_id} />
               </.detail_row>
@@ -561,89 +559,6 @@ defmodule PortalWeb.Logs.FlowLogs do
     </span>
     """
   end
-
-  attr :id, :string, required: true
-  attr :value, :map, required: true
-
-  defp json_view(assigns) do
-    encoded = JSONDiff.pretty(assigns.value)
-
-    assigns = assign(assigns, :tokens, json_tokens(encoded))
-
-    ~H"""
-    <section id={@id} phx-hook="CopyClipboard">
-      <.section_heading label="Flow log JSON" />
-      <div class="relative">
-        <pre class="max-h-96 overflow-auto rounded border border-[var(--border)] bg-[var(--surface-raised)] p-4 pr-24 text-xs leading-5"><code id={"#{@id}-code"} class="block min-w-max" phx-no-format><span :for={token <- @tokens} class={json_token_class(token.kind)}><%= token.text %></span></code></pre>
-        <button
-          type="button"
-          data-copy-to-clipboard-target={"#{@id}-code"}
-          title="Copy JSON to clipboard"
-          class="absolute end-2 top-2 inline-flex h-8 items-center gap-1.5 rounded border border-[var(--control-border)] bg-[var(--surface)] px-2.5 text-xs text-[var(--text-secondary)] shadow-sm hover:text-[var(--text-primary)]"
-        >
-          <span id={"#{@id}-default-message"} class="inline-flex items-center gap-1.5">
-            <.icon name="ri-clipboard-line" data-icon class="h-3.5 w-3.5" /> Copy
-          </span>
-          <span id={"#{@id}-success-message"} class="hidden items-center gap-1.5">
-            <.icon name="ri-check-line" data-icon class="h-3.5 w-3.5 text-emerald-600" /> Copied
-          </span>
-        </button>
-      </div>
-    </section>
-    """
-  end
-
-  defp json_tokens(json) do
-    {groups, cursor} =
-      @json_token_regex
-      |> Regex.scan(json, return: :index, capture: :first)
-      |> Enum.map_reduce(0, fn [{start, length}], cursor ->
-        token_end = start + length
-        leading = binary_part(json, cursor, start - cursor)
-        token = binary_part(json, start, length)
-
-        {[
-           %{kind: :plain, text: leading},
-           %{kind: json_token_kind(token, json, token_end), text: token}
-         ], token_end}
-      end)
-
-    trailing = binary_part(json, cursor, byte_size(json) - cursor)
-
-    groups
-    |> List.flatten()
-    |> Kernel.++([%{kind: :plain, text: trailing}])
-    |> Enum.reject(&(&1.text == ""))
-  end
-
-  defp json_token_kind(<<"\"", _::binary>>, json, token_end) do
-    remainder = binary_part(json, token_end, byte_size(json) - token_end)
-
-    if remainder |> String.trim_leading() |> String.starts_with?(":"),
-      do: :key,
-      else: :string
-  end
-
-  defp json_token_kind(token, _json, _token_end) when token in ["true", "false"],
-    do: :boolean
-
-  defp json_token_kind("null", _json, _token_end), do: :null
-  defp json_token_kind(_token, _json, _token_end), do: :number
-
-  defp json_token_class(:key),
-    do: "json-key text-sky-700 dark:text-sky-300"
-
-  defp json_token_class(:string),
-    do: "json-string text-emerald-700 dark:text-emerald-300"
-
-  defp json_token_class(:number),
-    do: "json-number text-violet-700 dark:text-violet-300"
-
-  defp json_token_class(:boolean),
-    do: "json-boolean text-amber-700 dark:text-amber-300"
-
-  defp json_token_class(:null), do: "json-null text-[var(--text-tertiary)]"
-  defp json_token_class(:plain), do: nil
 
   attr :matching_logs, :list, required: true
   attr :selected_role, :atom, required: true
@@ -920,7 +835,7 @@ defmodule PortalWeb.Logs.FlowLogs do
   end
 
   defp reporter_device_name(%{log: %{role: :initiator}, initiator_device: device}),
-    do: device_name(device, "Deleted client")
+    do: device_name(device, "Deleted device")
 
   defp reporter_device_name(%{log: %{role: :responder}, responder_device: device}),
     do: device_name(device, "Deleted responder")

--- a/elixir/lib/portal_web/live/logs/json_diff.ex
+++ b/elixir/lib/portal_web/live/logs/json_diff.ex
@@ -516,11 +516,13 @@ defmodule PortalWeb.Logs.JSONDiff do
   defp textdiff_class(:add), do: "json-diff-textdiff-added"
   defp textdiff_class(:del), do: "json-diff-textdiff-deleted"
 
-  # Recursive JSON pretty-printer. Returns a string with sorted keys and
-  # 2-space indentation so the rendered diff has a stable, readable shape
-  # regardless of the order the source maps were built in. Returned as a
-  # plain string so HEEx's `{}` interpolation HTML-escapes it.
-  @doc false
+  @doc """
+  Pretty-prints a JSON-shaped value.
+
+  Keys are sorted and nesting is indented two spaces, so the rendered shape is
+  stable regardless of the order the source maps were built in. Returned as a
+  plain string so HEEx's `{}` interpolation HTML-escapes it.
+  """
   def pretty(value), do: value |> pretty_io(0) |> IO.iodata_to_binary()
 
   defp pretty_io(map, _indent) when is_map(map) and map_size(map) == 0, do: "{}"

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -1498,16 +1498,8 @@ defmodule PortalWeb.Settings.DirectorySync do
           </div>
 
           <%= if Map.get(assigns, :public_jwk) do %>
-            <% kid = get_in(@public_jwk, ["keys", Access.at(0), "kid"]) %>
             <div class="mt-4">
-              <div id={"okta-public-jwk-wrapper-#{kid}"} phx-hook="FormatJSON">
-                <.code_block
-                  id="okta-public-jwk"
-                  class="text-xs rounded-md [&_code]:h-72 [&_code]:overflow-y-auto [&_code]:whitespace-pre-wrap [&_code]:break-all [&_code]:p-2"
-                >
-                  {JSON.encode!(@public_jwk)}
-                </.code_block>
-              </div>
+              <.json_view id="okta-public-jwk" value={@public_jwk} />
               <p class="mt-2 text-xs text-subtle">
                 Copy this public key and add it to your Okta application's JWKS configuration.
               </p>

--- a/elixir/lib/portal_web/live/settings/log_sinks.ex
+++ b/elixir/lib/portal_web/live/settings/log_sinks.ex
@@ -1302,7 +1302,9 @@ defmodule PortalWeb.Settings.LogSinks do
             <li>
               In IAM under <strong>Roles</strong>, choose
               <strong>Create role &rarr; Custom trust policy</strong> and paste:
-              <pre class="mt-2 mb-1 p-3 rounded border border-border bg-surface text-xs text-body overflow-x-auto"><code>{trust_policy_json(@form)}</code></pre>
+              <div class="mt-2 mb-1">
+                <.json_view id="s3-trust-policy" value={trust_policy(@form)} />
+              </div>
               Continue without adding permissions and give the role a name, e.g.
               <code class="text-xs">firezone-logs</code>.
             </li>
@@ -1310,7 +1312,9 @@ defmodule PortalWeb.Settings.LogSinks do
               On the new role, choose
               <strong>Add permissions &rarr; Create inline policy &rarr; JSON</strong>
               and paste:
-              <pre class="mt-2 mb-1 p-3 rounded border border-border bg-surface text-xs text-body overflow-x-auto"><code>{s3_permission_policy_json(@form)}</code></pre>
+              <div class="mt-2 mb-1">
+                <.json_view id="s3-permission-policy" value={s3_permission_policy(@form)} />
+              </div>
             </li>
             <li>
               Fill in the fields below: the bucket name, its region, and the role's ARN
@@ -2090,26 +2094,24 @@ defmodule PortalWeb.Settings.LogSinks do
   defp new_sink(S3.LogSink), do: %S3.LogSink{external_id: Ecto.UUID.generate()}
   defp new_sink(schema), do: struct(schema)
 
-  defp trust_policy_json(form) do
+  defp trust_policy(form) do
     external_id = get_field(form.source, :external_id)
     aws_account_id = S3.APIClient.aws_account_id()
 
-    """
-    {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Principal": { "AWS": "arn:aws:iam::#{aws_account_id}:root" },
-          "Action": "sts:AssumeRole",
-          "Condition": { "StringEquals": { "sts:ExternalId": "#{external_id}" } }
+    %{
+      "Version" => "2012-10-17",
+      "Statement" => [
+        %{
+          "Effect" => "Allow",
+          "Principal" => %{"AWS" => "arn:aws:iam::#{aws_account_id}:root"},
+          "Action" => "sts:AssumeRole",
+          "Condition" => %{"StringEquals" => %{"sts:ExternalId" => "#{external_id}"}}
         }
       ]
-    }\
-    """
+    }
   end
 
-  defp s3_permission_policy_json(form) do
+  defp s3_permission_policy(form) do
     bucket =
       case get_field(form.source, :bucket) do
         bucket when is_binary(bucket) and bucket != "" -> bucket
@@ -2119,18 +2121,16 @@ defmodule PortalWeb.Settings.LogSinks do
     resource =
       "arn:aws:s3:::#{bucket}/#{s3_objects_pattern(get_field(form.source, :key_prefix))}"
 
-    """
-    {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Action": "s3:PutObject",
-          "Resource": "#{resource}"
+    %{
+      "Version" => "2012-10-17",
+      "Statement" => [
+        %{
+          "Effect" => "Allow",
+          "Action" => "s3:PutObject",
+          "Resource" => resource
         }
       ]
-    }\
-    """
+    }
   end
 
   defp s3_objects_pattern(prefix) when is_binary(prefix) do

--- a/elixir/priv/repo/migrations/20260829000000_index_posture_provider_join_keys.exs
+++ b/elixir/priv/repo/migrations/20260829000000_index_posture_provider_join_keys.exs
@@ -1,0 +1,67 @@
+defmodule Portal.Repo.Migrations.IndexPostureProviderJoinKeys do
+  @moduledoc """
+  Indexes the columns a Client is matched against in each provider's inventory.
+
+  The remote identifier of every table is already the second half of its
+  primary key, so only the alternate keys need one: the hardware serial, and
+  the Entra device id that Intune and Defender both carry. The Clients list
+  looks all of them up for a page of Clients at a time, so without these the
+  page costs a sequential scan per configured provider.
+  """
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  def up do
+    create_if_not_exists(
+      index(:intune_devices, [:account_id, :serial_number],
+        where: "serial_number IS NOT NULL",
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:intune_devices, [:account_id, :entra_device_id],
+        where: "entra_device_id IS NOT NULL",
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:iru_devices, [:account_id, :serial_number],
+        where: "serial_number IS NOT NULL",
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:defender_devices, [:account_id, :entra_device_id],
+        where: "entra_device_id IS NOT NULL",
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:santa_devices, [:account_id, :serial_number],
+        where: "serial_number IS NOT NULL",
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:sentinelone_devices, [:account_id, :serial_number],
+        where: "serial_number IS NOT NULL",
+        concurrently: true
+      )
+    )
+  end
+
+  def down do
+    drop_if_exists(index(:sentinelone_devices, [:account_id, :serial_number], concurrently: true))
+    drop_if_exists(index(:santa_devices, [:account_id, :serial_number], concurrently: true))
+    drop_if_exists(index(:defender_devices, [:account_id, :entra_device_id], concurrently: true))
+    drop_if_exists(index(:iru_devices, [:account_id, :serial_number], concurrently: true))
+    drop_if_exists(index(:intune_devices, [:account_id, :entra_device_id], concurrently: true))
+    drop_if_exists(index(:intune_devices, [:account_id, :serial_number], concurrently: true))
+  end
+end

--- a/elixir/priv/repo/migrations/20260829000000_index_posture_provider_join_keys.exs
+++ b/elixir/priv/repo/migrations/20260829000000_index_posture_provider_join_keys.exs
@@ -4,9 +4,9 @@ defmodule Portal.Repo.Migrations.IndexPostureProviderJoinKeys do
 
   The remote identifier of every table is already the second half of its
   primary key, so only the alternate keys need one: the hardware serial, and
-  the Entra device id that Intune and Defender both carry. The Clients list
-  looks all of them up for a page of Clients at a time, so without these the
-  page costs a sequential scan per configured provider.
+  the Entra device id a Defender machine is reached by. The Clients list looks
+  all of them up for a page of Clients at a time, so without these the page
+  costs a sequential scan per configured provider.
   """
   use Ecto.Migration
 
@@ -16,13 +16,6 @@ defmodule Portal.Repo.Migrations.IndexPostureProviderJoinKeys do
     create_if_not_exists(
       index(:intune_devices, [:account_id, :serial_number],
         where: "serial_number IS NOT NULL",
-        concurrently: true
-      )
-    )
-
-    create_if_not_exists(
-      index(:intune_devices, [:account_id, :entra_device_id],
-        where: "entra_device_id IS NOT NULL",
         concurrently: true
       )
     )
@@ -61,7 +54,6 @@ defmodule Portal.Repo.Migrations.IndexPostureProviderJoinKeys do
     drop_if_exists(index(:santa_devices, [:account_id, :serial_number], concurrently: true))
     drop_if_exists(index(:defender_devices, [:account_id, :entra_device_id], concurrently: true))
     drop_if_exists(index(:iru_devices, [:account_id, :serial_number], concurrently: true))
-    drop_if_exists(index(:intune_devices, [:account_id, :entra_device_id], concurrently: true))
     drop_if_exists(index(:intune_devices, [:account_id, :serial_number], concurrently: true))
   end
 end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -1041,14 +1041,23 @@ defmodule Portal.Repo.Seeds do
     surface_intune_id = "1d84b7e0-92af-4c35-b6d1-70e5a3c8f429"
     surface_entra_id = "b71d2e88-3f56-4c09-8ad4-6e19f7c2a5d0"
     iphone_iru_id = "0c9a4f61-8b23-4de7-95f0-31a8c6b74e29"
+    kiosk_intune_id = "7e4a9c13-2b68-4f05-a3d7-16c8e0b492f5"
+    macbook_air_iru_id = "d3927f5a-6c40-4e81-b2a9-5087c1d6e34b"
 
     admin = attest_posture_client(clients.admin_laptop, admin_intune_id, "FVFHF246Q72Z", issuer, "3A7F2C91", now)
     surface = attest_posture_client(clients.user_surface, surface_intune_id, "046120283253", issuer, "5B1D8E04", now)
     iphone = attest_posture_client(clients.user_iphone, iphone_iru_id, "DX3QK7WPL9GH", issuer, "9E4C6A72", now)
 
-    # The rendering station never attested anything, so the only serial it has
-    # is the one it reports about itself. Its SentinelOne match is the case the
-    # panel cautions about.
+    # An MDM template that stamps a device id and nothing else. Neither of these
+    # attests a serial, so the only serial the list can show for them is the one
+    # their provider record holds against that device id.
+    kiosk = attest_mdm_device_id(clients.user_kiosk, kiosk_intune_id, issuer, "7C0B3F15", now)
+
+    macbook_air =
+      attest_mdm_device_id(clients.user_macbook_air, macbook_air_iru_id, issuer, "2D9A5E68", now)
+
+    # The rendering station never attested anything, so its only serial is
+    # self-reported. Its SentinelOne match is the case the panel labels.
     rendering = Repo.update!(change(clients.user_rendering_station, device_serial: "PF0J4KX2"))
 
     # Valid, revoked, and unknown, so the panel's three certificate states are
@@ -1073,8 +1082,8 @@ defmodule Portal.Repo.Seeds do
       reason: "keyCompromise"
     })
 
-    seed_intune_devices(account, intune, now, admin, surface, surface_entra_id)
-    seed_iru_devices(account, iru, now, iphone)
+    seed_intune_devices(account, intune, now, admin, surface, surface_entra_id, kiosk)
+    seed_iru_devices(account, iru, now, iphone, macbook_air)
     seed_defender_devices(account, defender, now, surface_entra_id)
     seed_santa_devices(account, santa, now, admin)
     seed_sentinelone_devices(account, sentinelone, now, admin, rendering)
@@ -1084,7 +1093,9 @@ defmodule Portal.Repo.Seeds do
     IO.puts("  #{admin.name}: attested, matched by MDM device id")
     IO.puts("  #{surface.name}: attested, matched by MDM device id and linked into Defender")
     IO.puts("  #{iphone.name}: attested with a revoked certificate")
-    IO.puts("  #{rendering.name}: unattested, matched by the serial it reports")
+    IO.puts("  #{rendering.name}: unattested, matched by a self-reported serial")
+    IO.puts("  #{kiosk.name}: attested a device id only, serial comes from Intune")
+    IO.puts("  #{macbook_air.name}: attested a device id only, serial comes from Iru")
     IO.puts("")
   end
 
@@ -1132,7 +1143,19 @@ defmodule Portal.Repo.Seeds do
     |> Repo.update!()
   end
 
-  defp seed_intune_devices(account, provider, now, admin, surface, surface_entra_id) do
+  defp attest_mdm_device_id(client, mdm_device_id, issuer, cert_serial, now) do
+    client
+    |> change(
+      last_attested_mdm_device_id: mdm_device_id,
+      last_attested_cert_serial: cert_serial,
+      last_attested_cert_fingerprint: posture_fingerprint(cert_serial),
+      last_attested_cert_issuer: issuer,
+      last_attested_at: DateTime.add(now, -3, :hour)
+    )
+    |> Repo.update!()
+  end
+
+  defp seed_intune_devices(account, provider, now, admin, surface, surface_entra_id, kiosk) do
     matched = [
       %{
         intune_id: admin.last_attested_mdm_device_id,
@@ -1158,6 +1181,18 @@ defmodule Portal.Repo.Seeds do
         device_enrollment_type: "windowsAzureADJoin",
         compliance_state: "compliant",
         person: 1
+      },
+      %{
+        intune_id: kiosk.last_attested_mdm_device_id,
+        device_name: "ENG-KIOSK-03",
+        serial_number: dell_tag(77),
+        operating_system: "Windows",
+        os_version: "10.0.26100.2894",
+        model: "OptiPlex 7010",
+        manufacturer: "Dell Inc.",
+        device_enrollment_type: "windowsAzureADJoin",
+        compliance_state: "compliant",
+        person: 6
       },
       %{
         intune_id: "6b02f5c4-1e79-4a63-8d50-92fb37e6c184",
@@ -1239,7 +1274,7 @@ defmodule Portal.Repo.Seeds do
     end
   end
 
-  defp seed_iru_devices(account, provider, now, iphone) do
+  defp seed_iru_devices(account, provider, now, iphone, macbook_air) do
     matched = [
       %{
         iru_id: iphone.last_attested_mdm_device_id,
@@ -1252,6 +1287,19 @@ defmodule Portal.Repo.Seeds do
         model_identifier: "iPhone17,1",
         blueprint_name: "Mobile Standard",
         person: 2
+      },
+      %{
+        iru_id: macbook_air.last_attested_mdm_device_id,
+        device_name: "ENG-MBA-021",
+        # Deliberately not the stale serial the Client still reports.
+        serial_number: "C02XY1CDKH6J",
+        platform: "Mac",
+        os_name: "macOS",
+        os_version: "15.6.1",
+        model: "MacBook Air 15-inch (M4, 2025)",
+        model_identifier: "Mac16,12",
+        blueprint_name: "Standard Laptop",
+        person: 3
       }
     ]
 
@@ -2340,6 +2388,39 @@ defmodule Portal.Repo.Seeds do
         @ua_ubuntu
       )
 
+    {:ok, user_kiosk} =
+      create_client(
+        %{
+          name: "FZ User Kiosk",
+          firezone_id: Ecto.UUID.generate(),
+          public_key: :crypto.strong_rand_bytes(32) |> Base.encode64(),
+          device_uuid: "WIN-#{Ecto.UUID.generate()}",
+          ipv4: "100.64.0.15",
+          ipv6: "fd00:2021:1111::15"
+        },
+        unprivileged_subject,
+        unprivileged_client_token.id,
+        @ua_windows
+      )
+
+    {:ok, user_macbook_air} =
+      create_client(
+        %{
+          name: "FZ User MacBook Air",
+          firezone_id: Ecto.UUID.generate(),
+          public_key: :crypto.strong_rand_bytes(32) |> Base.encode64(),
+          device_uuid: "MAC-#{Ecto.UUID.generate()}",
+          # Stale: the machine was reimaged and the Client never picked up the
+          # new serial, so the one Iru holds is the current one.
+          device_serial: "C02WX0ABJG5H",
+          ipv4: "100.64.0.16",
+          ipv6: "fd00:2021:1111::16"
+        },
+        unprivileged_subject,
+        unprivileged_client_token.id,
+        @ua_macos
+      )
+
     {:ok, admin_laptop} =
       create_client(
         %{
@@ -2388,7 +2469,9 @@ defmodule Portal.Repo.Seeds do
       admin_laptop: admin_laptop,
       user_surface: user_windows_laptop,
       user_iphone: user_iphone,
-      user_rendering_station: user_linux_laptop
+      user_rendering_station: user_linux_laptop,
+      user_kiosk: user_kiosk,
+      user_macbook_air: user_macbook_air
     })
 
     IO.puts("Created Groups: ")

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -1032,15 +1032,18 @@ defmodule Portal.Repo.Seeds do
       )
 
     # The identifiers the seeded certificates attest. Each is also written into
-    # the provider row that should match on it, so the Inventory tab of a
-    # seeded Client demonstrates one rung of the matching ladder.
+    # the provider row that should match on it, so the Posture tab of a seeded
+    # Client demonstrates one rung of the matching ladder. The Surface also
+    # carries an Entra device id on its Intune row and on a Defender machine,
+    # which is how a Defender record is reached at all.
     issuer = posture_issuer_der("Contoso Device CA")
     admin_intune_id = "5f3c1a90-7d24-4b8e-9a61-c0d2e4f68b31"
+    surface_intune_id = "1d84b7e0-92af-4c35-b6d1-70e5a3c8f429"
     surface_entra_id = "b71d2e88-3f56-4c09-8ad4-6e19f7c2a5d0"
     iphone_iru_id = "0c9a4f61-8b23-4de7-95f0-31a8c6b74e29"
 
     admin = attest_posture_client(clients.admin_laptop, admin_intune_id, "FVFHF246Q72Z", issuer, "3A7F2C91", now)
-    surface = attest_posture_client(clients.user_surface, surface_entra_id, "046120283253", issuer, "5B1D8E04", now)
+    surface = attest_posture_client(clients.user_surface, surface_intune_id, "046120283253", issuer, "5B1D8E04", now)
     iphone = attest_posture_client(clients.user_iphone, iphone_iru_id, "DX3QK7WPL9GH", issuer, "9E4C6A72", now)
 
     # The rendering station never attested anything, so the only serial it has
@@ -1070,16 +1073,16 @@ defmodule Portal.Repo.Seeds do
       reason: "keyCompromise"
     })
 
-    seed_intune_devices(account, intune, now, admin, surface)
+    seed_intune_devices(account, intune, now, admin, surface, surface_entra_id)
     seed_iru_devices(account, iru, now, iphone)
-    seed_defender_devices(account, defender, now, surface)
+    seed_defender_devices(account, defender, now, surface_entra_id)
     seed_santa_devices(account, santa, now, admin)
     seed_sentinelone_devices(account, sentinelone, now, admin, rendering)
 
     IO.puts("Device posture providers created")
     IO.puts("  Contoso Intune, Iru Apple Fleet, Defender for Endpoint, Santa Workshop, SentinelOne Production")
     IO.puts("  #{admin.name}: attested, matched by MDM device id")
-    IO.puts("  #{surface.name}: attested, matched by Entra device id")
+    IO.puts("  #{surface.name}: attested, matched by MDM device id and linked into Defender")
     IO.puts("  #{iphone.name}: attested with a revoked certificate")
     IO.puts("  #{rendering.name}: unattested, matched by the serial it reports")
     IO.puts("")
@@ -1129,7 +1132,7 @@ defmodule Portal.Repo.Seeds do
     |> Repo.update!()
   end
 
-  defp seed_intune_devices(account, provider, now, admin, surface) do
+  defp seed_intune_devices(account, provider, now, admin, surface, surface_entra_id) do
     matched = [
       %{
         intune_id: admin.last_attested_mdm_device_id,
@@ -1144,8 +1147,8 @@ defmodule Portal.Repo.Seeds do
         person: 0
       },
       %{
-        intune_id: "1d84b7e0-92af-4c35-b6d1-70e5a3c8f429",
-        entra_device_id: surface.last_attested_mdm_device_id,
+        intune_id: surface.last_attested_mdm_device_id,
+        entra_device_id: surface_entra_id,
         device_name: "ENG-SURFACE-07",
         serial_number: surface.last_attested_device_serial,
         operating_system: "Windows",
@@ -1336,11 +1339,11 @@ defmodule Portal.Repo.Seeds do
     end
   end
 
-  defp seed_defender_devices(account, provider, now, surface) do
+  defp seed_defender_devices(account, provider, now, surface_entra_id) do
     matched = [
       %{
         defender_id: "2f8c1b47ad9e05c3716b4d820ea935f1c6d704b8",
-        entra_device_id: surface.last_attested_mdm_device_id,
+        entra_device_id: surface_entra_id,
         computer_dns_name: "eng-surface-07.#{@posture_domain}",
         os_platform: "Windows11",
         version: "24H2",

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -16,18 +16,23 @@ defmodule Portal.Repo.Seeds do
     Crypto,
     EmailOTP,
     Entra,
+    Defender,
     ExternalIdentity,
     Device,
     FlowLog,
     PolicyAuthorization,
     Google,
     Group,
+    Intune,
+    Iru,
     Membership,
     NameGenerator,
     OIDC,
     Policy,
     Resource,
     Safe,
+    Santa,
+    SentinelOne,
     SessionLog,
     Site,
     ClientToken,
@@ -939,6 +944,758 @@ defmodule Portal.Repo.Seeds do
     }
   end
 
+
+  # ---------------------------------------------------------------------------
+  # Device posture inventory
+  # ---------------------------------------------------------------------------
+
+  # One fleet of people, reused across every provider, so the same person shows
+  # up consistently wherever a device of theirs is inventoried.
+  @posture_people [
+    {"Alice Nguyen", "alice"},
+    {"Ben Okafor", "ben"},
+    {"Carla Ruiz", "carla"},
+    {"Dmitri Volkov", "dmitri"},
+    {"Elena Petrova", "elena"},
+    {"Farhan Ahmed", "farhan"},
+    {"Grace Lim", "grace"},
+    {"Hugo Martins", "hugo"},
+    {"Ingrid Sorensen", "ingrid"},
+    {"Jonas Weber", "jonas"},
+    {"Keiko Tanaka", "keiko"},
+    {"Liam Doyle", "liam"},
+    {"Maya Shah", "maya"},
+    {"Noah Brenner", "noah"},
+    {"Olivia Fontaine", "olivia"},
+    {"Priya Raman", "priya"}
+  ]
+
+  @posture_domain "contoso.com"
+
+  # Serial numbers are generated rather than listed so the fleet can grow
+  # without hand-writing plausible strings. The alphabet drops I and O, which
+  # is what real serials do so they cannot be confused with 1 and 0.
+  @serial_alphabet ~c"0123456789ABCDEFGHJKLMNPQRSTUVWXYZ"
+
+  defp seed_device_posture(account, clients) do
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+    intune =
+      create_posture_provider(account, :intune, "Contoso Intune", Intune.PostureProvider, %{
+        tenant_id: "8a1e5f22-4c7b-4a10-9c8e-2f3b6d5a71c4",
+        is_verified: true,
+        synced_at: DateTime.add(now, -11, :minute)
+      })
+
+    iru =
+      create_posture_provider(account, :iru, "Iru Apple Fleet", Iru.PostureProvider, %{
+        subdomain: "contoso",
+        region: :us,
+        api_token: "iru_dev_api_token",
+        is_verified: true,
+        synced_at: DateTime.add(now, -23, :minute)
+      })
+
+    defender =
+      create_posture_provider(
+        account,
+        :defender,
+        "Defender for Endpoint",
+        Defender.PostureProvider,
+        %{
+          tenant_id: "8a1e5f22-4c7b-4a10-9c8e-2f3b6d5a71c4",
+          is_verified: true,
+          synced_at: DateTime.add(now, -7, :minute)
+        }
+      )
+
+    santa =
+      create_posture_provider(account, :santa, "Santa Workshop", Santa.PostureProvider, %{
+        api_url: "https://contoso.workshop.cloud",
+        api_key: "npsws_sk_dev_seed_key",
+        is_verified: true,
+        synced_at: DateTime.add(now, -4, :minute)
+      })
+
+    sentinelone =
+      create_posture_provider(
+        account,
+        :sentinelone,
+        "SentinelOne Production",
+        SentinelOne.PostureProvider,
+        %{
+          management_url: "https://contoso.sentinelone.net",
+          api_token: "s1_dev_api_token",
+          is_verified: true,
+          synced_at: DateTime.add(now, -2, :minute)
+        }
+      )
+
+    # The identifiers the seeded certificates attest. Each is also written into
+    # the provider row that should match on it, so the Inventory tab of a
+    # seeded Client demonstrates one rung of the matching ladder.
+    issuer = posture_issuer_der("Contoso Device CA")
+    admin_intune_id = "5f3c1a90-7d24-4b8e-9a61-c0d2e4f68b31"
+    surface_entra_id = "b71d2e88-3f56-4c09-8ad4-6e19f7c2a5d0"
+    iphone_iru_id = "0c9a4f61-8b23-4de7-95f0-31a8c6b74e29"
+
+    admin = attest_posture_client(clients.admin_laptop, admin_intune_id, "FVFHF246Q72Z", issuer, "3A7F2C91", now)
+    surface = attest_posture_client(clients.user_surface, surface_entra_id, "046120283253", issuer, "5B1D8E04", now)
+    iphone = attest_posture_client(clients.user_iphone, iphone_iru_id, "DX3QK7WPL9GH", issuer, "9E4C6A72", now)
+
+    # The rendering station never attested anything, so the only serial it has
+    # is the one it reports about itself. Its SentinelOne match is the case the
+    # panel cautions about.
+    rendering = Repo.update!(change(clients.user_rendering_station, device_serial: "PF0J4KX2"))
+
+    # Valid, revoked, and unknown, so the panel's three certificate states are
+    # all reachable from seeded data.
+    Repo.insert!(%Portal.OcspStatus{
+      account_id: account.id,
+      issuer: issuer,
+      serial: admin.last_attested_cert_serial,
+      status: "good",
+      produced_at: DateTime.add(now, -90, :minute) |> DateTime.truncate(:second),
+      this_update: DateTime.add(now, -90, :minute) |> DateTime.truncate(:second),
+      next_update: DateTime.add(now, 3, :day) |> DateTime.truncate(:second),
+      updated_at: now
+    })
+
+    Repo.insert!(%Portal.CrlRevocation{
+      account_id: account.id,
+      issuer: issuer,
+      serial: iphone.last_attested_cert_serial,
+      distribution_point: "http://crl.contoso.com/device-ca.crl",
+      revoked_at: DateTime.add(now, -2, :day) |> DateTime.truncate(:second),
+      reason: "keyCompromise"
+    })
+
+    seed_intune_devices(account, intune, now, admin, surface)
+    seed_iru_devices(account, iru, now, iphone)
+    seed_defender_devices(account, defender, now, surface)
+    seed_santa_devices(account, santa, now, admin)
+    seed_sentinelone_devices(account, sentinelone, now, admin, rendering)
+
+    IO.puts("Device posture providers created")
+    IO.puts("  Contoso Intune, Iru Apple Fleet, Defender for Endpoint, Santa Workshop, SentinelOne Production")
+    IO.puts("  #{admin.name}: attested, matched by MDM device id")
+    IO.puts("  #{surface.name}: attested, matched by Entra device id")
+    IO.puts("  #{iphone.name}: attested with a revoked certificate")
+    IO.puts("  #{rendering.name}: unattested, matched by the serial it reports")
+    IO.puts("")
+  end
+
+  # Seeded providers are disabled on purpose. Their credentials are made up, so
+  # leaving them enabled would have every scheduler run fire a sync at the real
+  # vendor API and fail. Disabled keeps the rows and the devices they own
+  # visible, which is the whole point of seeding them.
+  defp create_posture_provider(account, type, name, typed_module, typed_attrs) do
+    id = Ecto.UUID.generate()
+
+    typed_attrs =
+      Map.merge(typed_attrs, %{
+        is_disabled: true,
+        disabled_reason: "Seeded for local development"
+      })
+
+    shared =
+      %Portal.PostureProvider{}
+      |> change(%{id: id, account_id: account.id, type: type, name: name})
+      |> Portal.PostureProvider.changeset()
+      |> Repo.insert!()
+
+    attrs = Map.merge(typed_attrs, %{id: id, account_id: account.id, name: name})
+
+    typed_module
+    |> struct(posture_provider: shared)
+    |> cast(attrs, Map.keys(attrs))
+    |> typed_module.changeset()
+    |> Repo.insert!()
+  end
+
+  # Writes what a client certificate would have proved about this device onto
+  # the row, so the seeded Clients cover every rung of the matching ladder.
+  defp attest_posture_client(client, mdm_device_id, serial, issuer, cert_serial, now) do
+    client
+    |> change(
+      device_serial: serial,
+      last_attested_device_serial: serial,
+      last_attested_mdm_device_id: mdm_device_id,
+      last_attested_cert_serial: cert_serial,
+      last_attested_cert_fingerprint: posture_fingerprint(cert_serial),
+      last_attested_cert_issuer: issuer,
+      last_attested_at: DateTime.add(now, -3, :hour)
+    )
+    |> Repo.update!()
+  end
+
+  defp seed_intune_devices(account, provider, now, admin, surface) do
+    matched = [
+      %{
+        intune_id: admin.last_attested_mdm_device_id,
+        device_name: "ENG-MBP-014",
+        serial_number: admin.last_attested_device_serial,
+        operating_system: "macOS",
+        os_version: "15.6.1",
+        model: "MacBook Pro 16-inch (M3 Max, 2024)",
+        manufacturer: "Apple",
+        device_enrollment_type: "appleBulkWithUser",
+        compliance_state: "compliant",
+        person: 0
+      },
+      %{
+        intune_id: "1d84b7e0-92af-4c35-b6d1-70e5a3c8f429",
+        entra_device_id: surface.last_attested_mdm_device_id,
+        device_name: "ENG-SURFACE-07",
+        serial_number: surface.last_attested_device_serial,
+        operating_system: "Windows",
+        os_version: "10.0.26100.2894",
+        model: "Surface Laptop 6",
+        manufacturer: "Microsoft Corporation",
+        device_enrollment_type: "windowsAzureADJoin",
+        compliance_state: "compliant",
+        person: 1
+      },
+      %{
+        intune_id: "6b02f5c4-1e79-4a63-8d50-92fb37e6c184",
+        device_name: "ENG-WIN-042",
+        serial_number: dell_tag(42),
+        operating_system: "Windows",
+        os_version: "10.0.26100.2894",
+        model: "Latitude 7450",
+        manufacturer: "Dell Inc.",
+        device_enrollment_type: "windowsAzureADJoin",
+        compliance_state: "noncompliant",
+        person: 2
+      }
+    ]
+
+    generated =
+      for i <- 1..15 do
+        {os, version, model, manufacturer, enrollment, serial} = intune_hardware(i)
+
+        %{
+          intune_id: Ecto.UUID.generate(),
+          device_name: "#{intune_prefix(os)}-#{String.pad_leading(Integer.to_string(100 + i), 3, "0")}",
+          serial_number: serial,
+          operating_system: os,
+          os_version: version,
+          model: model,
+          manufacturer: manufacturer,
+          device_enrollment_type: enrollment,
+          compliance_state: Enum.at(~w[compliant compliant compliant noncompliant inGracePeriod], rem(i, 5)),
+          person: i + 2
+        }
+      end
+
+    for {row, i} <- Enum.with_index(matched ++ generated) do
+      {display_name, login} = posture_person(row.person)
+
+      %Intune.Device{}
+      |> Intune.Device.changeset(%{
+        account_id: account.id,
+        posture_provider_id: provider.id,
+        intune_id: row.intune_id,
+        device_name: row.device_name,
+        managed_device_name: "#{login}_#{String.replace(row.model, " ", "")}_#{8 + rem(i, 4)}/#{1 + rem(i, 28)}/2026",
+        serial_number: row.serial_number,
+        entra_device_id: Map.get(row, :entra_device_id, Ecto.UUID.generate()),
+        enrollment_profile_name: "Corporate Devices",
+        device_category_display_name: "Engineering",
+        user_id: Ecto.UUID.generate(),
+        user_principal_name: "#{login}@#{@posture_domain}",
+        user_display_name: display_name,
+        email_address: "#{login}@#{@posture_domain}",
+        operating_system: row.operating_system,
+        os_version: row.os_version,
+        model: row.model,
+        manufacturer: row.manufacturer,
+        udid: Ecto.UUID.generate(),
+        wifi_mac_address: posture_mac(i),
+        ethernet_mac_address: posture_mac(i + 128),
+        total_storage_space_bytes: 494_384_795_648 * (1 + rem(i, 3)),
+        free_storage_space_bytes: 121_856_204_800 + i * 1_073_741_824,
+        physical_memory_bytes: 17_179_869_184 * (1 + rem(i, 2)),
+        compliance_state: row.compliance_state,
+        management_state: "managed",
+        management_agent: "mdm",
+        managed_device_owner_type: if(rem(i, 7) == 0, do: "personal", else: "company"),
+        device_enrollment_type: row.device_enrollment_type,
+        device_registration_state: "registered",
+        partner_reported_threat_state: "unknown",
+        jail_broken: "False",
+        is_encrypted: rem(i, 9) != 0,
+        is_supervised: row.operating_system in ["iOS", "macOS"],
+        entra_registered: true,
+        enrolled_at: DateTime.add(now, -(120 + i * 9), :day),
+        last_sync_at: DateTime.add(now, -(17 + i * 13), :minute),
+        management_certificate_expires_at: DateTime.add(now, 240 - i, :day),
+        synced_at: provider.synced_at
+      })
+      |> Repo.insert!()
+    end
+  end
+
+  defp seed_iru_devices(account, provider, now, iphone) do
+    matched = [
+      %{
+        iru_id: iphone.last_attested_mdm_device_id,
+        device_name: "ENG-IPHONE-02",
+        serial_number: iphone.last_attested_device_serial,
+        platform: "iPhone",
+        os_name: "iOS",
+        os_version: "18.6",
+        model: "iPhone 16 Pro",
+        model_identifier: "iPhone17,1",
+        blueprint_name: "Mobile Standard",
+        person: 2
+      }
+    ]
+
+    generated =
+      for i <- 1..11 do
+        {platform, os_name, version, model, identifier} = iru_hardware(i)
+
+        %{
+          iru_id: Ecto.UUID.generate(),
+          device_name: "#{posture_person(i + 3) |> elem(1)}-#{String.downcase(String.replace(model, " ", "-"))}",
+          serial_number: apple_serial(i * 31),
+          platform: platform,
+          os_name: os_name,
+          os_version: version,
+          model: model,
+          model_identifier: identifier,
+          blueprint_name: Enum.at(["Standard Laptop", "Engineering Laptop", "Mobile Standard"], rem(i, 3)),
+          person: i + 3
+        }
+      end
+
+    for {row, i} <- Enum.with_index(matched ++ generated) do
+      {display_name, login} = posture_person(row.person)
+      mac? = row.platform == "Mac"
+
+      %Iru.Device{}
+      |> Iru.Device.changeset(%{
+        account_id: account.id,
+        posture_provider_id: provider.id,
+        iru_id: row.iru_id,
+        device_name: row.device_name,
+        serial_number: row.serial_number,
+        platform: row.platform,
+        os_name: row.os_name,
+        os_version: row.os_version,
+        display_os_version: row.os_version,
+        os_build: "24G8#{rem(i, 10)}",
+        model: row.model,
+        model_name: row.model,
+        model_identifier: row.model_identifier,
+        device_family: row.platform,
+        device_capacity_gb: 256.0 * (1 + rem(i, 3)),
+        host_name: row.device_name,
+        local_hostname: row.device_name,
+        apple_silicon: true,
+        user_id: Ecto.UUID.generate(),
+        user_name: display_name,
+        user_email: "#{login}@#{@posture_domain}",
+        user_is_archived: false,
+        asset_tag: "CT-#{String.pad_leading(Integer.to_string(4200 + i), 4, "0")}",
+        blueprint_id: Ecto.UUID.generate(),
+        blueprint_name: row.blueprint_name,
+        mdm_enabled: true,
+        agent_installed: mac?,
+        agent_version: if(mac?, do: "5.4.1", else: nil),
+        is_missing: false,
+        is_removed: false,
+        first_enrolled_at: DateTime.add(now, -(200 + i * 11), :day),
+        last_enrolled_at: DateTime.add(now, -(200 + i * 11), :day),
+        last_check_in_at: DateTime.add(now, -(9 + i * 17), :minute),
+        tags: ["engineering"],
+        inventory_collected_at: DateTime.add(now, -(30 + i), :minute),
+        filevault_enabled: mac? and rem(i, 8) != 0,
+        filevault_key_type: if(mac?, do: "Personal", else: nil),
+        filevault_key_escrowed: mac?,
+        filevault_collected_at: if(mac?, do: DateTime.add(now, -(30 + i), :minute), else: nil),
+        firewall_enabled: mac?,
+        firewall_stealth_mode: mac? and rem(i, 3) == 0,
+        firewall_collected_at: if(mac?, do: DateTime.add(now, -(30 + i), :minute), else: nil),
+        gatekeeper_enabled: mac?,
+        gatekeeper_trusted_developers: mac?,
+        xprotect_version: if(mac?, do: "5312", else: nil),
+        gatekeeper_collected_at: if(mac?, do: DateTime.add(now, -(30 + i), :minute), else: nil),
+        sip_enabled: mac?,
+        ssv_enabled: mac?,
+        bootstrap_token_escrowed: mac?,
+        secure_boot_level: if(mac?, do: "full", else: nil),
+        startup_settings_collected_at: if(mac?, do: DateTime.add(now, -(30 + i), :minute), else: nil),
+        activation_lock_supported: true,
+        device_activation_lock_enabled: rem(i, 4) == 0,
+        activation_lock_collected_at: DateTime.add(now, -(30 + i), :minute),
+        synced_at: provider.synced_at
+      })
+      |> Repo.insert!()
+    end
+  end
+
+  defp seed_defender_devices(account, provider, now, surface) do
+    matched = [
+      %{
+        defender_id: "2f8c1b47ad9e05c3716b4d820ea935f1c6d704b8",
+        entra_device_id: surface.last_attested_mdm_device_id,
+        computer_dns_name: "eng-surface-07.#{@posture_domain}",
+        os_platform: "Windows11",
+        version: "24H2",
+        os_build: 26_100,
+        health_status: "Active",
+        risk_score: "Low",
+        exposure_level: "Low"
+      }
+    ]
+
+    generated =
+      for i <- 1..13 do
+        {platform, version, build, health, risk, exposure} = defender_posture(i)
+
+        %{
+          defender_id: Base.encode16(:crypto.hash(:sha, "defender-seed-#{i}"), case: :lower),
+          entra_device_id: Ecto.UUID.generate(),
+          computer_dns_name: "#{defender_prefix(platform)}-#{String.pad_leading(Integer.to_string(200 + i), 3, "0")}.#{@posture_domain}",
+          os_platform: platform,
+          version: version,
+          os_build: build,
+          health_status: health,
+          risk_score: risk,
+          exposure_level: exposure
+        }
+      end
+
+    for {row, i} <- Enum.with_index(matched ++ generated) do
+      %Defender.Device{}
+      |> Defender.Device.changeset(%{
+        account_id: account.id,
+        posture_provider_id: provider.id,
+        defender_id: row.defender_id,
+        computer_dns_name: row.computer_dns_name,
+        entra_device_id: row.entra_device_id,
+        entra_joined: true,
+        machine_tags: ["engineering", "corp-managed"],
+        os_platform: row.os_platform,
+        version: row.version,
+        os_build: row.os_build,
+        os_processor: "x64",
+        os_architecture: "64-bit",
+        last_ip_address: "10.20.#{rem(i, 250)}.#{10 + rem(i * 7, 200)}",
+        last_external_ip_address: "203.0.113.#{10 + rem(i * 3, 200)}",
+        agent_version: "10.8760.26100.#{2000 + i}",
+        health_status: row.health_status,
+        onboarding_status: "Onboarded",
+        managed_by: "Intune",
+        managed_by_status: "Success",
+        risk_score: row.risk_score,
+        exposure_level: row.exposure_level,
+        device_value: if(rem(i, 6) == 0, do: "High", else: "Normal"),
+        rbac_group_id: "140",
+        rbac_group_name: "Engineering",
+        is_potential_duplication: false,
+        is_excluded: false,
+        ip_addresses: [
+          %{
+            "ipAddress" => "10.20.#{rem(i, 250)}.#{10 + rem(i * 7, 200)}",
+            "macAddress" => String.replace(posture_mac(i), ":", ""),
+            "operationalStatus" => "Up",
+            "type" => "Ethernet"
+          }
+        ],
+        first_seen_at: DateTime.add(now, -(180 + i * 7), :day),
+        last_seen_at: DateTime.add(now, -(5 + i * 11), :minute),
+        synced_at: provider.synced_at
+      })
+      |> Repo.insert!()
+    end
+  end
+
+  defp seed_santa_devices(account, provider, now, admin) do
+    matched = [
+      %{
+        santa_id: "9C1F4A72-3B6D-4E80-A5C9-27D0F8B1E463",
+        hostname: "eng-mbp-014",
+        serial_number: admin.last_attested_device_serial,
+        machine_model: "Mac16,7",
+        os_version: "15.6.1",
+        client_mode: "LOCKDOWN",
+        person: 0
+      }
+    ]
+
+    generated =
+      for i <- 1..9 do
+        %{
+          santa_id: String.upcase(Ecto.UUID.generate()),
+          hostname: "#{posture_person(i) |> elem(1)}-mbp",
+          serial_number: apple_serial(i * 17),
+          machine_model: Enum.at(~w[Mac16,7 Mac15,3 Mac14,2 MacBookPro18,3], rem(i, 4)),
+          os_version: Enum.at(~w[15.6.1 15.5 14.7.2], rem(i, 3)),
+          client_mode: if(rem(i, 3) == 0, do: "MONITOR", else: "LOCKDOWN"),
+          person: i
+        }
+      end
+
+    for {row, i} <- Enum.with_index(matched ++ generated) do
+      {_display_name, login} = posture_person(row.person)
+
+      %Santa.Device{}
+      |> Santa.Device.changeset(%{
+        account_id: account.id,
+        posture_provider_id: provider.id,
+        santa_id: row.santa_id,
+        hostname: row.hostname,
+        serial_number: row.serial_number,
+        machine_model: row.machine_model,
+        os_version: row.os_version,
+        os_build: "24G8#{rem(i, 10)}",
+        os_type: "OS_TYPE_MACOS",
+        sip_status: 1,
+        primary_user: "#{login}@#{@posture_domain}",
+        primary_user_locked: false,
+        primary_user_groups: ["engineering"],
+        santa_version: "2026.7",
+        santanetd_version: "2026.7",
+        last_seen_client_mode: row.client_mode,
+        configured_client_mode: row.client_mode,
+        last_sync_at: DateTime.add(now, -(6 + i * 13), :minute),
+        rule_sync_at: DateTime.add(now, -(6 + i * 13), :minute),
+        last_preflight_at: DateTime.add(now, -(6 + i * 13), :minute),
+        last_preflight_ip: "10.30.#{rem(i, 250)}.#{20 + rem(i * 5, 200)}",
+        tags: ["engineering"],
+        tags_locked: false,
+        tags_truncated: false,
+        first_seen_at: DateTime.add(now, -(150 + i * 8), :day),
+        synced_at: provider.synced_at
+      })
+      |> Repo.insert!()
+    end
+  end
+
+  defp seed_sentinelone_devices(account, provider, now, admin, rendering) do
+    matched = [
+      %{
+        computer_name: "ENG-MBP-014",
+        serial_number: admin.last_attested_device_serial,
+        model_name: "MacBookPro16,7",
+        machine_type: "laptop",
+        os_name: "macOS",
+        os_revision: "15.6.1",
+        os_type: "macos",
+        network_status: "connected",
+        person: 0
+      },
+      %{
+        computer_name: "ENG-RENDER-01",
+        serial_number: rendering.device_serial,
+        model_name: "ThinkStation P620",
+        machine_type: "desktop",
+        os_name: "Ubuntu",
+        os_revision: "24.04.2 LTS",
+        os_type: "linux",
+        network_status: "connected",
+        person: 3
+      }
+    ]
+
+    generated =
+      for i <- 1..13 do
+        {os_name, revision, os_type, model, machine_type, serial} = sentinelone_hardware(i)
+
+        %{
+          computer_name: "#{sentinelone_prefix(os_type)}-#{String.pad_leading(Integer.to_string(300 + i), 3, "0")}",
+          serial_number: serial,
+          model_name: model,
+          machine_type: machine_type,
+          os_name: os_name,
+          os_revision: revision,
+          os_type: os_type,
+          network_status: if(rem(i, 6) == 0, do: "disconnected", else: "connected"),
+          person: i + 4
+        }
+      end
+
+    for {row, i} <- Enum.with_index(matched ++ generated) do
+      {_display_name, login} = posture_person(row.person)
+      infected? = rem(i, 11) == 0 and i > 0
+
+      %SentinelOne.Device{}
+      |> SentinelOne.Device.changeset(%{
+        account_id: account.id,
+        posture_provider_id: provider.id,
+        uuid: Ecto.UUID.generate(),
+        sentinelone_id: Integer.to_string(1_845_000_000_000_000_000 + i),
+        sentinelone_account_id: "1845000000000000001",
+        account_name: "Contoso",
+        site_id: "1845000000000000002",
+        site_name: "Default site",
+        group_id: "1845000000000000003",
+        group_name: "Engineering",
+        computer_name: row.computer_name,
+        serial_number: row.serial_number,
+        model_name: row.model_name,
+        machine_type: row.machine_type,
+        domain: @posture_domain,
+        os_name: row.os_name,
+        os_revision: row.os_revision,
+        os_type: row.os_type,
+        os_arch: "64 bit",
+        os_username: login,
+        last_logged_in_user_name: login,
+        agent_version: "24.2.3.#{270 + rem(i, 9)}",
+        total_memory: 16_384 * (1 + rem(i, 2)),
+        cpu_count: 1,
+        core_count: Enum.at([8, 10, 12, 16], rem(i, 4)),
+        cpu_id: "Apple M3 Max",
+        external_ip: "203.0.113.#{20 + rem(i * 5, 200)}",
+        network_status: row.network_status,
+        is_active: row.network_status == "connected",
+        is_up_to_date: rem(i, 7) != 0,
+        infected: infected?,
+        active_threats: if(infected?, do: 1, else: 0),
+        threat_reboot_required: false,
+        encrypted_applications: true,
+        firewall_enabled: true,
+        scan_status: "finished",
+        scan_started_at: DateTime.add(now, -(2 + i), :day),
+        scan_finished_at: DateTime.add(now, -(2 + i), :day) |> DateTime.add(41, :minute),
+        last_successful_scan_at: DateTime.add(now, -(2 + i), :day),
+        mitigation_mode: "protect",
+        mitigation_mode_suspicious: "detect",
+        is_pending_uninstall: false,
+        is_uninstalled: false,
+        is_decommissioned: false,
+        registered_at: DateTime.add(now, -(160 + i * 6), :day),
+        last_active_at: DateTime.add(now, -(3 + i * 9), :minute),
+        network_interfaces: [
+          %{
+            "id" => "1845000000000#{String.pad_leading(Integer.to_string(i), 6, "0")}",
+            "name" => "en0",
+            "physical" => posture_mac(i),
+            "inet" => ["10.40.#{rem(i, 250)}.#{30 + rem(i * 3, 200)}"]
+          }
+        ],
+        tags: [],
+        synced_at: provider.synced_at
+      })
+      |> Repo.insert!()
+    end
+  end
+
+  defp posture_person(index) do
+    Enum.at(@posture_people, rem(index, length(@posture_people)))
+  end
+
+  # A DER-encoded X.509 name, which is how the portal stores a certificate
+  # issuer: a serial only identifies a certificate together with who issued it.
+  defp posture_issuer_der(common_name) do
+    :public_key.der_encode(
+      :Name,
+      {:rdnSequence, [[{:AttributeTypeAndValue, {2, 5, 4, 3}, {:utf8String, common_name}}]]}
+    )
+  end
+
+  defp posture_fingerprint(cert_serial) do
+    :sha256
+    |> :crypto.hash(cert_serial)
+    |> Base.encode16(case: :lower)
+    |> String.to_charlist()
+    |> Enum.chunk_every(2)
+    |> Enum.map_join(":", &List.to_string/1)
+  end
+
+  defp posture_mac(index) do
+    for offset <- 0..5 do
+      :io_lib.format("~2.16.0b", [rem(index * 37 + offset * 61 + 16, 256)]) |> List.to_string()
+    end
+    |> Enum.join(":")
+  end
+
+  defp apple_serial(index), do: "C02" <> serial_chunk(index * 7919, 9)
+  defp dell_tag(index), do: serial_chunk(index * 104_729, 7)
+  defp lenovo_serial(index), do: "PF" <> serial_chunk(index * 65_537, 6)
+
+  defp serial_chunk(value, size) do
+    base = length(@serial_alphabet)
+
+    {_remaining, characters} =
+      Enum.reduce(1..size, {value, []}, fn _position, {remaining, acc} ->
+        {div(remaining, base), [Enum.at(@serial_alphabet, rem(remaining, base)) | acc]}
+      end)
+
+    List.to_string(characters)
+  end
+
+  defp intune_hardware(index) do
+    case rem(index, 4) do
+      0 ->
+        {"Windows", "10.0.26100.2894", "Latitude 7450", "Dell Inc.", "windowsAzureADJoin",
+         dell_tag(index)}
+
+      1 ->
+        {"macOS", "15.6.1", "MacBook Air 15-inch (M3, 2024)", "Apple", "appleBulkWithUser",
+         apple_serial(index)}
+
+      2 ->
+        {"iOS", "18.6", "iPhone 15", "Apple", "appleUserEnrollment", apple_serial(index * 3)}
+
+      _ ->
+        {"Windows", "10.0.22631.4602", "ThinkPad X1 Carbon Gen 12", "LENOVO", "windowsAzureADJoin",
+         lenovo_serial(index)}
+    end
+  end
+
+  defp intune_prefix("Windows"), do: "ENG-WIN"
+  defp intune_prefix("macOS"), do: "ENG-MAC"
+  defp intune_prefix("iOS"), do: "ENG-IOS"
+  defp intune_prefix(_other), do: "ENG-DEV"
+
+  defp iru_hardware(index) do
+    case rem(index, 3) do
+      0 -> {"Mac", "macOS", "15.6.1", "MacBook Pro 14-inch", "Mac16,1"}
+      1 -> {"Mac", "macOS", "14.7.2", "MacBook Air", "Mac14,2"}
+      _ -> {"iPad", "iPadOS", "18.6", "iPad Pro 11-inch", "iPad16,3"}
+    end
+  end
+
+  defp defender_posture(index) do
+    case rem(index, 4) do
+      0 -> {"Windows11", "24H2", 26_100, "Active", "None", "Low"}
+      1 -> {"Windows10", "22H2", 19_045, "Active", "Low", "Medium"}
+      2 -> {"macOS", "15.6.1", 0, "Active", "Medium", "Medium"}
+      _ -> {"Linux", "24.04", 0, "Inactive", "None", "Low"}
+    end
+  end
+
+  defp defender_prefix("Windows11"), do: "eng-win11"
+  defp defender_prefix("Windows10"), do: "eng-win10"
+  defp defender_prefix("macOS"), do: "eng-mac"
+  defp defender_prefix(_other), do: "eng-linux"
+
+  defp sentinelone_hardware(index) do
+    case rem(index, 4) do
+      0 ->
+        {"Windows 11 Pro", "24H2", "windows", "Latitude 7450", "laptop", dell_tag(index * 11)}
+
+      1 ->
+        {"macOS", "15.6.1", "macos", "MacBookPro16,1", "laptop", apple_serial(index * 13)}
+
+      2 ->
+        {"Ubuntu", "24.04.2 LTS", "linux", "PowerEdge R660", "server", dell_tag(index * 19)}
+
+      _ ->
+        {"Windows Server 2022", "21H2", "windows", "PowerEdge R750", "server",
+         dell_tag(index * 23)}
+    end
+  end
+
+  defp sentinelone_prefix("windows"), do: "ENG-WIN"
+  defp sentinelone_prefix("macos"), do: "ENG-MAC"
+  defp sentinelone_prefix(_other), do: "ENG-LNX"
+
   def seed do
     # Seeds can be run both with MIX_ENV=prod and MIX_ENV=test, for test env we don't have
     # an adapter configured and creation of email provider will fail, so we will override it here.
@@ -1549,13 +2306,14 @@ defmodule Portal.Repo.Seeds do
         @ua_android
       )
 
-    {:ok, _user_windows_laptop} =
+    {:ok, user_windows_laptop} =
       create_client(
         %{
           name: "FZ User Surface",
           firezone_id: Ecto.UUID.generate(),
           public_key: :crypto.strong_rand_bytes(32) |> Base.encode64(),
           device_uuid: "WIN-#{Ecto.UUID.generate()}",
+          device_serial: "046120283253",
           ipv4: "100.64.0.12",
           ipv6: "fd00:2021:1111::12"
         },
@@ -1564,7 +2322,7 @@ defmodule Portal.Repo.Seeds do
         @ua_windows
       )
 
-    {:ok, _user_linux_laptop} =
+    {:ok, user_linux_laptop} =
       create_client(
         %{
           name: "FZ User Rendering Station",
@@ -1579,7 +2337,7 @@ defmodule Portal.Repo.Seeds do
         @ua_ubuntu
       )
 
-    {:ok, _admin_laptop} =
+    {:ok, admin_laptop} =
       create_client(
         %{
           name: "FZ Admin Laptop",
@@ -1622,6 +2380,13 @@ defmodule Portal.Repo.Seeds do
 
     IO.puts("Clients created")
     IO.puts("")
+
+    seed_device_posture(account, %{
+      admin_laptop: admin_laptop,
+      user_surface: user_windows_laptop,
+      user_iphone: user_iphone,
+      user_rendering_station: user_linux_laptop
+    })
 
     IO.puts("Created Groups: ")
 

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -7,6 +7,7 @@ defmodule PortalWeb.ClientsTest do
   import Portal.AccountFixtures
   import Portal.ActorFixtures
   import Portal.DefenderFixtures
+  import Portal.DevicePostureFixtures
   import Portal.IntuneFixtures
   import Portal.IruFixtures
   import Portal.SantaFixtures
@@ -148,6 +149,46 @@ defmodule PortalWeb.ClientsTest do
   end
 
   describe ":show action" do
+    test "cautions that the client reports its own device fields", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor, device_serial: "SN-SPOOFABLE")
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}")
+
+      assert html =~ "Reported by this Client"
+      assert html =~ "a malicious actor could spoof"
+      assert html =~ "X.509 Device Trust"
+      assert html =~ ~p"/#{account}/settings/trust_anchors"
+    end
+
+    test "drops the device trust call to action once the client has attested", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          device_serial: "SN-ATTESTED",
+          last_attested_at: DateTime.utc_now()
+        )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}")
+
+      assert html =~ "Reported by this Client"
+      refute html =~ "to strongly identify this device"
+    end
+
     test "renders client detail panel with device and network details", %{
       conn: conn,
       account: account,
@@ -716,11 +757,14 @@ defmodule PortalWeb.ClientsTest do
   end
 
   describe ":show action posture tab" do
-    test "hides the tab when no posture provider knows this client", %{
-      conn: conn,
-      account: account,
-      actor: actor
-    } do
+    setup do
+      enable_device_posture()
+      account = device_posture_account_fixture()
+      actor = admin_actor_fixture(account: account)
+      %{account: account, actor: actor}
+    end
+
+    test "offers the tab to every client", %{conn: conn, account: account, actor: actor} do
       client = client_fixture(account: account, actor: actor, device_serial: "UNKNOWN-SERIAL")
 
       {:ok, _lv, html} =
@@ -728,10 +772,26 @@ defmodule PortalWeb.ClientsTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/clients/#{client.id}")
 
-      refute html =~ "phx-value-tab=\"posture\""
+      assert html =~ "phx-value-tab=\"posture\""
     end
 
-    test "falls back to the overview when the tab is requested with no posture", %{
+    test "says so when a connected provider holds no record for the client", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      intune_posture_provider_fixture(account: account)
+      client = client_fixture(account: account, actor: actor, device_serial: "UNKNOWN-SERIAL")
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+
+      assert html =~ "No posture data was found for this device."
+    end
+
+    test "points at connecting a provider when the account has none", %{
       conn: conn,
       account: account,
       actor: actor
@@ -743,7 +803,23 @@ defmodule PortalWeb.ClientsTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
 
-      assert html =~ "Tunnel IPv4"
+      assert html =~ "Connect a posture provider"
+      assert html =~ ~p"/#{account}/settings/device_posture/new"
+    end
+
+    test "offers an upgrade when the account lacks the feature", %{conn: conn} do
+      account = account_fixture(features: %{device_posture: false})
+      actor = admin_actor_fixture(account: account)
+      client = client_fixture(account: account, actor: actor)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+
+      assert html =~ "Upgrade to unlock Device Posture"
+      assert html =~ "Upgrade to Unlock"
+      refute html =~ "No posture data was found for this device."
     end
 
     test "shows the Intune record matched on the attested MDM device id", %{
@@ -790,7 +866,7 @@ defmodule PortalWeb.ClientsTest do
       refute html =~ "android_security_patch_level"
     end
 
-    test "matches Intune on the Entra device id the certificate attested", %{
+    test "does not match Intune on the Entra device id of a record", %{
       conn: conn,
       account: account,
       actor: actor
@@ -817,8 +893,8 @@ defmodule PortalWeb.ClientsTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
 
-      assert html =~ "ENTRA-JOINED-01"
-      assert html =~ "Attested device ID"
+      refute html =~ "ENTRA-JOINED-01"
+      assert html =~ "No posture data was found for this device."
     end
 
     test "cautions when the match rests on the serial the client reports", %{
@@ -880,16 +956,21 @@ defmodule PortalWeb.ClientsTest do
       refute html =~ "Reported serial"
     end
 
-    test "shows the Defender record matched on the attested Entra device id", %{
+    test "reaches the Defender record through the Intune record's Entra device id", %{
       conn: conn,
       account: account,
       actor: actor
     } do
       entra_device_id = Ecto.UUID.generate()
-      provider = defender_posture_provider_fixture(account: account, name: "Defender Prod")
+
+      intune_device_fixture(
+        provider: intune_posture_provider_fixture(account: account, name: "Contoso Intune"),
+        intune_id: "managed-device-4",
+        entra_device_id: entra_device_id
+      )
 
       defender_device_fixture(
-        provider: provider,
+        provider: defender_posture_provider_fixture(account: account, name: "Defender Prod"),
         computer_dns_name: "eng-laptop-01.contoso.com",
         entra_device_id: entra_device_id,
         health_status: "Active"
@@ -899,7 +980,7 @@ defmodule PortalWeb.ClientsTest do
         client_fixture(
           account: account,
           actor: actor,
-          last_attested_mdm_device_id: entra_device_id,
+          last_attested_mdm_device_id: "managed-device-4",
           last_attested_cert_fingerprint: "fp-4"
         )
 
@@ -911,6 +992,34 @@ defmodule PortalWeb.ClientsTest do
       assert html =~ "Defender Prod"
       assert html =~ "eng-laptop-01.contoso.com"
       assert html =~ "Active"
+    end
+
+    test "leaves out a Defender record no Intune record links to the client", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      defender_device_fixture(
+        provider: defender_posture_provider_fixture(account: account, name: "Defender Prod"),
+        computer_dns_name: "unlinked-laptop.contoso.com",
+        entra_device_id: Ecto.UUID.generate()
+      )
+
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_mdm_device_id: Ecto.UUID.generate(),
+          last_attested_cert_fingerprint: "fp-8"
+        )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+
+      refute html =~ "unlinked-laptop.contoso.com"
+      assert html =~ "No posture data was found for this device."
     end
 
     test "shows the Santa record matched on serial", %{
@@ -1015,7 +1124,9 @@ defmodule PortalWeb.ClientsTest do
       account: account,
       actor: actor
     } do
-      other_account = account_fixture()
+      other_account = device_posture_account_fixture()
+
+      intune_posture_provider_fixture(account: account)
 
       intune_device_fixture(
         provider: intune_posture_provider_fixture(account: other_account),
@@ -1028,10 +1139,10 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
 
       refute html =~ "OTHER-ACCOUNT-01"
-      refute html =~ "phx-value-tab=\"posture\""
+      assert html =~ "No posture data was found for this device."
     end
 
     test "does not match a serial against a remote device id", %{
@@ -1095,6 +1206,112 @@ defmodule PortalWeb.ClientsTest do
         |> live(~p"/#{account}/clients")
 
       refute html =~ "logo-intune.svg"
+    end
+  end
+
+  describe "index serial column" do
+    setup do
+      enable_device_posture()
+      account = device_posture_account_fixture()
+      actor = admin_actor_fixture(account: account)
+      %{account: account, actor: actor}
+    end
+
+    test "shows the attested serial as proven", %{conn: conn, account: account, actor: actor} do
+      client_fixture(
+        account: account,
+        actor: actor,
+        last_attested_device_serial: "ATTESTED-SERIAL-1",
+        device_serial: "REPORTED-SERIAL-1"
+      )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients")
+
+      assert html =~ "ATTESTED-SERIAL-1"
+      refute html =~ "ri-lock-unlock-line"
+    end
+
+    test "shows the serial the MDM holds for the attested device id", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      intune_device_fixture(
+        provider: intune_posture_provider_fixture(account: account),
+        intune_id: "managed-device-serial",
+        serial_number: "MDM-HELD-SERIAL"
+      )
+
+      client_fixture(
+        account: account,
+        actor: actor,
+        last_attested_mdm_device_id: "managed-device-serial",
+        device_serial: "REPORTED-SERIAL-2"
+      )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients")
+
+      assert html =~ "MDM-HELD-SERIAL"
+      refute html =~ "ri-lock-unlock-line"
+    end
+
+    test "cautions about a serial the client reports about itself", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client_fixture(account: account, actor: actor, device_serial: "REPORTED-SERIAL-3")
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients")
+
+      assert html =~ "REPORTED-SERIAL-3"
+      assert html =~ "ri-lock-unlock-line"
+    end
+
+    test "falls back to the reported serial when the MDM holds none", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client_fixture(
+        account: account,
+        actor: actor,
+        last_attested_mdm_device_id: "managed-device-unknown",
+        device_serial: "REPORTED-SERIAL-4"
+      )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients")
+
+      assert html =~ "REPORTED-SERIAL-4"
+      assert html =~ "ri-lock-unlock-line"
+    end
+
+    test "leaves the column empty for a client with no serial at all", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client_fixture(account: account, actor: actor, name: "No Serial Client", device_serial: nil)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients")
+
+      assert html =~ "No Serial Client"
+      refute html =~ "ri-lock-unlock-line"
     end
   end
 

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -797,6 +797,23 @@ defmodule PortalWeb.ClientsTest do
       %{account: account, actor: actor}
     end
 
+    test "hides the tab while the feature is off for the deployment", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      enable_device_posture(false)
+      client = client_fixture(account: account, actor: actor)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+
+      refute html =~ "phx-value-tab=\"posture\""
+      assert html =~ "Tunnel IPv4"
+    end
+
     test "offers the tab to every client", %{conn: conn, account: account, actor: actor} do
       client = client_fixture(account: account, actor: actor, device_serial: "UNKNOWN-SERIAL")
 

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -141,7 +141,7 @@ defmodule PortalWeb.ClientsTest do
 
       assert has_element?(lv, "button[disabled]", "Verify")
       refute has_element?(lv, "button[phx-click='verify_client']")
-      assert render(lv) =~ "This device is already attested through X.509 Device Trust."
+      assert render(lv) =~ "This device is already attested through an X.509 certificate."
     end
 
     test "orders by name and opens the panel from row click", %{
@@ -192,8 +192,8 @@ defmodule PortalWeb.ClientsTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/clients/#{client.id}")
 
-      assert html =~ "Self-Reported"
-      assert html =~ "The Firezone Client supplies these values"
+      assert html =~ "Reported by Client"
+      assert html =~ "The Firezone Client reads and reports these values."
       assert html =~ "X.509 Device Trust"
       assert html =~ ~p"/#{account}/settings/trust_anchors"
     end
@@ -216,7 +216,7 @@ defmodule PortalWeb.ClientsTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/clients/#{client.id}")
 
-      assert html =~ "Self-Reported"
+      assert html =~ "Reported by Client"
       refute html =~ "to strongly identify this device"
     end
 
@@ -269,7 +269,7 @@ defmodule PortalWeb.ClientsTest do
       assert html =~ "Open remote IP location in Google Maps"
       assert html =~ "Tunnel IPv4"
       assert html =~ "Tunnel IPv6"
-      assert html =~ "Verification"
+      assert html =~ "Trust Status"
       assert html =~ "Verified"
       assert html =~ session.last_seen_version
 

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -142,6 +142,7 @@ defmodule PortalWeb.ClientsTest do
       assert has_element?(lv, "button[disabled]", "Verify")
       refute has_element?(lv, "button[phx-click='verify_client']")
       assert render(lv) =~ "This device is already attested through an X.509 certificate."
+      assert render(lv) =~ "This device is attested through an X.509 certificate."
     end
 
     test "orders by name and opens the panel from row click", %{
@@ -269,7 +270,8 @@ defmodule PortalWeb.ClientsTest do
       assert html =~ "Open remote IP location in Google Maps"
       assert html =~ "Tunnel IPv4"
       assert html =~ "Tunnel IPv6"
-      assert html =~ "Trust Status"
+      assert html =~ "Trust level"
+      assert html =~ "An admin vouched for the values this Client reports."
       assert html =~ "Verified"
       assert html =~ session.last_seen_version
 

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -6,6 +6,11 @@ defmodule PortalWeb.ClientsTest do
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
+  import Portal.DefenderFixtures
+  import Portal.IntuneFixtures
+  import Portal.IruFixtures
+  import Portal.SantaFixtures
+  import Portal.SentinelOneFixtures
   import Portal.DeviceFixtures
   import Portal.ClientSessionFixtures
   import Portal.GroupFixtures
@@ -708,5 +713,545 @@ defmodule PortalWeb.ClientsTest do
       assert html =~ "0"
       assert html =~ "Total"
     end
+  end
+
+  describe ":show action posture tab" do
+    test "hides the tab when no posture provider knows this client", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor, device_serial: "UNKNOWN-SERIAL")
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}")
+
+      refute html =~ "phx-value-tab=\"posture\""
+    end
+
+    test "falls back to the overview when the tab is requested with no posture", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+
+      assert html =~ "Tunnel IPv4"
+    end
+
+    test "shows the Intune record matched on the attested MDM device id", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      provider = intune_posture_provider_fixture(account: account, name: "Contoso Intune")
+
+      device =
+        intune_device_fixture(
+          provider: provider,
+          intune_id: "managed-device-1",
+          device_name: "ENG-LAPTOP-01",
+          serial_number: "INTUNE-1234",
+          compliance_state: "compliant"
+        )
+
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_mdm_device_id: "managed-device-1",
+          last_attested_cert_fingerprint: "fp-1"
+        )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+
+      assert html =~ "Contoso Intune"
+      assert html =~ "Microsoft Intune"
+      assert html =~ device.device_name
+      assert html =~ "INTUNE-1234"
+      assert html =~ "compliant"
+      assert html =~ "Attested device ID"
+      refute html =~ "Reported serial"
+
+      # Columns the summary grid leaves out are still in the copy-paste blob.
+      assert html =~ "Provider record"
+      assert html =~ "management_agent"
+      # Columns the provider left empty are not.
+      refute html =~ "android_security_patch_level"
+    end
+
+    test "matches Intune on the Entra device id the certificate attested", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      entra_device_id = Ecto.UUID.generate()
+      provider = intune_posture_provider_fixture(account: account)
+
+      intune_device_fixture(
+        provider: provider,
+        device_name: "ENTRA-JOINED-01",
+        entra_device_id: entra_device_id
+      )
+
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_mdm_device_id: entra_device_id,
+          last_attested_cert_fingerprint: "fp-2"
+        )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+
+      assert html =~ "ENTRA-JOINED-01"
+      assert html =~ "Attested device ID"
+    end
+
+    test "cautions when the match rests on the serial the client reports", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      provider = intune_posture_provider_fixture(account: account)
+
+      intune_device_fixture(
+        provider: provider,
+        device_name: "SELF-REPORTED-01",
+        serial_number: "SPOOFABLE-1"
+      )
+
+      client = client_fixture(account: account, actor: actor, device_serial: "SPOOFABLE-1")
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+
+      assert html =~ "SELF-REPORTED-01"
+      assert html =~ "Reported serial"
+      assert html =~ "spoofed by a malicious actor"
+      assert html =~ ~p"/#{account}/settings/trust_anchors"
+    end
+
+    test "prefers the attested serial over the reported one", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      provider = iru_posture_provider_fixture(account: account, name: "Iru Prod")
+
+      iru_device_fixture(
+        provider: provider,
+        device_name: "MACBOOK-01",
+        serial_number: "ATTESTED-1"
+      )
+
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_device_serial: "ATTESTED-1",
+          device_serial: "ATTESTED-1",
+          last_attested_cert_fingerprint: "fp-3"
+        )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+
+      assert html =~ "Iru Prod"
+      assert html =~ "MACBOOK-01"
+      assert html =~ "Attested serial"
+      refute html =~ "Reported serial"
+    end
+
+    test "shows the Defender record matched on the attested Entra device id", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      entra_device_id = Ecto.UUID.generate()
+      provider = defender_posture_provider_fixture(account: account, name: "Defender Prod")
+
+      defender_device_fixture(
+        provider: provider,
+        computer_dns_name: "eng-laptop-01.contoso.com",
+        entra_device_id: entra_device_id,
+        health_status: "Active"
+      )
+
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_mdm_device_id: entra_device_id,
+          last_attested_cert_fingerprint: "fp-4"
+        )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+
+      assert html =~ "Defender Prod"
+      assert html =~ "eng-laptop-01.contoso.com"
+      assert html =~ "Active"
+    end
+
+    test "shows the Santa record matched on serial", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      provider = santa_posture_provider_fixture(account: account, name: "Santa Prod")
+
+      santa_device_fixture(
+        provider: provider,
+        hostname: "santa-macbook-01",
+        serial_number: "SANTA-1"
+      )
+
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_device_serial: "SANTA-1",
+          last_attested_cert_fingerprint: "fp-5"
+        )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+
+      assert html =~ "Santa Prod"
+      assert html =~ "santa-macbook-01"
+    end
+
+    test "shows the SentinelOne record matched on serial", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      provider = sentinelone_posture_provider_fixture(account: account, name: "S1 Prod")
+
+      sentinelone_device_fixture(
+        provider: provider,
+        computer_name: "s1-endpoint-01",
+        serial_number: "S1-1"
+      )
+
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_device_serial: "S1-1",
+          last_attested_cert_fingerprint: "fp-7"
+        )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+
+      assert html =~ "S1 Prod"
+      assert html =~ "s1-endpoint-01"
+      assert html =~ "Attested serial"
+    end
+
+    test "renders one section per provider that knows the device", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      mdm_device_id = Ecto.UUID.generate()
+
+      intune_device_fixture(
+        provider: intune_posture_provider_fixture(account: account, name: "Contoso Intune"),
+        intune_id: mdm_device_id,
+        serial_number: "SHARED-1"
+      )
+
+      santa_device_fixture(
+        provider: santa_posture_provider_fixture(account: account, name: "Santa Prod"),
+        serial_number: "SHARED-1"
+      )
+
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_mdm_device_id: mdm_device_id,
+          last_attested_device_serial: "SHARED-1",
+          last_attested_cert_fingerprint: "fp-6"
+        )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+
+      assert html =~ "Contoso Intune"
+      assert html =~ "Santa Prod"
+    end
+
+    test "does not match posture belonging to another account", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      other_account = account_fixture()
+
+      intune_device_fixture(
+        provider: intune_posture_provider_fixture(account: other_account),
+        device_name: "OTHER-ACCOUNT-01",
+        serial_number: "SHARED-SERIAL"
+      )
+
+      client = client_fixture(account: account, actor: actor, device_serial: "SHARED-SERIAL")
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}")
+
+      refute html =~ "OTHER-ACCOUNT-01"
+      refute html =~ "phx-value-tab=\"posture\""
+    end
+
+    test "does not match a serial against a remote device id", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      intune_device_fixture(
+        provider: intune_posture_provider_fixture(account: account),
+        intune_id: "COLLIDING-VALUE",
+        device_name: "WRONG-COLUMN-01",
+        serial_number: "INTUNE-OWN-SERIAL"
+      )
+
+      client = client_fixture(account: account, actor: actor, device_serial: "COLLIDING-VALUE")
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}")
+
+      refute html =~ "WRONG-COLUMN-01"
+    end
+
+    test "badges the providers that know each client in the list", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      intune_device_fixture(
+        provider: intune_posture_provider_fixture(account: account),
+        serial_number: "LIST-SERIAL-1"
+      )
+
+      client_fixture(
+        account: account,
+        actor: actor,
+        name: "Inventoried Client",
+        device_serial: "LIST-SERIAL-1"
+      )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients")
+
+      assert html =~ "logo-intune.svg"
+    end
+
+    test "leaves the list badge empty for a client no provider knows", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      intune_posture_provider_fixture(account: account)
+      client_fixture(account: account, actor: actor, device_serial: "NOT-IN-INVENTORY")
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients")
+
+      refute html =~ "logo-intune.svg"
+    end
+  end
+
+  describe ":show action certificate section" do
+    test "omits the section for a client that never attested", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}")
+
+      refute html =~ "SHA-256 Fingerprint"
+    end
+
+    test "reports an unknown status when nothing has been published", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_cert_fingerprint: "ab:cd",
+          last_attested_cert_serial: "01",
+          last_attested_cert_issuer: issuer_der("Unpublished CA")
+        )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}")
+
+      assert html =~ "SHA-256 Fingerprint"
+      assert html =~ "Unpublished CA"
+      assert html =~ "Unknown"
+    end
+
+    test "reports a revoked certificate from the issuer's list", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      issuer = issuer_der("Revoking CA")
+
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_cert_fingerprint: "ab:cd",
+          last_attested_cert_serial: "02",
+          last_attested_cert_issuer: issuer
+        )
+
+      Repo.insert!(%Portal.CrlRevocation{
+        account_id: account.id,
+        issuer: issuer,
+        serial: "02",
+        distribution_point: "http://crl.example.test/ca.crl",
+        revoked_at: DateTime.utc_now() |> DateTime.truncate(:second),
+        reason: "keyCompromise"
+      })
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}")
+
+      assert html =~ "Revoked"
+      assert html =~ "keyCompromise"
+    end
+
+    test "reports a good certificate from the issuer's responder", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      issuer = issuer_der("Responding CA")
+
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_cert_fingerprint: "ab:cd",
+          last_attested_cert_serial: "03",
+          last_attested_cert_issuer: issuer
+        )
+
+      Repo.insert!(%Portal.OcspStatus{
+        account_id: account.id,
+        issuer: issuer,
+        serial: "03",
+        status: "good",
+        next_update: DateTime.utc_now() |> DateTime.add(1, :day) |> DateTime.truncate(:second),
+        updated_at: DateTime.utc_now()
+      })
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}")
+
+      assert html =~ "Valid"
+    end
+
+    test "a published revocation outranks a responder that still says good", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      issuer = issuer_der("Disagreeing CA")
+
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_cert_fingerprint: "ab:cd",
+          last_attested_cert_serial: "04",
+          last_attested_cert_issuer: issuer
+        )
+
+      Repo.insert!(%Portal.OcspStatus{
+        account_id: account.id,
+        issuer: issuer,
+        serial: "04",
+        status: "good",
+        updated_at: DateTime.utc_now()
+      })
+
+      Repo.insert!(%Portal.CrlRevocation{
+        account_id: account.id,
+        issuer: issuer,
+        serial: "04",
+        distribution_point: "http://crl.example.test/ca.crl",
+        revoked_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}")
+
+      assert html =~ "Revoked"
+      refute html =~ "Valid"
+    end
+  end
+
+  defp issuer_der(common_name) do
+    :public_key.der_encode(
+      :Name,
+      {:rdnSequence,
+       [[{:AttributeTypeAndValue, {2, 5, 4, 3}, {:utf8String, common_name}}]]}
+    )
   end
 end

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -89,28 +89,59 @@ defmodule PortalWeb.ClientsTest do
       end
     end
 
-    test "renders verified and unverified client states", %{
+    test "filters by attestation level", %{conn: conn, account: account, actor: actor} do
+      verified_actor = actor_fixture(account: account, name: "Verified Owner")
+
+      verified = verified_client_fixture(%{account: account, actor: verified_actor, name: "Work Mac"})
+
+      attested =
+        client_fixture(
+          account: account,
+          actor: actor,
+          name: "Attested Mac",
+          last_attested_at: DateTime.utc_now()
+        )
+
+      plain = client_fixture(account: account, actor: actor, name: "Lab Box")
+      conn = authorize_conn(conn, actor)
+
+      for {level, shown, hidden} <- [
+            {"verified", verified, [attested, plain]},
+            {"attested", attested, [verified, plain]},
+            {"none", plain, [verified, attested]}
+          ] do
+        {:ok, _lv, html} =
+          live(conn, ~p"/#{account}/clients?#{%{"clients_filter[attestation]" => level}}")
+
+        assert html =~ shown.name
+
+        for client <- hidden do
+          refute html =~ client.name
+        end
+      end
+    end
+
+    test "a client that attested cannot be verified by hand", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      verified_actor = actor_fixture(account: account, name: "Verified Owner")
-
-      verified_client =
-        verified_client_fixture(%{account: account, actor: verified_actor, name: "Work Mac"})
-
-      unverified_client = client_fixture(account: account, actor: actor, name: "Lab Box")
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          name: "Attested Mac",
+          last_attested_at: DateTime.utc_now()
+        )
 
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
+        |> live(~p"/#{account}/clients/#{client.id}")
 
-      html = render(lv)
-      assert html =~ verified_client.name
-      assert html =~ unverified_client.name
-      assert has_element?(lv, "#client-#{verified_client.id}", "Verified")
-      assert has_element?(lv, "#client-#{unverified_client.id}", "Unverified")
+      assert has_element?(lv, "button[disabled]", "Verify")
+      refute has_element?(lv, "button[phx-click='verify_client']")
+      assert render(lv) =~ "This device is already attested through X.509 Device Trust."
     end
 
     test "orders by name and opens the panel from row click", %{
@@ -1167,46 +1198,6 @@ defmodule PortalWeb.ClientsTest do
       refute html =~ "WRONG-COLUMN-01"
     end
 
-    test "badges the providers that know each client in the list", %{
-      conn: conn,
-      account: account,
-      actor: actor
-    } do
-      intune_device_fixture(
-        provider: intune_posture_provider_fixture(account: account),
-        serial_number: "LIST-SERIAL-1"
-      )
-
-      client_fixture(
-        account: account,
-        actor: actor,
-        name: "Inventoried Client",
-        device_serial: "LIST-SERIAL-1"
-      )
-
-      {:ok, _lv, html} =
-        conn
-        |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
-
-      assert html =~ "logo-intune.svg"
-    end
-
-    test "leaves the list badge empty for a client no provider knows", %{
-      conn: conn,
-      account: account,
-      actor: actor
-    } do
-      intune_posture_provider_fixture(account: account)
-      client_fixture(account: account, actor: actor, device_serial: "NOT-IN-INVENTORY")
-
-      {:ok, _lv, html} =
-        conn
-        |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
-
-      refute html =~ "logo-intune.svg"
-    end
   end
 
   describe "index serial column" do
@@ -1217,24 +1208,30 @@ defmodule PortalWeb.ClientsTest do
       %{account: account, actor: actor}
     end
 
-    test "shows the attested serial as proven", %{conn: conn, account: account, actor: actor} do
-      client_fixture(
-        account: account,
-        actor: actor,
-        last_attested_device_serial: "ATTESTED-SERIAL-1",
-        device_serial: "REPORTED-SERIAL-1"
-      )
+    test "marks an attested serial with the device trust icon", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_device_serial: "ATTESTED-SERIAL-1",
+          device_serial: "REPORTED-SERIAL-1"
+        )
 
-      {:ok, _lv, html} =
+      {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/clients")
 
       assert html =~ "ATTESTED-SERIAL-1"
-      refute html =~ "ri-lock-unlock-line"
+      refute html =~ "REPORTED-SERIAL-1"
+      assert has_element?(lv, "#client-#{client.id} .ri-shield-keyhole-line")
     end
 
-    test "shows the serial the MDM holds for the attested device id", %{
+    test "marks a serial the MDM holds with that provider's icon", %{
       conn: conn,
       account: account,
       actor: actor
@@ -1245,36 +1242,40 @@ defmodule PortalWeb.ClientsTest do
         serial_number: "MDM-HELD-SERIAL"
       )
 
-      client_fixture(
-        account: account,
-        actor: actor,
-        last_attested_mdm_device_id: "managed-device-serial",
-        device_serial: "REPORTED-SERIAL-2"
-      )
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_mdm_device_id: "managed-device-serial",
+          device_serial: "REPORTED-SERIAL-2"
+        )
 
-      {:ok, _lv, html} =
+      {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/clients")
 
       assert html =~ "MDM-HELD-SERIAL"
-      refute html =~ "ri-lock-unlock-line"
+      refute html =~ "REPORTED-SERIAL-2"
+      assert has_element?(lv, "#client-#{client.id} img[src*='logo-intune']")
+      refute has_element?(lv, "#client-#{client.id} .ri-shield-keyhole-line")
     end
 
-    test "cautions about a serial the client reports about itself", %{
+    test "leaves a serial the client reports about itself unmarked", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      client_fixture(account: account, actor: actor, device_serial: "REPORTED-SERIAL-3")
+      client = client_fixture(account: account, actor: actor, device_serial: "REPORTED-SERIAL-3")
 
-      {:ok, _lv, html} =
+      {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/clients")
 
       assert html =~ "REPORTED-SERIAL-3"
-      assert html =~ "ri-lock-unlock-line"
+      refute has_element?(lv, "#client-#{client.id} .ri-shield-keyhole-line")
+      refute has_element?(lv, "#client-#{client.id} img[src*='logo-intune']")
     end
 
     test "falls back to the reported serial when the MDM holds none", %{
@@ -1282,20 +1283,21 @@ defmodule PortalWeb.ClientsTest do
       account: account,
       actor: actor
     } do
-      client_fixture(
-        account: account,
-        actor: actor,
-        last_attested_mdm_device_id: "managed-device-unknown",
-        device_serial: "REPORTED-SERIAL-4"
-      )
+      client =
+        client_fixture(
+          account: account,
+          actor: actor,
+          last_attested_mdm_device_id: "managed-device-unknown",
+          device_serial: "REPORTED-SERIAL-4"
+        )
 
-      {:ok, _lv, html} =
+      {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/clients")
 
       assert html =~ "REPORTED-SERIAL-4"
-      assert html =~ "ri-lock-unlock-line"
+      refute has_element?(lv, "#client-#{client.id} .ri-shield-keyhole-line")
     end
 
     test "leaves the column empty for a client with no serial at all", %{
@@ -1303,15 +1305,16 @@ defmodule PortalWeb.ClientsTest do
       account: account,
       actor: actor
     } do
-      client_fixture(account: account, actor: actor, name: "No Serial Client", device_serial: nil)
+      client =
+        client_fixture(account: account, actor: actor, name: "No Serial Client", device_serial: nil)
 
-      {:ok, _lv, html} =
+      {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/clients")
 
       assert html =~ "No Serial Client"
-      refute html =~ "ri-lock-unlock-line"
+      refute has_element?(lv, "#client-#{client.id} .ri-shield-keyhole-line")
     end
   end
 

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -192,8 +192,8 @@ defmodule PortalWeb.ClientsTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/clients/#{client.id}")
 
-      assert html =~ "Reported by this Client"
-      assert html =~ "a malicious actor could spoof"
+      assert html =~ "Self-Reported"
+      assert html =~ "The Firezone Client supplies these values"
       assert html =~ "X.509 Device Trust"
       assert html =~ ~p"/#{account}/settings/trust_anchors"
     end
@@ -216,7 +216,7 @@ defmodule PortalWeb.ClientsTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/clients/#{client.id}")
 
-      assert html =~ "Reported by this Client"
+      assert html =~ "Self-Reported"
       refute html =~ "to strongly identify this device"
     end
 
@@ -888,7 +888,7 @@ defmodule PortalWeb.ClientsTest do
       assert html =~ "INTUNE-1234"
       assert html =~ "compliant"
       assert html =~ "Attested device ID"
-      refute html =~ "Reported serial"
+      refute html =~ "Self-reported serial"
 
       # Columns the summary grid leaves out are still in the copy-paste blob.
       assert html =~ "Provider record"
@@ -949,8 +949,8 @@ defmodule PortalWeb.ClientsTest do
         |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
 
       assert html =~ "SELF-REPORTED-01"
-      assert html =~ "Reported serial"
-      assert html =~ "spoofed by a malicious actor"
+      assert html =~ "Self-reported serial"
+      assert html =~ "Matched on a self-reported serial number"
       assert html =~ ~p"/#{account}/settings/trust_anchors"
     end
 
@@ -984,7 +984,7 @@ defmodule PortalWeb.ClientsTest do
       assert html =~ "Iru Prod"
       assert html =~ "MACBOOK-01"
       assert html =~ "Attested serial"
-      refute html =~ "Reported serial"
+      refute html =~ "Self-reported serial"
     end
 
     test "reaches the Defender record through the Intune record's Entra device id", %{

--- a/elixir/test/support/fixtures/sentinel_one_fixtures.ex
+++ b/elixir/test/support/fixtures/sentinel_one_fixtures.ex
@@ -45,6 +45,7 @@ defmodule Portal.SentinelOneFixtures do
       sentinelone_id: Map.get(attrs, :sentinelone_id, Integer.to_string(unique)),
       uuid: Map.get(attrs, :uuid, Ecto.UUID.generate()),
       computer_name: Map.get(attrs, :computer_name, "endpoint-#{unique}"),
+      serial_number: Map.get(attrs, :serial_number, "S1-SERIAL-#{unique}"),
       os_name: Map.get(attrs, :os_name, "Windows 11"),
       os_type: Map.get(attrs, :os_type, "windows"),
       agent_version: Map.get(attrs, :agent_version, "24.1.4.257"),


### PR DESCRIPTION
Firezone already syncs a device list from Intune, Iru, Defender, Santa and SentinelOne, but there was nowhere to look at it. A Client now has a Posture tab showing what each of those tools knows about that one device, with the raw record as JSON underneath so you can paste it into a ticket. The tab stays hidden until the global `device_posture` flag is on.

Firezone and your MDM keep separate lists, so we have to line them up. We try three IDs, best first: the MDM device ID from the device's certificate, then the hardware serial from that certificate, then the serial the Client told us about itself. The first two came off a certificate and are hard to fake. The third is only what the software on the device said, so we show it and label it. Defender is the odd one out. It has no ID a certificate can carry and no serial either, so we find the Intune record first and use the Entra device ID on it to reach the Defender machine.

The Clients list loses its Trust and Posture columns and gains a Serial column that covers both. A small icon says where that serial came from: a shield if the certificate proved it, your MDM's logo if the MDM has it on file, and no icon at all if only the Client claims it. The Verified filter becomes a Trust level dropdown: Verified, Attested, or None. A device that already proved itself with a certificate can no longer be verified by hand, because that would add nothing. The button is greyed out and says why.

The panel also shows the certificate a Client last used and whether the issuer has since revoked it.

Three other screens rendered JSON their own way, so they now share the viewer this adds: the two AWS policies in the log sink setup, which had no copy button, and the Okta public key.

Seeds create all five providers, switched off so nothing tries to sync with made-up credentials, plus enough fake inventory to see every kind of match and every certificate state while working locally.
