### PR TITLE
chore(portal): isolate worktree test databases

### DIFF
--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -11,12 +11,14 @@ partition_suffix =
     ""
   end
 
+database = "#{System.get_env("DATABASE_NAME", "firezone")}_test#{partition_suffix}"
+
 config :portal, sql_sandbox: true
 
 config :portal, run_manual_migrations: true
 
 config :portal, Portal.Repo,
-  database: "firezone_test#{partition_suffix}",
+  database: database,
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: 5,
   queue_target: 1000
@@ -28,7 +30,7 @@ for repo <- [
       Portal.Repo.Poller
     ] do
   config :portal, repo,
-    database: "firezone_test#{partition_suffix}",
+    database: database,
     pool: Ecto.Adapters.SQL.Sandbox,
     pool_size: 5,
     queue_target: 1000


### PR DESCRIPTION
Builds the test DB name from the environment similar to the dev env, so that agents working in separate worktrees don't clobber each other.