### PR TITLE
fix(connlib): retry DoH queries on closed connections

### DIFF
--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -16,7 +16,7 @@ use bufferpool::{Buffer, VecBuf};
 use dns_types::DoHUrl;
 use futures::{
     FutureExt as _, TryFutureExt as _,
-    future::{BoxFuture, Shared},
+    future::{BoxFuture, Remote, RemoteHandle, Shared},
 };
 use futures_bounded::FuturesTupleSet;
 use http_client::HttpClient;
@@ -74,12 +74,53 @@ struct DnsQueryMetaData {
 }
 
 enum DohClient {
-    Connecting(Bootstrap),
+    Connecting {
+        /// Dropping this before it completes makes polling `handle` panic; [`Io::reset`] drops the waiting queries along with it.
+        driver: Remote<BoxFuture<'static, BootstrapResult>>,
+        handle: Shared<RemoteHandle<BootstrapResult>>,
+    },
     Connected(HttpClient),
 }
 
-/// Shared between the [`Io`] event-loop, which drives it, and the queries waiting on it.
-type Bootstrap = Shared<BoxFuture<'static, Result<HttpClient, Arc<anyhow::Error>>>>;
+/// `anyhow::Error` is not `Clone`, which the output of a [`Shared`] future has to be.
+type BootstrapResult = Result<HttpClient, Arc<anyhow::Error>>;
+
+impl DohClient {
+    /// Only polling `driver` advances the bootstrap; `handle` merely observes its result.
+    fn connecting(
+        bootstrap_dns_client: &BootstrapDnsClient,
+        socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+        server: &DoHUrl,
+    ) -> Self {
+        let addresses = bootstrap_dns_client.resolve(server.host());
+        let server = server.clone();
+
+        let (driver, handle) = tokio::time::timeout(DNS_QUERY_TIMEOUT, async move {
+            tracing::debug!(%server, "Bootstrapping DoH client");
+
+            let addresses = addresses.await?;
+            let http_client =
+                HttpClient::new(server.host().to_string(), addresses, socket_factory).await?;
+
+            tracing::debug!(%server, "Bootstrapped DoH client");
+
+            Ok(http_client)
+        })
+        .map(|result| {
+            result
+                .map_err(anyhow::Error::new)
+                .flatten()
+                .map_err(Arc::new)
+        })
+        .boxed()
+        .remote_handle();
+
+        Self::Connecting {
+            driver,
+            handle: handle.shared(),
+        }
+    }
+}
 
 /// Represents all IO sources that may be ready during a single event-loop tick.
 ///
@@ -244,27 +285,31 @@ impl Io {
         // We purposely don't want to block the event loop here because we can do plenty of other work while this is running.
         let _ = self.nameservers.poll(cx);
 
-        self.doh_clients
-            .extract_if(.., |url, client| {
-                let DohClient::Connecting(bootstrap) = client else {
-                    return false;
-                };
+        let mut failed_bootstraps = Vec::new();
 
-                match bootstrap.poll_unpin(cx) {
-                    Poll::Ready(Ok(http_client)) => {
-                        *client = DohClient::Connected(http_client);
+        for (url, client) in self.doh_clients.iter_mut() {
+            let DohClient::Connecting { driver, handle } = client else {
+                continue;
+            };
 
-                        false
-                    }
-                    Poll::Ready(Err(e)) => {
-                        tracing::debug!(%url, "Failed to bootstrap DoH client: {e:#}");
+            if driver.poll_unpin(cx).is_pending() {
+                continue;
+            }
 
-                        true
-                    }
-                    Poll::Pending => false,
+            match handle.poll_unpin(cx) {
+                Poll::Ready(Ok(http_client)) => *client = DohClient::Connected(http_client),
+                Poll::Ready(Err(e)) => {
+                    tracing::debug!(%url, "Failed to bootstrap DoH client: {e:#}");
+
+                    failed_bootstraps.push(url.clone());
                 }
-            })
-            .for_each(drop);
+                Poll::Pending => {}
+            }
+        }
+
+        for url in failed_bootstraps {
+            self.doh_clients.remove(&url);
+        }
 
         let network = self.sockets.poll_recv_from(cx);
 
@@ -536,59 +581,36 @@ impl Io {
 
     /// Ensures a DoH client for `server` exists or is being bootstrapped.
     pub(crate) fn bootstrap_doh_client(&mut self, server: DoHUrl) {
-        drop(self.doh_client(server));
+        self.doh_client_entry(server);
     }
 
-    /// Returns the DoH client for `server`, bootstrapping a new one if there is none or its connection is closed.
+    /// Resolves to the DoH client for `server` once it is connected.
     fn doh_client(&mut self, server: DoHUrl) -> BoxFuture<'static, Result<HttpClient>> {
-        let bootstrap = match self.doh_clients.get(&server) {
-            Some(DohClient::Connected(client)) if !client.is_closed() => {
-                return futures::future::ready(Ok(client.clone())).boxed();
+        match self.doh_client_entry(server) {
+            DohClient::Connected(client) => futures::future::ready(Ok(client.clone())).boxed(),
+            DohClient::Connecting { handle, .. } => {
+                handle.clone().map_err(|e| anyhow::anyhow!("{e:#}")).boxed()
             }
-            Some(DohClient::Connected(_)) => {
-                tracing::debug!(%server, "DoH connection is closed");
-
-                self.start_doh_bootstrap(server)
-            }
-            Some(DohClient::Connecting(bootstrap)) => bootstrap.clone(),
-            None => self.start_doh_bootstrap(server),
-        };
-
-        bootstrap.map_err(|e| anyhow::anyhow!("{e:#}")).boxed()
+        }
     }
 
-    fn start_doh_bootstrap(&mut self, server: DoHUrl) -> Bootstrap {
-        let socket_factory = self.tcp_socket_factory.clone();
-        let addresses = self.bootstrap_dns_client.resolve(server.host());
+    /// Returns the entry for `server`, replacing a closed client with a fresh bootstrap.
+    fn doh_client_entry(&mut self, server: DoHUrl) -> &DohClient {
+        if let Some(DohClient::Connected(client)) = self.doh_clients.get(&server)
+            && client.is_closed()
+        {
+            tracing::debug!(%server, "DoH connection is closed");
 
-        let bootstrap = tokio::time::timeout(DNS_QUERY_TIMEOUT, {
-            let server = server.clone();
+            self.doh_clients.remove(&server);
+        }
 
-            async move {
-                tracing::debug!(%server, "Bootstrapping DoH client");
-
-                let addresses = addresses.await?;
-                let http_client =
-                    HttpClient::new(server.host().to_string(), addresses, socket_factory).await?;
-
-                tracing::debug!(%server, "Bootstrapped DoH client");
-
-                Ok(http_client)
-            }
+        self.doh_clients.entry(server).or_insert_with_key(|server| {
+            DohClient::connecting(
+                &self.bootstrap_dns_client,
+                self.tcp_socket_factory.clone(),
+                server,
+            )
         })
-        .map(|result| {
-            result
-                .map_err(anyhow::Error::new)
-                .flatten()
-                .map_err(Arc::new)
-        })
-        .boxed()
-        .shared();
-
-        self.doh_clients
-            .insert(server, DohClient::Connecting(bootstrap.clone()));
-
-        bootstrap
     }
 
     pub(crate) fn send_udp_dns_response(
@@ -676,7 +698,7 @@ mod tests {
 
         assert!(matches!(
             io.doh_clients.get(&DoHUrl::cloudflare()),
-            Some(DohClient::Connecting(_))
+            Some(DohClient::Connecting { .. })
         ));
     }
 

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -14,7 +14,11 @@ use anyhow::{ErrorExt, Result};
 use bootstrap_dns_client::BootstrapDnsClient;
 use bufferpool::{Buffer, VecBuf};
 use dns_types::DoHUrl;
-use futures_bounded::{FuturesMap, FuturesTupleSet};
+use futures::{
+    FutureExt as _, TryFutureExt as _,
+    future::{BoxFuture, Shared},
+};
+use futures_bounded::FuturesTupleSet;
 use http_client::HttpClient;
 use ip_packet::{Ecn, IpPacket};
 use nameserver_set::NameserverSet;
@@ -49,8 +53,7 @@ pub struct Io {
     dns_queries: FuturesTupleSet<Result<dns_types::Response>, DnsQueryMetaData>,
 
     bootstrap_dns_client: BootstrapDnsClient,
-    doh_clients: BTreeMap<DoHUrl, HttpClient>,
-    doh_clients_bootstrap: FuturesMap<DoHUrl, Result<HttpClient>>,
+    doh_clients: BTreeMap<DoHUrl, DohClient>,
 
     timeout: Timeout,
 
@@ -67,7 +70,16 @@ struct DnsQueryMetaData {
     remote: SocketAddr,
     transport: dns::Transport,
     started_at: Instant,
+    retried: bool,
 }
+
+enum DohClient {
+    Connecting(Bootstrap),
+    Connected(HttpClient),
+}
+
+/// Shared between the [`Io`] event-loop, which drives it, and the queries waiting on it.
+type Bootstrap = Shared<BoxFuture<'static, Result<HttpClient, Arc<anyhow::Error>>>>;
 
 /// Represents all IO sources that may be ready during a single event-loop tick.
 ///
@@ -155,10 +167,6 @@ impl Io {
                 1000,
             ),
             doh_clients: Default::default(),
-            doh_clients_bootstrap: FuturesMap::new(
-                || futures_bounded::Delay::tokio(DNS_QUERY_TIMEOUT),
-                10,
-            ),
             gso_queue: UdpGsoQueue::new(),
             tun: Device::new(),
             udp_dns_server: Default::default(),
@@ -236,15 +244,27 @@ impl Io {
         // We purposely don't want to block the event loop here because we can do plenty of other work while this is running.
         let _ = self.nameservers.poll(cx);
 
-        while let Poll::Ready((url, result)) = self.doh_clients_bootstrap.poll_unpin(cx) {
-            match result {
-                Ok(Ok(client)) => {
-                    self.doh_clients.insert(url.clone(), client);
+        self.doh_clients
+            .extract_if(.., |url, client| {
+                let DohClient::Connecting(bootstrap) = client else {
+                    return false;
+                };
+
+                match bootstrap.poll_unpin(cx) {
+                    Poll::Ready(Ok(http_client)) => {
+                        *client = DohClient::Connected(http_client);
+
+                        false
+                    }
+                    Poll::Ready(Err(e)) => {
+                        tracing::debug!(%url, "Failed to bootstrap DoH client: {e:#}");
+
+                        true
+                    }
+                    Poll::Pending => false,
                 }
-                Ok(Err(e)) => tracing::debug!(%url, "Failed to bootstrap DoH client: {e:#}"),
-                Err(e) => tracing::debug!(%url, "Failed to bootstrap DoH client: {e:#}"),
-            }
-        }
+            })
+            .for_each(drop);
 
         let network = self.sockets.poll_recv_from(cx);
 
@@ -302,40 +322,45 @@ impl Io {
             })
             .collect::<Vec<_>>();
 
-        let dns_response = match self.dns_queries.poll_unpin(cx) {
-            Poll::Ready((result, meta)) => {
-                let message = match result {
-                    Ok(message) => message,
-                    Err(e @ futures_bounded::Timeout { .. }) => Err(anyhow::Error::new(
-                        io::Error::new(io::ErrorKind::TimedOut, e),
-                    )),
-                };
+        let dns_response = loop {
+            let Poll::Ready((result, mut meta)) = self.dns_queries.poll_unpin(cx) else {
+                break Poll::Pending;
+            };
 
-                Poll::Ready(dns::RecursiveResponse {
-                    server: meta.server,
-                    query: meta.query,
-                    message,
-                    transport: meta.transport,
-                    local: meta.local,
-                    remote: meta.remote,
-                    started_at: meta.started_at,
-                    recursion: dns::Recursion::Local,
-                })
+            let message = match result {
+                Ok(message) => message,
+                Err(e @ futures_bounded::Timeout { .. }) => Err(anyhow::Error::new(
+                    io::Error::new(io::ErrorKind::TimedOut, e),
+                )),
+            };
+
+            if let dns::Upstream::DoH { server } = &meta.server
+                && let Err(e) = &message
+                && e.any_is::<http_client::Closed>()
+                && !meta.retried
+            {
+                tracing::debug!(%server, "DoH connection closed, retrying query on a new connection");
+
+                let server = server.clone();
+                let client = self.doh_client(server.clone());
+
+                meta.retried = true;
+                self.queue_dns_query(doh::send(client, server, meta.query.clone()), meta);
+
+                continue;
             }
-            Poll::Pending => Poll::Pending,
+
+            break Poll::Ready(dns::RecursiveResponse {
+                server: meta.server,
+                query: meta.query,
+                message,
+                transport: meta.transport,
+                local: meta.local,
+                remote: meta.remote,
+                started_at: meta.started_at,
+                recursion: dns::Recursion::Local,
+            });
         };
-
-        // We need to discard DoH clients if their queries fail because the connection got closed.
-        // They will get re-bootstrapped on the next requested DoH query.
-        if let Poll::Ready(response) = &dns_response
-            && let dns::Upstream::DoH { server } = &response.server
-            && let Err(e) = &response.message
-            && e.any_is::<http_client::Closed>()
-        {
-            tracing::debug!(%server, "Connection of DoH client failed");
-
-            self.doh_clients.remove(server);
-        }
 
         let timeout = self.timeout.poll_tick(cx).is_ready();
 
@@ -485,6 +510,7 @@ impl Io {
             local: query.local,
             remote: query.remote,
             started_at: now,
+            retried: false,
         };
 
         match (query.transport, query.server) {
@@ -501,47 +527,68 @@ impl Io {
                 );
             }
             (_, dns::Upstream::DoH { server }) => {
-                let Some(http_client) = self.doh_clients.get(&server).cloned() else {
-                    self.bootstrap_doh_client(server);
+                let client = self.doh_client(server.clone());
 
-                    // Queue a dummy "query" that instantly fails to ensure we don't let the application run into a timeout.
-                    // This will trigger a SERVFAIL response.
-                    self.queue_dns_query(async { anyhow::bail!("Bootstrapping DoH client") }, meta);
-
-                    return;
-                };
-
-                self.queue_dns_query(doh::send(http_client, server, query.message), meta);
+                self.queue_dns_query(doh::send(client, server, query.message), meta);
             }
         }
     }
 
+    /// Ensures a DoH client for `server` exists or is being bootstrapped.
     pub(crate) fn bootstrap_doh_client(&mut self, server: DoHUrl) {
-        if self.doh_clients.contains_key(&server) {
-            return;
-        }
+        drop(self.doh_client(server));
+    }
 
-        if self.doh_clients_bootstrap.contains(server.clone()) {
-            return; // Already bootstrapping.
-        }
+    /// Returns the DoH client for `server`, bootstrapping a new one if there is none or its connection is closed.
+    fn doh_client(&mut self, server: DoHUrl) -> BoxFuture<'static, Result<HttpClient>> {
+        let bootstrap = match self.doh_clients.get(&server) {
+            Some(DohClient::Connected(client)) if !client.is_closed() => {
+                return futures::future::ready(Ok(client.clone())).boxed();
+            }
+            Some(DohClient::Connected(_)) => {
+                tracing::debug!(%server, "DoH connection is closed");
 
+                self.start_doh_bootstrap(server)
+            }
+            Some(DohClient::Connecting(bootstrap)) => bootstrap.clone(),
+            None => self.start_doh_bootstrap(server),
+        };
+
+        bootstrap.map_err(|e| anyhow::anyhow!("{e:#}")).boxed()
+    }
+
+    fn start_doh_bootstrap(&mut self, server: DoHUrl) -> Bootstrap {
         let socket_factory = self.tcp_socket_factory.clone();
         let addresses = self.bootstrap_dns_client.resolve(server.host());
 
-        let _ = self
-            .doh_clients_bootstrap
-            .try_push(server.clone(), async move {
+        let bootstrap = tokio::time::timeout(DNS_QUERY_TIMEOUT, {
+            let server = server.clone();
+
+            async move {
                 tracing::debug!(%server, "Bootstrapping DoH client");
 
                 let addresses = addresses.await?;
                 let http_client =
-                    HttpClient::new(server.host().to_string(), addresses.clone(), socket_factory)
-                        .await?;
+                    HttpClient::new(server.host().to_string(), addresses, socket_factory).await?;
 
                 tracing::debug!(%server, "Bootstrapped DoH client");
 
                 Ok(http_client)
-            });
+            }
+        })
+        .map(|result| {
+            result
+                .map_err(anyhow::Error::new)
+                .flatten()
+                .map_err(Arc::new)
+        })
+        .boxed()
+        .shared();
+
+        self.doh_clients
+            .insert(server, DohClient::Connecting(bootstrap.clone()));
+
+        bootstrap
     }
 
     pub(crate) fn send_udp_dns_response(
@@ -603,31 +650,34 @@ mod tests {
         // dropped UDP packet to the real server doesn't flake the test.
         io.update_system_resolvers(vec![IpAddr::from([1, 1, 1, 1]); 5]);
 
-        {
-            io.send_dns_query(example_com_recursive_query(), Instant::now());
+        io.send_dns_query(example_com_recursive_query(), Instant::now());
 
-            let input = io.next().await;
+        let input = io.next().await;
 
-            assert_eq!(
-                input.dns_response.unwrap().message.unwrap_err().to_string(),
-                "Bootstrapping DoH client"
-            );
-        }
+        assert_eq!(
+            input.dns_response.unwrap().message.unwrap().response_code(),
+            dns_types::ResponseCode::NOERROR
+        );
+    }
 
-        // Hack: Advance for a bit but timeout after 10s. We don't emit an event when the client is bootstrapped so this will always be `Pending`.
-        // The window has to comfortably cover a real DNS resolution plus TLS handshake to the DoH server on slow CI runners.
-        let _ = tokio::time::timeout(Duration::from_secs(10), io.next()).await;
+    #[tokio::test]
+    async fn failed_bootstrap_is_evicted() {
+        let _guard = logging::test("debug");
 
-        {
-            io.send_dns_query(example_com_recursive_query(), Instant::now());
+        let mut io = Io::for_test();
 
-            let input = io.next().await;
+        io.send_dns_query(example_com_recursive_query(), Instant::now());
+        let input = io.next().await;
 
-            assert_eq!(
-                input.dns_response.unwrap().message.unwrap().response_code(),
-                dns_types::ResponseCode::NOERROR
-            );
-        }
+        assert!(input.dns_response.unwrap().message.is_err());
+        assert!(io.doh_clients.is_empty());
+
+        io.send_dns_query(example_com_recursive_query(), Instant::now());
+
+        assert!(matches!(
+            io.doh_clients.get(&DoHUrl::cloudflare()),
+            Some(DohClient::Connecting(_))
+        ));
     }
 
     #[tokio::test]

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -16,9 +16,10 @@ use bufferpool::{Buffer, VecBuf};
 use dns_types::DoHUrl;
 use futures::{
     FutureExt as _, TryFutureExt as _,
-    future::{BoxFuture, Remote, RemoteHandle, Shared},
+    channel::oneshot,
+    future::{BoxFuture, Shared},
 };
-use futures_bounded::FuturesTupleSet;
+use futures_bounded::{FuturesMap, FuturesTupleSet, PushError};
 use http_client::HttpClient;
 use ip_packet::{Ecn, IpPacket};
 use nameserver_set::NameserverSet;
@@ -54,6 +55,7 @@ pub struct Io {
 
     bootstrap_dns_client: BootstrapDnsClient,
     doh_clients: BTreeMap<DoHUrl, DohClient>,
+    doh_clients_bootstrap: FuturesMap<DoHUrl, Result<HttpClient>>,
 
     timeout: Timeout,
 
@@ -74,52 +76,9 @@ struct DnsQueryMetaData {
 }
 
 enum DohClient {
-    Connecting {
-        /// Dropping this before it completes makes polling `handle` panic; [`Io::reset`] drops the waiting queries along with it.
-        driver: Remote<BoxFuture<'static, BootstrapResult>>,
-        handle: Shared<RemoteHandle<BootstrapResult>>,
-    },
+    /// Resolves once the bootstrap driven by [`Io`] has connected, or fails once it gave up.
+    Connecting(Shared<oneshot::Receiver<HttpClient>>),
     Connected(HttpClient),
-}
-
-/// `anyhow::Error` is not `Clone`, which the output of a [`Shared`] future has to be.
-type BootstrapResult = Result<HttpClient, Arc<anyhow::Error>>;
-
-impl DohClient {
-    /// Only polling `driver` advances the bootstrap; `handle` merely observes its result.
-    fn connecting(
-        bootstrap_dns_client: &BootstrapDnsClient,
-        socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
-        server: &DoHUrl,
-    ) -> Self {
-        let addresses = bootstrap_dns_client.resolve(server.host());
-        let server = server.clone();
-
-        let (driver, handle) = tokio::time::timeout(DNS_QUERY_TIMEOUT, async move {
-            tracing::debug!(%server, "Bootstrapping DoH client");
-
-            let addresses = addresses.await?;
-            let http_client =
-                HttpClient::new(server.host().to_string(), addresses, socket_factory).await?;
-
-            tracing::debug!(%server, "Bootstrapped DoH client");
-
-            Ok(http_client)
-        })
-        .map(|result| {
-            result
-                .map_err(anyhow::Error::new)
-                .flatten()
-                .map_err(Arc::new)
-        })
-        .boxed()
-        .remote_handle();
-
-        Self::Connecting {
-            driver,
-            handle: handle.shared(),
-        }
-    }
 }
 
 /// Represents all IO sources that may be ready during a single event-loop tick.
@@ -208,6 +167,10 @@ impl Io {
                 1000,
             ),
             doh_clients: Default::default(),
+            doh_clients_bootstrap: FuturesMap::new(
+                || futures_bounded::Delay::tokio(DNS_QUERY_TIMEOUT),
+                10,
+            ),
             gso_queue: UdpGsoQueue::new(),
             tun: Device::new(),
             udp_dns_server: Default::default(),
@@ -285,30 +248,17 @@ impl Io {
         // We purposely don't want to block the event loop here because we can do plenty of other work while this is running.
         let _ = self.nameservers.poll(cx);
 
-        let mut failed_bootstraps = Vec::new();
-
-        for (url, client) in self.doh_clients.iter_mut() {
-            let DohClient::Connecting { driver, handle } = client else {
-                continue;
-            };
-
-            if driver.poll_unpin(cx).is_pending() {
-                continue;
-            }
-
-            match handle.poll_unpin(cx) {
-                Poll::Ready(Ok(http_client)) => *client = DohClient::Connected(http_client),
-                Poll::Ready(Err(e)) => {
+        while let Poll::Ready((url, result)) = self.doh_clients_bootstrap.poll_unpin(cx) {
+            match result.map_err(anyhow::Error::new).flatten() {
+                Ok(client) => {
+                    self.doh_clients.insert(url, DohClient::Connected(client));
+                }
+                Err(e) => {
                     tracing::debug!(%url, "Failed to bootstrap DoH client: {e:#}");
 
-                    failed_bootstraps.push(url.clone());
+                    self.doh_clients.remove(&url);
                 }
-                Poll::Pending => {}
             }
-        }
-
-        for url in failed_bootstraps {
-            self.doh_clients.remove(&url);
         }
 
         let network = self.sockets.poll_recv_from(cx);
@@ -504,6 +454,8 @@ impl Io {
         self.gso_queue.clear();
         self.dns_queries =
             FuturesTupleSet::new(|| futures_bounded::Delay::tokio(DNS_QUERY_TIMEOUT), 1000);
+        self.doh_clients_bootstrap =
+            FuturesMap::new(|| futures_bounded::Delay::tokio(DNS_QUERY_TIMEOUT), 10);
         self.nameservers.evaluate();
 
         for (server, _) in std::mem::take(&mut self.doh_clients) {
@@ -587,15 +539,24 @@ impl Io {
     /// Resolves to the DoH client for `server` once it is connected.
     fn doh_client(&mut self, server: DoHUrl) -> BoxFuture<'static, Result<HttpClient>> {
         match self.doh_client_entry(server) {
-            DohClient::Connected(client) => futures::future::ready(Ok(client.clone())).boxed(),
-            DohClient::Connecting { handle, .. } => {
-                handle.clone().map_err(|e| anyhow::anyhow!("{e:#}")).boxed()
+            Some(DohClient::Connected(client)) => {
+                futures::future::ready(Ok(client.clone())).boxed()
             }
+            Some(DohClient::Connecting(client)) => client
+                .clone()
+                .map_err(|oneshot::Canceled| anyhow::anyhow!("Failed to bootstrap DoH client"))
+                .boxed(),
+            None => futures::future::ready(Err(anyhow::anyhow!(
+                "Too many DoH clients are bootstrapping"
+            )))
+            .boxed(),
         }
     }
 
     /// Returns the entry for `server`, replacing a closed client with a fresh bootstrap.
-    fn doh_client_entry(&mut self, server: DoHUrl) -> &DohClient {
+    ///
+    /// `None` if the bootstrap could not be started.
+    fn doh_client_entry(&mut self, server: DoHUrl) -> Option<&DohClient> {
         if let Some(DohClient::Connected(client)) = self.doh_clients.get(&server)
             && client.is_closed()
         {
@@ -604,13 +565,43 @@ impl Io {
             self.doh_clients.remove(&server);
         }
 
-        self.doh_clients.entry(server).or_insert_with_key(|server| {
-            DohClient::connecting(
-                &self.bootstrap_dns_client,
-                self.tcp_socket_factory.clone(),
-                server,
-            )
-        })
+        if !self.doh_clients.contains_key(&server) {
+            let (ready, client) = oneshot::channel();
+            let addresses = self.bootstrap_dns_client.resolve(server.host());
+            let socket_factory = self.tcp_socket_factory.clone();
+
+            let bootstrap = {
+                let server = server.clone();
+
+                async move {
+                    tracing::debug!(%server, "Bootstrapping DoH client");
+
+                    let addresses = addresses.await?;
+                    let http_client =
+                        HttpClient::new(server.host().to_string(), addresses, socket_factory)
+                            .await?;
+
+                    tracing::debug!(%server, "Bootstrapped DoH client");
+
+                    let _ = ready.send(http_client.clone());
+
+                    Ok(http_client)
+                }
+            };
+
+            match self
+                .doh_clients_bootstrap
+                .try_push(server.clone(), bootstrap)
+            {
+                Ok(()) | Err(PushError::Replaced(_)) => {}
+                Err(PushError::BeyondCapacity(_)) => return None,
+            }
+
+            self.doh_clients
+                .insert(server.clone(), DohClient::Connecting(client.shared()));
+        }
+
+        self.doh_clients.get(&server)
     }
 
     pub(crate) fn send_udp_dns_response(
@@ -698,7 +689,7 @@ mod tests {
 
         assert!(matches!(
             io.doh_clients.get(&DoHUrl::cloudflare()),
-            Some(DohClient::Connecting { .. })
+            Some(DohClient::Connecting(_))
         ));
     }
 

--- a/rust/libs/connlib/tunnel/src/io/doh.rs
+++ b/rust/libs/connlib/tunnel/src/io/doh.rs
@@ -3,12 +3,14 @@ use dns_types::DoHUrl;
 use http_client::HttpClient;
 
 pub async fn send(
-    client: HttpClient,
+    client: impl Future<Output = Result<HttpClient>> + Send,
     server: DoHUrl,
     query: dns_types::Query,
 ) -> Result<dns_types::Response> {
     let domain = query.domain();
     let qtype = query.qtype();
+
+    let client = client.await?;
 
     tracing::trace!(target: "wire::dns::recursive::qry", %server, "{qtype} {domain}");
 

--- a/rust/libs/http-client/lib.rs
+++ b/rust/libs/http-client/lib.rs
@@ -136,8 +136,8 @@ impl HttpClient {
                     client
                         .send_request(request)
                         .await
-                        .context(Closed)
-                        .context("Failed to send HTTP/2 request")?
+                        .context("Failed to send HTTP/2 request")
+                        .context(Closed)?
                 }
                 Sender::H1(mutex) => {
                     // HTTP/1.1 carries the host in a `Host` header (HTTP/2 uses the
@@ -158,8 +158,8 @@ impl HttpClient {
                     client
                         .send_request(request)
                         .await
-                        .context(Closed)
-                        .context("Failed to send HTTP/1.1 request")?
+                        .context("Failed to send HTTP/1.1 request")
+                        .context(Closed)?
                 }
             };
 
@@ -168,8 +168,8 @@ impl HttpClient {
             let body = incoming
                 .collect()
                 .await
-                .context(Closed)
-                .context("Failed to receive HTTP response body")?;
+                .context("Failed to receive HTTP response body")
+                .context(Closed)?;
 
             Ok(http::Response::from_parts(parts, body.to_bytes()))
         })

--- a/rust/libs/http-client/lib.rs
+++ b/rust/libs/http-client/lib.rs
@@ -36,8 +36,8 @@ type ConnectionDriver = Pin<Box<dyn Future<Output = ()> + Send>>;
 ///
 /// One instance is tied to a given host. It negotiates HTTP/2 if the server
 /// supports it (ALPN `h2`) and falls back to HTTP/1.1 otherwise. The connection is
-/// maintained for the client's lifetime; if it fails, [`Closed`] is returned and
-/// the client becomes permanently unusable and should be discarded.
+/// maintained for the client's lifetime; once it fails, every request errors with
+/// [`Closed`] and the client should be discarded.
 #[derive(Clone)]
 pub struct HttpClient {
     host: String,
@@ -136,6 +136,7 @@ impl HttpClient {
                     client
                         .send_request(request)
                         .await
+                        .context(Closed)
                         .context("Failed to send HTTP/2 request")?
                 }
                 Sender::H1(mutex) => {
@@ -157,6 +158,7 @@ impl HttpClient {
                     client
                         .send_request(request)
                         .await
+                        .context(Closed)
                         .context("Failed to send HTTP/1.1 request")?
                 }
             };
@@ -166,6 +168,7 @@ impl HttpClient {
             let body = incoming
                 .collect()
                 .await
+                .context(Closed)
                 .context("Failed to receive HTTP response body")?;
 
             Ok(http::Response::from_parts(parts, body.to_bytes()))
@@ -173,6 +176,11 @@ impl HttpClient {
     }
 }
 
+/// The connection behind an [`HttpClient`] is closed or has failed.
+///
+/// A transport error on a persistent connection leaves it dead or dying, so
+/// every request that hits one carries this error, not only those sent after
+/// [`HttpClient::is_closed`] starts reporting `true`.
 #[derive(thiserror::Error, Debug)]
 #[error("The connection is closed")]
 pub struct Closed;


### PR DESCRIPTION
Quad9 closes its DoH HTTP/2 connection with a plain TCP FIN after roughly four seconds without a DNS request. Each such close currently costs two or three SERVFAILs in a row: the query in flight fails with a hyper transport error that does not carry `Closed`, so the dead client stays in the map; the next query hits the `is_closed()` guard and is only then evicted; and the query after that is failed on purpose while a new client is being bootstrapped.

Every transport error out of `HttpClient::send_request` now carries `Closed`, since a persistent connection that produced one is dead or dying and checking `is_closed()` afterwards races with the connection driver task. DoH queries wait on a shared bootstrap future instead of failing instantly, and a query that fails with `Closed` is retried once on a fresh connection.

Reconnects stay lazy: with a server-side idle limit this short, reconnecting eagerly would cost a TLS handshake every few seconds even without traffic.