### PR TITLE
fix(portal): fix malformed bearer token log amplification

### DIFF
--- a/elixir/lib/portal/authentication.ex
+++ b/elixir/lib/portal/authentication.ex
@@ -11,8 +11,6 @@ defmodule Portal.Authentication do
   alias Portal.Authentication.Credential
   alias Portal.Authentication.Subject
   alias __MODULE__.Database
-  require Logger
-
   # Client Tokens
 
   # Interactive client token - created during an interactive sign-in flow
@@ -382,11 +380,7 @@ defmodule Portal.Authentication do
          :ok <- verify_secret_hash(token, nonce, fragment) do
       {:ok, token}
     else
-      error ->
-        trace = Process.info(self(), :current_stacktrace)
-        Logger.info("Token use failed", stacktrace: trace, error: error)
-
-        {:error, :invalid_token}
+      _ -> {:error, :invalid_token}
     end
   end
 
@@ -427,11 +421,7 @@ defmodule Portal.Authentication do
          {:ok, subject} <- build_subject(token, context) do
       {:ok, subject}
     else
-      error ->
-        trace = Process.info(self(), :current_stacktrace)
-        Logger.info("Authentication failed", stacktrace: trace, error: error)
-
-        {:error, :invalid_token}
+      _ -> {:error, :invalid_token}
     end
   end
 

--- a/elixir/test/portal/authentication_test.exs
+++ b/elixir/test/portal/authentication_test.exs
@@ -1,5 +1,6 @@
 defmodule Portal.AuthenticationTest do
   use Portal.DataCase, async: true
+  import ExUnit.CaptureLog
   import Portal.Authentication
   import Portal.TokenFixtures
   import Portal.SubjectFixtures
@@ -209,6 +210,14 @@ defmodule Portal.AuthenticationTest do
   end
 
   describe "authenticate/2" do
+    test "does not log malformed tokens" do
+      context = build_context(type: :client)
+
+      assert capture_log(fn ->
+               assert authenticate("invalid.token", context) == {:error, :invalid_token}
+             end) == ""
+    end
+
     test "returns error when token is invalid" do
       context = build_context(type: :client)
 


### PR DESCRIPTION
Removes stacktrace logging for invalid bearer tokens.

Related: https://github.com/firezone/firezone/security/advisories/GHSA-ppj8-hq8j-598v