### PR TITLE
fix(portal): normalize X.509 expiry precision

### DIFF
--- a/elixir/lib/portal_api/client/device_trust.ex
+++ b/elixir/lib/portal_api/client/device_trust.ex
@@ -205,7 +205,11 @@ defmodule PortalAPI.Client.DeviceTrust do
          :ok <- ensure_account_enabled(account),
          {:ok, auth_provider} <- ensure_x509_authentication_enabled(auth_provider),
          {:ok, actor} <- Database.fetch_x509_actor(account, identity),
-         %DateTime{} = expires_at <- X509.not_after(leaf),
+         %DateTime{} = certificate_expires_at <- X509.not_after(leaf),
+         expires_at = %{
+           certificate_expires_at
+           | microsecond: {elem(certificate_expires_at.microsecond, 0), 6}
+         },
          subject = %Subject{
            account: account,
            actor: actor,

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -529,6 +529,7 @@ defmodule PortalAPI.Client.SocketTest do
       assert socket.assigns.subject.actor.id == actor.id
       assert socket.assigns.subject.credential.type == :x509
       assert socket.assigns.subject.credential.auth_provider_id == provider.id
+      assert socket.assigns.subject.expires_at.microsecond == {0, 6}
       assert socket.assigns.client.attested?
       assert is_nil(socket.assigns.client.client_token_id)
     end


### PR DESCRIPTION
Fixes #14967 