### PR TITLE
fix(portal): prevent email OTP account enumeration

### DIFF
--- a/elixir/lib/portal_web/controllers/email_otp_controller.ex
+++ b/elixir/lib/portal_web/controllers/email_otp_controller.ex
@@ -110,7 +110,7 @@ defmodule PortalWeb.EmailOTPController do
   end
 
   defp maybe_send_email_otp(conn, account, email, params, auth_provider_id) do
-    {actor_id, passcode_id, error} =
+    {actor_id, passcode_id, _} =
       Portal.Timing.execute_with_constant_time(
         fn ->
           with {:ok, actor} <- Database.fetch_actor_by_email(account, email),
@@ -148,17 +148,9 @@ defmodule PortalWeb.EmailOTPController do
 
     conn = PortalWeb.Cookie.EmailOTP.put(conn, cookie)
 
-    case error do
-      :rate_limited ->
-        put_flash(
-          conn,
-          :error,
-          "You're attempting to do that too quickly. Wait a few minutes and try again."
-        )
-
-      _ ->
-        conn
-    end
+    # Keep delivery rate limiting internal so it cannot be used to determine
+    # whether an address belongs to an eligible actor.
+    conn
   end
 
   defp send_email_otp(conn, actor, code, auth_provider_id, params) do

--- a/elixir/lib/portal_web/controllers/email_otp_controller.ex
+++ b/elixir/lib/portal_web/controllers/email_otp_controller.ex
@@ -110,10 +110,13 @@ defmodule PortalWeb.EmailOTPController do
   end
 
   defp maybe_send_email_otp(conn, account, email, params, auth_provider_id) do
-    {actor_id, passcode_id, _} =
+    {actor_id, passcode_id, error} =
       Portal.Timing.execute_with_constant_time(
         fn ->
-          with {:ok, actor} <- Database.fetch_actor_by_email(account, email),
+          # Apply recipient throttling before the actor lookup so its public
+          # feedback cannot reveal whether the address belongs to an eligible actor.
+          with :ok <- rate_limit_email_otp(email),
+               {:ok, actor} <- Database.fetch_actor_by_email(account, email),
                {:ok, otp} <- Authentication.create_one_time_passcode(account, actor),
                {:ok, _} <- send_email_otp(conn, actor, otp.code, auth_provider_id, params) do
             {actor.id, otp.id, nil}
@@ -148,9 +151,29 @@ defmodule PortalWeb.EmailOTPController do
 
     conn = PortalWeb.Cookie.EmailOTP.put(conn, cookie)
 
-    # Keep delivery rate limiting internal so it cannot be used to determine
-    # whether an address belongs to an eligible actor.
-    conn
+    case error do
+      :rate_limited ->
+        put_flash(
+          conn,
+          :error,
+          "You're attempting to do that too quickly. Wait a few minutes and try again."
+        )
+
+      _ ->
+        conn
+    end
+  end
+
+  defp rate_limit_email_otp(email) do
+    case Portal.Mailer.RateLimiter.rate_limit(
+           {:sign_in_link, email},
+           3,
+           :timer.minutes(5),
+           fn -> :ok end
+         ) do
+      {:ok, :ok} -> :ok
+      {:error, :rate_limited} -> {:error, :rate_limited}
+    end
   end
 
   defp send_email_otp(conn, actor, code, auth_provider_id, params) do
@@ -163,11 +186,7 @@ defmodule PortalWeb.EmailOTPController do
       conn.remote_ip,
       sanitize(params)
     )
-    |> Portal.Mailer.deliver_with_rate_limit(
-      rate_limit_key: {:sign_in_link, actor.email},
-      rate_limit: 3,
-      rate_limit_interval: :timer.minutes(5)
-    )
+    |> Portal.Mailer.deliver()
   end
 
   defp check_admin(%Portal.Actor{type: :account_admin_user}, _context_type), do: :ok

--- a/elixir/test/portal_web/controllers/email_otp_controller_test.exs
+++ b/elixir/test/portal_web/controllers/email_otp_controller_test.exs
@@ -145,7 +145,7 @@ defmodule PortalWeb.EmailOTPControllerTest do
       assert email.to == [{"", actor.email}]
     end
 
-    test "does not disclose recipient email rate limiting", %{
+    test "rate limits eligible and unknown addresses identically", %{
       conn: conn,
       account: account,
       provider: provider
@@ -157,8 +157,11 @@ defmodule PortalWeb.EmailOTPControllerTest do
           allow_email_otp_sign_in: true
         )
 
+      unknown_email = "unknown-#{Ecto.UUID.generate()}@example.com"
+
       on_exit(fn ->
         Portal.Mailer.RateLimiter.reset_rate_limit({:sign_in_link, actor.email})
+        Portal.Mailer.RateLimiter.reset_rate_limit({:sign_in_link, unknown_email})
       end)
 
       for _ <- 1..3 do
@@ -177,7 +180,18 @@ defmodule PortalWeb.EmailOTPControllerTest do
           "email" => %{"email" => actor.email}
         })
 
-      unknown_email = "unknown-#{Ecto.UUID.generate()}@example.com"
+      assert flash(rate_limited_conn, :error) ==
+               "You're attempting to do that too quickly. Wait a few minutes and try again."
+      refute_received {:email, _}
+
+      for _ <- 1..3 do
+        conn =
+          post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+            "email" => %{"email" => unknown_email}
+          })
+
+        assert flash(conn, :error) == nil
+      end
 
       unknown_email_conn =
         post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{

--- a/elixir/test/portal_web/controllers/email_otp_controller_test.exs
+++ b/elixir/test/portal_web/controllers/email_otp_controller_test.exs
@@ -145,6 +145,53 @@ defmodule PortalWeb.EmailOTPControllerTest do
       assert email.to == [{"", actor.email}]
     end
 
+    test "does not disclose recipient email rate limiting", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor =
+        actor_fixture(
+          type: :account_admin_user,
+          account: account,
+          allow_email_otp_sign_in: true
+        )
+
+      on_exit(fn ->
+        Portal.Mailer.RateLimiter.reset_rate_limit({:sign_in_link, actor.email})
+      end)
+
+      for _ <- 1..3 do
+        conn =
+          post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+            "email" => %{"email" => actor.email}
+        })
+
+        assert flash(conn, :error) == nil
+        assert_received {:email, email}
+        assert email.to == [{"", actor.email}]
+      end
+
+      rate_limited_conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => actor.email}
+        })
+
+      unknown_email = "unknown-#{Ecto.UUID.generate()}@example.com"
+
+      unknown_email_conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => unknown_email}
+        })
+
+      assert rate_limited_conn.status == unknown_email_conn.status
+      assert flash(rate_limited_conn, :error) == flash(unknown_email_conn, :error)
+      assert redirected_to(rate_limited_conn) =~
+               ~p"/#{account.id}/sign_in/email_otp/#{provider.id}"
+
+      refute_received {:email, _}
+    end
+
     # Note: This scenario shouldn't be possible in practice because a DB constraint
     # prevents api_client actors from having emails, but we test for defense in depth.
     test "does not send email for api_client actor type", %{


### PR DESCRIPTION
Related: https://github.com/firezone/firezone/security/advisories/GHSA-ppj8-hq8j-598v