### PR TITLE
fix(portal): window flow logs by flow_start

### DIFF
--- a/elixir/lib/portal_api/controllers/log_controller.ex
+++ b/elixir/lib/portal_api/controllers/log_controller.ex
@@ -94,6 +94,8 @@ defmodule PortalAPI.LogController do
         Inclusive start of the time window. RFC 3339 timestamp; non-UTC
         offsets are accepted and converted to UTC. Defaults to 90 days
         before the current time when omitted.
+
+        For `flow` entries the window applies to when the flow started.
         """,
         type: :string,
         example: "2026-02-25T00:00:00Z"
@@ -104,6 +106,8 @@ defmodule PortalAPI.LogController do
         Inclusive end of the time window. RFC 3339 timestamp; non-UTC
         offsets are accepted and converted to UTC. Defaults to the current
         time when omitted.
+
+        For `flow` entries the window applies to when the flow started.
         """,
         type: :string,
         example: "2026-05-26T00:00:00Z"
@@ -466,36 +470,18 @@ defmodule PortalAPI.LogController do
         ]
       end
 
-      # The window matches flows that were active at any point inside it:
-      # the flow's [flow_start, flow_end) range must overlap [begin, end].
-      # Each bound is written as a range-overlap against
-      # tstzrange(flow_start, flow_end, '[)') so it matches the expression
-      # indexed by the flow_logs_unique_flow_per_window exclusion constraint
-      # and can be served by its GiST index.
+      # The window is a plain range over flow_start, the same way the other log
+      # types filter on their one timestamp. flow_end is reported by the
+      # gateway from its own clock and is never queried, so a flow whose
+      # reported end precedes its start is listed like any other.
+      #
+      # flow_start is also the partition key, so both bounds prune.
       defp filter_by_begin(queryable, %DateTime{} = begin_at) do
-        {queryable,
-         dynamic(
-           [logs: l],
-           fragment(
-             "tstzrange(?, ?, '[)') && tstzrange(?, NULL, '[)')",
-             l.flow_start,
-             l.flow_end,
-             ^begin_at
-           )
-         )}
+        {queryable, dynamic([logs: l], l.flow_start >= ^begin_at)}
       end
 
       defp filter_by_end(queryable, %DateTime{} = end_at) do
-        {queryable,
-         dynamic(
-           [logs: l],
-           fragment(
-             "tstzrange(?, ?, '[)') && tstzrange(NULL, ?, '(]')",
-             l.flow_start,
-             l.flow_end,
-             ^end_at
-           )
-         )}
+        {queryable, dynamic([logs: l], l.flow_start <= ^end_at)}
       end
 
       # The `actor_id` / `actor_email` filter names are shared across all four

--- a/elixir/priv/static/openapi.json
+++ b/elixir/priv/static/openapi.json
@@ -17307,7 +17307,7 @@
             }
           },
           {
-            "description": "Inclusive start of the time window. RFC 3339 timestamp; non-UTC\noffsets are accepted and converted to UTC. Defaults to 90 days\nbefore the current time when omitted.\n",
+            "description": "Inclusive start of the time window. RFC 3339 timestamp; non-UTC\noffsets are accepted and converted to UTC. Defaults to 90 days\nbefore the current time when omitted.\n\nFor `flow` entries the window applies to when the flow started.\n",
             "example": "2026-02-25T00:00:00Z",
             "in": "query",
             "name": "begin",
@@ -17317,7 +17317,7 @@
             }
           },
           {
-            "description": "Inclusive end of the time window. RFC 3339 timestamp; non-UTC\noffsets are accepted and converted to UTC. Defaults to the current\ntime when omitted.\n",
+            "description": "Inclusive end of the time window. RFC 3339 timestamp; non-UTC\noffsets are accepted and converted to UTC. Defaults to the current\ntime when omitted.\n\nFor `flow` entries the window applies to when the flow started.\n",
             "example": "2026-05-26T00:00:00Z",
             "in": "query",
             "name": "end",

--- a/elixir/test/portal_api/controllers/log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/log_controller_test.exs
@@ -312,20 +312,41 @@ defmodule PortalAPI.LogControllerTest do
       assert Enum.all?(data, &(&1["type"] == "flow"))
     end
 
-    test "the window matches flows active inside it, not their ingestion time", %{
+    test "a flow whose reported end precedes its start is still listed", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      # Spans the whole window despite starting before it.
-      long_lived =
+      # Both timestamps come from the gateway's own clock, so skew can put the
+      # end before the start. That used to make tstzrange raise and fail the
+      # whole listing, not just drop the row.
+      skewed =
         flow_log_fixture(
           account: account,
-          flow_start: ~U[2026-06-01 00:00:00.000000Z],
-          flow_end: ~U[2026-06-05 00:00:00.000000Z]
+          flow_start: ~U[2026-06-02 00:01:00.000000Z],
+          flow_end: ~U[2026-06-02 00:00:00.000000Z]
         )
 
-      # Active inside the window, but ingested long after it.
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> get(~p"/logs?type=flow&begin=2026-06-01T00:00:00Z&end=2026-06-03T00:00:00Z")
+
+      assert %{"data" => data} = json_response(conn, 200)
+      assert Enum.map(data, & &1["log_id"]) == [skewed.log_id]
+
+      # and the reported timestamps are returned as they were recorded
+      assert [entry] = data
+      assert entry["flow_start"] == "2026-06-02T00:01:00.000000Z"
+      assert entry["flow_end"] == "2026-06-02T00:00:00.000000Z"
+    end
+
+    test "the window is when the flow started, not when it was ingested", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      # Started inside the window but ingested long after it.
       late_report =
         flow_log_fixture(
           account: account,
@@ -334,11 +355,20 @@ defmodule PortalAPI.LogControllerTest do
           inserted_at: ~U[2026-06-08 00:00:00.000000Z]
         )
 
-      # Ended before the window began.
+      # Still running, and started inside the window.
+      open_inside =
+        flow_log_fixture(
+          account: account,
+          flow_start: ~U[2026-06-03 12:00:00.000000Z],
+          flow_end: nil
+        )
+
+      # Running through the whole window, but started before it. The window
+      # applies to flow_start only, so this is deliberately not returned.
       flow_log_fixture(
         account: account,
-        flow_start: ~U[2026-06-02 00:00:00.000000Z],
-        flow_end: ~U[2026-06-03 00:00:00.000000Z]
+        flow_start: ~U[2026-06-01 00:00:00.000000Z],
+        flow_end: ~U[2026-06-05 00:00:00.000000Z]
       )
 
       # Started after the window ended.
@@ -354,10 +384,8 @@ defmodule PortalAPI.LogControllerTest do
         |> get(~p"/logs?type=flow&begin=2026-06-03T10:00:00Z&end=2026-06-03T14:00:00Z")
 
       assert %{"data" => data} = json_response(conn, 200)
-
-      assert Enum.map(data, & &1["log_id"]) == [late_report.log_id, long_lived.log_id]
+      assert Enum.map(data, & &1["log_id"]) == [open_inside.log_id, late_report.log_id]
     end
-
     test "renders flow log fields", %{conn: conn, account: account, actor: actor} do
       flow_log =
         flow_log_fixture(


### PR DESCRIPTION
If a `flow_end` came before `flow_start` such as during clock skew, the `flow_log` API query would 500 because it was looking for a strict overlap.

This fixes that by simplifying the query to search by flow_start only.
