### PR TITLE
fix(portal): move API admission ahead of JSON parsing

### DIFF
--- a/elixir/lib/portal_api/controllers/flow_log_controller.ex
+++ b/elixir/lib/portal_api/controllers/flow_log_controller.ex
@@ -14,7 +14,6 @@ defmodule PortalAPI.FlowLogController do
   import Ecto.Changeset
   alias OpenApiSpex.Schema
   alias Portal.FlowLog
-  alias Portal.FlowLogToken
   alias Portal.Types.LogId
   alias PortalAPI.ProblemDetails
   alias PortalAPI.Schemas.ProblemDetails, as: ProblemDetailsSchema
@@ -81,9 +80,9 @@ defmodule PortalAPI.FlowLogController do
   end
 
   def create(conn, %{"flow_logs" => records}) when is_list(records) do
-    with {:ok, claims} <- authenticate(conn),
-         :ok <- ensure_uploads_enabled(claims),
-         :ok <- ensure_single_authorization(records, claims) do
+    claims = conn.assigns.flow_log_claims
+
+    with :ok <- ensure_single_authorization(records, claims) do
       now = DateTime.utc_now()
 
       {valid, errors} =
@@ -108,16 +107,6 @@ defmodule PortalAPI.FlowLogController do
         })
       end
     else
-      {:error, :unauthenticated} ->
-        ProblemDetails.send(conn, 401, "Authentication credentials were missing or invalid.")
-
-      {:error, :uploads_disabled} ->
-        ProblemDetails.send(
-          conn,
-          401,
-          "Flow log uploads are not enabled for this authorization"
-        )
-
       {:error, :multiple_authorizations} ->
         ProblemDetails.send(
           conn,
@@ -130,25 +119,6 @@ defmodule PortalAPI.FlowLogController do
   def create(conn, _params) do
     ProblemDetails.send(conn, 400, "Expected a \"flow_logs\" array")
   end
-
-  # The single per-authorization ingest token authenticates the whole request.
-  # An unknown account, a bad signature, an expired or malformed token, and a
-  # missing header all collapse to the same 401 so the endpoint reveals nothing.
-  defp authenticate(conn) do
-    with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
-         {:ok, claims} <- FlowLogToken.verify(token) do
-      {:ok, claims}
-    else
-      _ -> {:error, :unauthenticated}
-    end
-  end
-
-  # Tokens are minted for every authorization so devices always receive their
-  # attribution, but the `uploads_enabled` claim carries the policy's opt-in.
-  # Devices honor it client-side; this is the server-side backstop. A token
-  # without the claim fails closed.
-  defp ensure_uploads_enabled(%{"uploads_enabled" => true}), do: :ok
-  defp ensure_uploads_enabled(_claims), do: {:error, :uploads_disabled}
 
   # The token names exactly one policy authorization; a record that declares a
   # different one means the reporter mixed authorizations into one request, which

--- a/elixir/lib/portal_api/plugs/flow_log_auth.ex
+++ b/elixir/lib/portal_api/plugs/flow_log_auth.ex
@@ -1,0 +1,32 @@
+defmodule PortalAPI.Plugs.FlowLogAuth do
+  @moduledoc """
+  Authenticates a flow-log ingestion request from its Bearer token.
+
+  This plug intentionally runs before `Plug.Parsers`: the token is entirely in
+  the request headers, so invalid or expired credentials can be rejected
+  without buffering or decoding the request body.
+  """
+
+  import Plug.Conn
+
+  alias Portal.FlowLogToken
+  alias PortalAPI.ProblemDetails
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
+         {:ok, claims} <- FlowLogToken.verify(token),
+         :ok <- ensure_uploads_enabled(claims) do
+      assign(conn, :flow_log_claims, claims)
+    else
+      {:error, :uploads_disabled} ->
+        ProblemDetails.send(conn, 401, "Flow log uploads are not enabled for this authorization")
+
+      _ -> ProblemDetails.send(conn, 401, "Authentication credentials were missing or invalid.")
+    end
+  end
+
+  defp ensure_uploads_enabled(%{"uploads_enabled" => true}), do: :ok
+  defp ensure_uploads_enabled(_claims), do: {:error, :uploads_disabled}
+end

--- a/elixir/lib/portal_api/plugs/ingestion_rate_limit.ex
+++ b/elixir/lib/portal_api/plugs/ingestion_rate_limit.ex
@@ -1,15 +1,14 @@
 defmodule PortalAPI.Plugs.IngestionRateLimit do
   import Plug.Conn
 
-  @default_refill_rate Portal.Config.fetch_env!(:portal, __MODULE__)[:refill_rate]
-  @default_capacity Portal.Config.fetch_env!(:portal, __MODULE__)[:capacity]
   @cost 1
 
   def init(opts), do: opts
 
   def call(conn, opts) do
-    refill_rate = Keyword.get(opts, :refill_rate, @default_refill_rate)
-    capacity = Keyword.get(opts, :capacity, @default_capacity)
+    config = Portal.Config.fetch_env!(:portal, __MODULE__)
+    refill_rate = Keyword.get(opts, :refill_rate, Keyword.fetch!(config, :refill_rate))
+    capacity = Keyword.get(opts, :capacity, Keyword.fetch!(config, :capacity))
     ip_key = "ingestion:ip:#{ip_to_string(conn.remote_ip)}"
 
     case PortalAPI.RateLimit.hit(ip_key, refill_rate, capacity, @cost) do

--- a/elixir/lib/portal_api/router.ex
+++ b/elixir/lib/portal_api/router.ex
@@ -2,14 +2,18 @@ defmodule PortalAPI.Router do
   use PortalAPI, :router
 
   pipeline :api do
+    plug :accepts, ["json"]
+    # Authentication and the account limiter use only request metadata. Keep
+    # them ahead of the body parser so rejected requests never buffer or decode
+    # an attacker-controlled JSON body.
+    plug PortalAPI.Plugs.Auth
+    plug PortalAPI.Plugs.RateLimit
+
     plug Plug.Parsers,
       parsers: [:json],
       pass: ["*/*"],
       json_decoder: Phoenix.json_library()
 
-    plug :accepts, ["json"]
-    plug PortalAPI.Plugs.Auth
-    plug PortalAPI.Plugs.RateLimit
     plug PortalAPI.Plugs.RequestLog
     plug PortalAPI.Plugs.ValidateUUIDParams
   end
@@ -31,17 +35,19 @@ defmodule PortalAPI.Router do
   end
 
   pipeline :ingestion do
+    plug :accepts, ["json"]
+    # Rate limiting is keyed on the source IP and runs before token
+    # verification and parsing. The ingest token is entirely in the
+    # Authorization header, so it can also be authenticated before reading the
+    # body.
+    plug PortalAPI.Plugs.IngestionRateLimit
+    plug PortalAPI.Plugs.FlowLogAuth
+
     plug Plug.Parsers,
       parsers: [:json],
       pass: ["*/*"],
       json_decoder: Phoenix.json_library(),
       length: 10_000_000
-
-    plug :accepts, ["json"]
-    # Auth is the per-authorization ingest token in the Authorization header,
-    # verified in the controller (it needs the token's account_id to load the
-    # signing key). Rate limiting is keyed on the source IP.
-    plug PortalAPI.Plugs.IngestionRateLimit
   end
 
   scope "/ingestion", PortalAPI do

--- a/elixir/test/portal_api/controllers/flow_log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/flow_log_controller_test.exs
@@ -56,6 +56,12 @@ defmodule PortalAPI.FlowLogControllerTest do
     post(conn, "/ingestion/flow_logs", %{"flow_logs" => records})
   end
 
+  defp unique_ip do
+    counter = System.unique_integer([:positive, :monotonic])
+
+    {10, rem(div(counter, 65_536), 256), rem(div(counter, 256), 256), rem(counter, 254) + 1}
+  end
+
   describe "create/2 request shape" do
     test "returns 400 when batch exceeds 10k records", %{conn: conn, account: account} do
       records = for _ <- 1..10_001, do: build_record()
@@ -91,6 +97,16 @@ defmodule PortalAPI.FlowLogControllerTest do
   end
 
   describe "create/2 request authentication" do
+    test "rejects an unauthenticated malformed JSON request before decoding it", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/ingestion/flow_logs", "{")
+
+      assert %{"status" => 401, "detail" => "Authentication credentials were missing or invalid."} =
+               json_response(conn, 401)
+    end
+
     test "returns 401 when the Authorization header is missing", %{conn: conn} do
       conn = post_logs(conn, [build_record()])
 
@@ -150,6 +166,35 @@ defmodule PortalAPI.FlowLogControllerTest do
              } = json_response(conn, 401)
 
       assert Repo.all(FlowLog) == []
+    end
+
+    test "rejects a rate-limited malformed JSON request before decoding it", %{
+      conn: conn,
+      account: account
+    } do
+      Portal.Config.put_env_override(:portal, PortalAPI.Plugs.IngestionRateLimit,
+        refill_rate: 0,
+        capacity: 1
+      )
+
+      remote_ip = unique_ip()
+
+      first_conn =
+        conn
+        |> Map.put(:remote_ip, remote_ip)
+        |> authorize(account)
+        |> post_logs([build_record()])
+
+      assert %{"data" => %{"status" => "ok"}} = json_response(first_conn, 200)
+
+      second_conn =
+        conn
+        |> Map.put(:remote_ip, remote_ip)
+        |> authorize(account)
+        |> put_req_header("content-type", "application/json")
+        |> post("/ingestion/flow_logs", "{")
+
+      assert %{"status" => 429} = json_response(second_conn, 429)
     end
 
     test "returns 401 when the token has no uploads_enabled claim", %{

--- a/elixir/test/portal_api/rate_limit_test.exs
+++ b/elixir/test/portal_api/rate_limit_test.exs
@@ -27,6 +27,16 @@ defmodule PortalAPI.RateLimitTest do
   end
 
   describe "REST API rate limit" do
+    test "rejects an unauthenticated malformed JSON request before decoding it", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/resources", "{")
+
+      assert %{"status" => 401, "detail" => "Authentication credentials were missing or invalid."} =
+               json_response(conn, 401)
+    end
+
     test "allows a request when bucket has tokens", %{conn: conn, actor: actor} do
       resp_conn = call_api(conn, actor)
       assert %{"data" => _data, "metadata" => _metadata} = json_response(resp_conn, 200)
@@ -47,6 +57,21 @@ defmodule PortalAPI.RateLimitTest do
 
       [retry_after] = get_resp_header(resp_conn, "retry-after")
       assert String.to_integer(retry_after) >= 1
+    end
+
+    test "rejects a rate-limited malformed JSON request before decoding it", %{
+      conn: conn,
+      actor: actor
+    } do
+      assert %{"data" => _data, "metadata" => _metadata} = call_api(conn, actor) |> json_response(200)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/resources", "{")
+
+      assert %{"status" => 429} = json_response(conn, 429)
     end
   end
 


### PR DESCRIPTION
Fixes #14836

Related: https://github.com/firezone/firezone/security/advisories/GHSA-ppj8-hq8j-598v