### PR TITLE
ci(android): report Kotlin coverage to Coveralls

### DIFF
--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -130,14 +130,17 @@ jobs:
           path: kotlin/android/classes
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          name: android-jacoco-cli
+          path: kotlin/android/jacoco-cli
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
           pattern: android-coverage-*
           path: kotlin/android/execution-data
-      # Matched against `jacocoVersion` in `app/build.gradle.kts`: execution data is only readable
-      # by the JaCoCo that wrote it.
+      # The build hands over the JaCoCo that wrote the execution data, which is the only one that
+      # can read it, so no version is named here.
       - name: Report on the execution data
         run: |
-          curl -sSfL -o jacoco-cli.jar \
-            https://repo1.maven.org/maven2/org/jacoco/org.jacoco.cli/0.8.13/org.jacoco.cli-0.8.13-nodeps.jar
+          jacoco_cli=$(find jacoco-cli -name '*.jar' | head -1)
 
           mapfile -t execution_data < <(find execution-data -name '*.ec')
 
@@ -147,7 +150,7 @@ jobs:
             exit 1
           fi
 
-          java -jar jacoco-cli.jar report "${execution_data[@]}" \
+          java -jar "$jacoco_cli" report "${execution_data[@]}" \
             --classfiles classes \
             --sourcefiles app/src/main/java \
             --xml coverage.xml
@@ -327,7 +330,7 @@ jobs:
       # test suite a Rust build of its own. The APK is universal, so it installs on the emulator.
       - name: Build debug APK
         run: |
-          ./gradlew assembleDebug assembleDebugAndroidTest
+          ./gradlew assembleDebug assembleDebugAndroidTest copyJacocoCli
       - name: Upload debug APK
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -343,3 +346,10 @@ jobs:
           path: |
             ./kotlin/android/app/build/tmp/kotlin-classes/debug
             ./kotlin/android/app/build/intermediates/javac/debug/classes
+      # Kept apart from the classes: the report reads that directory as the code under test, and
+      # would happily measure JaCoCo itself if the tool sat in it.
+      - name: Upload the reporting tool
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: android-jacoco-cli
+          path: ./kotlin/android/app/build/jacoco-cli

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -35,8 +35,29 @@ jobs:
         run: ./gradlew lint -Pandroid.injected.build.abi=x86_64
       # AGP 9 only creates unit test components for the tested build type
       # (debug). Narrowing to one ABI reuses the cargo build from lint above.
-      - name: Run unit tests
-        run: ./gradlew testDebugUnitTest -Pandroid.injected.build.abi=x86_64
+      # The report task runs the tests, so it stands in for them rather than following them.
+      - name: Run unit tests and report coverage
+        run: ./gradlew createDebugUnitTestCoverageReport -Pandroid.injected.build.abi=x86_64
+      # AGP writes the report under a variant path this pins nothing to, so failing here names
+      # what it did write instead of leaving Coveralls to upload nothing.
+      - name: Find the coverage report
+        run: |
+          report=$(find app/build/reports/coverage -name '*.xml' | head -1)
+
+          if [ -z "$report" ]; then
+            echo "No coverage report was written. What is under app/build/reports:"
+            find app/build/reports -name '*.xml'
+            exit 1
+          fi
+
+          echo "COVERAGE_REPORT=kotlin/android/${report}" >> "$GITHUB_ENV"
+      - uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ env.COVERAGE_REPORT }}
+          format: jacoco
+          flag-name: kotlin-test
+          parallel: true
       # Renders the app's screens to PNGs; nothing is compared against a reference.
       - name: Record screenshots
         run: ./gradlew recordRoborazziDebug -Pandroid.injected.build.abi=x86_64

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -33,8 +33,15 @@ jobs:
       # narrowing to one ABI keeps coverage identical while avoiding the 4-ABI build.
       - name: Run Android Lint
         run: ./gradlew lint -Pandroid.injected.build.abi=x86_64
-      # AGP 9 only creates unit test components for the tested build type
-      # (debug). Narrowing to one ABI reuses the cargo build from lint above.
+
+  unit-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup-android
+        with:
+          sccache-azure-connection-string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
+      # AGP 9 only creates unit test components for the tested build type (debug).
       # The report task runs the tests, so it stands in for them rather than following them.
       - name: Run unit tests and report coverage
         run: ./gradlew createDebugUnitTestCoverageReport -Pandroid.injected.build.abi=x86_64
@@ -58,6 +65,14 @@ jobs:
           format: jacoco
           flag-name: kotlin-test
           parallel: true
+
+  screenshots:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup-android
+        with:
+          sccache-azure-connection-string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       # Renders the app's screens to PNGs; nothing is compared against a reference.
       - name: Record screenshots
         run: ./gradlew recordRoborazziDebug -Pandroid.injected.build.abi=x86_64

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -165,10 +165,18 @@ jobs:
             exit 1
           fi
 
+          set -o pipefail
           java -jar "$jacoco_cli" report "${execution_data[@]}" \
             --classfiles classes \
             --sourcefiles app/src/main/java \
-            --xml coverage.xml
+            --xml coverage.xml 2>&1 | tee report.log
+
+          # A class whose bytecode JaCoCo cannot match has its execution data dropped and is
+          # reported as uncovered, so a mismatch understates the result instead of failing.
+          if grep -q 'does not match' report.log; then
+            echo "The classes above were not the ones the tests ran against, so their coverage was dropped."
+            exit 1
+          fi
 
           # A report that resolved no classes still writes valid XML, so it is worth saying so
           # here rather than uploading an empty one.

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -63,6 +63,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ env.COVERAGE_REPORT }}
           format: jacoco
+          # A JaCoCo report locates a file by its package, so without the source root in
+          # front of it nothing Coveralls is given resolves to a file in the repository.
+          base-path: kotlin/android/app/src/main/java
           flag-name: kotlin-test
           parallel: true
 
@@ -190,6 +193,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: kotlin/android/coverage.xml
           format: jacoco
+          base-path: kotlin/android/app/src/main/java
           flag-name: kotlin-emulator
           parallel: true
 

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -345,7 +345,7 @@ jobs:
       # test suite a Rust build of its own. The APK is universal, so it installs on the emulator.
       - name: Build debug APK
         run: |
-          ./gradlew assembleDebug assembleDebugAndroidTest copyJacocoCli
+          ./gradlew assembleDebug assembleDebugAndroidTest copyJacocoCli collectDebugClasses
       - name: Upload debug APK
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -358,9 +358,10 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: android-debug-classes
-          path: |
-            ./kotlin/android/app/build/tmp/kotlin-classes/debug
-            ./kotlin/android/app/build/intermediates/javac/debug/classes
+          # The default is to warn and upload nothing, which only surfaces much later as a
+          # missing artifact in the job that reports on it.
+          if-no-files-found: error
+          path: ./kotlin/android/app/build/debug-classes
       # Kept apart from the classes: the report reads that directory as the code under test, and
       # would happily measure JaCoCo itself if the tool sat in it.
       - name: Upload the reporting tool

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -114,6 +114,58 @@ jobs:
           # `working-directory` default and starts at the repository root.
           script: >-
             ./kotlin/android/mise-tasks/emulator-tests.sh
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: android-coverage-${{ matrix.suite }}
+          path: kotlin/android/coverage.ec
+
+  emulator-coverage:
+    needs: emulator-tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: android-debug-classes
+          path: kotlin/android/classes
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: android-coverage-*
+          path: kotlin/android/execution-data
+      # Matched against `jacocoVersion` in `app/build.gradle.kts`: execution data is only readable
+      # by the JaCoCo that wrote it.
+      - name: Report on the execution data
+        run: |
+          curl -sSfL -o jacoco-cli.jar \
+            https://repo1.maven.org/maven2/org/jacoco/org.jacoco.cli/0.8.13/org.jacoco.cli-0.8.13-nodeps.jar
+
+          mapfile -t execution_data < <(find execution-data -name '*.ec')
+
+          if [ ${#execution_data[@]} -eq 0 ]; then
+            echo "No suite recorded any execution data. What was downloaded:"
+            find execution-data
+            exit 1
+          fi
+
+          java -jar jacoco-cli.jar report "${execution_data[@]}" \
+            --classfiles classes \
+            --sourcefiles app/src/main/java \
+            --xml coverage.xml
+
+          # A report that resolved no classes still writes valid XML, so it is worth saying so
+          # here rather than uploading an empty one.
+          if ! grep -q '<counter' coverage.xml; then
+            echo "The report counted nothing. The classes it was given:"
+            find classes -name '*.class' | head
+            exit 1
+          fi
+      - uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: kotlin/android/coverage.xml
+          format: jacoco
+          flag-name: kotlin-emulator
+          parallel: true
 
   update-release-draft:
     name: update-release-draft
@@ -282,3 +334,12 @@ jobs:
           name: Android debug APK
           path: |
             ./kotlin/android/app/build/outputs/apk/*
+      # Execution data records which probes ran, and says nothing about what they belong to, so
+      # reporting on it later needs the classes these tests were built from.
+      - name: Upload the compiled classes
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: android-debug-classes
+          path: |
+            ./kotlin/android/app/build/tmp/kotlin-classes/debug
+            ./kotlin/android/app/build/intermediates/javac/debug/classes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,5 +564,5 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
-          carryforward: portal,rust-fuzz-ip-packet,rust-fuzz-relay-proto,rust-fuzz-tunnel-proto,rust-test-Linux,rust-test-macOS,rust-test-Windows,swift-test,kotlin-test
+          carryforward: portal,rust-fuzz-ip-packet,rust-fuzz-relay-proto,rust-fuzz-tunnel-proto,rust-test-Linux,rust-test-macOS,rust-test-Windows,swift-test,kotlin-test,kotlin-emulator
           fail-on-error: false # Make CI less flaky

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,11 +552,11 @@ jobs:
 
   coverage-finish:
     name: coverage-finish
-    needs: [elixir, rust, swift]
+    needs: [elixir, rust, swift, kotlin]
     # `!cancelled()` so the Coveralls parallel upload is still finalized when one
     # of the coverage jobs fails; otherwise the default `success()` gate skips
     # this step and coverage is never reported.
-    if: ${{ !cancelled() && (needs.elixir.result != 'skipped' || needs.rust.result != 'skipped' || needs.swift.result != 'skipped') }}
+    if: ${{ !cancelled() && (needs.elixir.result != 'skipped' || needs.rust.result != 'skipped' || needs.swift.result != 'skipped' || needs.kotlin.result != 'skipped') }}
     runs-on: ubuntu-24.04
     steps:
       - name: Finalize coverage upload
@@ -564,5 +564,5 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
-          carryforward: portal,rust-fuzz-ip-packet,rust-fuzz-relay-proto,rust-fuzz-tunnel-proto,rust-test-Linux,rust-test-macOS,rust-test-Windows,swift-test
+          carryforward: portal,rust-fuzz-ip-packet,rust-fuzz-relay-proto,rust-fuzz-tunnel-proto,rust-test-Linux,rust-test-macOS,rust-test-Windows,swift-test,kotlin-test
           fail-on-error: false # Make CI less flaky

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.api.artifact.ScopedArtifact
+import com.android.build.api.variant.ScopedArtifacts
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
 import org.gradle.process.ExecOperations
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -198,12 +200,36 @@ tasks.register<Copy>("copyJacocoCli") {
     into(layout.buildDirectory.dir("jacoco-cli"))
 }
 
-// Reporting on the execution data needs the classes the tests were built from. Taken from the
-// compile tasks because their names are stable across AGP versions where their output paths are not.
-tasks.register<Copy>("collectDebugClasses") {
-    from(tasks.named("compileDebugKotlin"), tasks.named("compileDebugJavaWithJavac"))
-    into(layout.buildDirectory.dir("debug-classes"))
-}
+// Reporting on the execution data needs the classes the tests ran against, which are not the ones
+// the compile tasks emit: `@AndroidEntryPoint` classes get rewritten to extend their generated Hilt
+// base class. JaCoCo matches execution data by a hash of the bytecode, so handing it the compile
+// output silently reports every one of those classes as uncovered.
+abstract class CollectClasses
+    @Inject
+    constructor() : DefaultTask() {
+        @get:InputFiles
+        @get:PathSensitive(PathSensitivity.RELATIVE)
+        abstract val jars: ListProperty<RegularFile>
+
+        @get:InputFiles
+        @get:PathSensitive(PathSensitivity.RELATIVE)
+        abstract val dirs: ListProperty<Directory>
+
+        @get:OutputDirectory
+        abstract val outputDir: DirectoryProperty
+
+        @get:Inject
+        abstract val fileSystem: FileSystemOperations
+
+        @TaskAction
+        fun collect() {
+            fileSystem.sync {
+                from(jars)
+                from(dirs)
+                into(outputDir)
+            }
+        }
+    }
 
 dependencies {
     // The `nodeps` jar is already shaded, so its declared dependencies would only add jars for the
@@ -618,5 +644,14 @@ androidComponents {
             generateUniffiBindings,
             GenerateUniffiBindings::outputDir,
         )
+
+        val collectClasses =
+            tasks.register<CollectClasses>("collect${variant.name.replaceFirstChar { it.uppercase() }}Classes") {
+                outputDir.set(layout.buildDirectory.dir("${variant.name}-classes"))
+            }
+        variant.artifacts
+            .forScope(ScopedArtifacts.Scope.PROJECT)
+            .use(collectClasses)
+            .toGet(ScopedArtifact.CLASSES, CollectClasses::jars, CollectClasses::dirs)
     }
 }

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -198,6 +198,13 @@ tasks.register<Copy>("copyJacocoCli") {
     into(layout.buildDirectory.dir("jacoco-cli"))
 }
 
+// Reporting on the execution data needs the classes the tests were built from. Taken from the
+// compile tasks because their names are stable across AGP versions where their output paths are not.
+tasks.register<Copy>("collectDebugClasses") {
+    from(tasks.named("compileDebugKotlin"), tasks.named("compileDebugJavaWithJavac"))
+    into(layout.buildDirectory.dir("debug-classes"))
+}
+
 dependencies {
     "jacocoCli"("org.jacoco:org.jacoco.cli:$jacocoToolVersion:nodeps")
     implementation("androidx.core:core-ktx:1.19.0")

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -83,6 +83,7 @@ android {
         getByName("debug") {
             isDebuggable = true
             enableUnitTestCoverage = true
+            enableAndroidTestCoverage = true
             resValue("string", "app_name", "\"Firezone (Dev)\"")
 
             buildConfigField("String", "AUTH_URL", "\"https://app.firez.one\"")
@@ -150,6 +151,12 @@ android {
         unitTests {
             isIncludeAndroidResources = true
         }
+    }
+
+    // Execution data is only readable by the same JaCoCo that wrote it, and the workflow reports
+    // on it with a standalone CLI, so the version is pinned here rather than left to AGP.
+    testCoverage {
+        jacocoVersion = "0.8.13"
     }
 
     // Escalate Slack's Compose lint checks (added via `lintChecks`) to build-failing

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -39,6 +39,12 @@ spotless {
     }
 }
 
+// Execution data is only readable by the JaCoCo that wrote it. The report is generated outside
+// Gradle, so rather than name this version again there, the build hands over the matching tool.
+val jacocoToolVersion = "0.8.13"
+
+val jacocoCli by configurations.creating
+
 android {
     buildFeatures {
         buildConfig = true
@@ -153,10 +159,8 @@ android {
         }
     }
 
-    // Execution data is only readable by the same JaCoCo that wrote it, and the workflow reports
-    // on it with a standalone CLI, so the version is pinned here rather than left to AGP.
     testCoverage {
-        jacocoVersion = "0.8.13"
+        jacocoVersion = jacocoToolVersion
     }
 
     // Escalate Slack's Compose lint checks (added via `lintChecks`) to build-failing
@@ -189,7 +193,13 @@ android {
     }
 }
 
+tasks.register<Copy>("copyJacocoCli") {
+    from(jacocoCli)
+    into(layout.buildDirectory.dir("jacoco-cli"))
+}
+
 dependencies {
+    "jacocoCli"("org.jacoco:org.jacoco.cli:$jacocoToolVersion:nodeps")
     implementation("androidx.core:core-ktx:1.19.0")
     // Desugaring - needed for Java 8+ APIs on older Android versions
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -82,6 +82,7 @@ android {
         // Debug Config
         getByName("debug") {
             isDebuggable = true
+            enableUnitTestCoverage = true
             resValue("string", "app_name", "\"Firezone (Dev)\"")
 
             buildConfigField("String", "AUTH_URL", "\"https://app.firez.one\"")

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -206,7 +206,9 @@ tasks.register<Copy>("collectDebugClasses") {
 }
 
 dependencies {
-    "jacocoCli"("org.jacoco:org.jacoco.cli:$jacocoToolVersion:nodeps")
+    // The `nodeps` jar is already shaded, so its declared dependencies would only add jars for the
+    // report step to pick the wrong one from.
+    "jacocoCli"("org.jacoco:org.jacoco.cli:$jacocoToolVersion:nodeps") { isTransitive = false }
     implementation("androidx.core:core-ktx:1.19.0")
     // Desugaring - needed for Java 8+ APIs on older Android versions
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -227,6 +227,22 @@ abstract class CollectClasses
                 from(jars)
                 from(dirs)
                 into(outputDir)
+                // Nobody writes or can test the output of a code generator, so counting it only
+                // moves the percentage around. Dagger's top-level classes are already dropped by
+                // JaCoCo because they carry `@DaggerGenerated`; their nested classes are not.
+                exclude(
+                    "uniffi/**",
+                    "dagger/**",
+                    "hilt_aggregated_deps/**",
+                    "dev/firezone/android/databinding/**",
+                    "**/Hilt_*.class",
+                    "**/Dagger*.class",
+                    "**/*_HiltModules*.class",
+                    "**/*Args.class",
+                    "**/*Args\$*.class",
+                    "**/*Directions*.class",
+                    "**/BuildConfig.class",
+                )
             }
         }
     }

--- a/kotlin/android/mise-tasks/emulator-tests.sh
+++ b/kotlin/android/mise-tasks/emulator-tests.sh
@@ -53,9 +53,21 @@ done
 
 echo "==> Running the tests..."
 # Guarded because bash 3.2, which macOS still ships, treats an empty array as unset.
-result="$(adb shell am instrument -w ${filter[@]+"${filter[@]}"} "$RUNNER")"
+result="$(adb shell am instrument -w \
+    -e coverage true -e coverageFile "$COVERAGE_ON_DEVICE" \
+    ${filter[@]+"${filter[@]}"} "$RUNNER")"
 
 echo "$result"
+
+# `am instrument` reports failures in its output and exits 0 regardless.
+case "$result" in
+*"OK ("*) ;;
+*)
+    echo >&2
+    echo "error: the instrumented tests did not pass" >&2
+    exit 1
+    ;;
+esac
 
 # The execution data is written into the app's private directory, which only `run-as` reaches,
 # and only for a debuggable build.
@@ -68,13 +80,3 @@ if [ ! -s coverage.ec ]; then
 fi
 
 echo "    $(wc -c <coverage.ec) bytes"
-
-# `am instrument` reports failures in its output and exits 0 regardless.
-case "$result" in
-*"OK ("*) ;;
-*)
-    echo >&2
-    echo "error: the instrumented tests did not pass" >&2
-    exit 1
-    ;;
-esac

--- a/kotlin/android/mise-tasks/emulator-tests.sh
+++ b/kotlin/android/mise-tasks/emulator-tests.sh
@@ -7,7 +7,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "${SCRIPT_DIR}/.."
 
 APK_DIR="app/build/outputs/apk"
-RUNNER="dev.firezone.android.test/dev.firezone.android.core.HiltTestRunner"
+APP_PACKAGE="dev.firezone.android"
+RUNNER="${APP_PACKAGE}.test/dev.firezone.android.core.HiltTestRunner"
+# The app's own directory is the one place the runner can write and `run-as` can read.
+COVERAGE_ON_DEVICE="/data/data/${APP_PACKAGE}/coverage.ec"
 
 find_apk() {
     find "$APK_DIR" -type f -name "$1" -exec ls -t {} + 2>/dev/null | head -1
@@ -53,6 +56,18 @@ echo "==> Running the tests..."
 result="$(adb shell am instrument -w ${filter[@]+"${filter[@]}"} "$RUNNER")"
 
 echo "$result"
+
+# The execution data is written into the app's private directory, which only `run-as` reaches,
+# and only for a debuggable build.
+echo "==> Collecting the execution data..."
+adb shell run-as "$APP_PACKAGE" cat "$COVERAGE_ON_DEVICE" >coverage.ec
+
+if [ ! -s coverage.ec ]; then
+    echo "error: the run recorded no execution data at ${COVERAGE_ON_DEVICE}" >&2
+    exit 1
+fi
+
+echo "    $(wc -c <coverage.ec) bytes"
 
 # `am instrument` reports failures in its output and exits 0 regardless.
 case "$result" in


### PR DESCRIPTION
Elixir, Rust and Swift all report their coverage and Kotlin reported none, so the Android client was the one part of the product whose coverage nobody could watch move.

Both halves are counted. The unit tests barely touch the app, so on their own they would have reported the screens, the service and everything the end-to-end tests drive as uncovered. Gradle used to collect the instrumented half for free; now that a suite is an emulator and an APK, the runner is asked for execution data directly and a job downstream turns it into a report, which is also what lets every suite contribute to one number.

The debug APK now carries JaCoCo probes, since that is what makes the emulator tests countable.
