### PR TITLE
feat(portal): list and show Gateway Tokens

### DIFF
--- a/elixir/lib/portal_api/controllers/gateway_token_controller.ex
+++ b/elixir/lib/portal_api/controllers/gateway_token_controller.ex
@@ -3,6 +3,7 @@ defmodule PortalAPI.GatewayTokenController do
   use OpenApiSpex.ControllerSpecs
   alias Portal.Authentication
   alias PortalAPI.Error
+  alias PortalAPI.Pagination
   alias PortalAPI.Schemas.ProblemDetails
   alias __MODULE__.Database
 
@@ -11,6 +12,94 @@ defmodule PortalAPI.GatewayTokenController do
   # Single-owner tokens replace multi-owner Site tokens; this endpoint is
   # deprecated ahead of its own removal, independent of any API versioning.
   @multi_owner_token_sunset_at ~D[2026-10-01]
+
+  # coveralls-ignore-start - OpenApiSpex operation specs are compile-time, not executable
+  operation :index,
+    summary: "List Gateway Tokens for a Site",
+    description:
+      "Retrieves metadata about a Site's Gateway Tokens, including the ones bound to a " <>
+        "single Gateway in it. Token values cannot be retrieved after creation.",
+    parameters: [
+      site_id: [
+        in: :path,
+        description: "Site ID",
+        type: :string,
+        example: "00000000-0000-0000-0000-000000000000"
+      ],
+      limit: [in: :query, description: "Limit Gateway Tokens returned", type: :integer],
+      page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string]
+    ],
+    responses:
+      [
+        ok:
+          {"Gateway Token List Response", "application/json",
+           PortalAPI.Schemas.GatewayToken.ListResponse}
+      ] ++
+        ProblemDetails.responses([
+          :bad_request,
+          :unauthorized,
+          :not_found,
+          :too_many_requests
+        ])
+
+  # coveralls-ignore-stop
+
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(conn, %{"site_id" => site_id} = params) do
+    subject = conn.assigns.subject
+
+    with {:ok, list_opts} <- Pagination.params_to_list_opts(params),
+         {:ok, site} <- Database.fetch_site(site_id, subject),
+         {:ok, tokens, metadata} <- Database.list_tokens(site, subject, list_opts) do
+      render(conn, :index, tokens: tokens, metadata: metadata)
+    else
+      error -> Error.handle(conn, error)
+    end
+  end
+
+  # coveralls-ignore-start - OpenApiSpex operation specs are compile-time, not executable
+  operation :show,
+    summary: "Show a Gateway Token",
+    description:
+      "Retrieves metadata about a Gateway Token. " <>
+        "Token values cannot be retrieved after creation.",
+    parameters: [
+      site_id: [
+        in: :path,
+        description: "Site ID",
+        type: :string,
+        example: "00000000-0000-0000-0000-000000000000"
+      ],
+      id: [
+        in: :path,
+        description: "Token ID",
+        type: :string,
+        example: "00000000-0000-0000-0000-000000000000"
+      ]
+    ],
+    responses:
+      [
+        ok:
+          {"Gateway Token Response", "application/json",
+           PortalAPI.Schemas.GatewayToken.ShowResponse}
+      ] ++
+        ProblemDetails.responses([
+          :bad_request,
+          :unauthorized,
+          :not_found,
+          :too_many_requests
+        ])
+
+  # coveralls-ignore-stop
+
+  @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def show(conn, %{"site_id" => site_id, "id" => token_id}) do
+    with {:ok, token} <- Database.fetch_token(token_id, site_id, conn.assigns.subject) do
+      render(conn, :show_metadata, token: token)
+    else
+      error -> Error.handle(conn, error)
+    end
+  end
 
   # coveralls-ignore-start - OpenApiSpex operation specs are compile-time, not executable
   operation :create,
@@ -304,6 +393,26 @@ defmodule PortalAPI.GatewayTokenController do
         site ->
           {:ok, site}
       end
+    end
+
+    # Mirrors fetch_token/3: a Site's tokens are the multi-owner ones it holds
+    # directly plus the single-owner ones held by its Gateways.
+    def list_tokens(site, subject, opts \\ []) do
+      from(t in GatewayToken, as: :gateway_tokens)
+      |> join(:left, [gateway_tokens: t], d in Device,
+        on: d.id == t.device_id and d.account_id == t.account_id,
+        as: :device
+      )
+      |> where([gateway_tokens: t, device: d], t.site_id == ^site.id or d.site_id == ^site.id)
+      |> Safe.scoped(subject)
+      |> Safe.list(__MODULE__, opts)
+    end
+
+    def cursor_fields do
+      [
+        {:gateway_tokens, :desc, :inserted_at},
+        {:gateway_tokens, :desc, :id}
+      ]
     end
 
     def fetch_token(id, site_id, subject) do

--- a/elixir/lib/portal_api/controllers/gateway_token_json.ex
+++ b/elixir/lib/portal_api/controllers/gateway_token_json.ex
@@ -1,4 +1,19 @@
 defmodule PortalAPI.GatewayTokenJSON do
+  alias PortalAPI.Pagination
+
+  def index(%{tokens: tokens, metadata: metadata}) do
+    %{
+      data: Enum.map(tokens, &data/1),
+      metadata: Pagination.metadata(metadata)
+    }
+  end
+
+  def show_metadata(%{token: token}) do
+    %{
+      data: data(token)
+    }
+  end
+
   def show(%{token: token, encoded_token: encoded_token}) do
     %{
       data: %{
@@ -21,6 +36,18 @@ defmodule PortalAPI.GatewayTokenJSON do
       data: %{
         deleted_count: count
       }
+    }
+  end
+
+  # device_id is a Gateway on the public API, and the secret columns are never
+  # rendered: a token value only exists in the response that created it.
+  defp data(token) do
+    %{
+      id: token.id,
+      site_id: token.site_id,
+      gateway_id: token.device_id,
+      rotated_at: token.rotated_at,
+      inserted_at: token.inserted_at
     }
   end
 end

--- a/elixir/lib/portal_api/router.ex
+++ b/elixir/lib/portal_api/router.ex
@@ -80,6 +80,8 @@ defmodule PortalAPI.Router do
     resources "/policies", PolicyController, except: [:new, :edit]
 
     resources "/sites", SiteController, except: [:new, :edit] do
+      get "/gateway_tokens", GatewayTokenController, :index
+      get "/gateway_tokens/:id", GatewayTokenController, :show
       post "/gateway_tokens", GatewayTokenController, :create
       delete "/gateway_tokens", GatewayTokenController, :delete_all
       delete "/gateway_tokens/:id", GatewayTokenController, :delete

--- a/elixir/lib/portal_api/schemas/gateway_token_schema.ex
+++ b/elixir/lib/portal_api/schemas/gateway_token_schema.ex
@@ -41,6 +41,119 @@ defmodule PortalAPI.Schemas.GatewayToken do
     })
   end
 
+  defmodule MetadataSchema do
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "GatewayTokenMetadata",
+      description:
+        "Gateway Token metadata. Token values cannot be retrieved after creation.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid, description: "Gateway Token ID"},
+        site_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description:
+            "Site whose Gateways may all use this token. " <>
+              "Null when the token is bound to a single Gateway."
+        },
+        gateway_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description:
+            "Gateway this token is bound to. " <>
+              "Null when any Gateway in the Site may use it."
+        },
+        rotated_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          nullable: true,
+          description:
+            "When the token was rotated out. It stays usable for a grace period after this, " <>
+              "until its replacement is first used."
+        },
+        inserted_at: %Schema{type: :string, format: :"date-time", description: "Creation timestamp"}
+      },
+      required: [:id, :site_id, :gateway_id, :rotated_at, :inserted_at],
+      example: %{
+        "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+        "site_id" => nil,
+        "gateway_id" => "43a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+        "rotated_at" => nil,
+        "inserted_at" => "2025-01-15T12:34:56.789Z"
+      }
+    })
+  end
+
+  defmodule ShowResponse do
+    require OpenApiSpex
+    alias PortalAPI.Schemas.GatewayToken
+
+    OpenApiSpex.schema(%{
+      title: "GatewayTokenShowResponse",
+      description:
+        "Response schema for Gateway Token metadata. " <>
+          "Token values cannot be retrieved after creation.",
+      type: :object,
+      properties: %{
+        data: GatewayToken.MetadataSchema
+      },
+      example: %{
+        "data" => %{
+          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+          "site_id" => nil,
+          "gateway_id" => "43a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+          "rotated_at" => nil,
+          "inserted_at" => "2025-01-15T12:34:56.789Z"
+        }
+      }
+    })
+  end
+
+  defmodule ListResponse do
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+    alias PortalAPI.Schemas.GatewayToken
+    alias PortalAPI.Schemas.PaginationMetadata
+
+    OpenApiSpex.schema(%{
+      title: "GatewayTokenListResponse",
+      description:
+        "Response schema for multiple Gateway Tokens. " <>
+          "Token values cannot be retrieved after creation.",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          description: "Gateway Token metadata",
+          type: :array,
+          items: GatewayToken.MetadataSchema
+        },
+        metadata: PaginationMetadata
+      },
+      example: %{
+        "data" => [
+          %{
+            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+            "site_id" => nil,
+            "gateway_id" => "43a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+            "rotated_at" => nil,
+            "inserted_at" => "2025-01-15T12:34:56.789Z"
+          }
+        ],
+        "metadata" => %{
+          "limit" => 10,
+          "count" => 1,
+          "prev_page" => nil,
+          "next_page" => nil
+        }
+      }
+    })
+  end
+
   defmodule DeletedResponse do
     require OpenApiSpex
     alias OpenApiSpex.Schema

--- a/elixir/priv/static/openapi.json
+++ b/elixir/priv/static/openapi.json
@@ -959,6 +959,25 @@
         "title": "EntraAuthProvider",
         "type": "object"
       },
+      "GatewayTokenShowResponse": {
+        "description": "Response schema for Gateway Token metadata. Token values cannot be retrieved after creation.",
+        "example": {
+          "data": {
+            "gateway_id": "43a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+            "inserted_at": "2025-01-15T12:34:56.789Z",
+            "rotated_at": null,
+            "site_id": null
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/GatewayTokenMetadata"
+          }
+        },
+        "title": "GatewayTokenShowResponse",
+        "type": "object"
+      },
       "EntraAuthProviderResponse": {
         "description": "Response schema for single Entra Auth Provider",
         "example": {
@@ -3142,6 +3161,40 @@
         "title": "ActorsResponse",
         "type": "object"
       },
+      "GatewayTokenListResponse": {
+        "description": "Response schema for multiple Gateway Tokens. Token values cannot be retrieved after creation.",
+        "example": {
+          "data": [
+            {
+              "gateway_id": "43a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+              "inserted_at": "2025-01-15T12:34:56.789Z",
+              "rotated_at": null,
+              "site_id": null
+            }
+          ],
+          "metadata": {
+            "count": 1,
+            "limit": 10,
+            "next_page": null,
+            "prev_page": null
+          }
+        },
+        "properties": {
+          "data": {
+            "description": "Gateway Token metadata",
+            "items": {
+              "$ref": "#/components/schemas/GatewayTokenMetadata"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PaginationMetadata"
+          }
+        },
+        "title": "GatewayTokenListResponse",
+        "type": "object"
+      },
       "GoogleAuthProviderResponse": {
         "description": "Response schema for single Google Auth Provider",
         "example": {
@@ -4972,6 +5025,55 @@
           "token"
         ],
         "title": "GatewayToken",
+        "type": "object"
+      },
+      "GatewayTokenMetadata": {
+        "description": "Gateway Token metadata. Token values cannot be retrieved after creation.",
+        "example": {
+          "gateway_id": "43a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+          "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+          "inserted_at": "2025-01-15T12:34:56.789Z",
+          "rotated_at": null,
+          "site_id": null
+        },
+        "properties": {
+          "gateway_id": {
+            "description": "Gateway this token is bound to. Null when any Gateway in the Site may use it.",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "Gateway Token ID",
+            "format": "uuid",
+            "type": "string"
+          },
+          "inserted_at": {
+            "description": "Creation timestamp",
+            "format": "date-time",
+            "type": "string"
+          },
+          "rotated_at": {
+            "description": "When the token was rotated out. It stays usable for a grace period after this, until its replacement is first used.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "site_id": {
+            "description": "Site whose Gateways may all use this token. Null when the token is bound to a single Gateway.",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "site_id",
+          "gateway_id",
+          "rotated_at",
+          "inserted_at"
+        ],
+        "title": "GatewayTokenMetadata",
         "type": "object"
       },
       "SiteID": {
@@ -8649,6 +8751,113 @@
           }
         },
         "summary": "Delete a Gateway Token",
+        "tags": [
+          "Gateway Tokens"
+        ]
+      },
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves metadata about a Gateway Token. Token values cannot be retrieved after creation.",
+        "operationId": "PortalAPI.GatewayTokenController.show",
+        "parameters": [
+          {
+            "description": "Site ID",
+            "example": "00000000-0000-0000-0000-000000000000",
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Token ID",
+            "example": "00000000-0000-0000-0000-000000000000",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatewayTokenShowResponse"
+                }
+              }
+            },
+            "description": "Gateway Token Response"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The request could not be processed.",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "type": "about:blank"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Authentication credentials were missing or invalid.",
+                  "status": 401,
+                  "title": "Unauthorized",
+                  "type": "about:blank"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The requested resource could not be found.",
+                  "status": 404,
+                  "title": "Not Found",
+                  "type": "about:blank"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Rate limit exceeded. Retry after the time indicated in the Retry-After header.",
+                  "status": 429,
+                  "title": "Too Many Requests",
+                  "type": "about:blank"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          }
+        },
+        "summary": "Show a Gateway Token",
         "tags": [
           "Gateway Tokens"
         ]
@@ -14768,6 +14977,121 @@
           }
         },
         "summary": "Delete all Gateway Tokens for a Site",
+        "tags": [
+          "Gateway Tokens"
+        ]
+      },
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves metadata about a Site's Gateway Tokens, including the ones bound to a single Gateway in it. Token values cannot be retrieved after creation.",
+        "operationId": "PortalAPI.GatewayTokenController.index",
+        "parameters": [
+          {
+            "description": "Site ID",
+            "example": "00000000-0000-0000-0000-000000000000",
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Limit Gateway Tokens returned",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Next/Prev page cursor",
+            "in": "query",
+            "name": "page_cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatewayTokenListResponse"
+                }
+              }
+            },
+            "description": "Gateway Token List Response"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The request could not be processed.",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "type": "about:blank"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Authentication credentials were missing or invalid.",
+                  "status": 401,
+                  "title": "Unauthorized",
+                  "type": "about:blank"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The requested resource could not be found.",
+                  "status": 404,
+                  "title": "Not Found",
+                  "type": "about:blank"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Rate limit exceeded. Retry after the time indicated in the Retry-After header.",
+                  "status": 429,
+                  "title": "Too Many Requests",
+                  "type": "about:blank"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          }
+        },
+        "summary": "List Gateway Tokens for a Site",
         "tags": [
           "Gateway Tokens"
         ]

--- a/elixir/test/portal_api/controllers/gateway_token_controller_test.exs
+++ b/elixir/test/portal_api/controllers/gateway_token_controller_test.exs
@@ -18,6 +18,127 @@ defmodule PortalAPI.GatewayTokenControllerTest do
     }
   end
 
+  describe "index/2" do
+    test "returns error when not authorized", %{conn: conn, account: account} do
+      site = site_fixture(%{account: account})
+      conn = get(conn, "/sites/#{site.id}/gateway_tokens")
+
+      assert %{"type" => "about:blank", "status" => 401, "title" => "Unauthorized"} =
+               json_response(conn, 401)
+    end
+
+    test "lists a site's own tokens and its gateways' tokens", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(%{account: account})
+      gateway = gateway_fixture(account: account, site: site)
+      site_token = gateway_token_fixture(account: account, site: site)
+      gateway_token = gateway_token_fixture(gateway: gateway)
+
+      other_site = site_fixture(%{account: account})
+      other_token = gateway_token_fixture(account: account, site: other_site)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> get("/sites/#{site.id}/gateway_tokens")
+
+      assert %{"data" => data} = json_response(conn, 200)
+      ids = Enum.map(data, & &1["id"])
+
+      assert site_token.id in ids
+      assert gateway_token.id in ids
+      refute other_token.id in ids
+    end
+
+    test "renders metadata and never a token value", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(%{account: account})
+      gateway = gateway_fixture(account: account, site: site)
+      token = gateway_token_fixture(gateway: gateway)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> get("/sites/#{site.id}/gateway_tokens")
+
+      assert %{"data" => data} = json_response(conn, 200)
+      assert entry = Enum.find(data, &(&1["id"] == token.id))
+
+      assert entry["gateway_id"] == gateway.id
+      assert entry["site_id"] == nil
+      assert entry["rotated_at"] == nil
+      assert entry["inserted_at"]
+      refute Map.has_key?(entry, "token")
+    end
+
+    test "returns not found when site does not exist", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> get("/sites/#{Ecto.UUID.generate()}/gateway_tokens")
+
+      assert %{"type" => "about:blank", "status" => 404, "title" => "Not Found"} =
+               json_response(conn, 404)
+    end
+  end
+
+  describe "show/2" do
+    test "returns error when not authorized", %{conn: conn, account: account} do
+      site = site_fixture(%{account: account})
+      token = gateway_token_fixture(account: account, site: site)
+      conn = get(conn, "/sites/#{site.id}/gateway_tokens/#{token.id}")
+
+      assert %{"type" => "about:blank", "status" => 401, "title" => "Unauthorized"} =
+               json_response(conn, 401)
+    end
+
+    test "renders metadata and never a token value", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(%{account: account})
+      token = gateway_token_fixture(account: account, site: site)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> get("/sites/#{site.id}/gateway_tokens/#{token.id}")
+
+      assert %{"data" => data} = json_response(conn, 200)
+
+      assert data["id"] == token.id
+      assert data["site_id"] == site.id
+      assert data["gateway_id"] == nil
+      assert data["inserted_at"]
+      refute Map.has_key?(data, "token")
+    end
+
+    test "returns not found for a token belonging to another site", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(%{account: account})
+      other_site = site_fixture(%{account: account})
+      token = gateway_token_fixture(account: account, site: other_site)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> get("/sites/#{site.id}/gateway_tokens/#{token.id}")
+
+      assert %{"type" => "about:blank", "status" => 404, "title" => "Not Found"} =
+               json_response(conn, 404)
+    end
+  end
+
   describe "create/2" do
     test "returns error when not authorized", %{conn: conn, account: account} do
       site = site_fixture(%{account: account})


### PR DESCRIPTION
A Gateway Token could be created, rotated and deleted, but never listed. That left no way to see what a Site holds, or to find the id of the one you want to revoke, unless you wrote it down when you created it. The only alternative was deleting all of them.

`GET /sites/{site_id}/gateway_tokens` and `GET /sites/{site_id}/gateway_tokens/{id}` fill that in. Both return metadata only: id, site, gateway, when it was rotated out, and when it was created. A token value still appears in exactly one response, the one that created it.

A Site's tokens are the multi-owner ones it holds directly plus the single-owner ones its Gateways hold, which is already what deleting one considers to belong to the Site. `device_id` is called `gateway_id` here because that is the name the API gives it, and whether it is set is what tells the two kinds of token apart.

Two follow-ups this creates:

- #14913 has `gateway_tokens: [:write]`, and its docs explain that as "a gateway token can be minted, rotated and deleted but never read back". That is no longer true, so it wants `[:read, :write]`.
- `priv/static/openapi.json` is generated and CI checks it is current, so this will conflict with #14996 for whichever merges second. Regenerating resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ANEYuDPYf4fS3LZxBfqjD
