### PR TITLE
fix(x509-claims): hide certificate gates a certificate meets

### DIFF
--- a/rust/libs/x509-claims-ffi/src/lib.rs
+++ b/rust/libs/x509-claims-ffi/src/lib.rs
@@ -54,6 +54,8 @@ pub enum ValidationError {
     UnknownAttribute,
     NotYetValid,
     Expired,
+    MissingClientAuthEku,
+    DigitalSignatureNotAllowed,
 }
 
 /// Metadata parsed from a client certificate, mirroring [`x509_claims::ParsedCertificate`].
@@ -175,6 +177,10 @@ impl From<x509_claims::ValidationError> for ValidationError {
             x509_claims::ValidationError::UnknownAttribute => Self::UnknownAttribute,
             x509_claims::ValidationError::NotYetValid => Self::NotYetValid,
             x509_claims::ValidationError::Expired => Self::Expired,
+            x509_claims::ValidationError::MissingClientAuthEku => Self::MissingClientAuthEku,
+            x509_claims::ValidationError::DigitalSignatureNotAllowed => {
+                Self::DigitalSignatureNotAllowed
+            }
         }
     }
 }

--- a/rust/libs/x509-claims/src/lib.rs
+++ b/rust/libs/x509-claims/src/lib.rs
@@ -112,6 +112,8 @@ pub enum ValidationError {
     UnknownAttribute,
     NotYetValid,
     Expired,
+    MissingClientAuthEku,
+    DigitalSignatureNotAllowed,
 }
 
 impl ValidationError {
@@ -127,6 +129,8 @@ impl ValidationError {
             Self::UnknownAttribute => "not an attribute we understand",
             Self::NotYetValid => "not yet valid",
             Self::Expired => "expired",
+            Self::MissingClientAuthEku => "required for mutual TLS",
+            Self::DigitalSignatureNotAllowed => "required to sign the TLS handshake",
         }
     }
 }
@@ -203,21 +207,24 @@ impl ParsedCertificate {
                     .is_some_and(|at| at > self.not_after_timestamp)
                     .then_some(ValidationError::Expired),
             ),
-            field(
+            gate_field(
                 "TLS Client Authentication EKU",
                 if self.has_client_auth_eku {
                     "Yes"
                 } else {
                     "No"
                 },
+                (!self.has_client_auth_eku).then_some(ValidationError::MissingClientAuthEku),
             ),
-            field(
+            gate_field(
                 "Digital Signature Key Usage",
                 if self.digital_signature_allowed {
                     "Allowed"
                 } else {
                     "Not allowed"
                 },
+                (!self.digital_signature_allowed)
+                    .then_some(ValidationError::DigitalSignatureNotAllowed),
             ),
             field(
                 "Signing Algorithm",
@@ -228,6 +235,8 @@ impl ParsedCertificate {
             ),
             field("SHA-256 Fingerprint", &self.fingerprint),
         ]);
+
+        fields.retain(DetailField::is_worth_reading);
 
         // What is wrong with a certificate is what the reader came for, so it reads before the
         // rows that are merely true. The sort is stable, which is what keeps a row from moving
@@ -326,6 +335,23 @@ pub struct DetailField {
     pub value: Option<String>,
     /// Why the value above is not usable, [`None`] when it is.
     pub problem: Option<ValidationError>,
+    pub visibility: Visibility,
+}
+
+/// Whether a row reads on a healthy certificate, or only once something is wrong with it.
+///
+/// A requirement the certificate meets is not what the reader came for, so its row is
+/// [`Visibility::OnlyWhenWrong`] and [`ParsedCertificate::detail_fields`] drops it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Visibility {
+    Always,
+    OnlyWhenWrong,
+}
+
+impl DetailField {
+    fn is_worth_reading(&self) -> bool {
+        self.problem.is_some() || self.visibility == Visibility::Always
+    }
 }
 
 pub fn parse_certificate(der: &[u8], now: SystemTime) -> Option<ParsedCertificate> {
@@ -897,6 +923,21 @@ fn field(label: impl Into<String>, value: impl Into<String>) -> DetailField {
         label: label.into(),
         value: Some(value.into()),
         problem: None,
+        visibility: Visibility::Always,
+    }
+}
+
+/// A row for a requirement the certificate as a whole has to meet.
+fn gate_field(
+    label: impl Into<String>,
+    value: impl Into<String>,
+    problem: Option<ValidationError>,
+) -> DetailField {
+    DetailField {
+        label: label.into(),
+        value: Some(value.into()),
+        problem,
+        visibility: Visibility::OnlyWhenWrong,
     }
 }
 
@@ -909,6 +950,7 @@ fn field_with_problem(
         label: label.into(),
         value: Some(value.into()),
         problem,
+        visibility: Visibility::Always,
     }
 }
 
@@ -918,6 +960,7 @@ fn optional_field(label: impl Into<String>, value: Option<String>) -> DetailFiel
         label: label.into(),
         value,
         problem: None,
+        visibility: Visibility::Always,
     }
 }
 
@@ -926,6 +969,7 @@ fn claim_field(label: impl Into<String>, claim: Claim) -> DetailField {
         label: label.into(),
         value: claim.value,
         problem: claim.error,
+        visibility: Visibility::Always,
     }
 }
 
@@ -940,6 +984,7 @@ fn unrecognised_claim_field(claim: &str) -> DetailField {
         label: attribute.to_owned(),
         value: value.filter(|value| !value.is_empty()).map(str::to_owned),
         problem: Some(ValidationError::UnknownAttribute),
+        visibility: Visibility::Always,
     }
 }
 

--- a/rust/libs/x509-claims/tests/parse_certificate.rs
+++ b/rust/libs/x509-claims/tests/parse_certificate.rs
@@ -233,7 +233,7 @@ fn diagnostics_show_derived_firezone_attributes() {
 }
 
 #[test]
-fn diagnostics_show_what_a_certificate_lacks_without_judging_it() {
+fn diagnostics_flag_the_requirements_a_certificate_fails() {
     let der = certificate_without_client_identity_extensions();
 
     let metadata = parse_certificate(&der, now()).expect("generated certificate should parse");
@@ -243,20 +243,60 @@ fn diagnostics_show_what_a_certificate_lacks_without_judging_it() {
         Some("No")
     );
     assert_eq!(
+        detail_problem(&metadata, "TLS Client Authentication EKU"),
+        Some(ValidationError::MissingClientAuthEku)
+    );
+    assert_eq!(
         detail_value(&metadata, "Digital Signature Key Usage").as_deref(),
         Some("Not allowed")
     );
     assert_eq!(
+        detail_problem(&metadata, "Digital Signature Key Usage"),
+        Some(ValidationError::DigitalSignatureNotAllowed)
+    );
+
+    let fields = metadata.detail_fields();
+
+    assert_eq!(
+        labels(&fields.iter().take(2).collect::<Vec<_>>()),
+        [
+            "TLS Client Authentication EKU",
+            "Digital Signature Key Usage"
+        ],
+        "a requirement the certificate fails is why it cannot be used, so it reads first"
+    );
+}
+
+#[test]
+fn diagnostics_omit_the_requirements_a_certificate_meets() {
+    let metadata = parse_certificate(RSA_LEAF, now()).expect("fixture should parse");
+    assert!(metadata.has_client_auth_eku);
+    assert!(metadata.digital_signature_allowed);
+
+    for label in [
+        "TLS Client Authentication EKU",
+        "Digital Signature Key Usage",
+    ] {
+        assert!(
+            !metadata
+                .detail_fields()
+                .iter()
+                .any(|field| field.label == label),
+            "a requirement the certificate meets says nothing, so {label} has no row"
+        );
+    }
+}
+
+#[test]
+fn diagnostics_show_an_algorithm_the_parser_cannot_name() {
+    let der = certificate_without_client_identity_extensions();
+
+    let metadata = parse_certificate(&der, now()).expect("generated certificate should parse");
+
+    assert_eq!(
         detail_value(&metadata, "Signing Algorithm").as_deref(),
         Some("1.3.101.112"),
         "an algorithm the parser has no name for should still be shown"
-    );
-    assert!(
-        metadata
-            .detail_fields()
-            .iter()
-            .all(|field| field.problem.is_none()),
-        "what the portal makes of these rows is not a problem with them"
     );
 }
 
@@ -564,8 +604,6 @@ fn diagnostics_read_from_the_identity_down_to_the_encoding() {
             "Serial Number",
             "Not Before",
             "Not After",
-            "TLS Client Authentication EKU",
-            "Digital Signature Key Usage",
             "Signing Algorithm",
             "SHA-256 Fingerprint",
         ],
@@ -674,8 +712,6 @@ fn sparse_diagnostics_keep_the_order_without_leaving_gaps() {
             "Serial Number",
             "Not Before",
             "Not After",
-            "TLS Client Authentication EKU",
-            "Digital Signature Key Usage",
             "Signing Algorithm",
             "SHA-256 Fingerprint",
         ],

--- a/rust/tests/fuzz/fuzz_targets/x509_claims.rs
+++ b/rust/tests/fuzz/fuzz_targets/x509_claims.rs
@@ -237,6 +237,8 @@ fn assert_every_validation_error_reads() {
         ValidationError::UnknownAttribute,
         ValidationError::NotYetValid,
         ValidationError::Expired,
+        ValidationError::MissingClientAuthEku,
+        ValidationError::DigitalSignatureNotAllowed,
     ]
     .map(ValidationError::label);
 


### PR DESCRIPTION
The client-auth EKU and key-usage rows appeared on every certificate, even though they only have something to say when the certificate fails them. Every detail field now carries a visibility marker: a gate row is only worth reading when its requirement is not met, and it then reads as a validation error ("required for mutual TLS", "required to sign the TLS handshake") so the existing sort and error styling carry it with no new mechanism.