### PR TITLE
fix(x509-claims): only identity attributes claim an identity

### DIFF
--- a/rust/libs/x509-claims/src/lib.rs
+++ b/rust/libs/x509-claims/src/lib.rs
@@ -256,12 +256,12 @@ impl ParsedCertificate {
 
     /// Who the certificate claims is connecting.
     ///
-    /// Carrying an account, actor or email claim at all commits the session to mutual TLS,
-    /// whatever the claim says: what the portal makes of it is the portal's answer.
+    /// A carried actor email or actor ID adopts the certificate as the session, whether or not
+    /// the client can read a valid value out of it: rejecting a claim is policy, and policy is
+    /// the portal's to make. An account ID scopes an account and names no actor, so it claims
+    /// nobody on its own.
     pub fn identity(&self) -> Identity {
-        let claims_somebody = [&self.account_id, &self.actor_id, &self.actor_email]
-            .into_iter()
-            .any(Claim::is_carried);
+        let claims_somebody = self.actor_email.is_carried() || self.actor_id.is_carried();
 
         if !claims_somebody {
             return Identity::Absent;
@@ -1000,4 +1000,68 @@ fn split_claim_attribute(claim: &str) -> (&str, Option<&str>) {
     };
 
     (&claim[..separator], Some(&claim[separator + 1..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_valid_actor_id_claims_an_identity_without_an_email() {
+        let mut certificate = certificate();
+        certificate.actor_id = Claim::present("31b57ec2-8a02-4d5e-9b41-5c1f7a0e6f21".to_owned());
+
+        assert_eq!(certificate.identity(), Identity::Claimed { email: None });
+    }
+
+    #[test]
+    fn an_account_id_alone_claims_nobody() {
+        let mut certificate = certificate();
+        certificate.account_id = Claim::present("6f3f8a2c-0b74-4f8a-9b1f-1c2d3e4f5a6b".to_owned());
+
+        assert_eq!(certificate.identity(), Identity::Absent);
+    }
+
+    #[test]
+    fn a_carried_but_invalid_email_still_claims_an_identity() {
+        let mut certificate = certificate();
+        certificate.actor_email = Claim::invalid(
+            "jane.doe(at)example.com",
+            ValidationError::NotAnEmailAddress,
+        );
+
+        assert_eq!(certificate.identity(), Identity::Claimed { email: None });
+    }
+
+    #[test]
+    fn no_identity_attribute_claims_nobody() {
+        assert_eq!(certificate().identity(), Identity::Absent);
+    }
+
+    fn certificate() -> ParsedCertificate {
+        ParsedCertificate {
+            subject_cn: None,
+            subject: String::new(),
+            subject_alternative_names: Vec::new(),
+            actor_email: Claim::absent(),
+            account_id: Claim::absent(),
+            actor_id: Claim::absent(),
+            mdm_device_id: Claim::absent(),
+            device_serial: Claim::absent(),
+            unrecognised_claims: Vec::new(),
+            issuer: String::new(),
+            serial: String::new(),
+            has_client_auth_eku: true,
+            digital_signature_allowed: true,
+            checked_at_timestamp: None,
+            not_before: String::new(),
+            not_before_timestamp: 0,
+            not_after: String::new(),
+            not_after_timestamp: 0,
+            signing_algorithm: None,
+            key_algorithm_oid: String::new(),
+            fingerprint: String::new(),
+            der_bytes: 0,
+        }
+    }
 }

--- a/rust/libs/x509-claims/tests/parse_certificate.rs
+++ b/rust/libs/x509-claims/tests/parse_certificate.rs
@@ -895,8 +895,8 @@ fn a_clock_that_cannot_be_read() -> SystemTime {
     SystemTime::UNIX_EPOCH - Duration::from_secs(1)
 }
 
-/// Claiming an identity at all is what suppresses signing in with a token, so the client has to
-/// tell "claims nobody" from "claims somebody it cannot name".
+/// Claiming an identity is what suppresses signing in with a token, so the boundary between
+/// "claims nobody" and "claims somebody" has to sit exactly on the carried identity attributes.
 #[test]
 fn an_identity_is_absent_or_claimed() {
     let identity_of = |uris: &[&str]| {
@@ -935,18 +935,28 @@ fn an_identity_is_absent_or_claimed() {
         );
     }
 
+    assert_eq!(
+        identity_of(&["firezone://account-id/5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3"]),
+        Identity::Absent,
+        "an account alone names no actor"
+    );
+
     for uris in [
-        vec!["firezone://account-id/5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3"],
         vec!["firezone://actor-id/9b4d1c07-6e2a-4f83-8c15-7ad0e39b2c64"],
-        // An address no user could have is a claim on nobody the client can name.
+        // A carried identity attribute claims somebody even where the parser cannot use it:
+        // whether to reject it is the portal's policy, not the client's.
         vec!["firezone://email/jane.doe"],
         vec![
             "firezone://email/jane.doe@example.com",
             "firezone://email/john.doe@example.com",
         ],
-        // An attribute written with no value at all still claims the certificate is somebody's.
         vec!["firezone://email/"],
         vec!["firezone://email"],
+        vec!["firezone://actor-id/not-a-uuid"],
+        vec![
+            "firezone://actor-id/9b4d1c07-6e2a-4f83-8c15-7ad0e39b2c64",
+            "firezone://email/jane.doe",
+        ],
     ] {
         assert_eq!(
             identity_of(&uris),

--- a/rust/tests/fuzz/fuzz_targets/x509_claims.rs
+++ b/rust/tests/fuzz/fuzz_targets/x509_claims.rs
@@ -105,22 +105,18 @@ fn assert_validity_is_contiguous(der: &[u8], first: u32, second: u32) {
 
 /// Asserts that claiming nobody and claiming somebody stay separate answers.
 ///
-/// The first signs the session in with a token and the second commits it to mutual TLS, so a
-/// certificate that slid from one to the other would authenticate as the wrong thing. A claim
-/// the parser could not use still names somebody: only a usable address reaches the client.
+/// The first signs the session in with a token and the second commits it to mutual TLS with no
+/// token. A carried actor email or actor ID claims somebody whatever it says, since rejecting
+/// a claim is the portal's policy; an account ID names no actor and claims nobody.
 fn assert_the_identity_answers_the_claims(certificate: &ParsedCertificate) {
-    let claims_somebody = [
-        &certificate.account_id,
-        &certificate.actor_id,
-        &certificate.actor_email,
-    ]
-    .into_iter()
-    .any(|claim| claim.value.is_some() || claim.error.is_some());
+    let claims_somebody = [&certificate.actor_email, &certificate.actor_id]
+        .into_iter()
+        .any(|claim| claim.value.is_some() || claim.error.is_some());
 
     match certificate.identity() {
         Identity::Absent => assert!(
             !claims_somebody,
-            "a certificate carrying an identity claim is not absent"
+            "a certificate carrying an identity attribute is not absent"
         ),
         Identity::Claimed { email } => {
             assert!(claims_somebody, "an identity was claimed by nothing");


### PR DESCRIPTION
When we find an x509 certificate on the device, we use it for mTLS with the portal. If the certificate also contains identity claim attributes, we skip the auth handshake to obtain a token and rely on the identity in the certificate itself.

This also applies to service accounts which are identified by the `actor-id` claim and don't carry an email.