### PR TITLE
ci(android): fan the emulator tests out over one build

### DIFF
--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -58,8 +58,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - suite: app
-            package: dev.firezone.android.e2e
+          # A suite is a device the tests need, since ownership is the one thing a test cannot
+          # set up for itself. Splitting them wants `--notAnnotation`/`--annotation` rather than
+          # a package, so that every test lands in exactly one suite by construction.
+          - suite: unmanaged
     name: emulator-tests (${{ matrix.suite }})
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -91,7 +93,6 @@ jobs:
           # `working-directory` default and starts at the repository root.
           script: >-
             ./kotlin/android/mise-tasks/emulator-tests.sh
-            ${{ matrix.package }}
 
   update-release-draft:
     name: update-release-draft

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -45,19 +45,32 @@ jobs:
           name: android-screenshots
           path: kotlin/android/screenshots
 
-  instrumented-tests:
+  emulator-tests:
+    # The tests run against what `build-debug` already produced, so a suite costs an emulator
+    # rather than another Rust build. Adding one is a matrix entry.
+    needs: build_debug
     # The emulator needs KVM, which only the Linux runners provide.
     runs-on: ubuntu-24.04
     # An emulator that never boots would otherwise hold the run open for six hours.
     timeout-minutes: 30
+    strategy:
+      # One suite failing says nothing about the others.
+      fail-fast: false
+      matrix:
+        include:
+          - suite: app
+            package: dev.firezone.android.e2e
+    name: emulator-tests (${{ matrix.suite }})
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/free-disk-space
         with:
           keep-android: "true"
-      - uses: ./.github/actions/setup-android
+      # Where a local build leaves them, so the task below finds them the same way here.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          sccache-azure-connection-string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
+          name: Android debug APK
+          path: kotlin/android/app/build/outputs/apk
       # The runner ships /dev/kvm but leaves it readable only by root.
       - name: Grant access to KVM
         run: |
@@ -65,7 +78,7 @@ jobs:
             | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - name: Run instrumented tests
+      - name: Run the tests
         uses: reactivecircus/android-emulator-runner@c9c93e6ba9c4194322e114c40970d5983d9a07cc # v2.38.0
         with:
           api-level: 34
@@ -76,11 +89,9 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           # `script` is not a `run:` step, so it does not pick up the workflow's
           # `working-directory` default and starts at the repository root.
-          # Narrowing the ABI reuses the cargo build the other jobs already do.
           script: >-
-            cd kotlin/android &&
-            ./gradlew connectedDebugAndroidTest
-            -Pandroid.injected.build.abi=x86_64
+            ./kotlin/android/mise-tasks/emulator-tests.sh
+            ${{ matrix.package }}
 
   update-release-draft:
     name: update-release-draft
@@ -238,9 +249,11 @@ jobs:
       - uses: ./.github/actions/setup-android
         with:
           sccache-azure-connection-string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
+      # The instrumented tests run against these, so building them here is what spares every
+      # test suite a Rust build of its own. The APK is universal, so it installs on the emulator.
       - name: Build debug APK
         run: |
-          ./gradlew assembleDebug
+          ./gradlew assembleDebug assembleDebugAndroidTest
       - name: Upload debug APK
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/kotlin/android/mise-tasks/emulator-tests.sh
+++ b/kotlin/android/mise-tasks/emulator-tests.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#MISE description="Run the instrumented tests on an attached device from already-built APKs"
+#USAGE arg "[package]" help="Only run tests in this package; runs all of them when omitted"
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${SCRIPT_DIR}/.."
+
+APK_DIR="app/build/outputs/apk"
+RUNNER="dev.firezone.android.test/dev.firezone.android.core.HiltTestRunner"
+
+find_apk() {
+    find "$APK_DIR" -type f -name "$1" -exec ls -t {} + 2>/dev/null | head -1
+}
+
+app_apk="$(find_apk 'app-debug.apk')"
+test_apk="$(find_apk '*androidTest.apk')"
+
+if [ -z "$app_apk" ] || [ -z "$test_apk" ]; then
+    echo "error: no APKs under ${APK_DIR}. Build them:" >&2
+    echo "           ./gradlew assembleDebug assembleDebugAndroidTest" >&2
+    exit 1
+fi
+
+echo "==> Installing ${app_apk}"
+# `-t` because a build narrowed to one ABI is marked `android:testOnly`.
+adb install -r -g -t "$app_apk"
+
+echo "==> Installing ${test_apk}"
+adb install -r -g -t "$test_apk"
+
+echo "==> Running the tests..."
+# Read positionally rather than through `#USAGE`, which only binds under `mise run` and would
+# leave the filter silently unset when a workflow calls this directly.
+if [ -n "${1:-}" ]; then
+    result="$(adb shell am instrument -w -e package "$1" "$RUNNER")"
+else
+    result="$(adb shell am instrument -w "$RUNNER")"
+fi
+
+echo "$result"
+
+# `am instrument` reports failures in its output and exits 0 regardless.
+case "$result" in
+*"OK ("*) ;;
+*)
+    echo >&2
+    echo "error: the instrumented tests did not pass" >&2
+    exit 1
+    ;;
+esac

--- a/kotlin/android/mise-tasks/emulator-tests.sh
+++ b/kotlin/android/mise-tasks/emulator-tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Run the instrumented tests on an attached device from already-built APKs"
-#USAGE arg "[package]" help="Only run tests in this package; runs all of them when omitted"
+#USAGE arg "[filter]..." help="AndroidJUnitRunner arguments to narrow what runs, e.g. --annotation <class> or --notAnnotation <class>"
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -29,14 +29,28 @@ adb install -r -g -t "$app_apk"
 echo "==> Installing ${test_apk}"
 adb install -r -g -t "$test_apk"
 
+# Flags are AndroidJUnitRunner's own argument names, so `--notAnnotation X` reaches it as
+# `-e notAnnotation X` and its documentation reads across. Read positionally rather than through
+# `#USAGE`, which only binds under `mise run` and would leave a filter silently unset when a
+# workflow calls this directly.
+filter=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --*)
+        filter+=(-e "${1#--}" "$2")
+        shift 2
+        ;;
+    *)
+        echo "error: expected a flag like '--annotation <class>', got '$1'" >&2
+        exit 1
+        ;;
+    esac
+done
+
 echo "==> Running the tests..."
-# Read positionally rather than through `#USAGE`, which only binds under `mise run` and would
-# leave the filter silently unset when a workflow calls this directly.
-if [ -n "${1:-}" ]; then
-    result="$(adb shell am instrument -w -e package "$1" "$RUNNER")"
-else
-    result="$(adb shell am instrument -w "$RUNNER")"
-fi
+# Guarded because bash 3.2, which macOS still ships, treats an empty array as unset.
+result="$(adb shell am instrument -w ${filter[@]+"${filter[@]}"} "$RUNNER")"
 
 echo "$result"
 


### PR DESCRIPTION
The emulator job built the app itself, so a workflow run paid for two Rust builds: one for the artifact and one to run the tests against. Every further test suite would have paid for another.

It now installs what `build-debug` already published, which leaves a suite costing an emulator rather than a build, and makes adding one a matrix entry. The debug APK is universal, so it installs on the emulator as it is.
