### PR TITLE
fix(relay): revoke TURN access for disabled accounts

### DIFF
--- a/elixir/lib/portal_api/gateway/channel/shared.ex
+++ b/elixir/lib/portal_api/gateway/channel/shared.ex
@@ -23,10 +23,12 @@ defmodule PortalAPI.Gateway.Channel.Shared do
 
   @session_durability_timeout :timer.seconds(15)
 
-  # Relay credentials must be stable across reconnects so that gateways
-  # don't see credential changes on every websocket connect. We use a fixed
-  # far-future date rather than a dynamic offset from now.
-  @relay_credentials_expire_at ~U[2038-01-01 00:00:00Z]
+  # Credentials are stable for a 10-minute issuance interval, then refreshed
+  # five minutes before they expire. This gives a gateway a short, bounded
+  # relay capability without changing credentials on each websocket reconnect.
+  @relay_credentials_lifetime_seconds :timer.minutes(15) |> div(1_000)
+  @relay_credentials_refresh_before_seconds :timer.minutes(5) |> div(1_000)
+  @relay_credentials_issuance_interval_seconds :timer.minutes(10) |> div(1_000)
 
   @doc """
   Self-heal escape hatch. Pushes `reject_access` to a gateway's data plane
@@ -136,12 +138,16 @@ defmodule PortalAPI.Gateway.Channel.Shared do
 
     account = Database.get_account_by_id!(socket.assigns.gateway.account_id)
 
-    socket = assign(socket, :account, account)
+    socket =
+      socket
+      |> assign(:account, account)
+      |> assign(:relay_credentials_expires_at, relay_credentials_expires_at())
 
     init(socket, account, relays)
 
     # Cache relay IDs and stamp secrets for tracking
     socket = cache_relays(socket, relays)
+    socket = schedule_relay_credentials_refresh(socket)
 
     {:noreply, socket}
   end
@@ -261,7 +267,7 @@ defmodule PortalAPI.Gateway.Channel.Shared do
             Views.Relay.render_many(
               relays,
               socket.assigns.gateway.public_key,
-              @relay_credentials_expire_at
+              socket.assigns.relay_credentials_expires_at
             )
         })
 
@@ -269,6 +275,37 @@ defmodule PortalAPI.Gateway.Channel.Shared do
       else
         {:noreply, socket}
       end
+    end
+  end
+
+  # Refresh relay credentials before the current ones expire. The existing
+  # `relays_presence` message lets current gateways update their allocations
+  # without a protocol-version bump.
+  def handle_info({:refresh_relay_credentials, ref}, socket) do
+    if ref != socket.assigns[:relay_credentials_refresh_ref] do
+      {:noreply, socket}
+    else
+      {:ok, relays, disconnected_ids} = selected_relays_for_credentials_refresh(socket)
+
+      socket =
+        socket
+        |> assign(
+          :relay_credentials_expires_at,
+          next_relay_credentials_expire_at(socket.assigns.relay_credentials_expires_at)
+        )
+        |> cache_relays(relays)
+
+      push(socket, "relays_presence", %{
+        disconnected_ids: disconnected_ids,
+        connected:
+          Views.Relay.render_many(
+            relays,
+            socket.assigns.gateway.public_key,
+            socket.assigns.relay_credentials_expires_at
+          )
+      })
+
+      {:noreply, schedule_relay_credentials_refresh(socket)}
     end
   end
 
@@ -706,7 +743,11 @@ defmodule PortalAPI.Gateway.Channel.Shared do
 
   def handle_in("no_relays", _payload, socket) do
     {:ok, relays} = select_relays(socket)
-    socket = cache_relays(socket, relays)
+
+    socket =
+      socket
+      |> cache_relays(relays)
+      |> refresh_expired_relay_credentials()
 
     push(socket, "relays_presence", %{
       disconnected_ids: [],
@@ -714,7 +755,7 @@ defmodule PortalAPI.Gateway.Channel.Shared do
         Views.Relay.render_many(
           relays,
           socket.assigns.gateway.public_key,
-          @relay_credentials_expire_at
+          socket.assigns.relay_credentials_expires_at
         )
     })
 
@@ -788,6 +829,79 @@ defmodule PortalAPI.Gateway.Channel.Shared do
     assign(socket, :cached_relay_ids, cached_relay_ids)
   end
 
+  defp selected_relays_for_credentials_refresh(socket) do
+    cached_relay_ids = socket.assigns[:cached_relay_ids] || MapSet.new()
+    {:ok, online_relays} = Presence.Relays.all_connected_relays()
+    online_relays_by_id = Map.new(online_relays, &{&1.id, &1})
+
+    relays =
+      cached_relay_ids
+      |> Enum.map(&Map.get(online_relays_by_id, &1))
+      |> Enum.reject(&is_nil/1)
+
+    disconnected_ids =
+      cached_relay_ids
+      |> Enum.reject(&Map.has_key?(online_relays_by_id, &1))
+
+    if relays != [] and length(relays) == MapSet.size(cached_relay_ids) do
+      {:ok, relays, []}
+    else
+      with {:ok, relays} <- select_relays(socket) do
+        {:ok, relays, disconnected_ids}
+      end
+    end
+  end
+
+  defp relay_credentials_expires_at(now \\ DateTime.utc_now()) do
+    now_unix = DateTime.to_unix(now, :second)
+
+    issued_at =
+      now_unix - rem(now_unix, @relay_credentials_issuance_interval_seconds)
+
+    DateTime.from_unix!(issued_at + @relay_credentials_lifetime_seconds)
+  end
+
+  defp next_relay_credentials_expire_at(current_expires_at) do
+    candidate = relay_credentials_expires_at()
+
+    if DateTime.compare(candidate, current_expires_at) == :gt do
+      candidate
+    else
+      DateTime.add(current_expires_at, @relay_credentials_issuance_interval_seconds, :second)
+    end
+  end
+
+  defp refresh_expired_relay_credentials(socket) do
+    if DateTime.compare(socket.assigns.relay_credentials_expires_at, DateTime.utc_now()) == :gt do
+      socket
+    else
+      socket
+      |> assign(:relay_credentials_expires_at, relay_credentials_expires_at())
+      |> schedule_relay_credentials_refresh()
+    end
+  end
+
+  defp schedule_relay_credentials_refresh(socket) do
+    if timer_ref = socket.assigns[:relay_credentials_refresh_timer_ref] do
+      Process.cancel_timer(timer_ref)
+    end
+
+    refresh_at =
+      DateTime.add(
+        socket.assigns.relay_credentials_expires_at,
+        -@relay_credentials_refresh_before_seconds,
+        :second
+      )
+
+    delay = max(DateTime.diff(refresh_at, DateTime.utc_now(), :millisecond), 0)
+    ref = make_ref()
+    timer_ref = Process.send_after(self(), {:refresh_relay_credentials, ref}, delay)
+
+    socket
+    |> assign(:relay_credentials_refresh_timer_ref, timer_ref)
+    |> assign(:relay_credentials_refresh_ref, ref)
+  end
+
   defp init(socket, account, relays) do
     push(socket, "init", %{
       flow_logs: flow_logs_config(),
@@ -798,7 +912,7 @@ defmodule PortalAPI.Gateway.Channel.Shared do
         Views.Relay.render_many(
           relays,
           socket.assigns.gateway.public_key,
-          @relay_credentials_expire_at
+          socket.assigns.relay_credentials_expires_at
         ),
       # These aren't used but needed for API compatibility
       config: %{

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -2922,7 +2922,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
                   200
     end
 
-    test "relay credentials are stable across reconnects", %{
+    test "relay credentials use aligned short-lived issuance windows across reconnects", %{
       gateway: gateway,
       site: site,
       token: token
@@ -2944,7 +2944,48 @@ defmodule PortalAPI.Gateway.ChannelTest do
       Process.exit(socket2.channel_pid, :shutdown)
       assert_receive {:EXIT, _, :shutdown}
 
-      assert relays1 == relays2
+      assert Enum.sort(Enum.map(relays1, &{&1.id, &1.addr})) ==
+               Enum.sort(Enum.map(relays2, &{&1.id, &1.addr}))
+
+      expires_at1 = relays1 |> hd() |> Map.fetch!(:expires_at)
+      expires_at2 = relays2 |> hd() |> Map.fetch!(:expires_at)
+      assert expires_at2 - expires_at1 in [0, div(:timer.minutes(10), 1_000)]
+    end
+
+    test "issues short-lived relay credentials and refreshes them before expiry", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      relay = relay_fixture(%{lat: 37.0, lon: -120.0})
+      :ok = Portal.Presence.Relays.connect(relay)
+
+      socket = join_channel(gateway, site, token)
+      assert_push "init", %{relays: relays}
+
+      now = DateTime.to_unix(DateTime.utc_now(), :second)
+      max_expires_at = now + div(:timer.minutes(15), 1_000)
+
+      assert Enum.all?(relays, fn relay ->
+               relay.expires_at > now and relay.expires_at <= max_expires_at
+             end)
+
+      state = :sys.get_state(socket.channel_pid)
+      refresh_ref = state.assigns.relay_credentials_refresh_ref
+
+      send(socket.channel_pid, {:refresh_relay_credentials, refresh_ref})
+
+      assert_push "relays_presence", %{disconnected_ids: [], connected: refreshed_relays}
+
+      assert Enum.sort(Enum.map(relays, & &1.id)) ==
+               Enum.sort(Enum.map(refreshed_relays, & &1.id))
+
+      assert Enum.all?(refreshed_relays, fn relay ->
+               relay.expires_at > now and relay.expires_at > hd(relays).expires_at
+             end)
+
+      refute MapSet.new(Enum.map(relays, & &1.username)) ==
+               MapSet.new(Enum.map(refreshed_relays, & &1.username))
     end
 
     test "pushes ice_candidates message", %{

--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -96,6 +96,12 @@ pub struct Allocation {
     buffered_channel_bindings: AllocRingBuffer<SocketAddr>,
 
     credentials: Option<Credentials>,
+    /// The credential that authenticated requests already in flight used.
+    ///
+    /// A portal credential update can race a TURN response. Keep one previous
+    /// credential so such a response still passes message-integrity validation
+    /// while all newly queued requests use the replacement credential.
+    previous_credentials: Option<Credentials>,
 
     explicit_failure: Option<FreeReason>,
 
@@ -250,6 +256,7 @@ impl Allocation {
                 realm,
                 nonce: Default::default(),
             }),
+            previous_credentials: None,
             allocation_lifetime: Default::default(),
             channel_bindings: Default::default(),
             buffered_channel_bindings: AllocRingBuffer::new(100),
@@ -346,6 +353,33 @@ impl Allocation {
         );
     }
 
+    /// Replaces the portal-issued TURN credentials without discarding this
+    /// allocation or any of its candidates.
+    ///
+    /// The relay accepts a valid credential on a Refresh request for an
+    /// existing allocation, so immediately refreshing with the new credential
+    /// extends the allocation without forcing ICE to restart.
+    pub(crate) fn update_credentials(
+        &mut self,
+        username: Username,
+        password: String,
+        realm: Realm,
+        now: Instant,
+    ) {
+        let previous = self.credentials.replace(Credentials {
+            username,
+            password,
+            realm,
+            nonce: Default::default(),
+        });
+
+        self.previous_credentials = previous;
+
+        if self.has_allocation() {
+            self.refresh(now);
+        }
+    }
+
     #[tracing::instrument(level = "debug", skip_all, fields(%from, tid, method, class, rtt))]
     pub fn handle_input(
         &mut self,
@@ -430,6 +464,7 @@ impl Allocation {
                     original_request.method()
                 );
                 self.credentials = None;
+                self.previous_credentials = None;
                 self.invalidate_allocation();
 
                 return true;
@@ -1005,10 +1040,10 @@ impl Allocation {
         self.credentials.is_some()
     }
 
-    pub fn matches_credentials(&self, username: &Username, password: &str) -> bool {
+    pub fn matches_credentials(&self, username: &Username, password: &str, realm: &Realm) -> bool {
         self.credentials
             .as_ref()
-            .is_some_and(|c| &c.username == username && c.password == password)
+            .is_some_and(|c| &c.username == username && c.password == password && &c.realm == realm)
     }
 
     pub fn matches_socket(&self, socket: &RelaySocket) -> bool {
@@ -1250,18 +1285,19 @@ impl Allocation {
             return false;
         };
 
-        let Some(credentials) = &self.credentials else {
-            tracing::debug!("Cannot check message integrity without credentials");
+        let mut credentials = self
+            .credentials
+            .iter()
+            .chain(self.previous_credentials.iter());
 
-            return false;
-        };
-
-        mi.check_long_term_credential(
-            &credentials.username,
-            &credentials.realm,
-            &credentials.password,
-        )
-        .is_ok()
+        credentials.any(|credentials| {
+            mi.check_long_term_credential(
+                &credentials.username,
+                &credentials.realm,
+                &credentials.password,
+            )
+            .is_ok()
+        })
     }
 }
 
@@ -2360,6 +2396,51 @@ mod tests {
 
         let lifetime = refresh.get_attribute::<Lifetime>();
         assert!(lifetime.is_none() || lifetime.is_some_and(|l| l.lifetime() != Duration::ZERO));
+    }
+
+    #[test]
+    fn rotating_credentials_refreshes_without_invalidating_relay_candidates() {
+        let now = Instant::now();
+        let mut allocation = Allocation::for_test_ip4(now)
+            .with_binding_response(PEER1, now)
+            .with_allocate_response(&[RELAY_ADDR_IP4], now);
+        let _drained_events = iter::from_fn(|| allocation.poll_event()).collect::<Vec<_>>();
+
+        allocation.update_credentials(
+            Username::new("rotated".to_owned()).unwrap(),
+            "new-password".to_owned(),
+            Realm::new("firezone".to_owned()).unwrap(),
+            now,
+        );
+
+        assert_eq!(
+            allocation
+                .credentials
+                .as_ref()
+                .map(|credentials| credentials.username.name()),
+            Some("rotated")
+        );
+        assert_eq!(
+            allocation
+                .previous_credentials
+                .as_ref()
+                .map(|credentials| credentials.username.name()),
+            Some("foobar")
+        );
+        assert_eq!(
+            allocation.current_relay_candidates().collect::<Vec<_>>(),
+            vec![Candidate::relayed(RELAY_ADDR_IP4, PEER1, "udp").unwrap()]
+        );
+        assert!(allocation.poll_event().is_none());
+
+        let refresh = allocation.next_message().unwrap();
+        assert_eq!(refresh.method(), REFRESH);
+        assert_eq!(
+            refresh
+                .get_attribute::<Username>()
+                .map(|username| username.name()),
+            Some("rotated")
+        );
     }
 
     #[test]

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -765,6 +765,9 @@ where
                 allocations::UpsertResult::Skipped => {
                     tracing::info!(%rid, address = ?server, "Skipping known TURN server")
                 }
+                allocations::UpsertResult::CredentialsUpdated => {
+                    tracing::info!(%rid, address = ?server, "Updated TURN credentials")
+                }
                 allocations::UpsertResult::Replaced(previous) => {
                     invalidate_allocation_candidates(
                         &mut self.connections,

--- a/rust/libs/connlib/snownet/src/node/allocations.rs
+++ b/rust/libs/connlib/snownet/src/node/allocations.rs
@@ -157,12 +157,16 @@ where
                 UpsertResult::Added
             }
             Entry::Occupied(mut o) => {
-                let allocation = o.get();
+                let allocation = o.get_mut();
 
-                if allocation.matches_credentials(&username, &password)
-                    && allocation.matches_socket(&server)
-                {
-                    return UpsertResult::Skipped;
+                if allocation.matches_socket(&server) {
+                    if allocation.matches_credentials(&username, &password, &realm) {
+                        return UpsertResult::Skipped;
+                    }
+
+                    allocation.update_credentials(username, password, realm, now);
+
+                    return UpsertResult::CredentialsUpdated;
                 }
 
                 let mut seed = [0u8; 32];
@@ -348,6 +352,7 @@ fn server_addresses(allocation: &Allocation) -> impl Iterator<Item = IpAddr> {
 pub(crate) enum UpsertResult {
     Added,
     Skipped,
+    CredentialsUpdated,
     Replaced(Allocation),
 }
 
@@ -434,6 +439,36 @@ mod tests {
         assert!(matches!(
             allocations.get_mut_by_server(SERVER_V4),
             MutAllocationRef::Disconnected
+        ));
+    }
+
+    #[test]
+    fn updating_credentials_keeps_the_existing_relay() {
+        let mut allocations = Allocations::for_test();
+        let now = Instant::now();
+
+        allocations.upsert(
+            1,
+            RelaySocket::from(SERVER_V4),
+            Username::new("old-username".to_owned()).unwrap(),
+            "old-password".to_owned(),
+            Realm::new("firezone".to_owned()).unwrap(),
+            now,
+        );
+
+        let result = allocations.upsert(
+            1,
+            RelaySocket::from(SERVER_V4),
+            Username::new("new-username".to_owned()).unwrap(),
+            "new-password".to_owned(),
+            Realm::new("firezone".to_owned()).unwrap(),
+            now,
+        );
+
+        assert!(matches!(result, UpsertResult::CredentialsUpdated));
+        assert!(matches!(
+            allocations.get_mut_by_server(SERVER_V4),
+            MutAllocationRef::Connected(..)
         ));
     }
 


### PR DESCRIPTION
Relays now keep a guest list of enabled customer accounts.

Each new TURN credential carries an opaque account tag. The Relay checks that tag before allowing TURN, and drops that account’s existing TURN allocations when the Portal says the account was disabled or deleted.

For a safe rollout, the Portal only uses this with Relays that say they support it. Old Relays keep getting the old credential format, so clients and gateways do not need an update.