### PR TITLE
fix(connlib): route one-shot DNS queries around the tunnel

### DIFF
--- a/rust/libs/connlib/bootstrap-dns-client/lib.rs
+++ b/rust/libs/connlib/bootstrap-dns-client/lib.rs
@@ -392,38 +392,6 @@ mod tests {
         assert_eq!(ips, vec![IpAddr::from(Ipv4Addr::new(20, 40, 122, 20))]);
     }
 
-    #[tokio::test]
-    async fn tcp_fallback_hands_the_server_address_to_the_socket_factory() {
-        // Platform TCP socket factories derive routing decisions from the address they
-        // are given (e.g. Windows creates a route around the tunnel for it), so the
-        // fallback must pass the server address, not a wildcard.
-        let (tcp, udp, server_addr) = bind_tcp_and_udp().await;
-
-        spawn_udp_responder(udp, empty_noerror);
-        spawn_tcp_responder(tcp, a_record(Ipv4Addr::new(20, 40, 122, 20)));
-
-        let factory_addrs = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let recorded_addrs = factory_addrs.clone();
-        let tcp_factory = move |addr: SocketAddr| {
-            recorded_addrs.lock().unwrap().push(addr);
-
-            socket_factory::tcp(addr)
-        };
-
-        let client = BootstrapDnsClient::with_servers(
-            Arc::new(socket_factory::udp),
-            Arc::new(tcp_factory),
-            vec![server_addr],
-        );
-
-        client.resolve("api.firez.one").await.unwrap();
-
-        let factory_addrs = factory_addrs.lock().unwrap();
-
-        assert!(!factory_addrs.is_empty());
-        assert!(factory_addrs.iter().all(|addr| *addr == server_addr));
-    }
-
     fn test_client(servers: impl IntoIterator<Item = SocketAddr>) -> BootstrapDnsClient {
         BootstrapDnsClient::with_servers(
             Arc::new(socket_factory::udp),

--- a/rust/libs/connlib/bootstrap-dns-client/lib.rs
+++ b/rust/libs/connlib/bootstrap-dns-client/lib.rs
@@ -165,7 +165,7 @@ async fn send_query_tcp(
     query: dns_types::Query,
 ) -> Result<dns_types::Response> {
     let socket = socket_factory
-        .bind(unspecified_bind_addr(server))
+        .bind(server)
         .context("Failed to create TCP socket")?;
 
     let response = tokio::time::timeout(BootstrapDnsClient::TIMEOUT, async move {
@@ -390,6 +390,38 @@ mod tests {
         let ips = client.resolve("api.firez.one").await.unwrap();
 
         assert_eq!(ips, vec![IpAddr::from(Ipv4Addr::new(20, 40, 122, 20))]);
+    }
+
+    #[tokio::test]
+    async fn tcp_fallback_hands_the_server_address_to_the_socket_factory() {
+        // Platform TCP socket factories derive routing decisions from the address they
+        // are given (e.g. Windows creates a route around the tunnel for it), so the
+        // fallback must pass the server address, not a wildcard.
+        let (tcp, udp, server_addr) = bind_tcp_and_udp().await;
+
+        spawn_udp_responder(udp, empty_noerror);
+        spawn_tcp_responder(tcp, a_record(Ipv4Addr::new(20, 40, 122, 20)));
+
+        let factory_addrs = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorded_addrs = factory_addrs.clone();
+        let tcp_factory = move |addr: SocketAddr| {
+            recorded_addrs.lock().unwrap().push(addr);
+
+            socket_factory::tcp(addr)
+        };
+
+        let client = BootstrapDnsClient::with_servers(
+            Arc::new(socket_factory::udp),
+            Arc::new(tcp_factory),
+            vec![server_addr],
+        );
+
+        client.resolve("api.firez.one").await.unwrap();
+
+        let factory_addrs = factory_addrs.lock().unwrap();
+
+        assert!(!factory_addrs.is_empty());
+        assert!(factory_addrs.iter().all(|addr| *addr == server_addr));
     }
 
     fn test_client(servers: impl IntoIterator<Item = SocketAddr>) -> BootstrapDnsClient {

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -736,7 +736,30 @@ impl UdpSocket {
         dst: SocketAddr,
         payload: &[u8],
     ) -> io::Result<Vec<u8>> {
-        self.inner.send_to(payload, dst).await?;
+        let src_ip = self
+            .source_ip_resolver
+            .as_ref()
+            .map(|resolve| resolve(dst.ip()))
+            .transpose()?;
+
+        // A plain `send_to` cannot carry a source IP; sending via [`quinn_udp`] pins the
+        // resolved source through a control message, like all other sends on our sockets.
+        let state = quinn_udp::UdpSocketState::new(UdpSockRef::from(&self.inner))?;
+        let transmit = Transmit {
+            destination: dst,
+            ecn: None,
+            contents: payload,
+            segment_size: None,
+            src_ip,
+        };
+
+        // A `Transmit` without a `segment_size` is a single datagram, so a successful send is complete.
+        let _ = self
+            .inner
+            .async_io(Interest::WRITABLE, || {
+                state.try_send(UdpSockRef::from(&self.inner), &transmit)
+            })
+            .await?;
 
         let mut buffer = vec![0u8; BUF_SIZE];
 

--- a/rust/libs/connlib/socket-factory/tests/handshake.rs
+++ b/rust/libs/connlib/socket-factory/tests/handshake.rs
@@ -1,0 +1,71 @@
+//! Integration tests for [`socket_factory::UdpSocket::handshake`], exercising it through its public API.
+
+use std::net::{IpAddr, Ipv4Addr};
+
+use socket_factory::udp;
+
+#[tokio::test]
+async fn handshake_roundtrips_without_source_ip_resolver() {
+    let peer = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let peer_addr = peer.local_addr().unwrap();
+
+    let socket = udp("0.0.0.0:0".parse().unwrap()).unwrap();
+
+    let handshake = tokio::spawn(async move { socket.handshake::<128>(peer_addr, b"ping").await });
+
+    let mut buf = [0u8; 128];
+    let (len, sender) = peer.recv_from(&mut buf).await.unwrap();
+    assert_eq!(&buf[..len], b"ping");
+
+    peer.send_to(b"pong", sender).await.unwrap();
+
+    let response = handshake.await.unwrap().unwrap();
+    assert_eq!(response, b"pong");
+}
+
+/// The configured source IP resolver determines the source address of the outbound query.
+///
+/// The resolver returns a second loopback address, so source selection by the operating
+/// system (which would pick `127.0.0.1`) cannot produce a false positive. Only Linux
+/// has the rest of `127.0.0.0/8` assigned to the loopback interface by default.
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn handshake_sends_from_resolved_source_ip() {
+    let peer = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let peer_addr = peer.local_addr().unwrap();
+
+    let socket = udp("0.0.0.0:0".parse().unwrap())
+        .unwrap()
+        .with_source_ip_resolver(Box::new(|_| Ok(IpAddr::from(Ipv4Addr::new(127, 0, 0, 2)))));
+
+    let handshake = tokio::spawn(async move { socket.handshake::<128>(peer_addr, b"ping").await });
+
+    let mut buf = [0u8; 128];
+    let (len, sender) = peer.recv_from(&mut buf).await.unwrap();
+    assert_eq!(&buf[..len], b"ping");
+    assert_eq!(sender.ip(), IpAddr::from(Ipv4Addr::new(127, 0, 0, 2)));
+
+    peer.send_to(b"pong", sender).await.unwrap();
+
+    let response = handshake.await.unwrap().unwrap();
+    assert_eq!(response, b"pong");
+}
+
+/// A failure to resolve the source IP fails the handshake instead of falling back to
+/// source selection by the operating system.
+#[tokio::test]
+async fn handshake_fails_when_source_ip_resolution_fails() {
+    let peer = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let peer_addr = peer.local_addr().unwrap();
+
+    let socket = udp("0.0.0.0:0".parse().unwrap())
+        .unwrap()
+        .with_source_ip_resolver(Box::new(|_| Err(std::io::Error::other("no route"))));
+
+    let error = socket
+        .handshake::<128>(peer_addr, b"ping")
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.to_string(), "no route");
+}

--- a/rust/libs/connlib/socket-factory/tests/handshake.rs
+++ b/rust/libs/connlib/socket-factory/tests/handshake.rs
@@ -1,5 +1,6 @@
 //! Integration tests for [`socket_factory::UdpSocket::handshake`], exercising it through its public API.
 
+#[cfg(target_os = "linux")]
 use std::net::{IpAddr, Ipv4Addr};
 
 use socket_factory::udp;


### PR DESCRIPTION
One-shot DNS queries (recursive queries from connlib and the bootstrap DNS client) sent their UDP query with a plain `send_to`, which bypasses the socket's source IP resolver. On Windows, where the resolver pins traffic to the best non-tunnel interface, the operating system could select the tunnel interface as the source instead, looping the query back into the tunnel. `UdpSocket::handshake` therefore sends via `quinn_udp`, attaching the resolved source IP as a control message, the same mechanism `PerfUdpSocket` uses for all other sends.

The TCP fallback of the bootstrap DNS client passed a wildcard address to the TCP socket factory even though platform factories derive routing decisions from that address, e.g. on Windows a bypass route around the tunnel. It hands over the DNS server address instead, like all other TCP connections.