### PR TITLE
test(portal): fix the flaky malformed token log assertion

### DIFF
--- a/elixir/test/portal/authentication_test.exs
+++ b/elixir/test/portal/authentication_test.exs
@@ -213,9 +213,14 @@ defmodule Portal.AuthenticationTest do
     test "does not log malformed tokens" do
       context = build_context(type: :client)
 
-      assert capture_log(fn ->
-               assert authenticate("invalid.token", context) == {:error, :invalid_token}
-             end) == ""
+      # capture_log/1 captures the whole deployment's log, not this process's,
+      # so an empty string only holds while no other async test happens to log.
+      log =
+        capture_log(fn ->
+          assert authenticate("invalid.token", context) == {:error, :invalid_token}
+        end)
+
+      refute log =~ "invalid.token"
     end
 
     test "returns error when token is invalid" do


### PR DESCRIPTION
`Portal.AuthenticationTest` "does not log malformed tokens" fails at random on any branch. It asserts that `capture_log/1` returns an empty string, but `capture_log/1` captures every log line the node emits while the block runs, not the lines the calling process emits. In an async suite that makes it an assertion about whether any other test happened to log in the same instant.

The run that caught it captured a Change Logs LiveView query and a Google directory sync job. The test calls neither.

It now asserts the token never reaches the log, which is what the test is named for and what #14969 was guarding, and which no test running beside it can knock over.

Related: #14969
