### PR TITLE
test(apple): script the mocked tunnel session from tests

### DIFF
--- a/swift/apple/Firezone/CLI/TunnelSupervisor.swift
+++ b/swift/apple/Firezone/CLI/TunnelSupervisor.swift
@@ -77,7 +77,7 @@ final class TunnelSupervisor {
   // MARK: - Status
 
   private func watchStatus(emit: AsyncStream<Action>.Continuation) async {
-    for await status in IPCClient.vpnStatusUpdates(session: session) {
+    for await status in session.statusUpdates() {
       await handle(status: status, emit: emit)
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -199,30 +199,6 @@ public enum IPCClient {
     }
   }
 
-  /// Returns a stream of VPN status updates for the given session.
-  ///
-  /// Every connection in the process posts `NEVPNStatusDidChange` with itself as the
-  /// object; only `session`'s are passed on. The caller is responsible for consuming the
-  /// stream in a task they manage.
-  public static func vpnStatusUpdates(
-    session: any TunnelSessionProtocol
-  ) -> AsyncStream<NEVPNStatus> {
-    AsyncStream { continuation in
-      let task = Task {
-        for await notification in NotificationCenter.default.notifications(
-          named: .NEVPNStatusDidChange)
-        {
-          guard let sender = notification.object as? any TunnelSessionProtocol, sender === session
-          else { continue }
-
-          continuation.yield(session.status)
-        }
-        continuation.finish()
-      }
-      continuation.onTermination = { _ in task.cancel() }
-    }
-  }
-
   /// Sends `message` to the provider, waking a stopped tunnel first if asked to.
   ///
   /// Polling opts out: cycle-starting from the poll loop would wake the extension

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -201,8 +201,9 @@ public enum IPCClient {
 
   /// Returns a stream of VPN status updates for the given session.
   ///
-  /// Filters `NEVPNStatusDidChange` notifications to only those matching `session`.
-  /// The caller is responsible for consuming the stream in a task they manage.
+  /// Every connection in the process posts `NEVPNStatusDidChange` with itself as the
+  /// object; only `session`'s are passed on. The caller is responsible for consuming the
+  /// stream in a task they manage.
   public static func vpnStatusUpdates(
     session: any TunnelSessionProtocol
   ) -> AsyncStream<NEVPNStatus> {
@@ -211,14 +212,10 @@ public enum IPCClient {
         for await notification in NotificationCenter.default.notifications(
           named: .NEVPNStatusDidChange)
         {
-          guard let notificationSession = notification.object as? NETunnelProviderSession
-          else {
-            return
-          }
+          guard let sender = notification.object as? any TunnelSessionProtocol, sender === session
+          else { continue }
 
-          if notificationSession === session {
-            continuation.yield(notificationSession.status)
-          }
+          continuation.yield(session.status)
         }
         continuation.finish()
       }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -123,14 +123,6 @@ public final class VPNConfigurationManager {
     return VPNConfigurationManager(from: manager)
   }
 
-  public static func load(using factory: TunnelProviderManagerFactory) async throws
-    -> VPNConfigurationManager?
-  {
-    try await load(
-      using: factory,
-      providerBundleIdentifier: NETunnelProviderManager.extensionBundleIdentifier)
-  }
-
   /// A candidate configuration and what we could learn about where it came from.
   private struct Candidate {
     let manager: any TunnelProviderManager
@@ -138,10 +130,9 @@ public final class VPNConfigurationManager {
     let isManaged: Bool
   }
 
-  static func load(
-    using factory: TunnelProviderManagerFactory,
-    providerBundleIdentifier: String
-  ) async throws -> VPNConfigurationManager? {
+  public static func load(using factory: TunnelProviderManagerFactory) async throws
+    -> VPNConfigurationManager?
+  {
     // MDM chooses the user-visible description, so it cannot identify our configuration.
     // The provider bundle identifier is the stable link between both app-created and
     // MDM-installed configurations and our extension.
@@ -155,7 +146,7 @@ public final class VPNConfigurationManager {
       // associated it with this app through the payload's VPNSubType. Our own
       // initializer always sets it.
       if let configured = configuration.providerBundleIdentifier,
-        configured != providerBundleIdentifier
+        configured != manager.extensionBundleIdentifier
       {
         return nil
       }
@@ -192,7 +183,7 @@ public final class VPNConfigurationManager {
     {
       Log.warning(
         "The managed VPN profile has no ProviderBundleIdentifier, so the tunnel cannot start "
-          + "from it; the payload needs \(providerBundleIdentifier)."
+          + "from it; the payload needs \(selected.manager.extensionBundleIdentifier)."
       )
     }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -177,6 +177,18 @@
 
       seedConfiguration(with: scenario)
 
+      let session = MockTunnelSession(
+        status: scenario.vpnStatus.status,
+        resources: scenario.resources,
+        connectedDevices: scenario.connectedDevices,
+        actorName: scenario.actorName,
+        providerLogFolderSize: scenario.providerLogFolderSize
+      )
+      let tunnelManagerFactory = MockTunnelProviderManagerFactory(
+        manager: MockTunnelProviderManager(session: session),
+        installed: scenario.hasVPNConfiguration
+      )
+
       #if os(macOS)
         return Store(
           sessionNotification: MockSessionNotification(decision: scenario.notifications.status),
@@ -184,14 +196,14 @@
             status: scenario.systemExtension.status
           ),
           updateChecker: MockUpdateChecker(),
-          tunnelManagerFactory: MockTunnelProviderManagerFactory(scenario: scenario),
+          tunnelManagerFactory: tunnelManagerFactory,
           x509CertificateSource: scenario.clientCertificate.source,
           logDirectory: logDirectory ?? MockFixtures.makeLogDirectory()
         )
       #else
         return Store(
           sessionNotification: MockSessionNotification(decision: scenario.notifications.status),
-          tunnelManagerFactory: MockTunnelProviderManagerFactory(scenario: scenario),
+          tunnelManagerFactory: tunnelManagerFactory,
           x509CertificateSource: scenario.clientCertificate.source,
           logDirectory: logDirectory ?? MockFixtures.makeLogDirectory()
         )
@@ -337,141 +349,6 @@
     }
   #endif
 
-  /// Answers `pollUpdates` with the scenario's snapshot and reports its tunnel status.
-  private final class MockTunnelSession: TunnelSessionProtocol {
-    private let scenario: MockScenario
-
-    var status: NEVPNStatus { scenario.vpnStatus.status }
-
-    /// Drops to zero when a clear is acknowledged, so the settings screen shows
-    /// the size a real provider would report afterwards.
-    ///
-    /// nonisolated(unsafe): the session is Sendable, but the mock is only ever
-    /// driven from the main actor.
-    nonisolated(unsafe) private var providerLogFolderSize: Int64
-
-    init(scenario: MockScenario) {
-      self.scenario = scenario
-      self.providerLogFolderSize = scenario.providerLogFolderSize
-    }
-
-    // swiftlint:disable:next discouraged_optional_collection
-    func startTunnel(options: [String: Any]?) throws {}
-    func stopTunnel() {}
-
-    func fetchLastDisconnectError(completionHandler: @escaping @Sendable (Error?) -> Void) {
-      completionHandler(nil)
-    }
-
-    func sendProviderMessage(_ messageData: Data, responseHandler: ((Data?) -> Void)?) throws {
-      guard let responseHandler else { return }
-
-      let message: ProviderMessage
-      do {
-        message = try PropertyListDecoder().decode(ProviderMessage.self, from: messageData)
-      } catch {
-        Log.warning("MockTunnelSession: ignoring undecodable ProviderMessage: \(error)")
-        responseHandler(nil)
-        return
-      }
-
-      // Listed exhaustively (no `default`) so adding a `ProviderMessage` variant
-      // fails to compile here and forces a decision about the mock's response.
-      switch message {
-      case .pollUpdates(let request):
-        do {
-          let stateChange = try ConnlibState.makeIfChanged(
-            resources: scenario.resources,
-            connectedDevices: scenario.connectedDevices,
-            isLogStreamingActive: false,
-            actorName: scenario.actorName,
-            comparedTo: request.stateHash
-          )
-
-          responseHandler(
-            try PropertyListEncoder().encode(
-              StatePollResponse(
-                stateChange: stateChange,
-                notifications: []
-              )
-            )
-          )
-        } catch {
-          Log.warning("MockTunnelSession: failed to encode state updates: \(error)")
-          responseHandler(nil)
-        }
-      case .getLogFolderSize:
-        // The provider answers with the raw bytes of an `Int64`.
-        responseHandler(withUnsafeBytes(of: providerLogFolderSize) { Data($0) })
-      case .clearLogs:
-        // The provider answers a successful clear with an empty response.
-        providerLogFolderSize = 0
-        responseHandler(nil)
-      case .exportLogs:
-        // The provider streams plist-encoded `LogChunk`s; everything fits in one
-        // final chunk here.
-        do {
-          responseHandler(
-            try PropertyListEncoder().encode(
-              LogChunk(done: true, data: MockFixtures.exportedTunnelLogs)
-            )
-          )
-        } catch {
-          Log.warning("MockTunnelSession: failed to encode the log chunk: \(error)")
-          responseHandler(nil)
-        }
-      case .setInternetResourceEnabled, .signOut, .getEncodedFirezoneId, .drainFlowLogs:
-        responseHandler(nil)
-      }
-    }
-  }
-
-  /// Both factory methods hand back the same `MockTunnelProviderManager`, so session
-  /// identity survives a reload and `Store` can subscribe to one mock session for the
-  /// life of the app.
-  @MainActor
-  private final class MockTunnelProviderManagerFactory: TunnelProviderManagerFactory {
-    private let scenario: MockScenario
-    private let manager: MockTunnelProviderManager
-
-    init(scenario: MockScenario) {
-      self.scenario = scenario
-      self.manager = MockTunnelProviderManager(scenario: scenario)
-    }
-
-    func loadAllFromPreferences() async throws -> [any TunnelProviderManager] {
-      scenario.hasVPNConfiguration ? [manager] : []
-    }
-
-    func createManager() -> any TunnelProviderManager { manager }
-  }
-
-  @MainActor
-  private final class MockTunnelProviderManager: TunnelProviderManager {
-    var isEnabled = true
-    var localizedDescription: String? = VPNConfigurationManager.bundleDescription
-    var protocolConfiguration: NEVPNProtocol?
-    var tunnelSession: (any TunnelSessionProtocol)? { session }
-    // Only the system would read this, to launch the extension; the mock never talks to
-    // the system, so the shipped identifier serves as well as a derived one.
-    let extensionBundleIdentifier = "dev.firezone.firezone.network-extension"
-
-    private let session: MockTunnelSession
-
-    init(scenario: MockScenario) {
-      session = MockTunnelSession(scenario: scenario)
-
-      let proto = NETunnelProviderProtocol()
-      proto.providerConfiguration = Configuration.shared.toProviderConfiguration()
-      proto.providerBundleIdentifier = extensionBundleIdentifier
-      proto.serverAddress = "Firezone"
-      protocolConfiguration = proto
-    }
-
-    func saveToPreferences() async throws {}
-    func loadFromPreferences() async throws {}
-  }
-
   #if os(macOS)
     @MainActor
     private final class MockSystemExtensionManager: SystemExtensionManagerProtocol {
@@ -495,14 +372,25 @@
     }
   #endif
 
-  /// Reports the scenario's answer to the notification prompt.
+  /// Reports the scenario's answer to the notification prompt and keeps what it was
+  /// asked to show.
   ///
   /// Both platforms use it: the real `SessionNotification` reaches
   /// `UNUserNotificationCenter`, which raises rather than returning an error when
   /// the process has no app bundle, so it cannot be built from a test.
   @MainActor
-  private final class MockSessionNotification: SessionNotificationProtocol {
+  final class MockSessionNotification: SessionNotificationProtocol {
+    enum Shown: Equatable {
+      case resource(title: String, body: String)
+      #if os(macOS)
+        case signedOut(String?)
+        case disconnected(String?)
+        case restartRequired
+      #endif
+    }
+
     var signInHandler: () async -> Void = {}
+    private(set) var shown: [Shown] = []
 
     private let decision: UNAuthorizationStatus
 
@@ -512,23 +400,27 @@
 
     func askUserForNotificationPermissions() async throws -> UNAuthorizationStatus { decision }
     func loadAuthorizationStatus() async -> UNAuthorizationStatus { decision }
-    func showResourceNotification(title: String, body: String) async {}
+
+    func showResourceNotification(title: String, body: String) async {
+      shown.append(.resource(title: title, body: body))
+    }
 
     #if os(macOS)
-      func showSignedOutAlertMacOS(_ message: String?) async {}
-      func showDisconnectedAlertMacOS(_ message: String?) async {}
-      func showRestartRequiredAlertMacOS() {}
+      func showSignedOutAlertMacOS(_ message: String?) async {
+        shown.append(.signedOut(message))
+      }
+
+      func showDisconnectedAlertMacOS(_ message: String?) async {
+        shown.append(.disconnected(message))
+      }
+
+      func showRestartRequiredAlertMacOS() {
+        shown.append(.restartRequired)
+      }
     #endif
   }
 
   private enum MockFixtures {
-    /// The provider streams the bytes of a ZIP archive, so answer with the
-    /// smallest valid one: an empty end-of-central-directory record. An export
-    /// produced against the mock then unzips cleanly.
-    static let exportedTunnelLogs = Data(
-      [0x50, 0x4B, 0x05, 0x06] + [UInt8](repeating: 0, count: 18)
-    )
-
     /// A throwaway log directory seeded with two files of fixed contents, so
     /// the computed app-side log size is real and deterministic.
     static func makeLogDirectory() -> URL {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnelSession.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnelSession.swift
@@ -20,8 +20,7 @@
     private(set) var status: NEVPNStatus
 
     /// What the next poll reports; `nil` resources are a portal that has not sent `init`.
-    // swiftlint:disable:next discouraged_optional_collection
-    var resources: [Resource]?
+    var resources: [Resource]?  // swiftlint:disable:this discouraged_optional_collection
     var connectedDevices: [ConnectedDevice]
     var actorName: String?
     var accountSlug: String?
@@ -35,9 +34,8 @@
     /// status falls back to disconnected with this as the last disconnect error.
     var startFailure: (any Error)?
 
-    /// The options of the most recent start, cycle starts included.
-    // swiftlint:disable:next discouraged_optional_collection
-    private(set) var startOptions: [String: Any]?
+    /// The options of every start, cycle starts included.
+    private(set) var starts: [[String: Any]] = []
     private(set) var messages: [ProviderMessage] = []
     private var lastDisconnectError: (any Error)?
 
@@ -57,7 +55,7 @@
 
     // swiftlint:disable:next discouraged_optional_collection
     func startTunnel(options: [String: Any]?) throws {
-      startOptions = options
+      starts.append(options ?? [:])
       lastDisconnectError = nil
       transition(to: .connecting)
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnelSession.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnelSession.swift
@@ -1,0 +1,208 @@
+//
+//  MockTunnelSession.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+#if DEBUG
+  import Foundation
+  @preconcurrency import NetworkExtension
+
+  /// Stands in for the provider behind `NETunnelProviderSession`.
+  ///
+  /// Answers the app's messages from state a scenario or a test sets, and moves through
+  /// the statuses a start or stop would, posting `NEVPNStatusDidChange` the way the real
+  /// session does so that `Store` observes it through the same notification.
+  ///
+  /// `@unchecked Sendable`: the protocol is `Sendable`, but the mock is only ever driven
+  /// from the main actor.
+  final class MockTunnelSession: TunnelSessionProtocol, @unchecked Sendable {
+    private(set) var status: NEVPNStatus
+
+    /// What the next poll reports; `nil` resources are a portal that has not sent `init`.
+    // swiftlint:disable:next discouraged_optional_collection
+    var resources: [Resource]?
+    var connectedDevices: [ConnectedDevice]
+    var actorName: String?
+    var accountSlug: String?
+    /// Handed over on the next poll and consumed by it, like the provider's mailbox.
+    var notifications: [UnreachableResource] = []
+    /// Drops to zero when a clear is acknowledged, so the settings screen shows the size
+    /// a real provider would report afterwards.
+    var providerLogFolderSize: Int64
+
+    /// Ends every start the way a provider that cannot bring the tunnel up does: the
+    /// status falls back to disconnected with this as the last disconnect error.
+    var startFailure: (any Error)?
+
+    /// The options of the most recent start, cycle starts included.
+    // swiftlint:disable:next discouraged_optional_collection
+    private(set) var startOptions: [String: Any]?
+    private(set) var messages: [ProviderMessage] = []
+    private var lastDisconnectError: (any Error)?
+
+    init(
+      status: NEVPNStatus,
+      resources: [Resource]? = nil,  // swiftlint:disable:this discouraged_optional_collection
+      connectedDevices: [ConnectedDevice] = [],
+      actorName: String? = nil,
+      providerLogFolderSize: Int64 = 0
+    ) {
+      self.status = status
+      self.resources = resources
+      self.connectedDevices = connectedDevices
+      self.actorName = actorName
+      self.providerLogFolderSize = providerLogFolderSize
+    }
+
+    // swiftlint:disable:next discouraged_optional_collection
+    func startTunnel(options: [String: Any]?) throws {
+      startOptions = options
+      lastDisconnectError = nil
+      transition(to: .connecting)
+
+      if let startFailure {
+        lastDisconnectError = startFailure
+        transition(to: .disconnected)
+        return
+      }
+
+      transition(to: .connected)
+    }
+
+    func stopTunnel() {
+      guard [.connected, .connecting, .reasserting].contains(status) else { return }
+
+      transition(to: .disconnecting)
+      transition(to: .disconnected)
+    }
+
+    /// Ends the session the way the provider does when connlib reports a disconnect.
+    func disconnect(with error: any Error) {
+      lastDisconnectError = error
+      transition(to: .disconnected)
+    }
+
+    func fetchLastDisconnectError(completionHandler: @escaping @Sendable (Error?) -> Void) {
+      completionHandler(lastDisconnectError)
+    }
+
+    func sendProviderMessage(_ messageData: Data, responseHandler: ((Data?) -> Void)?) throws {
+      let message: ProviderMessage
+      do {
+        message = try PropertyListDecoder().decode(ProviderMessage.self, from: messageData)
+      } catch {
+        Log.warning("MockTunnelSession: ignoring undecodable ProviderMessage: \(error)")
+        responseHandler?(nil)
+        return
+      }
+
+      messages.append(message)
+
+      guard let responseHandler else { return }
+
+      // Listed exhaustively (no `default`) so adding a `ProviderMessage` variant
+      // fails to compile here and forces a decision about the mock's response.
+      switch message {
+      case .pollUpdates(let request):
+        do {
+          let stateChange = try ConnlibState.makeIfChanged(
+            resources: resources,
+            connectedDevices: connectedDevices,
+            isLogStreamingActive: false,
+            accountSlug: accountSlug,
+            actorName: actorName,
+            comparedTo: request.stateHash
+          )
+          let response = StatePollResponse(stateChange: stateChange, notifications: notifications)
+          let encoded = try PropertyListEncoder().encode(response)
+
+          notifications.removeAll()
+          responseHandler(encoded)
+        } catch {
+          Log.warning("MockTunnelSession: failed to encode state updates: \(error)")
+          responseHandler(nil)
+        }
+      case .getLogFolderSize:
+        // The provider answers with the raw bytes of an `Int64`.
+        responseHandler(withUnsafeBytes(of: providerLogFolderSize) { Data($0) })
+      case .clearLogs:
+        // The provider answers a successful clear with an empty response.
+        providerLogFolderSize = 0
+        responseHandler(nil)
+      case .exportLogs:
+        // The provider streams plist-encoded `LogChunk`s; everything fits in one
+        // final chunk here.
+        do {
+          responseHandler(
+            try PropertyListEncoder().encode(LogChunk(done: true, data: Self.exportedTunnelLogs))
+          )
+        } catch {
+          Log.warning("MockTunnelSession: failed to encode the log chunk: \(error)")
+          responseHandler(nil)
+        }
+      case .setInternetResourceEnabled, .signOut, .getEncodedFirezoneId, .drainFlowLogs:
+        responseHandler(nil)
+      }
+    }
+
+    private func transition(to newStatus: NEVPNStatus) {
+      status = newStatus
+      NotificationCenter.default.post(name: .NEVPNStatusDidChange, object: self)
+    }
+
+    /// The provider streams the bytes of a ZIP archive, so answer with the smallest
+    /// valid one: an empty end-of-central-directory record. An export produced against
+    /// the mock then unzips cleanly.
+    private static let exportedTunnelLogs = Data(
+      [0x50, 0x4B, 0x05, 0x06] + [UInt8](repeating: 0, count: 18)
+    )
+  }
+
+  @MainActor
+  final class MockTunnelProviderManager: TunnelProviderManager {
+    var isEnabled = true
+    var localizedDescription: String? = VPNConfigurationManager.bundleDescription
+    var protocolConfiguration: NEVPNProtocol?
+    var tunnelSession: (any TunnelSessionProtocol)? { session }
+    // Only the system would read this, to launch the extension; the mock never talks to
+    // the system, so the shipped identifier serves as well as a derived one.
+    let extensionBundleIdentifier = "dev.firezone.firezone.network-extension"
+
+    let session: MockTunnelSession
+
+    init(session: MockTunnelSession) {
+      self.session = session
+
+      let proto = NETunnelProviderProtocol()
+      proto.providerConfiguration = Configuration.shared.toProviderConfiguration()
+      proto.providerBundleIdentifier = extensionBundleIdentifier
+      proto.serverAddress = "Firezone"
+      protocolConfiguration = proto
+    }
+
+    func saveToPreferences() async throws {}
+    func loadFromPreferences() async throws {}
+  }
+
+  /// Both factory methods hand back the same manager, so session identity survives a
+  /// reload and `Store` can subscribe to one mock session for the life of the app.
+  @MainActor
+  final class MockTunnelProviderManagerFactory: TunnelProviderManagerFactory {
+    private let manager: MockTunnelProviderManager
+    private let isInstalled: Bool
+
+    /// `installed` says whether a load finds the configuration; creating one hands it
+    /// out either way.
+    init(manager: MockTunnelProviderManager, installed: Bool = true) {
+      self.manager = manager
+      self.isInstalled = installed
+    }
+
+    func loadAllFromPreferences() async throws -> [any TunnelProviderManager] {
+      isInstalled ? [manager] : []
+    }
+
+    func createManager() -> any TunnelProviderManager { manager }
+  }
+#endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnelSession.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnelSession.swift
@@ -11,8 +11,7 @@
   /// Stands in for the provider behind `NETunnelProviderSession`.
   ///
   /// Answers the app's messages from state a scenario or a test sets, and moves through
-  /// the statuses a start or stop would, posting `NEVPNStatusDidChange` the way the real
-  /// session does so that `Store` observes it through the same notification.
+  /// the statuses a start or stop would.
   ///
   /// `@unchecked Sendable`: the protocol is `Sendable`, but the mock is only ever driven
   /// from the main actor.
@@ -38,6 +37,7 @@
     private(set) var starts: [[String: Any]] = []
     private(set) var messages: [ProviderMessage] = []
     private var lastDisconnectError: (any Error)?
+    private var statusObservers: [AsyncStream<NEVPNStatus>.Continuation] = []
 
     init(
       status: NEVPNStatus,
@@ -66,6 +66,10 @@
       }
 
       transition(to: .connected)
+    }
+
+    func statusUpdates() -> AsyncStream<NEVPNStatus> {
+      AsyncStream { statusObservers.append($0) }
     }
 
     func stopTunnel() {
@@ -146,7 +150,10 @@
 
     private func transition(to newStatus: NEVPNStatus) {
       status = newStatus
-      NotificationCenter.default.post(name: .NEVPNStatusDidChange, object: self)
+
+      for observer in statusObservers {
+        observer.yield(newStatus)
+      }
     }
 
     /// The provider streams the bytes of a ZIP archive, so answer with the smallest

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/TunnelSessionProtocol.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/TunnelSessionProtocol.swift
@@ -11,6 +11,8 @@
 ///
 /// The methods mirror Apple's API exactly, which lets `NETunnelProviderSession`
 /// conform via an empty extension — there is no "real" wrapper to keep in sync.
+/// Status changes travel the same way as Apple's: a conformer posts
+/// `NEVPNStatusDidChange` with itself as the notification's object.
 public protocol TunnelSessionProtocol: AnyObject, Sendable {
   var status: NEVPNStatus { get }
   // swiftlint:disable:next discouraged_optional_collection

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/TunnelSessionProtocol.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/TunnelSessionProtocol.swift
@@ -4,17 +4,19 @@
 //  LICENSE: Apache-2.0
 //
 
+import Foundation
 @preconcurrency import NetworkExtension
 
 /// Abstracts the slice of `NETunnelProviderSession` that the GUI talks to, so a
 /// mock session can drive `Store` without a real Network Extension.
 ///
 /// The methods mirror Apple's API exactly, which lets `NETunnelProviderSession`
-/// conform via an empty extension — there is no "real" wrapper to keep in sync.
-/// Status changes travel the same way as Apple's: a conformer posts
-/// `NEVPNStatusDidChange` with itself as the notification's object.
+/// conform without a wrapper to keep in sync. The one addition is the status
+/// stream, which Apple only offers as a notification.
 public protocol TunnelSessionProtocol: AnyObject, Sendable {
   var status: NEVPNStatus { get }
+  /// Every status the session takes on from now, in order.
+  func statusUpdates() -> AsyncStream<NEVPNStatus>
   // swiftlint:disable:next discouraged_optional_collection
   func startTunnel(options: [String: Any]?) throws
   func stopTunnel()
@@ -22,4 +24,23 @@ public protocol TunnelSessionProtocol: AnyObject, Sendable {
   func fetchLastDisconnectError(completionHandler: @escaping @Sendable (Error?) -> Void)
 }
 
-extension NETunnelProviderSession: TunnelSessionProtocol {}
+extension NETunnelProviderSession: TunnelSessionProtocol {
+  /// Every connection in the process posts `NEVPNStatusDidChange` with itself as the
+  /// object; only this session's are passed on.
+  public func statusUpdates() -> AsyncStream<NEVPNStatus> {
+    AsyncStream { continuation in
+      let task = Task {
+        for await notification in NotificationCenter.default.notifications(
+          named: .NEVPNStatusDidChange)
+        {
+          guard let sender = notification.object as? NETunnelProviderSession, sender === self
+          else { continue }
+
+          continuation.yield(self.status)
+        }
+        continuation.finish()
+      }
+      continuation.onTermination = { _ in task.cancel() }
+    }
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -287,7 +287,7 @@ public final class Store: ObservableObject {
       throw VPNConfigurationManagerError.managerNotInitialized
     }
 
-    let statusStream = IPCClient.vpnStatusUpdates(session: session)
+    let statusStream = session.statusUpdates()
 
     vpnStatusTask = CancellableTask { [weak self] in
       for await status in statusStream {

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/IPCClientTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/IPCClientTests.swift
@@ -34,6 +34,10 @@ private final class RecordingTunnelSession: TunnelSessionProtocol, @unchecked Se
     status = .connected
   }
 
+  func statusUpdates() -> AsyncStream<NEVPNStatus> {
+    AsyncStream { $0.finish() }
+  }
+
   func stopTunnel() {
     stopTunnelCallCount += 1
     status = .disconnected

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreSessionTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreSessionTests.swift
@@ -49,8 +49,9 @@
 
       try await app.store.signIn(token: Self.token)
 
-      #expect(app.tunnel.startOptions?["authentication"] as? String == "tokenAndCertificate")
-      #expect(app.tunnel.startOptions?["token"] as? String == Self.token)
+      let start = try #require(app.tunnel.starts.last)
+      #expect(start["authentication"] as? String == "tokenAndCertificate")
+      #expect(start["token"] as? String == Self.token)
       try await waitUntil { app.store.vpnStatus == .connected }
     }
 

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreSessionTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreSessionTests.swift
@@ -1,0 +1,220 @@
+//
+//  StoreSessionTests.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+#if os(macOS)
+  import Foundation
+  import NetworkExtension
+  import Testing
+
+  @testable import FirezoneKit
+
+  /// Runs a session through the real `Store` against the mocked extension, entered the way
+  /// a user enters it: the app starts, they sign in, what the tunnel reports arrives, they
+  /// act on it, and the session ends. The only thing standing in for production is the
+  /// extension. What the mock reports has to come out of the store, and what the store
+  /// does has to reach the mock.
+  ///
+  /// Serialised because every `Store` loads into the process-wide `Configuration`.
+  @MainActor
+  @Suite("Store session", .serialized)
+  struct StoreSessionTests {
+    private static let token = "stored-token"
+
+    // The deployment the screenshot fixtures describe, so the galleries and these tests
+    // tell one story.
+    private static let engineeringWiki = Resource(
+      id: "0854dca1-2c5b-468a-be85-0eec2f02a211",
+      name: "Engineering wiki",
+      address: "wiki.example.com",
+      addressDescription: "https://wiki.example.com",
+      status: .online,
+      sites: [Site(id: "917e9354-26b3-4704-867c-f84c8688d269", name: "Sydney Office")],
+      type: .dns
+    )
+
+    private static let benchController = ConnectedDevice(
+      id: "a21c9663-4d0e-4f4a-a8fa-48790b1e5cef",
+      name: "bench-controller-01",
+      tunIPv4: "100.64.3.18",
+      tunIPv6: "fd00:2021:1111::12",
+      pools: ["Lab hardware", "Shared storage"]
+    )
+
+    @Test("signing in starts the tunnel with the token")
+    func signingInStartsTheTunnelWithTheToken() async throws {
+      let app = try await signedOut()
+
+      try await app.store.signIn(token: Self.token)
+
+      #expect(app.tunnel.startOptions?["authentication"] as? String == "tokenAndCertificate")
+      #expect(app.tunnel.startOptions?["token"] as? String == Self.token)
+      try await waitUntil { app.store.vpnStatus == .connected }
+    }
+
+    @Test("resources reach the store")
+    func resourcesReachTheStore() async throws {
+      let app = try await signedOut()
+      app.tunnel.resources = [Self.engineeringWiki]
+
+      try await app.store.signIn(token: Self.token)
+
+      try await waitUntil { app.store.resourceList.asArray() == [Self.engineeringWiki] }
+    }
+
+    @Test("connected devices reach the store")
+    func connectedDevicesReachTheStore() async throws {
+      let app = try await signedOut()
+      app.tunnel.resources = [Self.engineeringWiki]
+      app.tunnel.connectedDevices = [Self.benchController]
+
+      try await app.store.signIn(token: Self.token)
+
+      try await waitUntil { app.store.connectedDevices == [Self.benchController] }
+    }
+
+    @Test("the actor and account the portal names reach the store")
+    func actorAndAccountReachTheStore() async throws {
+      let app = try await signedOut()
+      app.tunnel.actorName = "Jane Doe"
+      app.tunnel.accountSlug = "acme-corp"
+
+      try await app.store.signIn(token: Self.token)
+
+      try await waitUntil { app.store.actorName == "Jane Doe" }
+      #expect(app.store.sessionHeading == "Signed in as Jane Doe")
+      #expect(app.store.configuration.accountSlug == "acme-corp")
+    }
+
+    @Test("a resource update after the session is up reaches the store")
+    func aLaterResourceUpdateReachesTheStore() async throws {
+      let app = try await signedOut()
+      app.tunnel.resources = []
+      try await app.store.signIn(token: Self.token)
+      try await waitUntil {
+        if case .loaded = app.store.resourceList { return true }
+        return false
+      }
+
+      app.tunnel.resources = [Self.engineeringWiki]
+
+      try await waitUntil { app.store.resourceList.asArray() == [Self.engineeringWiki] }
+    }
+
+    @Test("enabling the Internet Resource reaches the tunnel")
+    func enablingTheInternetResourceReachesTheTunnel() async throws {
+      let app = try await signedOut()
+      try await app.store.signIn(token: Self.token)
+      try await waitUntil { app.store.vpnStatus == .connected }
+      // The setting is process-wide, so leave it the way the next test expects it.
+      defer { app.store.configuration.internetResourceEnabled = false }
+
+      app.store.configuration.internetResourceEnabled = true
+
+      try await waitUntil {
+        app.tunnel.messages.contains {
+          if case .setInternetResourceEnabled(true) = $0 { return true }
+          return false
+        }
+      }
+    }
+
+    @Test("an unreachable resource is reported by name")
+    func anUnreachableResourceIsReported() async throws {
+      let app = try await signedOut()
+      app.tunnel.resources = [Self.engineeringWiki]
+      try await app.store.signIn(token: Self.token)
+      try await waitUntil { app.store.resourceList.asArray() == [Self.engineeringWiki] }
+
+      app.tunnel.notifications = [
+        UnreachableResource(resourceId: Self.engineeringWiki.id, reason: .offline)
+      ]
+
+      try await waitUntil {
+        app.notifications.shown.contains {
+          if case .resource(let title, _) = $0 {
+            return title == "Failed to connect to 'Engineering wiki'"
+          }
+          return false
+        }
+      }
+    }
+
+    @Test("a disconnect says why and clears the session")
+    func aDisconnectSaysWhyAndClearsTheSession() async throws {
+      let app = try await signedOut()
+      app.tunnel.resources = [Self.engineeringWiki]
+      try await app.store.signIn(token: Self.token)
+      try await waitUntil { app.store.resourceList.asArray() == [Self.engineeringWiki] }
+
+      app.tunnel.disconnect(with: ConnlibError.disconnected("the portal hung up"))
+
+      try await waitUntil { app.notifications.shown.contains(.disconnected("the portal hung up")) }
+      #expect(app.store.vpnStatus == .disconnected)
+      #expect(app.store.resourceList.asArray().isEmpty)
+    }
+
+    @Test("a disconnect that requires signing in again says so")
+    func aDisconnectThatRequiresSigningInAgainSaysSo() async throws {
+      let app = try await signedOut()
+      try await app.store.signIn(token: Self.token)
+      try await waitUntil { app.store.vpnStatus == .connected }
+
+      app.tunnel.disconnect(with: ConnlibError.sessionExpired("your session expired"))
+
+      try await waitUntil { app.notifications.shown.contains(.signedOut("your session expired")) }
+      #expect(app.store.vpnStatus == .disconnected)
+    }
+
+    @Test("a tunnel that fails to come up reports the failure")
+    func aTunnelThatFailsToComeUpReportsTheFailure() async throws {
+      let app = try await signedOut()
+      app.tunnel.startFailure = ConnlibError.disconnected("connlib failed to start")
+
+      try await app.store.signIn(token: Self.token)
+
+      try await waitUntil {
+        app.notifications.shown.contains(.disconnected("connlib failed to start"))
+      }
+      #expect(app.store.vpnStatus == .disconnected)
+    }
+
+    @Test("signing out tells the tunnel and stops it without an alert")
+    func signingOutTellsTheTunnelAndStopsIt() async throws {
+      let app = try await signedOut()
+      try await app.store.signIn(token: Self.token)
+      try await waitUntil { app.store.vpnStatus == .connected }
+
+      try await app.store.signOut()
+
+      let toldTheTunnel = app.tunnel.messages.contains {
+        if case .signOut = $0 { return true }
+        return false
+      }
+      #expect(toldTheTunnel)
+      try await waitUntil { app.store.vpnStatus == .disconnected }
+      #expect(app.notifications.shown.isEmpty)
+    }
+
+    private struct App {
+      let store: Store
+      let tunnel: MockTunnelSession
+      let notifications: MockSessionNotification
+    }
+
+    /// The app as a signed-out user finds it: started, with a VPN configuration and an
+    /// installed extension, and nothing running.
+    private func signedOut() async throws -> App {
+      let store = Store.mock(scenario: .named("welcome"))
+      await store.start()
+
+      return App(
+        store: store,
+        tunnel: try #require(try store.manager().session() as? MockTunnelSession),
+        notifications: try #require(store.sessionNotification as? MockSessionNotification)
+      )
+    }
+  }
+#endif

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/VPNConfigurationManagerTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/VPNConfigurationManagerTests.swift
@@ -61,8 +61,7 @@ struct VPNConfigurationManagerTests {
     ])
 
     let manager = try #require(
-      await VPNConfigurationManager.load(
-        using: factory, providerBundleIdentifier: providerBundleIdentifier))
+      await VPNConfigurationManager.load(using: factory))
 
     #expect(!manager.isManaged)
     #expect(try manager.identityReference() == nil)
@@ -78,8 +77,7 @@ struct VPNConfigurationManagerTests {
     ])
 
     let manager = try #require(
-      await VPNConfigurationManager.load(
-        using: factory, providerBundleIdentifier: providerBundleIdentifier))
+      await VPNConfigurationManager.load(using: factory))
 
     #expect(manager.isManaged)
     #expect(try manager.identityReference() == reference)
@@ -91,8 +89,7 @@ struct VPNConfigurationManagerTests {
     let factory = StubFactory([StubTunnelProviderManager(providerBundleIdentifier: nil)])
 
     let manager = try #require(
-      await VPNConfigurationManager.load(
-        using: factory, providerBundleIdentifier: providerBundleIdentifier))
+      await VPNConfigurationManager.load(using: factory))
 
     #expect(manager.isManaged)
   }
@@ -104,8 +101,7 @@ struct VPNConfigurationManagerTests {
       StubTunnelProviderManager(providerBundleIdentifier: "com.example.vpn.extension")
     ])
 
-    let manager = try await VPNConfigurationManager.load(
-      using: factory, providerBundleIdentifier: providerBundleIdentifier)
+    let manager = try await VPNConfigurationManager.load(using: factory)
 
     #expect(manager == nil)
   }
@@ -121,8 +117,7 @@ struct VPNConfigurationManagerTests {
     ])
 
     let manager = try #require(
-      await VPNConfigurationManager.load(
-        using: factory, providerBundleIdentifier: providerBundleIdentifier))
+      await VPNConfigurationManager.load(using: factory))
 
     #expect(try manager.identityReference() == reference)
   }
@@ -135,8 +130,7 @@ struct VPNConfigurationManagerTests {
     let factory = StubFactory([stub])
 
     let manager = try #require(
-      await VPNConfigurationManager.load(
-        using: factory, providerBundleIdentifier: providerBundleIdentifier))
+      await VPNConfigurationManager.load(using: factory))
 
     try await manager.save(providerConfiguration: ["accountSlug": "other"])
 
@@ -157,8 +151,7 @@ struct VPNConfigurationManagerTests {
     ])
 
     let manager = try #require(
-      await VPNConfigurationManager.load(
-        using: factory, providerBundleIdentifier: providerBundleIdentifier))
+      await VPNConfigurationManager.load(using: factory))
     try await manager.loadConfiguration(into: configuration, userDefaults: defaults)
 
     #expect(configuration.isVPNConfigurationManaged)


### PR DESCRIPTION
Today, we don't have any bigger integration tests in the macOS / iOS client that exercise some of the main logic paths. Most tests are focused on parsing and / or pure functions around the view.

To plug at least some of these holes, this PR introduces a few more final seams around Apple's APIs which allows us to write integration tests against the public API of `Store`.

Related: #14905