### PR TITLE
chore(x509): drop the headless-client hint from the task output

### DIFF
--- a/mise-tasks/x509/install-linux.sh
+++ b/mise-tasks/x509/install-linux.sh
@@ -235,5 +235,3 @@ echo
 echo "The token is in the system store and its PIN is at ${PIN_PATH}, which is all the Client"
 echo "needs: it loads p11-kit's proxy module and takes the certificate whose subject common name is"
 echo "${SUBJECT_CN}. There is nothing to configure, packaged Tunnel service included."
-echo
-echo "'firezone-headless-client x509' prints what it makes of the token."

--- a/mise-tasks/x509/uninstall-linux.sh
+++ b/mise-tasks/x509/uninstall-linux.sh
@@ -80,5 +80,3 @@ fi
 echo
 echo "The Client has no identity to find now. A connected Tunnel service holds its PKCS#11"
 echo "session until it restarts, so restart it to see the change."
-echo
-echo "'firezone-headless-client x509' prints what it makes of the store."


### PR DESCRIPTION
The install and uninstall tasks closed by naming one client's subcommand. They provision the system store for every client, so the pointer goes rather than being kept current.