### PR TITLE
fix(portal): disconnect clients when an account is disabled

### DIFF
--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -1905,6 +1905,29 @@ defmodule PortalAPI.Client.Channel.Shared do
 
   # ACCOUNTS
 
+  # Disabling an account is broadcast as an account deletion. Unlike token-backed
+  # credentials, X.509 credentials have no ClientToken row for the account hook
+  # to delete, so every client channel for the account must be explicitly cut.
+  defp handle_change(
+         %Change{op: :delete, old_struct: %Portal.Account{id: account_id}},
+         %{assigns: %{client: %{account_id: account_id}}} = socket
+       ) do
+    disconnect_account(socket)
+  end
+
+  # Keep the channel fail-closed if an account-disabled update is ever broadcast
+  # directly instead of being normalized to the delete event above.
+  defp handle_change(
+         %Change{
+           op: :update,
+           old_struct: %Portal.Account{is_disabled: false},
+           struct: %Portal.Account{is_disabled: true}
+         },
+         socket
+       ) do
+    disconnect_account(socket)
+  end
+
   defp handle_change(
          %Change{
            op: :update,
@@ -2197,6 +2220,14 @@ defmodule PortalAPI.Client.Channel.Shared do
   end
 
   defp handle_change(%Change{}, socket), do: {:noreply, socket}
+
+  # A channel stop alone can leave the transport available for a reactive rejoin,
+  # which would bypass Socket.connect/3 and its account-enabled check. Drain the
+  # transport so the next attempt must authenticate again.
+  defp disconnect_account(socket) do
+    send(socket.transport_pid, :socket_drain)
+    handle_info(:disconnect, socket)
+  end
 
   # Shared eviction path for the CDC delete handler, the direct `:reject_access`
   # from `Portal.Queue`'s on_failed callback, and the authz durability timeout.

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -116,6 +116,41 @@ defmodule PortalAPI.Client.ChannelTest do
     %{subject | context: %{subject.context | user_agent: user_agent}}
   end
 
+  defp assert_x509_account_disable_disconnects_channel(
+         %{account: account, client: client, subject: subject},
+         channel
+       ) do
+    Process.flag(:trap_exit, true)
+    provider = x509_provider_fixture(account: account, is_disabled: false)
+
+    credential = %Portal.Authentication.Credential{
+      id: Ecto.UUID.generate(),
+      type: :x509,
+      auth_provider_id: provider.id
+    }
+
+    join_channel(client, %{subject | credential: credential}, channel: channel)
+    assert_push "init", _init_payload
+
+    account |> Ecto.Changeset.change(is_disabled: true) |> Repo.update!()
+
+    old_data = %{
+      "id" => account.id,
+      "is_disabled" => false
+    }
+
+    assert :ok =
+             Portal.Changes.Hooks.Accounts.on_update(
+               1,
+               old_data,
+               %{old_data | "is_disabled" => true}
+             )
+
+    assert_push "disconnect", %{reason: "token_expired"}
+    assert_receive :socket_drain
+    assert_receive {:EXIT, _pid, :shutdown}
+  end
+
   defp gateway_authorization_generation(channel_pid, resource_id) do
     {generation, _timer_ref, _initiator_token} =
       :sys.get_state(channel_pid).assigns.pending_authorizations |> Map.fetch!(resource_id)
@@ -1141,6 +1176,14 @@ defmodule PortalAPI.Client.ChannelTest do
 
       assert_push "disconnect", %{reason: "token_expired"}
       assert_receive {:EXIT, _pid, :shutdown}
+    end
+
+    test "disconnects an X.509 v1 channel when account CDC reports it disabled", context do
+      assert_x509_account_disable_disconnects_channel(context, PortalAPI.Client.Channel)
+    end
+
+    test "disconnects an X.509 v2 channel when account CDC reports it disabled", context do
+      assert_x509_account_disable_disconnects_channel(context, PortalAPI.Client.V2.Channel)
     end
 
     test "cuts the session when its own certificate is revoked", %{


### PR DESCRIPTION
Ensure account revocation closes active client channels.

---

Related: https://github.com/firezone/firezone/security/advisories/GHSA-ppj8-hq8j-598v