### PR TITLE
chore(portal): remove Intune remote assistance fields

### DIFF
--- a/elixir/lib/portal/intune/device.ex
+++ b/elixir/lib/portal/intune/device.ex
@@ -81,9 +81,6 @@ defmodule Portal.Intune.Device do
     field :exchange_access_state_reason, :string
     field :exchange_last_successful_sync_at, :utc_datetime_usec
 
-    field :remote_assistance_session_url, :string
-    field :remote_assistance_session_error_details, :string
-
     field :config_manager_inventory, :boolean
     field :config_manager_modern_apps, :boolean
     field :config_manager_resource_access, :boolean

--- a/elixir/lib/portal/intune/sync.ex
+++ b/elixir/lib/portal/intune/sync.ex
@@ -134,8 +134,6 @@ defmodule Portal.Intune.Sync do
     {:device_category_display_name, "deviceCategoryDisplayName"},
     {:exchange_access_state, "exchangeAccessState"},
     {:exchange_access_state_reason, "exchangeAccessStateReason"},
-    {:remote_assistance_session_url, "remoteAssistanceSessionUrl"},
-    {:remote_assistance_session_error_details, "remoteAssistanceSessionErrorDetails"},
     {:user_principal_name, "userPrincipalName"},
     {:model, "model"},
     {:manufacturer, "manufacturer"},

--- a/elixir/priv/repo/migrations/20260831000000_remove_remote_assistance_fields_from_intune_devices.exs
+++ b/elixir/priv/repo/migrations/20260831000000_remove_remote_assistance_fields_from_intune_devices.exs
@@ -1,0 +1,17 @@
+defmodule Portal.Repo.Migrations.RemoveRemoteAssistanceFieldsFromIntuneDevices do
+  use Ecto.Migration
+
+  def up do
+    alter table(:intune_devices) do
+      remove(:remote_assistance_session_url)
+      remove(:remote_assistance_session_error_details)
+    end
+  end
+
+  def down do
+    alter table(:intune_devices) do
+      add(:remote_assistance_session_url, :text)
+      add(:remote_assistance_session_error_details, :text)
+    end
+  end
+end

--- a/elixir/priv/static/openapi.json
+++ b/elixir/priv/static/openapi.json
@@ -6671,10 +6671,6 @@
             "nullable": true,
             "type": "string"
           },
-          "remote_assistance_session_url": {
-            "nullable": true,
-            "type": "string"
-          },
           "attestation_health_status_mismatch_info": {
             "nullable": true,
             "type": "string"
@@ -6737,10 +6733,6 @@
             "type": "string"
           },
           "attestation_virtual_secure_mode": {
-            "nullable": true,
-            "type": "string"
-          },
-          "remote_assistance_session_error_details": {
             "nullable": true,
             "type": "string"
           },

--- a/elixir/test/portal/intune/sync_test.exs
+++ b/elixir/test/portal/intune/sync_test.exs
@@ -84,8 +84,6 @@ defmodule Portal.Intune.SyncTest do
     assert device.exchange_last_successful_sync_at == ~U[2017-01-01 08:00:45.880308Z]
     assert device.exchange_access_state == "unknown"
     assert device.exchange_access_state_reason == "unknown"
-    assert device.remote_assistance_session_url == "https://example.com/session/"
-    assert device.remote_assistance_session_error_details == "Remote Assistance Error value"
     assert device.is_encrypted == true
     assert device.user_principal_name == "User Principal Name value"
     assert device.model == "Model value"
@@ -483,8 +481,6 @@ defmodule Portal.Intune.SyncTest do
       "exchangeLastSuccessfulSyncDateTime" => "2017-01-01T00:00:45.8803083-08:00",
       "exchangeAccessState" => "unknown",
       "exchangeAccessStateReason" => "unknown",
-      "remoteAssistanceSessionUrl" => "https://example.com/session/",
-      "remoteAssistanceSessionErrorDetails" => "Remote Assistance Error value",
       "isEncrypted" => true,
       "userPrincipalName" => "User Principal Name value",
       "model" => "Model value",


### PR DESCRIPTION
## Summary
- drop remote assistance session fields from `intune_devices`
- stop mapping those fields from Microsoft Graph
- remove them from the generated OpenAPI specification

## Testing
- `mix test test/portal/intune/sync_test.exs`