### PR TITLE
fix(connlib): poll new DoH bootstrap started by a retry

### DIFF
--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -341,6 +341,8 @@ impl Io {
 
                 meta.retried = true;
                 self.queue_dns_query(doh::send(client, server, meta.query.clone()), meta);
+                // `doh_clients_bootstrap` was already polled this tick and only wakes on a push into an empty set.
+                cx.waker().wake_by_ref();
 
                 continue;
             }


### PR DESCRIPTION
Follow-up to #14992, which made DoH queries wait on the bootstrap and retry once when Quad9 drops the HTTP/2 connection.

`Io::poll` polls `doh_clients_bootstrap` at the top of the tick. A retried DoH query can push a fresh bootstrap into that map later in the same tick. `FuturesMap::try_push` only wakes the task when the push lands in an empty set, so if another server is already bootstrapping, the new future sits unpolled until something else wakes the event loop, up to the next 5 second bootstrap timeout or 10 second tunnel tick.

```rust
meta.retried = true;
self.queue_dns_query(doh::send(client, server, meta.query.clone()), meta);
cx.waker().wake_by_ref();
```

Waking the task after the push guarantees the new bootstrap is polled on the next tick.

Related: #14992
