### PR TITLE
refactor(portal): track one presence for every device

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -406,7 +406,7 @@ config :portal, docker_registry: "ghcr.io/firezone"
 
 config :portal, outbound_email_adapter_configured?: false
 
-config :portal, relay_presence_topic: "presences:global_relays"
+config :portal, relay_presence_topic: "presences:relays"
 
 config :portal, region: ""
 

--- a/elixir/lib/portal/ops.ex
+++ b/elixir/lib/portal/ops.ex
@@ -17,12 +17,9 @@ defmodule Portal.Ops do
 
       iex> count_global_presences()
       [
-        {"presences:account_clients", 430},
-        {"presences:account_gateways", 421},
-        {"presences:actor_clients", 430},
-        {"presences:global_relays", 34},
-        {"presences:portal_sessions", 8},
-        {"presences:sites", 421}
+        {"presences:account_devices", 851},
+        {"presences:relays", 34},
+        {"presences:portal_sessions", 8}
       ]
 
   """
@@ -54,12 +51,9 @@ defmodule Portal.Ops do
 
       iex> count_local_presences()
       [
-        {"presences:account_clients", 215},
-        {"presences:account_gateways", 210},
-        {"presences:actor_clients", 215},
-        {"presences:global_relays", 17},
-        {"presences:portal_sessions", 4},
-        {"presences:sites", 210}
+        {"presences:account_devices", 425},
+        {"presences:relays", 17},
+        {"presences:portal_sessions", 4}
       ]
 
   """
@@ -76,12 +70,9 @@ defmodule Portal.Ops do
 
       iex> count_regional_presences("centralus")
       [
-        {"presences:account_clients", 215},
-        {"presences:account_gateways", 210},
-        {"presences:actor_clients", 215},
-        {"presences:global_relays", 17},
-        {"presences:portal_sessions", 4},
-        {"presences:sites", 210}
+        {"presences:account_devices", 425},
+        {"presences:relays", 17},
+        {"presences:portal_sessions", 4}
       ]
 
   """

--- a/elixir/lib/portal/presence.ex
+++ b/elixir/lib/portal/presence.ex
@@ -6,169 +6,220 @@ defmodule Portal.Presence do
   alias Portal.PubSub
   alias Portal.Device
 
-  defmodule Clients do
-    def connect(device, token_id, session_meta \\ %{})
+  defmodule Devices do
+    @moduledoc """
+    Presence for everything running Firezone in an account.
 
-    def connect(%Device{type: :client} = device, token_id, session_meta) do
-      with :ok <- __MODULE__.Account.track(device.account_id, device.id, session_meta),
-           :ok <- __MODULE__.Actor.track(device.actor_id, device.id, token_id) do
-        :ok
+    Clients and gateways used to be tracked apart, on two account topics whose
+    metadata had grown into two different shapes. They are one tracker now:
+    one account topic, and one meta shape built in one place, so a reader that
+    does not care which kind it is looking at does not have to know.
+    """
+    alias Portal.Device
+
+    @doc """
+    What every device puts in its presence, whichever kind it is.
+
+    The same keys either way, `nil` where a kind has no answer, so a reader
+    never has to know which one it is holding.
+    """
+    def session_meta(%Device{} = device, extra \\ %{}) do
+      %{
+        type: device.type,
+        name: device.name,
+        actor_id: device.actor_id,
+        ipv4: device.ipv4 && device.ipv4.address,
+        ipv6: device.ipv6 && device.ipv6.address,
+        public_key: device.public_key,
+        psk_base: device.psk_base,
+        site_id: device.site_id,
+        version: device.last_seen_version,
+        user_agent: device.last_seen_user_agent,
+        remote_ip: device.last_seen_remote_ip,
+        remote_ip_location_lat: device.last_seen_remote_ip_location_lat,
+        remote_ip_location_lon: device.last_seen_remote_ip_location_lon,
+        attested?: device.attested?
+      }
+      |> Map.merge(extra)
+    end
+
+    def connect(%Device{} = device, token_id, session_meta \\ %{}) do
+      __MODULE__.Account.track(device, Map.put(session_meta, :token_id, token_id))
+    end
+
+    @doc """
+    Fills in `online?` for a list holding either kind of device.
+    """
+    def preload_presence([device]) do
+      case __MODULE__.Account.get(device.account_id, device.id) do
+        [] -> [%{device | online?: false}]
+        %{metas: [_ | _]} -> [%{device | online?: true}]
       end
     end
 
-    @doc false
-    def preload_clients_presence([client]) do
-      __MODULE__.Account.get(client.account_id, client.id)
-      |> case do
-        [] -> %{client | online?: false}
-        %{metas: [_ | _]} -> %{client | online?: true}
-      end
-      |> List.wrap()
-    end
-
-    def preload_clients_presence(clients) do
-      connected_clients =
-        clients
+    def preload_presence(devices) do
+      online =
+        devices
         |> Enum.map(& &1.account_id)
         |> Enum.reject(&is_nil/1)
         |> Enum.uniq()
-        |> Enum.reduce([], fn account_id, acc ->
-          connected_client_ids = online_client_ids(account_id)
-          connected_client_ids ++ acc
-        end)
+        |> Enum.flat_map(&online_ids/1)
+        |> MapSet.new()
 
-      Enum.map(clients, fn client ->
-        %{client | online?: client.id in connected_clients}
-      end)
+      Enum.map(devices, &%{&1 | online?: MapSet.member?(online, &1.id)})
     end
 
-    def online_client_ids(account_id) do
+    @doc "The ids of every device of either kind connected to an account."
+    def online_ids(account_id) do
       account_id
       |> __MODULE__.Account.list()
       |> Map.keys()
     end
 
-    defmodule Account do
-      def track(account_id, client_id, session_meta \\ %{}) do
-        meta = Map.merge(session_meta, %{online_at: System.system_time(:second)})
+    @doc "The ids of the connected devices of one kind."
+    def online_ids(account_id, type) do
+      account_id
+      |> __MODULE__.Account.list()
+      |> Enum.filter(fn {_id, %{metas: [meta | _]}} -> meta.type == type end)
+      |> Enum.map(&elem(&1, 0))
+    end
 
-        case Portal.Presence.track(self(), topic(account_id), client_id, meta) do
+    @doc "How many gateways are connected to each site, keyed by site id."
+    def online_gateway_counts(account_id) do
+      account_id
+      |> __MODULE__.Account.list()
+      |> Enum.reduce(%{}, fn
+        {_id, %{metas: [%{type: :gateway, site_id: site_id} | _]}}, acc ->
+          Map.update(acc, site_id, 1, &(&1 + 1))
+
+        _client, acc ->
+          acc
+      end)
+    end
+
+    @doc "The ids of the sites with at least one gateway connected."
+    def online_site_ids(account_id) do
+      account_id |> online_gateway_counts() |> Map.keys() |> MapSet.new()
+    end
+
+    @doc "The ids of the tokens that a connected device of one actor is using."
+    def online_token_ids(account_id, actor_id) do
+      account_id
+      |> __MODULE__.Account.list()
+      |> Enum.flat_map(fn {_id, %{metas: metas}} ->
+        for %{actor_id: ^actor_id, token_id: token_id} <- metas, do: token_id
+      end)
+    end
+
+    @doc "Whether a presence diff carries a device of the actor."
+    def diff_includes_actor?(%{joins: joins, leaves: leaves}, actor_id) do
+      [joins, leaves]
+      |> Enum.flat_map(&Map.values/1)
+      |> Enum.any?(fn %{metas: metas} -> Enum.any?(metas, &(Map.get(&1, :actor_id) == actor_id)) end)
+    end
+
+    def fetch_gateway(account_id, gateway_id) do
+      case __MODULE__.Account.get(account_id, gateway_id) do
+        %{metas: [%{type: :gateway} = meta | _]} ->
+          {:ok, from_meta(gateway_id, account_id, meta)}
+
+        _offline_or_not_a_gateway ->
+          {:error, :offline}
+      end
+    end
+
+    def all_connected_gateways(account_id) do
+      account_id
+      |> __MODULE__.Account.list()
+      |> Enum.flat_map(fn
+        {id, %{metas: [%{type: :gateway} = meta | _]}} -> [from_meta(id, account_id, meta)]
+        _other_kind -> []
+      end)
+    end
+
+    defp from_meta(id, account_id, meta) do
+      %Device{
+        id: id,
+        account_id: account_id,
+        type: meta.type,
+        site_id: meta.site_id,
+        psk_base: meta.psk_base,
+        online?: true,
+        public_key: meta.public_key,
+        last_seen_version: meta.version,
+        last_seen_remote_ip: normalize_ip(meta.remote_ip),
+        last_seen_remote_ip_location_lat: meta.remote_ip_location_lat,
+        last_seen_remote_ip_location_lon: meta.remote_ip_location_lon
+      }
+    end
+
+    defp normalize_ip(%Postgrex.INET{} = inet), do: inet
+    defp normalize_ip(tuple) when is_tuple(tuple), do: %Postgrex.INET{address: tuple}
+    defp normalize_ip(nil), do: nil
+
+    @doc """
+    Preloads `online?` for client tokens.
+
+    A token is online when any device is connected using it.
+    """
+    def preload_client_tokens_presence(tokens) when is_list(tokens) do
+      online_token_ids =
+        tokens
+        |> Enum.map(&{&1.account_id, &1.actor_id})
+        |> Enum.uniq()
+        |> Enum.flat_map(fn {account_id, actor_id} -> online_token_ids(account_id, actor_id) end)
+        |> MapSet.new()
+
+      Enum.map(tokens, &%{&1 | online?: MapSet.member?(online_token_ids, &1.id)})
+    end
+
+    defmodule Account do
+      alias Portal.Presence.Devices
+
+      def track(device, extra \\ %{}) do
+        meta =
+          device
+          |> Devices.session_meta(extra)
+          |> Map.put(:online_at, System.system_time(:second))
+
+        case Portal.Presence.track(self(), topic(device.account_id), device.id, meta) do
           {:ok, _} ->
             :ok
 
           {:error, {:already_tracked, _, _, _}} ->
-            Portal.Presence.update(self(), topic(account_id), client_id, meta)
+            Portal.Presence.update(self(), topic(device.account_id), device.id, meta)
             :ok
         end
       end
 
-      def subscribe(account_id) do
-        account_id
-        |> topic()
-        |> PubSub.subscribe()
+      def subscribe(account_id), do: account_id |> topic() |> PubSub.subscribe()
+
+      def get(account_id, device_id) do
+        account_id |> topic() |> Portal.Presence.get_by_key(device_id)
       end
 
-      def get(account_id, client_id) do
-        account_id
-        |> topic()
-        |> Portal.Presence.get_by_key(client_id)
-      end
-
-      def list(account_id) do
-        account_id
-        |> topic()
-        |> Portal.Presence.list()
-      end
+      def list(account_id), do: account_id |> topic() |> Portal.Presence.list()
 
       def find_by_ipv4(account_id, ipv4_tuple) when is_tuple(ipv4_tuple) do
-        account_id
-        |> list()
-        |> Enum.find_value(fn {client_id, %{metas: [meta | _]}} ->
-          if meta.ipv4 == ipv4_tuple, do: {client_id, meta}
-        end)
+        find_by_address(account_id, :ipv4, ipv4_tuple)
       end
 
       def find_by_ipv6(account_id, ipv6_tuple) when is_tuple(ipv6_tuple) do
+        find_by_address(account_id, :ipv6, ipv6_tuple)
+      end
+
+      # Both kinds share this topic and both hold tunnel addresses, so the
+      # lookup says which kind it wants rather than trusting the address to
+      # belong to only one.
+      defp find_by_address(account_id, key, address) do
         account_id
         |> list()
-        |> Enum.find_value(fn {client_id, %{metas: [meta | _]}} ->
-          if meta.ipv6 == ipv6_tuple, do: {client_id, meta}
+        |> Enum.find_value(fn {device_id, %{metas: [meta | _]}} ->
+          if meta.type == :client and Map.get(meta, key) == address, do: {device_id, meta}
         end)
       end
 
-      defp topic(account_id) do
-        "presences:account_clients:" <> account_id
-      end
-    end
-
-    defmodule Actor do
-      def track(actor_id, client_id, token_id) do
-        meta = %{token_id: token_id}
-
-        case Portal.Presence.track(self(), topic(actor_id), client_id, meta) do
-          {:ok, _} ->
-            :ok
-
-          {:error, {:already_tracked, _, _, _}} ->
-            Portal.Presence.update(self(), topic(actor_id), client_id, meta)
-            :ok
-        end
-      end
-
-      def get(actor_id, client_id) do
-        actor_id
-        |> topic()
-        |> Portal.Presence.get_by_key(client_id)
-      end
-
-      def list(actor_id) do
-        actor_id
-        |> topic()
-        |> Portal.Presence.list()
-      end
-
-      def subscribe(actor_id) do
-        actor_id
-        |> topic()
-        |> PubSub.subscribe()
-      end
-
-      def unsubscribe(actor_id) do
-        actor_id
-        |> topic()
-        |> PubSub.unsubscribe()
-      end
-
-      def online_token_ids(actor_id) do
-        actor_id
-        |> list()
-        |> Enum.flat_map(fn {_client_id, %{metas: metas}} ->
-          Enum.map(metas, & &1.token_id)
-        end)
-      end
-
-      defp topic(actor_id) do
-        "presences:actor_clients:" <> actor_id
-      end
-    end
-
-    @doc """
-    Preloads the online? virtual field for client tokens based on actor presence.
-    A token is considered online if any client is connected using that token.
-    """
-    def preload_client_tokens_presence(tokens) when is_list(tokens) do
-      # Group tokens by actor_id to batch presence lookups
-      online_token_ids =
-        tokens
-        |> Enum.map(& &1.actor_id)
-        |> Enum.reject(&is_nil/1)
-        |> Enum.uniq()
-        |> Enum.flat_map(&Actor.online_token_ids/1)
-        |> MapSet.new()
-
-      Enum.map(tokens, fn token ->
-        %{token | online?: MapSet.member?(online_token_ids, token.id)}
-      end)
+      def topic(account_id), do: "presences:account_devices:" <> account_id
     end
   end
 
@@ -224,148 +275,6 @@ defmodule Portal.Presence do
     end
   end
 
-  defmodule Gateways do
-    def connect(device, token_id, session_meta \\ %{})
-
-    def connect(%Device{type: :gateway} = device, token_id, session_meta) do
-      with :ok <- __MODULE__.Site.track(device.site_id, device.id, token_id),
-           :ok <- __MODULE__.Account.track(device.account_id, device.id, session_meta) do
-        :ok
-      end
-    end
-
-    def fetch_gateway(account_id, gateway_id) do
-      case __MODULE__.Account.get(account_id, gateway_id) do
-        %{metas: [meta | _]} ->
-          {:ok, gateway_from_presence_meta(gateway_id, account_id, meta)}
-
-        [] ->
-          {:error, :offline}
-      end
-    end
-
-    def all_connected_gateways(account_id) do
-      __MODULE__.Account.list(account_id)
-      |> Enum.map(fn {gateway_id, %{metas: [meta | _]}} ->
-        gateway_from_presence_meta(gateway_id, account_id, meta)
-      end)
-    end
-
-    defp gateway_from_presence_meta(gateway_id, account_id, meta) do
-      %Device{
-        id: gateway_id,
-        account_id: account_id,
-        type: :gateway,
-        site_id: meta.site_id,
-        psk_base: meta.psk_base,
-        online?: true,
-        public_key: meta.public_key,
-        last_seen_version: meta.version,
-        last_seen_remote_ip: normalize_ip(meta.remote_ip),
-        last_seen_remote_ip_location_lat: meta.remote_ip_location_lat,
-        last_seen_remote_ip_location_lon: meta.remote_ip_location_lon
-      }
-    end
-
-    defp normalize_ip(%Postgrex.INET{} = inet), do: inet
-    defp normalize_ip(tuple) when is_tuple(tuple), do: %Postgrex.INET{address: tuple}
-    defp normalize_ip(nil), do: nil
-
-    @doc false
-    def preload_gateways_presence([gateway]) do
-      __MODULE__.Account.get(gateway.account_id, gateway.id)
-      |> case do
-        [] -> %{gateway | online?: false}
-        %{metas: [_ | _]} -> %{gateway | online?: true}
-      end
-      |> List.wrap()
-    end
-
-    def preload_gateways_presence(gateways) do
-      connected_gateways =
-        gateways
-        |> Enum.map(& &1.account_id)
-        |> Enum.reject(&is_nil/1)
-        |> Enum.uniq()
-        |> Enum.reduce(%{}, fn account_id, acc ->
-          connected_gateways = __MODULE__.Account.list(account_id)
-          Map.merge(acc, connected_gateways)
-        end)
-
-      Enum.map(gateways, fn gateway ->
-        %{gateway | online?: Map.has_key?(connected_gateways, gateway.id)}
-      end)
-    end
-
-    defmodule Account do
-      def track(account_id, gateway_id, session_meta \\ %{}) do
-        meta = Map.merge(session_meta, %{online_at: System.system_time(:second)})
-
-        case Portal.Presence.track(self(), topic(account_id), gateway_id, meta) do
-          {:ok, _} ->
-            :ok
-
-          {:error, {:already_tracked, _, _, _}} ->
-            Portal.Presence.update(self(), topic(account_id), gateway_id, meta)
-            :ok
-        end
-      end
-
-      def subscribe(account_id) do
-        account_id
-        |> topic()
-        |> PubSub.subscribe()
-      end
-
-      def get(account_id, gateway_id) do
-        account_id
-        |> topic()
-        |> Portal.Presence.get_by_key(gateway_id)
-      end
-
-      def list(account_id) do
-        account_id
-        |> topic()
-        |> Portal.Presence.list()
-      end
-
-      defp topic(account_id) do
-        "presences:account_gateways:" <> account_id
-      end
-    end
-
-    defmodule Site do
-      def track(site_id, gateway_id, token_id) do
-        meta = %{token_id: token_id}
-
-        case Portal.Presence.track(self(), topic(site_id), gateway_id, meta) do
-          {:ok, _} ->
-            :ok
-
-          {:error, {:already_tracked, _, _, _}} ->
-            Portal.Presence.update(self(), topic(site_id), gateway_id, meta)
-            :ok
-        end
-      end
-
-      def subscribe(site_id) do
-        site_id
-        |> topic()
-        |> PubSub.subscribe()
-      end
-
-      def list(site_id) do
-        site_id
-        |> topic()
-        |> Portal.Presence.list()
-      end
-
-      defp topic(site_id) do
-        "presences:sites:" <> site_id
-      end
-    end
-  end
-
   defmodule Relays do
     @moduledoc """
     Presence tracking for relays. Relays are ephemeral and only exist while connected.
@@ -375,7 +284,7 @@ defmodule Portal.Presence do
     alias Portal.Relay
 
     def send_metrics do
-      count = __MODULE__.Global.list() |> Enum.count()
+      count = list() |> Enum.count()
 
       :telemetry.execute([:portal, :relays], %{
         online_relays_count: count
@@ -389,7 +298,7 @@ defmodule Portal.Presence do
       disconnect_by_id(relay.id)
 
       with {:ok, _} <-
-             Portal.Presence.track(self(), __MODULE__.Global.topic(), relay.id, %{
+             Portal.Presence.track(self(), topic(), relay.id, %{
                stamp_secret: relay.stamp_secret,
                ipv4: relay.ipv4,
                ipv6: relay.ipv6,
@@ -403,7 +312,7 @@ defmodule Portal.Presence do
     end
 
     defp disconnect_by_id(id) do
-      topic = __MODULE__.Global.topic()
+      topic = topic()
 
       # Phoenix.Tracker.get_by_key returns [{pid, meta}] for each presence
       Phoenix.Tracker.get_by_key(Portal.Presence, topic, id)
@@ -418,11 +327,11 @@ defmodule Portal.Presence do
     Disconnects a relay from presence.
     """
     def disconnect(%Relay{id: id}) do
-      Portal.Presence.untrack(self(), __MODULE__.Global.topic(), id)
+      Portal.Presence.untrack(self(), topic(), id)
     end
 
     def all_connected_relays(except_ids \\ []) do
-      connected_relays = __MODULE__.Global.list()
+      connected_relays = list()
 
       relays =
         connected_relays
@@ -443,22 +352,12 @@ defmodule Portal.Presence do
       {:ok, relays}
     end
 
-    defmodule Global do
-      def topic do
-        Portal.Config.get_env(:portal, :relay_presence_topic, "presences:global_relays")
-      end
-
-      def list do
-        Portal.Presence.list(topic())
-      end
-
-      def subscribe do
-        PubSub.subscribe(topic())
-      end
-
-      def unsubscribe do
-        PubSub.unsubscribe(topic())
-      end
+    def topic do
+      Portal.Config.get_env(:portal, :relay_presence_topic, "presences:relays")
     end
+
+    def list, do: Portal.Presence.list(topic())
+    def subscribe, do: PubSub.subscribe(topic())
+    def unsubscribe, do: PubSub.unsubscribe(topic())
   end
 end

--- a/elixir/lib/portal/workers/outdated_gateways.ex
+++ b/elixir/lib/portal/workers/outdated_gateways.ex
@@ -41,13 +41,10 @@ defmodule Portal.Workers.OutdatedGateways do
   end
 
   defp all_online_gateways_for_account(account) do
-    gateways_by_id =
-      Database.all_gateways_for_account!(account)
-      |> Enum.group_by(& &1.id)
+    online_ids = Portal.Presence.Devices.online_ids(account.id, :gateway)
 
-    Database.all_sites_for_account!(account)
-    |> Enum.flat_map(&Database.all_online_gateway_ids_by_site_id!(&1.id))
-    |> Enum.flat_map(&Map.get(gateways_by_id, &1))
+    Database.all_gateways_for_account!(account)
+    |> Enum.filter(&(&1.id in online_ids))
   end
 
   defp send_notifications([], _account, _incompatible_client_count) do
@@ -197,17 +194,5 @@ defmodule Portal.Workers.OutdatedGateways do
       |> Safe.all()
     end
 
-    def all_sites_for_account!(account) do
-      from(g in Portal.Site,
-        where: g.account_id == ^account.id
-      )
-      |> Safe.unscoped()
-      |> Safe.all()
-    end
-
-    def all_online_gateway_ids_by_site_id!(site_id) do
-      Portal.Presence.Gateways.Site.list(site_id)
-      |> Map.keys()
-    end
   end
 end

--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -100,7 +100,7 @@ defmodule PortalAPI.Client.Channel.Shared do
 
     # Initialize relays and subscribe to global relay presence
     {:ok, relays} = select_relays(socket)
-    :ok = Presence.Relays.Global.subscribe()
+    :ok = Presence.Relays.subscribe()
 
     socket =
       socket
@@ -205,7 +205,7 @@ defmodule PortalAPI.Client.Channel.Shared do
   def handle_info(
         %Phoenix.Socket.Broadcast{
           event: "presence_diff",
-          topic: "presences:global_relays" <> _
+          topic: "presences:relays" <> _
         },
         socket
       ) do
@@ -915,7 +915,7 @@ defmodule PortalAPI.Client.Channel.Shared do
              socket.assigns.subject
            ),
          {:ok, gateway} <-
-           Presence.Gateways.fetch_gateway(socket.assigns.subject.account.id, gateway_id),
+           Presence.Devices.fetch_gateway(socket.assigns.subject.account.id, gateway_id),
          true <- resource.site != nil and resource.site.id == Ecto.UUID.dump!(gateway.site_id) do
       policy_authorization_id = Ecto.UUID.generate()
 
@@ -997,7 +997,7 @@ defmodule PortalAPI.Client.Channel.Shared do
              socket.assigns.subject
            ),
          {:ok, gateway} <-
-           Presence.Gateways.fetch_gateway(socket.assigns.subject.account.id, gateway_id),
+           Presence.Devices.fetch_gateway(socket.assigns.subject.account.id, gateway_id),
          true <- resource.site != nil and resource.site.id == Ecto.UUID.dump!(gateway.site_id) do
       policy_authorization_id = Ecto.UUID.generate()
 
@@ -1275,14 +1275,14 @@ defmodule PortalAPI.Client.Channel.Shared do
   end
 
   defp find_online_client_by_address(account_id, {:ipv4, ipv4_tuple}) do
-    case Presence.Clients.Account.find_by_ipv4(account_id, ipv4_tuple) do
+    case Presence.Devices.Account.find_by_ipv4(account_id, ipv4_tuple) do
       {target_client_id, target_meta} -> {:ok, target_client_id, target_meta}
       nil -> :offline
     end
   end
 
   defp find_online_client_by_address(account_id, {:ipv6, ipv6_tuple}) do
-    case Presence.Clients.Account.find_by_ipv6(account_id, ipv6_tuple) do
+    case Presence.Devices.Account.find_by_ipv6(account_id, ipv6_tuple) do
       {target_client_id, target_meta} -> {:ok, target_client_id, target_meta}
       nil -> :offline
     end
@@ -2681,25 +2681,13 @@ defmodule PortalAPI.Client.Channel.Shared do
         socket
 
       sup_pid ->
-        session_meta = %{
-          ipv4: socket.assigns.client.ipv4.address,
-          ipv6: socket.assigns.client.ipv6.address,
-          name: socket.assigns.client.name,
-          public_key: socket.assigns.client.public_key,
-          psk_base: socket.assigns.client.psk_base,
-          remote_ip: socket.assigns.client.last_seen_remote_ip,
-          version: socket.assigns.client.last_seen_version,
-          user_agent: socket.assigns.client.last_seen_user_agent,
-          # Whether THIS session presented a trusted MDM-provisioned
-          # certificate at connect and the device row adopted its identity.
-          attested?: socket.assigns.client.attested?
-        }
-
+        # Everything a device puts in its presence comes off the row itself,
+        # so both kinds carry the same shape. `attested?` is the exception,
+        # because it describes THIS session rather than the row's history.
         :ok =
-          Presence.Clients.connect(
+          Presence.Devices.connect(
             socket.assigns.client,
-            socket.assigns.subject.credential.id,
-            session_meta
+            socket.assigns.subject.credential.id
           )
 
         for {_pid, ref} <- socket.assigns[:presence_monitors] || [] do
@@ -2802,7 +2790,7 @@ defmodule PortalAPI.Client.Channel.Shared do
       resource_site_id = site_id_from_resource(resource)
 
       site_gateways =
-        Portal.Presence.Gateways.all_connected_gateways(account_id)
+        Portal.Presence.Devices.all_connected_gateways(account_id)
         |> Enum.filter(&(&1.site_id == resource_site_id))
 
       compatible_gateways =

--- a/elixir/lib/portal_api/controllers/client_controller.ex
+++ b/elixir/lib/portal_api/controllers/client_controller.ex
@@ -5,7 +5,7 @@ defmodule PortalAPI.ClientController do
   alias PortalAPI.Error
   alias PortalAPI.Filters
   alias PortalAPI.Schemas.ProblemDetails
-  alias Portal.Presence.Clients
+  alias Portal.Presence.Devices
   alias __MODULE__.Database
   import Ecto.Changeset
   import Portal.Changeset
@@ -76,7 +76,7 @@ defmodule PortalAPI.ClientController do
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show(conn, %{"id" => id}) do
     with {:ok, client} <- Database.fetch_client(id, conn.assigns.subject) do
-      client = Clients.preload_clients_presence([client]) |> List.first()
+      client = Devices.preload_presence([client]) |> List.first()
       render(conn, :show, client: client)
     else
       error -> Error.handle(conn, error)
@@ -231,7 +231,7 @@ defmodule PortalAPI.ClientController do
 
   defmodule Database do
     import Ecto.Query
-    alias Portal.{Presence.Clients, Safe}
+    alias Portal.{Presence.Devices, Safe}
     alias Portal.Device
 
     def list_clients(subject, opts \\ []) do
@@ -280,7 +280,7 @@ defmodule PortalAPI.ClientController do
 
     def preloads do
       [
-        online?: &Clients.preload_clients_presence/1
+        online?: &Devices.preload_presence/1
       ]
     end
 
@@ -303,7 +303,7 @@ defmodule PortalAPI.ClientController do
     def update_client(changeset, subject) do
       case Safe.scoped(changeset, subject) |> Safe.update() do
         {:ok, updated_client} ->
-          {:ok, Clients.preload_clients_presence([updated_client]) |> List.first()}
+          {:ok, Devices.preload_presence([updated_client]) |> List.first()}
 
         {:error, reason} ->
           {:error, reason}
@@ -313,7 +313,7 @@ defmodule PortalAPI.ClientController do
     def verify_client(changeset, subject) do
       case Safe.scoped(changeset, subject) |> Safe.update() do
         {:ok, updated_client} ->
-          {:ok, Clients.preload_clients_presence([updated_client]) |> List.first()}
+          {:ok, Devices.preload_presence([updated_client]) |> List.first()}
 
         # coveralls-ignore-start - defensive: Safe.update on a server-built changeset cannot fail
         {:error, reason} ->
@@ -325,7 +325,7 @@ defmodule PortalAPI.ClientController do
     def remove_client_verification(changeset, subject) do
       case Safe.scoped(changeset, subject) |> Safe.update() do
         {:ok, updated_client} ->
-          {:ok, Clients.preload_clients_presence([updated_client]) |> List.first()}
+          {:ok, Devices.preload_presence([updated_client]) |> List.first()}
 
         # coveralls-ignore-start - defensive: Safe.update on a server-built changeset cannot fail
         {:error, reason} ->
@@ -337,7 +337,7 @@ defmodule PortalAPI.ClientController do
     def delete_client(client, subject) do
       case Safe.scoped(client, subject) |> Safe.delete() do
         {:ok, deleted_client} ->
-          {:ok, Clients.preload_clients_presence([deleted_client]) |> List.first()}
+          {:ok, Devices.preload_presence([deleted_client]) |> List.first()}
 
         # coveralls-ignore-start - defensive: Safe.delete on an existing client cannot fail
         {:error, reason} ->

--- a/elixir/lib/portal_api/controllers/gateway_controller.ex
+++ b/elixir/lib/portal_api/controllers/gateway_controller.ex
@@ -80,7 +80,7 @@ defmodule PortalAPI.GatewayController do
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show(conn, %{"site_id" => site_id, "id" => id}) do
     with {:ok, gateway} <- Database.fetch_gateway(site_id, id, conn.assigns.subject) do
-      gateway = Presence.Gateways.preload_gateways_presence([gateway]) |> List.first()
+      gateway = Presence.Devices.preload_presence([gateway]) |> List.first()
       render(conn, :show, gateway: gateway)
     else
       error -> Error.handle(conn, error)
@@ -135,7 +135,7 @@ defmodule PortalAPI.GatewayController do
 
     with {:ok, site} <- Database.fetch_site(site_id, subject),
          {:ok, gateway, token, encoded_token} <- Database.provision_gateway(site, name, subject) do
-      gateway = Presence.Gateways.preload_gateways_presence([gateway]) |> List.first()
+      gateway = Presence.Devices.preload_presence([gateway]) |> List.first()
 
       conn
       |> put_status(:created)
@@ -189,7 +189,7 @@ defmodule PortalAPI.GatewayController do
 
     with {:ok, gateway} <- Database.fetch_gateway(site_id, id, subject),
          {:ok, gateway} <- Database.rename_gateway(gateway, name, subject) do
-      gateway = Presence.Gateways.preload_gateways_presence([gateway]) |> List.first()
+      gateway = Presence.Devices.preload_presence([gateway]) |> List.first()
       render(conn, :show, gateway: gateway)
     else
       error -> Error.handle(conn, error)
@@ -290,7 +290,7 @@ defmodule PortalAPI.GatewayController do
 
     def preloads do
       [
-        online?: &Presence.Gateways.preload_gateways_presence/1
+        online?: &Presence.Devices.preload_presence/1
       ]
     end
 
@@ -376,7 +376,7 @@ defmodule PortalAPI.GatewayController do
     def delete_gateway(gateway, subject) do
       case Safe.scoped(gateway, subject) |> Safe.delete() do
         {:ok, deleted_gateway} ->
-          {:ok, Presence.Gateways.preload_gateways_presence([deleted_gateway]) |> List.first()}
+          {:ok, Presence.Devices.preload_presence([deleted_gateway]) |> List.first()}
 
         {:error, reason} ->
           {:error, reason}

--- a/elixir/lib/portal_api/gateway/channel/shared.ex
+++ b/elixir/lib/portal_api/gateway/channel/shared.ex
@@ -132,7 +132,7 @@ defmodule PortalAPI.Gateway.Channel.Shared do
 
     # Return all connected relays and subscribe to global relay presence
     {:ok, relays} = select_relays(socket)
-    :ok = Presence.Relays.Global.subscribe()
+    :ok = Presence.Relays.subscribe()
 
     account = Database.get_account_by_id!(socket.assigns.gateway.account_id)
 
@@ -183,7 +183,7 @@ defmodule PortalAPI.Gateway.Channel.Shared do
   def handle_info(
         %Phoenix.Socket.Broadcast{
           event: "presence_diff",
-          topic: "presences:global_relays" <> _
+          topic: "presences:relays" <> _
         },
         socket
       ) do
@@ -1149,17 +1149,7 @@ defmodule PortalAPI.Gateway.Channel.Shared do
       sup_pid ->
         gateway = socket.assigns.gateway
 
-        session_meta = %{
-          site_id: gateway.site_id,
-          public_key: gateway.public_key,
-          psk_base: gateway.psk_base,
-          version: gateway.last_seen_version,
-          remote_ip: gateway.last_seen_remote_ip,
-          remote_ip_location_lat: gateway.last_seen_remote_ip_location_lat,
-          remote_ip_location_lon: gateway.last_seen_remote_ip_location_lon
-        }
-
-        :ok = Presence.Gateways.connect(gateway, socket.assigns.token_id, session_meta)
+        :ok = Presence.Devices.connect(gateway, socket.assigns.token_id)
 
         for {_pid, ref} <- socket.assigns[:presence_monitors] || [] do
           Process.demonitor(ref, [:flush])

--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -23,6 +23,7 @@ defmodule PortalWeb.Actors do
 
     if connected?(socket) do
       :ok = PubSub.Changes.subscribe(socket.assigns.account.id, :actors)
+      :ok = Presence.Devices.Account.subscribe(socket.assigns.account.id)
     end
 
     socket =
@@ -31,8 +32,7 @@ defmodule PortalWeb.Actors do
       |> assign_async(:actors_count, fn -> {:ok, %{actors_count: Database.count_actors(subject)}} end)
       |> assign(
         selected_actor: nil,
-        portal_sessions_subscribed_actor_id: nil,
-        client_tokens_subscribed_actor_id: nil
+        portal_sessions_subscribed_actor_id: nil
       )
       |> assign(base_actor_assigns())
       |> assign_live_table("actors",
@@ -81,7 +81,6 @@ defmodule PortalWeb.Actors do
           confirm_delete_session_id: nil
         )
         |> subscribe_portal_sessions(actor)
-        |> subscribe_client_tokens(actor)
 
       {:noreply, socket}
     else
@@ -136,7 +135,6 @@ defmodule PortalWeb.Actors do
       |> assign(selected_actor: nil)
       |> assign(base_actor_assigns())
       |> unsubscribe_portal_sessions()
-      |> unsubscribe_client_tokens()
 
     {:noreply, socket}
   end
@@ -789,7 +787,10 @@ defmodule PortalWeb.Actors do
   def handle_info(%Change{struct: %Actor{}}, socket), do: {:noreply, socket}
   def handle_info(%Change{old_struct: %Actor{}}, socket), do: {:noreply, socket}
 
-  def handle_info(%Phoenix.Socket.Broadcast{event: "presence_diff", topic: topic}, socket) do
+  def handle_info(
+        %Phoenix.Socket.Broadcast{event: "presence_diff", topic: topic, payload: payload},
+        socket
+      ) do
     actor = socket.assigns.selected_actor
 
     cond do
@@ -800,7 +801,8 @@ defmodule PortalWeb.Actors do
         sessions = Database.get_portal_sessions_for_actor(actor.id, socket.assigns.subject)
         {:noreply, merge_state(socket, :actor_related, sessions: sessions)}
 
-      topic == "presences:actor_clients:" <> actor.id ->
+      topic == "presences:account_devices:" <> socket.assigns.account.id and
+          Presence.Devices.diff_includes_actor?(payload, actor.id) ->
         tokens = Database.get_client_tokens_for_actor(actor.id, socket.assigns.subject)
         {:noreply, merge_state(socket, :actor_related, tokens: tokens)}
 
@@ -953,33 +955,6 @@ defmodule PortalWeb.Actors do
     end
   end
 
-  defp subscribe_client_tokens(socket, actor) do
-    if connected?(socket) and socket.assigns.client_tokens_subscribed_actor_id != actor.id do
-      if prev_id = socket.assigns.client_tokens_subscribed_actor_id do
-        Presence.Clients.Actor.unsubscribe(prev_id)
-      end
-
-      Presence.Clients.Actor.subscribe(actor.id)
-      assign(socket, client_tokens_subscribed_actor_id: actor.id)
-    else
-      socket
-    end
-  end
-
-  defp unsubscribe_client_tokens(socket) do
-    cond do
-      not connected?(socket) ->
-        socket
-
-      id = socket.assigns[:client_tokens_subscribed_actor_id] ->
-        Presence.Clients.Actor.unsubscribe(id)
-        assign(socket, client_tokens_subscribed_actor_id: nil)
-
-      true ->
-        socket
-    end
-  end
-
   defp maybe_update_actor_assign(socket, id, updated_actor) do
     if Map.get(socket.assigns, :selected_actor) && socket.assigns.selected_actor.id == id do
       assign(socket, selected_actor: updated_actor)
@@ -1001,7 +976,6 @@ defmodule PortalWeb.Actors do
         |> assign(base_actor_assigns())
         |> assign(actor_panel: actor_panel, actor_related: actor_related)
         |> subscribe_portal_sessions(actor)
-        |> subscribe_client_tokens(actor)
 
       :error ->
         socket
@@ -1598,7 +1572,7 @@ defmodule PortalWeb.Actors do
 
       tokens
       |> preload_last_used_devices_for_tokens(subject)
-      |> Presence.Clients.preload_client_tokens_presence()
+      |> Presence.Devices.preload_client_tokens_presence()
     end
 
     defp preload_last_used_devices_for_tokens(tokens, subject) do

--- a/elixir/lib/portal_web/live/devices.ex
+++ b/elixir/lib/portal_web/live/devices.ex
@@ -1,7 +1,7 @@
 defmodule PortalWeb.Devices do
   use PortalWeb, :live_view
   import PortalWeb.Devices.Components
-  alias Portal.{Presence.Clients, ComponentVersions}
+  alias Portal.{Presence.Devices, ComponentVersions}
   alias Portal.Changes.Change
   alias Portal.Device
   alias Portal.PubSub
@@ -12,7 +12,7 @@ defmodule PortalWeb.Devices do
     subject = socket.assigns.subject
 
     if connected?(socket) do
-      :ok = Clients.Account.subscribe(subject.account.id)
+      :ok = Devices.Account.subscribe(subject.account.id)
       :ok = PubSub.Changes.subscribe(socket.assigns.account.id, :devices)
     end
 
@@ -539,7 +539,7 @@ defmodule PortalWeb.Devices do
   def handle_info(%Change{old_struct: %Device{type: :gateway}}, socket), do: {:noreply, socket}
 
   def handle_info(
-        %Phoenix.Socket.Broadcast{topic: "presences:account_clients:" <> _account_id} = event,
+        %Phoenix.Socket.Broadcast{topic: "presences:account_devices:" <> _account_id} = event,
         socket
       ) do
     rendered_client_ids = Enum.map(socket.assigns.devices, & &1.id)
@@ -567,7 +567,7 @@ defmodule PortalWeb.Devices do
     import Ecto.Query
     import Portal.Changeset
     import Portal.Repo.Query
-    alias Portal.{Presence.Clients, Safe}
+    alias Portal.{Presence.Devices, Safe}
     alias Portal.Device
     alias Portal.Policy
     alias Portal.PolicyAuthorization
@@ -620,11 +620,11 @@ defmodule PortalWeb.Devices do
     defp maybe_filter_by_presence(base_query, presence, subject) do
       case presence do
         "online" ->
-          ids = Clients.online_client_ids(subject.account.id)
+          ids = Devices.online_ids(subject.account.id, :client)
           where(base_query, [devices: d], d.id in ^ids)
 
         "offline" ->
-          ids = Clients.online_client_ids(subject.account.id)
+          ids = Devices.online_ids(subject.account.id, :client)
           where(base_query, [devices: d], d.id not in ^ids)
 
         _ ->
@@ -663,7 +663,7 @@ defmodule PortalWeb.Devices do
           Safe.preload(devices, :actor)
 
         :online?, devices ->
-          Clients.preload_clients_presence(devices)
+          Devices.preload_presence(devices)
 
         _other, devices ->
           devices
@@ -685,7 +685,7 @@ defmodule PortalWeb.Devices do
     def update_device(changeset, subject) do
       case Safe.scoped(changeset, subject) |> Safe.update() do
         {:ok, updated_client} ->
-          {:ok, Clients.preload_clients_presence([updated_client]) |> List.first()}
+          {:ok, Devices.preload_presence([updated_client]) |> List.first()}
 
         {:error, reason} ->
           {:error, reason}
@@ -715,7 +715,7 @@ defmodule PortalWeb.Devices do
     def delete_device(device, subject) do
       case Safe.scoped(device, subject) |> Safe.delete() do
         {:ok, deleted_client} ->
-          {:ok, Clients.preload_clients_presence([deleted_client]) |> List.first()}
+          {:ok, Devices.preload_presence([deleted_client]) |> List.first()}
 
         {:error, reason} ->
           {:error, reason}
@@ -735,7 +735,7 @@ defmodule PortalWeb.Devices do
 
       case device do
         %Device{type: :client} ->
-          Clients.preload_clients_presence([device]) |> List.first()
+          Devices.preload_presence([device]) |> List.first()
 
         _ ->
           nil
@@ -773,7 +773,7 @@ defmodule PortalWeb.Devices do
     def preloads do
       [
         :actor,
-        online?: &Clients.preload_clients_presence/1
+        online?: &Devices.preload_presence/1
       ]
     end
 

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -33,13 +33,12 @@ defmodule PortalWeb.Resources do
 
     if connected?(socket) do
       :ok = PubSub.Changes.subscribe(socket.assigns.account.id, :resources)
-      :ok = Presence.Gateways.Account.subscribe(socket.assigns.account.id)
+      :ok = Presence.Devices.Account.subscribe(socket.assigns.account.id)
     end
 
     socket =
       socket
       |> assign(stale: false)
-      |> assign(presence_tick: 0)
       |> assign(page_title: "Resources")
       |> assign_async(:resources_count, fn -> {:ok, %{resources_count: Database.count_resources(subject)}} end)
       |> assign(
@@ -47,7 +46,8 @@ defmodule PortalWeb.Resources do
         selected_resource_pool_member_ids: [],
         selected_resource_pool_devices: [],
         devices_expanded_id: nil,
-        online_device_ids: MapSet.new(),
+        online_ids: MapSet.new(),
+        online_site_ids: MapSet.new(),
         selected_groups: [],
         policy_authorizations: [],
         policy_authorizations_page: 1,
@@ -359,7 +359,8 @@ defmodule PortalWeb.Resources do
          internet_resource: internet_resource,
          resource_policy_counts: resource_policy_counts,
          device_pool_members: device_pool_members,
-         online_device_ids: online_device_ids(socket.assigns.account.id),
+         online_ids: online_ids(socket.assigns.account.id),
+         online_site_ids: Presence.Devices.online_site_ids(socket.assigns.account.id),
          resources_metadata: metadata
        )}
     end
@@ -465,7 +466,7 @@ defmodule PortalWeb.Resources do
               </td>
               <td class="px-4 py-3 text-body text-xs">Internet</td>
               <td class="px-4 py-3">
-                <.resource_status_badge resource={@internet_resource} presence_tick={@presence_tick} />
+                <.resource_status_badge resource={@internet_resource} online_site_ids={@online_site_ids} />
               </td>
             </tr>
           </:prepend_rows>
@@ -551,9 +552,9 @@ defmodule PortalWeb.Resources do
           <:col :let={resource} label="Status" class="w-32">
             <.resource_status_badge
               resource={resource}
-              presence_tick={@presence_tick}
+              online_site_ids={@online_site_ids}
               pool_member_ids={Map.get(@device_pool_members, resource.id, [])}
-              online_device_ids={@online_device_ids}
+              online_ids={@online_ids}
             />
           </:col>
           <:empty>
@@ -596,8 +597,8 @@ defmodule PortalWeb.Resources do
             pool_member_ids={@selected_resource_pool_member_ids}
             pool_devices={@selected_resource_pool_devices}
             devices_expanded_id={@devices_expanded_id}
-            online_device_ids={@online_device_ids}
-            presence_tick={@presence_tick}
+            online_ids={@online_ids}
+            online_site_ids={@online_site_ids}
             groups={@selected_groups}
             policy_authorizations={@policy_authorizations}
             policy_authorizations_page={@policy_authorizations_page}
@@ -1264,18 +1265,19 @@ defmodule PortalWeb.Resources do
   def handle_info(%Phoenix.Socket.Broadcast{event: event}, socket)
       when event in ["presence_diff", "presence_state"] do
     {:noreply,
-     socket
-     |> update(:presence_tick, &(&1 + 1))
-     |> assign(online_device_ids: online_device_ids(socket.assigns.account.id))}
+     assign(socket,
+       online_ids: online_ids(socket.assigns.account.id),
+       online_site_ids: Presence.Devices.online_site_ids(socket.assigns.account.id)
+     )}
   end
 
   def handle_info(_, socket) do
     {:noreply, socket}
   end
 
-  defp online_device_ids(account_id) do
+  defp online_ids(account_id) do
     account_id
-    |> Presence.Clients.online_client_ids()
+    |> Presence.Devices.online_ids()
     |> MapSet.new()
   end
 
@@ -1524,7 +1526,7 @@ defmodule PortalWeb.Resources do
           []
 
         devices ->
-          Portal.Presence.Clients.preload_clients_presence(devices)
+          Portal.Presence.Devices.preload_presence(devices)
       end
     end
 

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -17,7 +17,6 @@ defmodule PortalWeb.Resources.Components do
     ]
 
   alias __MODULE__.Database
-  alias Portal.Presence
 
   @resource_types %{
     internet: %{index: 1, label: nil},
@@ -980,8 +979,8 @@ defmodule PortalWeb.Resources.Components do
   attr :pool_member_ids, :list, default: []
   attr :pool_devices, :list, default: []
   attr :devices_expanded_id, :string, default: nil
-  attr :online_device_ids, :any, default: %MapSet{}
-  attr :presence_tick, :integer, default: 0
+  attr :online_ids, :any, default: %MapSet{}
+  attr :online_site_ids, :any, default: %MapSet{}
   attr :groups, :list, default: []
   attr :policy_authorizations, :list, default: []
   attr :policy_authorizations_page, :integer, default: 1
@@ -1007,9 +1006,9 @@ defmodule PortalWeb.Resources.Components do
               </h2>
               <.resource_status_badge
                 resource={@resource}
-                presence_tick={@presence_tick}
+                online_site_ids={@online_site_ids}
                 pool_member_ids={@pool_member_ids}
-                online_device_ids={@online_device_ids}
+                online_ids={@online_ids}
               />
             </div>
             <p
@@ -1046,8 +1045,8 @@ defmodule PortalWeb.Resources.Components do
             :if={@tab == :devices}
             account={@account}
             devices={@pool_devices}
-            online_device_ids={@online_device_ids}
-            presence_tick={@presence_tick}
+            online_ids={@online_ids}
+            online_site_ids={@online_site_ids}
             expanded_id={@devices_expanded_id}
           />
           <.resource_access_list
@@ -1075,7 +1074,7 @@ defmodule PortalWeb.Resources.Components do
         <.resource_sidebar
           account={@account}
           resource={@resource}
-          presence_tick={@presence_tick}
+          online_site_ids={@online_site_ids}
           ui_state={@ui_state}
         />
       </div>
@@ -1170,8 +1169,8 @@ defmodule PortalWeb.Resources.Components do
 
   attr :account, :any, required: true
   attr :devices, :list, default: []
-  attr :online_device_ids, :any, default: %MapSet{}
-  attr :presence_tick, :integer, default: 0
+  attr :online_ids, :any, default: %MapSet{}
+  attr :online_site_ids, :any, default: %MapSet{}
   attr :expanded_id, :string, default: nil
 
   def resource_devices_tab(assigns) do
@@ -1229,7 +1228,7 @@ defmodule PortalWeb.Resources.Components do
                 <td class="px-4 py-2">
                   <.device_status_badge
                     device={device}
-                    online?={MapSet.member?(@online_device_ids, device.id)}
+                    online?={MapSet.member?(@online_ids, device.id)}
                   />
                 </td>
                 <td class="px-4 py-2 text-subtle">
@@ -1845,7 +1844,7 @@ defmodule PortalWeb.Resources.Components do
 
   attr :account, :any, required: true
   attr :resource, :any, required: true
-  attr :presence_tick, :integer, default: 0
+  attr :online_site_ids, :any, default: %MapSet{}
   attr :ui_state, :map, required: true
 
   def resource_sidebar(assigns) do
@@ -1944,7 +1943,7 @@ defmodule PortalWeb.Resources.Components do
                   {@resource.site.name}
                 </.link>
                 <span
-                  :if={resource_online?(@resource, @presence_tick)}
+                  :if={resource_online?(@resource, @online_site_ids)}
                   class="relative flex items-center justify-center w-1.5 h-1.5"
                 >
                   <span class="absolute inline-flex rounded-full opacity-60 animate-ping w-1.5 h-1.5 bg-success">
@@ -2012,26 +2011,18 @@ defmodule PortalWeb.Resources.Components do
     |> to_form(as: :policy)
   end
 
-  @spec resource_online?(map(), integer()) :: boolean()
-  def resource_online?(resource, _presence_tick \\ 0)
-  def resource_online?(%{site_id: nil}, _presence_tick), do: false
-
-  def resource_online?(%{site_id: site_id}, _presence_tick) do
-    Presence.Gateways.Site.list(site_id) |> map_size() > 0
-  end
-
-  @spec resource_status(map(), integer()) :: :online | :offline
-  def resource_status(resource, presence_tick \\ 0) do
-    if resource_online?(resource, presence_tick), do: :online, else: :offline
+  @spec resource_online?(map(), MapSet.t()) :: boolean()
+  def resource_online?(%{site_id: site_id}, online_site_ids) do
+    MapSet.member?(online_site_ids, site_id)
   end
 
   attr :resource, :any, required: true
-  attr :presence_tick, :integer, default: 0
+  attr :online_site_ids, :any, default: %MapSet{}
   attr :pool_member_ids, :list, default: []
-  attr :online_device_ids, :any, default: %MapSet{}
+  attr :online_ids, :any, default: %MapSet{}
 
   def resource_status_badge(%{resource: %{type: :static_device_pool}} = assigns) do
-    online = Enum.count(assigns.pool_member_ids, &MapSet.member?(assigns.online_device_ids, &1))
+    online = Enum.count(assigns.pool_member_ids, &MapSet.member?(assigns.online_ids, &1))
     assigns = assign(assigns, online: online, total: length(assigns.pool_member_ids))
 
     ~H"""
@@ -2045,7 +2036,7 @@ defmodule PortalWeb.Resources.Components do
   end
 
   def resource_status_badge(assigns) do
-    assigns = assign(assigns, :online?, resource_online?(assigns.resource, assigns.presence_tick))
+    assigns = assign(assigns, :online?, resource_online?(assigns.resource, assigns.online_site_ids))
 
     ~H"""
     <.status_badge style={if @online?, do: :success, else: :neutral}>
@@ -2135,7 +2126,7 @@ defmodule PortalWeb.Resources.Components do
 
     def search_devices(search_term, subject, selected_devices) do
       selected_ids = Enum.map(selected_devices, & &1.id)
-      online_ids = Portal.Presence.Clients.online_client_ids(subject.account.id)
+      online_ids = Portal.Presence.Devices.online_ids(subject.account.id)
       pattern = "%#{search_term}%"
 
       query =

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -21,6 +21,7 @@ defmodule PortalWeb.ServiceAccounts do
 
     if connected?(socket) do
       :ok = PubSub.Changes.subscribe(socket.assigns.account.id, :actors)
+      :ok = Presence.Devices.Account.subscribe(socket.assigns.account.id)
     end
 
     socket =
@@ -30,8 +31,7 @@ defmodule PortalWeb.ServiceAccounts do
       |> assign_async(:actors_count, fn -> {:ok, %{actors_count: Database.count_actors(subject)}} end)
       |> assign(
         selected_actor: nil,
-        portal_sessions_subscribed_actor_id: nil,
-        client_tokens_subscribed_actor_id: nil
+        portal_sessions_subscribed_actor_id: nil
       )
       |> assign(base_actor_assigns())
       |> assign_live_table("actors",
@@ -65,8 +65,6 @@ defmodule PortalWeb.ServiceAccounts do
     socket = handle_live_tables_params(socket, params, uri)
 
     if selected_actor_matches?(socket, id) do
-      actor = socket.assigns.selected_actor
-
       socket =
         socket
         |> merge_state(:actor_panel,
@@ -78,7 +76,6 @@ defmodule PortalWeb.ServiceAccounts do
           confirm_delete_token_id: nil,
           confirm_delete_session_id: nil
         )
-        |> subscribe_client_tokens(actor)
 
       {:noreply, socket}
     else
@@ -126,7 +123,6 @@ defmodule PortalWeb.ServiceAccounts do
       socket
       |> assign(selected_actor: nil)
       |> assign(base_actor_assigns())
-      |> unsubscribe_client_tokens()
 
     {:noreply, socket}
   end
@@ -603,14 +599,18 @@ defmodule PortalWeb.ServiceAccounts do
   def handle_info(%Change{struct: %Actor{}}, socket), do: {:noreply, socket}
   def handle_info(%Change{old_struct: %Actor{}}, socket), do: {:noreply, socket}
 
-  def handle_info(%Phoenix.Socket.Broadcast{event: "presence_diff", topic: topic}, socket) do
+  def handle_info(
+        %Phoenix.Socket.Broadcast{event: "presence_diff", topic: topic, payload: payload},
+        socket
+      ) do
     actor = socket.assigns.selected_actor
 
     cond do
       is_nil(actor) ->
         {:noreply, socket}
 
-      topic == "presences:actor_clients:" <> actor.id ->
+      topic == "presences:account_devices:" <> socket.assigns.account.id and
+          Presence.Devices.diff_includes_actor?(payload, actor.id) ->
         tokens = Database.get_client_tokens_for_actor(actor.id, socket.assigns.subject)
         {:noreply, merge_state(socket, :actor_related, tokens: tokens)}
 
@@ -794,33 +794,6 @@ defmodule PortalWeb.ServiceAccounts do
     match?(%{id: ^id}, socket.assigns.selected_actor)
   end
 
-  defp subscribe_client_tokens(socket, actor) do
-    if connected?(socket) and socket.assigns.client_tokens_subscribed_actor_id != actor.id do
-      if prev_id = socket.assigns.client_tokens_subscribed_actor_id do
-        Presence.Clients.Actor.unsubscribe(prev_id)
-      end
-
-      Presence.Clients.Actor.subscribe(actor.id)
-      assign(socket, client_tokens_subscribed_actor_id: actor.id)
-    else
-      socket
-    end
-  end
-
-  defp unsubscribe_client_tokens(socket) do
-    cond do
-      not connected?(socket) ->
-        socket
-
-      id = socket.assigns[:client_tokens_subscribed_actor_id] ->
-        Presence.Clients.Actor.unsubscribe(id)
-        assign(socket, client_tokens_subscribed_actor_id: nil)
-
-      true ->
-        socket
-    end
-  end
-
   defp maybe_update_actor_assign(socket, id, updated_actor) do
     if Map.get(socket.assigns, :selected_actor) && socket.assigns.selected_actor.id == id do
       assign(socket, selected_actor: updated_actor)
@@ -845,7 +818,6 @@ defmodule PortalWeb.ServiceAccounts do
           actor_related:
             actor_related_state(tokens: tokens, groups: groups, created_token: created_token)
         )
-        |> subscribe_client_tokens(actor)
 
       _ ->
         socket
@@ -1044,7 +1016,7 @@ defmodule PortalWeb.ServiceAccounts do
 
       tokens
       |> preload_last_used_devices_for_tokens(subject)
-      |> Presence.Clients.preload_client_tokens_presence()
+      |> Presence.Devices.preload_client_tokens_presence()
     end
 
     defp preload_last_used_devices_for_tokens(tokens, subject) do

--- a/elixir/lib/portal_web/live/sites.ex
+++ b/elixir/lib/portal_web/live/sites.ex
@@ -3,12 +3,11 @@ defmodule PortalWeb.Sites do
   import PortalWeb.Sites.Components
   import PortalWeb.Resources.Components, only: [map_filters_form_attrs: 1]
   alias Portal.Presence
-  alias Portal.PubSub
   alias __MODULE__.Database
 
   def mount(_params, _session, socket) do
     if connected?(socket) do
-      :ok = Presence.Gateways.Account.subscribe(socket.assigns.account.id)
+      :ok = Presence.Devices.Account.subscribe(socket.assigns.account.id)
     end
 
     socket =
@@ -19,6 +18,7 @@ defmodule PortalWeb.Sites do
       |> assign(resources_counts: %{})
       |> assign(policies_counts: %{})
       |> assign(gateway_counts: %{})
+      |> assign(online_gateway_counts: %{})
       |> assign(internet_resource: nil)
       |> assign(internet_site: nil)
       |> assign(site_state_reset_assigns())
@@ -37,7 +37,6 @@ defmodule PortalWeb.Sites do
     if selected_site_matches?(socket, id) do
       {:noreply,
        socket
-       |> unsubscribe_deploy_site_presence()
        |> merge_state(:site_panel, %{
          tab: parse_panel_tab(params, socket.assigns.site_panel.gateway_tokens),
          view: :gateways,
@@ -55,7 +54,6 @@ defmodule PortalWeb.Sites do
         site ->
           {:noreply,
            socket
-           |> unsubscribe_deploy_site_presence()
            |> assign(site_panel_assigns(site, params, socket))}
       end
     end
@@ -67,7 +65,6 @@ defmodule PortalWeb.Sites do
 
       {:noreply,
        socket
-       |> unsubscribe_deploy_site_presence()
        |> merge_state(:site_panel, %{
          tab: parse_panel_tab(params, socket.assigns.site_panel.gateway_tokens),
          view: :edit_site,
@@ -87,7 +84,6 @@ defmodule PortalWeb.Sites do
 
           {:noreply,
            socket
-           |> unsubscribe_deploy_site_presence()
            |> assign(
              Keyword.merge(site_assigns,
                site_panel: Map.put(Keyword.fetch!(site_assigns, :site_panel), :view, :edit_site),
@@ -103,13 +99,12 @@ defmodule PortalWeb.Sites do
 
     {:noreply,
      socket
-     |> unsubscribe_deploy_site_presence()
      |> assign(site_state_reset_assigns())
      |> put_state(:new_site, %{open: true, form: to_form(changeset)})}
   end
 
   def handle_params(_params, _uri, socket) do
-    {:noreply, socket |> unsubscribe_deploy_site_presence() |> assign(site_state_reset_assigns())}
+    {:noreply, assign(socket, site_state_reset_assigns())}
   end
 
   defp redirect_to_sites_index(socket, message) do
@@ -342,7 +337,7 @@ defmodule PortalWeb.Sites do
                 </div>
               </td>
               <td class="px-4 py-3">
-                <% online = gateway_online_count(@internet_site.id) %>
+                <% online = Map.get(@online_gateway_counts, @internet_site.id, 0) %>
                 <span class="text-sm text-body tabular-nums">
                   {online}<span class="ml-1.5 text-[10px] text-subtle">online</span>
                 </span>
@@ -354,7 +349,7 @@ defmodule PortalWeb.Sites do
               </td>
               <td class="px-4 py-3">
                 <.site_status_badge status={
-                  compute_site_status(@internet_site.id, @internet_site.health_threshold)
+                  compute_site_status(online, @internet_site.health_threshold)
                 } />
               </td>
             </tr>
@@ -385,7 +380,7 @@ defmodule PortalWeb.Sites do
                 </div>
               </td>
               <td class="px-4 py-3">
-                <% online = gateway_online_count(site.id) %>
+                <% online = Map.get(@online_gateway_counts, site.id, 0) %>
                 <span class="text-sm text-body tabular-nums">
                   {online}<span class="ml-1.5 text-[10px] text-subtle">online</span>
                 </span>
@@ -396,7 +391,7 @@ defmodule PortalWeb.Sites do
                 </span>
               </td>
               <td class="px-4 py-3">
-                <.site_status_badge status={compute_site_status(site.id, site.health_threshold)} />
+                <.site_status_badge status={compute_site_status(online, site.health_threshold)} />
               </td>
             </tr>
           </tbody>
@@ -479,7 +474,7 @@ defmodule PortalWeb.Sites do
     all_gateways =
       site_id
       |> Database.list_gateways_for_site(subject)
-      |> Presence.Gateways.preload_gateways_presence()
+      |> Presence.Devices.preload_presence()
 
     gateways =
       if show_all? do
@@ -496,8 +491,7 @@ defmodule PortalWeb.Sites do
       env: nil,
       tab: "debian-instructions",
       connected?: false,
-      token: nil,
-      subscribed_site_id: nil
+      token: nil
     }
   end
 
@@ -528,13 +522,7 @@ defmodule PortalWeb.Sites do
 
   # ---- Helpers ----
 
-  defp gateway_online_count(site_id) do
-    Presence.Gateways.Site.list(site_id) |> map_size()
-  end
-
-  defp compute_site_status(site_id, threshold) do
-    online = gateway_online_count(site_id)
-
+  defp compute_site_status(online, threshold) do
     cond do
       online == 0 -> :offline
       online < threshold -> :degraded
@@ -874,11 +862,6 @@ defmodule PortalWeb.Sites do
             subject
           )
 
-        socket =
-          socket
-          |> unsubscribe_deploy_site_presence()
-          |> subscribe_deploy_site_presence(site.id)
-
         env = [
           {"FIREZONE_ID", Ecto.UUID.generate()},
           {"FIREZONE_TOKEN", encoded_token}
@@ -900,8 +883,7 @@ defmodule PortalWeb.Sites do
            env: env,
            tab: "debian-instructions",
            token: token,
-           connected?: false,
-           subscribed_site_id: site.id
+           connected?: false
          })}
 
       {:error, _} ->
@@ -916,7 +898,6 @@ defmodule PortalWeb.Sites do
   def handle_event("close_deploy", _params, socket) do
     {:noreply,
      socket
-     |> unsubscribe_deploy_site_presence()
      |> merge_state(:site_panel, %{view: :gateways})
      |> put_state(:site_deploy, base_site_deploy_state())}
   end
@@ -1181,25 +1162,17 @@ defmodule PortalWeb.Sites do
 
   def handle_info(
         %Phoenix.Socket.Broadcast{
-          event: "presence_diff",
-          topic: "presences:sites:" <> _site_id,
+          topic: "presences:account_devices:" <> _account_id,
           payload: %{joins: joins}
         },
         socket
       ) do
-    case site_deploy_connection_status(socket.assigns.site_deploy, joins) do
-      :noop ->
-        {:noreply, socket}
+    socket =
+      case site_deploy_connection_status(socket.assigns.site_deploy, joins) do
+        :noop -> socket
+        connected? -> merge_state(socket, :site_deploy, %{connected?: connected?})
+      end
 
-      connected? ->
-        {:noreply, merge_state(socket, :site_deploy, %{connected?: connected?})}
-    end
-  end
-
-  def handle_info(
-        %Phoenix.Socket.Broadcast{topic: "presences:account_gateways:" <> _account_id},
-        socket
-      ) do
     socket = load_sites_index_data(socket)
 
     {device_tokens, panel_gateways, total_gateway_count} =
@@ -1239,25 +1212,6 @@ defmodule PortalWeb.Sites do
 
   defp selected_site_matches?(socket, id) do
     match?(%{id: ^id}, socket.assigns.selected_site)
-  end
-
-  defp subscribe_deploy_site_presence(socket, site_id) do
-    if connected?(socket) and socket.assigns.site_deploy.subscribed_site_id != site_id do
-      :ok = Presence.Gateways.Site.subscribe(site_id)
-      merge_state(socket, :site_deploy, %{subscribed_site_id: site_id})
-    else
-      socket
-    end
-  end
-
-  defp unsubscribe_deploy_site_presence(socket) do
-    if connected?(socket) do
-      site_id = socket.assigns.site_deploy.subscribed_site_id
-        :ok = PubSub.unsubscribe("presences:sites:#{site_id}")
-        merge_state(socket, :site_deploy, %{subscribed_site_id: nil})
-    else
-        socket
-    end
   end
 
   defp parse_site_tab("resources"), do: :resources
@@ -1316,6 +1270,7 @@ defmodule PortalWeb.Sites do
     |> assign(resources_counts: resources_counts)
     |> assign(policies_counts: policies_counts)
     |> assign(gateway_counts: gateway_counts)
+    |> assign(online_gateway_counts: Presence.Devices.online_gateway_counts(socket.assigns.account.id))
     |> assign(internet_resource: internet_resource)
     |> assign(internet_site: internet_site)
   end
@@ -1588,7 +1543,7 @@ defmodule PortalWeb.Sites do
           nil
 
         resource ->
-          gateways = Presence.Gateways.preload_gateways_presence(resource.site.gateways)
+          gateways = Presence.Devices.preload_presence(resource.site.gateways)
           put_in(resource.site.gateways, gateways)
       end
     end

--- a/elixir/test/portal/workers/outdated_gateways_test.exs
+++ b/elixir/test/portal/workers/outdated_gateways_test.exs
@@ -156,12 +156,12 @@ defmodule Portal.Workers.OutdatedGatewaysTest do
         )
 
       assert :ok =
-               Portal.Presence.Gateways.connect(
+               Portal.Presence.Devices.connect(
                  gateway,
                  gateway.gateway_token_id
                )
 
-      assert Map.has_key?(Portal.Presence.Gateways.Site.list(site.id), gateway.id)
+      assert gateway.id in Portal.Presence.Devices.online_ids(account.id, :gateway)
 
       assert :ok = perform_job(OutdatedGateways, %{})
 
@@ -193,7 +193,7 @@ defmodule Portal.Workers.OutdatedGatewaysTest do
           last_seen_version: "0.9.0"
         )
 
-      assert :ok = Portal.Presence.Gateways.connect(gateway, gateway.gateway_token_id)
+      assert :ok = Portal.Presence.Devices.connect(gateway, gateway.gateway_token_id)
 
       assert :ok = perform_job(OutdatedGateways, %{})
 
@@ -224,7 +224,7 @@ defmodule Portal.Workers.OutdatedGatewaysTest do
           last_seen_version: "0.9.0"
         )
 
-      assert :ok = Portal.Presence.Gateways.connect(gateway, gateway.gateway_token_id)
+      assert :ok = Portal.Presence.Devices.connect(gateway, gateway.gateway_token_id)
 
       assert :ok = perform_job(OutdatedGateways, %{})
 

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -109,7 +109,7 @@ defmodule PortalAPI.Client.ChannelTest do
       remote_ip_location_lon: gateway.last_seen_remote_ip_location_lon
     }
 
-    Presence.Gateways.connect(gateway, token_id, session_meta)
+    Presence.Devices.connect(gateway, token_id, session_meta)
   end
 
   defp put_user_agent(subject, user_agent) do
@@ -366,7 +366,7 @@ defmodule PortalAPI.Client.ChannelTest do
       join_channel(client, subject)
       assert_push "init", _init_payload
 
-      presence = Presence.Clients.Account.list(account.id)
+      presence = Presence.Devices.Account.list(account.id)
 
       assert %{metas: [%{online_at: online_at, phx_ref: _ref}]} = Map.fetch!(presence, client.id)
       assert is_number(online_at)
@@ -1036,7 +1036,7 @@ defmodule PortalAPI.Client.ChannelTest do
       socket = join_channel(client, subject)
       assert_push "init", _init_payload
 
-      assert Presence.Clients.Account.list(client.account_id) |> Map.has_key?(client.id)
+      assert Presence.Devices.Account.list(client.account_id) |> Map.has_key?(client.id)
 
       # Simulate a Presence shard crash by sending a :DOWN for one of the
       # monitored presence pids. We can't kill real shards in async tests
@@ -1046,7 +1046,7 @@ defmodule PortalAPI.Client.ChannelTest do
       send(socket.channel_pid, {:DOWN, make_ref(), :process, shard_pid, :killed})
       :sys.get_state(socket.channel_pid)
 
-      assert Presence.Clients.Account.list(client.account_id) |> Map.has_key?(client.id)
+      assert Presence.Devices.Account.list(client.account_id) |> Map.has_key?(client.id)
     end
 
     test "retries tracking when Presence supervisor name is temporarily unregistered", %{
@@ -1068,7 +1068,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
       wait_for(fn ->
         :sys.get_state(socket.channel_pid)
-        assert Presence.Clients.Account.list(client.account_id) |> Map.has_key?(client.id)
+        assert Presence.Devices.Account.list(client.account_id) |> Map.has_key?(client.id)
       end)
     end
 
@@ -1083,7 +1083,7 @@ defmodule PortalAPI.Client.ChannelTest do
       send(socket.channel_pid, :track_presence)
       :sys.get_state(socket.channel_pid)
 
-      assert Presence.Clients.Account.list(client.account_id) |> Map.has_key?(client.id)
+      assert Presence.Devices.Account.list(client.account_id) |> Map.has_key?(client.id)
     end
   end
 
@@ -2275,7 +2275,7 @@ defmodule PortalAPI.Client.ChannelTest do
       assert state.assigns.client.ipv6 == new_ipv6
 
       assert {client_id, %{ipv4: ipv4}} =
-               Presence.Clients.Account.find_by_ipv4(account.id, new_ipv4.address)
+               Presence.Devices.Account.find_by_ipv4(account.id, new_ipv4.address)
 
       assert client_id == client.id
       assert ipv4 == new_ipv4.address
@@ -5855,7 +5855,7 @@ defmodule PortalAPI.Client.ChannelTest do
       }
 
       :ok =
-        Presence.Clients.connect(
+        Presence.Devices.connect(
           target_client,
           target_subject.credential.id,
           session_meta
@@ -6227,7 +6227,7 @@ defmodule PortalAPI.Client.ChannelTest do
       }
 
       :ok =
-        Presence.Clients.connect(
+        Presence.Devices.connect(
           target_client,
           target_subject.credential.id,
           session_meta
@@ -6284,7 +6284,7 @@ defmodule PortalAPI.Client.ChannelTest do
         user_agent: "Mac OS/14 apple-client/1.5.16"
       }
 
-      :ok = Presence.Clients.connect(target_client, target_subject.credential.id, session_meta)
+      :ok = Presence.Devices.connect(target_client, target_subject.credential.id, session_meta)
       # Test pid stands in for the target's channel so we can capture (and
       # withhold) the ack.
       :ok = PG.register(target_client_id)
@@ -6335,7 +6335,7 @@ defmodule PortalAPI.Client.ChannelTest do
         user_agent: "Mac OS/14 apple-client/1.5.16"
       }
 
-      :ok = Presence.Clients.connect(target_client, target_subject.credential.id, session_meta)
+      :ok = Presence.Devices.connect(target_client, target_subject.credential.id, session_meta)
       :ok = PG.register(target_client_id)
 
       initiating_socket = join_channel(client, subject)

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -213,7 +213,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       join_channel(gateway, site, token)
       assert_push "init", _init_payload
 
-      presence = Portal.Presence.Gateways.Account.list(account.id)
+      presence = Portal.Presence.Devices.Account.list(account.id)
 
       assert %{metas: [%{online_at: online_at, phx_ref: _ref}]} = Map.fetch!(presence, gateway.id)
       assert is_number(online_at)
@@ -1034,7 +1034,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       socket = join_channel(gateway, site, token)
       assert_push "init", _init_payload
 
-      assert Portal.Presence.Gateways.Account.list(gateway.account_id)
+      assert Portal.Presence.Devices.Account.list(gateway.account_id)
              |> Map.has_key?(gateway.id)
 
       # Simulate a Presence shard crash by sending a :DOWN for one of the
@@ -1045,7 +1045,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       send(socket.channel_pid, {:DOWN, make_ref(), :process, shard_pid, :killed})
       :sys.get_state(socket.channel_pid)
 
-      assert Portal.Presence.Gateways.Account.list(gateway.account_id)
+      assert Portal.Presence.Devices.Account.list(gateway.account_id)
              |> Map.has_key?(gateway.id)
     end
 
@@ -1070,7 +1070,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       wait_for(fn ->
         :sys.get_state(socket.channel_pid)
 
-        assert Portal.Presence.Gateways.Account.list(gateway.account_id)
+        assert Portal.Presence.Devices.Account.list(gateway.account_id)
                |> Map.has_key?(gateway.id)
       end)
     end
@@ -1087,7 +1087,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       send(socket.channel_pid, :track_presence)
       :sys.get_state(socket.channel_pid)
 
-      assert Portal.Presence.Gateways.Account.list(gateway.account_id)
+      assert Portal.Presence.Devices.Account.list(gateway.account_id)
              |> Map.has_key?(gateway.id)
     end
   end

--- a/elixir/test/portal_api/relay/channel_test.exs
+++ b/elixir/test/portal_api/relay/channel_test.exs
@@ -34,7 +34,7 @@ defmodule PortalAPI.Relay.ChannelTest do
 
   describe "join/3" do
     test "tracks presence after join", %{relay: relay} do
-      presence = Portal.Presence.Relays.Global.list()
+      presence = Portal.Presence.Relays.list()
 
       assert %{metas: [%{ipv4: _, phx_ref: _ref}]} = Map.fetch!(presence, relay.id)
     end
@@ -131,7 +131,7 @@ defmodule PortalAPI.Relay.ChannelTest do
       test_pid = self()
 
       # Capture the test-specific topic before spawning
-      topic = Portal.Presence.Relays.Global.topic()
+      topic = Portal.Presence.Relays.topic()
 
       # First "connection" - spawn a process that tracks presence directly
       first_pid =
@@ -157,7 +157,7 @@ defmodule PortalAPI.Relay.ChannelTest do
       assert_receive :first_connected, 1000
 
       # Verify first connection is tracked
-      presence = Portal.Presence.Relays.Global.list()
+      presence = Portal.Presence.Relays.list()
       assert %{metas: [%{ipv4: _}]} = Map.fetch!(presence, relay.id)
 
       # Monitor the first process

--- a/elixir/test/portal_web/live/actors_test.exs
+++ b/elixir/test/portal_web/live/actors_test.exs
@@ -466,6 +466,37 @@ defmodule PortalWeb.ActorsTest do
       assert html =~ token.id
     end
 
+    test "marks a client token online when its device joins the account presence", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      other_actor = actor_fixture(account: account)
+      token = client_token_fixture(account: account, actor: other_actor)
+      client = client_fixture(account: account, actor: other_actor)
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/#{other_actor}?tab=client_sessions")
+
+      assert html =~ "Offline"
+      refute html =~ "Online"
+
+      :ok = Portal.Presence.Devices.connect(client, token.id)
+
+      send(lv.pid, %Phoenix.Socket.Broadcast{
+        topic: "presences:account_devices:#{account.id}",
+        event: "presence_diff",
+        payload: %{
+          joins: %{client.id => %{metas: [%{actor_id: other_actor.id, token_id: token.id}]}},
+          leaves: %{}
+        }
+      })
+
+      assert render(lv) =~ "Online"
+    end
+
     test "shows portal session details in the portal sessions tab", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_web/live/devices_test.exs
+++ b/elixir/test/portal_web/live/devices_test.exs
@@ -206,8 +206,8 @@ defmodule PortalWeb.DevicesTest do
       offline =
         client_fixture(account: account, actor: actor, last_attested_at: DateTime.utc_now())
 
-      :ok = Portal.Presence.Clients.Account.track(account.id, attested.id)
-      :ok = Portal.Presence.Clients.Account.track(account.id, plain.id)
+      :ok = Portal.Presence.Devices.Account.track(attested)
+      :ok = Portal.Presence.Devices.Account.track(plain)
 
       conn = authorize_conn(conn, actor)
       {:ok, lv, _html} = live(conn, ~p"/#{account}/devices")

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -496,7 +496,7 @@ defmodule PortalWeb.ResourcesTest do
       end
 
       online_device = client_fixture(account: account, actor: actor, name: "Bulk Online")
-      :ok = Portal.Presence.Clients.Account.track(account.id, online_device.id)
+      :ok = Portal.Presence.Devices.Account.track(online_device)
 
       results = PortalWeb.Resources.Components.Database.search_devices("Bulk", subject, [])
 
@@ -1387,7 +1387,7 @@ defmodule PortalWeb.ResourcesTest do
       resource =
         static_device_pool_resource_fixture(account: account, devices: [device])
 
-      :ok = Portal.Presence.Clients.Account.track(account.id, device.id)
+      :ok = Portal.Presence.Devices.Account.track(device)
 
       {:ok, _lv, html} =
         conn

--- a/elixir/test/portal_web/live/sites_test.exs
+++ b/elixir/test/portal_web/live/sites_test.exs
@@ -543,6 +543,32 @@ defmodule PortalWeb.SitesTest do
       assert is_nil(token.rotated_at)
     end
 
+    test "deploy flips to connected when its gateway joins the account presence", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/sites/#{site.id}")
+
+      assert render_click(lv, "deploy_gateway") =~ "Waiting for connection..."
+
+      gateway = Repo.get_by!(Device, account_id: account.id, site_id: site.id, type: :gateway)
+      token = Repo.get_by!(GatewayToken, account_id: account.id, device_id: gateway.id)
+
+      send(lv.pid, %Phoenix.Socket.Broadcast{
+        topic: "presences:account_devices:#{account.id}",
+        event: "presence_diff",
+        payload: %{joins: %{gateway.id => %{metas: [%{token_id: token.id}]}}, leaves: %{}}
+      })
+
+      assert render(lv) =~ "Connected, click to continue"
+    end
+
     test "deploy no longer creates multi-owner site tokens", %{
       conn: conn,
       account: account,
@@ -638,10 +664,10 @@ defmodule PortalWeb.SitesTest do
       |> Repo.delete!()
 
       :ok = Portal.PG.join(new_token.id)
-      :ok = Portal.Presence.Gateways.Account.track(account.id, gateway.id)
+      :ok = Portal.Presence.Devices.Account.track(gateway)
 
       send(lv.pid, %Phoenix.Socket.Broadcast{
-        topic: "presences:account_gateways:#{account.id}",
+        topic: "presences:account_devices:#{account.id}",
         event: "presence_diff",
         payload: %{joins: %{}, leaves: %{}}
       })
@@ -677,7 +703,7 @@ defmodule PortalWeb.SitesTest do
       |> Repo.delete!()
 
       send(lv.pid, %Phoenix.Socket.Broadcast{
-        topic: "presences:account_gateways:#{account.id}",
+        topic: "presences:account_devices:#{account.id}",
         event: "presence_diff",
         payload: %{joins: %{}, leaves: %{}}
       })

--- a/elixir/test/support/channel_case.ex
+++ b/elixir/test/support/channel_case.ex
@@ -84,7 +84,7 @@ defmodule PortalAPI.ChannelCase do
     Portal.Config.put_env_override(
       :portal,
       :relay_presence_topic,
-      "presences:global_relays:#{inspect(make_ref())}"
+      "presences:relays:#{inspect(make_ref())}"
     )
 
     # Set debounce to 0 in tests for faster execution

--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -46,8 +46,12 @@ Application.ensure_all_started(:portal)
 account_id = \"c89bcc8c-9392-4dae-a40d-888aef6d28e0\"
 
 site = Portal.Repo.get_by!(Portal.Site, account_id: account_id, name: \"$site_name\")
-[gateway_id | _] = Portal.Presence.Gateways.Site.list(site.id) |> Map.keys()
-[client_id | _] = Portal.Presence.Clients.Account.list(account_id) |> Map.keys()
+online = Portal.Presence.Devices.Account.list(account_id)
+
+[gateway_id | _] =
+  for {id, %{metas: [%{type: :gateway, site_id: site_id} | _]}} <- online, site_id == site.id, do: id
+
+[client_id | _] = for {id, %{metas: [%{type: :client} | _]}} <- online, do: id
 resource = Portal.Repo.get_by!(Portal.Resource, account_id: account_id, name: \"$resource_name\")
 
 PortalAPI.Gateway.Channel.revoke_pair_access(gateway_id, client_id, resource.id)


### PR DESCRIPTION
Clients and gateways were tracked apart, on `presences:account_clients:` and `presences:account_gateways:`. Their metadata had drifted into two shapes: a gateway carried what a connection needs to pick it, a client carried the tunnel addresses and keys a device pool needs to reach it, and neither carried the other's.

They are one tracker now, on `presences:account_devices:`, with one meta built in one place from the device row. Both kinds carry the same keys, `nil` where a kind has no answer, so a reader that does not care which kind it is holding does not have to know. The two channels no longer assemble their own meta.

The per-actor and per-site trackers are gone too. The account meta now carries the actor id and the token id, so every page and worker that asked `presences:actor_clients:` or `presences:sites:` now filters the account list instead. The Actors and Service Accounts pages subscribe to the account topic once at mount and refresh their token list only when a diff carries a device of the selected actor. The relay topic is renamed from `presences:global_relays` to `presences:relays`.

Draft, because two things want a second opinion before this is merged. Every subscriber to the account topic now wakes on every connect in the account, so the Actors, Service Accounts, Sites, and Resources pages see joins they do not care about. And the topic names change, so during a deploy the two versions track to different topics and each sees only its own half until the older one is gone.

Related: #14899
Related: #14907
