### PR TITLE
fix(portal): make dropdown filters look like the rest of the bar

### DIFF
--- a/elixir/lib/portal_web/live_table.ex
+++ b/elixir/lib/portal_web/live_table.ex
@@ -553,13 +553,33 @@ defmodule PortalWeb.LiveTable do
 
   defp filter(%{filter: %{type: {:string, :select}}} = assigns) do
     ~H"""
-    <div class="flex items-center order-4">
-      <.input
-        type="select"
-        field={@form[@filter.name]}
-        prompt={"All " <> pluralize(@filter.title)}
-        options={@filter.values}
-      />
+    <div class="relative shrink-0 order-4">
+      <select
+        id={"#{@live_table_id}-#{@filter.name}"}
+        name={@form[@filter.name].name}
+        class={[
+          "appearance-none bg-none h-8 pl-3 pr-8 rounded border text-xs font-medium",
+          "cursor-pointer transition-colors outline-none",
+          "focus:ring-1 focus:ring-[var(--control-focus)]/30",
+          if(@form[@filter.name].value in [nil, ""],
+            do:
+              "border-[var(--control-border)] bg-[var(--control-bg)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]",
+            else: "border-[var(--brand)]/40 bg-[var(--brand-muted)] text-[var(--text-primary)]"
+          )
+        ]}
+      >
+        <option value="">All {pluralize(String.downcase(@filter.title))}</option>
+        <option
+          :for={{label, value} <- @filter.values}
+          value={value}
+          selected={to_string(@form[@filter.name].value) == to_string(value)}
+        >
+          {label}
+        </option>
+      </select>
+      <span class="pointer-events-none absolute inset-y-0 right-2 flex items-center text-[var(--text-tertiary)]">
+        <.icon name="ri-arrow-down-s-line" class="w-3.5 h-3.5" />
+      </span>
     </div>
     """
   end

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -89,6 +89,18 @@ defmodule PortalWeb.ClientsTest do
       end
     end
 
+    test "offers the trust levels to filter by", %{conn: conn, account: account, actor: actor} do
+      client_fixture(account: account, actor: actor)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients")
+
+      assert html =~ "All trust levels"
+      refute html =~ "All Trust levels"
+    end
+
     test "filters by attestation level", %{conn: conn, account: account, actor: actor} do
       verified_actor = actor_fixture(account: account, name: "Verified Owner")
 


### PR DESCRIPTION
Dropdown filters rendered through the shared form select, which is sized for a form: taller than the 32px controls beside it, on a different background and border. Next to the search box, the segmented toggles and the multi-select that Change Logs uses, it was the one control in the bar that did not line up.

It now matches them: same height, same border and background tokens, same arrow icon, and the same brand colouring once a value is picked. It stays a native select, so picking a value still closes it the way it always has.

The prompt also stops capitalising mid-sentence, so it reads "All trust levels" rather than "All Trust levels".

Clients, Actors and Groups all had this.

Related: #14985
