### PR TITLE
fix(portal): unmap IPv4-mapped IPv6 remote addresses

### DIFF
--- a/elixir/lib/portal/authentication/context.ex
+++ b/elixir/lib/portal/authentication/context.ex
@@ -27,6 +27,7 @@ defmodule Portal.Authentication.Context do
   alias Portal.Geo
 
   def build(remote_ip, user_agent, headers, type) do
+    remote_ip = Portal.Types.IP.unmap(remote_ip)
     {region, city, {lat, lon}} = Geo.locate(remote_ip, headers)
 
     %__MODULE__{

--- a/elixir/lib/portal/endpoint.ex
+++ b/elixir/lib/portal/endpoint.ex
@@ -29,10 +29,13 @@ defmodule Portal.Endpoint do
   # they are dropped with the rest. Everything behind this endpoint reads the
   # connection and does not look at these headers again.
   def apply_forwarded_headers(%Plug.Conn{} = conn, _opts) do
+    conn = %{conn | remote_ip: Portal.Types.IP.unmap(conn.remote_ip)}
+
     if from_trusted_proxy?(conn) do
       conn
       |> Plug.RewriteOn.call(@rewrite_on)
       |> RemoteIp.call(@remote_ip)
+      |> then(&%{&1 | remote_ip: Portal.Types.IP.unmap(&1.remote_ip)})
     else
       Enum.reduce(@proxy_headers, conn, &Plug.Conn.delete_req_header(&2, &1))
     end

--- a/elixir/lib/portal/types/ip.ex
+++ b/elixir/lib/portal/types/ip.ex
@@ -44,4 +44,11 @@ defmodule Portal.Types.IP do
 
   def to_string(ip) when is_binary(ip), do: ip
   def to_string(%Postgrex.INET{} = inet), do: Portal.Types.INET.to_string(inet)
+
+  # A dual-stack listener reports IPv4 peers as ::ffff:a.b.c.d.
+  def unmap({0, 0, 0, 0, 0, 0xFFFF, w, x}) do
+    {Bitwise.bsr(w, 8), Bitwise.band(w, 0xFF), Bitwise.bsr(x, 8), Bitwise.band(x, 0xFF)}
+  end
+
+  def unmap(address), do: address
 end

--- a/elixir/test/portal/authentication/context_test.exs
+++ b/elixir/test/portal/authentication/context_test.exs
@@ -1,0 +1,11 @@
+defmodule Portal.Authentication.ContextTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Authentication.Context
+
+  test "build/4 stores an IPv4-mapped IPv6 address as IPv4" do
+    context = Context.build({0, 0, 0, 0, 0, 0xFFFF, 0x6BC5, 0x6844}, "testing", [], :client)
+
+    assert context.remote_ip == {107, 197, 104, 68}
+  end
+end

--- a/elixir/test/portal/endpoint_test.exs
+++ b/elixir/test/portal/endpoint_test.exs
@@ -123,6 +123,19 @@ defmodule Portal.EndpointTest do
       assert conn.remote_ip == {203, 0, 113, 5}
     end
 
+    test "reports an IPv4 peer on a dual-stack listener as IPv4" do
+      trust_proxy({127, 0, 0, 1})
+
+      conn =
+        :get
+        |> conn("http://unknown.firezone.test/")
+        |> Map.put(:remote_ip, {0, 0, 0, 0, 0, 0xFFFF, 0x7F00, 0x0001})
+        |> put_req_header("x-forwarded-for", "::ffff:107.197.104.68:53859")
+        |> Endpoint.call([])
+
+      assert conn.remote_ip == {107, 197, 104, 68}
+    end
+
     test "ignores forwarded headers on a request that skipped the proxy" do
       trust_proxy({10, 0, 0, 1})
 

--- a/elixir/test/portal/types/ip_test.exs
+++ b/elixir/test/portal/types/ip_test.exs
@@ -1,0 +1,17 @@
+defmodule Portal.Types.IPTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Types.IP
+
+  describe "unmap/1" do
+    test "converts an IPv4-mapped IPv6 address to IPv4" do
+      assert IP.unmap({0, 0, 0, 0, 0, 0xFFFF, 0x6BC5, 0x6844}) == {107, 197, 104, 68}
+    end
+
+    test "leaves other addresses unchanged" do
+      assert IP.unmap({107, 197, 104, 68}) == {107, 197, 104, 68}
+      assert IP.unmap({0x2601, 0, 0, 0, 0, 0, 0, 1}) == {0x2601, 0, 0, 0, 0, 0, 0, 1}
+      assert IP.unmap(nil) == nil
+    end
+  end
+end


### PR DESCRIPTION
The portal listens on a dual-stack socket. IPv4 clients arrived as IPv4-mapped IPv6 addresses, for example `::ffff:107.197.104.68`. That value was stored and shown as the remote IP on devices, sessions and sites. It also did not match IPv4 trusted-proxy blocks.

The portal now converts a mapped address to plain IPv4 at the endpoint and when it builds the auth context. Rows that already hold the mapped form are updated on the next connection.
