### PR TITLE
fix(portal): send enabled accounts to relays

### DIFF
--- a/elixir/lib/portal/changes/hooks/accounts.ex
+++ b/elixir/lib/portal/changes/hooks/accounts.ex
@@ -5,6 +5,13 @@ defmodule Portal.Changes.Hooks.Accounts do
   import Portal.SchemaHelpers
 
   @impl true
+  def on_insert(lsn, %{"is_disabled" => false} = data) do
+    account = struct_from_params(Portal.Account, data)
+    change = %Change{lsn: lsn, op: :insert, struct: account}
+
+    PubSub.Changes.broadcast_account(change)
+  end
+
   def on_insert(_lsn, _data), do: :ok
 
   # Account slug changed - disconnect gateways for updated init
@@ -22,6 +29,18 @@ defmodule Portal.Changes.Hooks.Accounts do
     Database.delete_client_tokens_for_account(account)
 
     on_delete(lsn, old_data)
+  end
+
+  # Account enabled - make its TURN credentials valid again.
+  def on_update(
+        lsn,
+        %{"is_disabled" => true},
+        %{"is_disabled" => false} = data
+      ) do
+    account = struct_from_params(Portal.Account, data)
+    change = %Change{lsn: lsn, op: :insert, struct: account}
+
+    PubSub.Changes.broadcast_account(change)
   end
 
   def on_update(lsn, old_data, data) do
@@ -46,6 +65,7 @@ defmodule Portal.Changes.Hooks.Accounts do
     change = %Change{lsn: lsn, op: :delete, old_struct: account}
 
     PubSub.Changes.broadcast(account.id, :accounts, change)
+    PubSub.Changes.broadcast_account(change)
   end
 
   defmodule Database do

--- a/elixir/lib/portal/presence.ex
+++ b/elixir/lib/portal/presence.ex
@@ -395,7 +395,8 @@ defmodule Portal.Presence do
                ipv6: relay.ipv6,
                port: relay.port,
                lat: relay.lat,
-               lon: relay.lon
+               lon: relay.lon,
+               turn_account_validation: relay.turn_account_validation == true
              }) do
         :ok
       end
@@ -434,7 +435,8 @@ defmodule Portal.Presence do
             ipv6: meta.ipv6,
             port: meta.port,
             lat: Map.get(meta, :lat),
-            lon: Map.get(meta, :lon)
+            lon: Map.get(meta, :lon),
+            turn_account_validation: Map.get(meta, :turn_account_validation, false)
           }
         end)
 

--- a/elixir/lib/portal/pubsub.ex
+++ b/elixir/lib/portal/pubsub.ex
@@ -74,6 +74,11 @@ defmodule Portal.PubSub do
       |> Portal.PubSub.subscribe()
     end
 
+    @spec subscribe_to_accounts() :: :ok | {:error, term()}
+    def subscribe_to_accounts do
+      Portal.PubSub.subscribe(accounts_topic())
+    end
+
     @spec broadcast(String.t(), entity(), term()) :: :ok
     def broadcast(account_id, entity, payload) do
       region = Portal.Config.get_env(:portal, :region, "")
@@ -86,8 +91,22 @@ defmodule Portal.PubSub do
       :ok
     end
 
+    @spec broadcast_account(term()) :: :ok
+    def broadcast_account(payload) do
+      region = Portal.Config.get_env(:portal, :region, "")
+
+      for node <- target_nodes(region) do
+        Phoenix.PubSub.direct_broadcast!(node, Portal.PubSub, accounts_topic(), payload)
+      end
+
+      :ok
+    end
+
     defp account_topic(account_id), do: "account:#{account_id}"
     defp entity_topic(account_id, entity), do: "account:#{account_id}:#{entity}"
+    defp accounts_topic do
+      Portal.Config.get_env(:portal, :account_changes_topic, "accounts")
+    end
 
     # In dev / test region we don't have a cluster / region; send to self
     defp target_nodes(""), do: [Node.self()]

--- a/elixir/lib/portal/relay.ex
+++ b/elixir/lib/portal/relay.ex
@@ -14,7 +14,8 @@ defmodule Portal.Relay do
     :ipv6,
     :port,
     :lat,
-    :lon
+    :lon,
+    :turn_account_validation
   ]
 
   @type t :: %__MODULE__{
@@ -24,7 +25,8 @@ defmodule Portal.Relay do
           ipv6: String.t() | nil,
           port: integer(),
           lat: float() | nil,
-          lon: float() | nil
+          lon: float() | nil,
+          turn_account_validation: boolean()
         }
 
   @doc """

--- a/elixir/lib/portal_api/client/channel/shared.ex
+++ b/elixir/lib/portal_api/client/channel/shared.ex
@@ -282,7 +282,8 @@ defmodule PortalAPI.Client.Channel.Shared do
             Views.Relay.render_many(
               relays,
               socket.assigns.client.public_key,
-              socket.assigns.subject.expires_at
+              socket.assigns.subject.expires_at,
+              socket.assigns.client.account_id
             )
         })
 
@@ -1161,7 +1162,8 @@ defmodule PortalAPI.Client.Channel.Shared do
         Views.Relay.render_many(
           relays,
           socket.assigns.client.public_key,
-          socket.assigns.subject.expires_at
+          socket.assigns.subject.expires_at,
+          socket.assigns.client.account_id
         )
     })
 
@@ -1767,7 +1769,8 @@ defmodule PortalAPI.Client.Channel.Shared do
         Views.Relay.render_many(
           relays,
           socket.assigns.client.public_key,
-          socket.assigns.subject.expires_at
+          socket.assigns.subject.expires_at,
+          socket.assigns.client.account_id
         ),
       interface:
         Views.Interface.render(%{

--- a/elixir/lib/portal_api/client/views/relay.ex
+++ b/elixir/lib/portal_api/client/views/relay.ex
@@ -1,25 +1,25 @@
 defmodule PortalAPI.Client.Views.Relay do
   alias Portal.Relay
 
-  def render_many(relays, salt, expires_at) do
+  def render_many(relays, salt, expires_at, account_id) do
     relays
     |> Enum.map(fn relay ->
       [
-        render_addr(relay, salt, expires_at, relay.ipv4),
-        render_addr(relay, salt, expires_at, relay.ipv6)
+        render_addr(relay, salt, expires_at, account_id, relay.ipv4),
+        render_addr(relay, salt, expires_at, account_id, relay.ipv6)
       ]
     end)
     |> List.flatten()
   end
 
-  defp render_addr(_relay, _salt, _expires_at, nil), do: []
+  defp render_addr(_relay, _salt, _expires_at, _account_id, nil), do: []
 
-  defp render_addr(%Relay{} = relay, salt, expires_at, address) do
+  defp render_addr(%Relay{} = relay, salt, expires_at, account_id, address) do
     %{
       username: username,
       password: password,
       expires_at: expires_at
-    } = generate_username_and_password(relay, salt, expires_at)
+    } = generate_username_and_password(relay, salt, expires_at, account_id)
 
     %{
       id: relay.id,
@@ -36,13 +36,33 @@ defmodule PortalAPI.Client.Views.Relay do
     if String.contains?(ip, ":"), do: "[#{ip}]", else: ip
   end
 
-  defp generate_username_and_password(%Relay{stamp_secret: stamp_secret}, public_key, expires_at)
+  defp generate_username_and_password(
+         %Relay{stamp_secret: stamp_secret, turn_account_validation: true},
+         public_key,
+         expires_at,
+         account_id
+       )
+       when is_binary(stamp_secret) do
+    salt = generate_hash(public_key)
+    account = hash_account_id(account_id)
+    expires_at = DateTime.to_unix(expires_at, :second)
+    username = "#{expires_at}:#{account}:#{salt}"
+    password = generate_hash("#{username}:#{stamp_secret}")
+
+    %{username: username, password: password, expires_at: expires_at}
+  end
+
+  defp generate_username_and_password(%Relay{stamp_secret: stamp_secret}, public_key, expires_at, _account_id)
        when is_binary(stamp_secret) do
     salt = generate_hash(public_key)
     expires_at = DateTime.to_unix(expires_at, :second)
     password = generate_hash("#{expires_at}:#{stamp_secret}:#{salt}")
 
     %{username: "#{expires_at}:#{salt}", password: password, expires_at: expires_at}
+  end
+
+  def hash_account_id(account_id) when is_binary(account_id) do
+    generate_hash(account_id)
   end
 
   defp generate_hash(string) do

--- a/elixir/lib/portal_api/gateway/channel/shared.ex
+++ b/elixir/lib/portal_api/gateway/channel/shared.ex
@@ -261,7 +261,8 @@ defmodule PortalAPI.Gateway.Channel.Shared do
             Views.Relay.render_many(
               relays,
               socket.assigns.gateway.public_key,
-              @relay_credentials_expire_at
+              @relay_credentials_expire_at,
+              socket.assigns.gateway.account_id
             )
         })
 
@@ -714,7 +715,8 @@ defmodule PortalAPI.Gateway.Channel.Shared do
         Views.Relay.render_many(
           relays,
           socket.assigns.gateway.public_key,
-          @relay_credentials_expire_at
+          @relay_credentials_expire_at,
+          socket.assigns.gateway.account_id
         )
     })
 
@@ -798,7 +800,8 @@ defmodule PortalAPI.Gateway.Channel.Shared do
         Views.Relay.render_many(
           relays,
           socket.assigns.gateway.public_key,
-          @relay_credentials_expire_at
+          @relay_credentials_expire_at,
+          socket.assigns.gateway.account_id
         ),
       # These aren't used but needed for API compatibility
       config: %{

--- a/elixir/lib/portal_api/gateway/views/relay.ex
+++ b/elixir/lib/portal_api/gateway/views/relay.ex
@@ -1,5 +1,5 @@
 defmodule PortalAPI.Gateway.Views.Relay do
-  def render_many(relays, salt, expires_at) do
-    PortalAPI.Client.Views.Relay.render_many(relays, salt, expires_at)
+  def render_many(relays, salt, expires_at, account_id) do
+    PortalAPI.Client.Views.Relay.render_many(relays, salt, expires_at, account_id)
   end
 end

--- a/elixir/lib/portal_api/relay/channel.ex
+++ b/elixir/lib/portal_api/relay/channel.ex
@@ -1,18 +1,25 @@
 defmodule PortalAPI.Relay.Channel do
   use PortalAPI, :channel
-  alias Portal.Presence
+  alias Portal.{Changes.Change, Presence, PubSub}
+  alias __MODULE__.Database
   require OpenTelemetry.Tracer
   require Logger
 
   @impl true
-  def join("relay", %{"stamp_secret" => stamp_secret}, socket) do
+  def join("relay", %{"stamp_secret" => stamp_secret} = payload, socket) do
     OpenTelemetry.Ctx.attach(socket.assigns.opentelemetry_ctx)
     OpenTelemetry.Tracer.set_current_span(socket.assigns.opentelemetry_span_ctx)
 
     OpenTelemetry.Tracer.with_span "relay.join" do
       opentelemetry_ctx = OpenTelemetry.Ctx.get_current()
       opentelemetry_span_ctx = OpenTelemetry.Tracer.current_span_ctx()
-      send(self(), {:after_join, stamp_secret, {opentelemetry_ctx, opentelemetry_span_ctx}})
+      turn_account_validation = payload["turn_account_validation"] == true
+
+      send(
+        self(),
+        {:after_join, stamp_secret, turn_account_validation,
+         {opentelemetry_ctx, opentelemetry_span_ctx}}
+      )
 
       socket =
         assign(socket,
@@ -40,21 +47,67 @@ defmodule PortalAPI.Relay.Channel do
 
   @impl true
   def handle_info(
-        {:after_join, stamp_secret, {opentelemetry_ctx, opentelemetry_span_ctx}},
+        {:after_join, stamp_secret, turn_account_validation,
+         {opentelemetry_ctx, opentelemetry_span_ctx}},
         socket
       ) do
     OpenTelemetry.Ctx.attach(opentelemetry_ctx)
     OpenTelemetry.Tracer.set_current_span(opentelemetry_span_ctx)
 
     OpenTelemetry.Tracer.with_span "relay.after_join" do
-      push(socket, "init", %{})
       relay = socket.assigns.relay
 
       # Generate the relay ID from the stamp_secret and connect
-      relay = %{relay | id: Portal.Relay.generate_id(stamp_secret), stamp_secret: stamp_secret}
+      relay = %{
+        relay
+        | id: Portal.Relay.generate_id(stamp_secret),
+          stamp_secret: stamp_secret,
+          turn_account_validation: turn_account_validation
+      }
+
+      # Old Relay binaries ignore unknown fields on `init`, but fail their
+      # Portal connection on unknown events. Account updates therefore remain
+      # capability-gated, while the initial snapshot uses the existing event.
+      init_payload =
+        if turn_account_validation do
+          :ok = PubSub.Changes.subscribe_to_accounts()
+
+          %{
+            account_ids: Database.all_enabled_account_ids()
+          }
+        else
+          %{}
+        end
+
+      push(socket, "init", init_payload)
       :ok = Presence.Relays.connect(relay)
 
       {:noreply, assign(socket, :relay, relay)}
+    end
+  end
+
+  @impl true
+  def handle_info(%Change{lsn: lsn} = change, socket) do
+    last_lsn = socket.assigns[:last_lsn] || 0
+
+    if lsn > last_lsn do
+      case change do
+        %Change{op: :insert, struct: %Portal.Account{id: id}} ->
+          push(socket, "account_added", %{account_id: id})
+
+        %Change{op: :delete, old_struct: %Portal.Account{id: id}} ->
+          push(socket, "account_removed", %{account_id: id})
+
+        _ ->
+          :ok
+      end
+
+      {:noreply, assign(socket, :last_lsn, lsn)}
+    else
+      # CDC changes can be replayed after a reconnect. The Relay cache is
+      # idempotent, but avoiding stale creates after a newer removal keeps the
+      # Portal and Relay convergent.
+      {:noreply, socket}
     end
   end
 
@@ -70,4 +123,18 @@ defmodule PortalAPI.Relay.Channel do
   defp abnormal_exit?(:shutdown), do: false
   defp abnormal_exit?({:shutdown, _reason}), do: false
   defp abnormal_exit?(_reason), do: true
+
+  defmodule Database do
+    import Ecto.Query
+    alias Portal.Safe
+
+    def all_enabled_account_ids do
+      from(account in Portal.Account,
+        where: account.is_disabled == false,
+        select: account.id
+      )
+      |> Safe.unscoped()
+      |> Safe.all()
+    end
+  end
 end

--- a/elixir/test/portal/changes/hooks/accounts_test.exs
+++ b/elixir/test/portal/changes/hooks/accounts_test.exs
@@ -7,9 +7,28 @@ defmodule Portal.Changes.Hooks.AccountsTest do
   alias Portal.PubSub
   import Portal.Changes.Hooks.Accounts
 
+  setup do
+    Portal.Config.put_env_override(
+      :portal,
+      :account_changes_topic,
+      "accounts:#{inspect(make_ref())}"
+    )
+
+    :ok
+  end
+
   describe "insert/1" do
     test "returns :ok for empty data" do
       assert :ok == on_insert(0, %{})
+    end
+
+    test "broadcasts an enabled account to relays" do
+      account_id = "00000000-0000-0000-0000-000000000000"
+      :ok = PubSub.Changes.subscribe_to_accounts()
+
+      assert :ok == on_insert(0, %{"id" => account_id, "is_disabled" => false})
+
+      assert_receive %Change{op: :insert, struct: %Portal.Account{id: ^account_id}, lsn: 0}
     end
   end
 
@@ -18,6 +37,7 @@ defmodule Portal.Changes.Hooks.AccountsTest do
       account_id = "00000000-0000-0000-0000-000000000001"
 
       :ok = PubSub.Changes.subscribe(account_id, :accounts)
+      :ok = PubSub.Changes.subscribe_to_accounts()
 
       old_data = %{
         "id" => account_id,
@@ -33,6 +53,21 @@ defmodule Portal.Changes.Hooks.AccountsTest do
       assert_receive %Change{op: :delete, old_struct: %Portal.Account{} = account, lsn: 0}
 
       assert account.id == account_id
+      assert_receive %Change{op: :delete, old_struct: %Portal.Account{id: ^account_id}, lsn: 0}
+    end
+
+    test "broadcasts an enabled account to relays" do
+      account_id = "00000000-0000-0000-0000-000000000002"
+      :ok = PubSub.Changes.subscribe_to_accounts()
+
+      assert :ok ==
+               on_update(
+                 0,
+                 %{"id" => account_id, "is_disabled" => true},
+                 %{"id" => account_id, "is_disabled" => false}
+               )
+
+      assert_receive %Change{op: :insert, struct: %Portal.Account{id: ^account_id}, lsn: 0}
     end
 
     test "deletes associated policy authorizations when account is disabled" do
@@ -76,12 +111,14 @@ defmodule Portal.Changes.Hooks.AccountsTest do
     test "delete broadcasts deleted account" do
       account_id = "00000000-0000-0000-0000-000000000003"
       :ok = PubSub.Changes.subscribe(account_id, :accounts)
+      :ok = PubSub.Changes.subscribe_to_accounts()
 
       old_data = %{"id" => account_id}
 
       assert :ok == on_delete(0, old_data)
       assert_receive %Change{op: :delete, old_struct: %Portal.Account{} = account, lsn: 0}
       assert account.id == account_id
+      assert_receive %Change{op: :delete, old_struct: %Portal.Account{id: ^account_id}, lsn: 0}
     end
   end
 end

--- a/elixir/test/portal_api/client/views/relay_test.exs
+++ b/elixir/test/portal_api/client/views/relay_test.exs
@@ -1,0 +1,55 @@
+defmodule PortalAPI.Client.Views.RelayTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Relay
+  alias PortalAPI.Client.Views.Relay, as: RelayView
+
+  @expires_at ~U[2038-01-01 00:00:00Z]
+
+  test "renders account-bound credentials for Relays that support validation" do
+    relay = %Relay{
+      id: "relay-id",
+      ipv4: "203.0.113.1",
+      port: 3478,
+      stamp_secret: "relay-secret",
+      turn_account_validation: true
+    }
+
+    account_id = "account-id"
+    public_key = "public-key"
+
+    [turn] = RelayView.render_many([relay], public_key, @expires_at, account_id)
+
+    expires_at = DateTime.to_unix(@expires_at, :second)
+    account = RelayView.hash_account_id(account_id)
+    salt = hash(public_key)
+    username = "#{expires_at}:#{account}:#{salt}"
+
+    assert turn.username == username
+    assert turn.password == hash("#{username}:relay-secret")
+  end
+
+  test "keeps the legacy credential format for Relays without validation support" do
+    relay = %Relay{
+      id: "relay-id",
+      ipv4: "203.0.113.1",
+      port: 3478,
+      stamp_secret: "relay-secret",
+      turn_account_validation: false
+    }
+
+    public_key = "public-key"
+    [turn] = RelayView.render_many([relay], public_key, @expires_at, "account-id")
+
+    expires_at = DateTime.to_unix(@expires_at, :second)
+    salt = hash(public_key)
+
+    assert turn.username == "#{expires_at}:#{salt}"
+    assert turn.password == hash("#{expires_at}:relay-secret:#{salt}")
+  end
+
+  defp hash(value) do
+    :crypto.hash(:sha256, value)
+    |> Base.encode64(padding: false)
+  end
+end

--- a/elixir/test/portal_api/relay/channel_test.exs
+++ b/elixir/test/portal_api/relay/channel_test.exs
@@ -2,10 +2,18 @@ defmodule PortalAPI.Relay.ChannelTest do
   use PortalAPI.ChannelCase, async: true
 
   import ExUnit.CaptureLog
+  import Portal.AccountFixtures
+  import Portal.Changes.Hooks.Accounts
   import Portal.RelayFixtures
   import Portal.TokenFixtures
 
   setup do
+    Portal.Config.put_env_override(
+      :portal,
+      :account_changes_topic,
+      "accounts:#{inspect(make_ref())}"
+    )
+
     relay = relay_fixture()
     token = relay_token_fixture()
 
@@ -61,6 +69,59 @@ defmodule PortalAPI.Relay.ChannelTest do
 
     test "sends init message after join" do
       assert_push "init", %{}
+    end
+
+    test "includes account IDs in init only for Relays that support account validation" do
+      assert_push "init", %{}
+      account = account_fixture()
+      relay = relay_fixture()
+      token = relay_token_fixture()
+
+      {:ok, _, _socket} =
+        PortalAPI.Relay.Socket
+        |> socket("relay:#{relay.stamp_secret}", %{
+          token_id: token.id,
+          relay: relay,
+          opentelemetry_ctx: OpenTelemetry.Ctx.new(),
+          opentelemetry_span_ctx: OpenTelemetry.Tracer.start_span("test")
+        })
+        |> subscribe_and_join(PortalAPI.Relay.Channel, "relay", %{
+          stamp_secret: relay.stamp_secret,
+          turn_account_validation: true
+      })
+
+      assert_push "init", %{account_ids: account_ids}
+      assert account.id in account_ids
+    end
+
+    test "forwards account lifecycle changes to capable Relays" do
+      assert_push "init", %{}
+      relay = relay_fixture()
+      token = relay_token_fixture()
+
+      {:ok, _, _socket} =
+        PortalAPI.Relay.Socket
+        |> socket("relay:#{relay.stamp_secret}", %{
+          token_id: token.id,
+          relay: relay,
+          opentelemetry_ctx: OpenTelemetry.Ctx.new(),
+          opentelemetry_span_ctx: OpenTelemetry.Tracer.start_span("test")
+        })
+        |> subscribe_and_join(PortalAPI.Relay.Channel, "relay", %{
+          stamp_secret: relay.stamp_secret,
+          turn_account_validation: true
+        })
+
+      assert_push "init", %{account_ids: _account_ids}
+
+      account_id = "00000000-0000-0000-0000-000000000004"
+      :ok = on_insert(1, %{"id" => account_id, "is_disabled" => false})
+
+      assert_push "account_added", %{account_id: ^account_id}
+
+      :ok = on_delete(2, %{"id" => account_id})
+
+      assert_push "account_removed", %{account_id: ^account_id}
     end
 
     test "kills existing connection when new relay connects with same id" do


### PR DESCRIPTION
Portal tells capable Relays which accounts can use TURN, then reports account additions and removals. Relays that have not opted in keep receiving legacy opaque credentials, so deploy this first.

Related: #14986