### PR TITLE
fix(portal): line up the controls in a filter bar

### DIFF
--- a/elixir/lib/portal_web/live_table.ex
+++ b/elixir/lib/portal_web/live_table.ex
@@ -228,7 +228,7 @@ defmodule PortalWeb.LiveTable do
           phx-click="filter"
           phx-value-table_id={@live_table_id}
           phx-value-filter={nil}
-          class="inline-flex items-center gap-1 px-2.5 h-8 rounded text-xs font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface)] cursor-pointer transition-colors shrink-0"
+          class="order-last inline-flex items-center gap-1 px-2.5 h-8 rounded text-xs font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface)] cursor-pointer transition-colors shrink-0"
           title="Clear all filters"
         >
           <.icon name="ri-close-line" class="w-3.5 h-3.5" /> Reset


### PR DESCRIPTION
Two things in the filter bar that did not match the rest of it.

The Reset button was not always last. Dropdown filters are given a CSS order so they line up after the search box and the segmented toggles, and Reset had no order at all, so any dropdown jumped in front of it. It is now ordered last rather than given a number of its own, so a filter added later cannot get behind it again.

Dropdown filters also rendered through the shared form select, which is sized for a form: taller than the 32px controls beside it, on a different background and border. They are now built the way the multi-select trigger on Change Logs is, down to the arrow icon and the brand colouring once a value is picked. Their prompt stops capitalising mid-sentence too, so it reads "All trust levels" rather than "All Trust levels".

Clients, Actors and Groups all had both.

Still mismatched, and worth a follow-up: the grouped dropdowns on Policies and Resources go through the shared form select the same way.
