### PR TITLE
feat(portal): show the trust shield on an online attested device

### DIFF
--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -1789,9 +1789,12 @@ defmodule PortalWeb.CoreComponents do
     <.status_badge style={:warning}>Degraded</.status_badge>
     <.status_badge style={:danger}>Disabled</.status_badge>
     <.status_badge style={:success} dot={false}>Active</.status_badge>
+    <.status_badge style={:success} icon="ri-shield-keyhole-line">Online</.status_badge>
   """
   attr :style, :atom, required: true, values: [:success, :warning, :danger, :neutral]
   attr :dot, :boolean, default: true
+  attr :icon, :string, default: nil, doc: "replaces the dot"
+  attr :icon_title, :string, default: nil
   slot :inner_block, required: true
 
   def status_badge(assigns) do
@@ -1800,7 +1803,12 @@ defmodule PortalWeb.CoreComponents do
       "inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] font-medium",
       badge_pill_class(@style)
     ]}>
-      <span :if={@dot} class={["w-1.5 h-1.5 rounded-full shrink-0", badge_dot_class(@style)]}></span>
+      <.icon :if={@icon} name={@icon} title={@icon_title} class="w-3 h-3 shrink-0" />
+      <span
+        :if={@dot and is_nil(@icon)}
+        class={["w-1.5 h-1.5 rounded-full shrink-0", badge_dot_class(@style)]}
+      >
+      </span>
       {render_slot(@inner_block)}
     </span>
     """

--- a/elixir/lib/portal_web/live/devices.ex
+++ b/elixir/lib/portal_web/live/devices.ex
@@ -199,7 +199,7 @@ defmodule PortalWeb.Devices do
             />
           </:col>
           <:col :let={device} label="Status" class="w-28">
-            <.device_status_badge online?={device.online?} />
+            <.device_status_badge device={device} />
           </:col>
           <:col
             :let={device}

--- a/elixir/lib/portal_web/live/devices/components.ex
+++ b/elixir/lib/portal_web/live/devices/components.ex
@@ -557,7 +557,6 @@ defmodule PortalWeb.Devices.Components do
           <div class="flex items-center gap-2">
             <h2 class="text-sm font-semibold text-heading truncate">{@device.name}</h2>
             <.device_status_badge device={@device} />
-            <.device_verified_badge device={@device} />
           </div>
           <p class="font-mono text-xs text-subtle mt-0.5 truncate">{@device.id}</p>
         </div>

--- a/elixir/lib/portal_web/live/devices/components.ex
+++ b/elixir/lib/portal_web/live/devices/components.ex
@@ -556,7 +556,7 @@ defmodule PortalWeb.Devices.Components do
         <div class="min-w-0 flex-1">
           <div class="flex items-center gap-2">
             <h2 class="text-sm font-semibold text-heading truncate">{@device.name}</h2>
-            <.device_status_badge online?={@device.online?} />
+            <.device_status_badge device={@device} />
             <.device_verified_badge device={@device} />
           </div>
           <p class="font-mono text-xs text-subtle mt-0.5 truncate">{@device.id}</p>
@@ -1272,11 +1272,21 @@ defmodule PortalWeb.Devices.Components do
     """
   end
 
-  attr :online?, :boolean, required: true
+  attr :device, :any, required: true
+  attr :online?, :boolean, default: nil, doc: "overrides device.online?"
 
   def device_status_badge(assigns) do
+    online? = if is_nil(assigns.online?), do: assigns.device.online?, else: assigns.online?
+    attested = online? and not is_nil(assigns.device.last_attested_at)
+
+    assigns = assign(assigns, online?: online?, attested: attested)
+
     ~H"""
-    <.status_badge style={if @online?, do: :success, else: :neutral}>
+    <.status_badge
+      style={if @online?, do: :success, else: :neutral}
+      icon={if @attested, do: "ri-shield-keyhole-line"}
+      icon_title={if @attested, do: "Attested"}
+    >
       {if @online?, do: "Online", else: "Offline"}
     </.status_badge>
     """

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1227,7 +1227,10 @@ defmodule PortalWeb.Resources.Components do
                   </.copy>
                 </td>
                 <td class="px-4 py-2">
-                  <.device_status_badge online?={MapSet.member?(@online_device_ids, device.id)} />
+                  <.device_status_badge
+                    device={device}
+                    online?={MapSet.member?(@online_device_ids, device.id)}
+                  />
                 </td>
                 <td class="px-4 py-2 text-subtle">
                   <.icon

--- a/elixir/test/portal_web/live/devices_test.exs
+++ b/elixir/test/portal_web/live/devices_test.exs
@@ -192,6 +192,36 @@ defmodule PortalWeb.DevicesTest do
     end
   end
 
+  describe "status badge" do
+    test "shows the device trust shield on an online attested device", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      attested =
+        client_fixture(account: account, actor: actor, last_attested_at: DateTime.utc_now())
+
+      plain = client_fixture(account: account, actor: actor)
+
+      offline =
+        client_fixture(account: account, actor: actor, last_attested_at: DateTime.utc_now())
+
+      :ok = Portal.Presence.Clients.Account.track(account.id, attested.id)
+      :ok = Portal.Presence.Clients.Account.track(account.id, plain.id)
+
+      conn = authorize_conn(conn, actor)
+      {:ok, lv, _html} = live(conn, ~p"/#{account}/devices")
+
+      assert has_element?(lv, "#device-#{attested.id} [title='Attested'].ri-shield-keyhole-line")
+      refute has_element?(lv, "#device-#{plain.id} [title='Attested']")
+      refute has_element?(lv, "#device-#{offline.id} [title='Attested']")
+
+      {:ok, lv, _html} = live(conn, ~p"/#{account}/devices/#{attested.id}")
+
+      assert has_element?(lv, "#device-panel [title='Attested'].ri-shield-keyhole-line")
+    end
+  end
+
   describe ":show action" do
     test "cautions that the device reports its own fields", %{
       conn: conn,


### PR DESCRIPTION
The Online badge for a client device shows a green dot. When the device attested through an X.509 certificate, the dot is now the device trust shield instead. An admin can see at a glance which online devices proved their identity.

This applies to the Devices table, the device panel, and the device pool member list on a resource. Offline devices and devices that did not attest look the same as before.
