### PR TITLE
feat(apple): Add AppEx for macOS

### DIFF
--- a/scripts/build/macos-standalone.sh
+++ b/scripts/build/macos-standalone.sh
@@ -39,7 +39,6 @@ xcodebuild build \
     FIREZONE_NO_TELEMETRY="$no_telemetry" \
     CODE_SIGN_STYLE=Manual \
     CODE_SIGN_IDENTITY="$code_sign_identity" \
-    PACKET_TUNNEL_PROVIDER_SUFFIX=-systemextension \
     OTHER_CODE_SIGN_FLAGS="--timestamp" \
     CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
     CONFIGURATION_BUILD_DIR="$temp_dir" \
@@ -50,7 +49,7 @@ xcodebuild build \
     -project "$project_file" \
     -skipMacroValidation \
     -configuration Release \
-    -scheme Firezone \
+    -scheme FirezoneStandalone \
     -sdk macosx \
     -destination 'platform=macOS'
 

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -29,8 +29,8 @@
 		8D5047FB2CE6AA37009802E9 /* FirezoneNetworkExtension-Bridging-Header.h in Sources */ = {isa = PBXBuildFile; fileRef = 6FE455112A5D13A2006549B1 /* FirezoneNetworkExtension-Bridging-Header.h */; };
 		8D5047FE2CE6AA54009802E9 /* PacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05833DFA28F73B070008FAB0 /* PacketTunnelProvider.swift */; };
 		8DC08BD72B297DB400675F46 /* FirezoneNetworkExtension-Bridging-Header.h in Sources */ = {isa = PBXBuildFile; fileRef = 6FE455112A5D13A2006549B1 /* FirezoneNetworkExtension-Bridging-Header.h */; };
-		8DC1699D2CFF77D1006801B5 /* dev.firezone.firezone.network-extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 05CF1CF0290B1CEE00CF4755 /* dev.firezone.firezone.network-extension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		8DC169A02CFF77D1006801B5 /* dev.firezone.firezone.network-extension.systemextension in Embed System Extensions */ = {isa = PBXBuildFile; fileRef = 8D5047E32CE6A8F4009802E9 /* dev.firezone.firezone.network-extension.systemextension */; platformFilters = (macos, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		8DC1699D2CFF77D1006801B5 /* dev.firezone.firezone.network-extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 05CF1CF0290B1CEE00CF4755 /* dev.firezone.firezone.network-extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		8DC169A02CFF77D1006801B5 /* dev.firezone.firezone.network-extension.systemextension in Embed System Extensions */ = {isa = PBXBuildFile; fileRef = 8D5047E32CE6A8F4009802E9 /* dev.firezone.firezone.network-extension.systemextension */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		8DC333F92D2FA85200E627D5 /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC333F72D2FA85200E627D5 /* libresolv.tbd */; };
 		8DC333FA2D2FA85200E627D5 /* libresolv.9.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC333F82D2FA85200E627D5 /* libresolv.9.tbd */; };
 		8DC333FB2D2FA89100E627D5 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FFECD5B2AD6998400E00273 /* SystemConfiguration.framework */; };
@@ -58,6 +58,21 @@
 		FZUIT0012E90000000000001 /* AppScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZUIT0012E90000000000010 /* AppScreenshotTests.swift */; };
 		FZUIT0012E90000000000002 /* ScreenshotDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZUIT0012E90000000000012 /* ScreenshotDelivery.swift */; };
 		FZUIT0012E90000000000003 /* IOSScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZUIT0012E90000000000013 /* IOSScreenshotTests.swift */; };
+		FZSA00000000000000000020 /* FirezoneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCC021C28D512AC007E12D2 /* FirezoneApp.swift */; };
+		FZSA00000000000000000021 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0F0A032E9A000100BEEF02 /* main.swift */; };
+		FZSA00000000000000000022 /* x509claims.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C0DE012E90000000000001 /* x509claims.swift */; };
+		FZSA00000000000000000023 /* FirezoneCLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E80000000000010 /* FirezoneCLI.swift */; };
+		FZSA00000000000000000024 /* SignIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E80000000000014 /* SignIn.swift */; };
+		FZSA00000000000000000025 /* TunnelSupervisor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E80000000000015 /* TunnelSupervisor.swift */; };
+		FZSA00000000000000000026 /* ConnectCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E80000000000016 /* ConnectCommand.swift */; };
+		FZSA00000000000000000027 /* SignOutCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E80000000000017 /* SignOutCommand.swift */; };
+		FZSA00000000000000000028 /* ExtensionCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E80000000000018 /* ExtensionCommand.swift */; };
+		FZSA00000000000000000050 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 8DA12C322BB7DA04007D91EB /* PrivacyInfo.xcprivacy */; };
+		FZSA00000000000000000051 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8DCC022928D512AE007E12D2 /* Preview Assets.xcassets */; };
+		FZSA00000000000000000052 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8DCC022528D512AE007E12D2 /* Assets.xcassets */; };
+		FZSA00000000000000000030 /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05D3BB1628FDBD8A00BC3727 /* NetworkExtension.framework */; };
+		FZSA00000000000000000031 /* FirezoneKit in Frameworks */ = {isa = PBXBuildFile; productRef = FZSA00000000000000000040 /* FirezoneKit */; };
+		FZSA00000000000000000032 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = FZSA00000000000000000041 /* ArgumentParser */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,7 +81,7 @@
 			containerPortal = 8DCC021128D512AC007E12D2 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 05CF1CEF290B1CEE00CF4755;
-			remoteInfo = FirezoneNetworkExtensioniOS;
+			remoteInfo = FirezoneNetworkExtensionAppex;
 		};
 		8DC169A12CFF77D1006801B5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -88,6 +103,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 8DCC021828D512AC007E12D2;
 			remoteInfo = Firezone;
+		};
+		FZSA00000000000000000071 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8DCC021128D512AC007E12D2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9A1000082F10000100BEEF01;
+			remoteInfo = KeepFirezoneRunning;
+		};
+		FZSA00000000000000000091 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8DCC021128D512AC007E12D2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FZSA00000000000000000001;
+			remoteInfo = FirezoneStandalone;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -147,8 +176,8 @@
 		8DCC022928D512AE007E12D2 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		8DD2C4C3297B37BA00F984BF /* FirezoneKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = FirezoneKit; sourceTree = "<group>"; };
 		8DDD0E8B2ADC6657001FA7E9 /* config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = config.xcconfig; path = xcconfig/config.xcconfig; sourceTree = "<group>"; };
-		8DE1077A2D2313EB00DB5A45 /* Info.iOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.iOS.plist; sourceTree = "<group>"; };
-		8DE1077B2D2313EB00DB5A45 /* Info.macOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.macOS.plist; sourceTree = "<group>"; };
+		8DE1077A2D2313EB00DB5A45 /* Info.appex.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.appex.plist; sourceTree = "<group>"; };
+		8DE1077B2D2313EB00DB5A45 /* Info.systemextension.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.systemextension.plist; sourceTree = "<group>"; };
 		9A1000022F10000100BEEF01 /* KeepFirezoneRunning.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KeepFirezoneRunning.entitlements; sourceTree = "<group>"; };
 		9A1000032F10000100BEEF01 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9A1000042F10000100BEEF01 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -166,6 +195,9 @@
 		FZUIT0012E90000000000012 /* ScreenshotDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotDelivery.swift; sourceTree = "<group>"; };
 		FZUIT0012E90000000000013 /* IOSScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSScreenshotTests.swift; sourceTree = "<group>"; };
 		FZUIT0012E90000000000011 /* FirezoneUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FirezoneUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FZSA00000000000000000080 /* FirezoneStandalone.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = FirezoneStandalone.entitlements; sourceTree = "<group>"; };
+		FZSA00000000000000000081 /* FirezoneNetworkExtensionStandalone.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = FirezoneNetworkExtensionStandalone.entitlements; sourceTree = "<group>"; };
+		FZSA00000000000000000002 /* Firezone.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Firezone.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -214,19 +246,30 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FZSA00000000000000000009 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FZSA00000000000000000030 /* NetworkExtension.framework in Frameworks */,
+				FZSA00000000000000000031 /* FirezoneKit in Frameworks */,
+				FZSA00000000000000000032 /* ArgumentParser in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		05833DF928F73B070008FAB0 /* FirezoneNetworkExtension */ = {
 			isa = PBXGroup;
 			children = (
-				8DE1077A2D2313EB00DB5A45 /* Info.iOS.plist */,
-				8DE1077B2D2313EB00DB5A45 /* Info.macOS.plist */,
+				8DE1077A2D2313EB00DB5A45 /* Info.appex.plist */,
+				8DE1077B2D2313EB00DB5A45 /* Info.systemextension.plist */,
 				6C09DC14A4A04715A37BC04C /* Channel.swift */,
 				8D0000012D41000000A2 /* NetworkPathUpdates.swift */,
 				8D0000012D41000000B1 /* ProviderCommand.swift */,
 				E14DC5E933BD4F63A844A8A6 /* SessionEventLoop.swift */,
 				05CF1CF6290B1CEE00CF4755 /* FirezoneNetworkExtension.entitlements */,
+				FZSA00000000000000000081 /* FirezoneNetworkExtensionStandalone.entitlements */,
 				8D5047E82CE6A8F4009802E9 /* main.swift */,
 				177FB893F19457A113042247 /* Adapter.swift */,
 				6F0EDF232E79B00000D6D632 /* FirezoneId.swift */,
@@ -296,6 +339,7 @@
 			isa = PBXGroup;
 			children = (
 				8DCC021928D512AC007E12D2 /* Firezone.app */,
+				FZSA00000000000000000002 /* Firezone.app */,
 				9A1000052F10000100BEEF01 /* KeepFirezoneRunning.app */,
 				05CF1CF0290B1CEE00CF4755 /* dev.firezone.firezone.network-extension.appex */,
 				8D5047E32CE6A8F4009802E9 /* dev.firezone.firezone.network-extension.systemextension */,
@@ -308,6 +352,7 @@
 			isa = PBXGroup;
 			children = (
 				8D1D405C2CFF6F5200E669F9 /* Firezone.entitlements */,
+				FZSA00000000000000000080 /* FirezoneStandalone.entitlements */,
 				8D1D405D2CFF6F5D00E669F9 /* Info.plist */,
 				D7C0DE012E90000000000007 /* Firezone-Bridging-Header.h */,
 				8DDD0E8B2ADC6657001FA7E9 /* config.xcconfig */,
@@ -371,9 +416,9 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		05CF1CEF290B1CEE00CF4755 /* FirezoneNetworkExtensioniOS */ = {
+		05CF1CEF290B1CEE00CF4755 /* FirezoneNetworkExtensionAppex */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 05CF1CFA290B1CEE00CF4755 /* Build configuration list for PBXNativeTarget "FirezoneNetworkExtensioniOS" */;
+			buildConfigurationList = 05CF1CFA290B1CEE00CF4755 /* Build configuration list for PBXNativeTarget "FirezoneNetworkExtensionAppex" */;
 			buildPhases = (
 				8D8555832D0A7CBB00A1EA09 /* Build Connlib */,
 				05CF1CEC290B1CEE00CF4755 /* Sources */,
@@ -384,11 +429,11 @@
 			);
 			dependencies = (
 			);
-			name = FirezoneNetworkExtensioniOS;
+			name = FirezoneNetworkExtensionAppex;
 			packageProductDependencies = (
 				794C38142970A2660029F38F /* FirezoneKit */,
 			);
-			productName = FirezoneNetworkExtensioniOS;
+			productName = FirezoneNetworkExtensionAppex;
 			productReference = 05CF1CF0290B1CEE00CF4755 /* dev.firezone.firezone.network-extension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
@@ -423,8 +468,8 @@
 				8DCC021628D512AC007E12D2 /* Frameworks */,
 				8DCC021728D512AC007E12D2 /* Resources */,
 				8D0F0A012E9A000100BEEF01 /* Bundle keep app running agent */,
+				FZSA00000000000000000014 /* Drop a stale system extension */,
 				8DC169A32CFF77D1006801B5 /* Embed Foundation Extensions */,
-				8DC169A42CFF77D1006801B5 /* Embed System Extensions */,
 				8D0F0A042E9A000100BEEF03 /* Link headless client */,
 			);
 			buildRules = (
@@ -432,7 +477,6 @@
 			dependencies = (
 				9A10000C2F10000100BEEF01 /* PBXTargetDependency */,
 				8DC1699F2CFF77D1006801B5 /* PBXTargetDependency */,
-				8DC169A22CFF77D1006801B5 /* PBXTargetDependency */,
 			);
 			name = Firezone;
 			packageProductDependencies = (
@@ -474,6 +518,7 @@
 			);
 			dependencies = (
 				FZUIT0012E90000000000051 /* PBXTargetDependency */,
+				FZSA00000000000000000090 /* PBXTargetDependency */,
 			);
 			name = FirezoneUITests;
 			packageProductDependencies = (
@@ -481,6 +526,34 @@
 			productName = FirezoneUITests;
 			productReference = FZUIT0012E90000000000011 /* FirezoneUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		FZSA00000000000000000001 /* FirezoneStandalone */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FZSA00000000000000000003 /* Build configuration list for PBXNativeTarget "FirezoneStandalone" */;
+			buildPhases = (
+				FZSA00000000000000000007 /* Generate build number */,
+				FZSA00000000000000000008 /* Sources */,
+				FZSA00000000000000000009 /* Frameworks */,
+				FZSA00000000000000000010 /* Resources */,
+				FZSA00000000000000000011 /* Bundle keep app running agent */,
+				FZSA00000000000000000012 /* Drop a stale app extension */,
+				8DC169A42CFF77D1006801B5 /* Embed System Extensions */,
+				FZSA00000000000000000013 /* Link headless client */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FZSA00000000000000000070 /* PBXTargetDependency */,
+				8DC169A22CFF77D1006801B5 /* PBXTargetDependency */,
+			);
+			name = FirezoneStandalone;
+			packageProductDependencies = (
+				FZSA00000000000000000040 /* FirezoneKit */,
+				FZSA00000000000000000041 /* ArgumentParser */,
+			);
+			productName = FirezoneStandalone;
+			productReference = FZSA00000000000000000002 /* Firezone.app */;
+			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
@@ -506,6 +579,9 @@
 					9A1000082F10000100BEEF01 = {
 						CreatedOnToolsVersion = 16.4;
 					};
+					FZSA00000000000000000001 = {
+						CreatedOnToolsVersion = 26.2;
+					};
 					FZUIT0012E90000000000040 = {
 						CreatedOnToolsVersion = 26.2;
 						TestTargetID = 8DCC021828D512AC007E12D2;
@@ -529,8 +605,9 @@
 			projectRoot = "";
 			targets = (
 				8DCC021828D512AC007E12D2 /* Firezone */,
+				FZSA00000000000000000001 /* FirezoneStandalone */,
 				9A1000082F10000100BEEF01 /* KeepFirezoneRunning */,
-				05CF1CEF290B1CEE00CF4755 /* FirezoneNetworkExtensioniOS */,
+				05CF1CEF290B1CEE00CF4755 /* FirezoneNetworkExtensionAppex */,
 				8D5047E22CE6A8F4009802E9 /* FirezoneNetworkExtensionmacOS */,
 				FZUIT0012E90000000000040 /* FirezoneUITests */,
 			);
@@ -576,6 +653,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FZSA00000000000000000010 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FZSA00000000000000000050 /* PrivacyInfo.xcprivacy in Resources */,
+				FZSA00000000000000000051 /* Preview Assets.xcassets in Resources */,
+				FZSA00000000000000000052 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
@@ -599,7 +686,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\nif [ \"${PLATFORM_NAME}\" != \"macosx\" ]; then\n  exit 0\nfi\nhelper_src=\"${BUILT_PRODUCTS_DIR}/KeepFirezoneRunning.app\"\nhelper_dir=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Library/LoginItems\"\nhelper_dst=\"${helper_dir}/KeepFirezoneRunning.app\"\nplist_template=\"${SRCROOT}/Firezone/LaunchAgents/dev.firezone.firezone.keep-app-running.plist.template\"\nplist_dir=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Library/LaunchAgents\"\nplist_dst=\"${plist_dir}/${PRODUCT_BUNDLE_IDENTIFIER}.keep-app-running.plist\"\nmkdir -p \"${helper_dir}\" \"${plist_dir}\"\nrm -rf \"${helper_dst}\"\n/usr/bin/ditto \"${helper_src}\" \"${helper_dst}\"\n/usr/bin/sed \"s#__PRODUCT_BUNDLE_IDENTIFIER__#${PRODUCT_BUNDLE_IDENTIFIER}#g\" \"${plist_template}\" > \"${plist_dst}\"\n";
+			shellScript = "set -eu\nif [ \"${PLATFORM_NAME}\" != \"macosx\" ]; then\n  exit 0\nfi\nhelper_src=\"${BUILT_PRODUCTS_DIR}/KeepFirezoneRunning.app\"\nhelper_dir=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Library/LoginItems\"\nhelper_dst=\"${helper_dir}/KeepFirezoneRunning.app\"\nplist_template=\"${SRCROOT}/Firezone/LaunchAgents/dev.firezone.firezone.keep-app-running.plist.template\"\nplist_dir=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Library/LaunchAgents\"\nplist_dst=\"${plist_dir}/${PRODUCT_BUNDLE_IDENTIFIER}.keep-app-running.plist\"\n# The two macOS apps build into one products directory and name their agent after\n# their own bundle id, so clear the folder rather than adding to it.\nrm -rf \"${plist_dir}\"\nmkdir -p \"${helper_dir}\" \"${plist_dir}\"\nrm -rf \"${helper_dst}\"\n/usr/bin/ditto \"${helper_src}\" \"${helper_dst}\"\n/usr/bin/sed \"s#__PRODUCT_BUNDLE_IDENTIFIER__#${PRODUCT_BUNDLE_IDENTIFIER}#g\" \"${plist_template}\" > \"${plist_dst}\"\n";
 		};
 		8D0F0A042E9A000100BEEF03 /* Link headless client */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -695,6 +782,93 @@
 			shellPath = /bin/sh;
 			shellScript = "export PLATFORM_NAME=\"${PLATFORM_NAME}\"\nexport CONFIGURATION=\"${CONFIGURATION}\"\nexport NATIVE_ARCH=\"${ARCHS}\"\nexport RUST_TARGET_DIR=\"${RUST_TARGET_DIR}\"\n./mise-tasks/build-rust.sh\n";
 		};
+		FZSA00000000000000000007 /* Generate build number */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Generate build number";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/Firezone/xcconfig/dynamic_build_number.xcconfig",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Set the project (build) version to the current epoch so that it monotonically increases\nseconds_since_epoch=$(date +%s)\necho \"CURRENT_PROJECT_VERSION = $seconds_since_epoch\" > \"${SRCROOT}/Firezone/xcconfig/dynamic_build_number.xcconfig\"\n";
+		};
+		FZSA00000000000000000011 /* Bundle keep app running agent */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/KeepFirezoneRunning.app",
+				"$(SRCROOT)/Firezone/LaunchAgents/dev.firezone.firezone.keep-app-running.plist.template",
+			);
+			name = "Bundle keep app running agent";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(CONTENTS_FOLDER_PATH)/Library/LoginItems/KeepFirezoneRunning.app",
+				"$(TARGET_BUILD_DIR)/$(CONTENTS_FOLDER_PATH)/Library/LaunchAgents/$(PRODUCT_BUNDLE_IDENTIFIER).keep-app-running.plist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\nif [ \"${PLATFORM_NAME}\" != \"macosx\" ]; then\n  exit 0\nfi\nhelper_src=\"${BUILT_PRODUCTS_DIR}/KeepFirezoneRunning.app\"\nhelper_dir=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Library/LoginItems\"\nhelper_dst=\"${helper_dir}/KeepFirezoneRunning.app\"\nplist_template=\"${SRCROOT}/Firezone/LaunchAgents/dev.firezone.firezone.keep-app-running.plist.template\"\nplist_dir=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Library/LaunchAgents\"\nplist_dst=\"${plist_dir}/${PRODUCT_BUNDLE_IDENTIFIER}.keep-app-running.plist\"\n# The two macOS apps build into one products directory and name their agent after\n# their own bundle id, so clear the folder rather than adding to it.\nrm -rf \"${plist_dir}\"\nmkdir -p \"${helper_dir}\" \"${plist_dir}\"\nrm -rf \"${helper_dst}\"\n/usr/bin/ditto \"${helper_src}\" \"${helper_dst}\"\n/usr/bin/sed \"s#__PRODUCT_BUNDLE_IDENTIFIER__#${PRODUCT_BUNDLE_IDENTIFIER}#g\" \"${plist_template}\" > \"${plist_dst}\"\n";
+		};
+		FZSA00000000000000000013 /* Link headless client */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Link headless client";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\nif [ \"${PLATFORM_NAME}\" != \"macosx\" ]; then\n  exit 0\nfi\n# The headless client is the app's own binary under another name, so that it runs\n# with the app's identity and sees the app's VPN configuration.\nln -sf \"${EXECUTABLE_NAME}\" \"${TARGET_BUILD_DIR}/${EXECUTABLE_FOLDER_PATH}/firezone-cli\"\n";
+		};
+		FZSA00000000000000000014 /* Drop a stale system extension */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Drop a stale system extension";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\nif [ \"${PLATFORM_NAME}\" != \"macosx\" ]; then\n  exit 0\nfi\nrm -rf \"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Library/SystemExtensions\"\n";
+		};
+		FZSA00000000000000000012 /* Drop a stale app extension */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Drop a stale app extension";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\nrm -rf \"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/PlugIns\"\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -769,20 +943,32 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FZSA00000000000000000008 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FZSA00000000000000000020 /* FirezoneApp.swift in Sources */,
+				FZSA00000000000000000021 /* main.swift in Sources */,
+				FZSA00000000000000000022 /* x509claims.swift in Sources */,
+				FZSA00000000000000000023 /* FirezoneCLI.swift in Sources */,
+				FZSA00000000000000000024 /* SignIn.swift in Sources */,
+				FZSA00000000000000000025 /* TunnelSupervisor.swift in Sources */,
+				FZSA00000000000000000026 /* ConnectCommand.swift in Sources */,
+				FZSA00000000000000000027 /* SignOutCommand.swift in Sources */,
+				FZSA00000000000000000028 /* ExtensionCommand.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		8DC1699F2CFF77D1006801B5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
-			target = 05CF1CEF290B1CEE00CF4755 /* FirezoneNetworkExtensioniOS */;
+			target = 05CF1CEF290B1CEE00CF4755 /* FirezoneNetworkExtensionAppex */;
 			targetProxy = 8DC1699E2CFF77D1006801B5 /* PBXContainerItemProxy */;
 		};
 		8DC169A22CFF77D1006801B5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				macos,
-			);
 			target = 8D5047E22CE6A8F4009802E9 /* FirezoneNetworkExtensionmacOS */;
 			targetProxy = 8DC169A12CFF77D1006801B5 /* PBXContainerItemProxy */;
 		};
@@ -796,8 +982,22 @@
 		};
 		FZUIT0012E90000000000051 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
+			platformFilter = ios;
 			target = 8DCC021828D512AC007E12D2 /* Firezone */;
 			targetProxy = FZUIT0012E90000000000050 /* PBXContainerItemProxy */;
+		};
+		FZSA00000000000000000070 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9A1000082F10000100BEEF01 /* KeepFirezoneRunning */;
+			targetProxy = FZSA00000000000000000071 /* PBXContainerItemProxy */;
+		};
+		FZSA00000000000000000090 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				macos,
+			);
+			target = FZSA00000000000000000001 /* FirezoneStandalone */;
+			targetProxy = FZSA00000000000000000091 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -812,35 +1012,46 @@
 				CURRENT_PROJECT_VERSION = "$(inherited)";
 				DEVELOPMENT_TEAM = "$(inherited)";
 				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = FirezoneNetworkExtension/Info.iOS.plist;
+				INFOPLIST_FILE = FirezoneNetworkExtension/Info.appex.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FirezoneNetworkExtension;
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSSystemExtensionUsageDescription = "Firezone tunnel service";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*][arch=arm64]" = "$(RUST_TARGET_DIR)/aarch64-apple-ios/debug";
 				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=arm64]" = "$(RUST_TARGET_DIR)/aarch64-apple-ios-sim/debug";
 				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=x86_64]" = "$(RUST_TARGET_DIR)/x86_64-apple-ios/debug";
+				"LIBRARY_SEARCH_PATHS[sdk=macosx*][arch=arm64]" = "$(RUST_TARGET_DIR)/aarch64-apple-darwin/debug";
+				"LIBRARY_SEARCH_PATHS[sdk=macosx*][arch=arm64e]" = "$(RUST_TARGET_DIR)/aarch64-apple-darwin/debug";
+				"LIBRARY_SEARCH_PATHS[sdk=macosx*][arch=x86_64]" = "$(RUST_TARGET_DIR)/x86_64-apple-darwin/debug";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-lconnlib";
 				OTHER_SWIFT_FLAGS = "-D UNIFFI";
-				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
+				REGISTER_APP_GROUPS = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(TUNNEL_PROVIDER_BUNDLE_ID)";
 				PRODUCT_NAME = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(NE_PROFILE_ID)";
-				SDKROOT = iphoneos;
+				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = UNIFFI;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/FirezoneNetworkExtension/Connlib/Generated";
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -861,34 +1072,45 @@
 				CURRENT_PROJECT_VERSION = "$(inherited)";
 				DEVELOPMENT_TEAM = "$(inherited)";
 				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = FirezoneNetworkExtension/Info.iOS.plist;
+				INFOPLIST_FILE = FirezoneNetworkExtension/Info.appex.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FirezoneNetworkExtension;
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSSystemExtensionUsageDescription = "Firezone tunnel service";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*][arch=arm64]" = "$(RUST_TARGET_DIR)/aarch64-apple-ios/release";
 				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=arm64]" = "$(RUST_TARGET_DIR)/aarch64-apple-ios-sim/release";
 				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=x86_64]" = "$(RUST_TARGET_DIR)/x86_64-apple-ios/release";
+				"LIBRARY_SEARCH_PATHS[sdk=macosx*][arch=arm64]" = "$(RUST_TARGET_DIR)/aarch64-apple-darwin/release";
+				"LIBRARY_SEARCH_PATHS[sdk=macosx*][arch=arm64e]" = "$(RUST_TARGET_DIR)/aarch64-apple-darwin/release";
+				"LIBRARY_SEARCH_PATHS[sdk=macosx*][arch=x86_64]" = "$(RUST_TARGET_DIR)/x86_64-apple-darwin/release";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = "$(inherited)";
 				OTHER_LDFLAGS = "-lconnlib";
 				OTHER_SWIFT_FLAGS = "-D UNIFFI";
-				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
+				REGISTER_APP_GROUPS = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(TUNNEL_PROVIDER_BUNDLE_ID)";
 				PRODUCT_NAME = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(NE_PROFILE_ID)";
-				SDKROOT = iphoneos;
+				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = UNIFFI;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/FirezoneNetworkExtension/Connlib/Generated";
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 6.2;
@@ -902,7 +1124,7 @@
 		8D5047F12CE6A8F4009802E9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_ENTITLEMENTS = FirezoneNetworkExtension/FirezoneNetworkExtension.entitlements;
+				CODE_SIGN_ENTITLEMENTS = FirezoneNetworkExtension/FirezoneNetworkExtensionStandalone.entitlements;
 				CODE_SIGN_IDENTITY = "$(inherited)";
 				CODE_SIGN_STYLE = "$(inherited)";
 				CURRENT_PROJECT_VERSION = "$(inherited)";
@@ -911,8 +1133,9 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				TUNNEL_PROVIDER_KIND = "system-extension";
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = FirezoneNetworkExtension/Info.macOS.plist;
+				INFOPLIST_FILE = FirezoneNetworkExtension/Info.systemextension.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FirezoneNetworkExtension;
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -928,7 +1151,7 @@
 				MARKETING_VERSION = "$(inherited)";
 				OTHER_LDFLAGS = "-lconnlib";
 				OTHER_SWIFT_FLAGS = "-D UNIFFI";
-				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(TUNNEL_PROVIDER_BUNDLE_ID)";
 				PRODUCT_NAME = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(NE_PROFILE_ID)";
 				REGISTER_APP_GROUPS = YES;
@@ -947,7 +1170,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = FirezoneNetworkExtension/FirezoneNetworkExtension.entitlements;
+				CODE_SIGN_ENTITLEMENTS = FirezoneNetworkExtension/FirezoneNetworkExtensionStandalone.entitlements;
 				CODE_SIGN_IDENTITY = "$(inherited)";
 				CODE_SIGN_STYLE = "$(inherited)";
 				CURRENT_PROJECT_VERSION = "$(inherited)";
@@ -957,8 +1180,9 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				TUNNEL_PROVIDER_KIND = "system-extension";
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = FirezoneNetworkExtension/Info.macOS.plist;
+				INFOPLIST_FILE = FirezoneNetworkExtension/Info.systemextension.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FirezoneNetworkExtension;
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -974,7 +1198,7 @@
 				MARKETING_VERSION = "$(inherited)";
 				OTHER_LDFLAGS = "-lconnlib";
 				OTHER_SWIFT_FLAGS = "-D UNIFFI";
-				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(TUNNEL_PROVIDER_BUNDLE_ID)";
 				PRODUCT_NAME = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(NE_PROFILE_ID)";
 				REGISTER_APP_GROUPS = YES;
@@ -1346,34 +1570,45 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "$(inherited)";
 				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = FirezoneNetworkExtension/Info.iOS.plist;
+				INFOPLIST_FILE = FirezoneNetworkExtension/Info.appex.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FirezoneNetworkExtension;
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSSystemExtensionUsageDescription = "Firezone tunnel service";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*][arch=arm64]" = "$(RUST_TARGET_DIR)/aarch64-apple-ios/release";
 				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=arm64]" = "$(RUST_TARGET_DIR)/aarch64-apple-ios-sim/release";
 				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=x86_64]" = "$(RUST_TARGET_DIR)/x86_64-apple-ios/release";
+				"LIBRARY_SEARCH_PATHS[sdk=macosx*][arch=arm64]" = "$(RUST_TARGET_DIR)/aarch64-apple-darwin/release";
+				"LIBRARY_SEARCH_PATHS[sdk=macosx*][arch=arm64e]" = "$(RUST_TARGET_DIR)/aarch64-apple-darwin/release";
+				"LIBRARY_SEARCH_PATHS[sdk=macosx*][arch=x86_64]" = "$(RUST_TARGET_DIR)/x86_64-apple-darwin/release";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = "$(inherited)";
 				OTHER_LDFLAGS = "-lconnlib";
 				OTHER_SWIFT_FLAGS = "-D UNIFFI";
-				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
+				REGISTER_APP_GROUPS = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(TUNNEL_PROVIDER_BUNDLE_ID)";
 				PRODUCT_NAME = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(NE_PROFILE_ID)";
-				SDKROOT = iphoneos;
+				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = UNIFFI;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/FirezoneNetworkExtension/Connlib/Generated";
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 6.2;
@@ -1388,7 +1623,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = FirezoneNetworkExtension/FirezoneNetworkExtension.entitlements;
+				CODE_SIGN_ENTITLEMENTS = FirezoneNetworkExtension/FirezoneNetworkExtensionStandalone.entitlements;
 				CODE_SIGN_IDENTITY = "$(inherited)";
 				CODE_SIGN_STYLE = "$(inherited)";
 				COPY_PHASE_STRIP = NO;
@@ -1400,8 +1635,9 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				TUNNEL_PROVIDER_KIND = "system-extension";
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = FirezoneNetworkExtension/Info.macOS.plist;
+				INFOPLIST_FILE = FirezoneNetworkExtension/Info.systemextension.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FirezoneNetworkExtension;
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -1417,7 +1653,7 @@
 				MARKETING_VERSION = "$(inherited)";
 				OTHER_LDFLAGS = "-lconnlib";
 				OTHER_SWIFT_FLAGS = "-D UNIFFI";
-				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(TUNNEL_PROVIDER_BUNDLE_ID)";
 				PRODUCT_NAME = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(NE_PROFILE_ID)";
 				REGISTER_APP_GROUPS = YES;
@@ -1599,6 +1835,7 @@
 				SWIFT_VERSION = 6.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = Firezone;
+				"TEST_TARGET_NAME[sdk=macosx*]" = FirezoneStandalone;
 			};
 			name = Debug;
 		};
@@ -1632,6 +1869,7 @@
 				SWIFT_VERSION = 6.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = Firezone;
+				"TEST_TARGET_NAME[sdk=macosx*]" = FirezoneStandalone;
 			};
 			name = Release;
 		};
@@ -1666,13 +1904,168 @@
 				SWIFT_VERSION = 6.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = Firezone;
+				"TEST_TARGET_NAME[sdk=macosx*]" = FirezoneStandalone;
+			};
+			name = Profile;
+		};
+		FZSA00000000000000000004 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Firezone/FirezoneStandalone.entitlements;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = "$(inherited)";
+				CURRENT_PROJECT_VERSION = "$(inherited)";
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "$(inherited)";
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readwrite;
+				TUNNEL_PROVIDER_KIND = "system-extension";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Firezone/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Firezone;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_LSUIElement = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = "";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(RUST_TARGET_DIR)/aarch64-apple-darwin/debug";
+				"LIBRARY_SEARCH_PATHS[arch=arm64e]" = "$(RUST_TARGET_DIR)/aarch64-apple-darwin/debug";
+				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(RUST_TARGET_DIR)/x86_64-apple-darwin/debug";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = "$(inherited)";
+				OTHER_LDFLAGS = "-lconnlib";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(MAIN_APP_BUNDLE_ID)";
+				PRODUCT_NAME = Firezone;
+				PROVISIONING_PROFILE_SPECIFIER = "$(APP_PROFILE_ID)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "Firezone/Firezone-Bridging-Header.h";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_VERSION = 6.2;
+				TVOS_DEPLOYMENT_TARGET = "";
+				WATCHOS_DEPLOYMENT_TARGET = "";
+				SWIFT_INSTALL_MODULE = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		FZSA00000000000000000005 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Firezone/FirezoneStandalone.entitlements;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = "$(inherited)";
+				CURRENT_PROJECT_VERSION = "$(inherited)";
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "$(inherited)";
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readwrite;
+				TUNNEL_PROVIDER_KIND = "system-extension";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Firezone/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Firezone;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_LSUIElement = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = "";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(RUST_TARGET_DIR)/aarch64-apple-darwin/release";
+				"LIBRARY_SEARCH_PATHS[arch=arm64e]" = "$(RUST_TARGET_DIR)/aarch64-apple-darwin/release";
+				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(RUST_TARGET_DIR)/x86_64-apple-darwin/release";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = "$(inherited)";
+				OTHER_LDFLAGS = "-lconnlib";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(MAIN_APP_BUNDLE_ID)";
+				PRODUCT_NAME = Firezone;
+				PROVISIONING_PROFILE_SPECIFIER = "$(APP_PROFILE_ID)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "Firezone/Firezone-Bridging-Header.h";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_VERSION = 6.2;
+				TVOS_DEPLOYMENT_TARGET = "";
+				WATCHOS_DEPLOYMENT_TARGET = "";
+				DEFINES_MODULE = NO;
+				DEVELOPMENT_ASSET_PATHS = "\"Firezone/Preview Content\"";
+				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
+				SWIFT_INSTALL_MODULE = NO;
+			};
+			name = Release;
+		};
+		FZSA00000000000000000006 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Firezone/FirezoneStandalone.entitlements;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = "$(inherited)";
+				CURRENT_PROJECT_VERSION = "$(inherited)";
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "$(inherited)";
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readwrite;
+				TUNNEL_PROVIDER_KIND = "system-extension";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Firezone/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Firezone;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_LSUIElement = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = "";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(RUST_TARGET_DIR)/aarch64-apple-darwin/release";
+				"LIBRARY_SEARCH_PATHS[arch=arm64e]" = "$(RUST_TARGET_DIR)/aarch64-apple-darwin/release";
+				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(RUST_TARGET_DIR)/x86_64-apple-darwin/release";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = "$(inherited)";
+				OTHER_LDFLAGS = "-lconnlib";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(MAIN_APP_BUNDLE_ID)";
+				PRODUCT_NAME = Firezone;
+				PROVISIONING_PROFILE_SPECIFIER = "$(APP_PROFILE_ID)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "Firezone/Firezone-Bridging-Header.h";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_VERSION = 6.2;
+				TVOS_DEPLOYMENT_TARGET = "";
+				WATCHOS_DEPLOYMENT_TARGET = "";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = NO;
+				DEVELOPMENT_ASSET_PATHS = "\"Firezone/Preview Content\"";
+				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
+				SWIFT_INSTALL_MODULE = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
 			name = Profile;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		05CF1CFA290B1CEE00CF4755 /* Build configuration list for PBXNativeTarget "FirezoneNetworkExtensioniOS" */ = {
+		05CF1CFA290B1CEE00CF4755 /* Build configuration list for PBXNativeTarget "FirezoneNetworkExtensionAppex" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				05CF1CFB290B1CEE00CF4755 /* Debug */,
@@ -1732,6 +2125,16 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		FZSA00000000000000000003 /* Build configuration list for PBXNativeTarget "FirezoneStandalone" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FZSA00000000000000000004 /* Debug */,
+				FZSA00000000000000000005 /* Release */,
+				FZSA00000000000000000006 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1748,6 +2151,15 @@
 			productName = FirezoneKit;
 		};
 		FZ0CLI012E80000000000030 /* ArgumentParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FZ0CLI012E80000000000300 /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
+			productName = ArgumentParser;
+		};
+		FZSA00000000000000000040 /* FirezoneKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirezoneKit;
+		};
+		FZSA00000000000000000041 /* ArgumentParser */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = FZ0CLI012E80000000000300 /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
 			productName = ArgumentParser;

--- a/swift/apple/Firezone.xcodeproj/xcshareddata/xcschemes/FirezoneStandalone (Mock).xcscheme
+++ b/swift/apple/Firezone.xcodeproj/xcshareddata/xcschemes/FirezoneStandalone (Mock).xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FZSA00000000000000000001"
+               BuildableName = "Firezone.app"
+               BlueprintName = "FirezoneStandalone"
+               ReferencedContainer = "container:Firezone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirezoneKitTests"
+               BuildableName = "FirezoneKitTests"
+               BlueprintName = "FirezoneKitTests"
+               ReferencedContainer = "container:FirezoneKit">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FZSA00000000000000000001"
+            BuildableName = "Firezone.app"
+            BlueprintName = "FirezoneStandalone"
+            ReferencedContainer = "container:Firezone.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "--mock-tunnel"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--mock-scenario"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "connected"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--mock-appearance"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "dark"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Profile"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FZSA00000000000000000001"
+            BuildableName = "Firezone.app"
+            BlueprintName = "FirezoneStandalone"
+            ReferencedContainer = "container:Firezone.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/swift/apple/Firezone.xcodeproj/xcshareddata/xcschemes/FirezoneStandalone.xcscheme
+++ b/swift/apple/Firezone.xcodeproj/xcshareddata/xcschemes/FirezoneStandalone.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FZSA00000000000000000001"
+               BuildableName = "Firezone.app"
+               BlueprintName = "FirezoneStandalone"
+               ReferencedContainer = "container:Firezone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirezoneKitTests"
+               BuildableName = "FirezoneKitTests"
+               BlueprintName = "FirezoneKitTests"
+               ReferencedContainer = "container:FirezoneKit">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FZSA00000000000000000001"
+            BuildableName = "Firezone.app"
+            BlueprintName = "FirezoneStandalone"
+            ReferencedContainer = "container:Firezone.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Profile"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FZSA00000000000000000001"
+            BuildableName = "Firezone.app"
+            BlueprintName = "FirezoneStandalone"
+            ReferencedContainer = "container:Firezone.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/swift/apple/Firezone/CLI/ExtensionCommand.swift
+++ b/swift/apple/Firezone/CLI/ExtensionCommand.swift
@@ -14,9 +14,14 @@ import Foundation
 /// against the requesting bundle's `Contents/Library/SystemExtensions`, and the
 /// extension lives in `Firezone.app` rather than in here, so only the app can
 /// install it.
+///
+/// The App Store build has no system extension at all: its tunnel is an app extension
+/// that ships inside the app, so there is nothing to install or report on.
 enum SystemExtension {
   @MainActor
   static func requireInstalled() async throws {
+    guard BundleHelper.tunnelProviderKind == .systemExtension else { return }
+
     switch try await SystemExtensionManager().check() {
     case .installed:
       Log.info("System extension is up to date")
@@ -59,6 +64,12 @@ extension FirezoneCLI {
       @MainActor
       func run() async throws {
         Log.useCLIOutput()
+
+        guard BundleHelper.tunnelProviderKind == .systemExtension else {
+          print("bundled with the app")
+
+          return
+        }
 
         switch try await SystemExtensionManager().check() {
         case .installed:

--- a/swift/apple/Firezone/FirezoneStandalone.entitlements
+++ b/swift/apple/Firezone/FirezoneStandalone.entitlements
@@ -4,8 +4,11 @@
 <dict>
 	<key>com.apple.developer.networking.networkextension</key>
 	<array>
-		<string>packet-tunnel-provider</string>
+		<!-- "-systemextension" is what a provider outside the App Store runs as -->
+		<string>packet-tunnel-provider-systemextension</string>
 	</array>
+	<key>com.apple.developer.system-extension.install</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>$(APP_GROUP_ID)</string>

--- a/swift/apple/Firezone/Info.plist
+++ b/swift/apple/Firezone/Info.plist
@@ -47,6 +47,8 @@
   <false/>
   <key>GitSha</key>
   <string>$(GIT_SHA)</string>
+  <key>TunnelProviderKind</key>
+  <string>$(TUNNEL_PROVIDER_KIND)</string>
   <key>NoTelemetry</key>
   <string>$(FIREZONE_NO_TELEMETRY)</string>
 	<key>LSEnvironment</key>

--- a/swift/apple/Firezone/xcconfig/config.xcconfig
+++ b/swift/apple/Firezone/xcconfig/config.xcconfig
@@ -1,7 +1,23 @@
 // Apple Developer account-specific configuration
 DEVELOPMENT_TEAM = 47R2M6779T
+
+// Bundle identifiers.
+//
+// The App Store and standalone macOS apps are one product shipped two ways, so they
+// share both identifiers. Only one of them can be installed on a Mac, and keeping the
+// identifiers means a Mac that switches between them keeps its settings, its MDM
+// configuration profile and the device id the provider stored.
 MAIN_APP_BUNDLE_ID = dev.firezone.firezone
+TUNNEL_PROVIDER_BUNDLE_ID = dev.firezone.firezone.network-extension
+
 PRODUCT_BUNDLE_IDENTIFIER = $(MAIN_APP_BUNDLE_ID)
+
+// How the tunnel provider ships. Bundled as an app extension it rides inside the
+// app, shares its container and only runs while the tunnel does. The standalone
+// macOS targets override this with `system-extension`, which the app installs into
+// the system and which then runs as root, outside the app's container.
+TUNNEL_PROVIDER_KIND = app-extension
+
 APP_GROUP_ID[sdk=macosx*] = 47R2M6779T.dev.firezone.firezone
 APP_GROUP_ID_PRE_1_4_0[sdk=macosx*] = 47R2M6779T.group.dev.firezone.firezone
 APP_GROUP_ID[sdk=iphoneos*] = group.dev.firezone.firezone

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Bundle.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Bundle.swift
@@ -6,6 +6,19 @@
 
 import Foundation
 
+/// How the tunnel provider ships, which is what separates the two macOS builds.
+public enum TunnelProviderKind: String, Sendable {
+  /// Bundled inside the app. It shares the app's group container, runs as the user
+  /// and only exists while the tunnel does. Every iOS build works this way, and a
+  /// Mac App Store build has to.
+  case appExtension = "app-extension"
+
+  /// Installed into the system by the app. It runs as root, outside the app's
+  /// container, and stays reachable while the tunnel is down. Only the standalone
+  /// macOS build ships one.
+  case systemExtension = "system-extension"
+}
+
 public enum BundleHelper {
   static func isAppStore() -> Bool {
     if let receiptURL = Bundle.main.appStoreReceiptURL,
@@ -15,6 +28,25 @@ public enum BundleHelper {
     }
 
     return false
+  }
+
+  /// How this build's tunnel provider ships.
+  ///
+  /// Both the app and the provider declare it, so either process can ask. A bundle
+  /// without the key predates the split or is a test bundle, and macOS shipped a
+  /// system extension then.
+  public static var tunnelProviderKind: TunnelProviderKind {
+    guard let raw = Bundle.main.object(forInfoDictionaryKey: "TunnelProviderKind") as? String,
+      let kind = TunnelProviderKind(rawValue: raw)
+    else {
+      #if os(macOS)
+        return .systemExtension
+      #else
+        return .appExtension
+      #endif
+    }
+
+    return kind
   }
 
   /// Whether telemetry was switched off when this bundle was built. Apple builds

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
@@ -9,23 +9,42 @@ import Foundation
 @preconcurrency import NetworkExtension
 import SystemPackage
 
-/// Convenience module for smoothing over the differences between exporting logs on macOS and iOS.
+/// Convenience module for smoothing over the differences between exporting logs from a
+/// bundled provider and from a system extension.
 ///
-/// On macOS, we must export the app's log dir and tunnel's log dir separately to temp files, and then join
-/// these into a final compressed archive saved at the user's specified location. This is because Apple Archive
-/// compression APIs do not easily allow compressing from multiple disparate paths in one go; only a single
-/// source directory is supported.
+/// A bundled provider writes into the same group container as the app, so the app
+/// compresses the whole log directory itself with no help from the tunnel process, thus
+/// avoiding IPC. Every iOS build and the Mac App Store build take this path.
 ///
-/// On iOS, the app process can compress the entire log directory itself, with no help from the tunnel process,
-/// thus avoiding IPC. In this case we write directly to the provided archiveURL.
+/// A system extension runs as root and so writes into a different group container. Its
+/// logs have to be fetched over IPC into a temp file and joined with the app's own
+/// archive, because the Apple Archive compression APIs only take a single source
+/// directory.
+enum LogExporter {
+  enum ExportError: Error {
+    case invalidSourceDirectory
+    case invalidFileHandle
+    case documentDirectoryNotAvailable
+  }
+
+  // @concurrent: zipping a large log tree must not run on the main actor.
+  /// Compresses `logFolderURL` straight into `archiveURL`, with no help from the tunnel.
+  @concurrent
+  static func export(to archiveURL: URL, from logFolderURL: URL) async throws {
+    // Remove existing archive if it exists
+    try? fileManager.removeItem(at: archiveURL)
+
+    // Write final log archive
+    try ZipService.createZip(
+      source: logFolderURL,
+      to: archiveURL
+    )
+  }
+}
 
 #if os(macOS)
-  enum LogExporter {
-    enum ExportError: Error {
-      case invalidSourceDirectory
-      case invalidFileHandle
-    }
-
+  extension LogExporter {
+    /// Joins the app's logs with the ones the system extension hands over IPC.
     @MainActor
     static func export(
       to archiveURL: URL,
@@ -97,25 +116,7 @@ import SystemPackage
 #endif
 
 #if os(iOS)
-  enum LogExporter {
-    enum ExportError: Error {
-      case invalidSourceDirectory
-      case documentDirectoryNotAvailable
-    }
-
-    // @concurrent: zipping a large log tree must not run on the main actor.
-    @concurrent
-    static func export(to archiveURL: URL, from logFolderURL: URL) async throws {
-      // Remove existing archive if it exists
-      try? fileManager.removeItem(at: archiveURL)
-
-      // Write final log archive
-      try ZipService.createZip(
-        source: logFolderURL,
-        to: archiveURL
-      )
-    }
-
+  extension LogExporter {
     static func tempFile() throws -> URL {
       let fileName = "firezone_logs_\(now()).zip"
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/SystemExtensionManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/SystemExtensionManager.swift
@@ -73,6 +73,21 @@
     func tryInstall() async throws -> SystemExtensionStatus
   }
 
+  /// Stands in for the manager in a build whose provider is bundled as an app
+  /// extension.
+  ///
+  /// Such a provider ships inside the app and needs no install, no approval and no
+  /// version comparison, so there is nothing for the user to do and nothing that can
+  /// go stale. Reporting it installed is what leaves the rest of the app, which is
+  /// written against a system extension, with nothing to ask for.
+  @MainActor
+  public struct BundledExtensionManager: SystemExtensionManagerProtocol {
+    public init() {}
+
+    public func check() async throws -> SystemExtensionStatus { .installed }
+    public func tryInstall() async throws -> SystemExtensionStatus { .installed }
+  }
+
   enum SystemExtensionRequestType {
     case install
     case check

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -139,7 +139,7 @@ public final class Store: ObservableObject {
       self.updateChecker =
         updateChecker ?? UpdateChecker(configuration: configuration, userDefaults: userDefaults)
       self.sessionNotification = sessionNotification
-      self.systemExtensionManager = systemExtensionManager ?? SystemExtensionManager()
+      self.systemExtensionManager = systemExtensionManager ?? Self.defaultSystemExtensionManager()
       self.tunnelManagerFactory = tunnelManagerFactory
       self.x509CertificateSource = x509CertificateSource
       self.logDirectory = logDirectory
@@ -271,6 +271,17 @@ public final class Store: ObservableObject {
         return "MenuBarIconConnecting3"
       @unknown default:
         return "MenuBarIconSignedOut"
+      }
+    }
+
+    /// The manager for however this build's provider ships.
+    ///
+    /// A bundled provider is already there, so the app asks the system about a system
+    /// extension only when it ships one.
+    private static func defaultSystemExtensionManager() -> any SystemExtensionManagerProtocol {
+      switch BundleHelper.tunnelProviderKind {
+      case .systemExtension: return SystemExtensionManager()
+      case .appExtension: return BundledExtensionManager()
       }
     }
 
@@ -759,6 +770,10 @@ public final class Store: ObservableObject {
     let appLogSize = await Log.size(of: logDirectory)
 
     #if os(macOS)
+      guard BundleHelper.tunnelProviderKind == .systemExtension else {
+        return UInt64(clamping: appLogSize)
+      }
+
       do {
         guard let session = try manager().session() else {
           throw VPNConfigurationManagerError.managerNotInitialized
@@ -796,6 +811,8 @@ public final class Store: ObservableObject {
     }.value
 
     #if os(macOS)
+      guard BundleHelper.tunnelProviderKind == .systemExtension else { return }
+
       guard let session = try manager().session() else {
         throw VPNConfigurationManagerError.managerNotInitialized
       }
@@ -809,6 +826,12 @@ public final class Store: ObservableObject {
       guard let logDirectory else {
         throw LogExporter.ExportError.invalidSourceDirectory
       }
+
+      guard BundleHelper.tunnelProviderKind == .systemExtension else {
+        try await LogExporter.export(to: destination, from: logDirectory)
+        return
+      }
+
       guard let session = try manager().session() else {
         throw VPNConfigurationManagerError.managerNotInitialized
       }
@@ -946,8 +969,12 @@ public final class Store: ObservableObject {
 
   #if os(macOS)
     // `vpnStatus == nil` means no Sign In button yet, so the cycle start can't race one.
+    //
+    // Only a system extension can hold a spool while the tunnel is down; a bundled
+    // provider is not running to be asked, and drains on its next connect instead.
     private func drainFlowLogsOnLaunch() async {
-      guard vpnStatus == nil,
+      guard BundleHelper.tunnelProviderKind == .systemExtension,
+        vpnStatus == nil,
         let session = try? manager().session(),
         session.status == .disconnected
       else { return }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
@@ -65,72 +65,26 @@ struct GrantVPNView: View {
             .padding(.horizontal, 10)
           Spacer()
           Spacer()
-          Text(
-            """
-            Firezone needs you to enable a System Extension and allow a VPN configuration in order to function.
-            """
-          )
-          .font(.title2)
-          .multilineTextAlignment(.center)
-          .padding(EdgeInsets(top: 0, leading: 10, bottom: 0, trailing: 15))
+          Text(needsSystemExtension ? Self.twoStepPrompt : Self.vpnOnlyPrompt)
+            .font(.title2)
+            .multilineTextAlignment(.center)
+            .padding(EdgeInsets(top: 0, leading: 10, bottom: 0, trailing: 15))
           Spacer()
           Spacer()
-          HStack(alignment: .top) {
-            Spacer()
-            VStack(alignment: .center) {
-              Text("Step 1: Enable the system extension")
-                .font(.title)
-                .strikethrough(isInstalled(), color: .primary)
-              Text(
-                """
-                1. Click the "Enable System Extension" button below.
-                2. Click "Open System Settings" in the dialog that appears.
-                3. Ensure the FirezoneNetworkExtension is toggled ON.
-                4. Click Done.
-                """
-              )
-              .font(.body)
-              .padding(.vertical, 10)
-              .opacity(isInstalled() ? 0.5 : 1.0)
+          if needsSystemExtension {
+            HStack(alignment: .top) {
               Spacer()
-              Button(
-                action: {
-                  installSystemExtension()
-                },
-                label: {
-                  Label("Enable System Extension", systemImage: "gearshape")
-                }
+              systemExtensionStep
+              Spacer()
+              vpnConfigurationStep(
+                title: "Step 2: Allow the VPN configuration",
+                enabled: isInstalled()
               )
-              .buttonStyle(.borderedProminent)
-              .controlSize(.large)
-              .disabled(isInstalled())
+              .opacity(isInstalled() ? 1.0 : 0.5)
+              Spacer()
             }
-            Spacer()
-            VStack(alignment: .center) {
-              Text("Step 2: Allow the VPN configuration")
-                .font(.title)
-              Text(
-                """
-                1. Click the "Grant VPN Permission" button below.
-                2. Click "Allow" in the dialog that appears.
-                """
-              )
-              .font(.body)
-              .padding(.vertical, 10)
-              Spacer()
-              Button(
-                action: {
-                  installVPNConfiguration()
-                },
-                label: {
-                  Label("Grant VPN Permission", systemImage: "network.badge.shield.half.filled")
-                }
-              )
-              .buttonStyle(.borderedProminent)
-              .controlSize(.large)
-              .disabled(!isInstalled())
-            }.opacity(isInstalled() ? 1.0 : 0.5)
-            Spacer()
+          } else {
+            vpnConfigurationStep(title: "Allow the VPN configuration", enabled: true)
           }
           Spacer()
           Spacer()
@@ -141,6 +95,79 @@ struct GrantVPNView: View {
   }
 
   #if os(macOS)
+    private static let twoStepPrompt =
+      "Firezone needs you to enable a System Extension and allow a VPN configuration in order to function."
+    private static let vpnOnlyPrompt =
+      "Firezone needs you to allow a VPN configuration in order to function."
+
+    /// Whether this build asks the user to enable a system extension.
+    ///
+    /// The Mac App Store build carries its tunnel inside the app, so the only thing
+    /// left to ask for is the VPN configuration, exactly as on iOS.
+    private var needsSystemExtension: Bool {
+      BundleHelper.tunnelProviderKind == .systemExtension
+    }
+
+    @ViewBuilder
+    private var systemExtensionStep: some View {
+      VStack(alignment: .center) {
+        Text("Step 1: Enable the system extension")
+          .font(.title)
+          .strikethrough(isInstalled(), color: .primary)
+        Text(
+          """
+          1. Click the "Enable System Extension" button below.
+          2. Click "Open System Settings" in the dialog that appears.
+          3. Ensure the FirezoneNetworkExtension is toggled ON.
+          4. Click Done.
+          """
+        )
+        .font(.body)
+        .padding(.vertical, 10)
+        .opacity(isInstalled() ? 0.5 : 1.0)
+        Spacer()
+        Button(
+          action: {
+            installSystemExtension()
+          },
+          label: {
+            Label("Enable System Extension", systemImage: "gearshape")
+          }
+        )
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .disabled(isInstalled())
+      }
+    }
+
+    @ViewBuilder
+    private func vpnConfigurationStep(title: String, enabled: Bool) -> some View {
+      VStack(alignment: .center) {
+        Text(title)
+          .font(.title)
+        Text(
+          """
+          1. Click the "Grant VPN Permission" button below.
+          2. Click "Allow" in the dialog that appears.
+          """
+        )
+        .font(.body)
+        .padding(.vertical, 10)
+        Spacer()
+        Button(
+          action: {
+            installVPNConfiguration()
+          },
+          label: {
+            Label("Grant VPN Permission", systemImage: "network.badge.shield.half.filled")
+          }
+        )
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .disabled(!enabled)
+      }
+    }
+
     func installSystemExtension() {
       Task {
         do {

--- a/swift/apple/FirezoneNetworkExtension/FirezoneNetworkExtension.entitlements
+++ b/swift/apple/FirezoneNetworkExtension/FirezoneNetworkExtension.entitlements
@@ -4,8 +4,7 @@
 <dict>
 	<key>com.apple.developer.networking.networkextension</key>
 	<array>
-    <!-- "-systemextension" is needed for standalone distribution -->
-		<string>packet-tunnel-provider$(PACKET_TUNNEL_PROVIDER_SUFFIX)</string>
+		<string>packet-tunnel-provider</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/swift/apple/FirezoneNetworkExtension/FirezoneNetworkExtensionStandalone.entitlements
+++ b/swift/apple/FirezoneNetworkExtension/FirezoneNetworkExtensionStandalone.entitlements
@@ -4,7 +4,8 @@
 <dict>
 	<key>com.apple.developer.networking.networkextension</key>
 	<array>
-		<string>packet-tunnel-provider</string>
+		<!-- "-systemextension" is what a provider outside the App Store runs as -->
+		<string>packet-tunnel-provider-systemextension</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/swift/apple/FirezoneNetworkExtension/Info.appex.plist
+++ b/swift/apple/FirezoneNetworkExtension/Info.appex.plist
@@ -11,6 +11,8 @@
 	</dict>
 	<key>AppGroupIdentifier</key>
 	<string>$(APP_GROUP_ID)</string>
+	<key>TunnelProviderKind</key>
+	<string>$(TUNNEL_PROVIDER_KIND)</string>
 	<key>NoTelemetry</key>
 	<string>$(FIREZONE_NO_TELEMETRY)</string>
 	<key>LSEnvironment</key>

--- a/swift/apple/FirezoneNetworkExtension/Info.systemextension.plist
+++ b/swift/apple/FirezoneNetworkExtension/Info.systemextension.plist
@@ -24,6 +24,8 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>AppGroupIdentifier</key>
 	<string>$(APP_GROUP_ID)</string>
+	<key>TunnelProviderKind</key>
+	<string>$(TUNNEL_PROVIDER_KIND)</string>
 	<key>NoTelemetry</key>
 	<string>$(FIREZONE_NO_TELEMETRY)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -488,8 +488,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         try token.save()
       } catch let error as KeychainError {
         // macOS 13 and below have a bug that raises an error when a root proc (such as our system extension) tries
-        // to add an item to the system keychain. We can safely ignore this.
-        if #unavailable(macOS 14.0), case .appleSecError("SecItemAdd", 100001) = error {
+        // to add an item to the system keychain. We can safely ignore this. An app
+        // extension runs as the user and writes to their keychain, so it never hits it.
+        if BundleHelper.tunnelProviderKind == .systemExtension, #unavailable(macOS 14.0),
+          case .appleSecError("SecItemAdd", 100001) = error
+        {
           // ignore
         } else {
           Log.error(error)

--- a/swift/apple/README.md
+++ b/swift/apple/README.md
@@ -16,6 +16,57 @@ You may consider using a macOS VM (such as Parallels Desktop) to test the
 standalone macOS client, as it can be easier to test different macOS versions
 and configurations without risking your main machine.
 
+## macOS build variants
+
+macOS ships two builds of the same app. They differ in how the tunnel runs.
+
+|                       | App Store                              | Standalone                                               |
+| --------------------- | -------------------------------------- | -------------------------------------------------------- |
+| Xcode target / scheme | `Firezone`                             | `FirezoneStandalone`                                     |
+| Tunnel                | app extension, in `Contents/PlugIns`   | system extension, in `Contents/Library/SystemExtensions` |
+| Tunnel entitlement    | `packet-tunnel-provider`               | `packet-tunnel-provider-systemextension`                 |
+| Signed with           | Apple Distribution                     | Developer ID Application                                 |
+| Shipped as            | a `.pkg` uploaded to App Store Connect | a `.dmg` and a `.pkg` attached to a GitHub release       |
+
+The `Firezone` target also builds the iOS app. iOS has always worked the way the
+macOS App Store build now does: one app, one app extension inside it.
+
+Both builds keep the same bundle identifiers, `dev.firezone.firezone` for the
+app and `dev.firezone.firezone.network-extension` for the tunnel. They are one
+product shipped two ways, and only one of them can be on a Mac at a time.
+Keeping the identifiers is what lets a Mac move between them and keep its
+settings, its MDM configuration profile and the device id the tunnel stored. It
+also means the two builds take one App ID between them, with a separate
+provisioning profile each.
+
+What the split changes when the app is running:
+
+- An app extension only exists while the tunnel is up, and it runs as you. It
+  shares the app's group container, so the app reads, clears and exports the
+  tunnel's logs by reading the files itself. There is nothing to install and
+  nothing for the user to approve.
+- A system extension keeps running after the tunnel goes down, and it runs as
+  root with its own group container. The app has to install it, ask the user to
+  approve it, and talk to it over IPC to do anything with its logs.
+
+A build cannot carry both. Apple takes only the app extension packaging on the
+App Store, and only the system extension packaging for Developer ID, so two
+things are standalone only:
+
+- Serving a tunnel before anyone logs in. An app extension lives in a login
+  session, and at the login window there is none.
+- Using a client certificate that MDM installed at device scope. That
+  certificate sits in the System keychain, and its private key needs root. A
+  certificate installed at user scope works in either build.
+
+Both of those need MDM, and MDM deploys the standalone `.pkg`, so the capability
+is where it is needed.
+
+Code that has to tell the two apart reads `BundleHelper.tunnelProviderKind`.
+That comes from the `TunnelProviderKind` key every bundle declares in its
+Info.plist, so the app, the tunnel and the headless client all get the same
+answer.
+
 ## Building
 
 1. Add required Rust targets:
@@ -94,6 +145,9 @@ iPhone or iPad. Network Extensions can't be debugged in the iOS simulator.
    scripts/build/macos-standalone.sh
    ```
 
+   `macos-appstore.sh` builds the `Firezone` scheme and `macos-standalone.sh`
+   builds `FirezoneStandalone`.
+
 ## Developing
 
 ### Prerequisites
@@ -155,6 +209,13 @@ mise tasks              # List all available tasks
 mise run <task>         # Run a task (e.g. mise run build)
 ```
 
+`build`, `install` and `cli` build the standalone variant, which is what most
+Macs run. Set `VARIANT=appstore` to work on the other one:
+
+```sh
+VARIANT=appstore mise run build
+```
+
 From the repository root:
 
 ```sh
@@ -179,11 +240,14 @@ mise run cli -- connect --account-slug my-account
 `connect` is the default, so plain `firezone-cli` brings the tunnel up and stays
 in the foreground until you stop it. `sign-out` drops the stored token.
 
-It talks to the same system extension as the GUI and will not start without it.
-`extension status` reports whether that extension is installed and matches the
-build, and exits non-zero when it does not, so a setup script can check before
-going further. It cannot install the extension, since installing one needs a
-user to approve it. Launch the app once to do that.
+In the standalone build it talks to the same system extension as the GUI and
+will not start without it. `extension status` reports whether that extension is
+installed and matches the build, and exits non-zero when it does not, so a setup
+script can check before going further. It cannot install the extension, since
+installing one needs a user to approve it. Launch the app once to do that.
+
+In the App Store build there is no system extension: the tunnel ships inside the
+app. `extension status` says so and always succeeds.
 
 These environment variables are read when the matching flag is absent:
 
@@ -327,6 +391,13 @@ item is missing. You can remove the keychain item with the following command:
 ```bash
 security delete-generic-password -s "dev.firezone.firezone"
 ```
+
+The tunnel is what writes the token, so which keychain holds it depends on the
+build. The App Store build's app extension runs as you and writes to your login
+keychain, which the command above reaches. The standalone build's system
+extension runs as root and writes to the system keychain, so run it under `sudo`
+there. Switching a Mac between the two builds leaves the token behind in the
+other keychain, and the user has to sign in again.
 
 ## Generating new signing certificates and provisioning profiles for app store distribution
 

--- a/swift/apple/mise-tasks/build.sh
+++ b/swift/apple/mise-tasks/build.sh
@@ -11,6 +11,18 @@ GIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo "unknown")"
 PLATFORM="${PLATFORM:-macOS}"
 CONFIGURATION="${CONFIGURATION:-Debug}"
 
+# macOS ships two variants: `standalone` carries the tunnel as a system extension it
+# installs, `appstore` bundles it as an app extension. They are separate app targets.
+VARIANT="${VARIANT:-standalone}"
+case "${VARIANT}" in
+standalone) SCHEME="FirezoneStandalone" ;;
+appstore) SCHEME="Firezone" ;;
+*)
+    echo "Unknown VARIANT '${VARIANT}'; expected 'standalone' or 'appstore'" >&2
+    exit 1
+    ;;
+esac
+
 cd "${APPLE_DIR}"
 
 if [ ! -f buildServer.json ]; then
@@ -26,7 +38,7 @@ if [ ! -f Firezone/xcconfig/dynamic_build_number.xcconfig ]; then
     echo "CURRENT_PROJECT_VERSION = $(date +%s)" > Firezone/xcconfig/dynamic_build_number.xcconfig
 fi
 
-echo "Building Xcode project for ${PLATFORM}, ${ARCH}"
+echo "Building Xcode project for ${PLATFORM}, ${ARCH} (${VARIANT})"
 echo "Git SHA: ${GIT_SHA}"
 
 # PRETTY=1 force on, PRETTY=0 force off, unset = auto-detect xcbeautify
@@ -53,7 +65,7 @@ xcodebuild_args=(
     # Dev builds sign automatically; xcodebuild won't fetch or create a profile without this.
     # Release builds pass explicit profile ids instead, so they never reach for it.
     -allowProvisioningUpdates
-    -scheme Firezone
+    -scheme "${SCHEME}"
     -configuration "${CONFIGURATION}"
     -sdk macosx
     -destination "platform=${PLATFORM},arch=${ARCH}"

--- a/swift/apple/mise-tasks/clean.sh
+++ b/swift/apple/mise-tasks/clean.sh
@@ -9,11 +9,13 @@ CONFIGURATION="${CONFIGURATION:-Debug}"
 cd "${APPLE_DIR}"
 
 echo "Cleaning Xcode build"
-xcodebuild clean \
-    -project Firezone.xcodeproj \
-    -scheme Firezone \
-    -configuration "${CONFIGURATION}" \
-    -sdk macosx
+for scheme in Firezone FirezoneStandalone; do
+    xcodebuild clean \
+        -project Firezone.xcodeproj \
+        -scheme "${scheme}" \
+        -configuration "${CONFIGURATION}" \
+        -sdk macosx
+done
 
 echo "Cleaning Rust build artifacts"
 cd "${RUST_DIR}/client-ffi" && cargo clean

--- a/swift/apple/mise-tasks/cli.sh
+++ b/swift/apple/mise-tasks/cli.sh
@@ -6,10 +6,22 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APPLE_DIR="${SCRIPT_DIR}/.."
 CONFIGURATION="${CONFIGURATION:-Debug}"
 
+# macOS ships two variants: `standalone` carries the tunnel as a system extension it
+# installs, `appstore` bundles it as an app extension. They are separate app targets.
+VARIANT="${VARIANT:-standalone}"
+case "${VARIANT}" in
+standalone) SCHEME="FirezoneStandalone" ;;
+appstore) SCHEME="Firezone" ;;
+*)
+    echo "Unknown VARIANT '${VARIANT}'; expected 'standalone' or 'appstore'" >&2
+    exit 1
+    ;;
+esac
+
 cd "${APPLE_DIR}"
 
 echo "Finding build location..."
-xcodebuild_output=$(xcodebuild -project Firezone.xcodeproj -scheme Firezone -configuration "${CONFIGURATION}" -showBuildSettings 2>&1) || {
+xcodebuild_output=$(xcodebuild -project Firezone.xcodeproj -scheme "${SCHEME}" -configuration "${CONFIGURATION}" -showBuildSettings 2>&1) || {
     echo "Error: xcodebuild failed:"
     echo "$xcodebuild_output" >&2
     exit 1

--- a/swift/apple/mise-tasks/install.sh
+++ b/swift/apple/mise-tasks/install.sh
@@ -5,12 +5,27 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APPLE_DIR="${SCRIPT_DIR}/.."
 CONFIGURATION="${CONFIGURATION:-Debug}"
 
+# macOS ships two variants: `standalone` carries the tunnel as a system extension it
+# installs, `appstore` bundles it as an app extension. They are separate app targets.
+VARIANT="${VARIANT:-standalone}"
+case "${VARIANT}" in
+standalone) SCHEME="FirezoneStandalone" ;;
+appstore) SCHEME="Firezone" ;;
+*)
+    echo "Unknown VARIANT '${VARIANT}'; expected 'standalone' or 'appstore'" >&2
+    exit 1
+    ;;
+esac
+
 cd "${APPLE_DIR}"
 
 echo "Stopping any running Firezone instances..."
 osascript -e 'tell application "Firezone" to quit' 2>/dev/null || true
 pkill -x Firezone 2>/dev/null || true
 
+# Both variants name the tunnel `dev.firezone.firezone.network-extension`, so an
+# already activated system extension would shadow the App Store build's app
+# extension. Clear it whichever variant is going in.
 echo "Stopping and removing Firezone network extension..."
 sudo pkill -f "Firezone.NetworkExtension" 2>/dev/null || true
 # systemextensionsctl may fail if extension not installed - log but continue
@@ -20,7 +35,7 @@ sudo systemextensionsctl uninstall 47R2M6779T dev.firezone.firezone.network-exte
 sleep 2
 
 echo "Finding build location..."
-xcodebuild_output=$(xcodebuild -project Firezone.xcodeproj -scheme Firezone -configuration "${CONFIGURATION}" -showBuildSettings 2>&1) || {
+xcodebuild_output=$(xcodebuild -project Firezone.xcodeproj -scheme "${SCHEME}" -configuration "${CONFIGURATION}" -showBuildSettings 2>&1) || {
     echo "Error: xcodebuild failed:"
     echo "$xcodebuild_output" >&2
     exit 1

--- a/swift/apple/mise-tasks/log/all-tail.sh
+++ b/swift/apple/mise-tasks/log/all-tail.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# The tunnel writes into its own group container. The standalone build's system
+# extension runs as root, so its logs land under root's home; the App Store
+# build's app extension runs as you, so they land under yours.
+group_container="47R2M6779T.dev.firezone.firezone"
+user_logs="${HOME}/Library/Group Containers/${group_container}/Library/Caches/logs"
+root_logs="/private/var/root/Library/Group Containers/${group_container}/Library/Caches/logs"
+
 echo "Following all Firezone logs (including connlib from file)..."
 
 # Trap to kill all children on exit
@@ -10,8 +17,10 @@ trap 'kill 0' INT TERM EXIT
 log stream --predicate '(process CONTAINS "Firezone" OR subsystem CONTAINS "dev.firezone" OR category == "connlib") AND process != "codebook-lsp"' &
 
 # Also tail connlib log file if accessible
-if [ -r "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest" ]; then
-    tail -f "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest" &
+if [ -r "${user_logs}/connlib/connlib.latest" ]; then
+    tail -f "${user_logs}/connlib/connlib.latest" &
+elif [ -r "${root_logs}/connlib/connlib.latest" ]; then
+    tail -f "${root_logs}/connlib/connlib.latest" &
 else
     echo "Note: connlib file logs require sudo access. Run 'mise run log:connlib-tail' with sudo for file logs."
 fi

--- a/swift/apple/mise-tasks/log/connlib-show.sh
+++ b/swift/apple/mise-tasks/log/connlib-show.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Viewing connlib log (requires sudo)..."
-if [ -r "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest" ]; then
-    less "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest"
+# The tunnel writes into its own group container. The standalone build's system
+# extension runs as root, so its logs land under root's home; the App Store
+# build's app extension runs as you, so they land under yours.
+group_container="47R2M6779T.dev.firezone.firezone"
+user_logs="${HOME}/Library/Group Containers/${group_container}/Library/Caches/logs"
+root_logs="/private/var/root/Library/Group Containers/${group_container}/Library/Caches/logs"
+
+echo "Viewing connlib log..."
+if [ -r "${user_logs}/connlib/connlib.latest" ]; then
+    less "${user_logs}/connlib/connlib.latest"
+elif [ -r "${root_logs}/connlib/connlib.latest" ]; then
+    less "${root_logs}/connlib/connlib.latest"
 else
-    sudo less "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest"
+    sudo less "${root_logs}/connlib/connlib.latest"
 fi

--- a/swift/apple/mise-tasks/log/connlib-tail.sh
+++ b/swift/apple/mise-tasks/log/connlib-tail.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Following connlib log (requires sudo)..."
-if [ -r "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest" ]; then
-    exec tail -f "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest"
+# The tunnel writes into its own group container. The standalone build's system
+# extension runs as root, so its logs land under root's home; the App Store
+# build's app extension runs as you, so they land under yours.
+group_container="47R2M6779T.dev.firezone.firezone"
+user_logs="${HOME}/Library/Group Containers/${group_container}/Library/Caches/logs"
+root_logs="/private/var/root/Library/Group Containers/${group_container}/Library/Caches/logs"
+
+echo "Following connlib log..."
+if [ -r "${user_logs}/connlib/connlib.latest" ]; then
+    exec tail -f "${user_logs}/connlib/connlib.latest"
+elif [ -r "${root_logs}/connlib/connlib.latest" ]; then
+    exec tail -f "${root_logs}/connlib/connlib.latest"
 else
-    exec sudo tail -f "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest"
+    exec sudo tail -f "${root_logs}/connlib/connlib.latest"
 fi

--- a/swift/apple/mise-tasks/log/tunnel-show.sh
+++ b/swift/apple/mise-tasks/log/tunnel-show.sh
@@ -1,8 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Viewing latest tunnel log (requires sudo)..."
-latest_log=$(sudo find "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/tunnel" -name "*.log" -print0 2>/dev/null | xargs -0 ls -t | head -1)
+# The tunnel writes into its own group container. The standalone build's system
+# extension runs as root, so its logs land under root's home; the App Store
+# build's app extension runs as you, so they land under yours.
+group_container="47R2M6779T.dev.firezone.firezone"
+user_logs="${HOME}/Library/Group Containers/${group_container}/Library/Caches/logs"
+root_logs="/private/var/root/Library/Group Containers/${group_container}/Library/Caches/logs"
+
+# `set -e` would abort on a find that has no directory to search, so only look
+# where there is something to look at.
+newest_log() {
+    local dir="$1"
+    [ -d "$dir" ] || return 0
+    find "$dir" -name "*.log" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1
+}
+
+echo "Viewing latest tunnel log..."
+latest_log=$(newest_log "${user_logs}/tunnel")
+if [ -n "$latest_log" ]; then
+    less "$latest_log"
+    exit 0
+fi
+
+latest_log=$(sudo bash -c 'find "$1" -name "*.log" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1' _ "${root_logs}/tunnel")
 if [ -n "$latest_log" ]; then
     sudo less "$latest_log"
 else

--- a/swift/apple/mise-tasks/log/tunnel-tail.sh
+++ b/swift/apple/mise-tasks/log/tunnel-tail.sh
@@ -1,8 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Following latest tunnel log (requires sudo)..."
-latest_log=$(sudo find "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/tunnel" -name "*.log" -print0 2>/dev/null | xargs -0 ls -t | head -1)
+# The tunnel writes into its own group container. The standalone build's system
+# extension runs as root, so its logs land under root's home; the App Store
+# build's app extension runs as you, so they land under yours.
+group_container="47R2M6779T.dev.firezone.firezone"
+user_logs="${HOME}/Library/Group Containers/${group_container}/Library/Caches/logs"
+root_logs="/private/var/root/Library/Group Containers/${group_container}/Library/Caches/logs"
+
+# `set -e` would abort on a find that has no directory to search, so only look
+# where there is something to look at.
+newest_log() {
+    local dir="$1"
+    [ -d "$dir" ] || return 0
+    find "$dir" -name "*.log" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1
+}
+
+echo "Following latest tunnel log..."
+latest_log=$(newest_log "${user_logs}/tunnel")
+if [ -n "$latest_log" ]; then
+    exec tail -f "$latest_log"
+fi
+
+latest_log=$(sudo bash -c 'find "$1" -name "*.log" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1' _ "${root_logs}/tunnel")
 if [ -n "$latest_log" ]; then
     exec sudo tail -f "$latest_log"
 else


### PR DESCRIPTION
Adds an AppEx bundle of the Network Extension on macOS so that its packet tunnel provider will run as the user and be able to reach certs provisioned through User channels / login Keychain.