### PR TITLE
test(portal): make log ordering deterministic

### DIFF
--- a/elixir/test/portal_api/controllers/log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/log_controller_test.exs
@@ -194,7 +194,7 @@ defmodule PortalAPI.LogControllerTest do
       conn =
         conn
         |> authorize_conn(actor)
-        |> get(~p"/logs?type=session")
+        |> get(~p"/logs?type=session&begin=2026-05-31T00:00:00Z&end=2026-06-04T00:00:00Z")
 
       assert %{"data" => data} = json_response(conn, 200)
 
@@ -305,7 +305,7 @@ defmodule PortalAPI.LogControllerTest do
       conn =
         conn
         |> authorize_conn(actor)
-        |> get(~p"/logs?type=flow")
+        |> get(~p"/logs?type=flow&begin=2026-05-31T00:00:00Z&end=2026-06-04T00:00:00Z")
 
       assert %{"data" => data} = json_response(conn, 200)
       assert Enum.map(data, & &1["log_id"]) == [newer.log_id, older.log_id]


### PR DESCRIPTION

- add explicit time windows to the session and flow log ordering tests
- prevent fixed June 2026 fixtures from falling outside the API's rolling 90-day default window
