### PR TITLE
feat(portal): call Clients devices

### DIFF
--- a/elixir/lib/portal/actor/preferences.ex
+++ b/elixir/lib/portal/actor/preferences.ex
@@ -2,7 +2,7 @@ defmodule Portal.Actor.Preferences do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @start_page_values [:sites, :resources, :groups, :policies, :clients, :actors]
+  @start_page_values [:sites, :resources, :groups, :policies, :devices, :actors]
 
   @primary_key false
   embedded_schema do

--- a/elixir/lib/portal/billing.ex
+++ b/elixir/lib/portal/billing.ex
@@ -738,17 +738,17 @@ defmodule Portal.Billing do
     end
 
     def count_1m_active_users_for_account(%Account{} = account) do
-      from(c in Device, as: :clients)
-      |> where([clients: c], c.type == :client)
-      |> where([clients: c], c.account_id == ^account.id)
-      |> where([clients: c], c.last_seen_at > ago(1, "month"))
-      |> join(:inner, [clients: c], a in Actor,
-        on: c.actor_id == a.id and c.account_id == a.account_id,
+      from(d in Device, as: :devices)
+      |> where([devices: d], d.type == :client)
+      |> where([devices: d], d.account_id == ^account.id)
+      |> where([devices: d], d.last_seen_at > ago(1, "month"))
+      |> join(:inner, [devices: d], a in Actor,
+        on: d.actor_id == a.id and d.account_id == a.account_id,
         as: :actor
       )
       |> where([actor: a], a.is_disabled == false)
       |> where([actor: a], a.type in [:account_user, :account_admin_user])
-      |> select([clients: c], c.actor_id)
+      |> select([devices: d], d.actor_id)
       |> distinct(true)
       |> Safe.unscoped()
       |> Safe.aggregate(:count)

--- a/elixir/lib/portal/cache/client.ex
+++ b/elixir/lib/portal/cache/client.ex
@@ -1067,14 +1067,14 @@ defmodule Portal.Cache.Client do
         on: m.account_id == r.account_id,
         as: :members
       )
-      |> join(:inner, [members: m], c in assoc(m, :client),
-        on: c.account_id == m.account_id,
-        as: :clients
+      |> join(:inner, [members: m], d in assoc(m, :client),
+        on: d.account_id == m.account_id,
+        as: :devices
       )
-      |> where([clients: c], c.type == :client)
+      |> where([devices: d], d.type == :client)
       |> select(
-        [resources: r, members: m, clients: c],
-        {r.id, m.device_id, c.ipv4, c.ipv6}
+        [resources: r, members: m, devices: d],
+        {r.id, m.device_id, d.ipv4, d.ipv6}
       )
       |> Safe.scoped(subject)
       |> Safe.all()

--- a/elixir/lib/portal/mailer/notifications.ex
+++ b/elixir/lib/portal/mailer/notifications.ex
@@ -12,8 +12,8 @@ defmodule Portal.Mailer.Notifications do
   embed_templates "notifications/*.text", suffix: "_text"
 
   def outdated_gateway_email(account, gateways, incompatible_client_count, recipients) do
-    params = %{clients_order_by: "devices:asc:last_seen_version"}
-    outdated_clients_url = url(~p"/#{account}/clients?#{params}")
+    params = %{devices_order_by: "devices:asc:last_seen_version"}
+    outdated_clients_url = url(~p"/#{account}/devices?#{params}")
 
     default_email()
     |> subject("Firezone Gateway Upgrade Available")

--- a/elixir/lib/portal/workers/check_account_limits.ex
+++ b/elixir/lib/portal/workers/check_account_limits.ex
@@ -292,18 +292,18 @@ defmodule Portal.Workers.CheckAccountLimits do
     end
 
     defp count_1m_active_users_by_account(account_ids) do
-      from(c in Device, as: :clients)
-      |> where([clients: c], c.type == :client)
-      |> where([clients: c], c.account_id in ^account_ids)
-      |> join(:inner, [clients: c], a in Actor,
-        on: c.actor_id == a.id and c.account_id == a.account_id,
+      from(d in Device, as: :devices)
+      |> where([devices: d], d.type == :client)
+      |> where([devices: d], d.account_id in ^account_ids)
+      |> join(:inner, [devices: d], a in Actor,
+        on: d.actor_id == a.id and d.account_id == a.account_id,
         as: :actor
       )
       |> where([actor: a], a.is_disabled == false)
       |> where([actor: a], a.type in [:account_user, :account_admin_user])
-      |> where([clients: c], c.last_seen_at > ago(1, "month"))
-      |> group_by([clients: c], c.account_id)
-      |> select([clients: c], {c.account_id, count(c.actor_id, :distinct)})
+      |> where([devices: d], d.last_seen_at > ago(1, "month"))
+      |> group_by([devices: d], d.account_id)
+      |> select([devices: d], {d.account_id, count(d.actor_id, :distinct)})
       |> Safe.unscoped()
       |> Safe.all()
       |> Map.new()

--- a/elixir/lib/portal/workers/outdated_gateways.ex
+++ b/elixir/lib/portal/workers/outdated_gateways.ex
@@ -169,18 +169,18 @@ defmodule Portal.Workers.OutdatedGateways do
     def count_incompatible_for(account, gateway_version) do
       %{major: g_major, minor: g_minor} = Version.parse!(gateway_version)
 
-      from(c in Device, as: :clients)
-      |> where([clients: c], c.type == :client)
-      |> where([clients: c], c.account_id == ^account.id)
-      |> where([clients: c], c.last_seen_at > ago(1, "week"))
+      from(d in Device, as: :devices)
+      |> where([devices: d], d.type == :client)
+      |> where([devices: d], d.account_id == ^account.id)
+      |> where([devices: d], d.last_seen_at > ago(1, "week"))
       |> where(
-        [clients: c],
-        fragment("split_part(?, '.', 1)::int", c.last_seen_version) < ^g_major or
-          (fragment("split_part(?, '.', 1)::int", c.last_seen_version) == ^g_major and
-             fragment("split_part(?, '.', 2)::int", c.last_seen_version) <= ^(g_minor - 2))
+        [devices: d],
+        fragment("split_part(?, '.', 1)::int", d.last_seen_version) < ^g_major or
+          (fragment("split_part(?, '.', 1)::int", d.last_seen_version) == ^g_major and
+             fragment("split_part(?, '.', 2)::int", d.last_seen_version) <= ^(g_minor - 2))
       )
-      |> join(:inner, [clients: c], a in Portal.Actor,
-        on: c.actor_id == a.id and c.account_id == a.account_id,
+      |> join(:inner, [devices: d], a in Portal.Actor,
+        on: d.actor_id == a.id and d.account_id == a.account_id,
         as: :actor
       )
       |> where([actor: a], a.is_disabled == false)

--- a/elixir/lib/portal_api/controllers/account_json.ex
+++ b/elixir/lib/portal_api/controllers/account_json.ex
@@ -90,17 +90,17 @@ defmodule PortalAPI.AccountJSON do
     end
 
     def count_1m_active_users_for_account(account) do
-      from(c in Device, as: :clients)
-      |> where([clients: c], c.type == :client)
-      |> where([clients: c], c.account_id == ^account.id)
-      |> where([clients: c], c.last_seen_at > ago(1, "month"))
-      |> join(:inner, [clients: c], a in Actor,
-        on: c.actor_id == a.id and c.account_id == a.account_id,
+      from(d in Device, as: :devices)
+      |> where([devices: d], d.type == :client)
+      |> where([devices: d], d.account_id == ^account.id)
+      |> where([devices: d], d.last_seen_at > ago(1, "month"))
+      |> join(:inner, [devices: d], a in Actor,
+        on: d.actor_id == a.id and d.account_id == a.account_id,
         as: :actor
       )
       |> where([actor: a], a.is_disabled == false)
       |> where([actor: a], a.type in [:account_user, :account_admin_user])
-      |> select([clients: c], c.actor_id)
+      |> select([devices: d], d.actor_id)
       |> distinct(true)
       |> Safe.unscoped()
       |> Safe.aggregate(:count)

--- a/elixir/lib/portal_api/controllers/client_controller.ex
+++ b/elixir/lib/portal_api/controllers/client_controller.ex
@@ -235,8 +235,8 @@ defmodule PortalAPI.ClientController do
     alias Portal.Device
 
     def list_clients(subject, opts \\ []) do
-      from(d in Device, as: :clients)
-      |> where([clients: d], d.type == :client)
+      from(d in Device, as: :devices)
+      |> where([devices: d], d.type == :client)
       |> Safe.scoped(subject)
       |> Safe.list(__MODULE__, opts)
     end
@@ -259,7 +259,7 @@ defmodule PortalAPI.ClientController do
     end
 
     defp filter_by_name(queryable, name) do
-      dynamic = dynamic([clients: d], d.name == ^name)
+      dynamic = dynamic([devices: d], d.name == ^name)
       {queryable, dynamic}
     end
 
@@ -267,14 +267,14 @@ defmodule PortalAPI.ClientController do
     # per account, so this can still match more than one row - callers
     # must handle that rather than assuming a single result.
     defp filter_by_firezone_id(queryable, firezone_id) do
-      dynamic = dynamic([clients: d], d.firezone_id == ^firezone_id)
+      dynamic = dynamic([devices: d], d.firezone_id == ^firezone_id)
       {queryable, dynamic}
     end
 
     def cursor_fields do
       [
-        {:clients, :asc, :inserted_at},
-        {:clients, :asc, :id}
+        {:devices, :asc, :inserted_at},
+        {:devices, :asc, :id}
       ]
     end
 
@@ -286,8 +286,8 @@ defmodule PortalAPI.ClientController do
 
     def fetch_client(id, subject) do
       result =
-        from(d in Device, as: :clients)
-        |> where([clients: d], d.id == ^id and d.type == :client)
+        from(d in Device, as: :devices)
+        |> where([devices: d], d.id == ^id and d.type == :client)
         |> Safe.scoped(subject)
         |> Safe.one()
 

--- a/elixir/lib/portal_api/controllers/pool_member_controller.ex
+++ b/elixir/lib/portal_api/controllers/pool_member_controller.ex
@@ -45,7 +45,7 @@ defmodule PortalAPI.PoolMemberController do
          :ok <- validate_device_pool(resource),
          {:ok, list_opts} <- Pagination.params_to_list_opts(params),
          list_opts = Keyword.put(list_opts, :filter, resource_id: resource_id),
-         {:ok, clients, metadata} <- Database.list_clients(subject, list_opts) do
+         {:ok, clients, metadata} <- Database.list_devices(subject, list_opts) do
       render(conn, :index, clients: clients, metadata: metadata)
     else
       error -> Error.handle(conn, error)
@@ -244,9 +244,9 @@ defmodule PortalAPI.PoolMemberController do
       end
     end
 
-    def list_clients(subject, opts \\ []) do
-      from(d in Device, as: :clients)
-      |> where([clients: d], d.type == :client)
+    def list_devices(subject, opts \\ []) do
+      from(d in Device, as: :devices)
+      |> where([devices: d], d.type == :client)
       |> Safe.scoped(subject)
       |> Safe.list(__MODULE__, opts)
     end
@@ -264,7 +264,7 @@ defmodule PortalAPI.PoolMemberController do
 
     defp filter_by_resource_id(queryable, resource_id) do
       queryable =
-        join(queryable, :inner, [clients: d], m in StaticDevicePoolMember,
+        join(queryable, :inner, [devices: d], m in StaticDevicePoolMember,
           on: m.device_id == d.id and m.account_id == d.account_id,
           as: :members
         )
@@ -274,8 +274,8 @@ defmodule PortalAPI.PoolMemberController do
 
     def cursor_fields do
       [
-        {:clients, :asc, :inserted_at},
-        {:clients, :asc, :id}
+        {:devices, :asc, :inserted_at},
+        {:devices, :asc, :id}
       ]
     end
 

--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -59,7 +59,7 @@ defmodule PortalWeb.CoreComponents do
   def device_name(%Portal.Device{name: name}) when not is_nil(name), do: name
 
   defp device_path(account, %Portal.Device{type: :client, id: id}),
-    do: ~p"/#{account}/clients/#{id}"
+    do: ~p"/#{account}/devices/#{id}"
 
   defp device_path(account, %Portal.Device{type: :gateway}),
     do: ~p"/#{account}"

--- a/elixir/lib/portal_web/components/navigation_components.ex
+++ b/elixir/lib/portal_web/components/navigation_components.ex
@@ -244,12 +244,15 @@ defmodule PortalWeb.NavigationComponents do
             >
               Sites
             </.sidebar_item>
+            <%!-- Signposts the rename for admins who knew this page as Clients. --%>
             <.sidebar_item
               current_path={@current_path}
-              navigate={~p"/#{@account}/clients"}
+              navigate={~p"/#{@account}/devices"}
               icon="ri-computer-line"
+              badge="NEW"
             >
-              Clients
+              <span class="line-through decoration-[1.3px]">Clients</span>
+              <span class="ml-0.5">Devices</span>
             </.sidebar_item>
           </ul>
         </div>

--- a/elixir/lib/portal_web/live/actors/components.ex
+++ b/elixir/lib/portal_web/live/actors/components.ex
@@ -1,7 +1,7 @@
 defmodule PortalWeb.Actors.Components do
   use PortalWeb, :component_library
 
-  import PortalWeb.Clients.Components, only: [client_os_icon_name: 1]
+  import PortalWeb.Devices.Components, only: [os_icon_name: 1]
 
   attr :account, :any, required: true
   attr :actor, :any, default: nil
@@ -468,7 +468,7 @@ defmodule PortalWeb.Actors.Components do
                   <div class="flex items-center justify-center w-7 h-7 rounded-full bg-raised border border-border shrink-0">
                     <.icon
                       name={
-                        client_os_icon_name(
+                        os_icon_name(
                           token.last_used_device && token.last_used_device.last_seen_user_agent
                         )
                       }

--- a/elixir/lib/portal_web/live/devices.ex
+++ b/elixir/lib/portal_web/live/devices.ex
@@ -1,6 +1,6 @@
-defmodule PortalWeb.Clients do
+defmodule PortalWeb.Devices do
   use PortalWeb, :live_view
-  import PortalWeb.Clients.Components
+  import PortalWeb.Devices.Components
   alias Portal.{Presence.Clients, ComponentVersions}
   alias Portal.Changes.Change
   alias Portal.Device
@@ -18,23 +18,23 @@ defmodule PortalWeb.Clients do
 
     socket =
       socket
-      |> assign(page_title: "Clients")
-      |> assign(selected_client: nil)
+      |> assign(page_title: "Devices")
+      |> assign(selected_device: nil)
       |> assign(stale: false)
-      |> assign_async(:clients_count, fn -> {:ok, %{clients_count: Database.count_clients(subject)}} end)
+      |> assign_async(:devices_count, fn -> {:ok, %{devices_count: Database.count_devices(subject)}} end)
       |> assign(
-        client_device_pools: [],
+        device_pools: [],
         policy_authorizations: [],
         policy_authorizations_page: 1,
         policy_authorizations_has_next: false,
         policy_authorizations_expanded_id: nil,
-        client_posture: [],
-        client_certificate: nil,
+        device_posture: [],
+        device_certificate: nil,
         posture_providers_connected?: false,
-        serials_by_client: %{}
+        serials_by_device: %{}
       )
-      |> assign(base_client_assigns())
-      |> assign_live_table("clients",
+      |> assign(base_device_assigns())
+      |> assign_live_table("devices",
         query_module: Database,
         sortable_fields: [
           {:devices, :name},
@@ -43,7 +43,7 @@ defmodule PortalWeb.Clients do
           {:devices, :inserted_at},
           {:devices, :last_seen_user_agent}
         ],
-        callback: &handle_clients_update!/2
+        callback: &handle_devices_update!/2
       )
 
     {:ok, socket}
@@ -52,29 +52,29 @@ defmodule PortalWeb.Clients do
   def handle_params(%{"id" => id} = params, uri, %{assigns: %{live_action: :show}} = socket) do
     socket = handle_live_tables_params(socket, params, uri)
 
-    case Database.get_client_for_panel(id, socket.assigns.subject) do
+    case Database.get_device_for_panel(id, socket.assigns.subject) do
       nil ->
-        redirect_to_clients_index(socket, "Client does not exist.")
+        redirect_to_devices_index(socket, "Device does not exist.")
 
-      client ->
+      device ->
         page = parse_page(params)
-        tab = parse_client_tab(Map.get(params, "tab", "overview"))
+        tab = parse_device_tab(Map.get(params, "tab", "overview"))
 
         {policy_authorizations, has_next} =
-          Database.list_policy_authorizations_for_client(client, socket.assigns.subject, page)
+          Database.list_policy_authorizations_for_device(device, socket.assigns.subject, page)
 
         {:noreply,
          socket
-         |> assign(selected_client: client)
-         |> assign(show_client_assigns(tab))
+         |> assign(selected_device: device)
+         |> assign(show_device_assigns(tab))
          |> assign(
-           client_device_pools: Database.list_device_pools_for_client(client, socket.assigns.subject),
+           device_pools: Database.list_device_pools(device, socket.assigns.subject),
            policy_authorizations: policy_authorizations,
            policy_authorizations_page: page,
            policy_authorizations_has_next: has_next,
            policy_authorizations_expanded_id: nil,
-           client_posture: Database.list_posture_for_client(client, socket.assigns.subject),
-           client_certificate: Database.certificate_status(client, socket.assigns.subject),
+           device_posture: Database.list_posture_for_device(device, socket.assigns.subject),
+           device_certificate: Database.certificate_status(device, socket.assigns.subject),
            posture_providers_connected?:
              Database.posture_providers_connected?(socket.assigns.subject)
          )}
@@ -84,17 +84,17 @@ defmodule PortalWeb.Clients do
   def handle_params(%{"id" => id} = params, uri, %{assigns: %{live_action: :edit}} = socket) do
     socket = handle_live_tables_params(socket, params, uri)
 
-    case Database.get_client_for_panel(id, socket.assigns.subject) do
+    case Database.get_device_for_panel(id, socket.assigns.subject) do
       nil ->
-        redirect_to_clients_index(socket, "Client does not exist.")
+        redirect_to_devices_index(socket, "Device does not exist.")
 
-      client ->
-        changeset = Database.change_client(client)
+      device ->
+        changeset = Database.change_device(device)
 
         {:noreply,
          socket
-         |> assign(selected_client: client)
-         |> assign(edit_client_assigns(to_form(changeset)))}
+         |> assign(selected_device: device)
+         |> assign(edit_device_assigns(to_form(changeset)))}
     end
   end
 
@@ -104,23 +104,23 @@ defmodule PortalWeb.Clients do
     {:noreply,
      socket
      |> assign(
-       selected_client: nil,
-       client_device_pools: [],
-       client_posture: [],
-       client_certificate: nil
+       selected_device: nil,
+       device_pools: [],
+       device_posture: [],
+       device_certificate: nil
      )
-     |> assign(base_client_assigns())}
+     |> assign(base_device_assigns())}
   end
 
-  def handle_clients_update!(socket, list_opts) do
+  def handle_devices_update!(socket, list_opts) do
     list_opts = Keyword.put(list_opts, :preload, [:actor, :online?])
 
-    with {:ok, clients, metadata} <- Database.list_clients(socket.assigns.subject, list_opts) do
+    with {:ok, devices, metadata} <- Database.list_devices(socket.assigns.subject, list_opts) do
       {:ok,
        assign(socket,
-         clients: clients,
-         clients_metadata: metadata,
-         serials_by_client: Database.serial_index(clients, socket.assigns.subject)
+         devices: devices,
+         devices_metadata: metadata,
+         serials_by_device: Database.serial_index(devices, socket.assigns.subject)
        )}
     end
   end
@@ -132,7 +132,7 @@ defmodule PortalWeb.Clients do
         <:icon>
           <.icon name="ri-computer-line" class="w-16 h-16 text-brand" />
         </:icon>
-        <:title>Clients</:title>
+        <:title>Devices</:title>
         <:description>
           End-user devices and servers that access your protected Resources.
         </:description>
@@ -140,7 +140,7 @@ defmodule PortalWeb.Clients do
           <.docs_action path="/deploy/clients" />
         </:action>
         <:stats>
-          <.async_result :let={count} assign={@clients_count}>
+          <.async_result :let={count} assign={@devices_count}>
             <:loading><.badge type="primary">Loading...</.badge></:loading>
             <.dual_badge type="primary">
               <:left>{count}</:left>
@@ -153,72 +153,72 @@ defmodule PortalWeb.Clients do
       <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
         <.live_table
           stale={@stale}
-          id="clients"
-          rows={@clients}
-          row_id={&"client-#{&1.id}"}
-          row_click={fn client -> ~p"/#{@account}/clients/#{client.id}?#{@query_params}" end}
+          id="devices"
+          rows={@devices}
+          row_id={&"device-#{&1.id}"}
+          row_click={fn device -> ~p"/#{@account}/devices/#{device.id}?#{@query_params}" end}
           row_selected={
-            fn client -> not is_nil(@selected_client) and client.id == @selected_client.id end
+            fn device -> not is_nil(@selected_device) and device.id == @selected_device.id end
           }
-          filters={@filters_by_table_id["clients"]}
-          filter={@filter_form_by_table_id["clients"]}
-          ordered_by={@order_by_table_id["clients"]}
-          metadata={@clients_metadata}
+          filters={@filters_by_table_id["devices"]}
+          filter={@filter_form_by_table_id["devices"]}
+          ordered_by={@order_by_table_id["devices"]}
+          metadata={@devices_metadata}
           class="flex-1 min-h-0"
         >
-          <:col :let={client} field={{:devices, :name}} label="Client" class="w-80">
+          <:col :let={device} field={{:devices, :name}} label="Device" class="w-80">
             <div class="flex items-center gap-2">
               <span class="mr-2">
-                <.client_os_icon client={client} />
+                <.device_os_icon device={device} />
               </span>
               <div>
                 <div class="font-medium text-heading group-hover:text-brand transition-colors">
-                  {client.name}
+                  {device.name}
                 </div>
                 <div class="font-mono text-[10px] text-subtle mt-0.5">
-                  {client.id}
+                  {device.id}
                 </div>
               </div>
             </div>
           </:col>
-          <:col :let={client} label="Owner">
+          <:col :let={device} label="Owner">
             <.actor_name_and_role
               account={@account}
-              actor={client.actor}
+              actor={device.actor}
               class="text-sm"
               return_to={@return_to}
             />
           </:col>
-          <:col :let={client} label="Serial" class="w-44">
-            <.client_serial serial={Map.get(@serials_by_client, client.id)} />
+          <:col :let={device} label="Serial" class="w-44">
+            <.serial_cell serial={Map.get(@serials_by_device, device.id)} />
           </:col>
-          <:col :let={client} field={{:devices, :last_seen_version}} label="Version" class="w-32">
+          <:col :let={device} field={{:devices, :last_seen_version}} label="Version" class="w-32">
             <.version
-              current={client.last_seen_version}
-              latest={ComponentVersions.client_version(client)}
+              current={device.last_seen_version}
+              latest={ComponentVersions.client_version(device)}
             />
           </:col>
-          <:col :let={client} label="Status" class="w-28">
-            <.client_status_badge online?={client.online?} />
+          <:col :let={device} label="Status" class="w-28">
+            <.device_status_badge online?={device.online?} />
           </:col>
           <:col
-            :let={client}
+            :let={device}
             field={{:devices, :last_seen_at}}
             label="Last Started"
             class="hidden lg:table-cell"
           >
             <span class="text-xs text-subtle">
-              <.relative_datetime datetime={client.last_seen_at} />
+              <.relative_datetime datetime={device.last_seen_at} />
             </span>
           </:col>
           <:col
-            :let={client}
+            :let={device}
             field={{:devices, :inserted_at}}
             label="Created"
             class="hidden lg:table-cell"
           >
             <span class="text-xs text-subtle">
-              <.relative_datetime datetime={client.inserted_at} />
+              <.relative_datetime datetime={device.inserted_at} />
             </span>
           </:col>
           <:empty>
@@ -227,9 +227,9 @@ defmodule PortalWeb.Clients do
                 <.icon name="ri-computer-line" class="w-5 h-5 text-subtle" />
               </div>
               <div class="text-center">
-                <p class="text-sm font-medium text-heading">No clients yet</p>
+                <p class="text-sm font-medium text-heading">No devices yet</p>
                 <p class="text-xs text-subtle mt-0.5">
-                  No clients have connected yet.
+                  No devices have connected yet.
                 </p>
               </div>
             </div>
@@ -237,16 +237,16 @@ defmodule PortalWeb.Clients do
         </.live_table>
       </div>
 
-      <.client_panel
+      <.device_panel
         account={@account}
-        client={@selected_client}
-        panel={client_panel_state(assigns)}
-        confirm_state={client_confirm_state(assigns)}
+        device={@selected_device}
+        panel={device_panel_state(assigns)}
+        confirm_state={device_confirm_state(assigns)}
         query_params={@query_params}
-        device_pools={@client_device_pools}
-        posture={@client_posture}
+        device_pools={@device_pools}
+        posture={@device_posture}
         posture_providers_connected?={@posture_providers_connected?}
-        certificate={@client_certificate}
+        certificate={@device_certificate}
         policy_authorizations={@policy_authorizations}
         policy_authorizations_page={@policy_authorizations_page}
         policy_authorizations_has_next={@policy_authorizations_has_next}
@@ -256,48 +256,48 @@ defmodule PortalWeb.Clients do
     """
   end
 
-  defp client_panel_state(assigns) do
+  defp device_panel_state(assigns) do
     %{
-      panel_view: assigns.client_panel.view,
-      panel_tab: assigns.client_panel.tab,
-      client_edit_form: assigns.client_panel.edit_form
+      panel_view: assigns.device_panel.view,
+      panel_tab: assigns.device_panel.tab,
+      device_edit_form: assigns.device_panel.edit_form
     }
   end
 
-  defp client_confirm_state(assigns) do
+  defp device_confirm_state(assigns) do
     %{
-      confirm_delete_client: assigns.client_confirm.delete?,
-      confirm_unverify_client: assigns.client_confirm.unverify?
+      confirm_delete_device: assigns.device_confirm.delete?,
+      confirm_unverify_device: assigns.device_confirm.unverify?
     }
   end
 
-  defp base_client_assigns do
+  defp base_device_assigns do
     [
-      client_panel: %{
+      device_panel: %{
         view: :details,
         tab: :overview,
         edit_form: nil
       },
-      client_confirm: %{
+      device_confirm: %{
         delete?: false,
         unverify?: false
       }
     ]
   end
 
-  defp show_client_assigns(tab) do
-    assigns = base_client_assigns()
-    Keyword.update!(assigns, :client_panel, &Map.put(&1, :tab, tab))
+  defp show_device_assigns(tab) do
+    assigns = base_device_assigns()
+    Keyword.update!(assigns, :device_panel, &Map.put(&1, :tab, tab))
   end
 
-  defp edit_client_assigns(form) do
+  defp edit_device_assigns(form) do
     [
-      client_panel: %{
-        view: :edit_client,
+      device_panel: %{
+        view: :edit_device,
         tab: :overview,
         edit_form: form
       },
-      client_confirm: %{
+      device_confirm: %{
         delete?: false,
         unverify?: false
       }
@@ -314,13 +314,13 @@ defmodule PortalWeb.Clients do
 
   def handle_event("close_panel", _params, socket) do
     params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/clients?#{params}")}
+    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/devices?#{params}")}
   end
 
   def handle_event(
-        "switch_client_tab",
+        "switch_device_tab",
         %{"tab" => tab},
-        %{assigns: %{selected_client: %Device{} = client}} = socket
+        %{assigns: %{selected_device: %Device{} = device}} = socket
       ) do
     params =
       socket.assigns.query_params
@@ -329,11 +329,11 @@ defmodule PortalWeb.Clients do
 
     {:noreply,
      push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/clients/#{client}?#{params}"
+       to: ~p"/#{socket.assigns.account}/devices/#{device}?#{params}"
      )}
   end
 
-  def handle_event("switch_client_tab", _params, %{assigns: %{selected_client: nil}} = socket) do
+  def handle_event("switch_device_tab", _params, %{assigns: %{selected_device: nil}} = socket) do
     {:noreply, socket}
   end
 
@@ -342,7 +342,7 @@ defmodule PortalWeb.Clients do
 
     {:noreply,
      push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/clients/#{socket.assigns.selected_client.id}?#{params}"
+       to: ~p"/#{socket.assigns.account}/devices/#{socket.assigns.selected_device.id}?#{params}"
      )}
   end
 
@@ -353,149 +353,149 @@ defmodule PortalWeb.Clients do
     {:noreply, assign(socket, policy_authorizations_expanded_id: expanded)}
   end
 
-  def handle_event("open_client_edit_form", _params, socket) do
+  def handle_event("open_device_edit_form", _params, socket) do
     {:noreply,
      push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/clients/#{socket.assigns.selected_client.id}/edit"
+       to: ~p"/#{socket.assigns.account}/devices/#{socket.assigns.selected_device.id}/edit"
      )}
   end
 
-  def handle_event("cancel_client_edit_form", _params, socket) do
+  def handle_event("cancel_device_edit_form", _params, socket) do
     {:noreply,
      push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/clients/#{socket.assigns.selected_client.id}"
+       to: ~p"/#{socket.assigns.account}/devices/#{socket.assigns.selected_device.id}"
      )}
   end
 
-  def handle_event("change_client_edit_form", %{"device" => attrs}, socket) do
+  def handle_event("change_device_edit_form", %{"device" => attrs}, socket) do
     changeset =
-      Database.change_client(socket.assigns.selected_client, attrs)
+      Database.change_device(socket.assigns.selected_device, attrs)
       |> Map.put(:action, :validate)
 
-    {:noreply, merge_state(socket, :client_panel, edit_form: to_form(changeset))}
+    {:noreply, merge_state(socket, :device_panel, edit_form: to_form(changeset))}
   end
 
-  def handle_event("submit_client_edit_form", %{"device" => attrs}, socket) do
-    changeset = Database.change_client(socket.assigns.selected_client, attrs)
+  def handle_event("submit_device_edit_form", %{"device" => attrs}, socket) do
+    changeset = Database.change_device(socket.assigns.selected_device, attrs)
 
-    case Database.update_client(changeset, socket.assigns.subject) do
+    case Database.update_device(changeset, socket.assigns.subject) do
       {:ok, updated_client} ->
         {:noreply,
          socket
-         |> put_flash(:success, "Client updated successfully.")
-         |> reload_live_table!("clients")
-         |> push_patch(to: ~p"/#{socket.assigns.account}/clients/#{updated_client.id}")}
+         |> put_flash(:success, "Device updated successfully.")
+         |> reload_live_table!("devices")
+         |> push_patch(to: ~p"/#{socket.assigns.account}/devices/#{updated_client.id}")}
 
       {:error, changeset} ->
         {:noreply,
-         merge_state(socket, :client_panel,
+         merge_state(socket, :device_panel,
            edit_form: to_form(Map.put(changeset, :action, :validate))
          )}
     end
   end
 
   def handle_event("handle_keydown", _params, socket)
-      when socket.assigns.client_panel.view == :edit_client do
+      when socket.assigns.device_panel.view == :edit_device do
     {:noreply,
      push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/clients/#{socket.assigns.selected_client.id}"
+       to: ~p"/#{socket.assigns.account}/devices/#{socket.assigns.selected_device.id}"
      )}
   end
 
   def handle_event("handle_keydown", _params, socket)
-      when not is_nil(socket.assigns.selected_client) do
+      when not is_nil(socket.assigns.selected_device) do
     params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/clients?#{params}")}
+    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/devices?#{params}")}
   end
 
   def handle_event("handle_keydown", _params, socket) do
     {:noreply, socket}
   end
 
-  def handle_event("confirm_delete_client", _params, socket) do
-    {:noreply, merge_state(socket, :client_confirm, delete?: true)}
+  def handle_event("confirm_delete_device", _params, socket) do
+    {:noreply, merge_state(socket, :device_confirm, delete?: true)}
   end
 
-  def handle_event("cancel_delete_client", _params, socket) do
-    {:noreply, merge_state(socket, :client_confirm, delete?: false)}
+  def handle_event("cancel_delete_device", _params, socket) do
+    {:noreply, merge_state(socket, :device_confirm, delete?: false)}
   end
 
-  def handle_event("verify_client", _params, socket) do
-    client = socket.assigns.selected_client
+  def handle_event("verify_device", _params, socket) do
+    device = socket.assigns.selected_device
 
-    case Database.verify_client(client, socket.assigns.subject) do
+    case Database.verify_device(device, socket.assigns.subject) do
       {:ok, updated_client} ->
         {:noreply,
          socket
-         |> put_flash(:success, "Client \"#{client.name}\" was verified.")
-         |> assign_updated_selected_client(updated_client)
-         |> merge_state(:client_confirm, unverify?: false)
-         |> reload_live_table!("clients")}
+         |> put_flash(:success, "Device \"#{device.name}\" was verified.")
+         |> assign_updated_selected_device(updated_client)
+         |> merge_state(:device_confirm, unverify?: false)
+         |> reload_live_table!("devices")}
 
       {:error, _} ->
-        {:noreply, put_flash(socket, :error, "Failed to verify client.")}
+        {:noreply, put_flash(socket, :error, "Failed to verify device.")}
     end
   end
 
-  def handle_event("confirm_unverify_client", _params, socket) do
-    {:noreply, merge_state(socket, :client_confirm, unverify?: true)}
+  def handle_event("confirm_unverify_device", _params, socket) do
+    {:noreply, merge_state(socket, :device_confirm, unverify?: true)}
   end
 
-  def handle_event("cancel_unverify_client", _params, socket) do
-    {:noreply, merge_state(socket, :client_confirm, unverify?: false)}
+  def handle_event("cancel_unverify_device", _params, socket) do
+    {:noreply, merge_state(socket, :device_confirm, unverify?: false)}
   end
 
-  def handle_event("unverify_client", _params, socket) do
-    client = socket.assigns.selected_client
+  def handle_event("unverify_device", _params, socket) do
+    device = socket.assigns.selected_device
 
-    case Database.remove_client_verification(client, socket.assigns.subject) do
+    case Database.remove_device_verification(device, socket.assigns.subject) do
       {:ok, updated_client} ->
         {:noreply,
          socket
-         |> put_flash(:success, "Client \"#{client.name}\" was unverified.")
-         |> assign_updated_selected_client(updated_client)
-         |> merge_state(:client_confirm, unverify?: false)
-         |> reload_live_table!("clients")}
+         |> put_flash(:success, "Device \"#{device.name}\" was unverified.")
+         |> assign_updated_selected_device(updated_client)
+         |> merge_state(:device_confirm, unverify?: false)
+         |> reload_live_table!("devices")}
 
       {:error, _} ->
         {:noreply,
          socket
-         |> put_flash(:error, "Failed to unverify client.")
-         |> merge_state(:client_confirm, unverify?: false)}
+         |> put_flash(:error, "Failed to unverify device.")
+         |> merge_state(:device_confirm, unverify?: false)}
     end
   end
 
-  def handle_event("delete_client", _params, socket) do
-    client = socket.assigns.selected_client
+  def handle_event("delete_device", _params, socket) do
+    device = socket.assigns.selected_device
 
-    case Database.delete_client(client, socket.assigns.subject) do
+    case Database.delete_device(device, socket.assigns.subject) do
       {:ok, _} ->
         {:noreply,
          socket
-         |> put_flash(:success, "Client \"#{client.name}\" was deleted.")
-         |> merge_state(:client_confirm, delete?: false)
-         |> reload_live_table!("clients")
-         |> push_patch(to: ~p"/#{socket.assigns.account}/clients")}
+         |> put_flash(:success, "Device \"#{device.name}\" was deleted.")
+         |> merge_state(:device_confirm, delete?: false)
+         |> reload_live_table!("devices")
+         |> push_patch(to: ~p"/#{socket.assigns.account}/devices")}
 
       {:error, _} ->
-        {:noreply, merge_state(socket, :client_confirm, delete?: false)}
+        {:noreply, merge_state(socket, :device_confirm, delete?: false)}
     end
   end
 
-  defp assign_updated_selected_client(socket, updated_client) do
-    selected_client = %{
-      socket.assigns.selected_client
+  defp assign_updated_selected_device(socket, updated_client) do
+    selected_device = %{
+      socket.assigns.selected_device
       | verified_at: updated_client.verified_at,
         updated_at: updated_client.updated_at
     }
 
-    assign(socket, :selected_client, selected_client)
+    assign(socket, :selected_device, selected_device)
   end
 
-  defp parse_client_tab("authorizations"), do: :authorizations
-  defp parse_client_tab("posture"), do: :posture
-  defp parse_client_tab("overview"), do: :overview
-  defp parse_client_tab(_), do: :overview
+  defp parse_device_tab("authorizations"), do: :authorizations
+  defp parse_device_tab("posture"), do: :posture
+  defp parse_device_tab("overview"), do: :overview
+  defp parse_device_tab(_), do: :overview
 
   defp parse_page(params) do
     case Integer.parse(Map.get(params, "page", "1")) do
@@ -504,17 +504,17 @@ defmodule PortalWeb.Clients do
     end
   end
 
-  defp redirect_to_clients_index(socket, message) do
+  defp redirect_to_devices_index(socket, message) do
     {:noreply,
      socket
      |> put_flash(:error, message)
-     |> push_patch(to: ~p"/#{socket.assigns.account}/clients?#{socket.assigns.query_params}")}
+     |> push_patch(to: ~p"/#{socket.assigns.account}/devices?#{socket.assigns.query_params}")}
   end
 
   def handle_info(%Change{op: :insert, struct: %Device{type: :client}} = change, socket) do
     {:noreply,
      socket
-     |> update(:clients_count, fn
+     |> update(:devices_count, fn
        %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, ar.result + 1)
        ar -> ar
      end)
@@ -524,7 +524,7 @@ defmodule PortalWeb.Clients do
   def handle_info(%Change{op: :delete, old_struct: %Device{type: :client}} = change, socket) do
     {:noreply,
      socket
-     |> update(:clients_count, fn
+     |> update(:devices_count, fn
        %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, max(ar.result - 1, 0))
        ar -> ar
      end)
@@ -542,10 +542,10 @@ defmodule PortalWeb.Clients do
         %Phoenix.Socket.Broadcast{topic: "presences:account_clients:" <> _account_id} = event,
         socket
       ) do
-    rendered_client_ids = Enum.map(socket.assigns.clients, & &1.id)
+    rendered_client_ids = Enum.map(socket.assigns.devices, & &1.id)
 
     if presence_updates_any_id?(event, rendered_client_ids) do
-      socket = reload_live_table!(socket, "clients")
+      socket = reload_live_table!(socket, "devices")
       {:noreply, socket}
     else
       {:noreply, socket}
@@ -555,7 +555,7 @@ defmodule PortalWeb.Clients do
   def handle_info(message, socket), do: PortalWeb.Live.Helpers.handle_info_fallback(message, socket)
 
   defp mark_stale_if_unreflected(socket, change) do
-    if PortalWeb.LiveTable.view_reflects_change?(socket.assigns.clients, change) do
+    if PortalWeb.LiveTable.view_reflects_change?(socket.assigns.devices, change) do
       socket
     else
       assign(socket, stale: true)
@@ -579,14 +579,14 @@ defmodule PortalWeb.Clients do
     alias Portal.PostureProvider
     alias Portal.{Defender, Intune, Iru, Santa, SentinelOne}
 
-    def count_clients(subject) do
+    def count_devices(subject) do
       from(d in Device, as: :devices)
       |> where([devices: d], d.type == :client)
       |> Safe.scoped(subject)
       |> Safe.aggregate(:count)
     end
 
-    def list_clients(subject, opts \\ []) do
+    def list_devices(subject, opts \\ []) do
       {preload, opts} = Keyword.pop(opts, :preload, [])
       {filter, opts} = Keyword.pop(opts, :filter, [])
       {order_by, opts} = Keyword.pop(opts, :order_by, [])
@@ -602,10 +602,10 @@ defmodule PortalWeb.Clients do
            {:ok, filtered_query} <- Filter.filter(base_query, __MODULE__, filter),
            count when is_integer(count) <-
              Safe.aggregate(Safe.scoped(filtered_query, subject), :count),
-           client_ids <- list_client_ids(filtered_query, paginator_opts, subject),
+           client_ids <- list_device_ids(filtered_query, paginator_opts, subject),
            {client_ids, metadata} <- OffsetPaginator.metadata(client_ids, paginator_opts) do
-        clients = fetch_clients_page(client_ids, preload, subject)
-        {:ok, clients, %{metadata | count: count}}
+        devices = fetch_devices_page(client_ids, preload, subject)
+        {:ok, devices, %{metadata | count: count}}
       else
         {:error, :unauthorized} = error -> error
         {:error, _reason} = error -> error
@@ -632,7 +632,7 @@ defmodule PortalWeb.Clients do
       end
     end
 
-    defp list_client_ids(filtered_query, paginator_opts, subject) do
+    defp list_device_ids(filtered_query, paginator_opts, subject) do
       filtered_query
       |> select([devices: d], d.id)
       |> OffsetPaginator.query(paginator_opts)
@@ -640,49 +640,49 @@ defmodule PortalWeb.Clients do
       |> Safe.all()
     end
 
-    defp fetch_clients_page([], _preload, _subject), do: []
+    defp fetch_devices_page([], _preload, _subject), do: []
 
-    defp fetch_clients_page(client_ids, preload, subject) do
-      clients =
+    defp fetch_devices_page(client_ids, preload, subject) do
+      devices =
         page_query(subject)
         |> where([devices: d], d.id in ^client_ids)
         |> Safe.scoped(subject)
         |> Safe.all()
-        |> maybe_preload_clients(preload, subject)
+        |> maybe_preload_devices(preload, subject)
 
-      clients_by_id = Map.new(clients, &{&1.id, &1})
+      clients_by_id = Map.new(devices, &{&1.id, &1})
 
       client_ids
       |> Enum.map(&Map.get(clients_by_id, &1))
       |> Enum.reject(&is_nil/1)
     end
 
-    defp maybe_preload_clients(clients, preload, _subject) do
-      Enum.reduce(preload, clients, fn
-        :actor, clients ->
-          Safe.preload(clients, :actor)
+    defp maybe_preload_devices(devices, preload, _subject) do
+      Enum.reduce(preload, devices, fn
+        :actor, devices ->
+          Safe.preload(devices, :actor)
 
-        :online?, clients ->
-          Clients.preload_clients_presence(clients)
+        :online?, devices ->
+          Clients.preload_clients_presence(devices)
 
-        _other, clients ->
-          clients
+        _other, devices ->
+          devices
       end)
     end
 
-    @spec change_client(Portal.Device.t(), map()) :: Ecto.Changeset.t()
-    def change_client(client, attrs \\ %{}) do
+    @spec change_device(Portal.Device.t(), map()) :: Ecto.Changeset.t()
+    def change_device(device, attrs \\ %{}) do
       import Ecto.Changeset
 
-      client
+      device
       |> cast(attrs, [:name])
       |> validate_required([:name])
       |> Portal.Device.changeset()
     end
 
-    @spec update_client(Ecto.Changeset.t(), Portal.Authentication.Subject.t()) ::
+    @spec update_device(Ecto.Changeset.t(), Portal.Authentication.Subject.t()) ::
             {:ok, Portal.Device.t()} | {:error, Ecto.Changeset.t()}
-    def update_client(changeset, subject) do
+    def update_device(changeset, subject) do
       case Safe.scoped(changeset, subject) |> Safe.update() do
         {:ok, updated_client} ->
           {:ok, Clients.preload_clients_presence([updated_client]) |> List.first()}
@@ -692,28 +692,28 @@ defmodule PortalWeb.Clients do
       end
     end
 
-    @spec verify_client(Portal.Device.t(), Portal.Authentication.Subject.t()) ::
+    @spec verify_device(Portal.Device.t(), Portal.Authentication.Subject.t()) ::
             {:ok, Portal.Device.t()} | {:error, Ecto.Changeset.t()}
-    def verify_client(client, subject) do
-      client
+    def verify_device(device, subject) do
+      device
       |> change()
       |> put_default_value(:verified_at, DateTime.utc_now())
-      |> update_client(subject)
+      |> update_device(subject)
     end
 
-    @spec remove_client_verification(Portal.Device.t(), Portal.Authentication.Subject.t()) ::
+    @spec remove_device_verification(Portal.Device.t(), Portal.Authentication.Subject.t()) ::
             {:ok, Portal.Device.t()} | {:error, Ecto.Changeset.t()}
-    def remove_client_verification(client, subject) do
-      client
+    def remove_device_verification(device, subject) do
+      device
       |> change()
       |> put_change(:verified_at, nil)
-      |> update_client(subject)
+      |> update_device(subject)
     end
 
-    @spec delete_client(Portal.Device.t(), Portal.Authentication.Subject.t()) ::
+    @spec delete_device(Portal.Device.t(), Portal.Authentication.Subject.t()) ::
             {:ok, Portal.Device.t()} | {:error, term()}
-    def delete_client(client, subject) do
-      case Safe.scoped(client, subject) |> Safe.delete() do
+    def delete_device(device, subject) do
+      case Safe.scoped(device, subject) |> Safe.delete() do
         {:ok, deleted_client} ->
           {:ok, Clients.preload_clients_presence([deleted_client]) |> List.first()}
 
@@ -722,10 +722,10 @@ defmodule PortalWeb.Clients do
       end
     end
 
-    @spec get_client_for_panel(binary(), Portal.Authentication.Subject.t()) ::
+    @spec get_device_for_panel(binary(), Portal.Authentication.Subject.t()) ::
             Portal.Device.t() | nil
-    def get_client_for_panel(id, subject) do
-      client =
+    def get_device_for_panel(id, subject) do
+      device =
         from(c in Device, as: :devices)
         |> where([devices: d], d.type == :client)
         |> where([devices: d], d.id == ^id)
@@ -733,24 +733,24 @@ defmodule PortalWeb.Clients do
         |> Safe.scoped(subject)
         |> Safe.one()
 
-      case client do
+      case device do
         %Device{type: :client} ->
-          Clients.preload_clients_presence([client]) |> List.first()
+          Clients.preload_clients_presence([device]) |> List.first()
 
         _ ->
           nil
       end
     end
 
-    @spec list_device_pools_for_client(Portal.Device.t(), Portal.Authentication.Subject.t()) ::
+    @spec list_device_pools(Portal.Device.t(), Portal.Authentication.Subject.t()) ::
             [Resource.t()]
-    def list_device_pools_for_client(%Device{} = client, subject) do
+    def list_device_pools(%Device{} = device, subject) do
       from(r in Resource, as: :resources)
       |> join(:inner, [resources: r], m in StaticDevicePoolMember,
         on: m.resource_id == r.id and m.account_id == r.account_id,
         as: :members
       )
-      |> where([members: m], m.device_id == ^client.id)
+      |> where([members: m], m.device_id == ^device.id)
       # The REST API can retype a pool without clearing its members, so filter on
       # the resource rather than trusting the membership rows alone.
       |> where([resources: r], r.type == :static_device_pool)
@@ -781,7 +781,7 @@ defmodule PortalWeb.Clients do
       [
         %Portal.Repo.Filter{
           name: :search,
-          title: "Client or Actor",
+          title: "Device or Actor",
           type: {:string, :websearch},
           fun: &filter_by_search_fts/2
         },
@@ -853,25 +853,25 @@ defmodule PortalWeb.Clients do
     end
 
     def filter_by_presence(queryable, _presence) do
-      # This is handled as a prefilter in list_clients
+      # This is handled as a prefilter in list_devices
       # Return the queryable unchanged since actual filtering happens above
       {queryable, true}
     end
 
     @page_size 25
 
-    @spec list_policy_authorizations_for_client(
+    @spec list_policy_authorizations_for_device(
             Portal.Device.t(),
             Portal.Authentication.Subject.t(),
             non_neg_integer()
           ) :: {[map()], boolean()}
-    def list_policy_authorizations_for_client(client, subject, page \\ 1) do
+    def list_policy_authorizations_for_device(device, subject, page \\ 1) do
       offset = (page - 1) * @page_size
 
       from(pa in PolicyAuthorization, as: :policy_authorizations)
       |> where(
         [policy_authorizations: pa],
-        pa.initiating_device_id == ^client.id or pa.receiving_device_id == ^client.id
+        pa.initiating_device_id == ^device.id or pa.receiving_device_id == ^device.id
       )
       |> join(:inner, [policy_authorizations: pa], p in Policy,
         on: p.id == pa.policy_id and p.account_id == pa.account_id,
@@ -946,7 +946,7 @@ defmodule PortalWeb.Clients do
     One row per configured provider rather than per provider type, so an
     account running two Intune tenants sees the device in both.
     """
-    @spec list_posture_for_client(Device.t(), Portal.Authentication.Subject.t()) :: [
+    @spec list_posture_for_device(Device.t(), Portal.Authentication.Subject.t()) :: [
             %{
               type: atom(),
               provider: PostureProvider.t(),
@@ -955,7 +955,7 @@ defmodule PortalWeb.Clients do
               via: :intune | nil
             }
           ]
-    def list_posture_for_client(%Device{type: :client} = device, subject) do
+    def list_posture_for_device(%Device{type: :client} = device, subject) do
       keys = match_keys(device)
       providers = list_posture_providers(subject)
 
@@ -974,7 +974,7 @@ defmodule PortalWeb.Clients do
       end
     end
 
-    def list_posture_for_client(_client, _subject), do: []
+    def list_posture_for_device(_device, _subject), do: []
 
     defp posture_entry({type, device, matched_on, via}, providers_by_id) do
       case Map.fetch(providers_by_id, device.posture_provider_id) do
@@ -991,7 +991,7 @@ defmodule PortalWeb.Clients do
     @doc """
     Whether the account has connected a posture provider at all.
 
-    The panel offers its Posture tab to every Client, so it has to tell a
+    The panel offers its Posture tab to every Device, so it has to tell a
     device no provider holds a record for apart from an account that has no
     provider to hold one.
     """
@@ -1007,10 +1007,10 @@ defmodule PortalWeb.Clients do
     end
 
     @doc """
-    The serial number the Clients list shows for each row, and where it came from.
+    The serial number the Devices list shows for each row, and where it came from.
 
-    A Client that attested a serial shows that one. Failing that, the serial the
-    account's MDM holds for the device id the Client did attest, which is as
+    A Device that attested a serial shows that one. Failing that, the serial the
+    account's MDM holds for the device id the Device did attest, which is as
     well proven as that id. Failing both, the self-reported serial, which
     nothing vouches for.
 
@@ -1131,7 +1131,7 @@ defmodule PortalWeb.Clients do
       |> normalize_certificate_status()
     end
 
-    def certificate_status(_client, _subject), do: nil
+    def certificate_status(_device, _subject), do: nil
 
     defp normalize_certificate_status(%{crl_revoked_at: revoked_at} = row)
          when not is_nil(revoked_at) do

--- a/elixir/lib/portal_web/live/devices/components.ex
+++ b/elixir/lib/portal_web/live/devices/components.ex
@@ -1,4 +1,4 @@
-defmodule PortalWeb.Clients.Components do
+defmodule PortalWeb.Devices.Components do
   use PortalWeb, :component_library
   import PortalWeb.CoreComponents
   alias Portal.ComponentVersions
@@ -46,85 +46,85 @@ defmodule PortalWeb.Clients.Components do
     device.last_seen_user_agent
   end
 
-  def client_os(assigns) do
-    assigns = assign(assigns, :user_agent, device_user_agent(assigns.client))
+  def device_os(assigns) do
+    assigns = assign(assigns, :user_agent, device_user_agent(assigns.device))
 
     ~H"""
     <div class="flex items-center text-xs text-body">
-      <span class="mr-1 mb-1"><.client_os_icon client={@client} /></span>
-      {get_client_os_name_and_version(@user_agent)}
+      <span class="mr-1 mb-1"><.device_os_icon device={@device} /></span>
+      {os_name_and_version(@user_agent)}
     </div>
     """
   end
 
-  def client_os_icon(assigns) do
-    assigns = assign(assigns, :user_agent, device_user_agent(assigns.client))
+  def device_os_icon(assigns) do
+    assigns = assign(assigns, :user_agent, device_user_agent(assigns.device))
 
     ~H"""
     <.icon
-      name={client_os_icon_name(@user_agent)}
-      title={get_client_os_name_and_version(@user_agent)}
+      name={os_icon_name(@user_agent)}
+      title={os_name_and_version(@user_agent)}
       class="w-5 h-5"
     />
     """
   end
 
-  def client_os_name_and_version(assigns) do
-    assigns = assign(assigns, :user_agent, device_user_agent(assigns.client))
+  def device_os_name_and_version(assigns) do
+    assigns = assign(assigns, :user_agent, device_user_agent(assigns.device))
 
     ~H"""
     <span>
-      {get_client_os_name_and_version(@user_agent)}
+      {os_name_and_version(@user_agent)}
     </span>
     """
   end
 
-  def client_as_icon(assigns) do
+  def device_as_icon(assigns) do
     ~H"""
     <.popover placement="right">
       <:target>
-        <.client_os_icon client={@client} />
+        <.device_os_icon device={@device} />
       </:target>
       <:content>
         <div>
-          {@client.name}
+          {@device.name}
           <.icon
-            :if={trust_state(@client)}
-            name={trust_state(@client).icon}
+            :if={trust_state(@device)}
+            name={trust_state(@device).icon}
             class="h-2.5 w-2.5 text-neutral-500"
-            title={trust_state(@client).title}
+            title={trust_state(@device).title}
           />
         </div>
         <div>
-          <.client_os_name_and_version client={@client} />
+          <.device_os_name_and_version device={@device} />
         </div>
         <div>
           <span>Last started:</span>
           <.relative_datetime
-            datetime={@client.last_seen_at}
+            datetime={@device.last_seen_at}
             popover={false}
           />
         </div>
         <div>
-          <.connection_status schema={@client} />
+          <.connection_status schema={@device} />
         </div>
       </:content>
     </.popover>
     """
   end
 
-  def client_os_icon_name(nil), do: "ri-computer-line"
-  def client_os_icon_name("Windows/" <> _), do: "icon-os-windows"
-  def client_os_icon_name("Mac OS/" <> _), do: "icon-os-macos"
-  def client_os_icon_name("iOS/" <> _), do: "icon-os-ios"
-  def client_os_icon_name("Android/" <> _), do: "icon-os-android"
-  def client_os_icon_name("Ubuntu/" <> _), do: "icon-os-ubuntu"
-  def client_os_icon_name("Debian/" <> _), do: "icon-os-debian"
-  def client_os_icon_name("Manjaro/" <> _), do: "icon-os-manjaro"
-  def client_os_icon_name("CentOS/" <> _), do: "icon-os-linux"
-  def client_os_icon_name("Fedora/" <> _), do: "icon-os-linux"
+  def os_icon_name(nil), do: "ri-computer-line"
+  def os_icon_name("Windows/" <> _), do: "icon-os-windows"
+  def os_icon_name("Mac OS/" <> _), do: "icon-os-macos"
+  def os_icon_name("iOS/" <> _), do: "icon-os-ios"
+  def os_icon_name("Android/" <> _), do: "icon-os-android"
+  def os_icon_name("Ubuntu/" <> _), do: "icon-os-ubuntu"
+  def os_icon_name("Debian/" <> _), do: "icon-os-debian"
+  def os_icon_name("Manjaro/" <> _), do: "icon-os-manjaro"
+  def os_icon_name("CentOS/" <> _), do: "icon-os-linux"
+  def os_icon_name("Fedora/" <> _), do: "icon-os-linux"
 
-  def client_os_icon_name(other) do
+  def os_icon_name(other) do
     if String.contains?(other, "linux") do
       "icon-os-linux"
     else
@@ -195,7 +195,7 @@ defmodule PortalWeb.Clients.Components do
   defp outdated_version?(_, _), do: false
 
   attr :account, :any, required: true
-  attr :client, :any, required: true
+  attr :device, :any, required: true
   attr :panel, :map, required: true
   attr :confirm_state, :map, required: true
   attr :query_params, :map, default: %{}
@@ -208,7 +208,7 @@ defmodule PortalWeb.Clients.Components do
   attr :policy_authorizations_has_next, :boolean, default: false
   attr :policy_authorizations_expanded_id, :string, default: nil
 
-  def client_panel(assigns) do
+  def device_panel(assigns) do
     assigns =
       assigns
       |> assign(assigns.panel)
@@ -216,30 +216,30 @@ defmodule PortalWeb.Clients.Components do
 
     ~H"""
     <div
-      id="client-panel"
+      id="device-panel"
       class={[
         "absolute inset-y-0 right-0 z-10 flex flex-col w-full lg:w-3/4 xl:w-2/3",
         "bg-elevated border-l border-border-strong",
         "shadow-[-4px_0px_20px_rgba(0,0,0,0.07)]",
         "transition-transform duration-200 ease-in-out",
-        if(@client, do: "translate-x-0", else: "translate-x-full")
+        if(@device, do: "translate-x-0", else: "translate-x-full")
       ]}
       phx-window-keydown="handle_keydown"
       phx-key="Escape"
     >
-      <div :if={@client} class="flex flex-col h-full overflow-hidden">
-        <.client_edit_view
-          :if={@panel_view == :edit_client}
-          client_edit_form={@client_edit_form}
+      <div :if={@device} class="flex flex-col h-full overflow-hidden">
+        <.device_edit_view
+          :if={@panel_view == :edit_device}
+          device_edit_form={@device_edit_form}
         />
 
-        <.client_details_view
-          :if={@panel_view != :edit_client}
+        <.device_details_view
+          :if={@panel_view != :edit_device}
           account={@account}
-          client={@client}
+          device={@device}
           tab={@panel_tab}
-          confirm_delete_client={@confirm_delete_client}
-          confirm_unverify_client={@confirm_unverify_client}
+          confirm_delete_device={@confirm_delete_device}
+          confirm_unverify_device={@confirm_unverify_device}
           device_pools={@device_pools}
           posture={@posture}
           posture_providers_connected?={@posture_providers_connected?}
@@ -254,43 +254,43 @@ defmodule PortalWeb.Clients.Components do
     """
   end
 
-  attr :client_edit_form, :any, default: nil
+  attr :device_edit_form, :any, default: nil
 
-  def client_edit_view(assigns) do
+  def device_edit_view(assigns) do
     ~H"""
     <div class="flex flex-1 min-h-0 flex-col overflow-hidden">
-      <.panel_header title="Edit Client" close_event="cancel_client_edit_form" />
+      <.panel_header title="Edit Device" close_event="cancel_device_edit_form" />
       <.form
-        :if={@client_edit_form}
-        id="client-edit-form"
-        for={@client_edit_form}
-        phx-submit="submit_client_edit_form"
-        phx-change="change_client_edit_form"
+        :if={@device_edit_form}
+        id="device-edit-form"
+        for={@device_edit_form}
+        phx-submit="submit_device_edit_form"
+        phx-change="change_device_edit_form"
         class="flex flex-col flex-1 min-h-0 overflow-hidden"
       >
-        <.client_edit_form_body client_edit_form={@client_edit_form} />
-        <.client_edit_actions />
+        <.device_edit_form_body device_edit_form={@device_edit_form} />
+        <.device_edit_actions />
       </.form>
     </div>
     """
   end
 
-  attr :client_edit_form, :any, required: true
+  attr :device_edit_form, :any, required: true
 
-  def client_edit_form_body(assigns) do
+  def device_edit_form_body(assigns) do
     ~H"""
     <div class="flex-1 overflow-y-auto px-5 py-4 space-y-4">
       <div>
         <label
-          for={@client_edit_form[:name].id}
+          for={@device_edit_form[:name].id}
           class="block text-xs font-medium text-body mb-1.5"
         >
           Name <span class="text-error">*</span>
         </label>
         <.input
-          field={@client_edit_form[:name]}
+          field={@device_edit_form[:name]}
           type="text"
-          placeholder="Client name"
+          placeholder="Device name"
           phx-debounce="300"
           required
         />
@@ -299,10 +299,10 @@ defmodule PortalWeb.Clients.Components do
     """
   end
 
-  def client_edit_actions(assigns) do
+  def device_edit_actions(assigns) do
     ~H"""
     <.panel_footer>
-      <.panel_footer_button type="button" phx-click="cancel_client_edit_form">
+      <.panel_footer_button type="button" phx-click="cancel_device_edit_form">
         Cancel
       </.panel_footer_button>
       <.panel_footer_button type="submit" style="primary">
@@ -313,10 +313,10 @@ defmodule PortalWeb.Clients.Components do
   end
 
   attr :account, :any, required: true
-  attr :client, :any, required: true
+  attr :device, :any, required: true
   attr :tab, :atom, default: :overview
-  attr :confirm_delete_client, :boolean, default: false
-  attr :confirm_unverify_client, :boolean, default: false
+  attr :confirm_delete_device, :boolean, default: false
+  attr :confirm_unverify_device, :boolean, default: false
   attr :device_pools, :list, default: []
   attr :posture, :list, default: []
   attr :posture_providers_connected?, :boolean, default: false
@@ -326,30 +326,30 @@ defmodule PortalWeb.Clients.Components do
   attr :policy_authorizations_has_next, :boolean, default: false
   attr :policy_authorizations_expanded_id, :string, default: nil
 
-  def client_details_view(assigns) do
+  def device_details_view(assigns) do
     posture_tab? = device_posture_enabled?()
 
     assigns =
       assigns
       |> assign(:posture_tab?, posture_tab?)
-      |> assign(:tab, visible_client_tab(assigns.tab, posture_tab?))
+      |> assign(:tab, visible_device_tab(assigns.tab, posture_tab?))
 
     ~H"""
     <div class="flex flex-col h-full overflow-hidden">
-      <.client_details_header client={@client} />
+      <.device_details_header device={@device} />
       <div class="flex flex-1 min-h-0 divide-x divide-border">
         <div class="flex-1 flex flex-col overflow-hidden">
           <div
             role="tablist"
             class="flex items-end gap-0 px-5 border-b border-border bg-raised shrink-0"
           >
-            <.client_tab tab="overview" label="Overview" selected={@tab == :overview} />
-            <.client_tab
+            <.device_tab tab="overview" label="Overview" selected={@tab == :overview} />
+            <.device_tab
               tab="authorizations"
               label="Authorizations"
               selected={@tab == :authorizations}
             />
-            <.client_tab
+            <.device_tab
               :if={@posture_tab?}
               tab="posture"
               label="Posture"
@@ -357,40 +357,40 @@ defmodule PortalWeb.Clients.Components do
             />
           </div>
           <div :if={@tab == :overview} class="flex-1 overflow-y-auto">
-            <.client_owner_section account={@account} client={@client} />
-            <.client_device_pools_section
+            <.device_owner_section account={@account} device={@device} />
+            <.device_pools_section
               :if={@device_pools != []}
               account={@account}
               device_pools={@device_pools}
             />
-            <.client_device_section account={@account} client={@client} />
-            <.client_certificate_section
-              :if={@client.last_attested_cert_fingerprint}
-              client={@client}
+            <.device_section account={@account} device={@device} />
+            <.device_certificate_section
+              :if={@device.last_attested_cert_fingerprint}
+              device={@device}
               certificate={@certificate}
             />
-            <.client_network_section client={@client} />
+            <.device_network_section device={@device} />
           </div>
-          <.client_posture_tab
+          <.device_posture_tab
             :if={@tab == :posture}
             account={@account}
             posture={@posture}
             providers_connected?={@posture_providers_connected?}
           />
-          <.client_policy_authorizations_tab
+          <.device_policy_authorizations_tab
             :if={@tab == :authorizations}
             account={@account}
-            client={@client}
+            device={@device}
             policy_authorizations={@policy_authorizations}
             page={@policy_authorizations_page}
             has_next={@policy_authorizations_has_next}
             expanded_id={@policy_authorizations_expanded_id}
           />
         </div>
-        <.client_sidebar
-          client={@client}
-          confirm_delete_client={@confirm_delete_client}
-          confirm_unverify_client={@confirm_unverify_client}
+        <.device_sidebar
+          device={@device}
+          confirm_delete_device={@confirm_delete_device}
+          confirm_unverify_device={@confirm_unverify_device}
         />
       </div>
     </div>
@@ -398,13 +398,13 @@ defmodule PortalWeb.Clients.Components do
   end
 
   attr :account, :any, required: true
-  attr :client, :any, required: true
+  attr :device, :any, required: true
   attr :policy_authorizations, :list, default: []
   attr :page, :integer, default: 1
   attr :has_next, :boolean, default: false
   attr :expanded_id, :string, default: nil
 
-  def client_policy_authorizations_tab(assigns) do
+  def device_policy_authorizations_tab(assigns) do
     ~H"""
     <div class="flex-1 flex flex-col overflow-hidden">
       <.authorization_flow_logs_notice account={@account} />
@@ -503,7 +503,7 @@ defmodule PortalWeb.Clients.Components do
                       <div>
                         <p class="text-subtle font-medium mb-1">Owner</p>
                         <p class="text-heading">
-                          {if @client.actor, do: @client.actor.name, else: "—"}
+                          {if @device.actor, do: @device.actor.name, else: "—"}
                         </p>
                       </div>
                       <div>
@@ -546,24 +546,24 @@ defmodule PortalWeb.Clients.Components do
     """
   end
 
-  attr :client, :any, required: true
+  attr :device, :any, required: true
 
-  def client_details_header(assigns) do
+  def device_details_header(assigns) do
     ~H"""
     <div class="shrink-0 px-5 py-4 border-b border-border bg-elevated">
       <div class="flex items-center gap-4">
         <%!-- Left: name + status + ID --%>
         <div class="min-w-0 flex-1">
           <div class="flex items-center gap-2">
-            <h2 class="text-sm font-semibold text-heading truncate">{@client.name}</h2>
-            <.client_status_badge online?={@client.online?} />
-            <.client_verified_badge client={@client} />
+            <h2 class="text-sm font-semibold text-heading truncate">{@device.name}</h2>
+            <.device_status_badge online?={@device.online?} />
+            <.device_verified_badge device={@device} />
           </div>
-          <p class="font-mono text-xs text-subtle mt-0.5 truncate">{@client.id}</p>
+          <p class="font-mono text-xs text-subtle mt-0.5 truncate">{@device.id}</p>
         </div>
         <%!-- Right: actions --%>
         <div class="flex items-center gap-1.5 shrink-0">
-          <.button phx-click="open_client_edit_form" size="xs">
+          <.button phx-click="open_device_edit_form" size="xs">
             <.icon name="ri-pencil-line" class="w-3.5 h-3.5" /> Edit
           </.button>
           <.icon_button icon="ri-close-line" title="Close (Esc)" phx-click="close_panel" />
@@ -574,25 +574,25 @@ defmodule PortalWeb.Clients.Components do
   end
 
   attr :account, :any, required: true
-  attr :client, :any, required: true
+  attr :device, :any, required: true
 
-  def client_owner_section(assigns) do
+  def device_owner_section(assigns) do
     ~H"""
     <div class="px-5 pt-4 pb-3 border-b border-border">
       <.section_heading title="Owner" />
       <.link
-        navigate={~p"/#{@account}/actors/#{@client.actor.id}"}
+        navigate={~p"/#{@account}/actors/#{@device.actor.id}"}
         class="flex items-center gap-3 px-3 py-2.5 rounded border border-border bg-raised hover:border-border-strong transition-colors group"
       >
         <div class="flex items-center justify-center w-8 h-8 rounded-full shrink-0 text-xs font-semibold bg-brand-muted text-brand">
-          {String.slice(@client.actor.name, 0, 2) |> String.upcase()}
+          {String.slice(@device.actor.name, 0, 2) |> String.upcase()}
         </div>
         <div class="min-w-0">
           <p class="text-sm font-medium text-heading group-hover:text-brand truncate transition-colors">
-            {@client.actor.name}
+            {@device.actor.name}
           </p>
-          <p :if={@client.actor.email} class="text-xs text-subtle truncate">
-            {@client.actor.email}
+          <p :if={@device.actor.email} class="text-xs text-subtle truncate">
+            {@device.actor.email}
           </p>
         </div>
       </.link>
@@ -603,12 +603,12 @@ defmodule PortalWeb.Clients.Components do
   attr :account, :any, required: true
   attr :device_pools, :list, required: true
 
-  def client_device_pools_section(assigns) do
+  def device_pools_section(assigns) do
     ~H"""
     <div class="px-5 pt-4 pb-3 border-b border-border">
       <.section_heading title="Device Pools" />
       <p class="mb-2 text-xs text-subtle">
-        Anyone granted access to these pools can reach this Client directly on its tunnel address.
+        Anyone granted access to these pools can reach this device directly on its tunnel address.
       </p>
       <ul class="space-y-1">
         <li :for={pool <- @device_pools}>
@@ -628,9 +628,9 @@ defmodule PortalWeb.Clients.Components do
   end
 
   attr :account, :any, required: true
-  attr :client, :any, required: true
+  attr :device, :any, required: true
 
-  def client_device_section(assigns) do
+  def device_section(assigns) do
     ~H"""
     <div class="px-5 pt-4 pb-3 border-b border-border">
       <.section_heading title="Reported by Client">
@@ -644,7 +644,7 @@ defmodule PortalWeb.Clients.Components do
                 The Firezone Client reads and reports these values. Only trust them if you trust
                 the actor and device.
               </p>
-              <p :if={is_nil(@client.last_attested_at)} class="mt-1">
+              <p :if={is_nil(@device.last_attested_at)} class="mt-1">
                 Set up
                 <.link
                   navigate={~p"/#{@account}/settings/trust_anchors"}
@@ -659,56 +659,56 @@ defmodule PortalWeb.Clients.Components do
         </:info>
       </.section_heading>
       <dl class="space-y-3">
-        <.client_detail_row :if={@client.last_seen_at} label="Operating System">
-          <.client_os client={@client} />
-        </.client_detail_row>
-        <.client_detail_row :if={@client.device_serial} label="Serial Number">
+        <.device_detail_row :if={@device.last_seen_at} label="Operating System">
+          <.device_os device={@device} />
+        </.device_detail_row>
+        <.device_detail_row :if={@device.device_serial} label="Serial Number">
           <span class="font-mono text-sm text-heading font-medium">
-            {@client.device_serial}
+            {@device.device_serial}
           </span>
-        </.client_detail_row>
-        <.client_detail_row :if={@client.device_uuid} label="Device UUID">
+        </.device_detail_row>
+        <.device_detail_row :if={@device.device_uuid} label="Device UUID">
           <span class="font-mono text-xs text-body break-all">
-            {@client.device_uuid}
+            {@device.device_uuid}
           </span>
-        </.client_detail_row>
-        <.client_detail_row :if={@client.identifier_for_vendor} label="App Installation ID">
+        </.device_detail_row>
+        <.device_detail_row :if={@device.identifier_for_vendor} label="App Installation ID">
           <span class="font-mono text-xs text-body break-all">
-            {@client.identifier_for_vendor}
+            {@device.identifier_for_vendor}
           </span>
-        </.client_detail_row>
-        <.client_detail_row :if={@client.firebase_installation_id} label="App Installation ID">
+        </.device_detail_row>
+        <.device_detail_row :if={@device.firebase_installation_id} label="App Installation ID">
           <span class="font-mono text-xs text-body break-all">
-            {@client.firebase_installation_id}
+            {@device.firebase_installation_id}
           </span>
-        </.client_detail_row>
+        </.device_detail_row>
       </dl>
     </div>
     """
   end
 
-  attr :client, :any, required: true
+  attr :device, :any, required: true
 
-  def client_network_section(assigns) do
+  def device_network_section(assigns) do
     ~H"""
     <div class="px-5 pt-4 pb-3">
       <.section_heading title="Network" />
       <dl class="space-y-3">
-        <.client_detail_row :if={@client.last_seen_remote_ip} label="Remote IP">
+        <.device_detail_row :if={@device.last_seen_remote_ip} label="Remote IP">
           <span class="text-xs text-body">
-            <.last_seen schema={@client} />
+            <.last_seen schema={@device} />
           </span>
-        </.client_detail_row>
-        <.client_detail_row label="Tunnel IPv4">
+        </.device_detail_row>
+        <.device_detail_row label="Tunnel IPv4">
           <span class="font-mono text-xs text-body">
-            {@client.ipv4}
+            {@device.ipv4}
           </span>
-        </.client_detail_row>
-        <.client_detail_row label="Tunnel IPv6">
+        </.device_detail_row>
+        <.device_detail_row label="Tunnel IPv6">
           <span class="font-mono text-xs text-body break-all">
-            {@client.ipv6}
+            {@device.ipv6}
           </span>
-        </.client_detail_row>
+        </.device_detail_row>
       </dl>
     </div>
     """
@@ -718,12 +718,12 @@ defmodule PortalWeb.Clients.Components do
   attr :label, :string, required: true
   attr :selected, :boolean, required: true
 
-  def client_tab(assigns) do
+  def device_tab(assigns) do
     ~H"""
     <button
       role="tab"
       aria-selected={@selected}
-      phx-click="switch_client_tab"
+      phx-click="switch_device_tab"
       phx-value-tab={@tab}
       class={[
         "flex items-center gap-1.5 px-1 py-2.5 mr-5 text-xs font-medium border-b-2 transition-colors",
@@ -742,13 +742,13 @@ defmodule PortalWeb.Clients.Components do
   attr :posture, :list, required: true
   attr :providers_connected?, :boolean, default: false
 
-  def client_posture_tab(assigns) do
+  def device_posture_tab(assigns) do
     assigns = assign(assigns, :state, posture_tab_state(assigns))
 
     ~H"""
     <div class="flex-1 overflow-y-auto">
       <div :if={@state == :records}>
-        <.client_posture_section :for={entry <- @posture} account={@account} entry={entry} />
+        <.device_posture_section :for={entry <- @posture} account={@account} entry={entry} />
       </div>
       <.posture_locked :if={@state == :locked} account={@account} />
       <div
@@ -776,7 +776,7 @@ defmodule PortalWeb.Clients.Components do
   attr :account, :any, required: true
   attr :entry, :map, required: true
 
-  def client_posture_section(assigns) do
+  def device_posture_section(assigns) do
     assigns =
       assigns
       |> assign(:attributes, posture_attributes(assigns.entry.type, assigns.entry.device))
@@ -796,9 +796,9 @@ defmodule PortalWeb.Clients.Components do
       </div>
 
       <dl class="grid grid-cols-2 gap-x-6 gap-y-3 mb-4">
-        <.client_detail_row :for={{label, value} <- @attributes} label={label}>
+        <.device_detail_row :for={{label, value} <- @attributes} label={label}>
           <.posture_value value={value} />
-        </.client_detail_row>
+        </.device_detail_row>
       </dl>
 
       <.json_view
@@ -892,13 +892,13 @@ defmodule PortalWeb.Clients.Components do
 
   attr :serial, :map, default: nil
 
-  def client_serial(%{serial: nil} = assigns) do
+  def serial_cell(%{serial: nil} = assigns) do
     ~H"""
     <span class="text-xs text-muted">—</span>
     """
   end
 
-  def client_serial(assigns) do
+  def serial_cell(assigns) do
     ~H"""
     <div class="flex items-center gap-1.5">
       <.popover :if={@serial.source != :reported} placement="right">
@@ -917,45 +917,45 @@ defmodule PortalWeb.Clients.Components do
     """
   end
 
-  attr :client, :any, required: true
+  attr :device, :any, required: true
   attr :certificate, :map, default: nil
 
-  def client_certificate_section(assigns) do
-    assigns = assign(assigns, :issuer, describe_issuer(assigns.client.last_attested_cert_issuer))
+  def device_certificate_section(assigns) do
+    assigns = assign(assigns, :issuer, describe_issuer(assigns.device.last_attested_cert_issuer))
 
     ~H"""
     <div class="px-5 pt-4 pb-3 border-b border-border">
       <.section_heading title="Certificate" />
       <dl class="space-y-3">
-        <.client_detail_row label="Status">
+        <.device_detail_row label="Status">
           <.certificate_status_badge certificate={@certificate} />
-        </.client_detail_row>
-        <.client_detail_row :if={@issuer} label="Issuer">
+        </.device_detail_row>
+        <.device_detail_row :if={@issuer} label="Issuer">
           <span class="text-xs text-body break-all">{@issuer}</span>
-        </.client_detail_row>
-        <.client_detail_row :if={@client.last_attested_cert_serial} label="Serial">
+        </.device_detail_row>
+        <.device_detail_row :if={@device.last_attested_cert_serial} label="Serial">
           <span class="font-mono text-xs text-body break-all">
-            {@client.last_attested_cert_serial}
+            {@device.last_attested_cert_serial}
           </span>
-        </.client_detail_row>
-        <.client_detail_row :if={@client.last_attested_cert_fingerprint} label="SHA-256 Fingerprint">
+        </.device_detail_row>
+        <.device_detail_row :if={@device.last_attested_cert_fingerprint} label="SHA-256 Fingerprint">
           <span class="font-mono text-xs text-body break-all">
-            {@client.last_attested_cert_fingerprint}
+            {@device.last_attested_cert_fingerprint}
           </span>
-        </.client_detail_row>
-        <.client_detail_row :if={@certificate && @certificate.revoked_at} label="Revoked">
+        </.device_detail_row>
+        <.device_detail_row :if={@certificate && @certificate.revoked_at} label="Revoked">
           <span class="text-xs text-body">
             <.relative_datetime datetime={@certificate.revoked_at} />
           </span>
-        </.client_detail_row>
-        <.client_detail_row :if={@certificate && @certificate.reason} label="Revocation Reason">
+        </.device_detail_row>
+        <.device_detail_row :if={@certificate && @certificate.reason} label="Revocation Reason">
           <span class="text-xs text-body">{@certificate.reason}</span>
-        </.client_detail_row>
-        <.client_detail_row :if={@client.last_attested_at} label="Last Attested">
+        </.device_detail_row>
+        <.device_detail_row :if={@device.last_attested_at} label="Last Attested">
           <span class="text-xs text-body">
-            <.relative_datetime datetime={@client.last_attested_at} />
+            <.relative_datetime datetime={@device.last_attested_at} />
           </span>
-        </.client_detail_row>
+        </.device_detail_row>
       </dl>
     </div>
     """
@@ -1013,97 +1013,97 @@ defmodule PortalWeb.Clients.Components do
     """
   end
 
-  attr :client, :any, required: true
-  attr :confirm_delete_client, :boolean, default: false
-  attr :confirm_unverify_client, :boolean, default: false
+  attr :device, :any, required: true
+  attr :confirm_delete_device, :boolean, default: false
+  attr :confirm_unverify_device, :boolean, default: false
 
-  def client_sidebar(assigns) do
+  def device_sidebar(assigns) do
     ~H"""
     <div class="w-1/3 shrink-0 overflow-y-auto p-4 space-y-5">
-      <.client_details_card client={@client} />
+      <.device_details_card device={@device} />
       <div class="border-t border-border"></div>
-      <.client_actions client={@client} confirm_unverify_client={@confirm_unverify_client} />
+      <.device_actions device={@device} confirm_unverify_device={@confirm_unverify_device} />
       <div class="border-t border-border"></div>
-      <.client_danger_zone confirm_delete_client={@confirm_delete_client} />
+      <.device_danger_zone confirm_delete_device={@confirm_delete_device} />
     </div>
     """
   end
 
-  attr :client, :any, required: true
+  attr :device, :any, required: true
 
-  def client_details_card(assigns) do
+  def device_details_card(assigns) do
     ~H"""
     <section>
       <.section_heading title="Details" />
       <dl class="space-y-2.5">
-        <.client_detail_row label="Client ID">
+        <.device_detail_row label="Device ID">
           <span class="font-mono text-[11px] text-body break-all">
-            {@client.id}
+            {@device.id}
           </span>
-        </.client_detail_row>
-        <.client_detail_row :if={@client.firezone_id} label="Firezone ID">
+        </.device_detail_row>
+        <.device_detail_row :if={@device.firezone_id} label="Firezone ID">
           <span class="font-mono text-[11px] text-body break-all">
-            {@client.firezone_id}
+            {@device.firezone_id}
           </span>
-        </.client_detail_row>
-        <.client_detail_row :if={@client.last_attested_mdm_device_id} label="MDM Device ID">
+        </.device_detail_row>
+        <.device_detail_row :if={@device.last_attested_mdm_device_id} label="MDM Device ID">
           <span class="font-mono text-[11px] text-body break-all">
-            {@client.last_attested_mdm_device_id}
+            {@device.last_attested_mdm_device_id}
           </span>
-        </.client_detail_row>
-        <.client_detail_row :if={@client.last_attested_device_serial} label="Attested Serial">
+        </.device_detail_row>
+        <.device_detail_row :if={@device.last_attested_device_serial} label="Attested Serial">
           <span class="font-mono text-[11px] text-body break-all">
-            {@client.last_attested_device_serial}
+            {@device.last_attested_device_serial}
           </span>
-        </.client_detail_row>
-        <.client_detail_row :if={@client.last_attested_device_uuid} label="Attested UUID">
+        </.device_detail_row>
+        <.device_detail_row :if={@device.last_attested_device_uuid} label="Attested UUID">
           <span class="font-mono text-[11px] text-body break-all">
-            {@client.last_attested_device_uuid}
+            {@device.last_attested_device_uuid}
           </span>
-        </.client_detail_row>
-        <.client_detail_row :if={@client.last_attested_at} label="Last Attested">
+        </.device_detail_row>
+        <.device_detail_row :if={@device.last_attested_at} label="Last Attested">
           <span class="inline-flex items-center gap-1 text-xs text-body">
             <.icon name="ri-shield-keyhole-line" class="w-3 h-3 text-success" />
-            <.relative_datetime datetime={@client.last_attested_at} />
+            <.relative_datetime datetime={@device.last_attested_at} />
           </span>
-        </.client_detail_row>
-        <.client_detail_row label="Trust level">
+        </.device_detail_row>
+        <.device_detail_row label="Trust level">
           <:info>
             <.popover placement="left">
               <:target>
                 <.icon name="ri-information-line" class="w-3 h-3" />
               </:target>
-              <:content>{trust_hint(@client)}</:content>
+              <:content>{trust_hint(@device)}</:content>
             </.popover>
           </:info>
-          <.client_verified_status client={@client} />
-        </.client_detail_row>
-        <.client_detail_row label="Version">
+          <.device_verified_status device={@device} />
+        </.device_detail_row>
+        <.device_detail_row label="Version">
           <.version
-            current={@client.last_seen_version}
-            latest={ComponentVersions.client_version(@client)}
+            current={@device.last_seen_version}
+            latest={ComponentVersions.client_version(@device)}
           />
-        </.client_detail_row>
-        <.client_detail_row label="Last Seen">
+        </.device_detail_row>
+        <.device_detail_row label="Last Seen">
           <span class="text-xs text-body">
-            <.relative_datetime datetime={@client.last_seen_at} />
+            <.relative_datetime datetime={@device.last_seen_at} />
           </span>
-        </.client_detail_row>
-        <.client_detail_row label="Created">
+        </.device_detail_row>
+        <.device_detail_row label="Created">
           <span class="text-xs text-body">
-            <.relative_datetime datetime={@client.inserted_at} />
+            <.relative_datetime datetime={@device.inserted_at} />
           </span>
-        </.client_detail_row>
+        </.device_detail_row>
       </dl>
     </section>
     """
   end
 
-  attr :client, :any, required: true
-  attr :confirm_unverify_client, :boolean, default: false
+  attr :device, :any, required: true
+  attr :confirm_unverify_device, :boolean, default: false
 
-  def client_actions(assigns) do
-    assigns = assign(assigns, :action, client_action(assigns))
+  def device_actions(assigns) do
+    assigns = assign(assigns, :action, device_action(assigns))
 
     ~H"""
     <section>
@@ -1126,14 +1126,14 @@ defmodule PortalWeb.Clients.Components do
         <.action_button
           :if={@action == :verify}
           icon="ri-shield-check-line"
-          phx-click="verify_client"
+          phx-click="verify_device"
         >
           Verify
         </.action_button>
         <.action_button
           :if={@action == :unverify}
           icon="ri-prohibited-line"
-          phx-click="confirm_unverify_client"
+          phx-click="confirm_unverify_device"
         >
           Revoke verification
         </.action_button>
@@ -1142,16 +1142,16 @@ defmodule PortalWeb.Clients.Components do
           class="px-3 py-2.5 rounded border border-border bg-raised"
         >
           <p class="text-xs font-medium text-heading mb-1">
-            Revoke verification for this client?
+            Revoke verification for this device?
           </p>
           <p class="text-xs text-body mb-3">
-            Current authorizations for this client may be revoked.
+            Current authorizations for this device may be revoked.
           </p>
           <div class="flex items-center gap-1.5">
-            <.button type="button" phx-click="cancel_unverify_client" size="xs">
+            <.button type="button" phx-click="cancel_unverify_device" size="xs">
               Cancel
             </.button>
-            <.button type="button" phx-click="unverify_client" size="xs">
+            <.button type="button" phx-click="unverify_device" size="xs">
               Unverify
             </.button>
           </div>
@@ -1161,37 +1161,37 @@ defmodule PortalWeb.Clients.Components do
     """
   end
 
-  attr :confirm_delete_client, :boolean, default: false
+  attr :confirm_delete_device, :boolean, default: false
 
-  def client_danger_zone(assigns) do
+  def device_danger_zone(assigns) do
     ~H"""
     <section>
       <h3 class="text-[10px] font-semibold tracking-widest uppercase text-error/60 mb-3">
         Danger Zone
       </h3>
       <button
-        :if={not @confirm_delete_client}
+        :if={not @confirm_delete_device}
         type="button"
-        phx-click="confirm_delete_client"
+        phx-click="confirm_delete_device"
         class="w-full flex items-center gap-2 px-3 py-2 rounded border border-error/20 text-xs text-error hover:bg-error-light transition-colors"
       >
-        <.icon name="ri-delete-bin-line" class="w-4 h-4 shrink-0" /> Delete client
+        <.icon name="ri-delete-bin-line" class="w-4 h-4 shrink-0" /> Delete device
       </button>
       <div
-        :if={@confirm_delete_client}
+        :if={@confirm_delete_device}
         class="px-3 py-2.5 rounded border border-error/20 bg-error-light"
       >
         <p class="text-xs font-medium text-error mb-1">
-          Delete this client?
+          Delete this device?
         </p>
         <p class="text-xs text-error/70 mb-3">
           This won't prevent the owner from signing in again; to block access, disable the owning actor instead.
         </p>
         <div class="flex items-center gap-1.5">
-          <.button type="button" phx-click="cancel_delete_client" size="xs">
+          <.button type="button" phx-click="cancel_delete_device" size="xs">
             Cancel
           </.button>
-          <.button type="button" phx-click="delete_client" style="danger" size="xs">
+          <.button type="button" phx-click="delete_device" style="danger" size="xs">
             Delete
           </.button>
         </div>
@@ -1200,10 +1200,10 @@ defmodule PortalWeb.Clients.Components do
     """
   end
 
-  attr :client, :any, required: true
+  attr :device, :any, required: true
 
-  def client_verified_badge(assigns) do
-    assigns = assign(assigns, :trust, trust_state(assigns.client))
+  def device_verified_badge(assigns) do
+    assigns = assign(assigns, :trust, trust_state(assigns.device))
 
     ~H"""
     <span
@@ -1219,10 +1219,10 @@ defmodule PortalWeb.Clients.Components do
     """
   end
 
-  attr :client, :any, required: true
+  attr :device, :any, required: true
 
-  def client_verified_status(assigns) do
-    assigns = assign(assigns, :trust, trust_state(assigns.client))
+  def device_verified_status(assigns) do
+    assigns = assign(assigns, :trust, trust_state(assigns.device))
 
     ~H"""
     <span
@@ -1260,7 +1260,7 @@ defmodule PortalWeb.Clients.Components do
   attr :label, :string, required: true
   slot :info, doc: "Rendered beside the label, for a popover explaining the row"
 
-  def client_detail_row(assigns) do
+  def device_detail_row(assigns) do
     ~H"""
     <div>
       <dt class="flex items-center gap-1 text-[10px] text-subtle mb-0.5">
@@ -1274,7 +1274,7 @@ defmodule PortalWeb.Clients.Components do
 
   attr :online?, :boolean, required: true
 
-  def client_status_badge(assigns) do
+  def device_status_badge(assigns) do
     ~H"""
     <.status_badge style={if @online?, do: :success, else: :neutral}>
       {if @online?, do: "Online", else: "Offline"}
@@ -1284,9 +1284,9 @@ defmodule PortalWeb.Clients.Components do
 
   # This is more complex than it needs to be, but
   # connlib can send "Mac OS" (with a space) violating the User-Agent spec
-  def get_client_os_name_and_version(nil), do: ""
+  def os_name_and_version(nil), do: ""
 
-  def get_client_os_name_and_version(user_agent) do
+  def os_name_and_version(user_agent) do
     String.split(user_agent, " ")
     |> Enum.reduce_while("", fn component, acc ->
       if String.contains?(component, "/") do
@@ -1314,7 +1314,7 @@ defmodule PortalWeb.Clients.Components do
       label: "Verified",
       icon: "ri-shield-check-line",
       class: "text-success bg-success-light",
-      title: "An admin vouched for the values this Client reports."
+      title: "An admin vouched for the values this Device reports."
     }
   end
 
@@ -1323,7 +1323,7 @@ defmodule PortalWeb.Clients.Components do
   defp trust_hint(client) do
     case trust_state(client) do
       %{title: title} -> title
-      nil -> "No certificate or admin has vouched for the values this Client reports."
+      nil -> "No certificate or admin has vouched for the values this Device reports."
     end
   end
 
@@ -1359,9 +1359,9 @@ defmodule PortalWeb.Clients.Components do
           </span>
         </div>
         <dl class="grid grid-cols-2 gap-x-6 gap-y-3">
-          <.client_detail_row :for={{label, value} <- sample.attributes} label={label}>
+          <.device_detail_row :for={{label, value} <- sample.attributes} label={label}>
             <span class="font-mono text-xs text-body">{value}</span>
-          </.client_detail_row>
+          </.device_detail_row>
         </dl>
       </div>
     </div>
@@ -1370,15 +1370,15 @@ defmodule PortalWeb.Clients.Components do
 
   # Attestation supersedes manual verification, so an attested device offers the
   # button it would otherwise offer, disabled, rather than hiding it.
-  defp client_action(%{client: %{last_attested_at: at, verified_at: nil}}) when not is_nil(at),
+  defp device_action(%{device: %{last_attested_at: at, verified_at: nil}}) when not is_nil(at),
     do: :attested_verify
 
-  defp client_action(%{client: %{last_attested_at: at}}) when not is_nil(at),
+  defp device_action(%{device: %{last_attested_at: at}}) when not is_nil(at),
     do: :attested_unverify
 
-  defp client_action(%{client: %{verified_at: nil}}), do: :verify
-  defp client_action(%{confirm_unverify_client: true}), do: :confirm_unverify
-  defp client_action(_assigns), do: :unverify
+  defp device_action(%{device: %{verified_at: nil}}), do: :verify
+  defp device_action(%{confirm_unverify_device: true}), do: :confirm_unverify
+  defp device_action(_assigns), do: :unverify
 
   defp attested_action_icon(:attested_verify), do: "ri-shield-check-line"
   defp attested_action_icon(_action), do: "ri-prohibited-line"
@@ -1389,8 +1389,8 @@ defmodule PortalWeb.Clients.Components do
   # The Posture tab is hidden while the feature is off for the whole
   # deployment, so a link into it lands on the overview rather than on blank
   # space.
-  defp visible_client_tab(:posture, false), do: :overview
-  defp visible_client_tab(tab, _posture_tab?), do: tab
+  defp visible_device_tab(:posture, false), do: :overview
+  defp visible_device_tab(tab, _posture_tab?), do: tab
 
   defp posture_tab_state(assigns) do
     cond do

--- a/elixir/lib/portal_web/live/logs/components.ex
+++ b/elixir/lib/portal_web/live/logs/components.ex
@@ -9,7 +9,7 @@ defmodule PortalWeb.Logs.Components do
   """
   use Phoenix.Component
   use PortalWeb, :verified_routes
-  alias PortalWeb.Clients
+  alias PortalWeb.Devices
   alias PortalWeb.CoreComponents
 
   @doc """
@@ -114,7 +114,7 @@ defmodule PortalWeb.Logs.Components do
 
   def format_ip(other), do: to_string(other)
 
-  @doc "Renders an initiating Client and its first observed outer source IP."
+  @doc "Renders an initiating device and its first observed outer source IP."
   attr :device_name, :string, required: true
   attr :ip, :any, required: true
 
@@ -426,7 +426,7 @@ defmodule PortalWeb.Logs.Components do
 
   def session_context_icon(%{context: :client} = assigns) do
     assigns =
-      assign(assigns, :icon_name, Clients.Components.client_os_icon_name(assigns.user_agent))
+      assign(assigns, :icon_name, Devices.Components.os_icon_name(assigns.user_agent))
 
     ~H"""
     <CoreComponents.icon name={@icon_name} title={@user_agent || "Client"} class={@class} />

--- a/elixir/lib/portal_web/live/logs/session_logs.ex
+++ b/elixir/lib/portal_web/live/logs/session_logs.ex
@@ -3,7 +3,7 @@ defmodule PortalWeb.Logs.SessionLogs do
 
   import PortalWeb.Logs.Components
 
-  alias PortalWeb.Clients
+  alias PortalWeb.Devices
   alias __MODULE__.Database
 
   @table_id "session_logs"
@@ -304,7 +304,7 @@ defmodule PortalWeb.Logs.SessionLogs do
     log
     |> ua()
     |> Kernel.||("")
-    |> Clients.Components.get_client_os_name_and_version()
+    |> Devices.Components.os_name_and_version()
     |> String.trim()
   end
 

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -1157,7 +1157,7 @@ defmodule PortalWeb.Policies.Components do
                         <p class="text-subtle font-medium mb-1">
                           {case row.initiating_device && row.initiating_device.type do
                             :gateway -> "Initiator (Gateway)"
-                            :client -> "Initiator (Client)"
+                            :client -> "Initiator (Device)"
                             _ -> "Initiator"
                           end}
                         </p>
@@ -1174,7 +1174,7 @@ defmodule PortalWeb.Policies.Components do
                         <p class="text-subtle font-medium mb-1">
                           {case row.receiving_device && row.receiving_device.type do
                             :gateway -> "Receiver (Gateway)"
-                            :client -> "Receiver (Client)"
+                            :client -> "Receiver (Device)"
                             _ -> "Receiver"
                           end}
                         </p>
@@ -1435,7 +1435,7 @@ defmodule PortalWeb.Policies.Components do
 
   @spec condition_values_display(map(), list(), any()) :: String.t()
   defp condition_values_display(%{property: :client_verified}, _providers, _account),
-    do: "Client must be verified"
+    do: "Device must be verified"
 
   defp condition_values_display(
          %{property: :auth_provider_id, values: values},
@@ -1813,7 +1813,7 @@ defmodule PortalWeb.Policies.Components do
         ]}
       >
         <p class="text-sm text-neutral-500 mb-4">
-          Allow access when the location of the Client meets the criteria specified below.
+          Allow access when the location of the device meets the criteria specified below.
         </p>
         <div class="grid gap-2 sm:grid-cols-5 sm:gap-4">
           <.input
@@ -1900,7 +1900,7 @@ defmodule PortalWeb.Policies.Components do
         ]}
       >
         <p class="text-sm text-neutral-500 mb-4">
-          Allow access when the IP of the Client meets the criteria specified below.
+          Allow access when the IP of the device meets the criteria specified below.
         </p>
         <div class="grid gap-2 sm:grid-cols-5 sm:gap-4">
           <.input
@@ -2082,11 +2082,11 @@ defmodule PortalWeb.Policies.Components do
         ]}
       >
         <p class="text-sm text-neutral-500 mb-4">
-          Allow access when the Client is manually verified by the administrator.
+          Allow access when the device is manually verified by the administrator.
         </p>
         <div class="space-y-2" phx-update="ignore" id="conditions-client-verified-values">
           <.toggle
-            label="Require client verification"
+            label="Require device verification"
             name="policy[conditions][client_verified][values][]"
             id="policy_conditions_client_verified_value"
             value="true"
@@ -2254,9 +2254,9 @@ defmodule PortalWeb.Policies.Components do
     ]
 
   @spec condition_type_label(atom()) :: String.t()
-  def condition_type_label(:client_verified), do: "Require Verified Client"
+  def condition_type_label(:client_verified), do: "Require Verified Device"
   def condition_type_label(:auth_provider_id), do: "Authentication Provider"
-  def condition_type_label(:remote_ip_location_region), do: "Client Location"
+  def condition_type_label(:remote_ip_location_region), do: "Device Location"
   def condition_type_label(:remote_ip), do: "IP Range"
   def condition_type_label(:current_utc_datetime), do: "Time of Day"
 

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -45,9 +45,9 @@ defmodule PortalWeb.Resources do
       |> assign(
         selected_resource: nil,
         selected_resource_pool_member_ids: [],
-        selected_resource_pool_clients: [],
-        clients_expanded_id: nil,
-        online_client_ids: MapSet.new(),
+        selected_resource_pool_devices: [],
+        devices_expanded_id: nil,
+        online_device_ids: MapSet.new(),
         selected_groups: [],
         policy_authorizations: [],
         policy_authorizations_page: 1,
@@ -86,8 +86,8 @@ defmodule PortalWeb.Resources do
 
         filter_site = filter_site_from_params(params, socket.assigns.subject)
 
-        pool_clients = Database.list_pool_members(resource, socket.assigns.subject)
-        pool_member_ids = Enum.map(pool_clients, & &1.id)
+        pool_devices = Database.list_pool_members(resource, socket.assigns.subject)
+        pool_member_ids = Enum.map(pool_devices, & &1.id)
 
         {:noreply,
          socket
@@ -95,8 +95,8 @@ defmodule PortalWeb.Resources do
            filter_site: filter_site,
            selected_resource: resource,
            selected_resource_pool_member_ids: pool_member_ids,
-           selected_resource_pool_clients: pool_clients,
-           clients_expanded_id: nil,
+           selected_resource_pool_devices: pool_devices,
+           devices_expanded_id: nil,
            selected_groups: groups,
            policy_authorizations: policy_authorizations,
            policy_authorizations_page: page,
@@ -130,7 +130,7 @@ defmodule PortalWeb.Resources do
       resource ->
         sites = Database.all_sites(socket.assigns.subject)
         changeset = Database.change_resource(resource, socket.assigns.subject)
-        selected_clients = Database.list_pool_members(resource, socket.assigns.subject)
+        selected_devices = Database.list_pool_members(resource, socket.assigns.subject)
 
         {:noreply,
          socket
@@ -141,7 +141,7 @@ defmodule PortalWeb.Resources do
              to_form(changeset),
              sites,
              resource,
-             selected_clients
+             selected_devices
            )
          )}
     end
@@ -179,13 +179,13 @@ defmodule PortalWeb.Resources do
     ]
   end
 
-  defp edit_resource_state_assigns(socket, resource_form, sites, resource, selected_clients) do
+  defp edit_resource_state_assigns(socket, resource_form, sites, resource, selected_devices) do
     [
       resource_panel: base_resource_panel(socket, view: :edit_form),
       resource_form:
         base_resource_form(resource_form, sites,
           active_protocols: Enum.map(resource.filters, & &1.protocol),
-          selected_clients: selected_clients
+          selected_devices: selected_devices
         ),
       resource_grant: base_resource_grant(socket),
       resource_ui: base_resource_ui()
@@ -214,9 +214,9 @@ defmodule PortalWeb.Resources do
         address_description_changed?: false,
         active_protocols: [],
         filters_dropdown_open?: false,
-        selected_clients: [],
-        client_search: "",
-        client_search_results: nil
+        selected_devices: [],
+        device_search: "",
+        device_search_results: nil
       }
     )
   end
@@ -294,11 +294,11 @@ defmodule PortalWeb.Resources do
   end
 
   defp parse_show_tab(params, resource) do
-    default = if device_pool?(resource), do: "clients", else: "groups"
+    default = if device_pool?(resource), do: "devices", else: "groups"
 
     case Map.get(params, "tab", default) do
-      "clients" ->
-        if device_pool?(resource), do: :clients, else: :groups
+      "devices" ->
+        if device_pool?(resource), do: :devices, else: :groups
 
       tab when tab in ~w[groups authorizations] ->
         String.to_existing_atom(tab)
@@ -359,7 +359,7 @@ defmodule PortalWeb.Resources do
          internet_resource: internet_resource,
          resource_policy_counts: resource_policy_counts,
          device_pool_members: device_pool_members,
-         online_client_ids: online_client_ids(socket.assigns.account.id),
+         online_device_ids: online_device_ids(socket.assigns.account.id),
          resources_metadata: metadata
        )}
     end
@@ -553,7 +553,7 @@ defmodule PortalWeb.Resources do
               resource={resource}
               presence_tick={@presence_tick}
               pool_member_ids={Map.get(@device_pool_members, resource.id, [])}
-              online_client_ids={@online_client_ids}
+              online_device_ids={@online_device_ids}
             />
           </:col>
           <:empty>
@@ -594,9 +594,9 @@ defmodule PortalWeb.Resources do
             account={@account}
             resource={@selected_resource}
             pool_member_ids={@selected_resource_pool_member_ids}
-            pool_clients={@selected_resource_pool_clients}
-            clients_expanded_id={@clients_expanded_id}
-            online_client_ids={@online_client_ids}
+            pool_devices={@selected_resource_pool_devices}
+            devices_expanded_id={@devices_expanded_id}
+            online_device_ids={@online_device_ids}
             presence_tick={@presence_tick}
             groups={@selected_groups}
             policy_authorizations={@policy_authorizations}
@@ -692,11 +692,11 @@ defmodule PortalWeb.Resources do
     {:noreply, assign(socket, policy_authorizations_expanded_id: expanded)}
   end
 
-  def handle_event("toggle_pool_client_row", %{"id" => id}, socket) do
+  def handle_event("toggle_pool_device_row", %{"id" => id}, socket) do
     expanded =
-      if socket.assigns.clients_expanded_id == id, do: nil, else: id
+      if socket.assigns.devices_expanded_id == id, do: nil, else: id
 
-    {:noreply, assign(socket, clients_expanded_id: expanded)}
+    {:noreply, assign(socket, devices_expanded_id: expanded)}
   end
 
   def handle_event("change_resource_form", %{"resource" => attrs} = payload, socket) do
@@ -728,7 +728,7 @@ defmodule PortalWeb.Resources do
     if socket.assigns.resource_panel.view == :new_form do
       case Database.create_resource(
              attrs,
-             socket.assigns.resource_form.selected_clients,
+             socket.assigns.resource_form.selected_devices,
              socket.assigns.subject
            ) do
         {:ok, resource} ->
@@ -749,7 +749,7 @@ defmodule PortalWeb.Resources do
       case Database.update_resource(
              resource,
              attrs,
-             socket.assigns.resource_form.selected_clients,
+             socket.assigns.resource_form.selected_devices,
              socket.assigns.subject
            ) do
         {:ok, updated_resource} ->
@@ -814,66 +814,66 @@ defmodule PortalWeb.Resources do
     {:noreply, merge_state(socket, :resource_form, filters_dropdown_open?: false)}
   end
 
-  def handle_event("focus_client_search", _params, socket) do
+  def handle_event("focus_device_search", _params, socket) do
     results =
-      Database.search_clients(
-        socket.assigns.resource_form.client_search,
+      Database.search_devices(
+        socket.assigns.resource_form.device_search,
         socket.assigns.subject,
-        socket.assigns.resource_form.selected_clients
+        socket.assigns.resource_form.selected_devices
       )
 
-    {:noreply, merge_state(socket, :resource_form, client_search_results: results)}
+    {:noreply, merge_state(socket, :resource_form, device_search_results: results)}
   end
 
-  def handle_event("blur_client_search", _params, socket) do
-    {:noreply, merge_state(socket, :resource_form, client_search_results: nil)}
+  def handle_event("blur_device_search", _params, socket) do
+    {:noreply, merge_state(socket, :resource_form, device_search_results: nil)}
   end
 
-  def handle_event("search_client", %{"client_search" => search}, socket) do
+  def handle_event("search_device", %{"device_search" => search}, socket) do
     results =
-      Database.search_clients(
+      Database.search_devices(
         search,
         socket.assigns.subject,
-        socket.assigns.resource_form.selected_clients
+        socket.assigns.resource_form.selected_devices
       )
 
     {:noreply,
-     merge_state(socket, :resource_form, client_search: search, client_search_results: results)}
+     merge_state(socket, :resource_form, device_search: search, device_search_results: results)}
   end
 
-  def handle_event("add_client", %{"client_id" => client_id}, socket) do
-    case Database.get_client(client_id, socket.assigns.subject) do
+  def handle_event("add_device", %{"device_id" => device_id}, socket) do
+    case Database.get_device(device_id, socket.assigns.subject) do
       nil ->
         {:noreply, socket}
 
-      client ->
+      device ->
         selected =
-          Enum.uniq_by([client | socket.assigns.resource_form.selected_clients], & &1.id)
+          Enum.uniq_by([device | socket.assigns.resource_form.selected_devices], & &1.id)
 
         {:noreply,
          merge_state(socket, :resource_form,
-           selected_clients: selected,
-           client_search: "",
-           client_search_results: nil
+           selected_devices: selected,
+           device_search: "",
+           device_search_results: nil
          )}
     end
   end
 
-  def handle_event("remove_client", %{"client_id" => client_id}, socket) do
+  def handle_event("remove_device", %{"device_id" => device_id}, socket) do
     selected =
-      Enum.reject(socket.assigns.resource_form.selected_clients, &(&1.id == client_id))
+      Enum.reject(socket.assigns.resource_form.selected_devices, &(&1.id == device_id))
 
     results =
-      Database.search_clients(
-        socket.assigns.resource_form.client_search,
+      Database.search_devices(
+        socket.assigns.resource_form.device_search,
         socket.assigns.subject,
         selected
       )
 
     {:noreply,
      merge_state(socket, :resource_form,
-       selected_clients: selected,
-       client_search_results: results
+       selected_devices: selected,
+       device_search_results: results
      )}
   end
 
@@ -1266,14 +1266,14 @@ defmodule PortalWeb.Resources do
     {:noreply,
      socket
      |> update(:presence_tick, &(&1 + 1))
-     |> assign(online_client_ids: online_client_ids(socket.assigns.account.id))}
+     |> assign(online_device_ids: online_device_ids(socket.assigns.account.id))}
   end
 
   def handle_info(_, socket) do
     {:noreply, socket}
   end
 
-  defp online_client_ids(account_id) do
+  defp online_device_ids(account_id) do
     account_id
     |> Presence.Clients.online_client_ids()
     |> MapSet.new()
@@ -1317,9 +1317,9 @@ defmodule PortalWeb.Resources do
       resource_form_sites: assigns.resource_form.sites,
       resource_form_active_protocols: assigns.resource_form.active_protocols,
       resource_form_filters_dropdown_open: assigns.resource_form.filters_dropdown_open?,
-      resource_form_selected_clients: assigns.resource_form.selected_clients,
-      resource_form_client_search: assigns.resource_form.client_search,
-      resource_form_client_search_results: assigns.resource_form.client_search_results,
+      resource_form_selected_devices: assigns.resource_form.selected_devices,
+      resource_form_device_search: assigns.resource_form.device_search,
+      resource_form_device_search_results: assigns.resource_form.device_search_results,
       filter_ports: resource_filter_ports(assigns.resource_form.form),
       filter_errors: resource_filter_errors(assigns.resource_form.form)
     }
@@ -1403,8 +1403,8 @@ defmodule PortalWeb.Resources do
     alias Portal.Directory
     alias PortalWeb.Resources.Components
 
-    defdelegate get_client(client_id, subject), to: Components.Database
-    defdelegate search_clients(search_term, subject, selected_clients), to: Components.Database
+    defdelegate get_device(device_id, subject), to: Components.Database
+    defdelegate search_devices(search_term, subject, selected_devices), to: Components.Database
 
     def all_sites(subject) do
       from(s in Site, as: :sites)
@@ -1428,23 +1428,23 @@ defmodule PortalWeb.Resources do
       end
     end
 
-    def create_resource(attrs, selected_clients, subject) do
+    def create_resource(attrs, selected_devices, subject) do
       changeset =
         new_resource(subject, attrs)
         |> maybe_validate_required_fields()
 
-      with {:ok, validated_clients} <-
-             Components.Database.validate_selected_clients(selected_clients, subject),
+      with {:ok, validated_devices} <-
+             Components.Database.validate_selected_devices(selected_devices, subject),
            {:ok, resource} <- Safe.scoped(changeset, subject) |> Safe.insert(),
            :ok <-
-             Components.Database.sync_static_pool_members(resource, validated_clients, subject) do
+             Components.Database.sync_static_pool_members(resource, validated_devices, subject) do
         {:ok, resource}
       else
         {:error, %Ecto.Changeset{} = cs} ->
           {:error, cs}
 
-        {:error, :invalid_clients} ->
-          {:error, add_error(changeset, :name, "one or more selected clients are invalid")}
+        {:error, :invalid_devices} ->
+          {:error, add_error(changeset, :name, "one or more selected devices are invalid")}
 
         {:error, :unauthorized} ->
           {:error, add_error(changeset, :name, "you are not authorized to perform this action")}
@@ -1475,16 +1475,16 @@ defmodule PortalWeb.Resources do
       end
     end
 
-    def update_resource(resource, attrs, selected_clients, subject) do
+    def update_resource(resource, attrs, selected_devices, subject) do
       changeset = change_resource(resource, subject, attrs)
 
-      with {:ok, validated_clients} <-
-             Components.Database.validate_selected_clients(selected_clients, subject),
+      with {:ok, validated_devices} <-
+             Components.Database.validate_selected_devices(selected_devices, subject),
            {:ok, updated_resource} <- Safe.scoped(changeset, subject) |> Safe.update(),
            :ok <-
              Components.Database.sync_static_pool_members(
                updated_resource,
-               validated_clients,
+               validated_devices,
                subject
              ) do
         {:ok, updated_resource}
@@ -1492,8 +1492,8 @@ defmodule PortalWeb.Resources do
         {:error, %Ecto.Changeset{} = cs} ->
           {:error, cs}
 
-        {:error, :invalid_clients} ->
-          {:error, add_error(changeset, :name, "one or more selected clients are invalid")}
+        {:error, :invalid_devices} ->
+          {:error, add_error(changeset, :name, "one or more selected devices are invalid")}
 
         {:error, :unauthorized} ->
           {:error, add_error(changeset, :name, "you are not authorized to perform this action")}
@@ -1501,7 +1501,7 @@ defmodule PortalWeb.Resources do
     end
 
     def list_pool_members(%Resource{type: :static_device_pool} = resource, subject) do
-      client_ids =
+      device_ids =
         from(m in StaticDevicePoolMember,
           where: m.resource_id == ^resource.id,
           select: m.device_id
@@ -1515,7 +1515,7 @@ defmodule PortalWeb.Resources do
 
       from(c in Device, as: :devices)
       |> where([devices: d], d.type == :client)
-      |> where([devices: d], d.id in ^client_ids)
+      |> where([devices: d], d.id in ^device_ids)
       |> preload(:actor)
       |> Safe.scoped(subject)
       |> Safe.all()
@@ -1523,8 +1523,8 @@ defmodule PortalWeb.Resources do
         {:error, _} ->
           []
 
-        clients ->
-          Portal.Presence.Clients.preload_clients_presence(clients)
+        devices ->
+          Portal.Presence.Clients.preload_clients_presence(devices)
       end
     end
 

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -9,11 +9,11 @@ defmodule PortalWeb.Resources.Components do
       flow_log_uploads_toggle: 1
     ]
 
-  import PortalWeb.Clients.Components,
+  import PortalWeb.Devices.Components,
     only: [
-      client_status_badge: 1,
-      client_verified_badge: 1,
-      client_os: 1
+      device_status_badge: 1,
+      device_verified_badge: 1,
+      device_os: 1
     ]
 
   alias __MODULE__.Database
@@ -506,9 +506,9 @@ defmodule PortalWeb.Resources.Components do
     """
   end
 
-  attr :selected_clients, :list, required: true
-  attr :client_search_results, :any, default: nil
-  attr :client_search, :string, default: ""
+  attr :selected_devices, :list, required: true
+  attr :device_search_results, :any, default: nil
+  attr :device_search, :string, default: ""
 
   def resource_device_pool_section(assigns) do
     ~H"""
@@ -517,12 +517,12 @@ defmodule PortalWeb.Resources.Components do
         Devices <span class="text-muted font-normal">(optional)</span>
       </span>
       <p class="mb-2 text-xs text-subtle">
-        Select clients to include in this pool.
+        Select devices to include in this pool.
       </p>
-      <.client_picker
-        selected_clients={@selected_clients}
-        client_search={@client_search}
-        client_search_results={@client_search_results}
+      <.device_picker
+        selected_devices={@selected_devices}
+        device_search={@device_search}
+        device_search_results={@device_search_results}
       />
     </div>
     """
@@ -772,48 +772,48 @@ defmodule PortalWeb.Resources.Components do
     """
   end
 
-  attr :selected_clients, :list, required: true
-  attr :client_search_results, :any, default: nil
-  attr :client_search, :string, default: ""
+  attr :selected_devices, :list, required: true
+  attr :device_search_results, :any, default: nil
+  attr :device_search, :string, default: ""
 
-  def client_picker(assigns) do
+  def device_picker(assigns) do
     ~H"""
     <div class="space-y-1">
-      <div class="relative mb-2" phx-click-away="blur_client_search">
+      <div class="relative mb-2" phx-click-away="blur_device_search">
         <.icon
           name="ri-search-line"
           class="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-subtle pointer-events-none"
         />
         <input
           type="text"
-          name="client_search"
-          value={@client_search}
-          placeholder="Search clients to add…"
-          phx-change="search_client"
+          name="device_search"
+          value={@device_search}
+          placeholder="Search devices to add…"
+          phx-change="search_device"
           phx-debounce="300"
-          phx-focus="focus_client_search"
+          phx-focus="focus_device_search"
           autocomplete="off"
           data-1p-ignore
           class="w-full pl-7 pr-3 py-1.5 text-xs rounded border border-border bg-raised text-heading placeholder:text-muted outline-none focus:border-border-focus focus:ring-1 focus:ring-border-focus/30 transition-colors"
         />
       </div>
 
-      <ul :if={@selected_clients != []} class="space-y-1 mb-1">
-        <li :for={client <- @selected_clients}>
+      <ul :if={@selected_devices != []} class="space-y-1 mb-1">
+        <li :for={device <- @selected_devices}>
           <div class="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-brand bg-brand-muted">
             <div class="flex items-center justify-center w-7 h-7 rounded-full bg-raised border border-border shrink-0">
               <.icon name="ri-computer-line" class="w-4 h-4 text-brand" />
             </div>
             <div class="flex-1 min-w-0">
-              <p class="text-sm font-medium text-brand truncate">{client.name}</p>
-              <p class="text-[10px] text-subtle truncate">{client_details(client)}</p>
+              <p class="text-sm font-medium text-brand truncate">{device.name}</p>
+              <p class="text-[10px] text-subtle truncate">{device_details(device)}</p>
             </div>
             <button
               type="button"
-              phx-click="remove_client"
-              phx-value-client_id={client.id}
+              phx-click="remove_device"
+              phx-value-device_id={device.id}
               class="shrink-0 flex items-center justify-center w-5 h-5 rounded text-brand/50 hover:text-brand transition-colors"
-              aria-label="Remove client"
+              aria-label="Remove device"
             >
               <.icon name="ri-close-line" class="w-3.5 h-3.5" />
             </button>
@@ -821,38 +821,38 @@ defmodule PortalWeb.Resources.Components do
         </li>
       </ul>
 
-      <ul :if={@client_search_results != nil && @client_search_results != []} class="space-y-1">
-        <li :for={client <- @client_search_results}>
+      <ul :if={@device_search_results != nil && @device_search_results != []} class="space-y-1">
+        <li :for={device <- @device_search_results}>
           <button
             type="button"
-            phx-click="add_client"
-            phx-value-client_id={client.id}
+            phx-click="add_device"
+            phx-value-device_id={device.id}
             class="flex items-center gap-3 px-3 py-2.5 w-full rounded-lg border border-border bg-raised hover:border-border-emphasis hover:bg-surface cursor-pointer transition-colors"
           >
             <div class="flex items-center justify-center w-7 h-7 rounded-full bg-raised border border-border shrink-0">
               <.icon name="ri-computer-line" class="w-4 h-4 text-subtle" />
             </div>
             <div class="flex-1 min-w-0 text-left">
-              <p class="text-sm font-medium text-heading truncate">{client.name}</p>
-              <p class="text-[10px] text-subtle truncate">{client_details(client)}</p>
+              <p class="text-sm font-medium text-heading truncate">{device.name}</p>
+              <p class="text-[10px] text-subtle truncate">{device_details(device)}</p>
             </div>
             <span class={[
               "w-1.5 h-1.5 rounded-full shrink-0",
-              if(client.online?, do: "bg-success", else: "bg-neutral-status")
+              if(device.online?, do: "bg-success", else: "bg-neutral-status")
             ]} />
           </button>
         </li>
       </ul>
 
       <div
-        :if={@client_search_results == []}
+        :if={@device_search_results == []}
         class="flex items-center justify-center h-16 text-xs text-subtle"
       >
-        No clients found
+        No devices found
       </div>
 
       <div
-        :if={@selected_clients == [] && is_nil(@client_search_results)}
+        :if={@selected_devices == [] && is_nil(@device_search_results)}
         class="flex items-center justify-center h-12 text-xs text-subtle"
       >
         Search above to add devices
@@ -861,13 +861,13 @@ defmodule PortalWeb.Resources.Components do
     """
   end
 
-  defp client_details(client) do
+  defp device_details(device) do
     [
-      Portal.Types.INET.to_string(client.ipv4),
-      Portal.Types.INET.to_string(client.ipv6),
-      client.device_serial,
-      client.device_uuid,
-      client.id
+      Portal.Types.INET.to_string(device.ipv4),
+      Portal.Types.INET.to_string(device.ipv6),
+      device.device_serial,
+      device.device_uuid,
+      device.id
     ]
     |> Enum.reject(&(&1 in [nil, ""]))
     |> Enum.join(" | ")
@@ -940,9 +940,9 @@ defmodule PortalWeb.Resources.Components do
 
           <.resource_device_pool_section
             :if={to_string(@resource_form[:type].value) == "static_device_pool"}
-            selected_clients={@resource_form_selected_clients}
-            client_search={@resource_form_client_search}
-            client_search_results={@resource_form_client_search_results}
+            selected_devices={@resource_form_selected_devices}
+            device_search={@resource_form_device_search}
+            device_search_results={@resource_form_device_search_results}
           />
 
           <.resource_dns_ip_stack_section
@@ -978,9 +978,9 @@ defmodule PortalWeb.Resources.Components do
   attr :account, :any, required: true
   attr :resource, :any, required: true
   attr :pool_member_ids, :list, default: []
-  attr :pool_clients, :list, default: []
-  attr :clients_expanded_id, :string, default: nil
-  attr :online_client_ids, :any, default: %MapSet{}
+  attr :pool_devices, :list, default: []
+  attr :devices_expanded_id, :string, default: nil
+  attr :online_device_ids, :any, default: %MapSet{}
   attr :presence_tick, :integer, default: 0
   attr :groups, :list, default: []
   attr :policy_authorizations, :list, default: []
@@ -1009,7 +1009,7 @@ defmodule PortalWeb.Resources.Components do
                 resource={@resource}
                 presence_tick={@presence_tick}
                 pool_member_ids={@pool_member_ids}
-                online_client_ids={@online_client_ids}
+                online_device_ids={@online_device_ids}
               />
             </div>
             <p
@@ -1039,16 +1039,16 @@ defmodule PortalWeb.Resources.Components do
             resource={@resource}
             tab={@tab}
             groups_count={length(@groups)}
-            clients_count={length(@pool_clients)}
+            devices_count={length(@pool_devices)}
             panel_view={@panel_view}
           />
-          <.resource_clients_tab
-            :if={@tab == :clients}
+          <.resource_devices_tab
+            :if={@tab == :devices}
             account={@account}
-            clients={@pool_clients}
-            online_client_ids={@online_client_ids}
+            devices={@pool_devices}
+            online_device_ids={@online_device_ids}
             presence_tick={@presence_tick}
-            expanded_id={@clients_expanded_id}
+            expanded_id={@devices_expanded_id}
           />
           <.resource_access_list
             :if={@tab == :groups && @panel_view == :list}
@@ -1086,7 +1086,7 @@ defmodule PortalWeb.Resources.Components do
   attr :resource, :any, required: true
   attr :tab, :atom, required: true
   attr :groups_count, :integer, default: 0
-  attr :clients_count, :integer, default: 0
+  attr :devices_count, :integer, default: 0
   attr :panel_view, :atom, required: true
 
   def resource_tabs(assigns) do
@@ -1098,12 +1098,12 @@ defmodule PortalWeb.Resources.Components do
       <button
         :if={@resource.type == :static_device_pool}
         role="tab"
-        aria-selected={@tab == :clients}
+        aria-selected={@tab == :devices}
         phx-click="switch_resource_tab"
-        phx-value-tab="clients"
+        phx-value-tab="devices"
         class={[
           "flex items-center gap-1.5 px-1 py-2.5 mr-5 text-xs font-medium border-b-2 transition-colors",
-          if(@tab == :clients,
+          if(@tab == :devices,
             do: "border-brand text-brand",
             else: "border-transparent text-body hover:text-heading"
           )
@@ -1112,12 +1112,12 @@ defmodule PortalWeb.Resources.Components do
         Pool Members
         <span class={[
           "tabular-nums px-1.5 py-0.5 rounded text-[10px] font-semibold",
-          if(@tab == :clients,
+          if(@tab == :devices,
             do: "bg-brand-muted text-brand",
             else: "bg-raised text-subtle"
           )
         ]}>
-          {@clients_count}
+          {@devices_count}
         </span>
       </button>
       <button
@@ -1169,16 +1169,16 @@ defmodule PortalWeb.Resources.Components do
   end
 
   attr :account, :any, required: true
-  attr :clients, :list, default: []
-  attr :online_client_ids, :any, default: %MapSet{}
+  attr :devices, :list, default: []
+  attr :online_device_ids, :any, default: %MapSet{}
   attr :presence_tick, :integer, default: 0
   attr :expanded_id, :string, default: nil
 
-  def resource_clients_tab(assigns) do
+  def resource_devices_tab(assigns) do
     ~H"""
     <div class="flex-1 flex flex-col overflow-hidden">
       <div
-        :if={@clients == []}
+        :if={@devices == []}
         class="flex flex-col items-center justify-center h-full gap-2 px-6 text-center"
       >
         <.icon name="ri-error-warning-line" class="w-8 h-8 text-warning" />
@@ -1188,7 +1188,7 @@ defmodule PortalWeb.Resources.Components do
           effect. Edit this Resource to add devices.
         </p>
       </div>
-      <div :if={@clients != []} class="flex-1 overflow-y-auto">
+      <div :if={@devices != []} class="flex-1 overflow-y-auto">
         <table class="w-full text-xs">
           <thead class="sticky top-0 bg-surface z-10">
             <tr class="border-b border-border text-subtle">
@@ -1200,39 +1200,39 @@ defmodule PortalWeb.Resources.Components do
             </tr>
           </thead>
           <tbody>
-            <%= for client <- @clients do %>
+            <%= for device <- @devices do %>
               <tr
-                phx-click="toggle_pool_client_row"
-                phx-keydown="toggle_pool_client_row"
+                phx-click="toggle_pool_device_row"
+                phx-keydown="toggle_pool_device_row"
                 phx-key="Enter"
-                phx-value-id={client.id}
+                phx-value-id={device.id}
                 tabindex="0"
                 class="border-b border-border hover:bg-raised cursor-pointer focus:outline-none focus:bg-raised"
               >
                 <td class="px-4 py-2 text-heading">
                   <div class="flex items-center gap-1.5">
-                    <span class="truncate">{client.name}</span>
-                    <.client_verified_badge client={client} />
+                    <span class="truncate">{device.name}</span>
+                    <.device_verified_badge device={device} />
                   </div>
                 </td>
                 <td class="px-4 py-2 text-body">
-                  {if client.actor, do: client.actor.name, else: "—"}
+                  {if device.actor, do: device.actor.name, else: "—"}
                 </td>
                 <td class="px-4 py-2 text-subtle font-mono">
                   <.copy
-                    id={"pool-member-#{client.id}-ipv4"}
+                    id={"pool-member-#{device.id}-ipv4"}
                     class="flex items-center gap-1.5"
                   >
-                    {client.ipv4}
+                    {device.ipv4}
                   </.copy>
                 </td>
                 <td class="px-4 py-2">
-                  <.client_status_badge online?={MapSet.member?(@online_client_ids, client.id)} />
+                  <.device_status_badge online?={MapSet.member?(@online_device_ids, device.id)} />
                 </td>
                 <td class="px-4 py-2 text-subtle">
                   <.icon
                     name={
-                      if @expanded_id == client.id,
+                      if @expanded_id == device.id,
                         do: "ri-arrow-up-s-line",
                         else: "ri-arrow-down-s-line"
                     }
@@ -1240,60 +1240,60 @@ defmodule PortalWeb.Resources.Components do
                   />
                 </td>
               </tr>
-              <tr :if={@expanded_id == client.id} class="border-b border-border bg-raised">
+              <tr :if={@expanded_id == device.id} class="border-b border-border bg-raised">
                 <td colspan="5" class="px-4 py-3">
                   <div class="grid grid-cols-2 gap-x-8 gap-y-3 text-xs">
-                    <div :if={client.actor}>
+                    <div :if={device.actor}>
                       <p class="text-subtle font-medium mb-1">Owner</p>
                       <.link
-                        navigate={~p"/#{@account}/actors/#{client.actor.id}"}
+                        navigate={~p"/#{@account}/actors/#{device.actor.id}"}
                         class="text-brand hover:underline"
                       >
-                        {client.actor.name}
+                        {device.actor.name}
                       </.link>
-                      <p :if={client.actor.email} class="text-subtle mt-0.5">
-                        {client.actor.email}
+                      <p :if={device.actor.email} class="text-subtle mt-0.5">
+                        {device.actor.email}
                       </p>
                     </div>
-                    <div :if={client.last_seen_at}>
+                    <div :if={device.last_seen_at}>
                       <p class="text-subtle font-medium mb-1">Operating System</p>
-                      <.client_os client={client} />
+                      <.device_os device={device} />
                     </div>
                     <div>
                       <p class="text-subtle font-medium mb-1">Tunnel IPv4</p>
                       <.copy
-                        id={"pool-member-#{client.id}-detail-ipv4"}
+                        id={"pool-member-#{device.id}-detail-ipv4"}
                         class="flex items-center gap-1.5 text-heading font-mono"
                       >
-                        {client.ipv4}
+                        {device.ipv4}
                       </.copy>
                     </div>
                     <div>
                       <p class="text-subtle font-medium mb-1">Tunnel IPv6</p>
                       <.copy
-                        id={"pool-member-#{client.id}-detail-ipv6"}
+                        id={"pool-member-#{device.id}-detail-ipv6"}
                         class="flex items-start gap-1.5 text-heading font-mono break-all"
                       >
-                        {client.ipv6}
+                        {device.ipv6}
                       </.copy>
                     </div>
-                    <div :if={client.last_seen_at}>
+                    <div :if={device.last_seen_at}>
                       <p class="text-subtle font-medium mb-1">Last Seen</p>
                       <p class="text-heading">
-                        <.relative_datetime datetime={client.last_seen_at} />
+                        <.relative_datetime datetime={device.last_seen_at} />
                       </p>
                     </div>
-                    <div :if={client.device_serial}>
+                    <div :if={device.device_serial}>
                       <p class="text-subtle font-medium mb-1">Serial Number</p>
-                      <p class="text-heading font-mono">{client.device_serial}</p>
+                      <p class="text-heading font-mono">{device.device_serial}</p>
                     </div>
                     <div>
-                      <p class="text-subtle font-medium mb-1">Client</p>
+                      <p class="text-subtle font-medium mb-1">Device</p>
                       <.link
-                        navigate={~p"/#{@account}/clients/#{client.id}"}
+                        navigate={~p"/#{@account}/devices/#{device.id}"}
                         class="text-brand hover:underline font-mono break-all"
                       >
-                        {client.id}
+                        {device.id}
                       </.link>
                     </div>
                   </div>
@@ -1764,7 +1764,7 @@ defmodule PortalWeb.Resources.Components do
                         <p class="text-subtle font-medium mb-1">
                           {case row.initiating_device && row.initiating_device.type do
                             :gateway -> "Initiator (Gateway)"
-                            :client -> "Initiator (Client)"
+                            :client -> "Initiator (Device)"
                             _ -> "Initiator"
                           end}
                         </p>
@@ -1781,7 +1781,7 @@ defmodule PortalWeb.Resources.Components do
                         <p class="text-subtle font-medium mb-1">
                           {case row.receiving_device && row.receiving_device.type do
                             :gateway -> "Receiver (Gateway)"
-                            :client -> "Receiver (Client)"
+                            :client -> "Receiver (Device)"
                             _ -> "Receiver"
                           end}
                         </p>
@@ -1977,7 +1977,7 @@ defmodule PortalWeb.Resources.Components do
             Delete this resource?
           </p>
           <p class="text-xs text-error/70 mb-3">
-            All Policies associated with this Resource will also be deleted and all Clients will immediately lose access.
+            All Policies associated with this Resource will also be deleted and all devices will immediately lose access.
           </p>
           <div class="flex items-center gap-1.5">
             <.button type="button" phx-click="cancel_delete_resource" size="xs">
@@ -2025,10 +2025,10 @@ defmodule PortalWeb.Resources.Components do
   attr :resource, :any, required: true
   attr :presence_tick, :integer, default: 0
   attr :pool_member_ids, :list, default: []
-  attr :online_client_ids, :any, default: %MapSet{}
+  attr :online_device_ids, :any, default: %MapSet{}
 
   def resource_status_badge(%{resource: %{type: :static_device_pool}} = assigns) do
-    online = Enum.count(assigns.pool_member_ids, &MapSet.member?(assigns.online_client_ids, &1))
+    online = Enum.count(assigns.pool_member_ids, &MapSet.member?(assigns.online_device_ids, &1))
     assigns = assign(assigns, online: online, total: length(assigns.pool_member_ids))
 
     ~H"""
@@ -2119,95 +2119,95 @@ defmodule PortalWeb.Resources.Components do
       |> Safe.all()
     end
 
-    def get_client(client_id, subject) do
-      from(c in Device, as: :clients)
-      |> where([clients: c], c.type == :client)
-      |> where([clients: c], c.id == ^client_id)
+    def get_device(device_id, subject) do
+      from(d in Device, as: :devices)
+      |> where([devices: d], d.type == :client)
+      |> where([devices: d], d.id == ^device_id)
       |> Safe.scoped(subject)
       |> Safe.one()
     end
 
-    def search_clients(search_term, _subject, _selected_clients) when search_term in [nil, ""],
+    def search_devices(search_term, _subject, _selected_devices) when search_term in [nil, ""],
       do: nil
 
-    def search_clients(search_term, subject, selected_clients) do
-      selected_ids = Enum.map(selected_clients, & &1.id)
+    def search_devices(search_term, subject, selected_devices) do
+      selected_ids = Enum.map(selected_devices, & &1.id)
       online_ids = Portal.Presence.Clients.online_client_ids(subject.account.id)
       pattern = "%#{search_term}%"
 
       query =
-        from(c in Device, as: :clients)
-        |> where([clients: c], c.type == :client)
-        |> join(:inner, [clients: c], a in assoc(c, :actor),
-          on: a.account_id == c.account_id,
+        from(d in Device, as: :devices)
+        |> where([devices: d], d.type == :client)
+        |> join(:inner, [devices: d], a in assoc(d, :actor),
+          on: a.account_id == d.account_id,
           as: :actors
         )
-        |> where([clients: c], c.id not in ^selected_ids)
-        |> where(^client_search_filter(pattern))
-        |> order_by([clients: c], desc: c.id in ^online_ids)
+        |> where([devices: d], d.id not in ^selected_ids)
+        |> where(^device_search_filter(pattern))
+        |> order_by([devices: d], desc: d.id in ^online_ids)
         |> limit(10)
 
       case query |> Safe.scoped(subject) |> Safe.all() do
         {:error, _} ->
           []
 
-        clients ->
-          Enum.map(clients, &%{&1 | online?: &1.id in online_ids})
+        devices ->
+          Enum.map(devices, &%{&1 | online?: &1.id in online_ids})
       end
     end
 
-    defp client_search_filter(pattern) do
+    defp device_search_filter(pattern) do
       dynamic(
-        [clients: c, actors: a],
-        ilike(c.name, ^pattern) or
+        [devices: d, actors: a],
+        ilike(d.name, ^pattern) or
           ilike(a.name, ^pattern) or
           ilike(coalesce(a.email, ""), ^pattern) or
-          ilike(type(c.id, :string), ^pattern) or
-          ilike(type(c.ipv4, :string), ^pattern) or
-          ilike(type(c.ipv6, :string), ^pattern) or
+          ilike(type(d.id, :string), ^pattern) or
+          ilike(type(d.ipv4, :string), ^pattern) or
+          ilike(type(d.ipv6, :string), ^pattern) or
           ^device_identifier_filter(pattern)
       )
     end
 
     defp device_identifier_filter(pattern) do
       Enum.reduce(@device_identifier_fields, dynamic(false), fn field, dyn ->
-        dynamic([clients: c], ^dyn or ilike(coalesce(field(c, ^field), ""), ^pattern))
+        dynamic([devices: d], ^dyn or ilike(coalesce(field(d, ^field), ""), ^pattern))
       end)
     end
 
-    def validate_selected_clients([], _subject), do: {:ok, []}
+    def validate_selected_devices([], _subject), do: {:ok, []}
 
-    def validate_selected_clients(selected_clients, subject) do
+    def validate_selected_devices(selected_devices, subject) do
       ids =
-        selected_clients
+        selected_devices
         |> Enum.map(& &1.id)
         |> Enum.uniq()
 
-      from(c in Device, as: :clients)
-      |> where([clients: c], c.type == :client)
-      |> where([clients: c], c.id in ^ids)
+      from(d in Device, as: :devices)
+      |> where([devices: d], d.type == :client)
+      |> where([devices: d], d.id in ^ids)
       |> Safe.scoped(subject)
       |> Safe.all()
       |> case do
         {:error, _} ->
-          {:error, :invalid_clients}
+          {:error, :invalid_devices}
 
-        clients when length(clients) == length(ids) ->
-          {:ok, clients}
+        devices when length(devices) == length(ids) ->
+          {:ok, devices}
 
         _ ->
-          {:error, :invalid_clients}
+          {:error, :invalid_devices}
       end
     end
 
     def sync_static_pool_members(
           %Portal.Resource{type: :static_device_pool} = resource,
-          clients,
+          devices,
           subject
         ) do
-      selected_client_ids = clients |> Enum.map(& &1.id) |> Enum.uniq()
+      selected_device_ids = devices |> Enum.map(& &1.id) |> Enum.uniq()
 
-      existing_client_ids =
+      existing_device_ids =
         from(m in StaticDevicePoolMember,
           where: m.resource_id == ^resource.id,
           select: m.device_id
@@ -2219,8 +2219,8 @@ defmodule PortalWeb.Resources.Components do
           ids -> ids
         end
 
-      to_remove = existing_client_ids -- selected_client_ids
-      to_add = selected_client_ids -- existing_client_ids
+      to_remove = existing_device_ids -- selected_device_ids
+      to_add = selected_device_ids -- existing_device_ids
 
       with :ok <- maybe_delete_pool_members(resource, to_remove, subject),
            :ok <- maybe_insert_pool_members(resource, to_add, subject) do
@@ -2228,7 +2228,7 @@ defmodule PortalWeb.Resources.Components do
       end
     end
 
-    def sync_static_pool_members(%Portal.Resource{} = resource, _clients, subject) do
+    def sync_static_pool_members(%Portal.Resource{} = resource, _devices, subject) do
       case from(m in StaticDevicePoolMember, where: m.resource_id == ^resource.id)
            |> Safe.scoped(subject)
            |> Safe.delete_all() do

--- a/elixir/lib/portal_web/live/settings/dns.ex
+++ b/elixir/lib/portal_web/live/settings/dns.ex
@@ -325,7 +325,7 @@ defmodule PortalWeb.Settings.DNS do
                   :if={not Enum.empty?(dns_form[:addresses].value || [])}
                   class="text-xs text-body"
                 >
-                  Upstream resolvers will be used by Client devices in the order listed below.
+                  Upstream resolvers will be used by devices when the Firezone Client is signed in, in the order listed below.
                 </p>
                 <p
                   :if={Enum.empty?(dns_form[:addresses].value || [])}

--- a/elixir/lib/portal_web/live/settings/profile.ex
+++ b/elixir/lib/portal_web/live/settings/profile.ex
@@ -9,7 +9,7 @@ defmodule PortalWeb.Settings.Profile do
     %{value: "resources", label: "Resources", icon: "ri-server-line"},
     %{value: "groups", label: "Groups", icon: "ri-team-line"},
     %{value: "policies", label: "Policies", icon: "ri-shield-check-line"},
-    %{value: "clients", label: "Clients", icon: "ri-computer-line"},
+    %{value: "devices", label: "Devices", icon: "ri-computer-line"},
     %{value: "actors", label: "Actors", icon: "ri-user-line"}
   ]
 

--- a/elixir/lib/portal_web/router.ex
+++ b/elixir/lib/portal_web/router.ex
@@ -234,10 +234,10 @@ defmodule PortalWeb.Router do
       live "/groups/:id/edit", Groups, :edit
       live "/groups/:id", Groups, :show
 
-      # Clients
-      live "/clients", Clients
-      live "/clients/:id/edit", Clients, :edit
-      live "/clients/:id", Clients, :show
+      # Devices
+      live "/devices", Devices
+      live "/devices/:id/edit", Devices, :edit
+      live "/devices/:id", Devices, :show
 
       # Sites
       live "/sites", Sites

--- a/elixir/lib/portal_web/session/redirector.ex
+++ b/elixir/lib/portal_web/session/redirector.ex
@@ -220,7 +220,7 @@ defmodule PortalWeb.Session.Redirector do
       :resources -> ~p"/#{account}/resources"
       :groups -> ~p"/#{account}/groups"
       :policies -> ~p"/#{account}/policies"
-      :clients -> ~p"/#{account}/clients"
+      :devices -> ~p"/#{account}/devices"
       :actors -> ~p"/#{account}/actors"
       :sites -> ~p"/#{account}/sites"
       _ -> ~p"/#{account}/sites"

--- a/elixir/priv/repo/migrations/20260901000001_rename_clients_start_page_preference.exs
+++ b/elixir/priv/repo/migrations/20260901000001_rename_clients_start_page_preference.exs
@@ -1,0 +1,26 @@
+defmodule Portal.Repo.Migrations.RenameClientsStartPagePreference do
+  @moduledoc """
+  Moves the saved landing-page choice to the page's new name.
+
+  An admin who picked the Clients page stored `clients`, which is no longer one
+  of the values the preference accepts, so without this their portal would fall
+  back to Sites on the next sign-in.
+  """
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    UPDATE actors
+    SET preferences = jsonb_set(preferences, '{start_page}', '"devices"')
+    WHERE preferences->>'start_page' = 'clients'
+    """)
+  end
+
+  def down do
+    execute("""
+    UPDATE actors
+    SET preferences = jsonb_set(preferences, '{start_page}', '"clients"')
+    WHERE preferences->>'start_page' = 'devices'
+    """)
+  end
+end

--- a/elixir/test/portal/cache/client_test.exs
+++ b/elixir/test/portal/cache/client_test.exs
@@ -250,7 +250,7 @@ defmodule Portal.Cache.ClientTest do
       group = group_fixture(account: account)
       membership_fixture(account: account, actor: actor, group: group)
 
-      resource = static_device_pool_resource_fixture(account: account, clients: [target_client])
+      resource = static_device_pool_resource_fixture(account: account, devices: [target_client])
       policy_fixture(account: account, group: group, resource: resource)
 
       client = %{
@@ -286,7 +286,7 @@ defmodule Portal.Cache.ClientTest do
       group = group_fixture(account: account)
       membership_fixture(account: account, actor: actor, group: group)
 
-      resource = static_device_pool_resource_fixture(account: account, clients: [target_client])
+      resource = static_device_pool_resource_fixture(account: account, devices: [target_client])
       policy_fixture(account: account, group: group, resource: resource)
 
       client = %{
@@ -348,7 +348,7 @@ defmodule Portal.Cache.ClientTest do
       group = group_fixture(account: account)
       membership_fixture(account: account, actor: actor, group: group)
 
-      resource = static_device_pool_resource_fixture(account: account, clients: [target_client])
+      resource = static_device_pool_resource_fixture(account: account, devices: [target_client])
       policy_fixture(account: account, group: group, resource: resource)
 
       client = %{
@@ -397,7 +397,7 @@ defmodule Portal.Cache.ClientTest do
       group = group_fixture(account: account)
       membership_fixture(account: account, actor: actor, group: group)
 
-      resource = static_device_pool_resource_fixture(account: account, clients: [target_client])
+      resource = static_device_pool_resource_fixture(account: account, devices: [target_client])
       policy_fixture(account: account, group: group, resource: resource)
 
       client = %{
@@ -648,7 +648,7 @@ defmodule Portal.Cache.ClientTest do
       ipv6_tuple = target.ipv6.address
 
       pool =
-        static_device_pool_resource_fixture(account: account, clients: [])
+        static_device_pool_resource_fixture(account: account, devices: [])
 
       rid_bytes = Ecto.UUID.dump!(pool.id)
 
@@ -685,7 +685,7 @@ defmodule Portal.Cache.ClientTest do
       did_a = Ecto.UUID.dump!(target_a.id)
       did_b = Ecto.UUID.dump!(target_b.id)
 
-      pool = static_device_pool_resource_fixture(account: account, clients: [])
+      pool = static_device_pool_resource_fixture(account: account, devices: [])
       rid_bytes = Ecto.UUID.dump!(pool.id)
 
       cacheable_pool = Cacheable.to_cache(pool)
@@ -770,7 +770,7 @@ defmodule Portal.Cache.ClientTest do
       did_a = Ecto.UUID.dump!(target_a.id)
       did_b = Ecto.UUID.dump!(target_b.id)
 
-      pool = static_device_pool_resource_fixture(account: account, clients: [])
+      pool = static_device_pool_resource_fixture(account: account, devices: [])
       rid_bytes = Ecto.UUID.dump!(pool.id)
 
       cacheable_pool = Cacheable.to_cache(pool)
@@ -843,7 +843,7 @@ defmodule Portal.Cache.ClientTest do
       did_a = Ecto.UUID.dump!(target_a.id)
       did_b = Ecto.UUID.dump!(target_b.id)
 
-      pool = static_device_pool_resource_fixture(account: account, clients: [])
+      pool = static_device_pool_resource_fixture(account: account, devices: [])
       rid_bytes = Ecto.UUID.dump!(pool.id)
 
       cacheable_pool = Cacheable.to_cache(pool)
@@ -899,7 +899,7 @@ defmodule Portal.Cache.ClientTest do
       pool =
         static_device_pool_resource_fixture(
           account: account,
-          clients: [target_a, target_b]
+          devices: [target_a, target_b]
         )
 
       policy_fixture(account: account, group: group, resource: pool)
@@ -930,7 +930,7 @@ defmodule Portal.Cache.ClientTest do
       actor = actor_fixture(type: :account_admin_user, account: account)
       subject = subject_fixture(account: account, actor: actor, type: :client)
 
-      pool = static_device_pool_resource_fixture(account: account, clients: [])
+      pool = static_device_pool_resource_fixture(account: account, devices: [])
       rid_bytes = Ecto.UUID.dump!(pool.id)
 
       cacheable_pool = Cacheable.to_cache(pool)

--- a/elixir/test/portal/mailer/notifications_test.exs
+++ b/elixir/test/portal/mailer/notifications_test.exs
@@ -135,7 +135,7 @@ defmodule Portal.Mailer.NotificationsTest do
       assert email_body.html_body =~ gateway_2.name
 
       assert email_body.html_body =~
-               "/#{account.slug}/clients?clients_order_by=devices%3Aasc%3Alast_seen_version\" target=\"_blank\" rel=\"noopener noreferrer\">#{incompatible_client_count} recently connected client(s)</a> are not compatible"
+               "/#{account.slug}/devices?devices_order_by=devices%3Aasc%3Alast_seen_version\" target=\"_blank\" rel=\"noopener noreferrer\">#{incompatible_client_count} recently connected client(s)</a> are not compatible"
 
       assert email_body.html_body =~ "See all outdated clients"
     end

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -2223,7 +2223,7 @@ defmodule PortalAPI.Client.ChannelTest do
       # Client is not verified, so resource should not be accessible
       refute_push "resource_created_or_updated", _payload
 
-      verified_client = verify_client(client)
+      verified_client = verify_device(client)
 
       send(socket.channel_pid, %Changes.Change{
         lsn: 200,
@@ -5541,7 +5541,7 @@ defmodule PortalAPI.Client.ChannelTest do
         )
 
       pool_resource =
-        static_device_pool_resource_fixture(account: account, clients: [target_client])
+        static_device_pool_resource_fixture(account: account, devices: [target_client])
 
       policy_fixture(account: account, group: group, resource: pool_resource)
 
@@ -5775,7 +5775,7 @@ defmodule PortalAPI.Client.ChannelTest do
            target_client: target_client
          } do
       pool =
-        static_device_pool_resource_fixture(account: account, clients: [target_client])
+        static_device_pool_resource_fixture(account: account, devices: [target_client])
 
       # Create a policy in another group the actor is not a member of — the resource
       # is therefore not in the actor's connectable_resources.
@@ -6531,7 +6531,7 @@ defmodule PortalAPI.Client.ChannelTest do
       target_client: target_client
     } do
       static_pool =
-        static_device_pool_resource_fixture(account: account, clients: [target_client])
+        static_device_pool_resource_fixture(account: account, devices: [target_client])
 
       policy_fixture(account: account, group: group, resource: static_pool)
 
@@ -6728,7 +6728,7 @@ defmodule PortalAPI.Client.ChannelTest do
       target_client = client_fixture(account: account, actor: target_actor) |> fetch_device!()
 
       pool_resource =
-        static_device_pool_resource_fixture(account: account, clients: [target_client])
+        static_device_pool_resource_fixture(account: account, devices: [target_client])
 
       policy_fixture(account: account, group: group, resource: pool_resource)
 
@@ -6773,8 +6773,8 @@ defmodule PortalAPI.Client.ChannelTest do
       target_actor = actor_fixture(account: account)
       target_client = client_fixture(account: account, actor: target_actor) |> fetch_device!()
 
-      pool_a = static_device_pool_resource_fixture(account: account, clients: [target_client])
-      pool_b = static_device_pool_resource_fixture(account: account, clients: [target_client])
+      pool_a = static_device_pool_resource_fixture(account: account, devices: [target_client])
+      pool_b = static_device_pool_resource_fixture(account: account, devices: [target_client])
       policy_fixture(account: account, group: group, resource: pool_a)
       policy_fixture(account: account, group: group, resource: pool_b)
 
@@ -6819,7 +6819,7 @@ defmodule PortalAPI.Client.ChannelTest do
       target_client = client_fixture(account: account, actor: target_actor) |> fetch_device!()
 
       pool_resource =
-        static_device_pool_resource_fixture(account: account, clients: [target_client])
+        static_device_pool_resource_fixture(account: account, devices: [target_client])
 
       policy_fixture(account: account, group: group, resource: pool_resource)
 
@@ -7170,7 +7170,7 @@ defmodule PortalAPI.Client.ChannelTest do
       pool_resource =
         Portal.ResourceFixtures.static_device_pool_resource_fixture(
           account: account,
-          clients: [target_client]
+          devices: [target_client]
         )
 
       policy_fixture(account: account, group: group, resource: pool_resource)

--- a/elixir/test/portal_api/controllers/pool_member_controller_test.exs
+++ b/elixir/test/portal_api/controllers/pool_member_controller_test.exs
@@ -40,7 +40,7 @@ defmodule PortalAPI.PoolMemberControllerTest do
       client2 = client_fixture(account: account)
       _unrelated = client_fixture(account: account)
 
-      pool = static_device_pool_resource_fixture(account: account, clients: [client1, client2])
+      pool = static_device_pool_resource_fixture(account: account, devices: [client1, client2])
 
       conn =
         conn
@@ -104,7 +104,7 @@ defmodule PortalAPI.PoolMemberControllerTest do
       other_client = client_fixture(account: other_account)
 
       other_pool =
-        static_device_pool_resource_fixture(account: other_account, clients: [other_client])
+        static_device_pool_resource_fixture(account: other_account, devices: [other_client])
 
       _local_pool = static_device_pool_resource_fixture(account: account)
 
@@ -124,7 +124,7 @@ defmodule PortalAPI.PoolMemberControllerTest do
       drop = client_fixture(account: account)
       add = client_fixture(account: account)
 
-      pool = static_device_pool_resource_fixture(account: account, clients: [keep, drop])
+      pool = static_device_pool_resource_fixture(account: account, devices: [keep, drop])
 
       conn =
         conn
@@ -141,7 +141,7 @@ defmodule PortalAPI.PoolMemberControllerTest do
 
     test "an empty list clears the pool", %{conn: conn, account: account, actor: api_actor} do
       client = client_fixture(account: account)
-      pool = static_device_pool_resource_fixture(account: account, clients: [client])
+      pool = static_device_pool_resource_fixture(account: account, devices: [client])
 
       conn =
         conn
@@ -160,7 +160,7 @@ defmodule PortalAPI.PoolMemberControllerTest do
     } do
       keep = client_fixture(account: account)
       add = client_fixture(account: account)
-      pool = static_device_pool_resource_fixture(account: account, clients: [keep])
+      pool = static_device_pool_resource_fixture(account: account, devices: [keep])
 
       original_row_id =
         Repo.one!(
@@ -197,7 +197,7 @@ defmodule PortalAPI.PoolMemberControllerTest do
       actor: api_actor
     } do
       keep = client_fixture(account: account)
-      pool = static_device_pool_resource_fixture(account: account, clients: [keep])
+      pool = static_device_pool_resource_fixture(account: account, devices: [keep])
 
       for {label, body} <- [
             {"entry with no device_id", [%{}]},
@@ -227,7 +227,7 @@ defmodule PortalAPI.PoolMemberControllerTest do
       actor: api_actor
     } do
       client = client_fixture(account: account)
-      pool = static_device_pool_resource_fixture(account: account, clients: [client])
+      pool = static_device_pool_resource_fixture(account: account, devices: [client])
 
       conn =
         conn
@@ -340,7 +340,7 @@ defmodule PortalAPI.PoolMemberControllerTest do
       drop = client_fixture(account: account)
       add = client_fixture(account: account)
 
-      pool = static_device_pool_resource_fixture(account: account, clients: [keep, drop])
+      pool = static_device_pool_resource_fixture(account: account, devices: [keep, drop])
 
       conn =
         conn
@@ -361,7 +361,7 @@ defmodule PortalAPI.PoolMemberControllerTest do
       actor: api_actor
     } do
       client = client_fixture(account: account)
-      pool = static_device_pool_resource_fixture(account: account, clients: [client])
+      pool = static_device_pool_resource_fixture(account: account, devices: [client])
 
       conn =
         conn
@@ -377,7 +377,7 @@ defmodule PortalAPI.PoolMemberControllerTest do
     test "removing a non-member is a no-op", %{conn: conn, account: account, actor: api_actor} do
       member = client_fixture(account: account)
       stranger = client_fixture(account: account)
-      pool = static_device_pool_resource_fixture(account: account, clients: [member])
+      pool = static_device_pool_resource_fixture(account: account, devices: [member])
 
       conn =
         conn
@@ -417,7 +417,7 @@ defmodule PortalAPI.PoolMemberControllerTest do
       actor: api_actor
     } do
       client = client_fixture(account: account)
-      pool = static_device_pool_resource_fixture(account: account, clients: [client])
+      pool = static_device_pool_resource_fixture(account: account, devices: [client])
 
       conn =
         conn
@@ -435,7 +435,7 @@ defmodule PortalAPI.PoolMemberControllerTest do
       actor: api_actor
     } do
       member = client_fixture(account: account)
-      pool = static_device_pool_resource_fixture(account: account, clients: [member])
+      pool = static_device_pool_resource_fixture(account: account, devices: [member])
 
       conn =
         conn
@@ -461,7 +461,7 @@ defmodule PortalAPI.PoolMemberControllerTest do
         actor: api_actor
       } do
         member = client_fixture(account: account)
-        pool = static_device_pool_resource_fixture(account: account, clients: [member])
+        pool = static_device_pool_resource_fixture(account: account, devices: [member])
 
         conn =
           conn

--- a/elixir/test/portal_web/live/devices_test.exs
+++ b/elixir/test/portal_web/live/devices_test.exs
@@ -1,4 +1,4 @@
-defmodule PortalWeb.ClientsTest do
+defmodule PortalWeb.DevicesTest do
   use PortalWeb.ConnCase, async: true
 
   alias Portal.{Device, Repo}
@@ -30,7 +30,7 @@ defmodule PortalWeb.ClientsTest do
 
   describe "unauthorized" do
     test "redirects to sign-in when not authenticated", %{conn: conn, account: account} do
-      path = ~p"/#{account}/clients"
+      path = ~p"/#{account}/devices"
 
       assert live(conn, path) ==
                {:error,
@@ -43,7 +43,7 @@ defmodule PortalWeb.ClientsTest do
   end
 
   describe "index (default action)" do
-    test "renders empty state when no clients exist", %{
+    test "renders empty state when no devices exist", %{
       conn: conn,
       account: account,
       actor: actor
@@ -51,10 +51,10 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
+        |> live(~p"/#{account}/devices")
 
-      assert html =~ "Clients"
-      assert html =~ "No clients yet"
+      assert html =~ "Devices"
+      assert html =~ "No devices yet"
     end
 
     test "renders client list page", %{conn: conn, account: account, actor: actor} do
@@ -63,13 +63,13 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
+        |> live(~p"/#{account}/devices")
 
-      assert html =~ "Clients"
+      assert html =~ "Devices"
       assert html =~ client.name
     end
 
-    test "filters clients by client name or actor name/email", %{
+    test "filters devices by client name or actor name/email", %{
       conn: conn,
       account: account,
       actor: actor
@@ -82,7 +82,7 @@ defmodule PortalWeb.ClientsTest do
 
       for search <- [client.name, owner.name, owner.email] do
         {:ok, _lv, html} =
-          live(conn, ~p"/#{account}/clients?#{%{"clients_filter[search]" => search}}")
+          live(conn, ~p"/#{account}/devices?#{%{"devices_filter[search]" => search}}")
 
         assert html =~ client.name
         refute html =~ other_client.name
@@ -95,7 +95,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
+        |> live(~p"/#{account}/devices")
 
       assert html =~ "All trust levels"
       refute html =~ "All Trust levels"
@@ -123,7 +123,7 @@ defmodule PortalWeb.ClientsTest do
             {"none", plain, [verified, attested]}
           ] do
         {:ok, _lv, html} =
-          live(conn, ~p"/#{account}/clients?#{%{"clients_filter[attestation]" => level}}")
+          live(conn, ~p"/#{account}/devices?#{%{"devices_filter[attestation]" => level}}")
 
         assert html =~ shown.name
 
@@ -133,7 +133,7 @@ defmodule PortalWeb.ClientsTest do
       end
     end
 
-    test "a client that attested cannot be verified by hand", %{
+    test "a device that attested cannot be verified by hand", %{
       conn: conn,
       account: account,
       actor: actor
@@ -149,10 +149,10 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       assert has_element?(lv, "button[disabled]", "Verify")
-      refute has_element?(lv, "button[phx-click='verify_client']")
+      refute has_element?(lv, "button[phx-click='verify_device']")
       assert render(lv) =~ "This device is already attested through an X.509 certificate."
       assert render(lv) =~ "This device is attested through an X.509 certificate."
     end
@@ -168,12 +168,12 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
+        |> live(~p"/#{account}/devices")
 
       html =
         element(
           lv,
-          "button[phx-click='order_by'][phx-value-table_id='clients'][phx-value-order_by='devices:asc:name']"
+          "button[phx-click='order_by'][phx-value-table_id='devices'][phx-value-order_by='devices:asc:name']"
         )
         |> render_click()
 
@@ -181,11 +181,11 @@ defmodule PortalWeb.ClientsTest do
       assert html =~ omega.name
       assert elem(:binary.match(html, omega.name), 0) < elem(:binary.match(html, alpha.name), 0)
 
-      render_click(element(lv, "#client-#{omega.id}"))
+      render_click(element(lv, "#device-#{omega.id}"))
 
       assert_patch(
         lv,
-        ~p"/#{account}/clients/#{omega.id}?#{%{clients_order_by: "devices:desc:name"}}"
+        ~p"/#{account}/devices/#{omega.id}?#{%{devices_order_by: "devices:desc:name"}}"
       )
 
       assert render(lv) =~ omega.name
@@ -193,7 +193,7 @@ defmodule PortalWeb.ClientsTest do
   end
 
   describe ":show action" do
-    test "cautions that the client reports its own device fields", %{
+    test "cautions that the device reports its own fields", %{
       conn: conn,
       account: account,
       actor: actor
@@ -203,7 +203,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       assert html =~ "Reported by Client"
       assert html =~ "The Firezone Client reads and reports these values."
@@ -211,7 +211,7 @@ defmodule PortalWeb.ClientsTest do
       assert html =~ ~p"/#{account}/settings/trust_anchors"
     end
 
-    test "drops the device trust call to action once the client has attested", %{
+    test "drops the device trust call to action once the device has attested", %{
       conn: conn,
       account: account,
       actor: actor
@@ -227,7 +227,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       assert html =~ "Reported by Client"
       refute html =~ "to strongly identify this device"
@@ -267,7 +267,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       assert html =~ client.name
       assert html =~ owner.name
@@ -283,12 +283,12 @@ defmodule PortalWeb.ClientsTest do
       assert html =~ "Tunnel IPv4"
       assert html =~ "Tunnel IPv6"
       assert html =~ "Trust level"
-      assert html =~ "An admin vouched for the values this Client reports."
+      assert html =~ "An admin vouched for the values this Device reports."
       assert html =~ "Verified"
       assert html =~ session.last_seen_version
 
       render_click(lv, "close_panel")
-      assert_patch(lv, ~p"/#{account}/clients")
+      assert_patch(lv, ~p"/#{account}/devices")
     end
 
     test "lists the device pools the client belongs to", %{
@@ -302,13 +302,13 @@ defmodule PortalWeb.ClientsTest do
         static_device_pool_resource_fixture(
           account: account,
           name: "Engineering Laptops",
-          clients: [client]
+          devices: [client]
         )
 
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       assert html =~ "Device Pools"
       assert html =~ pool.name
@@ -325,7 +325,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       refute html =~ "Device Pools"
     end
@@ -340,19 +340,19 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       render_click(lv, "close_panel")
-      assert_patch(lv, ~p"/#{account}/clients")
+      assert_patch(lv, ~p"/#{account}/devices")
 
-      render_click(lv, "switch_client_tab", %{"tab" => "authorizations"})
+      render_click(lv, "switch_device_tab", %{"tab" => "authorizations"})
 
-      refute has_element?(lv, "#client-panel > div")
+      refute has_element?(lv, "#device-panel > div")
     end
 
     test "marks only older client versions as outdated" do
       older_html =
-        render_component(&PortalWeb.Clients.Components.version/1,
+        render_component(&PortalWeb.Devices.Components.version/1,
           current: "0.9.0",
           latest: "1.0.0"
         )
@@ -361,7 +361,7 @@ defmodule PortalWeb.ClientsTest do
       assert older_html =~ "1.0.0"
 
       latest_html =
-        render_component(&PortalWeb.Clients.Components.version/1,
+        render_component(&PortalWeb.Devices.Components.version/1,
           current: "1.0.0",
           latest: "1.0.0"
         )
@@ -370,7 +370,7 @@ defmodule PortalWeb.ClientsTest do
       refute latest_html =~ "A newer version"
 
       newer_html =
-        render_component(&PortalWeb.Clients.Components.version/1,
+        render_component(&PortalWeb.Devices.Components.version/1,
           current: "1.0.1",
           latest: "1.0.0"
         )
@@ -389,18 +389,18 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
-      html = render_click(lv, "confirm_delete_client")
-      assert html =~ "Delete this client?"
+      html = render_click(lv, "confirm_delete_device")
+      assert html =~ "Delete this device?"
 
-      html = render_click(lv, "cancel_delete_client")
-      refute html =~ "Delete this client?"
+      html = render_click(lv, "cancel_delete_device")
+      refute html =~ "Delete this device?"
 
-      render_click(lv, "confirm_delete_client")
-      render_click(lv, "delete_client")
+      render_click(lv, "confirm_delete_device")
+      render_click(lv, "delete_device")
 
-      assert_patch(lv, ~p"/#{account}/clients")
+      assert_patch(lv, ~p"/#{account}/devices")
       assert is_nil(Repo.get_by(Device, account_id: account.id, id: client.id))
     end
 
@@ -414,20 +414,20 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
-      assert has_element?(lv, "button[phx-click='verify_client']", "Verify")
+      assert has_element?(lv, "button[phx-click='verify_device']", "Verify")
 
-      html = render_click(lv, "verify_client")
+      html = render_click(lv, "verify_device")
       updated_client = Repo.get_by!(Device, account_id: account.id, id: client.id)
 
-      assert html =~ "Client &quot;#{client.name}&quot; was verified."
+      assert html =~ "Device &quot;#{client.name}&quot; was verified."
       assert html =~ "Verified"
       assert updated_client.verified_at
-      refute has_element?(lv, "button[phx-click='verify_client']", "Verify")
+      refute has_element?(lv, "button[phx-click='verify_device']", "Verify")
       assert has_element?(
                lv,
-               "button[phx-click='confirm_unverify_client']",
+               "button[phx-click='confirm_unverify_device']",
                "Revoke verification"
              )
     end
@@ -442,24 +442,24 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
-      html = render_click(lv, "confirm_unverify_client")
-      assert html =~ "Revoke verification for this client?"
-      assert html =~ "Current authorizations for this client may be revoked."
+      html = render_click(lv, "confirm_unverify_device")
+      assert html =~ "Revoke verification for this device?"
+      assert html =~ "Current authorizations for this device may be revoked."
 
-      html = render_click(lv, "cancel_unverify_client")
+      html = render_click(lv, "cancel_unverify_device")
       updated_client = Repo.get_by!(Device, account_id: account.id, id: client.id)
 
-      refute html =~ "Revoke verification for this client?"
+      refute html =~ "Revoke verification for this device?"
       assert updated_client.verified_at
       assert has_element?(
                lv,
-               "button[phx-click='confirm_unverify_client']",
+               "button[phx-click='confirm_unverify_device']",
                "Revoke verification"
              )
 
-      refute has_element?(lv, "button[phx-click='verify_client']", "Verify")
+      refute has_element?(lv, "button[phx-click='verify_device']", "Verify")
     end
 
     test "shows unverify confirmation and accepts", %{
@@ -472,24 +472,24 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
-      render_click(lv, "confirm_unverify_client")
-      html = render_click(lv, "unverify_client")
+      render_click(lv, "confirm_unverify_device")
+      html = render_click(lv, "unverify_device")
       updated_client = Repo.get_by!(Device, account_id: account.id, id: client.id)
 
-      assert html =~ "Client &quot;#{client.name}&quot; was unverified."
-      refute html =~ "Revoke verification for this client?"
+      assert html =~ "Device &quot;#{client.name}&quot; was unverified."
+      refute html =~ "Revoke verification for this device?"
       assert is_nil(updated_client.verified_at)
-      assert has_element?(lv, "button[phx-click='verify_client']", "Verify")
+      assert has_element?(lv, "button[phx-click='verify_device']", "Verify")
       refute has_element?(
                lv,
-               "button[phx-click='confirm_unverify_client']",
+               "button[phx-click='confirm_unverify_device']",
                "Revoke verification"
              )
     end
 
-    test "patches to clients index with flash when client does not exist", %{
+    test "patches to devices index with flash when device does not exist", %{
       conn: conn,
       account: account,
       actor: actor
@@ -499,10 +499,10 @@ defmodule PortalWeb.ClientsTest do
       assert {:error, {:live_redirect, %{to: to, flash: flash}}} =
                conn
                |> authorize_conn(actor)
-               |> live(~p"/#{account}/clients/#{missing_id}")
+               |> live(~p"/#{account}/devices/#{missing_id}")
 
-      assert to == ~p"/#{account}/clients"
-      assert flash["error"] =~ "Client does not exist"
+      assert to == ~p"/#{account}/devices"
+      assert flash["error"] =~ "Device does not exist"
     end
   end
 
@@ -517,9 +517,9 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}/edit")
+        |> live(~p"/#{account}/devices/#{client.id}/edit")
 
-      assert html =~ "Edit Client"
+      assert html =~ "Edit Device"
       assert html =~ "Save"
       assert html =~ client.name
     end
@@ -534,34 +534,34 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
-      render_click(lv, "open_client_edit_form")
-      assert_patch(lv, ~p"/#{account}/clients/#{client.id}/edit")
+      render_click(lv, "open_device_edit_form")
+      assert_patch(lv, ~p"/#{account}/devices/#{client.id}/edit")
 
       html =
         lv
-        |> form("[phx-submit='submit_client_edit_form']", device: %{name: ""})
+        |> form("[phx-submit='submit_device_edit_form']", device: %{name: ""})
         |> render_change()
 
       assert html =~ "can&#39;t be blank"
 
-      render_click(lv, "cancel_client_edit_form")
-      assert_patch(lv, ~p"/#{account}/clients/#{client.id}")
+      render_click(lv, "cancel_device_edit_form")
+      assert_patch(lv, ~p"/#{account}/devices/#{client.id}")
 
-      render_click(lv, "open_client_edit_form")
+      render_click(lv, "open_device_edit_form")
 
       html =
         lv
-        |> form("[phx-submit='submit_client_edit_form']", device: %{name: "Updated Client Name"})
+        |> form("[phx-submit='submit_device_edit_form']", device: %{name: "Updated Client Name"})
         |> render_submit()
 
       updated_client = Repo.get_by!(Device, account_id: account.id, id: client.id)
 
-      assert html =~ "Client updated successfully."
+      assert html =~ "Device updated successfully."
       assert html =~ "Updated Client Name"
       assert updated_client.name == "Updated Client Name"
-      assert_patch(lv, ~p"/#{account}/clients/#{client.id}")
+      assert_patch(lv, ~p"/#{account}/devices/#{client.id}")
     end
   end
 
@@ -576,7 +576,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       assert html =~ "Overview"
       assert html =~ "Authorizations"
@@ -592,13 +592,13 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       lv
-      |> element("button[phx-click='switch_client_tab'][phx-value-tab='authorizations']")
+      |> element("button[phx-click='switch_device_tab'][phx-value-tab='authorizations']")
       |> render_click()
 
-      assert_patch(lv, ~p"/#{account}/clients/#{client.id}?tab=authorizations")
+      assert_patch(lv, ~p"/#{account}/devices/#{client.id}?tab=authorizations")
     end
 
     test "switching back to Overview tab patches URL", %{
@@ -611,13 +611,13 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=authorizations")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=authorizations")
 
       lv
-      |> element("button[phx-click='switch_client_tab'][phx-value-tab='overview']")
+      |> element("button[phx-click='switch_device_tab'][phx-value-tab='overview']")
       |> render_click()
 
-      assert_patch(lv, ~p"/#{account}/clients/#{client.id}?tab=overview")
+      assert_patch(lv, ~p"/#{account}/devices/#{client.id}?tab=overview")
     end
 
     test "Authorizations tab shows empty state when no authorizations exist", %{
@@ -630,7 +630,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=authorizations")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=authorizations")
 
       assert html =~ "No recent authorizations"
 
@@ -670,7 +670,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=authorizations")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=authorizations")
 
       assert html =~ resource.name
       assert html =~ group.name
@@ -691,7 +691,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       assert html =~ "Regression Laptop"
       assert html =~ "Tunnel IPv4"
@@ -706,7 +706,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
+        |> live(~p"/#{account}/devices")
 
       assert html =~ "Loading..."
 
@@ -725,7 +725,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
+        |> live(~p"/#{account}/devices")
 
       render_async(lv)
 
@@ -746,7 +746,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
+        |> live(~p"/#{account}/devices")
 
       render_async(lv)
 
@@ -767,10 +767,10 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
+        |> live(~p"/#{account}/devices")
 
       render_async(lv)
-      refute has_element?(lv, "#clients-reload-btn")
+      refute has_element?(lv, "#devices-reload-btn")
 
       {:ok, _updated} =
         client
@@ -779,9 +779,9 @@ defmodule PortalWeb.ClientsTest do
 
       send(lv.pid, %Change{op: :update, struct: %Device{type: :client, id: client.id}})
 
-      assert has_element?(lv, "#clients-reload-btn")
+      assert has_element?(lv, "#devices-reload-btn")
 
-      render_click(lv, "reload", %{"table_id" => "clients"})
+      render_click(lv, "reload", %{"table_id" => "devices"})
       assert render(lv) =~ "Renamed Client"
     end
 
@@ -789,7 +789,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
+        |> live(~p"/#{account}/devices")
 
       render_async(lv)
 
@@ -820,24 +820,24 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=posture")
 
       refute html =~ "phx-value-tab=\"posture\""
       assert html =~ "Tunnel IPv4"
     end
 
-    test "offers the tab to every client", %{conn: conn, account: account, actor: actor} do
+    test "offers the tab to every device", %{conn: conn, account: account, actor: actor} do
       client = client_fixture(account: account, actor: actor, device_serial: "UNKNOWN-SERIAL")
 
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       assert html =~ "phx-value-tab=\"posture\""
     end
 
-    test "says so when a connected provider holds no record for the client", %{
+    test "says so when a connected provider holds no record for the device", %{
       conn: conn,
       account: account,
       actor: actor
@@ -848,7 +848,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=posture")
 
       assert html =~ "No posture data was found for this device."
     end
@@ -863,7 +863,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=posture")
 
       assert html =~ "Connect a posture provider"
       assert html =~ ~p"/#{account}/settings/device_posture/new"
@@ -877,7 +877,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=posture")
 
       assert html =~ "Upgrade to unlock Device Posture"
       assert html =~ "Upgrade to Unlock"
@@ -911,7 +911,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=posture")
 
       assert html =~ "Contoso Intune"
       assert html =~ "Microsoft Intune"
@@ -953,7 +953,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=posture")
 
       refute html =~ "ENTRA-JOINED-01"
       assert html =~ "No posture data was found for this device."
@@ -977,7 +977,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=posture")
 
       assert html =~ "SELF-REPORTED-01"
       assert html =~ "Self-reported serial"
@@ -1010,7 +1010,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=posture")
 
       assert html =~ "Iru Prod"
       assert html =~ "MACBOOK-01"
@@ -1049,14 +1049,14 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=posture")
 
       assert html =~ "Defender Prod"
       assert html =~ "eng-laptop-01.contoso.com"
       assert html =~ "Active"
     end
 
-    test "leaves out a Defender record no Intune record links to the client", %{
+    test "leaves out a Defender record no Intune record links to the device", %{
       conn: conn,
       account: account,
       actor: actor
@@ -1078,7 +1078,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=posture")
 
       refute html =~ "unlinked-laptop.contoso.com"
       assert html =~ "No posture data was found for this device."
@@ -1108,7 +1108,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=posture")
 
       assert html =~ "Santa Prod"
       assert html =~ "santa-macbook-01"
@@ -1138,7 +1138,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=posture")
 
       assert html =~ "S1 Prod"
       assert html =~ "s1-endpoint-01"
@@ -1175,7 +1175,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=posture")
 
       assert html =~ "Contoso Intune"
       assert html =~ "Santa Prod"
@@ -1201,7 +1201,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}?tab=posture")
+        |> live(~p"/#{account}/devices/#{client.id}?tab=posture")
 
       refute html =~ "OTHER-ACCOUNT-01"
       assert html =~ "No posture data was found for this device."
@@ -1224,7 +1224,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       refute html =~ "WRONG-COLUMN-01"
     end
@@ -1255,11 +1255,11 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
+        |> live(~p"/#{account}/devices")
 
       assert html =~ "ATTESTED-SERIAL-1"
       refute html =~ "REPORTED-SERIAL-1"
-      assert has_element?(lv, "#client-#{client.id} .ri-shield-keyhole-line")
+      assert has_element?(lv, "#device-#{client.id} .ri-shield-keyhole-line")
     end
 
     test "marks a serial the MDM holds with that provider's icon", %{
@@ -1284,15 +1284,15 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
+        |> live(~p"/#{account}/devices")
 
       assert html =~ "MDM-HELD-SERIAL"
       refute html =~ "REPORTED-SERIAL-2"
-      assert has_element?(lv, "#client-#{client.id} img[src*='logo-intune']")
-      refute has_element?(lv, "#client-#{client.id} .ri-shield-keyhole-line")
+      assert has_element?(lv, "#device-#{client.id} img[src*='logo-intune']")
+      refute has_element?(lv, "#device-#{client.id} .ri-shield-keyhole-line")
     end
 
-    test "leaves a serial the client reports about itself unmarked", %{
+    test "leaves a serial the device reports about itself unmarked", %{
       conn: conn,
       account: account,
       actor: actor
@@ -1302,11 +1302,11 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
+        |> live(~p"/#{account}/devices")
 
       assert html =~ "REPORTED-SERIAL-3"
-      refute has_element?(lv, "#client-#{client.id} .ri-shield-keyhole-line")
-      refute has_element?(lv, "#client-#{client.id} img[src*='logo-intune']")
+      refute has_element?(lv, "#device-#{client.id} .ri-shield-keyhole-line")
+      refute has_element?(lv, "#device-#{client.id} img[src*='logo-intune']")
     end
 
     test "falls back to the reported serial when the MDM holds none", %{
@@ -1325,13 +1325,13 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
+        |> live(~p"/#{account}/devices")
 
       assert html =~ "REPORTED-SERIAL-4"
-      refute has_element?(lv, "#client-#{client.id} .ri-shield-keyhole-line")
+      refute has_element?(lv, "#device-#{client.id} .ri-shield-keyhole-line")
     end
 
-    test "leaves the column empty for a client with no serial at all", %{
+    test "leaves the column empty for a device with no serial at all", %{
       conn: conn,
       account: account,
       actor: actor
@@ -1342,10 +1342,10 @@ defmodule PortalWeb.ClientsTest do
       {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients")
+        |> live(~p"/#{account}/devices")
 
       assert html =~ "No Serial Client"
-      refute has_element?(lv, "#client-#{client.id} .ri-shield-keyhole-line")
+      refute has_element?(lv, "#device-#{client.id} .ri-shield-keyhole-line")
     end
   end
 
@@ -1360,7 +1360,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       refute html =~ "SHA-256 Fingerprint"
     end
@@ -1382,7 +1382,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       assert html =~ "SHA-256 Fingerprint"
       assert html =~ "Unpublished CA"
@@ -1417,7 +1417,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       assert html =~ "Revoked"
       assert html =~ "keyCompromise"
@@ -1451,7 +1451,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       assert html =~ "Valid"
     end
@@ -1491,7 +1491,7 @@ defmodule PortalWeb.ClientsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/clients/#{client.id}")
+        |> live(~p"/#{account}/devices/#{client.id}")
 
       assert html =~ "Revoked"
       refute html =~ "Valid"

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -1273,7 +1273,7 @@ defmodule PortalWeb.PoliciesTest do
 
       render_click(lv, "toggle_conditions_dropdown")
       html = render_click(lv, "add_condition", %{"type" => "client_verified"})
-      assert html =~ "Require Verified Client"
+      assert html =~ "Require Verified Device"
     end
 
     test "saves client_verified condition to DB", %{conn: conn, account: account, actor: actor} do
@@ -1336,7 +1336,7 @@ defmodule PortalWeb.PoliciesTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/policies/#{policy.id}/edit")
 
-      assert html =~ "Require Verified Client"
+      assert html =~ "Require Verified Device"
     end
   end
 

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -111,11 +111,11 @@ defmodule PortalWeb.ResourcesTest do
       account: account,
       actor: actor
     } do
-      client_one = client_fixture(account: account, actor: actor)
-      client_two = client_fixture(account: account, actor: actor)
+      device_one = client_fixture(account: account, actor: actor)
+      device_two = client_fixture(account: account, actor: actor)
 
       _resource =
-        static_device_pool_resource_fixture(account: account, clients: [client_one, client_two])
+        static_device_pool_resource_fixture(account: account, devices: [device_one, device_two])
 
       {:ok, _lv, html} =
         conn
@@ -441,12 +441,12 @@ defmodule PortalWeb.ResourcesTest do
              }
     end
 
-    test "manages static device pool client picker", %{
+    test "manages static device pool device picker", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      client = client_fixture(account: account, actor: actor, name: "Workstation Alpha")
+      device = client_fixture(account: account, actor: actor, name: "Workstation Alpha")
 
       {:ok, lv, _html} =
         conn
@@ -457,35 +457,35 @@ defmodule PortalWeb.ResourcesTest do
       |> form("[phx-submit='submit_resource_form']", resource: %{type: "static_device_pool"})
       |> render_change()
 
-      assert render_focus(element(lv, "input[name='client_search']")) =~ "Search clients to add"
+      assert render_focus(element(lv, "input[name='device_search']")) =~ "Search devices to add"
 
       html =
         lv
-        |> element("input[name='client_search']")
-        |> render_change(%{"client_search" => "Workstation"})
+        |> element("input[name='device_search']")
+        |> render_change(%{"device_search" => "Workstation"})
 
-      assert html =~ client.name
+      assert html =~ device.name
 
-      html = render_click(lv, "add_client", %{"client_id" => client.id})
-      assert html =~ client.name
+      html = render_click(lv, "add_device", %{"device_id" => device.id})
+      assert html =~ device.name
 
-      html = render_click(lv, "remove_client", %{"client_id" => client.id})
+      html = render_click(lv, "remove_device", %{"device_id" => device.id})
       assert html =~ "Search above to add devices"
 
       lv
-      |> element("input[name='client_search']")
-      |> render_change(%{"client_search" => "Workstation"})
+      |> element("input[name='device_search']")
+      |> render_change(%{"device_search" => "Workstation"})
 
-      html = render_click(lv, "add_client", %{"client_id" => client.id})
-      assert html =~ client.name
+      html = render_click(lv, "add_device", %{"device_id" => device.id})
+      assert html =~ device.name
 
       assert has_element?(
                lv,
-               "button[phx-click='remove_client'][phx-value-client_id='#{client.id}']"
+               "button[phx-click='remove_device'][phx-value-device_id='#{device.id}']"
              )
     end
 
-    test "client picker search surfaces online clients ahead of the result limit", %{
+    test "device picker search surfaces online devices ahead of the result limit", %{
       account: account,
       actor: actor
     } do
@@ -495,14 +495,14 @@ defmodule PortalWeb.ResourcesTest do
         client_fixture(account: account, actor: actor, name: "Bulk Offline #{i}")
       end
 
-      online_client = client_fixture(account: account, actor: actor, name: "Bulk Online")
-      :ok = Portal.Presence.Clients.Account.track(account.id, online_client.id)
+      online_device = client_fixture(account: account, actor: actor, name: "Bulk Online")
+      :ok = Portal.Presence.Clients.Account.track(account.id, online_device.id)
 
-      results = PortalWeb.Resources.Components.Database.search_clients("Bulk", subject, [])
+      results = PortalWeb.Resources.Components.Database.search_devices("Bulk", subject, [])
 
       assert length(results) == 10
       assert [%{id: id, online?: true} | _] = results
-      assert id == online_client.id
+      assert id == online_device.id
     end
   end
 
@@ -1162,7 +1162,7 @@ defmodule PortalWeb.ResourcesTest do
       resource = resource_fixture(account: account, site: site)
       group = group_fixture(account: account)
       policy = policy_fixture(account: account, group: group, resource: resource)
-      client = client_fixture(account: account, actor: actor)
+      device = client_fixture(account: account, actor: actor)
       gateway = gateway_fixture(account: account, site: site)
       token = client_token_fixture(account: account, actor: actor)
 
@@ -1171,7 +1171,7 @@ defmodule PortalWeb.ResourcesTest do
         |> Ecto.Changeset.cast(
           %{
             policy_id: policy.id,
-            initiating_device_id: client.id,
+            initiating_device_id: device.id,
             receiving_device_id: gateway.id,
             resource_id: resource.id,
             token_id: token.id,
@@ -1319,16 +1319,16 @@ defmodule PortalWeb.ResourcesTest do
     end
   end
 
-  describe ":show clients tab (device pool)" do
-    test "defaults to the clients tab for device pool resources", %{
+  describe ":show devices tab (device pool)" do
+    test "defaults to the devices tab for device pool resources", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      client = client_fixture(account: account, actor: actor)
+      device = client_fixture(account: account, actor: actor)
 
       resource =
-        static_device_pool_resource_fixture(account: account, clients: [client])
+        static_device_pool_resource_fixture(account: account, devices: [device])
 
       {:ok, lv, _html} =
         conn
@@ -1338,35 +1338,35 @@ defmodule PortalWeb.ResourcesTest do
       assert has_element?(lv, "button[role='tab'][aria-selected]", "Pool Members")
     end
 
-    test "lists pool clients with owner and tunnel IPs", %{
+    test "lists pool devices with owner and tunnel IPs", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      client = client_fixture(account: account, actor: actor)
+      device = client_fixture(account: account, actor: actor)
 
       resource =
-        static_device_pool_resource_fixture(account: account, clients: [client])
+        static_device_pool_resource_fixture(account: account, devices: [device])
 
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/resources/#{resource.id}")
 
-      assert html =~ client.name
-      assert html =~ client.actor.name
-      assert html =~ to_string(client.ipv4)
+      assert html =~ device.name
+      assert html =~ device.actor.name
+      assert html =~ to_string(device.ipv4)
     end
 
-    test "shows an offline status for clients without presence", %{
+    test "shows an offline status for devices without presence", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      client = client_fixture(account: account, actor: actor)
+      device = client_fixture(account: account, actor: actor)
 
       resource =
-        static_device_pool_resource_fixture(account: account, clients: [client])
+        static_device_pool_resource_fixture(account: account, devices: [device])
 
       {:ok, _lv, html} =
         conn
@@ -1377,17 +1377,17 @@ defmodule PortalWeb.ResourcesTest do
       assert html =~ "0 / 1 online"
     end
 
-    test "shows an online status for connected clients", %{
+    test "shows an online status for connected devices", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      client = client_fixture(account: account, actor: actor)
+      device = client_fixture(account: account, actor: actor)
 
       resource =
-        static_device_pool_resource_fixture(account: account, clients: [client])
+        static_device_pool_resource_fixture(account: account, devices: [device])
 
-      :ok = Portal.Presence.Clients.Account.track(account.id, client.id)
+      :ok = Portal.Presence.Clients.Account.track(account.id, device.id)
 
       {:ok, _lv, html} =
         conn
@@ -1414,7 +1414,7 @@ defmodule PortalWeb.ResourcesTest do
       assert html =~ "An empty pool has nothing to connect to"
     end
 
-    test "warns in the resources list when the pool has no clients", %{
+    test "warns in the resources list when the pool has no devices", %{
       conn: conn,
       account: account,
       actor: actor
@@ -1430,16 +1430,16 @@ defmodule PortalWeb.ResourcesTest do
       refute html =~ "0 / 0 online"
     end
 
-    test "expands and collapses a client row to reveal details", %{
+    test "expands and collapses a device row to reveal details", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      client =
+      device =
         client_fixture(account: account, actor: actor, device_serial: "SERIAL-1234")
 
       resource =
-        static_device_pool_resource_fixture(account: account, clients: [client])
+        static_device_pool_resource_fixture(account: account, devices: [device])
 
       {:ok, lv, html} =
         conn
@@ -1448,13 +1448,13 @@ defmodule PortalWeb.ResourcesTest do
 
       refute html =~ "Tunnel IPv6"
 
-      html = render_click(lv, "toggle_pool_client_row", %{"id" => client.id})
+      html = render_click(lv, "toggle_pool_device_row", %{"id" => device.id})
       assert html =~ "Tunnel IPv6"
-      assert html =~ to_string(client.ipv6)
+      assert html =~ to_string(device.ipv6)
       assert html =~ "SERIAL-1234"
-      assert has_element?(lv, ~s|a[href="/#{account.slug}/clients/#{client.id}"]|)
+      assert has_element?(lv, ~s|a[href="/#{account.slug}/devices/#{device.id}"]|)
 
-      html = render_click(lv, "toggle_pool_client_row", %{"id" => client.id})
+      html = render_click(lv, "toggle_pool_device_row", %{"id" => device.id})
       refute html =~ "Tunnel IPv6"
     end
 
@@ -1463,53 +1463,53 @@ defmodule PortalWeb.ResourcesTest do
       account: account,
       actor: actor
     } do
-      client = client_fixture(account: account, actor: actor)
+      device = client_fixture(account: account, actor: actor)
 
       _session =
         client_session_fixture(
           account: account,
           actor: actor,
-          client: client,
+          client: device,
           user_agent: "Mac OS/14.0 connlib/1.3.0"
         )
 
       resource =
-        static_device_pool_resource_fixture(account: account, clients: [client])
+        static_device_pool_resource_fixture(account: account, devices: [device])
 
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/resources/#{resource.id}")
 
-      html = render_click(lv, "toggle_pool_client_row", %{"id" => client.id})
+      html = render_click(lv, "toggle_pool_device_row", %{"id" => device.id})
 
       assert html =~ "Operating System"
       assert html =~ "Mac OS 14.0"
       assert html =~ "Last Seen"
     end
 
-    test "switching to the clients tab patches the URL", %{
+    test "switching to the devices tab patches the URL", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      client = client_fixture(account: account, actor: actor)
+      device = client_fixture(account: account, actor: actor)
 
       resource =
-        static_device_pool_resource_fixture(account: account, clients: [client])
+        static_device_pool_resource_fixture(account: account, devices: [device])
 
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/resources/#{resource.id}?tab=groups")
 
-      render_click(lv, "switch_resource_tab", %{"tab" => "clients"})
-      assert_patch(lv, ~p"/#{account}/resources/#{resource.id}?tab=clients")
+      render_click(lv, "switch_resource_tab", %{"tab" => "devices"})
+      assert_patch(lv, ~p"/#{account}/resources/#{resource.id}?tab=devices")
 
       assert has_element?(lv, "button[role='tab'][aria-selected]", "Pool Members")
     end
 
-    test "does not show the clients tab for non-device-pool resources", %{
+    test "does not show the devices tab for non-device-pool resources", %{
       conn: conn,
       account: account,
       actor: actor
@@ -1525,7 +1525,7 @@ defmodule PortalWeb.ResourcesTest do
       assert has_element?(lv, "button[role='tab'][aria-selected]", "Groups")
     end
 
-    test "ignores the clients tab for non-device-pool resources and falls back to groups", %{
+    test "ignores the devices tab for non-device-pool resources and falls back to groups", %{
       conn: conn,
       account: account,
       actor: actor
@@ -1535,7 +1535,7 @@ defmodule PortalWeb.ResourcesTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/resources/#{resource.id}?tab=clients")
+        |> live(~p"/#{account}/resources/#{resource.id}?tab=devices")
 
       assert has_element?(lv, "button[role='tab'][aria-selected]", "Groups")
     end

--- a/elixir/test/portal_web/live/settings/profile_test.exs
+++ b/elixir/test/portal_web/live/settings/profile_test.exs
@@ -87,7 +87,7 @@ defmodule PortalWeb.Settings.ProfileTest do
             resources: ~p"/#{account}/resources",
             groups: ~p"/#{account}/groups",
             policies: ~p"/#{account}/policies",
-            clients: ~p"/#{account}/clients",
+            devices: ~p"/#{account}/devices",
             actors: ~p"/#{account}/actors",
             sites: ~p"/#{account}/sites"
           ] do

--- a/elixir/test/support/fixtures/device_fixtures.ex
+++ b/elixir/test/support/fixtures/device_fixtures.ex
@@ -232,10 +232,10 @@ defmodule Portal.DeviceFixtures do
   end
 
   @doc """
-  Verify a client (sets verified_at timestamp).
+  Verify a device (sets verified_at timestamp).
   """
-  def verify_client(client) do
-    client
+  def verify_device(device) do
+    device
     |> Ecto.Changeset.change(verified_at: DateTime.utc_now())
     |> Portal.Repo.update!()
   end

--- a/elixir/test/support/fixtures/resource_fixtures.ex
+++ b/elixir/test/support/fixtures/resource_fixtures.ex
@@ -192,18 +192,18 @@ defmodule Portal.ResourceFixtures do
   end
 
   @doc """
-  Generate a static device pool resource and optionally attach clients to it.
+  Generate a static device pool resource and optionally attach devices to it.
   """
   def static_device_pool_resource_fixture(attrs \\ %{}) do
     attrs = Enum.into(attrs, %{})
     account = Map.get(attrs, :account) || account_fixture()
-    clients = Map.get(attrs, :clients, [])
+    devices = Map.get(attrs, :devices, [])
     unique_num = System.unique_integer([:positive, :monotonic])
 
     resource =
       resource_fixture(
         attrs
-        |> Map.delete(:clients)
+        |> Map.delete(:devices)
         |> Map.put(:account, account)
         |> Map.put(:type, :static_device_pool)
         |> Map.put_new(:name, "Device Pool #{unique_num}")
@@ -211,13 +211,13 @@ defmodule Portal.ResourceFixtures do
         |> Map.delete(:address)
       )
 
-    Enum.each(clients, fn client ->
+    Enum.each(devices, fn device ->
       %Portal.StaticDevicePoolMember{}
       |> Ecto.Changeset.cast(
         %{
           account_id: account.id,
           resource_id: resource.id,
-          device_id: client.id
+          device_id: device.id
         },
         [:account_id, :resource_id, :device_id]
       )


### PR DESCRIPTION
The endpoints running our Client are devices, so the page is named after them. `/clients` becomes `/devices`, and the module, live table, page copy and the code behind it follow. Old `/clients` links stop working.

An admin who chose Clients as their landing page has `clients` saved in their preferences. That is no longer a value the preference accepts, so a migration moves it across rather than dropping them back on Sites.

The word stays wherever it means something other than a device: the `client` row type, the Firezone Client app and its version, API clients, OIDC client ids, and presence topics.

Initiator and Receiver in an authorization now name the device rather than the client, since a gateway on the other side is a device too.

The REST API is untouched. `/clients` there is a separate contract and moves on its own schedule.

Related: #14899
