### PR TITLE
fix(portal): route posture provider interest to engineering

### DIFF
--- a/elixir/lib/portal/mailer/posture_provider_interest_email.ex
+++ b/elixir/lib/portal/mailer/posture_provider_interest_email.ex
@@ -4,7 +4,7 @@ defmodule Portal.Mailer.PostureProviderInterestEmail do
   import Portal.Mailer
   import Swoosh.Email
 
-  @support_email "support@firezone.dev"
+  @engineering_email "engineering@firezone.dev"
   @subject "Posture Provider interest"
 
   def interest_email(%Portal.Authentication.Subject{} = subject, provider) do
@@ -37,7 +37,7 @@ defmodule Portal.Mailer.PostureProviderInterestEmail do
   defp base_email(subject) do
     default_email()
     |> subject(@subject)
-    |> to(@support_email)
+    |> to(@engineering_email)
     |> with_account_id(subject.account.id)
   end
 end

--- a/elixir/lib/portal_web/live/settings/device_posture.ex
+++ b/elixir/lib/portal_web/live/settings/device_posture.ex
@@ -866,11 +866,6 @@ defmodule PortalWeb.Settings.DevicePosture do
                   </span>
                 </.link>
               </li>
-              <li class="pt-3 pb-1">
-                <p class="text-[10px] font-semibold tracking-widest uppercase text-subtle">
-                  Coming soon
-                </p>
-              </li>
               <li :for={provider <- @coming_soon_providers}>
                 <button
                   id={"register-interest-#{provider.type}"}

--- a/elixir/test/portal/mailer/posture_provider_interest_email_test.exs
+++ b/elixir/test/portal/mailer/posture_provider_interest_email_test.exs
@@ -15,10 +15,10 @@ defmodule Portal.Mailer.PostureProviderInterestEmailTest do
     %{account: account, actor: actor, subject: subject}
   end
 
-  test "builds an interest email for support", context do
+  test "builds an interest email for engineering", context do
     email = PostureProviderInterestEmail.interest_email(context.subject, "Jamf Pro")
 
-    assert email.to == [{"", "support@firezone.dev"}]
+    assert email.to == [{"", "engineering@firezone.dev"}]
     assert email.subject == "Posture Provider interest"
     assert email.text_body =~ "Actor ID: #{context.actor.id}"
     assert email.text_body =~ "Account ID: #{context.account.id}"
@@ -26,7 +26,7 @@ defmodule Portal.Mailer.PostureProviderInterestEmailTest do
     refute email.text_body =~ "Feedback:"
   end
 
-  test "builds a separate feedback email for support", context do
+  test "builds a separate feedback email for engineering", context do
     email =
       PostureProviderInterestEmail.feedback_email(
         context.subject,
@@ -34,7 +34,7 @@ defmodule Portal.Mailer.PostureProviderInterestEmailTest do
         "We need device compliance and encryption status."
       )
 
-    assert email.to == [{"", "support@firezone.dev"}]
+    assert email.to == [{"", "engineering@firezone.dev"}]
     assert email.subject == "Posture Provider interest"
     assert email.text_body =~ "Actor ID: #{context.actor.id}"
     assert email.text_body =~ "Account ID: #{context.account.id}"

--- a/elixir/test/portal_web/live/settings/device_posture_test.exs
+++ b/elixir/test/portal_web/live/settings/device_posture_test.exs
@@ -167,6 +167,8 @@ defmodule PortalWeb.Settings.DevicePostureTest do
       assert html =~ provider
     end
 
+    refute html =~ "Coming soon"
+
     assert has_element?(lv, ~s(img[src="/images/logo-crowdstrike.svg"]))
     assert has_element?(lv, ~s(img[src="/images/logo-sophos.svg"]))
     assert has_element?(lv, ~s(img[src="/images/logo-jamf.svg"]))
@@ -192,7 +194,7 @@ defmodule PortalWeb.Settings.DevicePostureTest do
              "We&#39;ve registered your interest in CrowdStrike Falcon support in Firezone."
 
     assert_email_sent(fn email ->
-      assert email.to == [{"", "support@firezone.dev"}]
+      assert email.to == [{"", "engineering@firezone.dev"}]
       assert email.subject == "Posture Provider interest"
       assert email.text_body =~ "Actor ID: #{context.actor.id}"
       assert email.text_body =~ "Account ID: #{context.account.id}"
@@ -212,7 +214,7 @@ defmodule PortalWeb.Settings.DevicePostureTest do
     refute html =~ "Send feedback"
 
     assert_email_sent(fn email ->
-      assert email.to == [{"", "support@firezone.dev"}]
+      assert email.to == [{"", "engineering@firezone.dev"}]
       assert email.subject == "Posture Provider interest"
       assert email.text_body =~ "Actor ID: #{context.actor.id}"
       assert email.text_body =~ "Account ID: #{context.account.id}"


### PR DESCRIPTION
## Summary
- remove the misleading "Coming soon" label from the posture provider create form
- route posture provider interest and feedback emails to engineering@firezone.dev
- retain the shared default mailer sender and delivery path

## Testing
- `mix format --check-formatted lib/portal/mailer/posture_provider_interest_email.ex lib/portal_web/live/settings/device_posture.ex test/portal/mailer/posture_provider_interest_email_test.exs test/portal_web/live/settings/device_posture_test.exs`
- `mix test test/portal/mailer/posture_provider_interest_email_test.exs test/portal_web/live/settings/device_posture_test.exs`