### PR TITLE
fix(apple): offer the extension install from the menu bar

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBarView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBarView.swift
@@ -63,6 +63,12 @@
         Text("Loading VPN configurations from system settings…")
           .foregroundStyle(.secondary)
 
+      case .disconnected where store.systemExtensionStatus == .needsInstall:
+        // An MDM profile can hand us a configuration before the extension exists.
+        Button("Enable the system extension to sign in…") {
+          installSystemExtension()
+        }
+
       case .disconnected where store.systemExtensionStatus == .needsReboot:
         // Signing in would run against whichever version the system still has.
         Text("Restart your Mac to finish updating Firezone…")
@@ -108,6 +114,17 @@
       Task {
         do {
           try await store.signOut()
+        } catch {
+          Log.error(error)
+          MacOSAlert.show(for: error)
+        }
+      }
+    }
+
+    func installSystemExtension() {
+      Task {
+        do {
+          try await store.installSystemExtension()
         } catch {
           Log.error(error)
           MacOSAlert.show(for: error)


### PR DESCRIPTION
Fixes a regression where if the macOS system extension needs install, the menu item was not displaying this status, instead showing `Sign in` which would lead to the same alert screen that #15010 hits.

Fixes that by changing the menu item in this state so that it's not possible to initiate a sign in unless the system extension is installed.

Related: #14742
Related: #15010
