### PR TITLE
ci(kotlin): warm the Gradle build cache from `main`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -144,6 +144,16 @@ jobs:
       id-token: write # OIDC auth
       security-events: write # trivy SARIF upload from setup-mise
 
+  # Gradle only writes its build cache from the default branch, so PR and merge-queue
+  # runs restore nothing unless `main` is built too.
+  kotlin:
+    uses: ./.github/workflows/_kotlin.yml
+    secrets: inherit
+    permissions:
+      contents: write # release draft
+      id-token: write # OIDC auth
+      security-events: write # trivy SARIF upload from setup-mise
+
   coverage-finish:
     name: coverage-finish
     needs: [elixir, rust, swift]

--- a/kotlin/android/settings.gradle.kts
+++ b/kotlin/android/settings.gradle.kts
@@ -65,10 +65,3 @@ dependencyResolutionManagement {
 
 rootProject.name = "Firezone App"
 include(":app")
-
-buildCache {
-    local {
-        isEnabled = true
-        directory = file("$rootDir/.gradle/build-cache")
-    }
-}


### PR DESCRIPTION
Gradle's build cache is only written from the default branch, and CI never runs there, so every Android job so far has restored nothing and saved nothing. Building the app as part of CD gives the cache a writer; PR and merge-queue runs then read it. The dispatch to `firezone/infra` does not wait for it.

The local build cache also has to live in the Gradle user home for `setup-gradle` to persist it, so the project-local override that put it in the workspace goes away.

This does not cover the Rust half of the build: neither `cargoBuild` nor `generateUniffiBindings` is a `@CacheableTask`, so both re-run in every job regardless.
