### PR TITLE
test(android): end-to-end tests against a scripted connlib

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -270,6 +270,7 @@ dependencies {
     val composeBom = platform("androidx.compose:compose-bom:2026.08.00")
     implementation(composeBom)
     androidTestImplementation(composeBom)
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/di/TestAppModule.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/di/TestAppModule.kt
@@ -1,0 +1,32 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.core.di
+
+import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.res.Resources
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import javax.inject.Singleton
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [AppModule::class],
+)
+object TestAppModule {
+    @Provides
+    internal fun provideContext(app: Application): Context = app.applicationContext
+
+    @Provides
+    internal fun provideResources(app: Application): Resources = app.resources
+
+    // Plain preferences rather than the encrypted ones: tests need to wipe them between runs,
+    // and nothing here is worth a keystore round-trip.
+    @Provides
+    @Singleton
+    internal fun provideSharedPreferences(app: Application): SharedPreferences =
+        app.getSharedPreferences("test_preferences", Context.MODE_PRIVATE)
+}

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/di/TestDataModule.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/di/TestDataModule.kt
@@ -1,0 +1,35 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.core.di
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Bundle
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import dev.firezone.android.core.data.Repository
+import dev.firezone.android.tunnel.TestRestrictions
+import kotlinx.coroutines.CoroutineDispatcher
+import javax.inject.Singleton
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [DataModule::class],
+)
+object TestDataModule {
+    // The real restrictions come from `RestrictionsManager`, which stays empty until a device
+    // owner sets them. Tests write into this bundle instead to stand in for a managed config.
+    @Provides
+    internal fun provideApplicationRestrictions(): Bundle = TestRestrictions.bundle
+
+    @Provides
+    @Singleton
+    internal fun provideRepository(
+        @ApplicationContext context: Context,
+        @IoDispatcher coroutineDispatcher: CoroutineDispatcher,
+        sharedPreferences: SharedPreferences,
+    ): Repository = Repository(context, coroutineDispatcher, sharedPreferences)
+}

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/di/TestTunnelModule.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/di/TestTunnelModule.kt
@@ -1,0 +1,19 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.core.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import dev.firezone.android.tunnel.FakeSessionFactory
+import dev.firezone.android.tunnel.SessionFactory
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [TunnelModule::class],
+)
+object TestTunnelModule {
+    @Provides
+    internal fun provideSessionFactory(): SessionFactory = FakeSessionFactory
+}

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
@@ -6,7 +6,7 @@ import android.app.NotificationManager
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
@@ -1,0 +1,233 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.e2e
+
+import android.content.SharedPreferences
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dev.firezone.android.core.data.Repository
+import dev.firezone.android.features.session.ui.SessionActivity
+import dev.firezone.android.tunnel.FakeDisconnectError
+import dev.firezone.android.tunnel.FakeSession
+import dev.firezone.android.tunnel.FakeSessionFactory
+import dev.firezone.android.tunnel.TestRestrictions
+import dev.firezone.android.tunnel.connectedDevice
+import dev.firezone.android.tunnel.dnsResource
+import dev.firezone.android.tunnel.grantVpnConsent
+import dev.firezone.android.tunnel.internetResource
+import dev.firezone.android.tunnel.startTunnelService
+import dev.firezone.android.tunnel.stopTunnelService
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import uniffi.connlib.ConnlibException
+import uniffi.connlib.Event
+import uniffi.connlib.NoHandle
+import javax.inject.Inject
+
+// End-to-end through the real app: a signed-in device starts the real `TunnelService`, and the
+// only thing standing in for production is connlib itself. What the fake session emits has to
+// come out the other end on screen, and what the screen does has to reach the fake session.
+@HiltAndroidTest
+class TunnelE2eTest {
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeRule = createEmptyComposeRule()
+
+    @Inject
+    lateinit var repo: Repository
+
+    @Inject
+    lateinit var preferences: SharedPreferences
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+        grantVpnConsent()
+        // Ending the last test's sessions first is what lets its service finish and stop.
+        FakeSessionFactory.reset()
+        stopTunnelService()
+        preferences.edit().clear().commit()
+        TestRestrictions.bundle.clear()
+    }
+
+    @Test
+    fun resourcesReachTheScreen() {
+        val session = signInAndConnect()
+
+        session.emit(
+            Event.ResourcesUpdated(
+                resources = listOf(dnsResource(name = "GitLab")),
+                connectedDevices = emptyList(),
+            ),
+        )
+
+        onSessionScreen {
+            awaitText("GitLab")
+            composeRule.onNodeWithText("gitlab.example.com").assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun connectedDevicesReachTheScreen() {
+        val session = signInAndConnect()
+
+        session.emit(
+            Event.ResourcesUpdated(
+                resources = listOf(dnsResource(name = "GitLab")),
+                connectedDevices = listOf(connectedDevice(name = "Ada's Laptop")),
+            ),
+        )
+
+        onSessionScreen {
+            awaitText("Ada's Laptop")
+            composeRule.onNodeWithText("Connected Devices").assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun theActorNameReachesTheProfileMenu() {
+        val session = signInAndConnect()
+
+        session.emit(Event.ConnectedToPortal(accountSlug = "acme", actorName = "Ada Lovelace"))
+
+        onSessionScreen {
+            // The top bar shows the initial; the name itself is behind the menu.
+            awaitText("A")
+            composeRule.onNodeWithText("A").performClick()
+            awaitText("Ada Lovelace")
+        }
+    }
+
+    @Test
+    fun aResourceUpdateAfterTheScreenIsOpenReachesIt() {
+        val session = signInAndConnect()
+
+        onSessionScreen {
+            session.emit(
+                Event.ResourcesUpdated(
+                    resources = listOf(dnsResource(name = "GitLab")),
+                    connectedDevices = emptyList(),
+                ),
+            )
+            awaitText("GitLab")
+        }
+    }
+
+    @Test
+    fun enablingTheInternetResourceReachesConnlib() {
+        val session = signInAndConnect()
+
+        session.emit(
+            Event.ResourcesUpdated(
+                resources = listOf(internetResource()),
+                connectedDevices = emptyList(),
+            ),
+        )
+
+        onSessionScreen {
+            awaitText("Internet Resource", substring = true)
+            composeRule.onNodeWithText("Internet Resource", substring = true).performClick()
+            awaitText("Enable this resource")
+            composeRule.onNodeWithText("Enable this resource").performClick()
+
+            runBlocking {
+                withTimeout(TIMEOUT_MS) { session.awaitCommand("setInternetResourceState=true") }
+            }
+        }
+    }
+
+    @Test
+    fun aShutdownClosesTheScreen() {
+        val session = signInAndConnect()
+
+        ActivityScenario.launch(SessionActivity::class.java).use { scenario ->
+            composeRule.waitUntil(TIMEOUT_MS) { scenario.state == Lifecycle.State.RESUMED }
+
+            session.emit(Event.Disconnected(FakeDisconnectError(signInRequired = false)))
+
+            composeRule.waitUntil(TIMEOUT_MS) { scenario.state == Lifecycle.State.DESTROYED }
+            assertEquals(TOKEN, repo.getTokenSync())
+        }
+    }
+
+    @Test
+    fun aShutdownThatRequiresSigningInAgainDiscardsTheToken() {
+        val session = signInAndConnect()
+
+        ActivityScenario.launch(SessionActivity::class.java).use { scenario ->
+            composeRule.waitUntil(TIMEOUT_MS) { scenario.state == Lifecycle.State.RESUMED }
+
+            session.emit(Event.Disconnected(FakeDisconnectError(signInRequired = true)))
+
+            composeRule.waitUntil(TIMEOUT_MS) { scenario.state == Lifecycle.State.DESTROYED }
+            assertNull(repo.getTokenSync())
+        }
+    }
+
+    @Test
+    fun aConnlibThatRefusesToStartClosesTheScreen() {
+        FakeSessionFactory.failWith = { ConnlibException(NoHandle) }
+        signIn()
+        startTunnelService()
+
+        ActivityScenario.launch(SessionActivity::class.java).use { scenario ->
+            composeRule.waitUntil(TIMEOUT_MS) { scenario.state == Lifecycle.State.DESTROYED }
+        }
+    }
+
+    @Test
+    fun aManagedTokenAndDeviceNameReachConnlib() {
+        signIn()
+        TestRestrictions.bundle.putString("token", "managed-token")
+        TestRestrictions.bundle.putString("deviceName", "Managed Pixel")
+
+        startTunnelService()
+        val session = awaitSession()
+
+        assertEquals("managed-token", session.config.token)
+        assertEquals("Managed Pixel", session.config.deviceName)
+    }
+
+    private fun signInAndConnect(): FakeSession {
+        signIn()
+        startTunnelService()
+
+        return awaitSession()
+    }
+
+    private fun signIn() = runBlocking { repo.saveToken(TOKEN).first() }
+
+    private fun awaitSession(): FakeSession = runBlocking { withTimeout(TIMEOUT_MS) { FakeSessionFactory.awaitSession() } }
+
+    private fun onSessionScreen(block: () -> Unit) {
+        ActivityScenario.launch(SessionActivity::class.java).use { block() }
+    }
+
+    private fun awaitText(
+        text: String,
+        substring: Boolean = false,
+    ) {
+        composeRule.waitUntil(TIMEOUT_MS) {
+            composeRule.onAllNodesWithText(text, substring = substring).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private companion object {
+        const val TOKEN = "stored-token"
+        const val TIMEOUT_MS = 20_000L
+    }
+}

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
@@ -26,6 +26,7 @@ import dev.firezone.android.tunnel.grantNotificationPermission
 import dev.firezone.android.tunnel.grantVpnConsent
 import dev.firezone.android.tunnel.internetResource
 import dev.firezone.android.tunnel.launchApp
+import dev.firezone.android.tunnel.resumedActivity
 import dev.firezone.android.tunnel.startTunnelService
 import dev.firezone.android.tunnel.stopTunnelService
 import kotlinx.coroutines.flow.first
@@ -39,6 +40,7 @@ import org.junit.Test
 import uniffi.connlib.ConnlibException
 import uniffi.connlib.Event
 import uniffi.connlib.NoHandle
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 // End-to-end through the real app, entered the way a user enters it: the launcher activity, the
@@ -224,16 +226,33 @@ class TunnelE2eTest {
     private fun awaitText(
         text: String,
         substring: Boolean = false,
-    ) {
-        composeRule.waitUntil(TIMEOUT_MS) {
+    ) = await("\"$text\" on screen") {
+        // The splash screen is a View, so there are moments with no Compose content at all, which
+        // `fetchSemanticsNodes` reports as an error rather than as an empty screen.
+        runCatching {
             composeRule.onAllNodesWithText(text, substring = substring).fetchSemanticsNodes().isNotEmpty()
-        }
+        }.getOrDefault(false)
     }
 
     private fun awaitDisconnectedNotification(): String? {
-        composeRule.waitUntil(TIMEOUT_MS) { disconnectedNotification() != null }
+        await("the disconnected notification") { disconnectedNotification() != null }
 
         return disconnectedNotification()
+    }
+
+    private fun await(
+        what: String,
+        condition: () -> Boolean,
+    ) {
+        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(TIMEOUT_MS)
+
+        while (!condition()) {
+            if (System.nanoTime() > deadline) {
+                throw AssertionError("Timed out waiting for $what, showing ${resumedActivity()}")
+            }
+
+            Thread.sleep(50)
+        }
     }
 
     private fun disconnectedNotification(): String? =

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
@@ -14,13 +14,15 @@ import androidx.test.core.app.ApplicationProvider
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dev.firezone.android.core.data.Repository
+import dev.firezone.android.tunnel.ACCOUNT_SLUG
+import dev.firezone.android.tunnel.ACTOR_NAME
 import dev.firezone.android.tunnel.FakeDisconnectError
 import dev.firezone.android.tunnel.FakeSession
 import dev.firezone.android.tunnel.FakeSessionFactory
 import dev.firezone.android.tunnel.TestRestrictions
 import dev.firezone.android.tunnel.TunnelNotification
-import dev.firezone.android.tunnel.connectedDevice
-import dev.firezone.android.tunnel.dnsResource
+import dev.firezone.android.tunnel.benchController
+import dev.firezone.android.tunnel.engineeringWiki
 import dev.firezone.android.tunnel.finishAllActivities
 import dev.firezone.android.tunnel.grantNotificationPermission
 import dev.firezone.android.tunnel.grantVpnConsent
@@ -82,14 +84,14 @@ class TunnelE2eTest {
 
         session.emit(
             Event.ResourcesUpdated(
-                resources = listOf(dnsResource(name = "GitLab")),
+                resources = listOf(engineeringWiki),
                 connectedDevices = emptyList(),
             ),
         )
         launchApp()
 
-        awaitText("GitLab")
-        composeRule.onNodeWithText("gitlab.example.com").assertIsDisplayed()
+        awaitText("Engineering wiki")
+        composeRule.onNodeWithText("wiki.example.com").assertIsDisplayed()
     }
 
     @Test
@@ -98,27 +100,29 @@ class TunnelE2eTest {
 
         session.emit(
             Event.ResourcesUpdated(
-                resources = listOf(dnsResource(name = "GitLab")),
-                connectedDevices = listOf(connectedDevice(name = "Ada's Laptop")),
+                resources = listOf(engineeringWiki),
+                connectedDevices = listOf(benchController),
             ),
         )
         launchApp()
 
-        awaitText("Ada's Laptop")
+        awaitText("bench-controller-01")
         composeRule.onNodeWithText("Connected Devices").assertIsDisplayed()
     }
 
     @Test
-    fun theActorNameReachesTheProfileMenu() {
+    fun signingInReachesTheProfileMenuAndTheStoredAccount() {
         val session = signInAndConnect()
 
-        session.emit(Event.ConnectedToPortal(accountSlug = "acme", actorName = "Ada Lovelace"))
+        session.emit(Event.ConnectedToPortal(accountSlug = ACCOUNT_SLUG, actorName = ACTOR_NAME))
         launchApp()
 
         // The top bar shows the initial; the name itself is behind the menu.
-        awaitText("A")
-        composeRule.onNodeWithText("A").performClick()
-        awaitText("Ada Lovelace")
+        awaitText("J")
+        composeRule.onNodeWithText("J").performClick()
+        awaitText(ACTOR_NAME)
+
+        await("the account slug to be stored") { repo.getConfigSync().accountSlug == ACCOUNT_SLUG }
     }
 
     @Test
@@ -129,12 +133,12 @@ class TunnelE2eTest {
 
         session.emit(
             Event.ResourcesUpdated(
-                resources = listOf(dnsResource(name = "GitLab")),
+                resources = listOf(engineeringWiki),
                 connectedDevices = emptyList(),
             ),
         )
 
-        awaitText("GitLab")
+        awaitText("Engineering wiki")
     }
 
     @Test
@@ -143,7 +147,7 @@ class TunnelE2eTest {
 
         session.emit(
             Event.ResourcesUpdated(
-                resources = listOf(internetResource()),
+                resources = listOf(internetResource),
                 connectedDevices = emptyList(),
             ),
         )

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
@@ -1,26 +1,31 @@
 // Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
 package dev.firezone.android.e2e
 
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
 import android.content.SharedPreferences
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dev.firezone.android.core.data.Repository
-import dev.firezone.android.features.session.ui.SessionActivity
 import dev.firezone.android.tunnel.FakeDisconnectError
 import dev.firezone.android.tunnel.FakeSession
 import dev.firezone.android.tunnel.FakeSessionFactory
 import dev.firezone.android.tunnel.TestRestrictions
+import dev.firezone.android.tunnel.TunnelNotification
 import dev.firezone.android.tunnel.connectedDevice
 import dev.firezone.android.tunnel.dnsResource
+import dev.firezone.android.tunnel.finishAllActivities
+import dev.firezone.android.tunnel.grantNotificationPermission
 import dev.firezone.android.tunnel.grantVpnConsent
 import dev.firezone.android.tunnel.internetResource
+import dev.firezone.android.tunnel.launchApp
 import dev.firezone.android.tunnel.startTunnelService
 import dev.firezone.android.tunnel.stopTunnelService
 import kotlinx.coroutines.flow.first
@@ -36,9 +41,10 @@ import uniffi.connlib.Event
 import uniffi.connlib.NoHandle
 import javax.inject.Inject
 
-// End-to-end through the real app: a signed-in device starts the real `TunnelService`, and the
-// only thing standing in for production is connlib itself. What the fake session emits has to
-// come out the other end on screen, and what the screen does has to reach the fake session.
+// End-to-end through the real app, entered the way a user enters it: the launcher activity, the
+// splash screen's own routing and the real `TunnelService`. The only thing standing in for
+// production is connlib. What the fake session emits has to come out on screen, and what the
+// screen does has to reach the fake session.
 @HiltAndroidTest
 class TunnelE2eTest {
     @get:Rule(order = 0)
@@ -57,9 +63,13 @@ class TunnelE2eTest {
     fun setUp() {
         hiltRule.inject()
         grantVpnConsent()
-        // Ending the last test's sessions first is what lets its service finish and stop.
+        grantNotificationPermission()
+        // Order matters: ending the last test's sessions lets its service finish, and finishing
+        // its activities releases the binding that would otherwise keep the service alive.
         FakeSessionFactory.reset()
+        finishAllActivities()
         stopTunnelService()
+        notificationManager().cancelAll()
         preferences.edit().clear().commit()
         TestRestrictions.bundle.clear()
     }
@@ -74,11 +84,10 @@ class TunnelE2eTest {
                 connectedDevices = emptyList(),
             ),
         )
+        launchApp()
 
-        onSessionScreen {
-            awaitText("GitLab")
-            composeRule.onNodeWithText("gitlab.example.com").assertIsDisplayed()
-        }
+        awaitText("GitLab")
+        composeRule.onNodeWithText("gitlab.example.com").assertIsDisplayed()
     }
 
     @Test
@@ -91,11 +100,10 @@ class TunnelE2eTest {
                 connectedDevices = listOf(connectedDevice(name = "Ada's Laptop")),
             ),
         )
+        launchApp()
 
-        onSessionScreen {
-            awaitText("Ada's Laptop")
-            composeRule.onNodeWithText("Connected Devices").assertIsDisplayed()
-        }
+        awaitText("Ada's Laptop")
+        composeRule.onNodeWithText("Connected Devices").assertIsDisplayed()
     }
 
     @Test
@@ -103,28 +111,28 @@ class TunnelE2eTest {
         val session = signInAndConnect()
 
         session.emit(Event.ConnectedToPortal(accountSlug = "acme", actorName = "Ada Lovelace"))
+        launchApp()
 
-        onSessionScreen {
-            // The top bar shows the initial; the name itself is behind the menu.
-            awaitText("A")
-            composeRule.onNodeWithText("A").performClick()
-            awaitText("Ada Lovelace")
-        }
+        // The top bar shows the initial; the name itself is behind the menu.
+        awaitText("A")
+        composeRule.onNodeWithText("A").performClick()
+        awaitText("Ada Lovelace")
     }
 
     @Test
     fun aResourceUpdateAfterTheScreenIsOpenReachesIt() {
         val session = signInAndConnect()
+        launchApp()
+        awaitSessionScreen()
 
-        onSessionScreen {
-            session.emit(
-                Event.ResourcesUpdated(
-                    resources = listOf(dnsResource(name = "GitLab")),
-                    connectedDevices = emptyList(),
-                ),
-            )
-            awaitText("GitLab")
-        }
+        session.emit(
+            Event.ResourcesUpdated(
+                resources = listOf(dnsResource(name = "GitLab")),
+                connectedDevices = emptyList(),
+            ),
+        )
+
+        awaitText("GitLab")
     }
 
     @Test
@@ -137,56 +145,52 @@ class TunnelE2eTest {
                 connectedDevices = emptyList(),
             ),
         )
+        launchApp()
 
-        onSessionScreen {
-            awaitText("Internet Resource", substring = true)
-            composeRule.onNodeWithText("Internet Resource", substring = true).performClick()
-            awaitText("Enable this resource")
-            composeRule.onNodeWithText("Enable this resource").performClick()
+        awaitText("Internet Resource", substring = true)
+        composeRule.onNodeWithText("Internet Resource", substring = true).performClick()
+        awaitText("Enable this resource")
+        composeRule.onNodeWithText("Enable this resource").performClick()
 
-            runBlocking {
-                withTimeout(TIMEOUT_MS) { session.awaitCommand("setInternetResourceState=true") }
-            }
-        }
+        runBlocking { withTimeout(TIMEOUT_MS) { session.awaitCommand("setInternetResourceState=true") } }
     }
 
     @Test
-    fun aShutdownClosesTheScreen() {
+    fun aDisconnectErrorReturnsToTheSignInScreenAndNotifies() {
         val session = signInAndConnect()
+        launchApp()
+        awaitSessionScreen()
 
-        ActivityScenario.launch(SessionActivity::class.java).use { scenario ->
-            composeRule.waitUntil(TIMEOUT_MS) { scenario.state == Lifecycle.State.RESUMED }
+        session.emit(Event.Disconnected(FakeDisconnectError(signInRequired = false, text = "the portal hung up")))
 
-            session.emit(Event.Disconnected(FakeDisconnectError(signInRequired = false)))
-
-            composeRule.waitUntil(TIMEOUT_MS) { scenario.state == Lifecycle.State.DESTROYED }
-            assertEquals(TOKEN, repo.getTokenSync())
-        }
+        awaitSignInScreen()
+        assertEquals("the portal hung up", awaitDisconnectedNotification())
+        // The token is still good, so the disconnect must not have discarded it.
+        assertEquals(TOKEN, repo.getTokenSync())
     }
 
     @Test
-    fun aShutdownThatRequiresSigningInAgainDiscardsTheToken() {
+    fun aDisconnectErrorThatRequiresSigningInAgainAlsoDiscardsTheToken() {
         val session = signInAndConnect()
+        launchApp()
+        awaitSessionScreen()
 
-        ActivityScenario.launch(SessionActivity::class.java).use { scenario ->
-            composeRule.waitUntil(TIMEOUT_MS) { scenario.state == Lifecycle.State.RESUMED }
+        session.emit(Event.Disconnected(FakeDisconnectError(signInRequired = true, text = "your session expired")))
 
-            session.emit(Event.Disconnected(FakeDisconnectError(signInRequired = true)))
-
-            composeRule.waitUntil(TIMEOUT_MS) { scenario.state == Lifecycle.State.DESTROYED }
-            assertNull(repo.getTokenSync())
-        }
+        awaitSignInScreen()
+        assertEquals("your session expired", awaitDisconnectedNotification())
+        assertNull(repo.getTokenSync())
     }
 
     @Test
-    fun aConnlibThatRefusesToStartClosesTheScreen() {
+    fun aConnlibThatRefusesToStartLeavesTheUserOnTheSignInScreen() {
         FakeSessionFactory.failWith = { ConnlibException(NoHandle) }
         signIn()
-        startTunnelService()
 
-        ActivityScenario.launch(SessionActivity::class.java).use { scenario ->
-            composeRule.waitUntil(TIMEOUT_MS) { scenario.state == Lifecycle.State.DESTROYED }
-        }
+        startTunnelService()
+        launchApp()
+
+        awaitSignInScreen()
     }
 
     @Test
@@ -213,9 +217,9 @@ class TunnelE2eTest {
 
     private fun awaitSession(): FakeSession = runBlocking { withTimeout(TIMEOUT_MS) { FakeSessionFactory.awaitSession() } }
 
-    private fun onSessionScreen(block: () -> Unit) {
-        ActivityScenario.launch(SessionActivity::class.java).use { block() }
-    }
+    private fun awaitSessionScreen() = awaitText("Resources")
+
+    private fun awaitSignInScreen() = awaitText("Sign in to access Resources.")
 
     private fun awaitText(
         text: String,
@@ -225,6 +229,25 @@ class TunnelE2eTest {
             composeRule.onAllNodesWithText(text, substring = substring).fetchSemanticsNodes().isNotEmpty()
         }
     }
+
+    private fun awaitDisconnectedNotification(): String? {
+        composeRule.waitUntil(TIMEOUT_MS) { disconnectedNotification() != null }
+
+        return disconnectedNotification()
+    }
+
+    private fun disconnectedNotification(): String? =
+        notificationManager()
+            .activeNotifications
+            .firstOrNull { it.id == TunnelNotification.DISCONNECTED_NOTIFICATION_ID }
+            ?.notification
+            ?.extras
+            ?.getString(Notification.EXTRA_TEXT)
+
+    private fun notificationManager(): NotificationManager =
+        ApplicationProvider
+            .getApplicationContext<Context>()
+            .getSystemService(NotificationManager::class.java)
 
     private companion object {
         const val TOKEN = "stored-token"

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Connlib.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Connlib.kt
@@ -1,0 +1,56 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.tunnel
+
+import uniffi.connlib.DisconnectError
+import uniffi.connlib.DnsResource
+import uniffi.connlib.InternetResource
+import uniffi.connlib.NoHandle
+import uniffi.connlib.Resource
+import uniffi.connlib.ResourceStatus
+
+// UniFFI hands out `NoHandle` constructors precisely so foreign code can build these
+// without a live Rust object behind them.
+class FakeDisconnectError(
+    private val signInRequired: Boolean,
+    private val text: String = "session ended",
+) : DisconnectError(NoHandle) {
+    override fun message(): String = text
+
+    override fun requiresSignIn(): Boolean = signInRequired
+}
+
+fun dnsResource(
+    name: String,
+    address: String = "gitlab.example.com",
+    id: String = "9e1c1a3a-8a9b-4e3a-9a4a-3b1c0d5e6f70",
+) = Resource.Dns(
+    DnsResource(
+        id = id,
+        address = address,
+        name = name,
+        addressDescription = null,
+        sites = emptyList(),
+        status = ResourceStatus.ONLINE,
+    ),
+)
+
+fun connectedDevice(
+    name: String,
+    id: String = "1d2c3b4a-5f6e-4a7b-8c9d-0e1f2a3b4c5d",
+) = uniffi.connlib.ConnectedDevice(
+    id = id,
+    name = name,
+    tunIpv4 = "100.64.0.2",
+    tunIpv6 = "fd00:2021:1111::2",
+    pools = emptyList(),
+)
+
+fun internetResource(id: String = "0854dca1-2c5b-468a-be85-0eec2f02a211") =
+    Resource.Internet(
+        InternetResource(
+            id = id,
+            name = "Internet Resource",
+            sites = emptyList(),
+            status = ResourceStatus.ONLINE,
+        ),
+    )

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Connlib.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Connlib.kt
@@ -1,12 +1,14 @@
 // Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
 package dev.firezone.android.tunnel
 
+import uniffi.connlib.ConnectedDevice
 import uniffi.connlib.DisconnectError
 import uniffi.connlib.DnsResource
 import uniffi.connlib.InternetResource
 import uniffi.connlib.NoHandle
 import uniffi.connlib.Resource
 import uniffi.connlib.ResourceStatus
+import uniffi.connlib.Site
 
 // UniFFI hands out `NoHandle` constructors precisely so foreign code can build these
 // without a live Rust object behind them.
@@ -19,38 +21,37 @@ class FakeDisconnectError(
     override fun requiresSignIn(): Boolean = signInRequired
 }
 
-fun dnsResource(
-    name: String,
-    address: String = "gitlab.example.com",
-    id: String = "9e1c1a3a-8a9b-4e3a-9a4a-3b1c0d5e6f70",
-) = Resource.Dns(
-    DnsResource(
-        id = id,
-        address = address,
-        name = name,
-        addressDescription = null,
-        sites = emptyList(),
-        status = ResourceStatus.ONLINE,
-    ),
-)
+// The deployment the screenshot fixtures describe, so the galleries and these tests tell one story.
+const val ACTOR_NAME = "Jane Doe"
+const val ACCOUNT_SLUG = "example-corp"
 
-fun connectedDevice(
-    name: String,
-    id: String = "1d2c3b4a-5f6e-4a7b-8c9d-0e1f2a3b4c5d",
-) = uniffi.connlib.ConnectedDevice(
-    id = id,
-    name = name,
-    tunIpv4 = "100.64.0.2",
-    tunIpv6 = "fd00:2021:1111::2",
-    pools = emptyList(),
-)
-
-fun internetResource(id: String = "0854dca1-2c5b-468a-be85-0eec2f02a211") =
-    Resource.Internet(
-        InternetResource(
-            id = id,
-            name = "Internet Resource",
-            sites = emptyList(),
+val engineeringWiki =
+    Resource.Dns(
+        DnsResource(
+            id = "0854dca1-2c5b-468a-be85-0eec2f02a211",
+            address = "wiki.example.com",
+            name = "Engineering wiki",
+            addressDescription = "https://wiki.example.com",
+            sites = listOf(Site(id = "917e9354-26b3-4704-867c-f84c8688d269", name = "Sydney Office")),
             status = ResourceStatus.ONLINE,
         ),
+    )
+
+val internetResource =
+    Resource.Internet(
+        InternetResource(
+            id = "425233f2-a1cb-4b7d-84f3-850367fa122a",
+            name = "Internet Resource",
+            sites = listOf(Site(id = "1a4f0f4e-8f3f-4a2e-9b6d-3c5e7a1b2d40", name = "Internet")),
+            status = ResourceStatus.ONLINE,
+        ),
+    )
+
+val benchController =
+    ConnectedDevice(
+        id = "a21c9663-4d0e-4f4a-a8fa-48790b1e5cef",
+        name = "bench-controller-01",
+        tunIpv4 = "100.64.3.18",
+        tunIpv6 = "fd00:2021:1111::12",
+        pools = listOf("Lab hardware", "Shared storage"),
     )

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/FakeSession.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/FakeSession.kt
@@ -1,0 +1,59 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.tunnel
+
+import kotlinx.coroutines.channels.Channel
+import uniffi.connlib.AndroidSessionConfig
+import uniffi.connlib.Event
+
+// Stands in for a connlib session. `disconnect` ends the event stream, which is the part of the
+// real session's behaviour the service's event loop is built around.
+class FakeSession(
+    val config: AndroidSessionConfig,
+) : TunnelSession {
+    private val events = Channel<Event>(Channel.UNLIMITED)
+
+    val commands = Channel<String>(Channel.UNLIMITED)
+
+    fun emit(event: Event) {
+        events.trySend(event).getOrThrow()
+    }
+
+    // Lets the service's event loop finish, which is what makes the service stop itself.
+    fun endEventStream() {
+        events.close()
+    }
+
+    override suspend fun nextEvent(): Event? = events.receiveCatching().getOrNull()
+
+    override fun disconnect() {
+        commands.trySend("disconnect")
+        events.close()
+    }
+
+    override fun reset(reason: String) {
+        commands.trySend("reset")
+    }
+
+    override fun setDns(dnsServers: List<String>) {
+        commands.trySend("setDns=$dnsServers")
+    }
+
+    override fun setInternetResourceState(active: Boolean) {
+        commands.trySend("setInternetResourceState=$active")
+    }
+
+    suspend fun awaitCommand(command: String) {
+        while (commands.receive() != command) {
+            // Skip the commands the service sends on its own, such as the initial resource state.
+        }
+    }
+
+    override fun setTun(fd: Int) {
+        commands.trySend("setTun")
+    }
+
+    override fun close() {
+        events.close()
+        commands.close()
+    }
+}

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/FakeSession.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/FakeSession.kt
@@ -3,12 +3,14 @@ package dev.firezone.android.tunnel
 
 import kotlinx.coroutines.channels.Channel
 import uniffi.connlib.AndroidSessionConfig
+import uniffi.connlib.ClientTlsIdentity
 import uniffi.connlib.Event
 
 // Stands in for a connlib session. `disconnect` ends the event stream, which is the part of the
 // real session's behaviour the service's event loop is built around.
 class FakeSession(
     val config: AndroidSessionConfig,
+    val tlsIdentity: ClientTlsIdentity?,
 ) : TunnelSession {
     private val events = Channel<Event>(Channel.UNLIMITED)
 

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/FakeSessionFactory.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/FakeSessionFactory.kt
@@ -3,6 +3,7 @@ package dev.firezone.android.tunnel
 
 import kotlinx.coroutines.channels.Channel
 import uniffi.connlib.AndroidSessionConfig
+import uniffi.connlib.ClientTlsIdentity
 import java.util.concurrent.CopyOnWriteArrayList
 
 // Deliberately outlives the per-test object graph: a service can still be running when the graph
@@ -19,11 +20,14 @@ object FakeSessionFactory : SessionFactory {
     var opened: Int = 0
         private set
 
-    override fun open(config: AndroidSessionConfig): TunnelSession {
+    override fun open(
+        config: AndroidSessionConfig,
+        tlsIdentity: ClientTlsIdentity?,
+    ): TunnelSession {
         opened++
         failWith?.let { throw it() }
 
-        return FakeSession(config).also {
+        return FakeSession(config, tlsIdentity).also {
             handedOut += it
             sessions.trySend(it).getOrThrow()
         }

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/FakeSessionFactory.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/FakeSessionFactory.kt
@@ -1,0 +1,47 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.tunnel
+
+import kotlinx.coroutines.channels.Channel
+import uniffi.connlib.AndroidSessionConfig
+import java.util.concurrent.CopyOnWriteArrayList
+
+// Deliberately outlives the per-test object graph: a service can still be running when the graph
+// it was injected from is torn down, and the next test has to see the sessions it opens.
+object FakeSessionFactory : SessionFactory {
+    private val sessions = Channel<FakeSession>(Channel.UNLIMITED)
+    private val handedOut = CopyOnWriteArrayList<FakeSession>()
+
+    // Set to make the next `open` fail the way a connlib constructor would.
+    @Volatile
+    var failWith: (() -> Throwable)? = null
+
+    @Volatile
+    var opened: Int = 0
+        private set
+
+    override fun open(config: AndroidSessionConfig): TunnelSession {
+        opened++
+        failWith?.let { throw it() }
+
+        return FakeSession(config).also {
+            handedOut += it
+            sessions.trySend(it).getOrThrow()
+        }
+    }
+
+    suspend fun awaitSession(): FakeSession = sessions.receive()
+
+    fun reset() {
+        failWith = null
+        opened = 0
+
+        // A session still handing out events keeps the service's event loop alive, and a live
+        // loop is what keeps a service the last test started from ever stopping.
+        handedOut.forEach { it.endEventStream() }
+        handedOut.clear()
+
+        while (sessions.tryReceive().isSuccess) {
+            // Drain whatever the last test left behind.
+        }
+    }
+}

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
@@ -73,6 +73,23 @@ fun finishAllActivities() {
     }
 }
 
+// Names what the user would be looking at, which is what tells a screen that has not arrived yet
+// apart from an app that has closed.
+fun resumedActivity(): String {
+    var name = "nothing"
+
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+        name =
+            ActivityLifecycleMonitorRegistry
+                .getInstance()
+                .getActivitiesInStage(Stage.RESUMED)
+                .joinToString { it::class.java.simpleName }
+                .ifEmpty { "nothing" }
+    }
+
+    return name
+}
+
 // A started service outlives the test that started it, so without this the next test would drive
 // whatever the previous one left running.
 fun stopTunnelService() {

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
@@ -1,0 +1,54 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.tunnel
+
+import android.app.ActivityManager
+import android.content.Context
+import android.content.Intent
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import java.util.concurrent.TimeUnit
+
+// The tunnel runs as a `systemExempted` foreground service, which the platform only lets an app
+// start while it holds VPN consent. Without this the first `startForeground` throws and takes the
+// whole instrumentation process with it.
+fun grantVpnConsent() {
+    val instrumentation = InstrumentationRegistry.getInstrumentation()
+
+    UiDevice
+        .getInstance(instrumentation)
+        .executeShellCommand("appops set ${instrumentation.targetContext.packageName} ACTIVATE_VPN allow")
+}
+
+fun startTunnelService() {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    context.startService(Intent(context, TunnelService::class.java))
+}
+
+// A started service outlives the test that started it, so without this the next test would drive
+// whatever the previous one left running.
+fun stopTunnelService() {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    context.stopService(Intent(context, TunnelService::class.java))
+
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15)
+
+    while (TunnelService.isRunning(context)) {
+        if (System.nanoTime() > deadline) {
+            throw AssertionError("The tunnel service is still running: ${describeTunnelService(context)}")
+        }
+
+        Thread.sleep(50)
+    }
+}
+
+@Suppress("DEPRECATION")
+private fun describeTunnelService(context: Context): String {
+    val info =
+        (context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager)
+            .getRunningServices(Int.MAX_VALUE)
+            .firstOrNull { it.service.className == TunnelService::class.java.name }
+            ?: return "no record"
+
+    return "started=${info.started}, clients=${info.clientCount}, foreground=${info.foreground}"
+}

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
@@ -5,24 +5,72 @@ import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
+import androidx.test.runner.lifecycle.Stage
 import androidx.test.uiautomator.UiDevice
+import dev.firezone.android.core.presentation.MainActivity
 import java.util.concurrent.TimeUnit
 
 // The tunnel runs as a `systemExempted` foreground service, which the platform only lets an app
 // start while it holds VPN consent. Without this the first `startForeground` throws and takes the
 // whole instrumentation process with it.
 fun grantVpnConsent() {
-    val instrumentation = InstrumentationRegistry.getInstrumentation()
-
-    UiDevice
-        .getInstance(instrumentation)
-        .executeShellCommand("appops set ${instrumentation.targetContext.packageName} ACTIVATE_VPN allow")
+    shell("appops set ${packageName()} ACTIVATE_VPN allow")
 }
 
+// Without it the splash screen sends the app to the permission prompt instead of the session, and
+// nothing the tunnel posts on disconnect ever reaches the shade.
+fun grantNotificationPermission() {
+    shell("pm grant ${packageName()} android.permission.POST_NOTIFICATIONS")
+}
+
+// The same entry point the splash screen and the boot receiver use, so `startedByUser` is set
+// the way it is in production.
 fun startTunnelService() {
+    TunnelService.start(InstrumentationRegistry.getInstrumentation().targetContext)
+}
+
+// Enters through the launcher, so that the splash screen's own routing decides which screen the
+// test ends up on.
+fun launchApp() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
 
-    context.startService(Intent(context, TunnelService::class.java))
+    context.startActivity(
+        Intent(context, MainActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK),
+    )
+}
+
+// The app spans several activities and the test only starts the first, so it cannot clean up by
+// handle. Whatever is left standing would otherwise show the previous test's screen to the next.
+fun finishAllActivities() {
+    val instrumentation = InstrumentationRegistry.getInstrumentation()
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15)
+
+    while (true) {
+        var remaining = emptyList<String>()
+
+        instrumentation.runOnMainSync {
+            val activities =
+                Stage
+                    .values()
+                    .filter { it != Stage.DESTROYED }
+                    .flatMap { ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(it) }
+
+            remaining = activities.map { it::class.java.simpleName }
+            activities.forEach { it.finish() }
+        }
+
+        if (remaining.isEmpty()) {
+            return
+        }
+
+        if (System.nanoTime() > deadline) {
+            throw AssertionError("Activities are still up: $remaining")
+        }
+
+        Thread.sleep(50)
+    }
 }
 
 // A started service outlives the test that started it, so without this the next test would drive
@@ -40,6 +88,12 @@ fun stopTunnelService() {
 
         Thread.sleep(50)
     }
+}
+
+private fun packageName() = InstrumentationRegistry.getInstrumentation().targetContext.packageName
+
+private fun shell(command: String) {
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).executeShellCommand(command)
 }
 
 @Suppress("DEPRECATION")

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/TestRestrictions.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/TestRestrictions.kt
@@ -1,0 +1,10 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.tunnel
+
+import android.os.Bundle
+
+// Stands in for the managed configuration a device owner would push. Process-wide for the same
+// reason as the session factory: the service reading it may predate the test writing it.
+object TestRestrictions {
+    val bundle = Bundle()
+}

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/di/TunnelModule.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/di/TunnelModule.kt
@@ -1,0 +1,31 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.core.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dev.firezone.android.tunnel.SessionFactory
+import dev.firezone.android.tunnel.TunnelService
+import dev.firezone.android.tunnel.TunnelSession
+import uniffi.connlib.Session
+import uniffi.connlib.SessionInterface
+
+@Module
+@InstallIn(SingletonComponent::class)
+object TunnelModule {
+    @Provides
+    internal fun provideSessionFactory(): SessionFactory =
+        SessionFactory { config ->
+            val session =
+                Session.newAndroid(
+                    config = config,
+                    protectSocket = TunnelService.protectSocketCallback,
+                    tlsIdentity = null,
+                )
+
+            object : TunnelSession, SessionInterface by session {
+                override fun close() = session.close()
+            }
+        }
+}

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/di/TunnelModule.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/di/TunnelModule.kt
@@ -16,12 +16,12 @@ import uniffi.connlib.SessionInterface
 object TunnelModule {
     @Provides
     internal fun provideSessionFactory(): SessionFactory =
-        SessionFactory { config ->
+        SessionFactory { config, tlsIdentity ->
             val session =
                 Session.newAndroid(
                     config = config,
                     protectSocket = TunnelService.protectSocketCallback,
-                    tlsIdentity = null,
+                    tlsIdentity = tlsIdentity,
                 )
 
             object : TunnelSession, SessionInterface by session {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/SessionFactory.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/SessionFactory.kt
@@ -1,0 +1,16 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.tunnel
+
+import uniffi.connlib.AndroidSessionConfig
+import uniffi.connlib.SessionInterface
+
+// A connlib session together with the `close` that releases it.
+interface TunnelSession :
+    SessionInterface,
+    AutoCloseable
+
+// Opens connlib sessions. Tests bind a factory handing out a scripted session, which is
+// what puts the service's event loop within reach of a test that has no portal.
+fun interface SessionFactory {
+    fun open(config: AndroidSessionConfig): TunnelSession
+}

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/SessionFactory.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/SessionFactory.kt
@@ -2,6 +2,7 @@
 package dev.firezone.android.tunnel
 
 import uniffi.connlib.AndroidSessionConfig
+import uniffi.connlib.ClientTlsIdentity
 import uniffi.connlib.SessionInterface
 
 // A connlib session together with the `close` that releases it.
@@ -12,5 +13,8 @@ interface TunnelSession :
 // Opens connlib sessions. Tests bind a factory handing out a scripted session, which is
 // what puts the service's event loop within reach of a test that has no portal.
 fun interface SessionFactory {
-    fun open(config: AndroidSessionConfig): TunnelSession
+    fun open(
+        config: AndroidSessionConfig,
+        tlsIdentity: ClientTlsIdentity?,
+    ): TunnelSession
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -359,6 +359,7 @@ class TunnelService : VpnService() {
                                 isInternetResourceActive = resourceState.isEnabled(),
                                 deviceInfo = deviceInfo,
                             ),
+                            tlsIdentity = null,
                         ).use { session ->
                             startNetworkMonitoring()
                             startLogCleanup()

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -51,7 +51,6 @@ import uniffi.connlib.ConnlibException
 import uniffi.connlib.DeviceInfo
 import uniffi.connlib.Event
 import uniffi.connlib.ProtectSocket
-import uniffi.connlib.Session
 import uniffi.connlib.SessionInterface
 import uniffi.connlib.configureLogger
 import uniffi.connlib.enforceLogSizeCap
@@ -77,6 +76,9 @@ class TunnelService : VpnService() {
 
     @Inject
     internal lateinit var moshi: Moshi
+
+    @Inject
+    internal lateinit var sessionFactory: SessionFactory
 
     private var tunnelIpv4Address: String? = null
     private var tunnelIpv6Address: String? = null
@@ -346,19 +348,16 @@ class TunnelService : VpnService() {
                         flowLogsDir(this@TunnelService),
                     )
 
-                    Session
-                        .newAndroid(
-                            config =
-                                AndroidSessionConfig(
-                                    apiUrl = config.apiUrl,
-                                    token = token,
-                                    deviceId = deviceIdValue,
-                                    deviceName = getDeviceName(),
-                                    isInternetResourceActive = resourceState.isEnabled(),
-                                    deviceInfo = deviceInfo,
-                                ),
-                            protectSocket = protectSocketCallback,
-                            tlsIdentity = null,
+                    sessionFactory
+                        .open(
+                            AndroidSessionConfig(
+                                apiUrl = config.apiUrl,
+                                token = token,
+                                deviceId = deviceIdValue,
+                                deviceName = getDeviceName(),
+                                isInternetResourceActive = resourceState.isEnabled(),
+                                deviceInfo = deviceInfo,
+                            ),
                         ).use { session ->
                             startNetworkMonitoring()
                             startLogCleanup()


### PR DESCRIPTION
`TunnelService` built its connlib `Session` itself, so nothing downstream of that call was reachable from a test without a portal to talk to. `SessionFactory` is the seam that changes: the service asks for a session, and the real factory is a Hilt provider doing what the service used to do inline.

That is enough to run the app end to end on an emulator. The tests enter through the launcher, let the splash screen route and drive the real screen against the real service; the only thing standing in for production is connlib. What the fake session emits has to appear on screen (resources, connected devices, the actor name behind the profile menu), and what the screen does has to reach connlib (enabling the Internet resource). A disconnect has to leave the user on the sign-in screen with a notification saying why, rather than closing the app, and the sign-in-required variant has to discard the token as well. A connlib that refuses to start and managed configuration reaching the session round it out.
