### PR TITLE
fix(apple): repair managed VPN profiles missing the extension id

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -175,16 +175,22 @@ public final class VPNConfigurationManager {
       "Loaded the Firezone VPN configuration (managed=\(selected.isManaged), clientCertificate=\(selected.hasIdentityReference))"
     )
 
-    // Some MDM-generated VPN payloads omit the system-extension link. Say so here: adoption
-    // runs at launch and on every preferences reload, so a re-pushed profile is re-checked.
+    // Some MDMs (for example Intune's built-in VPN payload) cannot set ProviderBundleIdentifier,
+    // and the tunnel cannot start from a profile without it. Fill it in ourselves.
     if selected.isManaged,
-      (selected.manager.protocolConfiguration as? NETunnelProviderProtocol)?
-        .providerBundleIdentifier == nil
+      let configuration = selected.manager.protocolConfiguration as? NETunnelProviderProtocol,
+      configuration.providerBundleIdentifier == nil
     {
       Log.warning(
-        "The managed VPN profile has no ProviderBundleIdentifier, so the tunnel cannot start "
-          + "from it; the payload needs \(selected.manager.extensionBundleIdentifier)."
+        "The managed VPN profile has no ProviderBundleIdentifier; "
+          + "setting it to \(selected.manager.extensionBundleIdentifier)"
       )
+
+      configuration.providerBundleIdentifier = selected.manager.extensionBundleIdentifier
+      selected.manager.protocolConfiguration = configuration
+
+      try await selected.manager.saveToPreferences()
+      try await selected.manager.loadFromPreferences()
     }
 
     return VPNConfigurationManager(from: selected.manager, isManaged: selected.isManaged)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -142,17 +142,18 @@ public final class VPNConfigurationManager {
       guard let configuration = manager.protocolConfiguration as? NETunnelProviderProtocol
       else { return nil }
 
-      // A com.apple.vpn.managed payload can leave this unset even though
-      // loadAllFromPreferences returned the configuration for us: NetworkExtension
-      // associated it with this app through the payload's VPNSubType. Our own
-      // initializer always sets it.
-      if let configured = configuration.providerBundleIdentifier,
-        configured != manager.extensionBundleIdentifier
-      {
+      switch configuration.providerBundleIdentifier {
+      case nil:
+        // A com.apple.vpn.managed payload can leave this unset even though
+        // loadAllFromPreferences returned the configuration for us: NetworkExtension
+        // associated it with this app through the payload's VPNSubType. Our own
+        // initializer always sets it.
+        return Candidate(manager: manager, configuration: configuration)
+      case .some(manager.extensionBundleIdentifier):
+        return Candidate(manager: manager, configuration: configuration)
+      default:
         return nil
       }
-
-      return Candidate(manager: manager, configuration: configuration)
     }
 
     guard let selected = candidates.first(where: \.hasIdentityReference) ?? candidates.first else {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -127,8 +127,8 @@ public final class VPNConfigurationManager {
   private struct Candidate {
     let manager: any TunnelProviderManager
     let configuration: NETunnelProviderProtocol
-    let hasIdentityReference: Bool
-    let isManaged: Bool
+
+    var hasIdentityReference: Bool { configuration.identityReference != nil }
   }
 
   public static func load(using factory: TunnelProviderManagerFactory) async throws
@@ -152,15 +152,7 @@ public final class VPNConfigurationManager {
         return nil
       }
 
-      let hasIdentityReference = configuration.identityReference != nil
-
-      // Captured before the repair below fills in the provider bundle identifier.
-      return Candidate(
-        manager: manager,
-        configuration: configuration,
-        hasIdentityReference: hasIdentityReference,
-        isManaged: configuration.providerBundleIdentifier == nil || hasIdentityReference
-      )
+      return Candidate(manager: manager, configuration: configuration)
     }
 
     guard let selected = candidates.first(where: \.hasIdentityReference) ?? candidates.first else {
@@ -174,13 +166,16 @@ public final class VPNConfigurationManager {
       )
     }
 
+    let missingProviderBundleIdentifier = selected.configuration.providerBundleIdentifier == nil
+    let isManaged = missingProviderBundleIdentifier || selected.hasIdentityReference
+
     Log.info(
-      "Loaded the Firezone VPN configuration (managed=\(selected.isManaged), clientCertificate=\(selected.hasIdentityReference))"
+      "Loaded the Firezone VPN configuration (managed=\(isManaged), clientCertificate=\(selected.hasIdentityReference))"
     )
 
     // Some MDMs (for example Intune's built-in VPN payload) cannot set ProviderBundleIdentifier,
     // and the tunnel cannot start from a profile without it. Fill it in ourselves.
-    if selected.configuration.providerBundleIdentifier == nil {
+    if missingProviderBundleIdentifier {
       Log.warning(
         "The managed VPN profile has no ProviderBundleIdentifier; "
           + "setting it to \(selected.manager.extensionBundleIdentifier)"
@@ -193,7 +188,7 @@ public final class VPNConfigurationManager {
       try await selected.manager.loadFromPreferences()
     }
 
-    return VPNConfigurationManager(from: selected.manager, isManaged: selected.isManaged)
+    return VPNConfigurationManager(from: selected.manager, isManaged: isManaged)
   }
 
   // If another VPN is activated on the system, ours becomes disabled. This is provided so that we may call it before

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -156,15 +156,15 @@ public final class VPNConfigurationManager {
       }
     }
 
-    guard let selected = candidates.first(where: \.hasIdentityReference) ?? candidates.first else {
-      Log.info("No Firezone VPN configuration was found")
-      return nil
-    }
-
     if candidates.count > 1 {
       Log.warning(
         "Found \(candidates.count) Firezone VPN configurations; preferring one with a client certificate"
       )
+    }
+
+    guard let selected = candidates.first(where: \.hasIdentityReference) ?? candidates.first else {
+      Log.info("No Firezone VPN configuration was found")
+      return nil
     }
 
     let missingProviderBundleIdentifier = selected.configuration.providerBundleIdentifier == nil

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -126,6 +126,7 @@ public final class VPNConfigurationManager {
   /// A candidate configuration and what we could learn about where it came from.
   private struct Candidate {
     let manager: any TunnelProviderManager
+    let configuration: NETunnelProviderProtocol
     let hasIdentityReference: Bool
     let isManaged: Bool
   }
@@ -153,8 +154,10 @@ public final class VPNConfigurationManager {
 
       let hasIdentityReference = configuration.identityReference != nil
 
+      // Captured before the repair below fills in the provider bundle identifier.
       return Candidate(
         manager: manager,
+        configuration: configuration,
         hasIdentityReference: hasIdentityReference,
         isManaged: configuration.providerBundleIdentifier == nil || hasIdentityReference
       )
@@ -177,17 +180,14 @@ public final class VPNConfigurationManager {
 
     // Some MDMs (for example Intune's built-in VPN payload) cannot set ProviderBundleIdentifier,
     // and the tunnel cannot start from a profile without it. Fill it in ourselves.
-    if selected.isManaged,
-      let configuration = selected.manager.protocolConfiguration as? NETunnelProviderProtocol,
-      configuration.providerBundleIdentifier == nil
-    {
+    if selected.configuration.providerBundleIdentifier == nil {
       Log.warning(
         "The managed VPN profile has no ProviderBundleIdentifier; "
           + "setting it to \(selected.manager.extensionBundleIdentifier)"
       )
 
-      configuration.providerBundleIdentifier = selected.manager.extensionBundleIdentifier
-      selected.manager.protocolConfiguration = configuration
+      selected.configuration.providerBundleIdentifier = selected.manager.extensionBundleIdentifier
+      selected.manager.protocolConfiguration = selected.configuration
 
       try await selected.manager.saveToPreferences()
       try await selected.manager.loadFromPreferences()

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/VPNConfigurationManagerTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/VPNConfigurationManagerTests.swift
@@ -83,15 +83,20 @@ struct VPNConfigurationManagerTests {
     #expect(try manager.identityReference() == reference)
   }
 
-  @Test("A profile without a provider bundle identifier is managed")
+  @Test("A profile without a provider bundle identifier is managed and repaired")
   @MainActor
   func profileWithoutProviderBundleIdentifierIsManaged() async throws {
-    let factory = StubFactory([StubTunnelProviderManager(providerBundleIdentifier: nil)])
+    let stub = StubTunnelProviderManager(providerBundleIdentifier: nil)
+    let factory = StubFactory([stub])
 
     let manager = try #require(
       await VPNConfigurationManager.load(using: factory))
 
     #expect(manager.isManaged)
+    #expect(stub.saveCount == 1)
+    #expect(
+      (stub.protocolConfiguration as? NETunnelProviderProtocol)?.providerBundleIdentifier
+        == providerBundleIdentifier)
   }
 
   @Test("Configurations for another extension are ignored")


### PR DESCRIPTION
Some MDMs, for example Intune's built-in VPN payload, cannot set `ProviderBundleIdentifier` on the VPN profile they push. The macOS client found such a profile, logged a warning, and then tried to start the tunnel from it anyway. macOS could not find the provider for the profile and showed "The VPN app used by the VPN configuration is not installed" at every launch.

The client now writes its own extension identifier into the managed profile and saves it, then starts the tunnel as usual. Everything else in the profile, including the client certificate reference, stays as the administrator wrote it.

Fixes: #15009 
Related: #14742
