### PR TITLE
fix(android): honour NO_TELEMETRY for connlib's telemetry

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -20,6 +20,7 @@ import com.google.firebase.installations.FirebaseInstallations
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
 import dagger.hilt.android.AndroidEntryPoint
+import dev.firezone.android.BuildConfig
 import dev.firezone.android.core.Log
 import dev.firezone.android.core.Telemetry
 import dev.firezone.android.core.data.Repository
@@ -253,7 +254,11 @@ class TunnelService : VpnService() {
         activeService = this
         registerReceiver(restrictionsReceiver, restrictionsFilter)
 
-        startTelemetry(protectSocketCallback)
+        // `Telemetry.start` honours this for the Kotlin side; connlib's telemetry is a separate
+        // client, so without this a build stamped as not reporting still reports.
+        if (!BuildConfig.NO_TELEMETRY) {
+            startTelemetry(protectSocketCallback)
+        }
     }
 
     override fun onDestroy() {
@@ -261,7 +266,9 @@ class TunnelService : VpnService() {
         unregisterReceiver(restrictionsReceiver)
         serviceScope.cancel()
 
-        stopTelemetry()
+        if (!BuildConfig.NO_TELEMETRY) {
+            stopTelemetry()
+        }
         super.onDestroy()
     }
 


### PR DESCRIPTION
`FIREZONE_NO_TELEMETRY` is stamped into every build CI produces so that neither a CI run nor a debug artifact someone installs later reports to Sentry. `Telemetry.start` honours it, but connlib keeps its own Sentry client and `startTelemetry` was called unconditionally, so the flag only ever covered half of what it names.

Related: #14905
