### PR TITLE
feat(portal): list Gateways on the Devices page

### DIFF
--- a/elixir/lib/portal/repo/filter.ex
+++ b/elixir/lib/portal/repo/filter.ex
@@ -89,6 +89,7 @@ defmodule Portal.Repo.Filter do
             | Range.t()
             | (Portal.Authentication.Subject.t() -> values() | Range.t())
             | nil,
+          icons: %{term() => String.t()},
           fun: fun()
         }
 
@@ -96,6 +97,7 @@ defmodule Portal.Repo.Filter do
             title: nil,
             type: nil,
             values: nil,
+            icons: %{},
             fun: nil
 
   @doc """

--- a/elixir/lib/portal_web/live/devices.ex
+++ b/elixir/lib/portal_web/live/devices.ex
@@ -1,7 +1,7 @@
 defmodule PortalWeb.Devices do
   use PortalWeb, :live_view
   import PortalWeb.Devices.Components
-  alias Portal.{Presence.Clients, ComponentVersions}
+  alias Portal.Presence
   alias Portal.Changes.Change
   alias Portal.Device
   alias Portal.PubSub
@@ -12,7 +12,8 @@ defmodule PortalWeb.Devices do
     subject = socket.assigns.subject
 
     if connected?(socket) do
-      :ok = Clients.Account.subscribe(subject.account.id)
+      :ok = Presence.Clients.Account.subscribe(subject.account.id)
+      :ok = Presence.Gateways.Account.subscribe(subject.account.id)
       :ok = PubSub.Changes.subscribe(socket.assigns.account.id, :devices)
     end
 
@@ -24,14 +25,14 @@ defmodule PortalWeb.Devices do
       |> assign_async(:devices_count, fn -> {:ok, %{devices_count: Database.count_devices(subject)}} end)
       |> assign(
         device_pools: [],
-        policy_authorizations: [],
-        policy_authorizations_page: 1,
-        policy_authorizations_has_next: false,
-        policy_authorizations_expanded_id: nil,
         device_posture: [],
         device_certificate: nil,
         posture_providers_connected?: false,
-        serials_by_device: %{}
+        serials_by_device: %{},
+        policy_authorizations: [],
+        policy_authorizations_page: 1,
+        policy_authorizations_has_next: false,
+        policy_authorizations_expanded_id: nil
       )
       |> assign(base_device_assigns())
       |> assign_live_table("devices",
@@ -69,14 +70,14 @@ defmodule PortalWeb.Devices do
          |> assign(show_device_assigns(tab))
          |> assign(
            device_pools: Database.list_device_pools(device, socket.assigns.subject),
-           policy_authorizations: policy_authorizations,
-           policy_authorizations_page: page,
-           policy_authorizations_has_next: has_next,
-           policy_authorizations_expanded_id: nil,
            device_posture: Database.list_posture_for_device(device, socket.assigns.subject),
            device_certificate: Database.certificate_status(device, socket.assigns.subject),
            posture_providers_connected?:
-             Database.posture_providers_connected?(socket.assigns.subject)
+             Database.posture_providers_connected?(socket.assigns.subject),
+           policy_authorizations: policy_authorizations,
+           policy_authorizations_page: page,
+           policy_authorizations_has_next: has_next,
+           policy_authorizations_expanded_id: nil
          )}
     end
   end
@@ -87,6 +88,9 @@ defmodule PortalWeb.Devices do
     case Database.get_device_for_panel(id, socket.assigns.subject) do
       nil ->
         redirect_to_devices_index(socket, "Device does not exist.")
+
+      %Device{type: :gateway} = device ->
+        {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/devices/#{device.id}")}
 
       device ->
         changeset = Database.change_device(device)
@@ -103,17 +107,12 @@ defmodule PortalWeb.Devices do
 
     {:noreply,
      socket
-     |> assign(
-       selected_device: nil,
-       device_pools: [],
-       device_posture: [],
-       device_certificate: nil
-     )
+     |> assign(selected_device: nil, device_pools: [], device_posture: [], device_certificate: nil)
      |> assign(base_device_assigns())}
   end
 
   def handle_devices_update!(socket, list_opts) do
-    list_opts = Keyword.put(list_opts, :preload, [:actor, :online?])
+    list_opts = Keyword.put(list_opts, :preload, [:actor, :site, :online?])
 
     with {:ok, devices, metadata} <- Database.list_devices(socket.assigns.subject, list_opts) do
       {:ok,
@@ -134,7 +133,7 @@ defmodule PortalWeb.Devices do
         </:icon>
         <:title>Devices</:title>
         <:description>
-          End-user devices and servers that access your protected Resources.
+          Machines in your organization running a Firezone client or gateway.
         </:description>
         <:action>
           <.docs_action path="/deploy/clients" />
@@ -182,21 +181,13 @@ defmodule PortalWeb.Devices do
             </div>
           </:col>
           <:col :let={device} label="Owner">
-            <.actor_name_and_role
-              account={@account}
-              actor={device.actor}
-              class="text-sm"
-              return_to={@return_to}
-            />
+            <.device_owner_cell account={@account} device={device} return_to={@return_to} />
           </:col>
           <:col :let={device} label="Serial" class="w-44">
             <.serial_cell serial={Map.get(@serials_by_device, device.id)} />
           </:col>
           <:col :let={device} field={{:devices, :last_seen_version}} label="Version" class="w-32">
-            <.version
-              current={device.last_seen_version}
-              latest={ComponentVersions.client_version(device)}
-            />
+            <.version current={device.last_seen_version} latest={latest_version(device)} />
           </:col>
           <:col :let={device} label="Status" class="w-28">
             <.device_status_badge online?={device.online?} />
@@ -353,6 +344,17 @@ defmodule PortalWeb.Devices do
     {:noreply, assign(socket, policy_authorizations_expanded_id: expanded)}
   end
 
+  def handle_event(event, _params, %{assigns: %{selected_device: %Device{type: :gateway}}} = socket)
+      when event in [
+             "open_device_edit_form",
+             "submit_device_edit_form",
+             "verify_device",
+             "unverify_device",
+             "delete_device"
+           ] do
+    {:noreply, socket}
+  end
+
   def handle_event("open_device_edit_form", _params, socket) do
     {:noreply,
      push_patch(socket,
@@ -379,12 +381,12 @@ defmodule PortalWeb.Devices do
     changeset = Database.change_device(socket.assigns.selected_device, attrs)
 
     case Database.update_device(changeset, socket.assigns.subject) do
-      {:ok, updated_client} ->
+      {:ok, updated_device} ->
         {:noreply,
          socket
          |> put_flash(:success, "Device updated successfully.")
          |> reload_live_table!("devices")
-         |> push_patch(to: ~p"/#{socket.assigns.account}/devices/#{updated_client.id}")}
+         |> push_patch(to: ~p"/#{socket.assigns.account}/devices/#{updated_device.id}")}
 
       {:error, changeset} ->
         {:noreply,
@@ -424,11 +426,11 @@ defmodule PortalWeb.Devices do
     device = socket.assigns.selected_device
 
     case Database.verify_device(device, socket.assigns.subject) do
-      {:ok, updated_client} ->
+      {:ok, updated_device} ->
         {:noreply,
          socket
          |> put_flash(:success, "Device \"#{device.name}\" was verified.")
-         |> assign_updated_selected_device(updated_client)
+         |> assign_updated_selected_device(updated_device)
          |> merge_state(:device_confirm, unverify?: false)
          |> reload_live_table!("devices")}
 
@@ -449,11 +451,11 @@ defmodule PortalWeb.Devices do
     device = socket.assigns.selected_device
 
     case Database.remove_device_verification(device, socket.assigns.subject) do
-      {:ok, updated_client} ->
+      {:ok, updated_device} ->
         {:noreply,
          socket
          |> put_flash(:success, "Device \"#{device.name}\" was unverified.")
-         |> assign_updated_selected_device(updated_client)
+         |> assign_updated_selected_device(updated_device)
          |> merge_state(:device_confirm, unverify?: false)
          |> reload_live_table!("devices")}
 
@@ -482,11 +484,11 @@ defmodule PortalWeb.Devices do
     end
   end
 
-  defp assign_updated_selected_device(socket, updated_client) do
+  defp assign_updated_selected_device(socket, updated_device) do
     selected_device = %{
       socket.assigns.selected_device
-      | verified_at: updated_client.verified_at,
-        updated_at: updated_client.updated_at
+      | verified_at: updated_device.verified_at,
+        updated_at: updated_device.updated_at
     }
 
     assign(socket, :selected_device, selected_device)
@@ -511,7 +513,7 @@ defmodule PortalWeb.Devices do
      |> push_patch(to: ~p"/#{socket.assigns.account}/devices?#{socket.assigns.query_params}")}
   end
 
-  def handle_info(%Change{op: :insert, struct: %Device{type: :client}} = change, socket) do
+  def handle_info(%Change{op: :insert, struct: %Device{}} = change, socket) do
     {:noreply,
      socket
      |> update(:devices_count, fn
@@ -521,7 +523,7 @@ defmodule PortalWeb.Devices do
      |> mark_stale_if_unreflected(change)}
   end
 
-  def handle_info(%Change{op: :delete, old_struct: %Device{type: :client}} = change, socket) do
+  def handle_info(%Change{op: :delete, old_struct: %Device{}} = change, socket) do
     {:noreply,
      socket
      |> update(:devices_count, fn
@@ -531,28 +533,30 @@ defmodule PortalWeb.Devices do
      |> mark_stale_if_unreflected(change)}
   end
 
-  def handle_info(%Change{struct: %Device{type: :client}} = change, socket) do
+  def handle_info(%Change{struct: %Device{}} = change, socket) do
     {:noreply, mark_stale_if_unreflected(socket, change)}
   end
 
-  def handle_info(%Change{struct: %Device{type: :gateway}}, socket), do: {:noreply, socket}
-  def handle_info(%Change{old_struct: %Device{type: :gateway}}, socket), do: {:noreply, socket}
+  def handle_info(%Phoenix.Socket.Broadcast{topic: "presences:account_clients:" <> _rest} = event, socket) do
+    handle_presence_event(event, socket)
+  end
 
-  def handle_info(
-        %Phoenix.Socket.Broadcast{topic: "presences:account_clients:" <> _account_id} = event,
-        socket
-      ) do
-    rendered_client_ids = Enum.map(socket.assigns.devices, & &1.id)
+  def handle_info(%Phoenix.Socket.Broadcast{topic: "presences:account_gateways:" <> _rest} = event, socket) do
+    handle_presence_event(event, socket)
+  end
 
-    if presence_updates_any_id?(event, rendered_client_ids) do
+  def handle_info(message, socket), do: PortalWeb.Live.Helpers.handle_info_fallback(message, socket)
+
+  defp handle_presence_event(event, socket) do
+    rendered_ids = Enum.map(socket.assigns.devices, & &1.id)
+
+    if presence_updates_any_id?(event, rendered_ids) do
       socket = reload_live_table!(socket, "devices")
       {:noreply, socket}
     else
       {:noreply, socket}
     end
   end
-
-  def handle_info(message, socket), do: PortalWeb.Live.Helpers.handle_info_fallback(message, socket)
 
   defp mark_stale_if_unreflected(socket, change) do
     if PortalWeb.LiveTable.view_reflects_change?(socket.assigns.devices, change) do
@@ -567,7 +571,7 @@ defmodule PortalWeb.Devices do
     import Ecto.Query
     import Portal.Changeset
     import Portal.Repo.Query
-    alias Portal.{Presence.Clients, Safe}
+    alias Portal.{Presence.Clients, Presence.Gateways, Safe}
     alias Portal.Device
     alias Portal.Policy
     alias Portal.PolicyAuthorization
@@ -581,7 +585,6 @@ defmodule PortalWeb.Devices do
 
     def count_devices(subject) do
       from(d in Device, as: :devices)
-      |> where([devices: d], d.type == :client)
       |> Safe.scoped(subject)
       |> Safe.aggregate(:count)
     end
@@ -614,22 +617,25 @@ defmodule PortalWeb.Devices do
 
     defp page_query(_subject) do
       from(d in Device, as: :devices)
-      |> where([devices: d], d.type == :client)
     end
 
     defp maybe_filter_by_presence(base_query, presence, subject) do
       case presence do
         "online" ->
-          ids = Clients.online_client_ids(subject.account.id)
+          ids = online_device_ids(subject.account.id)
           where(base_query, [devices: d], d.id in ^ids)
 
         "offline" ->
-          ids = Clients.online_client_ids(subject.account.id)
+          ids = online_device_ids(subject.account.id)
           where(base_query, [devices: d], d.id not in ^ids)
 
         _ ->
           base_query
       end
+    end
+
+    defp online_device_ids(account_id) do
+      Clients.online_client_ids(account_id) ++ Map.keys(Gateways.Account.list(account_id))
     end
 
     defp list_device_ids(filtered_query, paginator_opts, subject) do
@@ -662,8 +668,11 @@ defmodule PortalWeb.Devices do
         :actor, devices ->
           Safe.preload(devices, :actor)
 
+        :site, devices ->
+          Safe.preload(devices, :site)
+
         :online?, devices ->
-          Clients.preload_clients_presence(devices)
+          preload_presence(devices)
 
         _other, devices ->
           devices
@@ -684,8 +693,8 @@ defmodule PortalWeb.Devices do
             {:ok, Portal.Device.t()} | {:error, Ecto.Changeset.t()}
     def update_device(changeset, subject) do
       case Safe.scoped(changeset, subject) |> Safe.update() do
-        {:ok, updated_client} ->
-          {:ok, Clients.preload_clients_presence([updated_client]) |> List.first()}
+        {:ok, updated_device} ->
+          {:ok, List.first(preload_presence([updated_device]))}
 
         {:error, reason} ->
           {:error, reason}
@@ -714,31 +723,39 @@ defmodule PortalWeb.Devices do
             {:ok, Portal.Device.t()} | {:error, term()}
     def delete_device(device, subject) do
       case Safe.scoped(device, subject) |> Safe.delete() do
-        {:ok, deleted_client} ->
-          {:ok, Clients.preload_clients_presence([deleted_client]) |> List.first()}
+        {:ok, deleted_device} ->
+          {:ok, List.first(preload_presence([deleted_device]))}
 
         {:error, reason} ->
           {:error, reason}
       end
     end
 
+    # Each type has its own presence, so ask both and keep the input order.
+    def preload_presence(devices) do
+      {gateways, clients} = Enum.split_with(devices, &(&1.type == :gateway))
+
+      by_id =
+        (Clients.preload_clients_presence(clients) ++
+           Gateways.preload_gateways_presence(gateways))
+        |> Map.new(&{&1.id, &1})
+
+      Enum.map(devices, &Map.fetch!(by_id, &1.id))
+    end
+
     @spec get_device_for_panel(binary(), Portal.Authentication.Subject.t()) ::
             Portal.Device.t() | nil
     def get_device_for_panel(id, subject) do
       device =
-        from(c in Device, as: :devices)
-        |> where([devices: d], d.type == :client)
+        from(d in Device, as: :devices)
         |> where([devices: d], d.id == ^id)
-        |> preload([:actor])
+        |> preload([:actor, :site])
         |> Safe.scoped(subject)
         |> Safe.one()
 
       case device do
-        %Device{type: :client} ->
-          Clients.preload_clients_presence([device]) |> List.first()
-
-        _ ->
-          nil
+        %Device{} -> List.first(preload_presence([device]))
+        _refused_or_missing -> nil
       end
     end
 
@@ -773,7 +790,8 @@ defmodule PortalWeb.Devices do
     def preloads do
       [
         :actor,
-        online?: &Clients.preload_clients_presence/1
+        :site,
+        online?: &preload_presence/1
       ]
     end
 
@@ -781,9 +799,20 @@ defmodule PortalWeb.Devices do
       [
         %Portal.Repo.Filter{
           name: :search,
-          title: "Device or Actor",
+          title: "Device, Actor or Site",
           type: {:string, :websearch},
           fun: &filter_by_search_fts/2
+        },
+        %Portal.Repo.Filter{
+          name: :type,
+          title: "Type",
+          type: :string,
+          values: [
+            {"Client", "client"},
+            {"Gateway", "gateway"}
+          ],
+          icons: %{"client" => "ri-computer-line", "gateway" => "ri-server-line"},
+          fun: &filter_by_type/2
         },
         %Portal.Repo.Filter{
           name: :attestation,
@@ -809,29 +838,49 @@ defmodule PortalWeb.Devices do
       ]
     end
 
+    # Left joins: an inner join on actor or site drops the other type from every search.
     def filter_by_search_fts(queryable, search_term) do
       queryable =
         if has_named_binding?(queryable, :actors) do
           queryable
         else
-          join(queryable, :inner, [devices: d], a in assoc(d, :actor),
+          join(queryable, :left, [devices: d], a in assoc(d, :actor),
             on: a.account_id == d.account_id,
             as: :actors
           )
         end
 
+      queryable =
+        if has_named_binding?(queryable, :sites) do
+          queryable
+        else
+          join(queryable, :left, [devices: d], s in assoc(d, :site),
+            on: s.account_id == d.account_id,
+            as: :sites
+          )
+        end
+
       {queryable,
        dynamic(
-         [devices: devices, actors: actors],
+         [devices: devices, actors: actors, sites: sites],
          fulltext_search(actors.name, ^search_term) or
            fulltext_search(devices.name, ^search_term) or
-           fulltext_search(actors.email, ^search_term)
+           fulltext_search(actors.email, ^search_term) or
+           fulltext_search(sites.name, ^search_term)
        )}
     end
 
     # A device that attested is badged "Attested" rather than "Verified" however
     # its verified_at reads, so the two options have to be exclusive here too or
     # the filter would disagree with the panel.
+    def filter_by_type(queryable, "client") do
+      {queryable, dynamic([devices: devices], devices.type == :client)}
+    end
+
+    def filter_by_type(queryable, "gateway") do
+      {queryable, dynamic([devices: devices], devices.type == :gateway)}
+    end
+
     def filter_by_attestation(queryable, "verified") do
       {queryable,
        dynamic(
@@ -848,7 +897,8 @@ defmodule PortalWeb.Devices do
       {queryable,
        dynamic(
          [devices: devices],
-         is_nil(devices.verified_at) and is_nil(devices.last_attested_at)
+         devices.type == :client and is_nil(devices.verified_at) and
+           is_nil(devices.last_attested_at)
        )}
     end
 
@@ -955,7 +1005,7 @@ defmodule PortalWeb.Devices do
               via: :intune | nil
             }
           ]
-    def list_posture_for_device(%Device{type: :client} = device, subject) do
+    def list_posture_for_device(%Device{} = device, subject) do
       keys = match_keys(device)
       providers = list_posture_providers(subject)
 

--- a/elixir/lib/portal_web/live/devices/components.ex
+++ b/elixir/lib/portal_web/live/devices/components.ex
@@ -2,6 +2,7 @@ defmodule PortalWeb.Devices.Components do
   use PortalWeb, :component_library
   import PortalWeb.CoreComponents
   alias Portal.ComponentVersions
+  alias PortalWeb.Logs
 
   def actor_show_url(account, actor, return_to \\ nil)
 
@@ -58,16 +59,53 @@ defmodule PortalWeb.Devices.Components do
   end
 
   def device_os_icon(assigns) do
-    assigns = assign(assigns, :user_agent, device_user_agent(assigns.device))
+    assigns =
+      assigns
+      |> assign(:user_agent, device_user_agent(assigns.device))
+      |> assign(:icon, device_icon_name(assigns.device))
+      |> assign(:label, device_icon_label(assigns.device))
 
     ~H"""
-    <.icon
-      name={os_icon_name(@user_agent)}
-      title={os_name_and_version(@user_agent)}
-      class="w-5 h-5"
-    />
+    <.icon name={@icon} title={@label} class="w-5 h-5" />
     """
   end
+
+  attr :account, :any, required: true
+  attr :device, :any, required: true
+  attr :return_to, :string, default: nil
+
+  def device_owner_cell(%{device: %{type: :gateway}} = assigns) do
+    assigns = assign(assigns, :site, loaded(assigns.device.site))
+
+    ~H"""
+    <.link
+      :if={@site}
+      navigate={~p"/#{@account}/sites/#{@site}"}
+      class="text-sm text-brand hover:underline"
+    >
+      {@site.name}
+    </.link>
+    <span :if={is_nil(@site)} class="text-xs text-muted">—</span>
+    """
+  end
+
+  def device_owner_cell(assigns) do
+    assigns = assign(assigns, :actor, loaded(assigns.device.actor))
+
+    ~H"""
+    <.actor_name_and_role
+      :if={@actor}
+      account={@account}
+      actor={@actor}
+      class="text-sm"
+      return_to={@return_to}
+    />
+    <span :if={is_nil(@actor)} class="text-xs text-muted">—</span>
+    """
+  end
+
+  defp loaded(%Ecto.Association.NotLoaded{}), do: nil
+  defp loaded(other), do: other
 
   def device_os_name_and_version(assigns) do
     assigns = assign(assigns, :user_agent, device_user_agent(assigns.device))
@@ -370,6 +408,7 @@ defmodule PortalWeb.Devices.Components do
               certificate={@certificate}
             />
             <.device_network_section device={@device} />
+            <.device_location_section device={@device} />
           </div>
           <.device_posture_tab
             :if={@tab == :posture}
@@ -394,6 +433,30 @@ defmodule PortalWeb.Devices.Components do
         />
       </div>
     </div>
+    """
+  end
+
+  attr :tab, :string, required: true
+  attr :label, :string, required: true
+  attr :selected, :boolean, required: true
+
+  def device_tab(assigns) do
+    ~H"""
+    <button
+      role="tab"
+      aria-selected={@selected}
+      phx-click="switch_device_tab"
+      phx-value-tab={@tab}
+      class={[
+        "flex items-center gap-1.5 px-1 py-2.5 mr-5 text-xs font-medium border-b-2 transition-colors",
+        if(@selected,
+          do: "border-brand text-brand",
+          else: "border-transparent text-body hover:text-heading"
+        )
+      ]}
+    >
+      {@label}
+    </button>
     """
   end
 
@@ -470,7 +533,7 @@ defmodule PortalWeb.Devices.Components do
                         <p class="text-subtle font-medium mb-1">
                           {case row.initiating_device && row.initiating_device.type do
                             :gateway -> "Initiator (Gateway)"
-                            :client -> "Initiator (Client)"
+                            :client -> "Initiator (Device)"
                             _ -> "Initiator"
                           end}
                         </p>
@@ -487,7 +550,7 @@ defmodule PortalWeb.Devices.Components do
                         <p class="text-subtle font-medium mb-1">
                           {case row.receiving_device && row.receiving_device.type do
                             :gateway -> "Receiver (Gateway)"
-                            :client -> "Receiver (Client)"
+                            :client -> "Receiver (Device)"
                             _ -> "Receiver"
                           end}
                         </p>
@@ -563,7 +626,7 @@ defmodule PortalWeb.Devices.Components do
         </div>
         <%!-- Right: actions --%>
         <div class="flex items-center gap-1.5 shrink-0">
-          <.button phx-click="open_device_edit_form" size="xs">
+          <.button :if={@device.type == :client} phx-click="open_device_edit_form" size="xs">
             <.icon name="ri-pencil-line" class="w-3.5 h-3.5" /> Edit
           </.button>
           <.icon_button icon="ri-close-line" title="Close (Esc)" phx-click="close_panel" />
@@ -575,6 +638,25 @@ defmodule PortalWeb.Devices.Components do
 
   attr :account, :any, required: true
   attr :device, :any, required: true
+
+  def device_owner_section(%{device: %{type: :gateway}} = assigns) do
+    assigns = assign(assigns, :site, loaded(assigns.device.site))
+
+    ~H"""
+    <div :if={@site} class="px-5 pt-4 pb-3 border-b border-border">
+      <.section_heading title="Site" hint="Managed from its Site" />
+      <.link
+        navigate={~p"/#{@account}/sites/#{@site}"}
+        class="flex items-center gap-3 px-3 py-2.5 rounded border border-border bg-raised hover:border-border-strong transition-colors group"
+      >
+        <.icon name="ri-map-pin-line" class="w-4 h-4 shrink-0 text-subtle" />
+        <p class="text-sm font-medium text-heading group-hover:text-brand truncate transition-colors">
+          {@site.name}
+        </p>
+      </.link>
+    </div>
+    """
+  end
 
   def device_owner_section(assigns) do
     ~H"""
@@ -633,7 +715,7 @@ defmodule PortalWeb.Devices.Components do
   def device_section(assigns) do
     ~H"""
     <div class="px-5 pt-4 pb-3 border-b border-border">
-      <.section_heading title="Reported by Client">
+      <.section_heading title="Self-Reported">
         <:info>
           <.popover placement="right">
             <:target>
@@ -641,8 +723,8 @@ defmodule PortalWeb.Devices.Components do
             </:target>
             <:content>
               <p>
-                The Firezone Client reads and reports these values. Only trust them if you trust
-                the actor and device.
+                The software on this device reads and reports these values. Only trust them if
+                you trust the device and whoever operates it.
               </p>
               <p :if={is_nil(@device.last_attested_at)} class="mt-1">
                 Set up
@@ -661,6 +743,19 @@ defmodule PortalWeb.Devices.Components do
       <dl class="space-y-3">
         <.device_detail_row :if={@device.last_seen_at} label="Operating System">
           <.device_os device={@device} />
+        </.device_detail_row>
+        <.device_detail_row :if={@device.last_seen_version} label="Version">
+          <.version current={@device.last_seen_version} latest={latest_version(@device)} />
+        </.device_detail_row>
+        <.device_detail_row :if={@device.last_seen_user_agent} label="User Agent">
+          <span class="font-mono text-[11px] text-body break-all">
+            {@device.last_seen_user_agent}
+          </span>
+        </.device_detail_row>
+        <.device_detail_row :if={@device.hostname} label="Hostname">
+          <span class="font-mono text-xs text-body break-all">
+            {@device.hostname}
+          </span>
         </.device_detail_row>
         <.device_detail_row :if={@device.device_serial} label="Serial Number">
           <span class="font-mono text-sm text-heading font-medium">
@@ -691,7 +786,7 @@ defmodule PortalWeb.Devices.Components do
 
   def device_network_section(assigns) do
     ~H"""
-    <div class="px-5 pt-4 pb-3">
+    <div class="px-5 pt-4 pb-3 border-b border-border">
       <.section_heading title="Network" />
       <dl class="space-y-3">
         <.device_detail_row :if={@device.last_seen_remote_ip} label="Remote IP">
@@ -714,27 +809,43 @@ defmodule PortalWeb.Devices.Components do
     """
   end
 
-  attr :tab, :string, required: true
-  attr :label, :string, required: true
-  attr :selected, :boolean, required: true
+  attr :device, :any, required: true
 
-  def device_tab(assigns) do
+  def device_location_section(assigns) do
     ~H"""
-    <button
-      role="tab"
-      aria-selected={@selected}
-      phx-click="switch_device_tab"
-      phx-value-tab={@tab}
-      class={[
-        "flex items-center gap-1.5 px-1 py-2.5 mr-5 text-xs font-medium border-b-2 transition-colors",
-        if(@selected,
-          do: "border-brand text-brand",
-          else: "border-transparent text-body hover:text-heading"
-        )
-      ]}
-    >
-      {@label}
-    </button>
+    <div class="px-5 pt-4 pb-3">
+      <.section_heading title="Location" />
+      <Logs.Components.location_map
+        lat={@device.last_seen_remote_ip_location_lat}
+        lon={@device.last_seen_remote_ip_location_lon}
+      >
+        <:caption>
+          <div class="flex items-center justify-between gap-2 text-xs">
+            <div class="flex items-center gap-2 min-w-0">
+              <.icon name="ri-map-pin-line" class="w-3.5 h-3.5 shrink-0 text-subtle" />
+              <span class="text-heading truncate">{device_location_caption(@device)}</span>
+              <span
+                :if={@device.last_seen_remote_ip}
+                class="font-mono text-[10px] text-subtle shrink-0"
+              >
+                · {Portal.Types.INET.to_string(@device.last_seen_remote_ip)}
+              </span>
+            </div>
+            <span
+              :if={
+                is_number(@device.last_seen_remote_ip_location_lat) and
+                  is_number(@device.last_seen_remote_ip_location_lon)
+              }
+              class="font-mono text-[10px] text-subtle tabular-nums shrink-0"
+            >
+              {format_coord(@device.last_seen_remote_ip_location_lat)}, {format_coord(
+                @device.last_seen_remote_ip_location_lon
+              )}
+            </span>
+          </div>
+        </:caption>
+      </Logs.Components.location_map>
+    </div>
     """
   end
 
@@ -1021,10 +1132,12 @@ defmodule PortalWeb.Devices.Components do
     ~H"""
     <div class="w-1/3 shrink-0 overflow-y-auto p-4 space-y-5">
       <.device_details_card device={@device} />
-      <div class="border-t border-border"></div>
-      <.device_actions device={@device} confirm_unverify_device={@confirm_unverify_device} />
-      <div class="border-t border-border"></div>
-      <.device_danger_zone confirm_delete_device={@confirm_delete_device} />
+      <%= if @device.type == :client do %>
+        <div class="border-t border-border"></div>
+        <.device_actions device={@device} confirm_unverify_device={@confirm_unverify_device} />
+        <div class="border-t border-border"></div>
+        <.device_danger_zone confirm_delete_device={@confirm_delete_device} />
+      <% end %>
     </div>
     """
   end
@@ -1036,6 +1149,9 @@ defmodule PortalWeb.Devices.Components do
     <section>
       <.section_heading title="Details" />
       <dl class="space-y-2.5">
+        <.device_detail_row label="Type">
+          <span class="text-xs text-body">{device_kind_label(@device)}</span>
+        </.device_detail_row>
         <.device_detail_row label="Device ID">
           <span class="font-mono text-[11px] text-body break-all">
             {@device.id}
@@ -1067,7 +1183,7 @@ defmodule PortalWeb.Devices.Components do
             <.relative_datetime datetime={@device.last_attested_at} />
           </span>
         </.device_detail_row>
-        <.device_detail_row label="Trust level">
+        <.device_detail_row :if={@device.type == :client} label="Trust level">
           <:info>
             <.popover placement="left">
               <:target>
@@ -1079,10 +1195,7 @@ defmodule PortalWeb.Devices.Components do
           <.device_verified_status device={@device} />
         </.device_detail_row>
         <.device_detail_row label="Version">
-          <.version
-            current={@device.last_seen_version}
-            latest={ComponentVersions.client_version(@device)}
-          />
+          <.version current={@device.last_seen_version} latest={latest_version(@device)} />
         </.device_detail_row>
         <.device_detail_row label="Last Seen">
           <span class="text-xs text-body">
@@ -1245,14 +1358,18 @@ defmodule PortalWeb.Devices.Components do
   end
 
   attr :title, :string, required: true
+  attr :hint, :string, default: nil
   slot :info, doc: "Rendered beside the title, for a popover explaining the section"
 
   def section_heading(assigns) do
     ~H"""
-    <h3 class="flex items-center gap-1 text-[10px] font-semibold tracking-widest uppercase text-subtle mb-3">
-      {@title}
-      {render_slot(@info)}
-    </h3>
+    <div class="mb-3 flex items-baseline justify-between gap-3">
+      <h3 class="flex items-center gap-1 text-[10px] font-semibold tracking-widest uppercase text-subtle">
+        {@title}
+        {render_slot(@info)}
+      </h3>
+      <span :if={@hint} class="text-[10px] text-subtle">{@hint}</span>
+    </div>
     """
   end
 
@@ -1318,10 +1435,10 @@ defmodule PortalWeb.Devices.Components do
     }
   end
 
-  defp trust_state(_client), do: nil
+  defp trust_state(_device), do: nil
 
-  defp trust_hint(client) do
-    case trust_state(client) do
+  defp trust_hint(device) do
+    case trust_state(device) do
       %{title: title} -> title
       nil -> "No certificate or admin has vouched for the values this Device reports."
     end
@@ -1434,6 +1551,41 @@ defmodule PortalWeb.Devices.Components do
     "This serial is reported by #{posture_provider_label(provider)} and matches " <>
       "the attested device ID from an X.509 certificate."
   end
+
+  defp device_icon_name(%{type: :gateway}), do: "ri-server-line"
+  defp device_icon_name(device), do: os_icon_name(device.last_seen_user_agent)
+
+  defp device_icon_label(%{type: :gateway} = device) do
+    case os_name_and_version(device.last_seen_user_agent) do
+      "" -> "Gateway"
+      os -> "Gateway on#{os}"
+    end
+  end
+
+  defp device_icon_label(device) do
+    case os_name_and_version(device.last_seen_user_agent) do
+      "" -> "Client"
+      os -> "Client on#{os}"
+    end
+  end
+
+  def latest_version(%{type: :gateway}), do: ComponentVersions.gateway_version()
+  def latest_version(device), do: ComponentVersions.client_version(device)
+
+  defp device_kind_label(%{type: :gateway}), do: "Gateway"
+  defp device_kind_label(_device), do: "Client"
+
+  defp device_location_caption(device) do
+    region_code = device.last_seen_remote_ip_location_region
+    region = if region_code, do: Portal.Geo.country_common_name!(region_code) || region_code
+
+    case Enum.reject([device.last_seen_remote_ip_location_city, region], &(&1 in [nil, ""])) do
+      [] -> "Location unknown"
+      parts -> Enum.join(parts, ", ")
+    end
+  end
+
+  defp format_coord(n) when is_number(n), do: :erlang.float_to_binary(n * 1.0, decimals: 3)
 
   defp posture_provider_label(:intune), do: "Microsoft Intune"
   defp posture_provider_label(:iru), do: "Iru"

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -1513,7 +1513,7 @@ defmodule PortalWeb.Resources do
           ids -> ids
         end
 
-      from(c in Device, as: :devices)
+      from(d in Device, as: :devices)
       |> where([devices: d], d.type == :client)
       |> where([devices: d], d.id in ^device_ids)
       |> preload(:actor)

--- a/elixir/lib/portal_web/live_table.ex
+++ b/elixir/lib/portal_web/live_table.ex
@@ -627,7 +627,10 @@ defmodule PortalWeb.LiveTable do
           checked={@form[@filter.name].value == value}
           class="hidden"
         />
-        {label}
+        <span class="inline-flex items-center gap-1">
+          <.icon :if={@filter.icons[value]} name={@filter.icons[value]} class="w-3.5 h-3.5" />
+          {label}
+        </span>
       </label>
     </div>
     """

--- a/elixir/test/portal_web/live/devices_test.exs
+++ b/elixir/test/portal_web/live/devices_test.exs
@@ -12,6 +12,7 @@ defmodule PortalWeb.DevicesTest do
   import Portal.IruFixtures
   import Portal.SantaFixtures
   import Portal.SentinelOneFixtures
+  import Portal.SubjectFixtures
   import Portal.DeviceFixtures
   import Portal.ClientSessionFixtures
   import Portal.GroupFixtures
@@ -205,8 +206,8 @@ defmodule PortalWeb.DevicesTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/devices/#{client.id}")
 
-      assert html =~ "Reported by Client"
-      assert html =~ "The Firezone Client reads and reports these values."
+      assert html =~ "Self-Reported"
+      assert html =~ "The software on this device reads and reports these values."
       assert html =~ "X.509 Device Trust"
       assert html =~ ~p"/#{account}/settings/trust_anchors"
     end
@@ -229,7 +230,7 @@ defmodule PortalWeb.DevicesTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/devices/#{client.id}")
 
-      assert html =~ "Reported by Client"
+      assert html =~ "Self-Reported"
       refute html =~ "to strongly identify this device"
     end
 
@@ -1498,6 +1499,219 @@ defmodule PortalWeb.DevicesTest do
     end
   end
 
+
+  describe "gateways" do
+    test "lists gateways alongside clients", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor, name: "Eng Laptop")
+      site = site_fixture(account: account, name: "AWS US-East")
+      gateway = gateway_fixture(account: account, site: site, name: "gw-alpha")
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/devices")
+
+      assert html =~ client.name
+      assert html =~ gateway.name
+      assert html =~ site.name
+      assert html =~ ~p"/#{account}/sites/#{site}"
+    end
+
+    test "counts both kinds in the total", %{account: account, actor: actor} do
+      client_fixture(account: account, actor: actor)
+      gateway_fixture(account: account)
+
+      subject = admin_subject_fixture(account: account, actor: actor)
+
+      assert PortalWeb.Devices.Database.count_devices(subject) == 2
+    end
+
+    test "shows a server icon for a gateway rather than an OS icon", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      gateway = gateway_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/devices")
+
+      assert has_element?(lv, "#device-#{gateway.id} .ri-server-line")
+    end
+
+    test "finds a gateway by its site name", %{conn: conn, account: account, actor: actor} do
+      site = site_fixture(account: account, name: "Frankfurt Edge")
+      gateway = gateway_fixture(account: account, site: site)
+      other = client_fixture(account: account, actor: actor, name: "Unrelated Laptop")
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/devices?#{%{"devices_filter[search]" => "Frankfurt"}}")
+
+      assert html =~ gateway.name
+      refute html =~ other.name
+    end
+
+    test "opens a read-only panel for a gateway", %{conn: conn, account: account, actor: actor} do
+      site = site_fixture(account: account, name: "AWS US-East")
+      gateway = gateway_fixture(account: account, site: site)
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/devices/#{gateway.id}")
+
+      assert html =~ gateway.name
+      assert html =~ "Gateway"
+      assert html =~ site.name
+
+      refute has_element?(lv, "button[phx-click='open_device_edit_form']")
+      refute has_element?(lv, "button[phx-click='verify_device']")
+      refute has_element?(lv, "button[phx-click='confirm_delete_device']")
+    end
+
+    test "shows what the gateway reported about itself", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      gateway = gateway_fixture(account: account)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/devices/#{gateway.id}")
+
+      assert html =~ "Reported"
+      assert html =~ gateway.firezone_id
+      assert html =~ gateway.last_seen_version
+    end
+
+    test "matches a gateway on the serial it self-reports", %{conn: conn} do
+      enable_device_posture()
+      account = device_posture_account_fixture()
+      actor = admin_actor_fixture(account: account)
+
+      intune_device_fixture(
+        provider: intune_posture_provider_fixture(account: account),
+        device_name: "GW-INVENTORY-01",
+        serial_number: "GW-SERIAL"
+      )
+
+      gateway = gateway_fixture(account: account, device_serial: "GW-SERIAL")
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/devices/#{gateway.id}?tab=posture")
+
+      assert html =~ "GW-INVENTORY-01"
+      assert html =~ "Self-reported serial"
+    end
+
+    test "sends the edit route for a gateway back to its panel", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      gateway = gateway_fixture(account: account)
+
+      assert {:error, {:live_redirect, %{to: to}}} =
+               conn
+               |> authorize_conn(actor)
+               |> live(~p"/#{account}/devices/#{gateway.id}/edit")
+
+      assert to == ~p"/#{account}/devices/#{gateway.id}"
+    end
+
+    test "ignores an edit or delete event for a gateway", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      gateway = gateway_fixture(account: account, name: "keep-me")
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/devices/#{gateway.id}")
+
+      render_click(lv, "submit_device_edit_form", %{"device" => %{"name" => "renamed"}})
+      render_click(lv, "delete_device", %{})
+
+      assert Repo.get_by!(Device, id: gateway.id).name == "keep-me"
+    end
+
+    test "filters by type", %{conn: conn, account: account, actor: actor} do
+      client = client_fixture(account: account, actor: actor, name: "Typed Laptop")
+      gateway = gateway_fixture(account: account, name: "typed-gw")
+
+      conn = authorize_conn(conn, actor)
+
+      {:ok, _lv, html} =
+        live(conn, ~p"/#{account}/devices?#{%{"devices_filter[type]" => "client"}}")
+
+      assert html =~ client.name
+      refute html =~ gateway.name
+
+      {:ok, _lv, html} =
+        live(conn, ~p"/#{account}/devices?#{%{"devices_filter[type]" => "gateway"}}")
+
+      assert html =~ gateway.name
+      refute html =~ client.name
+    end
+
+    test "shows the type and the last seen location on the panel", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      gateway =
+        gateway_fixture(
+          account: account,
+          last_seen_remote_ip_location_city: "Frankfurt",
+          last_seen_remote_ip_location_region: "DE",
+          last_seen_remote_ip_location_lat: 50.11,
+          last_seen_remote_ip_location_lon: 8.68
+        )
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/devices/#{gateway.id}")
+
+      assert html =~ "Type"
+      refute html =~ "Kind"
+      assert html =~ "Location"
+      assert html =~ "Frankfurt, Germany"
+      assert html =~ "50.110, 8.680"
+      assert has_element?(lv, "svg[aria-label='Location map']")
+    end
+
+    test "leaves gateways out of the None trust level", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor, name: "Unverified Laptop")
+      gateway = gateway_fixture(account: account, name: "gw-untrusted")
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/devices?#{%{"devices_filter[attestation]" => "none"}}")
+
+      assert html =~ client.name
+      refute html =~ gateway.name
+    end
+  end
   defp issuer_der(common_name) do
     :public_key.der_encode(
       :Name,


### PR DESCRIPTION
The page listed only the endpoints running our Client, which left the other half of what runs Firezone off a page named after all of it. It lists both now.

One icon says which kind a row is: the OS a Client runs on, a server for a Gateway. A Gateway is always Linux, so its own OS glyph would say nothing the row does not already say.

What a device reports about itself is shown the same way for either kind: what it runs, its version, its Firezone ID and its hostname.

A Gateway is still managed from its Site. Its panel shows the Site and links across to it rather than offering a second place to rename, verify or delete one. Verification is client-only in the schema anyway.

Gateways report a hardware serial as of #14895, so posture matching finds them on the same ladder a Client uses, on the rung that cautions about a self-reported value.

Related: #14899
Related: #14907
