### PR TITLE
fix(portal): align OpenAPI spec with REST API responses

### DIFF
--- a/elixir/lib/portal_api/controllers/account_json.ex
+++ b/elixir/lib/portal_api/controllers/account_json.ex
@@ -1,4 +1,28 @@
 defmodule PortalAPI.AccountJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Account,
+    schema: PortalAPI.Schemas.Account.Schema,
+    computed: [:limits],
+    # ingest_signing_key is credential material and must never leave the portal.
+    internal: [
+      :admins_limit_exceeded,
+      :config,
+      :disabled_reason,
+      :features,
+      :ingest_signing_key,
+      :inserted_at,
+      :is_disabled,
+      :lock_enabled_at,
+      :metadata,
+      :scheduled_deletion_at,
+      :seats_limit_exceeded,
+      :service_accounts_limit_exceeded,
+      :sites_limit_exceeded,
+      :updated_at,
+      :users_limit_exceeded,
+      :warning_last_sent_at
+    ]
+
   alias __MODULE__.Database
 
   @doc """
@@ -9,14 +33,7 @@ defmodule PortalAPI.AccountJSON do
   end
 
   defp data(%Portal.Account{} = account) do
-    %{
-      id: account.id,
-      slug: account.slug,
-      key: account.key,
-      name: account.name,
-      legal_name: account.legal_name,
-      limits: build_limits(account)
-    }
+    render_fields(account, %{limits: build_limits(account)})
   end
 
   defp build_limits(account) do

--- a/elixir/lib/portal_api/controllers/account_json.ex
+++ b/elixir/lib/portal_api/controllers/account_json.ex
@@ -1,7 +1,5 @@
 defmodule PortalAPI.AccountJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Account,
-    schema: PortalAPI.Schemas.Account.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Account, PortalAPI.Schemas.Account.Schema,
     computed: [:limits],
     # ingest_signing_key is credential material and must never leave the portal.
     internal: [
@@ -22,6 +20,7 @@ defmodule PortalAPI.AccountJSON do
       :users_limit_exceeded,
       :warning_last_sent_at
     ]
+  )
 
   alias __MODULE__.Database
 
@@ -33,7 +32,7 @@ defmodule PortalAPI.AccountJSON do
   end
 
   defp data(%Portal.Account{} = account) do
-    render_fields(account, %{limits: build_limits(account)})
+    PortalAPI.JSON.render(account, PortalAPI.Schemas.Account.Schema, %{limits: build_limits(account)})
   end
 
   defp build_limits(account) do

--- a/elixir/lib/portal_api/controllers/actor_json.ex
+++ b/elixir/lib/portal_api/controllers/actor_json.ex
@@ -1,8 +1,7 @@
 defmodule PortalAPI.ActorJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Actor,
-    schema: PortalAPI.Schemas.Actor.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Actor, PortalAPI.Schemas.Actor.Schema,
     internal: [:account_id, :identity_count, :password_hash, :preferences]
+  )
 
   alias PortalAPI.Pagination
   alias Portal.Actor
@@ -24,5 +23,5 @@ defmodule PortalAPI.ActorJSON do
     %{data: data(actor)}
   end
 
-  defp data(%Actor{} = actor), do: render_fields(actor)
+  defp data(%Actor{} = actor), do: PortalAPI.JSON.render(actor, PortalAPI.Schemas.Actor.Schema)
 end

--- a/elixir/lib/portal_api/controllers/actor_json.ex
+++ b/elixir/lib/portal_api/controllers/actor_json.ex
@@ -1,4 +1,9 @@
 defmodule PortalAPI.ActorJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Actor,
+    schema: PortalAPI.Schemas.Actor.Schema,
+    internal: [:account_id, :identity_count, :password_hash, :preferences]
+
   alias PortalAPI.Pagination
   alias Portal.Actor
 
@@ -19,18 +24,5 @@ defmodule PortalAPI.ActorJSON do
     %{data: data(actor)}
   end
 
-  defp data(%Actor{} = actor) do
-    %{
-      id: actor.id,
-      name: actor.name,
-      type: actor.type,
-      email: actor.email,
-      allow_email_otp_sign_in: actor.allow_email_otp_sign_in,
-      is_disabled: actor.is_disabled,
-      last_seen_at: actor.last_seen_at,
-      created_by_directory_id: actor.created_by_directory_id,
-      inserted_at: actor.inserted_at,
-      updated_at: actor.updated_at
-    }
-  end
+  defp data(%Actor{} = actor), do: render_fields(actor)
 end

--- a/elixir/lib/portal_api/controllers/client_json.ex
+++ b/elixir/lib/portal_api/controllers/client_json.ex
@@ -1,4 +1,22 @@
 defmodule PortalAPI.ClientJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Device,
+    schema: PortalAPI.Schemas.Client.GetSchema,
+    aliases: [online: :online?, created_at: :inserted_at],
+    # psk_base is key material and must never leave the portal.
+    internal: [
+      :account_id,
+      :attested?,
+      :client_token_id,
+      :firezone_id_merged?,
+      :gateway_token_id,
+      :gateway_token_rotated_at,
+      :last_attested_cert_issuer,
+      :psk_base,
+      :site_id,
+      :type
+    ]
+
   alias PortalAPI.Pagination
   alias Portal.Device
 
@@ -19,38 +37,5 @@ defmodule PortalAPI.ClientJSON do
     %{data: data(client)}
   end
 
-  defp data(%Device{} = device) do
-    %{
-      id: device.id,
-      firezone_id: device.firezone_id,
-      actor_id: device.actor_id,
-      name: device.name,
-      ipv4: device.ipv4,
-      ipv6: device.ipv6,
-      online: device.online?,
-      device_serial: device.device_serial,
-      device_uuid: device.device_uuid,
-      identifier_for_vendor: device.identifier_for_vendor,
-      firebase_installation_id: device.firebase_installation_id,
-      hostname: device.hostname,
-      last_attested_device_serial: device.last_attested_device_serial,
-      last_attested_device_uuid: device.last_attested_device_uuid,
-      last_attested_mdm_device_id: device.last_attested_mdm_device_id,
-      last_attested_cert_serial: device.last_attested_cert_serial,
-      last_attested_cert_fingerprint: device.last_attested_cert_fingerprint,
-      last_attested_at: device.last_attested_at,
-      verified_at: device.verified_at,
-      public_key: device.public_key,
-      last_seen_at: device.last_seen_at,
-      last_seen_version: device.last_seen_version,
-      last_seen_user_agent: device.last_seen_user_agent,
-      last_seen_remote_ip: device.last_seen_remote_ip,
-      last_seen_remote_ip_location_region: device.last_seen_remote_ip_location_region,
-      last_seen_remote_ip_location_city: device.last_seen_remote_ip_location_city,
-      last_seen_remote_ip_location_lat: device.last_seen_remote_ip_location_lat,
-      last_seen_remote_ip_location_lon: device.last_seen_remote_ip_location_lon,
-      created_at: device.inserted_at,
-      updated_at: device.updated_at
-    }
-  end
+  defp data(%Device{} = device), do: render_fields(device)
 end

--- a/elixir/lib/portal_api/controllers/client_json.ex
+++ b/elixir/lib/portal_api/controllers/client_json.ex
@@ -1,10 +1,10 @@
 defmodule PortalAPI.ClientJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Device,
-    schema: PortalAPI.Schemas.Client.GetSchema,
-    aliases: [online: :online?, created_at: :inserted_at],
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Device, PortalAPI.Schemas.Client.GetSchema,
+    computed: [:online, :created_at],
     # psk_base is key material and must never leave the portal.
     internal: [
+      :inserted_at,
+      :online?,
       :account_id,
       :attested?,
       :client_token_id,
@@ -16,6 +16,7 @@ defmodule PortalAPI.ClientJSON do
       :site_id,
       :type
     ]
+  )
 
   alias PortalAPI.Pagination
   alias Portal.Device
@@ -37,5 +38,10 @@ defmodule PortalAPI.ClientJSON do
     %{data: data(client)}
   end
 
-  defp data(%Device{} = device), do: render_fields(device)
+  defp data(%Device{} = device) do
+    PortalAPI.JSON.render(device, PortalAPI.Schemas.Client.GetSchema, %{
+      online: device.online?,
+      created_at: device.inserted_at
+    })
+  end
 end

--- a/elixir/lib/portal_api/controllers/client_token_json.ex
+++ b/elixir/lib/portal_api/controllers/client_token_json.ex
@@ -1,7 +1,5 @@
 defmodule PortalAPI.ClientTokenJSON do
-  use PortalAPI.JSON,
-    struct: Portal.ClientToken,
-    schema: PortalAPI.Schemas.ClientToken.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.ClientToken, PortalAPI.Schemas.ClientToken.Schema,
     # secret_* fields are credential material and must never leave the portal.
     internal: [
       :account_id,
@@ -15,6 +13,7 @@ defmodule PortalAPI.ClientTokenJSON do
       :secret_nonce,
       :secret_salt
     ]
+  )
 
   alias PortalAPI.Pagination
 
@@ -55,5 +54,5 @@ defmodule PortalAPI.ClientTokenJSON do
     }
   end
 
-  defp data(%Portal.ClientToken{} = token), do: render_fields(token)
+  defp data(%Portal.ClientToken{} = token), do: PortalAPI.JSON.render(token, PortalAPI.Schemas.ClientToken.Schema)
 end

--- a/elixir/lib/portal_api/controllers/client_token_json.ex
+++ b/elixir/lib/portal_api/controllers/client_token_json.ex
@@ -1,4 +1,21 @@
 defmodule PortalAPI.ClientTokenJSON do
+  use PortalAPI.JSON,
+    struct: Portal.ClientToken,
+    schema: PortalAPI.Schemas.ClientToken.Schema,
+    # secret_* fields are credential material and must never leave the portal.
+    internal: [
+      :account_id,
+      :auth_provider_id,
+      :auth_provider_name,
+      :auth_provider_type,
+      :last_used_device,
+      :online?,
+      :secret_fragment,
+      :secret_hash,
+      :secret_nonce,
+      :secret_salt
+    ]
+
   alias PortalAPI.Pagination
 
   def index(%{tokens: tokens, metadata: metadata}) do
@@ -38,13 +55,5 @@ defmodule PortalAPI.ClientTokenJSON do
     }
   end
 
-  defp data(token) do
-    %{
-      id: token.id,
-      actor_id: token.actor_id,
-      expires_at: token.expires_at,
-      inserted_at: token.inserted_at,
-      updated_at: token.updated_at
-    }
-  end
+  defp data(%Portal.ClientToken{} = token), do: render_fields(token)
 end

--- a/elixir/lib/portal_api/controllers/defender_device_json.ex
+++ b/elixir/lib/portal_api/controllers/defender_device_json.ex
@@ -1,7 +1,6 @@
 defmodule PortalAPI.DefenderDeviceJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Defender.Device,
-    schema: PortalAPI.Schemas.DefenderDevice.Schema
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Defender.Device, PortalAPI.Schemas.DefenderDevice.Schema
+  )
 
   alias Portal.Defender
   alias PortalAPI.Pagination
@@ -12,5 +11,5 @@ defmodule PortalAPI.DefenderDeviceJSON do
 
   def show(%{device: device}), do: %{data: data(device)}
 
-  defp data(%Defender.Device{} = device), do: render_fields(device)
+  defp data(%Defender.Device{} = device), do: PortalAPI.JSON.render(device, PortalAPI.Schemas.DefenderDevice.Schema)
 end

--- a/elixir/lib/portal_api/controllers/defender_device_json.ex
+++ b/elixir/lib/portal_api/controllers/defender_device_json.ex
@@ -1,8 +1,10 @@
 defmodule PortalAPI.DefenderDeviceJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Defender.Device,
+    schema: PortalAPI.Schemas.DefenderDevice.Schema
+
   alias Portal.Defender
   alias PortalAPI.Pagination
-
-  @fields Defender.Device.__schema__(:fields)
 
   def index(%{devices: devices, metadata: metadata}) do
     %{data: Enum.map(devices, &data/1), metadata: Pagination.metadata(metadata)}
@@ -10,5 +12,5 @@ defmodule PortalAPI.DefenderDeviceJSON do
 
   def show(%{device: device}), do: %{data: data(device)}
 
-  defp data(%Defender.Device{} = device), do: Map.take(device, @fields)
+  defp data(%Defender.Device{} = device), do: render_fields(device)
 end

--- a/elixir/lib/portal_api/controllers/defender_posture_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/defender_posture_provider_json.ex
@@ -1,9 +1,13 @@
 defmodule PortalAPI.DefenderPostureProviderJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Defender.PostureProvider,
+    schema: PortalAPI.Schemas.DefenderPostureProvider.Schema,
+    computed: [:type, :name],
+    # error_email_count is notification bookkeeping, not part of the public shape.
+    internal: [:error_email_count]
+
   alias Portal.Defender
   alias PortalAPI.Pagination
-
-  # error_email_count is notification bookkeeping, not part of the public shape.
-  @fields Defender.PostureProvider.__schema__(:fields) -- [:error_email_count]
 
   def index(%{providers: providers, metadata: metadata}) do
     %{data: Enum.map(providers, &data/1), metadata: Pagination.metadata(metadata)}
@@ -11,10 +15,7 @@ defmodule PortalAPI.DefenderPostureProviderJSON do
 
   def show(%{provider: provider}), do: %{data: data(provider)}
 
-  defp data(%Defender.PostureProvider{} = provider),
-    do:
-      provider
-      |> Map.take(@fields)
-      |> Map.put(:type, "defender")
-      |> Map.put(:name, provider.posture_provider.name)
+  defp data(%Defender.PostureProvider{} = provider) do
+    render_fields(provider, %{type: "defender", name: provider.posture_provider.name})
+  end
 end

--- a/elixir/lib/portal_api/controllers/defender_posture_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/defender_posture_provider_json.ex
@@ -1,10 +1,9 @@
 defmodule PortalAPI.DefenderPostureProviderJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Defender.PostureProvider,
-    schema: PortalAPI.Schemas.DefenderPostureProvider.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Defender.PostureProvider, PortalAPI.Schemas.DefenderPostureProvider.Schema,
     computed: [:type, :name],
     # error_email_count is notification bookkeeping, not part of the public shape.
     internal: [:error_email_count]
+  )
 
   alias Portal.Defender
   alias PortalAPI.Pagination
@@ -16,6 +15,6 @@ defmodule PortalAPI.DefenderPostureProviderJSON do
   def show(%{provider: provider}), do: %{data: data(provider)}
 
   defp data(%Defender.PostureProvider{} = provider) do
-    render_fields(provider, %{type: "defender", name: provider.posture_provider.name})
+    PortalAPI.JSON.render(provider, PortalAPI.Schemas.DefenderPostureProvider.Schema, %{type: "defender", name: provider.posture_provider.name})
   end
 end

--- a/elixir/lib/portal_api/controllers/email_otp_auth_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/email_otp_auth_provider_json.ex
@@ -1,7 +1,6 @@
 defmodule PortalAPI.EmailOTPAuthProviderJSON do
-  use PortalAPI.JSON,
-    struct: Portal.EmailOTP.AuthProvider,
-    schema: PortalAPI.Schemas.EmailOTPAuthProvider.Schema
+  PortalAPI.JSON.verify!(__MODULE__, Portal.EmailOTP.AuthProvider, PortalAPI.Schemas.EmailOTPAuthProvider.Schema
+  )
 
   alias Portal.EmailOTP
   alias PortalAPI.Pagination
@@ -14,5 +13,5 @@ defmodule PortalAPI.EmailOTPAuthProviderJSON do
     %{data: data(provider)}
   end
 
-  defp data(%EmailOTP.AuthProvider{} = provider), do: render_fields(provider)
+  defp data(%EmailOTP.AuthProvider{} = provider), do: PortalAPI.JSON.render(provider, PortalAPI.Schemas.EmailOTPAuthProvider.Schema)
 end

--- a/elixir/lib/portal_api/controllers/email_otp_auth_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/email_otp_auth_provider_json.ex
@@ -1,4 +1,8 @@
 defmodule PortalAPI.EmailOTPAuthProviderJSON do
+  use PortalAPI.JSON,
+    struct: Portal.EmailOTP.AuthProvider,
+    schema: PortalAPI.Schemas.EmailOTPAuthProvider.Schema
+
   alias Portal.EmailOTP
   alias PortalAPI.Pagination
 
@@ -10,18 +14,5 @@ defmodule PortalAPI.EmailOTPAuthProviderJSON do
     %{data: data(provider)}
   end
 
-  defp data(%EmailOTP.AuthProvider{} = provider) do
-    %{
-      id: provider.id,
-      account_id: provider.account_id,
-      name: provider.name,
-      issuer: provider.issuer,
-      context: provider.context,
-      client_session_lifetime_secs: provider.client_session_lifetime_secs,
-      portal_session_lifetime_secs: provider.portal_session_lifetime_secs,
-      is_disabled: provider.is_disabled,
-      inserted_at: provider.inserted_at,
-      updated_at: provider.updated_at
-    }
-  end
+  defp data(%EmailOTP.AuthProvider{} = provider), do: render_fields(provider)
 end

--- a/elixir/lib/portal_api/controllers/entra_auth_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/entra_auth_provider_json.ex
@@ -1,8 +1,7 @@
 defmodule PortalAPI.EntraAuthProviderJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Entra.AuthProvider,
-    schema: PortalAPI.Schemas.EntraAuthProvider.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Entra.AuthProvider, PortalAPI.Schemas.EntraAuthProvider.Schema,
     internal: [:is_verified]
+  )
 
   alias Portal.Entra
   alias PortalAPI.Pagination
@@ -15,5 +14,5 @@ defmodule PortalAPI.EntraAuthProviderJSON do
     %{data: data(provider)}
   end
 
-  defp data(%Entra.AuthProvider{} = provider), do: render_fields(provider)
+  defp data(%Entra.AuthProvider{} = provider), do: PortalAPI.JSON.render(provider, PortalAPI.Schemas.EntraAuthProvider.Schema)
 end

--- a/elixir/lib/portal_api/controllers/entra_auth_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/entra_auth_provider_json.ex
@@ -1,4 +1,9 @@
 defmodule PortalAPI.EntraAuthProviderJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Entra.AuthProvider,
+    schema: PortalAPI.Schemas.EntraAuthProvider.Schema,
+    internal: [:is_verified]
+
   alias Portal.Entra
   alias PortalAPI.Pagination
 
@@ -10,20 +15,5 @@ defmodule PortalAPI.EntraAuthProviderJSON do
     %{data: data(provider)}
   end
 
-  defp data(%Entra.AuthProvider{} = provider) do
-    %{
-      id: provider.id,
-      account_id: provider.account_id,
-      name: provider.name,
-      issuer: provider.issuer,
-      context: provider.context,
-      client_session_lifetime_secs: provider.client_session_lifetime_secs,
-      portal_session_lifetime_secs: provider.portal_session_lifetime_secs,
-      email_claim: provider.email_claim,
-      is_disabled: provider.is_disabled,
-      is_default: provider.is_default,
-      inserted_at: provider.inserted_at,
-      updated_at: provider.updated_at
-    }
-  end
+  defp data(%Entra.AuthProvider{} = provider), do: render_fields(provider)
 end

--- a/elixir/lib/portal_api/controllers/entra_directory_json.ex
+++ b/elixir/lib/portal_api/controllers/entra_directory_json.ex
@@ -1,4 +1,9 @@
 defmodule PortalAPI.EntraDirectoryJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Entra.Directory,
+    schema: PortalAPI.Schemas.EntraDirectory.Schema,
+    internal: [:error_email_count, :is_verified]
+
   alias Portal.Entra
   alias PortalAPI.Pagination
 
@@ -10,22 +15,5 @@ defmodule PortalAPI.EntraDirectoryJSON do
     %{data: data(directory)}
   end
 
-  defp data(%Entra.Directory{} = directory) do
-    %{
-      id: directory.id,
-      account_id: directory.account_id,
-      name: directory.name,
-      tenant_id: directory.tenant_id,
-      error_email_count: directory.error_email_count,
-      is_disabled: directory.is_disabled,
-      disabled_reason: directory.disabled_reason,
-      synced_at: directory.synced_at,
-      error_message: directory.error_message,
-      errored_at: directory.errored_at,
-      email_field: directory.email_field,
-      sync_all_groups: directory.sync_all_groups,
-      inserted_at: directory.inserted_at,
-      updated_at: directory.updated_at
-    }
-  end
+  defp data(%Entra.Directory{} = directory), do: render_fields(directory)
 end

--- a/elixir/lib/portal_api/controllers/entra_directory_json.ex
+++ b/elixir/lib/portal_api/controllers/entra_directory_json.ex
@@ -1,8 +1,7 @@
 defmodule PortalAPI.EntraDirectoryJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Entra.Directory,
-    schema: PortalAPI.Schemas.EntraDirectory.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Entra.Directory, PortalAPI.Schemas.EntraDirectory.Schema,
     internal: [:error_email_count, :is_verified]
+  )
 
   alias Portal.Entra
   alias PortalAPI.Pagination
@@ -15,5 +14,5 @@ defmodule PortalAPI.EntraDirectoryJSON do
     %{data: data(directory)}
   end
 
-  defp data(%Entra.Directory{} = directory), do: render_fields(directory)
+  defp data(%Entra.Directory{} = directory), do: PortalAPI.JSON.render(directory, PortalAPI.Schemas.EntraDirectory.Schema)
 end

--- a/elixir/lib/portal_api/controllers/external_identity_json.ex
+++ b/elixir/lib/portal_api/controllers/external_identity_json.ex
@@ -1,4 +1,13 @@
 defmodule PortalAPI.ExternalIdentityJSON do
+  use PortalAPI.JSON,
+    struct: Portal.ExternalIdentity,
+    schema: PortalAPI.Schemas.ExternalIdentity.Schema,
+    computed: [:email, :idp_id, :synced_at],
+    internal: [
+      :directory_name,
+      :updated_at
+    ]
+
   alias PortalAPI.Pagination
   alias Portal.ExternalIdentity
 
@@ -20,26 +29,11 @@ defmodule PortalAPI.ExternalIdentityJSON do
   end
 
   defp data(%ExternalIdentity{} = external_identity) do
-    %{
-      id: external_identity.id,
-      actor_id: external_identity.actor_id,
-      account_id: external_identity.account_id,
-      issuer: external_identity.issuer,
-      directory_id: external_identity.directory_id,
+    render_fields(external_identity, %{
       email: external_identity.email || external_identity.idp_id,
       idp_id: extract_idp_id(external_identity.idp_id),
-      name: external_identity.name,
-      given_name: external_identity.given_name,
-      family_name: external_identity.family_name,
-      middle_name: external_identity.middle_name,
-      nickname: external_identity.nickname,
-      preferred_username: external_identity.preferred_username,
-      profile: external_identity.profile,
-      picture: external_identity.picture,
-      firezone_avatar_url: external_identity.firezone_avatar_url,
-      synced_at: synced_at_from_state(external_identity.sync_state),
-      inserted_at: external_identity.inserted_at
-    }
+      synced_at: synced_at_from_state(external_identity.sync_state)
+    })
   end
 
   defp synced_at_from_state(%Portal.ExternalIdentitySyncState{synced_at: t}), do: t

--- a/elixir/lib/portal_api/controllers/external_identity_json.ex
+++ b/elixir/lib/portal_api/controllers/external_identity_json.ex
@@ -1,12 +1,8 @@
 defmodule PortalAPI.ExternalIdentityJSON do
-  use PortalAPI.JSON,
-    struct: Portal.ExternalIdentity,
-    schema: PortalAPI.Schemas.ExternalIdentity.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.ExternalIdentity, PortalAPI.Schemas.ExternalIdentity.Schema,
     computed: [:email, :idp_id, :synced_at],
-    internal: [
-      :directory_name,
-      :updated_at
-    ]
+    internal: [:directory_name, :updated_at]
+  )
 
   alias PortalAPI.Pagination
   alias Portal.ExternalIdentity
@@ -29,7 +25,7 @@ defmodule PortalAPI.ExternalIdentityJSON do
   end
 
   defp data(%ExternalIdentity{} = external_identity) do
-    render_fields(external_identity, %{
+    PortalAPI.JSON.render(external_identity, PortalAPI.Schemas.ExternalIdentity.Schema, %{
       email: external_identity.email || external_identity.idp_id,
       idp_id: extract_idp_id(external_identity.idp_id),
       synced_at: synced_at_from_state(external_identity.sync_state)

--- a/elixir/lib/portal_api/controllers/gateway_json.ex
+++ b/elixir/lib/portal_api/controllers/gateway_json.ex
@@ -1,10 +1,10 @@
 defmodule PortalAPI.GatewayJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Device,
-    schema: PortalAPI.Schemas.Gateway.Schema,
-    aliases: [online: :online?, rotated_at: :gateway_token_rotated_at],
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Device, PortalAPI.Schemas.Gateway.Schema,
+    computed: [:online, :rotated_at],
     # psk_base is key material and must never leave the portal.
     internal: [
+      :gateway_token_rotated_at,
+      :online?,
       :account_id,
       :actor_id,
       :attested?,
@@ -30,6 +30,7 @@ defmodule PortalAPI.GatewayJSON do
       :updated_at,
       :verified_at
     ]
+  )
 
   alias PortalAPI.Pagination
   alias Portal.Device
@@ -58,5 +59,10 @@ defmodule PortalAPI.GatewayJSON do
     %{data: Map.put(data(gateway), :token, encoded_token)}
   end
 
-  defp data(%Device{} = device), do: render_fields(device)
+  defp data(%Device{} = device) do
+    PortalAPI.JSON.render(device, PortalAPI.Schemas.Gateway.Schema, %{
+      online: device.online?,
+      rotated_at: device.gateway_token_rotated_at
+    })
+  end
 end

--- a/elixir/lib/portal_api/controllers/gateway_json.ex
+++ b/elixir/lib/portal_api/controllers/gateway_json.ex
@@ -1,4 +1,36 @@
 defmodule PortalAPI.GatewayJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Device,
+    schema: PortalAPI.Schemas.Gateway.Schema,
+    aliases: [online: :online?, rotated_at: :gateway_token_rotated_at],
+    # psk_base is key material and must never leave the portal.
+    internal: [
+      :account_id,
+      :actor_id,
+      :attested?,
+      :client_token_id,
+      :device_serial,
+      :device_uuid,
+      :firebase_installation_id,
+      :firezone_id,
+      :firezone_id_merged?,
+      :hostname,
+      :identifier_for_vendor,
+      :inserted_at,
+      :last_attested_at,
+      :last_attested_cert_fingerprint,
+      :last_attested_cert_issuer,
+      :last_attested_cert_serial,
+      :last_attested_device_serial,
+      :last_attested_device_uuid,
+      :last_attested_mdm_device_id,
+      :psk_base,
+      :site_id,
+      :type,
+      :updated_at,
+      :verified_at
+    ]
+
   alias PortalAPI.Pagination
   alias Portal.Device
 
@@ -26,24 +58,5 @@ defmodule PortalAPI.GatewayJSON do
     %{data: Map.put(data(gateway), :token, encoded_token)}
   end
 
-  defp data(%Device{} = device) do
-    %{
-      id: device.id,
-      name: device.name,
-      ipv4: device.ipv4,
-      ipv6: device.ipv6,
-      online: device.online?,
-      public_key: device.public_key,
-      gateway_token_id: device.gateway_token_id,
-      rotated_at: device.gateway_token_rotated_at,
-      last_seen_at: device.last_seen_at,
-      last_seen_version: device.last_seen_version,
-      last_seen_user_agent: device.last_seen_user_agent,
-      last_seen_remote_ip: device.last_seen_remote_ip,
-      last_seen_remote_ip_location_region: device.last_seen_remote_ip_location_region,
-      last_seen_remote_ip_location_city: device.last_seen_remote_ip_location_city,
-      last_seen_remote_ip_location_lat: device.last_seen_remote_ip_location_lat,
-      last_seen_remote_ip_location_lon: device.last_seen_remote_ip_location_lon
-    }
-  end
+  defp data(%Device{} = device), do: render_fields(device)
 end

--- a/elixir/lib/portal_api/controllers/gateway_token_json.ex
+++ b/elixir/lib/portal_api/controllers/gateway_token_json.ex
@@ -1,11 +1,26 @@
 defmodule PortalAPI.GatewayTokenJSON do
+  use PortalAPI.JSON,
+    struct: Portal.GatewayToken,
+    schema: PortalAPI.Schemas.GatewayToken.Schema,
+    computed: [:token],
+    # secret_hash and secret_salt are credential material and must never leave
+    # the portal.
+    internal: [
+      :account_id,
+      :device_id,
+      :inserted_at,
+      :rotated_at,
+      :rotated_sibling_id,
+      :secret_fragment,
+      :secret_hash,
+      :secret_salt,
+      :site_id
+    ]
+
+  # `deleted/1` and `deleted_all/1` acknowledge a deletion rather than render a
+  # token, so they build their own payloads instead of using the schema.
   def show(%{token: token, encoded_token: encoded_token}) do
-    %{
-      data: %{
-        id: token.id,
-        token: encoded_token
-      }
-    }
+    %{data: render_fields(token, %{token: encoded_token})}
   end
 
   def deleted(%{token: token}) do

--- a/elixir/lib/portal_api/controllers/gateway_token_json.ex
+++ b/elixir/lib/portal_api/controllers/gateway_token_json.ex
@@ -1,7 +1,5 @@
 defmodule PortalAPI.GatewayTokenJSON do
-  use PortalAPI.JSON,
-    struct: Portal.GatewayToken,
-    schema: PortalAPI.Schemas.GatewayToken.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.GatewayToken, PortalAPI.Schemas.GatewayToken.Schema,
     computed: [:token],
     # secret_hash and secret_salt are credential material and must never leave
     # the portal.
@@ -16,11 +14,12 @@ defmodule PortalAPI.GatewayTokenJSON do
       :secret_salt,
       :site_id
     ]
+  )
 
   # `deleted/1` and `deleted_all/1` acknowledge a deletion rather than render a
   # token, so they build their own payloads instead of using the schema.
   def show(%{token: token, encoded_token: encoded_token}) do
-    %{data: render_fields(token, %{token: encoded_token})}
+    %{data: PortalAPI.JSON.render(token, PortalAPI.Schemas.GatewayToken.Schema, %{token: encoded_token})}
   end
 
   def deleted(%{token: token}) do

--- a/elixir/lib/portal_api/controllers/google_auth_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/google_auth_provider_json.ex
@@ -1,4 +1,9 @@
 defmodule PortalAPI.GoogleAuthProviderJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Google.AuthProvider,
+    schema: PortalAPI.Schemas.GoogleAuthProvider.Schema,
+    internal: [:is_verified]
+
   alias Portal.Google
   alias PortalAPI.Pagination
 
@@ -10,19 +15,5 @@ defmodule PortalAPI.GoogleAuthProviderJSON do
     %{data: data(provider)}
   end
 
-  defp data(%Google.AuthProvider{} = provider) do
-    %{
-      id: provider.id,
-      account_id: provider.account_id,
-      name: provider.name,
-      issuer: provider.issuer,
-      context: provider.context,
-      client_session_lifetime_secs: provider.client_session_lifetime_secs,
-      portal_session_lifetime_secs: provider.portal_session_lifetime_secs,
-      is_disabled: provider.is_disabled,
-      is_default: provider.is_default,
-      inserted_at: provider.inserted_at,
-      updated_at: provider.updated_at
-    }
-  end
+  defp data(%Google.AuthProvider{} = provider), do: render_fields(provider)
 end

--- a/elixir/lib/portal_api/controllers/google_auth_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/google_auth_provider_json.ex
@@ -1,8 +1,7 @@
 defmodule PortalAPI.GoogleAuthProviderJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Google.AuthProvider,
-    schema: PortalAPI.Schemas.GoogleAuthProvider.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Google.AuthProvider, PortalAPI.Schemas.GoogleAuthProvider.Schema,
     internal: [:is_verified]
+  )
 
   alias Portal.Google
   alias PortalAPI.Pagination
@@ -15,5 +14,5 @@ defmodule PortalAPI.GoogleAuthProviderJSON do
     %{data: data(provider)}
   end
 
-  defp data(%Google.AuthProvider{} = provider), do: render_fields(provider)
+  defp data(%Google.AuthProvider{} = provider), do: PortalAPI.JSON.render(provider, PortalAPI.Schemas.GoogleAuthProvider.Schema)
 end

--- a/elixir/lib/portal_api/controllers/google_directory_json.ex
+++ b/elixir/lib/portal_api/controllers/google_directory_json.ex
@@ -1,13 +1,12 @@
 defmodule PortalAPI.GoogleDirectoryJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Google.Directory,
-    schema: PortalAPI.Schemas.GoogleDirectory.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Google.Directory, PortalAPI.Schemas.GoogleDirectory.Schema,
     internal: [
       :error_email_count,
       :is_verified,
       :legacy_service_account_key,
       :sync_all_domains
     ]
+  )
 
   alias Portal.Google
   alias PortalAPI.Pagination
@@ -20,5 +19,5 @@ defmodule PortalAPI.GoogleDirectoryJSON do
     %{data: data(directory)}
   end
 
-  defp data(%Google.Directory{} = directory), do: render_fields(directory)
+  defp data(%Google.Directory{} = directory), do: PortalAPI.JSON.render(directory, PortalAPI.Schemas.GoogleDirectory.Schema)
 end

--- a/elixir/lib/portal_api/controllers/google_directory_json.ex
+++ b/elixir/lib/portal_api/controllers/google_directory_json.ex
@@ -1,4 +1,14 @@
 defmodule PortalAPI.GoogleDirectoryJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Google.Directory,
+    schema: PortalAPI.Schemas.GoogleDirectory.Schema,
+    internal: [
+      :error_email_count,
+      :is_verified,
+      :legacy_service_account_key,
+      :sync_all_domains
+    ]
+
   alias Portal.Google
   alias PortalAPI.Pagination
 
@@ -10,23 +20,5 @@ defmodule PortalAPI.GoogleDirectoryJSON do
     %{data: data(directory)}
   end
 
-  defp data(%Google.Directory{} = directory) do
-    %{
-      id: directory.id,
-      account_id: directory.account_id,
-      name: directory.name,
-      domain: directory.domain,
-      impersonation_email: directory.impersonation_email,
-      error_email_count: directory.error_email_count,
-      is_disabled: directory.is_disabled,
-      disabled_reason: directory.disabled_reason,
-      synced_at: directory.synced_at,
-      error_message: directory.error_message,
-      errored_at: directory.errored_at,
-      group_sync_mode: directory.group_sync_mode,
-      orgunit_sync_enabled: directory.orgunit_sync_enabled,
-      inserted_at: directory.inserted_at,
-      updated_at: directory.updated_at
-    }
-  end
+  defp data(%Google.Directory{} = directory), do: render_fields(directory)
 end

--- a/elixir/lib/portal_api/controllers/group_json.ex
+++ b/elixir/lib/portal_api/controllers/group_json.ex
@@ -1,4 +1,13 @@
 defmodule PortalAPI.GroupJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Group,
+    schema: PortalAPI.Schemas.Group.Schema,
+    computed: [:synced_at],
+    internal: [
+      :account_id,
+      :type
+    ]
+
   alias PortalAPI.Pagination
   alias Portal.Group
 
@@ -20,17 +29,7 @@ defmodule PortalAPI.GroupJSON do
   end
 
   defp data(%Group{} = group) do
-    %{
-      id: group.id,
-      name: group.name,
-      email: group.email,
-      entity_type: group.entity_type,
-      directory_id: group.directory_id,
-      idp_id: group.idp_id,
-      synced_at: synced_at_from_state(group.sync_state),
-      inserted_at: group.inserted_at,
-      updated_at: group.updated_at
-    }
+    render_fields(group, %{synced_at: synced_at_from_state(group.sync_state)})
   end
 
   defp synced_at_from_state(%Portal.GroupSyncState{synced_at: t}), do: t

--- a/elixir/lib/portal_api/controllers/group_json.ex
+++ b/elixir/lib/portal_api/controllers/group_json.ex
@@ -1,12 +1,8 @@
 defmodule PortalAPI.GroupJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Group,
-    schema: PortalAPI.Schemas.Group.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Group, PortalAPI.Schemas.Group.Schema,
     computed: [:synced_at],
-    internal: [
-      :account_id,
-      :type
-    ]
+    internal: [:account_id, :type]
+  )
 
   alias PortalAPI.Pagination
   alias Portal.Group
@@ -29,7 +25,7 @@ defmodule PortalAPI.GroupJSON do
   end
 
   defp data(%Group{} = group) do
-    render_fields(group, %{synced_at: synced_at_from_state(group.sync_state)})
+    PortalAPI.JSON.render(group, PortalAPI.Schemas.Group.Schema, %{synced_at: synced_at_from_state(group.sync_state)})
   end
 
   defp synced_at_from_state(%Portal.GroupSyncState{synced_at: t}), do: t

--- a/elixir/lib/portal_api/controllers/intune_device_json.ex
+++ b/elixir/lib/portal_api/controllers/intune_device_json.ex
@@ -1,8 +1,10 @@
 defmodule PortalAPI.IntuneDeviceJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Intune.Device,
+    schema: PortalAPI.Schemas.IntuneDevice.Schema
+
   alias Portal.Intune
   alias PortalAPI.Pagination
-
-  @fields Intune.Device.__schema__(:fields)
 
   def index(%{devices: devices, metadata: metadata}) do
     %{data: Enum.map(devices, &data/1), metadata: Pagination.metadata(metadata)}
@@ -10,5 +12,5 @@ defmodule PortalAPI.IntuneDeviceJSON do
 
   def show(%{device: device}), do: %{data: data(device)}
 
-  defp data(%Intune.Device{} = device), do: Map.take(device, @fields)
+  defp data(%Intune.Device{} = device), do: render_fields(device)
 end

--- a/elixir/lib/portal_api/controllers/intune_device_json.ex
+++ b/elixir/lib/portal_api/controllers/intune_device_json.ex
@@ -1,7 +1,6 @@
 defmodule PortalAPI.IntuneDeviceJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Intune.Device,
-    schema: PortalAPI.Schemas.IntuneDevice.Schema
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Intune.Device, PortalAPI.Schemas.IntuneDevice.Schema
+  )
 
   alias Portal.Intune
   alias PortalAPI.Pagination
@@ -12,5 +11,5 @@ defmodule PortalAPI.IntuneDeviceJSON do
 
   def show(%{device: device}), do: %{data: data(device)}
 
-  defp data(%Intune.Device{} = device), do: render_fields(device)
+  defp data(%Intune.Device{} = device), do: PortalAPI.JSON.render(device, PortalAPI.Schemas.IntuneDevice.Schema)
 end

--- a/elixir/lib/portal_api/controllers/intune_posture_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/intune_posture_provider_json.ex
@@ -1,10 +1,9 @@
 defmodule PortalAPI.IntunePostureProviderJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Intune.PostureProvider,
-    schema: PortalAPI.Schemas.IntunePostureProvider.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Intune.PostureProvider, PortalAPI.Schemas.IntunePostureProvider.Schema,
     computed: [:type, :name],
     # error_email_count is notification bookkeeping, not part of the public shape.
     internal: [:error_email_count]
+  )
 
   alias Portal.Intune
   alias PortalAPI.Pagination
@@ -16,6 +15,6 @@ defmodule PortalAPI.IntunePostureProviderJSON do
   def show(%{provider: provider}), do: %{data: data(provider)}
 
   defp data(%Intune.PostureProvider{} = provider) do
-    render_fields(provider, %{type: "intune", name: provider.posture_provider.name})
+    PortalAPI.JSON.render(provider, PortalAPI.Schemas.IntunePostureProvider.Schema, %{type: "intune", name: provider.posture_provider.name})
   end
 end

--- a/elixir/lib/portal_api/controllers/intune_posture_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/intune_posture_provider_json.ex
@@ -1,9 +1,13 @@
 defmodule PortalAPI.IntunePostureProviderJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Intune.PostureProvider,
+    schema: PortalAPI.Schemas.IntunePostureProvider.Schema,
+    computed: [:type, :name],
+    # error_email_count is notification bookkeeping, not part of the public shape.
+    internal: [:error_email_count]
+
   alias Portal.Intune
   alias PortalAPI.Pagination
-
-  # error_email_count is notification bookkeeping, not part of the public shape.
-  @fields Intune.PostureProvider.__schema__(:fields) -- [:error_email_count]
 
   def index(%{providers: providers, metadata: metadata}) do
     %{data: Enum.map(providers, &data/1), metadata: Pagination.metadata(metadata)}
@@ -11,10 +15,7 @@ defmodule PortalAPI.IntunePostureProviderJSON do
 
   def show(%{provider: provider}), do: %{data: data(provider)}
 
-  defp data(%Intune.PostureProvider{} = provider),
-    do:
-      provider
-      |> Map.take(@fields)
-      |> Map.put(:type, "intune")
-      |> Map.put(:name, provider.posture_provider.name)
+  defp data(%Intune.PostureProvider{} = provider) do
+    render_fields(provider, %{type: "intune", name: provider.posture_provider.name})
+  end
 end

--- a/elixir/lib/portal_api/controllers/iru_device_json.ex
+++ b/elixir/lib/portal_api/controllers/iru_device_json.ex
@@ -1,8 +1,10 @@
 defmodule PortalAPI.IruDeviceJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Iru.Device,
+    schema: PortalAPI.Schemas.IruDevice.Schema
+
   alias Portal.Iru
   alias PortalAPI.Pagination
-
-  @fields Iru.Device.__schema__(:fields)
 
   def index(%{devices: devices, metadata: metadata}) do
     %{data: Enum.map(devices, &data/1), metadata: Pagination.metadata(metadata)}
@@ -10,5 +12,5 @@ defmodule PortalAPI.IruDeviceJSON do
 
   def show(%{device: device}), do: %{data: data(device)}
 
-  defp data(%Iru.Device{} = device), do: Map.take(device, @fields)
+  defp data(%Iru.Device{} = device), do: render_fields(device)
 end

--- a/elixir/lib/portal_api/controllers/iru_device_json.ex
+++ b/elixir/lib/portal_api/controllers/iru_device_json.ex
@@ -1,7 +1,6 @@
 defmodule PortalAPI.IruDeviceJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Iru.Device,
-    schema: PortalAPI.Schemas.IruDevice.Schema
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Iru.Device, PortalAPI.Schemas.IruDevice.Schema
+  )
 
   alias Portal.Iru
   alias PortalAPI.Pagination
@@ -12,5 +11,5 @@ defmodule PortalAPI.IruDeviceJSON do
 
   def show(%{device: device}), do: %{data: data(device)}
 
-  defp data(%Iru.Device{} = device), do: render_fields(device)
+  defp data(%Iru.Device{} = device), do: PortalAPI.JSON.render(device, PortalAPI.Schemas.IruDevice.Schema)
 end

--- a/elixir/lib/portal_api/controllers/iru_posture_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/iru_posture_provider_json.ex
@@ -1,11 +1,10 @@
 defmodule PortalAPI.IruPostureProviderJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Iru.PostureProvider,
-    schema: PortalAPI.Schemas.IruPostureProvider.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Iru.PostureProvider, PortalAPI.Schemas.IruPostureProvider.Schema,
     computed: [:type, :name],
     # The API token authenticates against the tenant, so it never leaves the
     # portal. error_email_count is notification bookkeeping.
     internal: [:api_token, :error_email_count]
+  )
 
   alias Portal.Iru
   alias PortalAPI.Pagination
@@ -17,6 +16,6 @@ defmodule PortalAPI.IruPostureProviderJSON do
   def show(%{provider: provider}), do: %{data: data(provider)}
 
   defp data(%Iru.PostureProvider{} = provider) do
-    render_fields(provider, %{type: "iru", name: provider.posture_provider.name})
+    PortalAPI.JSON.render(provider, PortalAPI.Schemas.IruPostureProvider.Schema, %{type: "iru", name: provider.posture_provider.name})
   end
 end

--- a/elixir/lib/portal_api/controllers/iru_posture_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/iru_posture_provider_json.ex
@@ -1,10 +1,14 @@
 defmodule PortalAPI.IruPostureProviderJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Iru.PostureProvider,
+    schema: PortalAPI.Schemas.IruPostureProvider.Schema,
+    computed: [:type, :name],
+    # The API token authenticates against the tenant, so it never leaves the
+    # portal. error_email_count is notification bookkeeping.
+    internal: [:api_token, :error_email_count]
+
   alias Portal.Iru
   alias PortalAPI.Pagination
-
-  # The API token authenticates against the tenant, so it never leaves the
-  # portal. error_email_count is notification bookkeeping.
-  @fields Iru.PostureProvider.__schema__(:fields) -- [:api_token, :error_email_count]
 
   def index(%{providers: providers, metadata: metadata}) do
     %{data: Enum.map(providers, &data/1), metadata: Pagination.metadata(metadata)}
@@ -12,10 +16,7 @@ defmodule PortalAPI.IruPostureProviderJSON do
 
   def show(%{provider: provider}), do: %{data: data(provider)}
 
-  defp data(%Iru.PostureProvider{} = provider),
-    do:
-      provider
-      |> Map.take(@fields)
-      |> Map.put(:type, "iru")
-      |> Map.put(:name, provider.posture_provider.name)
+  defp data(%Iru.PostureProvider{} = provider) do
+    render_fields(provider, %{type: "iru", name: provider.posture_provider.name})
+  end
 end

--- a/elixir/lib/portal_api/controllers/log_json.ex
+++ b/elixir/lib/portal_api/controllers/log_json.ex
@@ -1,4 +1,34 @@
 defmodule PortalAPI.LogJSON do
+  use PortalAPI.JSON,
+    variants: [
+      [
+        struct: Portal.ChangeLog,
+        schema: PortalAPI.Schemas.Log.Change,
+        computed: [:type],
+        internal: [:account_id, :lsn, :seq, :vsn]
+      ],
+      [
+        struct: Portal.SessionLog,
+        schema: PortalAPI.Schemas.Log.Session,
+        computed: [:type],
+        internal: [:account_id, :seq]
+      ],
+      [
+        struct: Portal.FlowLog,
+        schema: PortalAPI.Schemas.Log.Flow,
+        computed: [:type, :inner_src_ip, :inner_dst_ip, :outers],
+        aliases: [timestamp: :inserted_at, inner_domain: :domain],
+        internal: [:account_id, :seq, :start_seq]
+      ],
+      [
+        struct: Portal.APIRequestLog,
+        schema: PortalAPI.Schemas.Log.APIRequest,
+        computed: [:type, :ip],
+        aliases: [timestamp: :inserted_at],
+        internal: [:account_id, :seq]
+      ]
+    ]
+
   alias PortalAPI.Pagination
   alias Portal.APIRequestLog
   alias Portal.ChangeLog
@@ -18,91 +48,21 @@ defmodule PortalAPI.LogJSON do
 
   def flow_log(%FlowLog{} = log), do: data(log)
 
-  defp data(%ChangeLog{} = log) do
-    %{
-      type: "change",
-      log_id: log.log_id,
-      timestamp: log.timestamp,
-      object: log.object,
-      operation: log.operation,
-      before: log.before,
-      after: log.after,
-      subject: log.subject
-    }
-  end
+  defp data(%ChangeLog{} = log), do: render_fields(log, %{type: "change"})
 
-  defp data(%SessionLog{} = log) do
-    %{
-      type: "session",
-      log_id: log.log_id,
-      timestamp: log.timestamp,
-      context: log.context,
-      subject: log.subject
-    }
-  end
+  defp data(%SessionLog{} = log), do: render_fields(log, %{type: "session"})
 
   defp data(%FlowLog{} = log) do
-    %{
+    render_fields(log, %{
       type: "flow",
-      log_id: log.log_id,
-      timestamp: log.inserted_at,
-      initiator_device_id: log.initiator_device_id,
-      responder_device_id: log.responder_device_id,
-      role: log.role,
-      policy_authorization_id: log.policy_authorization_id,
-      policy_id: log.policy_id,
-      protocol: log.protocol,
-      flow_start: log.flow_start,
-      flow_end: log.flow_end,
-      last_packet: log.last_packet,
-      authorized_at: log.authorized_at,
-      authorization_expires_at: log.authorization_expires_at,
-      initiator_auth_provider_id: log.initiator_auth_provider_id,
-      initiator_actor_id: log.initiator_actor_id,
-      initiator_actor_name: log.initiator_actor_name,
-      initiator_actor_email: log.initiator_actor_email,
-      initiator_client_version: log.initiator_client_version,
-      initiator_device_os_name: log.initiator_device_os_name,
-      initiator_device_os_version: log.initiator_device_os_version,
-      initiator_device_serial: log.initiator_device_serial,
-      initiator_device_uuid: log.initiator_device_uuid,
-      initiator_device_identifier_for_vendor: log.initiator_device_identifier_for_vendor,
-      initiator_device_firebase_installation_id:
-        log.initiator_device_firebase_installation_id,
-      resource_id: log.resource_id,
-      resource_name: log.resource_name,
-      resource_address: log.resource_address,
       inner_src_ip: log.inner_src_ip && "#{log.inner_src_ip}",
       inner_dst_ip: log.inner_dst_ip && "#{log.inner_dst_ip}",
-      inner_src_port: log.inner_src_port,
-      inner_dst_port: log.inner_dst_port,
-      inner_domain: log.domain,
-      outers: flow_outers(log),
-      rx_packets: log.rx_packets,
-      tx_packets: log.tx_packets,
-      rx_bytes: log.rx_bytes,
-      tx_bytes: log.tx_bytes
-    }
+      outers: flow_outers(log)
+    })
   end
 
   defp data(%APIRequestLog{} = log) do
-    %{
-      type: "api_request",
-      log_id: log.log_id,
-      timestamp: log.inserted_at,
-      actor_id: log.actor_id,
-      api_token_id: log.api_token_id,
-      method: log.method,
-      path: log.path,
-      content_length: log.content_length,
-      request_id: log.request_id,
-      user_agent: log.user_agent,
-      ip: log.ip && "#{log.ip}",
-      ip_region: log.ip_region,
-      ip_city: log.ip_city,
-      ip_lat: log.ip_lat,
-      ip_lon: log.ip_lon
-    }
+    render_fields(log, %{type: "api_request", ip: log.ip && "#{log.ip}"})
   end
 
   defp flow_outers(%FlowLog{flow_end: nil}), do: nil

--- a/elixir/lib/portal_api/controllers/log_json.ex
+++ b/elixir/lib/portal_api/controllers/log_json.ex
@@ -1,34 +1,27 @@
 defmodule PortalAPI.LogJSON do
-  use PortalAPI.JSON,
-    variants: [
-      [
-        struct: Portal.ChangeLog,
-        schema: PortalAPI.Schemas.Log.Change,
-        computed: [:type],
-        internal: [:account_id, :lsn, :seq, :vsn]
-      ],
-      [
-        struct: Portal.SessionLog,
-        schema: PortalAPI.Schemas.Log.Session,
-        computed: [:type],
-        internal: [:account_id, :seq]
-      ],
-      [
-        struct: Portal.FlowLog,
-        schema: PortalAPI.Schemas.Log.Flow,
-        computed: [:type, :inner_src_ip, :inner_dst_ip, :outers],
-        aliases: [timestamp: :inserted_at, inner_domain: :domain],
-        internal: [:account_id, :seq, :start_seq]
-      ],
-      [
-        struct: Portal.APIRequestLog,
-        schema: PortalAPI.Schemas.Log.APIRequest,
-        computed: [:type, :ip],
-        aliases: [timestamp: :inserted_at],
-        internal: [:account_id, :seq]
-      ]
-    ]
+  alias PortalAPI.Schemas.Log
 
+  PortalAPI.JSON.verify!(__MODULE__, Portal.ChangeLog, Log.Change,
+    computed: [:type],
+    internal: [:account_id, :lsn, :seq, :vsn]
+  )
+
+  PortalAPI.JSON.verify!(__MODULE__, Portal.SessionLog, Log.Session,
+    computed: [:type],
+    internal: [:account_id, :seq]
+  )
+
+  PortalAPI.JSON.verify!(__MODULE__, Portal.FlowLog, Log.Flow,
+    computed: [:type, :timestamp, :inner_src_ip, :inner_dst_ip, :inner_domain, :outers],
+    internal: [:account_id, :domain, :inserted_at, :seq, :start_seq]
+  )
+
+  PortalAPI.JSON.verify!(__MODULE__, Portal.APIRequestLog, Log.APIRequest,
+    computed: [:type, :timestamp, :ip],
+    internal: [:account_id, :inserted_at, :seq]
+  )
+
+  alias PortalAPI.JSON
   alias PortalAPI.Pagination
   alias Portal.APIRequestLog
   alias Portal.ChangeLog
@@ -48,21 +41,29 @@ defmodule PortalAPI.LogJSON do
 
   def flow_log(%FlowLog{} = log), do: data(log)
 
-  defp data(%ChangeLog{} = log), do: render_fields(log, %{type: "change"})
+  defp data(%ChangeLog{} = log),
+    do: JSON.render(log, Log.Change, %{type: "change"})
 
-  defp data(%SessionLog{} = log), do: render_fields(log, %{type: "session"})
+  defp data(%SessionLog{} = log),
+    do: JSON.render(log, Log.Session, %{type: "session"})
 
   defp data(%FlowLog{} = log) do
-    render_fields(log, %{
+    JSON.render(log, Log.Flow, %{
       type: "flow",
+      timestamp: log.inserted_at,
       inner_src_ip: log.inner_src_ip && "#{log.inner_src_ip}",
       inner_dst_ip: log.inner_dst_ip && "#{log.inner_dst_ip}",
+      inner_domain: log.domain,
       outers: flow_outers(log)
     })
   end
 
   defp data(%APIRequestLog{} = log) do
-    render_fields(log, %{type: "api_request", ip: log.ip && "#{log.ip}"})
+    JSON.render(log, Log.APIRequest, %{
+      type: "api_request",
+      timestamp: log.inserted_at,
+      ip: log.ip && "#{log.ip}"
+    })
   end
 
   defp flow_outers(%FlowLog{flow_end: nil}), do: nil

--- a/elixir/lib/portal_api/controllers/membership_json.ex
+++ b/elixir/lib/portal_api/controllers/membership_json.ex
@@ -1,4 +1,21 @@
 defmodule PortalAPI.MembershipJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Actor,
+    schema: PortalAPI.Schemas.Membership.Schema,
+    internal: [
+      :account_id,
+      :allow_email_otp_sign_in,
+      :created_by_directory_id,
+      :email,
+      :identity_count,
+      :inserted_at,
+      :is_disabled,
+      :last_seen_at,
+      :password_hash,
+      :preferences,
+      :updated_at
+    ]
+
   alias PortalAPI.Pagination
   alias Portal.Actor
 
@@ -19,11 +36,5 @@ defmodule PortalAPI.MembershipJSON do
     %{data: %{actor_ids: actor_ids}}
   end
 
-  defp data(%Actor{} = actor) do
-    %{
-      id: actor.id,
-      name: actor.name,
-      type: actor.type
-    }
-  end
+  defp data(%Actor{} = actor), do: render_fields(actor)
 end

--- a/elixir/lib/portal_api/controllers/membership_json.ex
+++ b/elixir/lib/portal_api/controllers/membership_json.ex
@@ -1,7 +1,5 @@
 defmodule PortalAPI.MembershipJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Actor,
-    schema: PortalAPI.Schemas.Membership.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Actor, PortalAPI.Schemas.Membership.Schema,
     internal: [
       :account_id,
       :allow_email_otp_sign_in,
@@ -15,6 +13,7 @@ defmodule PortalAPI.MembershipJSON do
       :preferences,
       :updated_at
     ]
+  )
 
   alias PortalAPI.Pagination
   alias Portal.Actor
@@ -36,5 +35,5 @@ defmodule PortalAPI.MembershipJSON do
     %{data: %{actor_ids: actor_ids}}
   end
 
-  defp data(%Actor{} = actor), do: render_fields(actor)
+  defp data(%Actor{} = actor), do: PortalAPI.JSON.render(actor, PortalAPI.Schemas.Membership.Schema)
 end

--- a/elixir/lib/portal_api/controllers/oidc_auth_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/oidc_auth_provider_json.ex
@@ -1,8 +1,7 @@
 defmodule PortalAPI.OIDCAuthProviderJSON do
-  use PortalAPI.JSON,
-    struct: Portal.OIDC.AuthProvider,
-    schema: PortalAPI.Schemas.OIDCAuthProvider.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.OIDC.AuthProvider, PortalAPI.Schemas.OIDCAuthProvider.Schema,
     internal: [:client_secret, :is_legacy, :is_verified]
+  )
 
   alias Portal.OIDC
   alias PortalAPI.Pagination
@@ -15,5 +14,5 @@ defmodule PortalAPI.OIDCAuthProviderJSON do
     %{data: data(provider)}
   end
 
-  defp data(%OIDC.AuthProvider{} = provider), do: render_fields(provider)
+  defp data(%OIDC.AuthProvider{} = provider), do: PortalAPI.JSON.render(provider, PortalAPI.Schemas.OIDCAuthProvider.Schema)
 end

--- a/elixir/lib/portal_api/controllers/oidc_auth_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/oidc_auth_provider_json.ex
@@ -1,4 +1,9 @@
 defmodule PortalAPI.OIDCAuthProviderJSON do
+  use PortalAPI.JSON,
+    struct: Portal.OIDC.AuthProvider,
+    schema: PortalAPI.Schemas.OIDCAuthProvider.Schema,
+    internal: [:client_secret, :is_legacy, :is_verified]
+
   alias Portal.OIDC
   alias PortalAPI.Pagination
 
@@ -10,22 +15,5 @@ defmodule PortalAPI.OIDCAuthProviderJSON do
     %{data: data(provider)}
   end
 
-  defp data(%OIDC.AuthProvider{} = provider) do
-    %{
-      id: provider.id,
-      account_id: provider.account_id,
-      name: provider.name,
-      issuer: provider.issuer,
-      context: provider.context,
-      client_session_lifetime_secs: provider.client_session_lifetime_secs,
-      portal_session_lifetime_secs: provider.portal_session_lifetime_secs,
-      is_disabled: provider.is_disabled,
-      is_default: provider.is_default,
-      client_id: provider.client_id,
-      discovery_document_uri: provider.discovery_document_uri,
-      email_verification_method: provider.email_verification_method,
-      inserted_at: provider.inserted_at,
-      updated_at: provider.updated_at
-    }
-  end
+  defp data(%OIDC.AuthProvider{} = provider), do: render_fields(provider)
 end

--- a/elixir/lib/portal_api/controllers/okta_auth_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/okta_auth_provider_json.ex
@@ -1,4 +1,9 @@
 defmodule PortalAPI.OktaAuthProviderJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Okta.AuthProvider,
+    schema: PortalAPI.Schemas.OktaAuthProvider.Schema,
+    internal: [:client_secret, :discovery_document_uri, :is_verified]
+
   alias Portal.Okta
   alias PortalAPI.Pagination
 
@@ -10,21 +15,5 @@ defmodule PortalAPI.OktaAuthProviderJSON do
     %{data: data(provider)}
   end
 
-  defp data(%Okta.AuthProvider{} = provider) do
-    %{
-      id: provider.id,
-      account_id: provider.account_id,
-      name: provider.name,
-      issuer: provider.issuer,
-      context: provider.context,
-      client_session_lifetime_secs: provider.client_session_lifetime_secs,
-      portal_session_lifetime_secs: provider.portal_session_lifetime_secs,
-      is_disabled: provider.is_disabled,
-      is_default: provider.is_default,
-      client_id: provider.client_id,
-      okta_domain: provider.okta_domain,
-      inserted_at: provider.inserted_at,
-      updated_at: provider.updated_at
-    }
-  end
+  defp data(%Okta.AuthProvider{} = provider), do: render_fields(provider)
 end

--- a/elixir/lib/portal_api/controllers/okta_auth_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/okta_auth_provider_json.ex
@@ -1,8 +1,7 @@
 defmodule PortalAPI.OktaAuthProviderJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Okta.AuthProvider,
-    schema: PortalAPI.Schemas.OktaAuthProvider.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Okta.AuthProvider, PortalAPI.Schemas.OktaAuthProvider.Schema,
     internal: [:client_secret, :discovery_document_uri, :is_verified]
+  )
 
   alias Portal.Okta
   alias PortalAPI.Pagination
@@ -15,5 +14,5 @@ defmodule PortalAPI.OktaAuthProviderJSON do
     %{data: data(provider)}
   end
 
-  defp data(%Okta.AuthProvider{} = provider), do: render_fields(provider)
+  defp data(%Okta.AuthProvider{} = provider), do: PortalAPI.JSON.render(provider, PortalAPI.Schemas.OktaAuthProvider.Schema)
 end

--- a/elixir/lib/portal_api/controllers/okta_directory_json.ex
+++ b/elixir/lib/portal_api/controllers/okta_directory_json.ex
@@ -1,4 +1,9 @@
 defmodule PortalAPI.OktaDirectoryJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Okta.Directory,
+    schema: PortalAPI.Schemas.OktaDirectory.Schema,
+    internal: [:error_email_count, :is_verified, :private_key_jwk]
+
   alias Portal.Okta
   alias PortalAPI.Pagination
 
@@ -10,22 +15,5 @@ defmodule PortalAPI.OktaDirectoryJSON do
     %{data: data(directory)}
   end
 
-  defp data(%Okta.Directory{} = directory) do
-    %{
-      id: directory.id,
-      account_id: directory.account_id,
-      name: directory.name,
-      client_id: directory.client_id,
-      kid: directory.kid,
-      okta_domain: directory.okta_domain,
-      error_email_count: directory.error_email_count,
-      is_disabled: directory.is_disabled,
-      disabled_reason: directory.disabled_reason,
-      synced_at: directory.synced_at,
-      error_message: directory.error_message,
-      errored_at: directory.errored_at,
-      inserted_at: directory.inserted_at,
-      updated_at: directory.updated_at
-    }
-  end
+  defp data(%Okta.Directory{} = directory), do: render_fields(directory)
 end

--- a/elixir/lib/portal_api/controllers/okta_directory_json.ex
+++ b/elixir/lib/portal_api/controllers/okta_directory_json.ex
@@ -1,8 +1,7 @@
 defmodule PortalAPI.OktaDirectoryJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Okta.Directory,
-    schema: PortalAPI.Schemas.OktaDirectory.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Okta.Directory, PortalAPI.Schemas.OktaDirectory.Schema,
     internal: [:error_email_count, :is_verified, :private_key_jwk]
+  )
 
   alias Portal.Okta
   alias PortalAPI.Pagination
@@ -15,5 +14,5 @@ defmodule PortalAPI.OktaDirectoryJSON do
     %{data: data(directory)}
   end
 
-  defp data(%Okta.Directory{} = directory), do: render_fields(directory)
+  defp data(%Okta.Directory{} = directory), do: PortalAPI.JSON.render(directory, PortalAPI.Schemas.OktaDirectory.Schema)
 end

--- a/elixir/lib/portal_api/controllers/policy_json.ex
+++ b/elixir/lib/portal_api/controllers/policy_json.ex
@@ -1,4 +1,15 @@
 defmodule PortalAPI.PolicyJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Policy,
+    schema: PortalAPI.Schemas.Policy.ResponseSchema,
+    computed: [:conditions],
+    internal: [
+      :account_id,
+      :group_idp_id,
+      :inserted_at,
+      :updated_at
+    ]
+
   alias PortalAPI.Pagination
 
   @doc """
@@ -19,15 +30,7 @@ defmodule PortalAPI.PolicyJSON do
   end
 
   defp data(%Portal.Policy{} = policy) do
-    %{
-      id: policy.id,
-      group_id: policy.group_id,
-      resource_id: policy.resource_id,
-      description: policy.description,
-      flow_log_uploads_enabled: policy.flow_log_uploads_enabled,
-      is_disabled: policy.is_disabled,
-      conditions: Enum.map(policy.conditions, &condition/1)
-    }
+    render_fields(policy, %{conditions: Enum.map(policy.conditions, &condition/1)})
   end
 
   defp condition(%Portal.Policies.Condition{} = condition) do

--- a/elixir/lib/portal_api/controllers/policy_json.ex
+++ b/elixir/lib/portal_api/controllers/policy_json.ex
@@ -1,14 +1,8 @@
 defmodule PortalAPI.PolicyJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Policy,
-    schema: PortalAPI.Schemas.Policy.ResponseSchema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Policy, PortalAPI.Schemas.Policy.ResponseSchema,
     computed: [:conditions],
-    internal: [
-      :account_id,
-      :group_idp_id,
-      :inserted_at,
-      :updated_at
-    ]
+    internal: [:account_id, :group_idp_id, :inserted_at, :updated_at]
+  )
 
   alias PortalAPI.Pagination
 
@@ -30,7 +24,7 @@ defmodule PortalAPI.PolicyJSON do
   end
 
   defp data(%Portal.Policy{} = policy) do
-    render_fields(policy, %{conditions: Enum.map(policy.conditions, &condition/1)})
+    PortalAPI.JSON.render(policy, PortalAPI.Schemas.Policy.ResponseSchema, %{conditions: Enum.map(policy.conditions, &condition/1)})
   end
 
   defp condition(%Portal.Policies.Condition{} = condition) do

--- a/elixir/lib/portal_api/controllers/pool_member_json.ex
+++ b/elixir/lib/portal_api/controllers/pool_member_json.ex
@@ -1,4 +1,47 @@
 defmodule PortalAPI.PoolMemberJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Device,
+    schema: PortalAPI.Schemas.PoolMember.Schema,
+    internal: [
+      :account_id,
+      :actor_id,
+      :attested?,
+      :client_token_id,
+      :device_serial,
+      :device_uuid,
+      :firebase_installation_id,
+      :firezone_id,
+      :firezone_id_merged?,
+      :gateway_token_id,
+      :gateway_token_rotated_at,
+      :hostname,
+      :identifier_for_vendor,
+      :inserted_at,
+      :ipv4,
+      :ipv6,
+      :last_attested_at,
+      :last_attested_cert_fingerprint,
+      :last_attested_cert_issuer,
+      :last_attested_cert_serial,
+      :last_attested_device_serial,
+      :last_attested_device_uuid,
+      :last_attested_mdm_device_id,
+      :last_seen_remote_ip,
+      :last_seen_remote_ip_location_city,
+      :last_seen_remote_ip_location_lat,
+      :last_seen_remote_ip_location_lon,
+      :last_seen_remote_ip_location_region,
+      :last_seen_user_agent,
+      :last_seen_version,
+      :online?,
+      :psk_base,
+      :public_key,
+      :site_id,
+      :type,
+      :updated_at,
+      :verified_at
+    ]
+
   alias PortalAPI.Pagination
   alias Portal.Device
 
@@ -19,11 +62,5 @@ defmodule PortalAPI.PoolMemberJSON do
     %{data: %{device_ids: device_ids}}
   end
 
-  defp data(%Device{} = device) do
-    %{
-      id: device.id,
-      name: device.name,
-      last_seen_at: device.last_seen_at
-    }
-  end
+  defp data(%Device{} = device), do: render_fields(device)
 end

--- a/elixir/lib/portal_api/controllers/pool_member_json.ex
+++ b/elixir/lib/portal_api/controllers/pool_member_json.ex
@@ -1,7 +1,5 @@
 defmodule PortalAPI.PoolMemberJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Device,
-    schema: PortalAPI.Schemas.PoolMember.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Device, PortalAPI.Schemas.PoolMember.Schema,
     internal: [
       :account_id,
       :actor_id,
@@ -41,6 +39,7 @@ defmodule PortalAPI.PoolMemberJSON do
       :updated_at,
       :verified_at
     ]
+  )
 
   alias PortalAPI.Pagination
   alias Portal.Device
@@ -62,5 +61,5 @@ defmodule PortalAPI.PoolMemberJSON do
     %{data: %{device_ids: device_ids}}
   end
 
-  defp data(%Device{} = device), do: render_fields(device)
+  defp data(%Device{} = device), do: PortalAPI.JSON.render(device, PortalAPI.Schemas.PoolMember.Schema)
 end

--- a/elixir/lib/portal_api/controllers/resource_controller.ex
+++ b/elixir/lib/portal_api/controllers/resource_controller.ex
@@ -382,6 +382,19 @@ defmodule PortalAPI.ResourceController do
     # read, update, delete, and the /resources/:id/pool_members endpoints -
     # works normally against a pool that already exists.
     #
+    # Why: a pool is only useful once it has members, and there is no stable,
+    # human-writable handle for a Client to populate one with. Client names
+    # are not unique, and firezone_id is unique per actor rather than per
+    # account, so neither identifies a single device. That leaves raw device
+    # IDs - fine to click through in the portal, where you search and pick
+    # devices one at a time, but cumbersome in API scripting and unworkable
+    # in Terraform, where the IDs are opaque and do not exist until a device
+    # enrolls. Creating a pool that cannot then be populated declaratively is
+    # worse than not creating it, so the whole operation waits on a unique
+    # client identifier. Note this blocks *authoring* only: adopting an
+    # existing pool is unaffected, since its member IDs already exist and can
+    # be read back.
+    #
     # What this rejects is any request that *changes* a Resource's type to
     # static_device_pool, which is why it runs on the update path too: doing
     # it there would be creating a pool by another name. It is not a block on
@@ -407,9 +420,10 @@ defmodule PortalAPI.ResourceController do
     # required-fields branches above and in Database.changeset/3 already
     # special-case them, Portal.Resource nulls site_id for pool types, and
     # PortalAPI.PoolMemberController manages membership. Outside this repo,
-    # the Terraform provider's firezone_resource still advertises
-    # static_device_pool in its type validator - it will start getting 422s
-    # until it is updated to match.
+    # the Terraform provider's firezone_resource still accepts
+    # static_device_pool in its type validator, but rejects creating one in
+    # ModifyPlan, so it fails in plan rather than reaching this 422. Dropping
+    # that guard is the matching change there.
     def reject_device_pool_type(changeset) do
       Ecto.Changeset.validate_exclusion(changeset, :type, [:static_device_pool],
         message: "device pools cannot be created via the API"

--- a/elixir/lib/portal_api/controllers/resource_json.ex
+++ b/elixir/lib/portal_api/controllers/resource_json.ex
@@ -1,4 +1,10 @@
 defmodule PortalAPI.ResourceJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Resource,
+    schema: PortalAPI.Schemas.Resource.Schema,
+    computed: [:filters],
+    internal: [:account_id, :inserted_at, :updated_at]
+
   alias PortalAPI.Pagination
   alias Portal.Resource
 
@@ -20,16 +26,9 @@ defmodule PortalAPI.ResourceJSON do
   end
 
   defp data(%Resource{} = resource) do
-    %{
-      id: resource.id,
-      name: resource.name,
-      address: resource.address,
-      address_description: resource.address_description,
-      type: resource.type,
-      filters: Enum.map(resource.filters, &filter/1)
-    }
-    |> maybe_put_ip_stack(resource)
-    |> maybe_put_site_id(resource)
+    resource
+    |> render_fields(%{filters: Enum.map(resource.filters, &filter/1)})
+    |> PortalAPI.JSON.omit_nils([:ip_stack, :site_id])
   end
 
   defp filter(%Resource.Filter{} = filter) do
@@ -37,21 +36,5 @@ defmodule PortalAPI.ResourceJSON do
       protocol: filter.protocol,
       ports: filter.ports
     }
-  end
-
-  defp maybe_put_ip_stack(attrs, %{ip_stack: nil}) do
-    attrs
-  end
-
-  defp maybe_put_ip_stack(attrs, resource) do
-    Map.put(attrs, :ip_stack, resource.ip_stack)
-  end
-
-  defp maybe_put_site_id(attrs, %{site_id: nil}) do
-    attrs
-  end
-
-  defp maybe_put_site_id(attrs, resource) do
-    Map.put(attrs, :site_id, resource.site_id)
   end
 end

--- a/elixir/lib/portal_api/controllers/resource_json.ex
+++ b/elixir/lib/portal_api/controllers/resource_json.ex
@@ -1,9 +1,8 @@
 defmodule PortalAPI.ResourceJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Resource,
-    schema: PortalAPI.Schemas.Resource.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Resource, PortalAPI.Schemas.Resource.Schema,
     computed: [:filters],
     internal: [:account_id, :inserted_at, :updated_at]
+  )
 
   alias PortalAPI.Pagination
   alias Portal.Resource
@@ -27,7 +26,9 @@ defmodule PortalAPI.ResourceJSON do
 
   defp data(%Resource{} = resource) do
     resource
-    |> render_fields(%{filters: Enum.map(resource.filters, &filter/1)})
+    |> PortalAPI.JSON.render(PortalAPI.Schemas.Resource.Schema, %{
+      filters: Enum.map(resource.filters, &filter/1)
+    })
     |> PortalAPI.JSON.omit_nils([:ip_stack, :site_id])
   end
 

--- a/elixir/lib/portal_api/controllers/santa_device_json.ex
+++ b/elixir/lib/portal_api/controllers/santa_device_json.ex
@@ -1,7 +1,6 @@
 defmodule PortalAPI.SantaDeviceJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Santa.Device,
-    schema: PortalAPI.Schemas.SantaDevice.Schema
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Santa.Device, PortalAPI.Schemas.SantaDevice.Schema
+  )
 
   alias Portal.Santa
   alias PortalAPI.Pagination
@@ -12,5 +11,5 @@ defmodule PortalAPI.SantaDeviceJSON do
 
   def show(%{device: device}), do: %{data: data(device)}
 
-  defp data(%Santa.Device{} = device), do: render_fields(device)
+  defp data(%Santa.Device{} = device), do: PortalAPI.JSON.render(device, PortalAPI.Schemas.SantaDevice.Schema)
 end

--- a/elixir/lib/portal_api/controllers/santa_device_json.ex
+++ b/elixir/lib/portal_api/controllers/santa_device_json.ex
@@ -1,8 +1,10 @@
 defmodule PortalAPI.SantaDeviceJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Santa.Device,
+    schema: PortalAPI.Schemas.SantaDevice.Schema
+
   alias Portal.Santa
   alias PortalAPI.Pagination
-
-  @fields Santa.Device.__schema__(:fields)
 
   def index(%{devices: devices, metadata: metadata}) do
     %{data: Enum.map(devices, &data/1), metadata: Pagination.metadata(metadata)}
@@ -10,5 +12,5 @@ defmodule PortalAPI.SantaDeviceJSON do
 
   def show(%{device: device}), do: %{data: data(device)}
 
-  defp data(%Santa.Device{} = device), do: Map.take(device, @fields)
+  defp data(%Santa.Device{} = device), do: render_fields(device)
 end

--- a/elixir/lib/portal_api/controllers/santa_posture_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/santa_posture_provider_json.ex
@@ -1,8 +1,14 @@
 defmodule PortalAPI.SantaPostureProviderJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Santa.PostureProvider,
+    schema: PortalAPI.Schemas.SantaPostureProvider.Schema,
+    computed: [:type, :name],
+    # The API key authenticates against the tenant, so it never leaves the
+    # portal. error_email_count is notification bookkeeping.
+    internal: [:api_key, :error_email_count]
+
   alias Portal.Santa
   alias PortalAPI.Pagination
-
-  @fields Santa.PostureProvider.__schema__(:fields) -- [:api_key, :error_email_count]
 
   def index(%{providers: providers, metadata: metadata}) do
     %{data: Enum.map(providers, &data/1), metadata: Pagination.metadata(metadata)}
@@ -11,9 +17,6 @@ defmodule PortalAPI.SantaPostureProviderJSON do
   def show(%{provider: provider}), do: %{data: data(provider)}
 
   defp data(%Santa.PostureProvider{} = provider) do
-    provider
-    |> Map.take(@fields)
-    |> Map.put(:type, "santa")
-    |> Map.put(:name, provider.posture_provider.name)
+    render_fields(provider, %{type: "santa", name: provider.posture_provider.name})
   end
 end

--- a/elixir/lib/portal_api/controllers/santa_posture_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/santa_posture_provider_json.ex
@@ -1,11 +1,10 @@
 defmodule PortalAPI.SantaPostureProviderJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Santa.PostureProvider,
-    schema: PortalAPI.Schemas.SantaPostureProvider.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Santa.PostureProvider, PortalAPI.Schemas.SantaPostureProvider.Schema,
     computed: [:type, :name],
     # The API key authenticates against the tenant, so it never leaves the
     # portal. error_email_count is notification bookkeeping.
     internal: [:api_key, :error_email_count]
+  )
 
   alias Portal.Santa
   alias PortalAPI.Pagination
@@ -17,6 +16,6 @@ defmodule PortalAPI.SantaPostureProviderJSON do
   def show(%{provider: provider}), do: %{data: data(provider)}
 
   defp data(%Santa.PostureProvider{} = provider) do
-    render_fields(provider, %{type: "santa", name: provider.posture_provider.name})
+    PortalAPI.JSON.render(provider, PortalAPI.Schemas.SantaPostureProvider.Schema, %{type: "santa", name: provider.posture_provider.name})
   end
 end

--- a/elixir/lib/portal_api/controllers/sentinel_one_device_json.ex
+++ b/elixir/lib/portal_api/controllers/sentinel_one_device_json.ex
@@ -1,9 +1,8 @@
 defmodule PortalAPI.SentinelOneDeviceJSON do
-  use PortalAPI.JSON,
-    struct: Portal.SentinelOne.Device,
-    schema: PortalAPI.Schemas.SentinelOneDevice.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.SentinelOne.Device, PortalAPI.Schemas.SentinelOneDevice.Schema,
     # The endpoint license key is credential-like and never published.
     internal: [:license_key]
+  )
 
   alias Portal.SentinelOne
   alias PortalAPI.Pagination
@@ -14,5 +13,5 @@ defmodule PortalAPI.SentinelOneDeviceJSON do
 
   def show(%{device: device}), do: %{data: data(device)}
 
-  defp data(%SentinelOne.Device{} = device), do: render_fields(device)
+  defp data(%SentinelOne.Device{} = device), do: PortalAPI.JSON.render(device, PortalAPI.Schemas.SentinelOneDevice.Schema)
 end

--- a/elixir/lib/portal_api/controllers/sentinel_one_device_json.ex
+++ b/elixir/lib/portal_api/controllers/sentinel_one_device_json.ex
@@ -1,10 +1,12 @@
 defmodule PortalAPI.SentinelOneDeviceJSON do
+  use PortalAPI.JSON,
+    struct: Portal.SentinelOne.Device,
+    schema: PortalAPI.Schemas.SentinelOneDevice.Schema,
+    # The endpoint license key is credential-like and never published.
+    internal: [:license_key]
+
   alias Portal.SentinelOne
   alias PortalAPI.Pagination
-
-  # The endpoint license key is inventory data in SentinelOne's source schema,
-  # but it is credential-like and therefore never returned from Firezone's API.
-  @fields SentinelOne.Device.__schema__(:fields) -- [:license_key]
 
   def index(%{devices: devices, metadata: metadata}) do
     %{data: Enum.map(devices, &data/1), metadata: Pagination.metadata(metadata)}
@@ -12,5 +14,5 @@ defmodule PortalAPI.SentinelOneDeviceJSON do
 
   def show(%{device: device}), do: %{data: data(device)}
 
-  defp data(%SentinelOne.Device{} = device), do: Map.take(device, @fields)
+  defp data(%SentinelOne.Device{} = device), do: render_fields(device)
 end

--- a/elixir/lib/portal_api/controllers/sentinel_one_posture_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/sentinel_one_posture_provider_json.ex
@@ -1,8 +1,12 @@
 defmodule PortalAPI.SentinelOnePostureProviderJSON do
+  use PortalAPI.JSON,
+    struct: Portal.SentinelOne.PostureProvider,
+    schema: PortalAPI.Schemas.SentinelOnePostureProvider.Schema,
+    computed: [:type, :name],
+    internal: [:api_token, :error_email_count]
+
   alias Portal.SentinelOne
   alias PortalAPI.Pagination
-
-  @fields SentinelOne.PostureProvider.__schema__(:fields) -- [:api_token, :error_email_count]
 
   def index(%{providers: providers, metadata: metadata}) do
     %{data: Enum.map(providers, &data/1), metadata: Pagination.metadata(metadata)}
@@ -10,10 +14,7 @@ defmodule PortalAPI.SentinelOnePostureProviderJSON do
 
   def show(%{provider: provider}), do: %{data: data(provider)}
 
-  defp data(%SentinelOne.PostureProvider{} = provider),
-    do:
-      provider
-      |> Map.take(@fields)
-      |> Map.put(:type, "sentinelone")
-      |> Map.put(:name, provider.posture_provider.name)
+  defp data(%SentinelOne.PostureProvider{} = provider) do
+    render_fields(provider, %{type: "sentinelone", name: provider.posture_provider.name})
+  end
 end

--- a/elixir/lib/portal_api/controllers/sentinel_one_posture_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/sentinel_one_posture_provider_json.ex
@@ -1,9 +1,8 @@
 defmodule PortalAPI.SentinelOnePostureProviderJSON do
-  use PortalAPI.JSON,
-    struct: Portal.SentinelOne.PostureProvider,
-    schema: PortalAPI.Schemas.SentinelOnePostureProvider.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.SentinelOne.PostureProvider, PortalAPI.Schemas.SentinelOnePostureProvider.Schema,
     computed: [:type, :name],
     internal: [:api_token, :error_email_count]
+  )
 
   alias Portal.SentinelOne
   alias PortalAPI.Pagination
@@ -15,6 +14,6 @@ defmodule PortalAPI.SentinelOnePostureProviderJSON do
   def show(%{provider: provider}), do: %{data: data(provider)}
 
   defp data(%SentinelOne.PostureProvider{} = provider) do
-    render_fields(provider, %{type: "sentinelone", name: provider.posture_provider.name})
+    PortalAPI.JSON.render(provider, PortalAPI.Schemas.SentinelOnePostureProvider.Schema, %{type: "sentinelone", name: provider.posture_provider.name})
   end
 end

--- a/elixir/lib/portal_api/controllers/site_json.ex
+++ b/elixir/lib/portal_api/controllers/site_json.ex
@@ -1,4 +1,9 @@
 defmodule PortalAPI.SiteJSON do
+  use PortalAPI.JSON,
+    struct: Portal.Site,
+    schema: PortalAPI.Schemas.Site.Schema,
+    internal: [:account_id, :health_threshold, :inserted_at, :managed_by, :updated_at]
+
   alias PortalAPI.Pagination
 
   @doc """
@@ -18,10 +23,5 @@ defmodule PortalAPI.SiteJSON do
     %{data: data(site)}
   end
 
-  defp data(%Portal.Site{} = site) do
-    %{
-      id: site.id,
-      name: site.name
-    }
-  end
+  defp data(%Portal.Site{} = site), do: render_fields(site)
 end

--- a/elixir/lib/portal_api/controllers/site_json.ex
+++ b/elixir/lib/portal_api/controllers/site_json.ex
@@ -1,8 +1,7 @@
 defmodule PortalAPI.SiteJSON do
-  use PortalAPI.JSON,
-    struct: Portal.Site,
-    schema: PortalAPI.Schemas.Site.Schema,
+  PortalAPI.JSON.verify!(__MODULE__, Portal.Site, PortalAPI.Schemas.Site.Schema,
     internal: [:account_id, :health_threshold, :inserted_at, :managed_by, :updated_at]
+  )
 
   alias PortalAPI.Pagination
 
@@ -23,5 +22,5 @@ defmodule PortalAPI.SiteJSON do
     %{data: data(site)}
   end
 
-  defp data(%Portal.Site{} = site), do: render_fields(site)
+  defp data(%Portal.Site{} = site), do: PortalAPI.JSON.render(site, PortalAPI.Schemas.Site.Schema)
 end

--- a/elixir/lib/portal_api/controllers/x509_auth_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/x509_auth_provider_json.ex
@@ -1,17 +1,11 @@
 defmodule PortalAPI.X509AuthProviderJSON do
+  use PortalAPI.JSON,
+    struct: Portal.X509.AuthProvider,
+    schema: PortalAPI.Schemas.X509AuthProvider.Schema
+
   alias Portal.X509
 
   def show(%{provider: provider}), do: %{data: data(provider)}
 
-  defp data(%X509.AuthProvider{} = provider) do
-    %{
-      id: provider.id,
-      account_id: provider.account_id,
-      name: provider.name,
-      context: provider.context,
-      is_disabled: provider.is_disabled,
-      inserted_at: provider.inserted_at,
-      updated_at: provider.updated_at
-    }
-  end
+  defp data(%X509.AuthProvider{} = provider), do: render_fields(provider)
 end

--- a/elixir/lib/portal_api/controllers/x509_auth_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/x509_auth_provider_json.ex
@@ -1,11 +1,10 @@
 defmodule PortalAPI.X509AuthProviderJSON do
-  use PortalAPI.JSON,
-    struct: Portal.X509.AuthProvider,
-    schema: PortalAPI.Schemas.X509AuthProvider.Schema
+  PortalAPI.JSON.verify!(__MODULE__, Portal.X509.AuthProvider, PortalAPI.Schemas.X509AuthProvider.Schema
+  )
 
   alias Portal.X509
 
   def show(%{provider: provider}), do: %{data: data(provider)}
 
-  defp data(%X509.AuthProvider{} = provider), do: render_fields(provider)
+  defp data(%X509.AuthProvider{} = provider), do: PortalAPI.JSON.render(provider, PortalAPI.Schemas.X509AuthProvider.Schema)
 end

--- a/elixir/lib/portal_api/json.ex
+++ b/elixir/lib/portal_api/json.ex
@@ -120,6 +120,10 @@ defmodule PortalAPI.JSON do
       MapSet.difference(alias_keys, declared),
       "The left-hand side of :aliases is the payload key, which must be a declared property.")
 
+    bail!(view, "lists :computed keys the OpenAPI schema does not declare",
+      MapSet.difference(computed, declared),
+      "A computed value still has to be a declared property of #{inspect(schema_module)}.")
+
     bail!(view, "declares fields that #{inspect(struct_module)} does not have",
       MapSet.difference(exposed, known),
       "Remove them from #{inspect(schema_module)}, or list them as :computed if the view supplies them.")
@@ -160,13 +164,18 @@ defmodule PortalAPI.JSON do
   Builds a payload containing exactly the OpenAPI schema's declared fields.
 
   Values are taken from `source` by key; `computed` supplies fields the struct
-  does not carry. The compile-time checks in `__using__/1` make a mismatch here
-  unreachable, so this raises only if called directly with a mismatched pair.
+  does not carry. Both are narrowed to the declared fields, so a stray computed
+  key cannot widen the payload beyond the schema. Rendering stays total: a key
+  the schema does not declare is dropped rather than raised on, since this runs
+  on every response. Declaring one is caught at compile time instead, and a
+  misspelled key still raises here because the field it was meant to supply
+  goes missing.
   """
   @spec render(struct(), module(), map()) :: map()
   def render(source, schema_module, computed \\ %{}) do
     fields = schema_module.field_names()
-    payload = source |> Map.take(fields) |> Map.merge(computed)
+    payload = source |> Map.take(fields) |> Map.merge(Map.take(computed, fields))
+
     optional =
       if Code.ensure_loaded?(schema_module) and
            function_exported?(schema_module, :optional_field_names, 0),
@@ -174,8 +183,13 @@ defmodule PortalAPI.JSON do
          else: []
 
     case (fields -- Map.keys(payload)) -- optional do
-      [] -> payload
-      missing -> raise ArgumentError, "#{inspect(schema_module)} declares unprovided fields: #{inspect(missing)}"
+      [] ->
+        payload
+
+      missing ->
+        raise ArgumentError,
+              "#{inspect(schema_module)} declares fields the payload does not provide: " <>
+                "#{inspect(missing)}"
     end
   end
 

--- a/elixir/lib/portal_api/json.ex
+++ b/elixir/lib/portal_api/json.ex
@@ -29,104 +29,56 @@ defmodule PortalAPI.JSON do
   exposure.
   """
 
-  @doc false
-  defmacro __using__(opts) do
-    if Keyword.has_key?(opts, :variants) do
-      PortalAPI.JSON.__variants__(opts)
-    else
-      PortalAPI.JSON.__single__(opts)
-    end
-  end
+  @doc """
+  Asserts that a view's declared exposure matches the struct it renders.
 
-  @doc false
-  def __variants__(opts) do
-    clauses =
-      for variant <- Keyword.fetch!(opts, :variants) do
-        struct_module = Keyword.fetch!(variant, :struct)
-        schema_module = Keyword.fetch!(variant, :schema)
+  Called from the view's module body, so a mismatch fails the build:
 
-        quote do
-          PortalAPI.JSON.__verify__!(
-            __MODULE__,
-            unquote(struct_module),
-            unquote(schema_module),
-            unquote(Keyword.get(variant, :computed, [])),
-            unquote(Keyword.get(variant, :internal, [])),
-            unquote(Keyword.get(variant, :aliases, []))
-          )
+      PortalAPI.JSON.verify!(__MODULE__, Portal.Site, PortalAPI.Schemas.Site.Schema,
+        internal: [:account_id, :inserted_at, :updated_at])
 
-          defp render_fields(%unquote(struct_module){} = source, computed) do
-            aliased =
-              Map.new(unquote(Keyword.get(variant, :aliases, [])), fn {key, field} ->
-                {key, Map.fetch!(source, field)}
-              end)
+  Options:
 
-            PortalAPI.JSON.render(source, unquote(schema_module), Map.merge(aliased, computed))
-          end
-        end
-      end
+    * `:internal` - fields deliberately withheld from the API.
+    * `:computed` - declared properties the view supplies itself rather than
+      reading from the struct.
 
-    quote do
-      defp render_fields(source, computed \\ %{})
-      unquote_splicing(clauses)
-    end
-  end
+  Three properties are enforced:
 
-  @doc false
-  def __single__(opts) do
-    quote bind_quoted: [opts: opts] do
-      @json_struct Keyword.fetch!(opts, :struct)
-      @json_schema Keyword.fetch!(opts, :schema)
-      @json_computed Keyword.get(opts, :computed, [])
-      @json_internal Keyword.get(opts, :internal, [])
-      @json_aliases Keyword.get(opts, :aliases, [])
+    * every property the schema declares exists on the struct, so a rename
+      cannot leave the spec describing a field that is no longer emitted;
 
-      PortalAPI.JSON.__verify__!(
-        __MODULE__,
-        @json_struct,
-        @json_schema,
-        @json_computed,
-        @json_internal,
-        @json_aliases
-      )
+    * every struct field is classified as exposed or `:internal`, so a newly
+      added column fails the build until someone decides which it is;
 
-      @doc false
-      def render_fields(source, computed \\ %{}) do
-        aliased = Map.new(@json_aliases, fn {key, field} -> {key, Map.fetch!(source, field)} end)
-        PortalAPI.JSON.render(source, @json_schema, Map.merge(aliased, computed))
-      end
-    end
-  end
+    * `:computed` and `:internal` name only fields that are real, so stale
+      entries cannot quietly accumulate.
 
-  @doc false
-  def __verify__!(view, struct_module, schema_module, computed, internal, aliases \\ []) do
+  Exposure is therefore an allowlist: a field reaches the API only by being
+  declared in the schema, and the build fails rather than defaulting to
+  exposure.
+  """
+  @spec verify!(module(), module(), module(), keyword()) :: :ok
+  def verify!(view, struct_module, schema_module, opts \\ []) do
     Code.ensure_compiled!(struct_module)
     Code.ensure_compiled!(schema_module)
 
+    computed = MapSet.new(Keyword.get(opts, :computed, []))
+    internal = MapSet.new(Keyword.get(opts, :internal, []))
+
     known =
       MapSet.new(struct_module.__schema__(:fields) ++ struct_module.__schema__(:virtual_fields))
-    declared = MapSet.new(schema_module.field_names())
-    alias_keys = MapSet.new(Keyword.keys(aliases))
-    alias_sources = MapSet.new(Keyword.values(aliases))
-    computed = MapSet.new(computed)
-    internal = MapSet.new(internal)
-    exposed = declared |> MapSet.difference(computed) |> MapSet.difference(alias_keys)
 
-    bail!(view, "aliases fields that #{inspect(struct_module)} does not have",
-      MapSet.difference(alias_sources, known),
-      "Fix the right-hand side of :aliases — it names the struct field to read.")
-
-    bail!(view, "aliases keys the OpenAPI schema does not declare",
-      MapSet.difference(alias_keys, declared),
-      "The left-hand side of :aliases is the payload key, which must be a declared property.")
-
-    bail!(view, "lists :computed keys the OpenAPI schema does not declare",
-      MapSet.difference(computed, declared),
-      "A computed value still has to be a declared property of #{inspect(schema_module)}.")
+    declared = MapSet.new(declared_fields(schema_module))
+    exposed = MapSet.difference(declared, computed)
 
     bail!(view, "declares fields that #{inspect(struct_module)} does not have",
       MapSet.difference(exposed, known),
       "Remove them from #{inspect(schema_module)}, or list them as :computed if the view supplies them.")
+
+    bail!(view, "lists :computed keys the OpenAPI schema does not declare",
+      MapSet.difference(computed, declared),
+      "A computed value still has to be a declared property of #{inspect(schema_module)}.")
 
     bail!(view, "lists :internal fields that #{inspect(struct_module)} does not have",
       MapSet.difference(internal, known),
@@ -137,11 +89,11 @@ defmodule PortalAPI.JSON do
       "A field is either in the OpenAPI schema or :internal, not both.")
 
     bail!(view, "does not classify every field of #{inspect(struct_module)}",
-      known |> MapSet.difference(declared) |> MapSet.difference(internal) |> MapSet.difference(alias_sources),
+      known |> MapSet.difference(declared) |> MapSet.difference(internal),
       """
       Each field must be either declared in #{inspect(schema_module)} (exposed to
       the API) or listed as :internal (deliberately withheld). New fields are not
-      exposed by default — this is the allowlist working.\
+      exposed by default - this is the allowlist working.\
       """)
 
     :ok
@@ -160,6 +112,8 @@ defmodule PortalAPI.JSON do
     :ok
   end
 
+  defp declared_fields(schema_module), do: schema_module.schema().properties |> Map.keys()
+
   @doc """
   Builds a payload containing exactly the OpenAPI schema's declared fields.
 
@@ -173,14 +127,11 @@ defmodule PortalAPI.JSON do
   """
   @spec render(struct(), module(), map()) :: map()
   def render(source, schema_module, computed \\ %{}) do
-    fields = schema_module.field_names()
-    payload = source |> Map.take(fields) |> Map.merge(Map.take(computed, fields))
+    schema = schema_module.schema()
+    fields = Map.keys(schema.properties)
+    optional = fields -- List.wrap(schema.required)
 
-    optional =
-      if Code.ensure_loaded?(schema_module) and
-           function_exported?(schema_module, :optional_field_names, 0),
-         do: schema_module.optional_field_names(),
-         else: []
+    payload = source |> Map.take(fields) |> Map.merge(Map.take(computed, fields))
 
     case (fields -- Map.keys(payload)) -- optional do
       [] ->

--- a/elixir/lib/portal_api/json.ex
+++ b/elixir/lib/portal_api/json.ex
@@ -1,0 +1,194 @@
+defmodule PortalAPI.JSON do
+  @moduledoc """
+  Compile-time contract between an Ecto schema, its OpenAPI schema, and the JSON
+  view that renders it.
+
+  A view declares the struct it renders, the OpenAPI schema describing the
+  payload, and — exhaustively — which of the struct's fields are deliberately
+  withheld:
+
+      use PortalAPI.JSON,
+        struct: Portal.Iru.PostureProvider,
+        schema: PortalAPI.Schemas.IruPostureProvider.Schema,
+        computed: [:type, :name],
+        internal: [:api_token, :error_email_count]
+
+  Three properties are enforced at compile time:
+
+    * every field the OpenAPI schema declares exists on the struct, so a rename
+      cannot leave the spec describing a field that is no longer emitted;
+
+    * every struct field is classified as either exposed or `:internal`, so a
+      newly added column fails the build until someone decides which it is;
+
+    * `:computed` and `:internal` name only fields that are real, so stale
+      entries cannot quietly accumulate.
+
+  Exposure is therefore an allowlist: a field reaches the API only by being
+  declared in the OpenAPI schema, and the build fails rather than defaulting to
+  exposure.
+  """
+
+  @doc false
+  defmacro __using__(opts) do
+    if Keyword.has_key?(opts, :variants) do
+      PortalAPI.JSON.__variants__(opts)
+    else
+      PortalAPI.JSON.__single__(opts)
+    end
+  end
+
+  @doc false
+  def __variants__(opts) do
+    clauses =
+      for variant <- Keyword.fetch!(opts, :variants) do
+        struct_module = Keyword.fetch!(variant, :struct)
+        schema_module = Keyword.fetch!(variant, :schema)
+
+        quote do
+          PortalAPI.JSON.__verify__!(
+            __MODULE__,
+            unquote(struct_module),
+            unquote(schema_module),
+            unquote(Keyword.get(variant, :computed, [])),
+            unquote(Keyword.get(variant, :internal, [])),
+            unquote(Keyword.get(variant, :aliases, []))
+          )
+
+          defp render_fields(%unquote(struct_module){} = source, computed) do
+            aliased =
+              Map.new(unquote(Keyword.get(variant, :aliases, [])), fn {key, field} ->
+                {key, Map.fetch!(source, field)}
+              end)
+
+            PortalAPI.JSON.render(source, unquote(schema_module), Map.merge(aliased, computed))
+          end
+        end
+      end
+
+    quote do
+      defp render_fields(source, computed \\ %{})
+      unquote_splicing(clauses)
+    end
+  end
+
+  @doc false
+  def __single__(opts) do
+    quote bind_quoted: [opts: opts] do
+      @json_struct Keyword.fetch!(opts, :struct)
+      @json_schema Keyword.fetch!(opts, :schema)
+      @json_computed Keyword.get(opts, :computed, [])
+      @json_internal Keyword.get(opts, :internal, [])
+      @json_aliases Keyword.get(opts, :aliases, [])
+
+      PortalAPI.JSON.__verify__!(
+        __MODULE__,
+        @json_struct,
+        @json_schema,
+        @json_computed,
+        @json_internal,
+        @json_aliases
+      )
+
+      @doc false
+      def render_fields(source, computed \\ %{}) do
+        aliased = Map.new(@json_aliases, fn {key, field} -> {key, Map.fetch!(source, field)} end)
+        PortalAPI.JSON.render(source, @json_schema, Map.merge(aliased, computed))
+      end
+    end
+  end
+
+  @doc false
+  def __verify__!(view, struct_module, schema_module, computed, internal, aliases \\ []) do
+    Code.ensure_compiled!(struct_module)
+    Code.ensure_compiled!(schema_module)
+
+    known =
+      MapSet.new(struct_module.__schema__(:fields) ++ struct_module.__schema__(:virtual_fields))
+    declared = MapSet.new(schema_module.field_names())
+    alias_keys = MapSet.new(Keyword.keys(aliases))
+    alias_sources = MapSet.new(Keyword.values(aliases))
+    computed = MapSet.new(computed)
+    internal = MapSet.new(internal)
+    exposed = declared |> MapSet.difference(computed) |> MapSet.difference(alias_keys)
+
+    bail!(view, "aliases fields that #{inspect(struct_module)} does not have",
+      MapSet.difference(alias_sources, known),
+      "Fix the right-hand side of :aliases — it names the struct field to read.")
+
+    bail!(view, "aliases keys the OpenAPI schema does not declare",
+      MapSet.difference(alias_keys, declared),
+      "The left-hand side of :aliases is the payload key, which must be a declared property.")
+
+    bail!(view, "declares fields that #{inspect(struct_module)} does not have",
+      MapSet.difference(exposed, known),
+      "Remove them from #{inspect(schema_module)}, or list them as :computed if the view supplies them.")
+
+    bail!(view, "lists :internal fields that #{inspect(struct_module)} does not have",
+      MapSet.difference(internal, known),
+      "Remove the stale entries from :internal.")
+
+    bail!(view, "exposes fields that are also marked :internal",
+      MapSet.intersection(declared, internal),
+      "A field is either in the OpenAPI schema or :internal, not both.")
+
+    bail!(view, "does not classify every field of #{inspect(struct_module)}",
+      known |> MapSet.difference(declared) |> MapSet.difference(internal) |> MapSet.difference(alias_sources),
+      """
+      Each field must be either declared in #{inspect(schema_module)} (exposed to
+      the API) or listed as :internal (deliberately withheld). New fields are not
+      exposed by default — this is the allowlist working.\
+      """)
+
+    :ok
+  end
+
+  defp bail!(view, problem, offenders, hint) do
+    if MapSet.size(offenders) > 0 do
+      raise CompileError,
+        description: """
+        #{inspect(view)} #{problem}: #{inspect(Enum.sort(offenders))}
+
+        #{hint}\
+        """
+    end
+
+    :ok
+  end
+
+  @doc """
+  Builds a payload containing exactly the OpenAPI schema's declared fields.
+
+  Values are taken from `source` by key; `computed` supplies fields the struct
+  does not carry. The compile-time checks in `__using__/1` make a mismatch here
+  unreachable, so this raises only if called directly with a mismatched pair.
+  """
+  @spec render(struct(), module(), map()) :: map()
+  def render(source, schema_module, computed \\ %{}) do
+    fields = schema_module.field_names()
+    payload = source |> Map.take(fields) |> Map.merge(computed)
+    optional =
+      if Code.ensure_loaded?(schema_module) and
+           function_exported?(schema_module, :optional_field_names, 0),
+         do: schema_module.optional_field_names(),
+         else: []
+
+    case (fields -- Map.keys(payload)) -- optional do
+      [] -> payload
+      missing -> raise ArgumentError, "#{inspect(schema_module)} declares unprovided fields: #{inspect(missing)}"
+    end
+  end
+
+  @doc """
+  Drops keys whose value is nil.
+
+  For payloads that omit a field entirely rather than sending null. The keys
+  must be declared `optional:` on the schema.
+  """
+  @spec omit_nils(map(), [atom()]) :: map()
+  def omit_nils(payload, keys) do
+    Enum.reduce(keys, payload, fn key, acc ->
+      if Map.get(acc, key) == nil, do: Map.delete(acc, key), else: acc
+    end)
+  end
+end

--- a/elixir/lib/portal_api/schemas/account_schema.ex
+++ b/elixir/lib/portal_api/schemas/account_schema.ex
@@ -37,9 +37,10 @@ defmodule PortalAPI.Schemas.Account do
   end
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "Account",
       description: "Account schema",
       type: :object,
@@ -56,7 +57,7 @@ defmodule PortalAPI.Schemas.Account do
         legal_name: %Schema{type: :string, description: "Account legal name"},
         limits: PortalAPI.Schemas.Account.LimitsSchema
       },
-    })
+    }))
   end
 
   defmodule Response do

--- a/elixir/lib/portal_api/schemas/account_schema.ex
+++ b/elixir/lib/portal_api/schemas/account_schema.ex
@@ -37,10 +37,9 @@ defmodule PortalAPI.Schemas.Account do
   end
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "Account",
       description: "Account schema",
       type: :object,
@@ -57,7 +56,6 @@ defmodule PortalAPI.Schemas.Account do
         legal_name: %Schema{type: :string, description: "Account legal name"},
         limits: PortalAPI.Schemas.Account.LimitsSchema
       },
-      required: [:id, :slug, :key, :name]
     })
   end
 

--- a/elixir/lib/portal_api/schemas/actor_schema.ex
+++ b/elixir/lib/portal_api/schemas/actor_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.Actor do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "Actor",
       description: "Actor",
       type: :object,
@@ -51,7 +50,6 @@ defmodule PortalAPI.Schemas.Actor do
           description: "When the actor was last updated"
         }
       },
-      required: [:name, :email, :type],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "John Doe",

--- a/elixir/lib/portal_api/schemas/actor_schema.ex
+++ b/elixir/lib/portal_api/schemas/actor_schema.ex
@@ -182,20 +182,6 @@ defmodule PortalAPI.Schemas.Actor do
       type: :object,
       properties: %{
         data: Actor.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name" => "John Doe",
-          "type" => "account_admin_user",
-          "email" => "john.doe@example.com",
-          "allow_email_otp_sign_in" => false,
-          "is_disabled" => false,
-          "last_seen_at" => "2024-01-15T10:30:00Z",
-          "created_by_directory_id" => nil,
-          "inserted_at" => "2024-01-01T00:00:00Z",
-          "updated_at" => "2024-01-15T10:30:00Z"
-        }
       }
     })
   end
@@ -213,40 +199,6 @@ defmodule PortalAPI.Schemas.Actor do
       properties: %{
         data: %Schema{description: "Actors details", type: :array, items: Actor.Schema},
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "John Doe",
-            "type" => "account_admin_user",
-            "email" => "john.doe@example.com",
-            "allow_email_otp_sign_in" => false,
-            "is_disabled" => false,
-            "last_seen_at" => "2024-01-15T10:30:00Z",
-            "created_by_directory_id" => nil,
-            "inserted_at" => "2024-01-01T00:00:00Z",
-            "updated_at" => "2024-01-15T10:30:00Z"
-          },
-          %{
-            "id" => "84e7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "Jane Smith",
-            "type" => "account_user",
-            "email" => "jane.smith@example.com",
-            "allow_email_otp_sign_in" => true,
-            "is_disabled" => false,
-            "last_seen_at" => "2024-01-14T15:45:00Z",
-            "created_by_directory_id" => "98776234-1234-5678-9012-345678901234",
-            "inserted_at" => "2024-01-02T00:00:00Z",
-            "updated_at" => "2024-01-14T15:45:00Z"
-          }
-        ],
-        "metadata" => %{
-          "limit" => 10,
-          "total" => 100,
-          "prev_page" => "123123425",
-          "next_page" => "98776234123"
-        }
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/actor_schema.ex
+++ b/elixir/lib/portal_api/schemas/actor_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.Actor do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "Actor",
       description: "Actor",
       type: :object,
@@ -62,7 +63,7 @@ defmodule PortalAPI.Schemas.Actor do
         "inserted_at" => "2024-01-01T00:00:00Z",
         "updated_at" => "2024-01-15T10:30:00Z"
       }
-    })
+    }))
   end
 
   defmodule CreateRequest do
@@ -172,25 +173,26 @@ defmodule PortalAPI.Schemas.Actor do
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.Actor
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ActorResponse",
       description: "Response schema for single Actor",
       type: :object,
       properties: %{
         data: Actor.Schema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.Actor
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ActorsResponse",
       description: "Response schema for multiple Actors",
       type: :object,
@@ -198,6 +200,6 @@ defmodule PortalAPI.Schemas.Actor do
         data: %Schema{description: "Actors details", type: :array, items: Actor.Schema},
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/actor_schema.ex
+++ b/elixir/lib/portal_api/schemas/actor_schema.ex
@@ -172,11 +172,10 @@ defmodule PortalAPI.Schemas.Actor do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Actor
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ActorResponse",
       description: "Response schema for single Actor",
       type: :object,
@@ -187,12 +186,11 @@ defmodule PortalAPI.Schemas.Actor do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Actor
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ActorsResponse",
       description: "Response schema for multiple Actors",
       type: :object,

--- a/elixir/lib/portal_api/schemas/client_schema.ex
+++ b/elixir/lib/portal_api/schemas/client_schema.ex
@@ -240,31 +240,6 @@ defmodule PortalAPI.Schemas.Client do
       type: :object,
       properties: %{
         data: Client.GetSchema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "firezone_id" => "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c",
-          "actor_id" => "6ecc106b-75c1-48a5-846c-14782180c1ff",
-          "name" => "John's Macbook Air",
-          "ipv4" => "100.64.0.1",
-          "ipv6" => "fd00:2021:1111::1",
-          "online" => true,
-          "device_serial" => "GCCFX0DBQ6L5",
-          "device_uuid" => "7A461FF9-0BE2-64A9-A418-539D9A21827B",
-          "identifier_for_vendor" => nil,
-          "firebase_installation_id" => nil,
-          "hostname" => "johns-macbook.example.com",
-          "last_attested_device_serial" => "GCCFX0DBQ6L5",
-          "last_attested_device_uuid" => "7A461FF9-0BE2-64A9-A418-539D9A21827B",
-          "last_attested_mdm_device_id" => "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3",
-          "last_attested_cert_serial" => "4A:2F:00:8C:11:03:9E:5B",
-          "last_attested_cert_fingerprint" => "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
-          "last_attested_at" => "2025-01-01T00:00:00Z",
-          "verified_at" => "2025-01-01T00:00:00Z",
-          "created_at" => "2025-01-01T00:00:00Z",
-          "updated_at" => "2025-01-01T00:00:00Z"
-        }
       }
     })
   end
@@ -282,61 +257,6 @@ defmodule PortalAPI.Schemas.Client do
       properties: %{
         data: %Schema{description: "Clients details", type: :array, items: Client.GetSchema},
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "firezone_id" => "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c",
-            "actor_id" => "6ecc106b-75c1-48a5-846c-14782180c1ff",
-            "name" => "John's Macbook Air",
-            "ipv4" => "100.64.0.1",
-            "ipv6" => "fd00:2021:1111::1",
-            "online" => true,
-            "device_serial" => "GCCFX0DBQ6L5",
-            "device_uuid" => "7A461FF9-0BE2-64A9-A418-539D9A21827B",
-            "identifier_for_vendor" => nil,
-            "firebase_installation_id" => nil,
-            "hostname" => "johns-macbook.example.com",
-            "last_attested_device_serial" => "GCCFX0DBQ6L5",
-            "last_attested_device_uuid" => "7A461FF9-0BE2-64A9-A418-539D9A21827B",
-            "last_attested_mdm_device_id" => "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3",
-            "last_attested_cert_serial" => "4A:2F:00:8C:11:03:9E:5B",
-            "last_attested_cert_fingerprint" => "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
-            "verified_at" => "2025-01-01T00:00:00Z",
-            "created_at" => "2025-01-01T00:00:00Z",
-            "updated_at" => "2025-01-01T00:00:00Z"
-          },
-          %{
-            "id" => "9a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "firezone_id" => "6c37c0042f40bbb16e007d0d6c8e77c0ac2cab3cc3b923c42d1157a934e436ac",
-            "actor_id" => "2ecc106b-75c1-48a5-846c-14782180c1ff",
-            "name" => "iPad",
-            "ipv4" => "100.64.0.2",
-            "ipv6" => "fd00:2021:1111::2",
-            "online" => false,
-            "device_serial" => nil,
-            "device_uuid" => nil,
-            "identifier_for_vendor" => "7A461FF9-0BE2-64A9-A418-539D9A21827B",
-            "firebase_installation_id" => nil,
-            "hostname" => nil,
-            "last_attested_device_serial" => nil,
-            "last_attested_device_uuid" => nil,
-            "last_attested_mdm_device_id" => nil,
-            "last_attested_cert_serial" => nil,
-            "last_attested_cert_fingerprint" => nil,
-            "last_attested_at" => nil,
-            "verified_at" => nil,
-            "created_at" => "2025-01-01T00:00:00Z",
-            "updated_at" => "2025-01-01T00:00:00Z"
-          }
-        ],
-        "metadata" => %{
-          "limit" => 2,
-          "total" => 100,
-          "prev_page" => "123123425",
-          "next_page" => "98776234123"
-        }
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/client_schema.ex
+++ b/elixir/lib/portal_api/schemas/client_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.Client do
   alias OpenApiSpex.Schema
 
   defmodule GetSchema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "Client",
       description: "Client",
       type: :object,
@@ -153,17 +152,6 @@ defmodule PortalAPI.Schemas.Client do
           description: "Client update timestamp"
         }
       },
-      required: [
-        :id,
-        :actor_id,
-        :firezone_id,
-        :name,
-        :ipv4,
-        :ipv6,
-        :online,
-        :created_at,
-        :updated_at
-      ],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "firezone_id" => "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c",

--- a/elixir/lib/portal_api/schemas/client_schema.ex
+++ b/elixir/lib/portal_api/schemas/client_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.Client do
   alias OpenApiSpex.Schema
 
   defmodule GetSchema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "Client",
       description: "Client",
       type: :object,
@@ -184,7 +185,7 @@ defmodule PortalAPI.Schemas.Client do
         "created_at" => "2025-01-01T00:00:00Z",
         "updated_at" => "2025-01-01T00:00:00Z"
       }
-    })
+    }))
   end
 
   defmodule PutSchema do
@@ -230,25 +231,26 @@ defmodule PortalAPI.Schemas.Client do
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.Client
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ClientResponse",
       description: "Response schema for single Client",
       type: :object,
       properties: %{
         data: Client.GetSchema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.Client
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ClientsResponse",
       description: "Response schema for multiple Clients",
       type: :object,
@@ -256,6 +258,6 @@ defmodule PortalAPI.Schemas.Client do
         data: %Schema{description: "Clients details", type: :array, items: Client.GetSchema},
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/client_schema.ex
+++ b/elixir/lib/portal_api/schemas/client_schema.ex
@@ -230,11 +230,10 @@ defmodule PortalAPI.Schemas.Client do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Client
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ClientResponse",
       description: "Response schema for single Client",
       type: :object,
@@ -245,12 +244,11 @@ defmodule PortalAPI.Schemas.Client do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Client
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ClientsResponse",
       description: "Response schema for multiple Clients",
       type: :object,

--- a/elixir/lib/portal_api/schemas/client_token_schema.ex
+++ b/elixir/lib/portal_api/schemas/client_token_schema.ex
@@ -95,10 +95,10 @@ defmodule PortalAPI.Schemas.ClientToken do
   end
 
   defmodule Response do
-    require OpenApiSpex
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.ClientToken
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ClientTokenCreateResponse",
       description: "Response schema for a new Client Token",
       type: :object,
@@ -109,10 +109,10 @@ defmodule PortalAPI.Schemas.ClientToken do
   end
 
   defmodule ShowResponse do
-    require OpenApiSpex
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.ClientToken
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ClientTokenShowResponse",
       description: "Response schema for Client Token metadata",
       type: :object,
@@ -123,12 +123,11 @@ defmodule PortalAPI.Schemas.ClientToken do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.ClientToken
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ClientTokenListResponse",
       description: "Response schema for multiple Client Tokens",
       type: :object,
@@ -140,10 +139,9 @@ defmodule PortalAPI.Schemas.ClientToken do
   end
 
   defmodule DeletedResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "DeletedClientTokenResponse",
       description: "Response schema for a deleted Client Token",
       type: :object,
@@ -160,10 +158,9 @@ defmodule PortalAPI.Schemas.ClientToken do
   end
 
   defmodule DeletedAllResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "DeletedClientTokensResponse",
       description: "Response schema for deleted Client Tokens",
       type: :object,

--- a/elixir/lib/portal_api/schemas/client_token_schema.ex
+++ b/elixir/lib/portal_api/schemas/client_token_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.ClientToken do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ClientToken",
       description: "Client Token metadata",
       type: :object,
@@ -16,7 +15,6 @@ defmodule PortalAPI.Schemas.ClientToken do
         inserted_at: %Schema{type: :string, format: :"date-time", description: "Creation timestamp"},
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
-      required: [:id, :actor_id, :expires_at, :inserted_at, :updated_at],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "actor_id" => "43a7f82f-831a-4a9d-8f17-c66c2bb6e205",

--- a/elixir/lib/portal_api/schemas/client_token_schema.ex
+++ b/elixir/lib/portal_api/schemas/client_token_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.ClientToken do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ClientToken",
       description: "Client Token metadata",
       type: :object,
@@ -22,7 +23,7 @@ defmodule PortalAPI.Schemas.ClientToken do
         "inserted_at" => "2025-01-15T12:34:56.789Z",
         "updated_at" => "2025-01-15T12:34:56.789Z"
       }
-    })
+    }))
   end
 
   defmodule CreateSchema do
@@ -95,39 +96,40 @@ defmodule PortalAPI.Schemas.ClientToken do
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.ClientToken
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ClientTokenCreateResponse",
       description: "Response schema for a new Client Token",
       type: :object,
       properties: %{
         data: ClientToken.ResponseSchema
       }
-    })
+    }))
   end
 
   defmodule ShowResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.ClientToken
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ClientTokenShowResponse",
       description: "Response schema for Client Token metadata",
       type: :object,
       properties: %{
         data: ClientToken.Schema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.ClientToken
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ClientTokenListResponse",
       description: "Response schema for multiple Client Tokens",
       type: :object,
@@ -135,13 +137,14 @@ defmodule PortalAPI.Schemas.ClientToken do
         data: %Schema{description: "Client Token metadata", type: :array, items: ClientToken.Schema},
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 
   defmodule DeletedResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "DeletedClientTokenResponse",
       description: "Response schema for a deleted Client Token",
       type: :object,
@@ -154,13 +157,14 @@ defmodule PortalAPI.Schemas.ClientToken do
           required: [:id]
         }
       }
-    })
+    }))
   end
 
   defmodule DeletedAllResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "DeletedClientTokensResponse",
       description: "Response schema for deleted Client Tokens",
       type: :object,
@@ -176,6 +180,6 @@ defmodule PortalAPI.Schemas.ClientToken do
           required: [:deleted_count]
         }
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/client_token_schema.ex
+++ b/elixir/lib/portal_api/schemas/client_token_schema.ex
@@ -49,8 +49,10 @@ defmodule PortalAPI.Schemas.ClientToken do
     alias PortalAPI.Schemas.ClientToken
 
     OpenApiSpex.schema(%{
-      title: "ClientTokenResponse",
-      description: "Client Token response",
+      title: "ClientTokenWithSecret",
+      description:
+        "Client Token as returned when it is created, including the encoded secret. " <>
+          "The secret is shown once and cannot be retrieved later.",
       type: :object,
       properties: %{
         id: %Schema{type: :string, format: :uuid, description: "Client Token ID"},
@@ -102,16 +104,6 @@ defmodule PortalAPI.Schemas.ClientToken do
       type: :object,
       properties: %{
         data: ClientToken.ResponseSchema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "actor_id" => "43a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "expires_at" => "2025-01-15T12:34:56.789Z",
-          "inserted_at" => "2025-01-15T12:34:56.789Z",
-          "updated_at" => "2025-01-15T12:34:56.789Z",
-          "token" => "secret-token-here"
-        }
       }
     })
   end
@@ -121,20 +113,11 @@ defmodule PortalAPI.Schemas.ClientToken do
     alias PortalAPI.Schemas.ClientToken
 
     OpenApiSpex.schema(%{
-      title: "ClientTokenResponse",
+      title: "ClientTokenShowResponse",
       description: "Response schema for Client Token metadata",
       type: :object,
       properties: %{
         data: ClientToken.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "actor_id" => "43a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "expires_at" => "2025-01-15T12:34:56.789Z",
-          "inserted_at" => "2025-01-15T12:34:56.789Z",
-          "updated_at" => "2025-01-15T12:34:56.789Z"
-        }
       }
     })
   end
@@ -152,23 +135,6 @@ defmodule PortalAPI.Schemas.ClientToken do
       properties: %{
         data: %Schema{description: "Client Token metadata", type: :array, items: ClientToken.Schema},
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "actor_id" => "43a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "expires_at" => "2025-01-15T12:34:56.789Z",
-            "inserted_at" => "2025-01-15T12:34:56.789Z",
-            "updated_at" => "2025-01-15T12:34:56.789Z"
-          }
-        ],
-        "metadata" => %{
-          "limit" => 10,
-          "count" => 1,
-          "prev_page" => nil,
-          "next_page" => nil
-        }
       }
     })
   end
@@ -188,11 +154,6 @@ defmodule PortalAPI.Schemas.ClientToken do
             id: %Schema{type: :string, format: :uuid, description: "Client Token ID"}
           },
           required: [:id]
-        }
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205"
         }
       }
     })
@@ -216,11 +177,6 @@ defmodule PortalAPI.Schemas.ClientToken do
             }
           },
           required: [:deleted_count]
-        }
-      },
-      example: %{
-        "data" => %{
-          "deleted_count" => 3
         }
       }
     })

--- a/elixir/lib/portal_api/schemas/defender_device_schema.ex
+++ b/elixir/lib/portal_api/schemas/defender_device_schema.ex
@@ -102,10 +102,9 @@ defmodule PortalAPI.Schemas.DefenderDevice do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "DefenderDeviceResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.DefenderDevice.Schema}
@@ -113,11 +112,10 @@ defmodule PortalAPI.Schemas.DefenderDevice do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "DefenderDeviceListResponse",
       type: :object,
       properties: %{

--- a/elixir/lib/portal_api/schemas/defender_device_schema.ex
+++ b/elixir/lib/portal_api/schemas/defender_device_schema.ex
@@ -2,15 +2,60 @@ defmodule PortalAPI.Schemas.DefenderDevice do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
+    # Exposure is an explicit allowlist: a newly synced column must be added to
+    # @exposed or @internal before it compiles. Property types stay derived.
     # The device table mirrors the Defender for Endpoint machine resource field
     # for field, so the documented properties are derived from the Ecto schema.
     # A newly synced field cannot end up in the database but missing here.
     @required [:account_id, :posture_provider_id, :defender_id, :synced_at]
 
-    @properties Map.new(Portal.Defender.Device.__schema__(:fields), fn field ->
+    @exposed [
+                :account_id,
+                :defender_id,
+                :posture_provider_id,
+                :computer_dns_name,
+                :entra_device_id,
+                :entra_joined,
+                :machine_tags,
+                :os_platform,
+                :version,
+                :os_build,
+                :os_processor,
+                :os_architecture,
+                :last_ip_address,
+                :last_external_ip_address,
+                :agent_version,
+                :health_status,
+                :onboarding_status,
+                :managed_by,
+                :managed_by_status,
+                :risk_score,
+                :exposure_level,
+                :device_value,
+                :rbac_group_id,
+                :rbac_group_name,
+                :is_potential_duplication,
+                :merged_into_machine_id,
+                :is_excluded,
+                :exclusion_reason,
+                :vm_id,
+                :vm_cloud_provider,
+                :vm_resource_id,
+                :vm_subscription_id,
+                :ip_addresses,
+                :first_seen_at,
+                :last_seen_at,
+                :synced_at,
+                :inserted_at,
+                :updated_at
+             ]
+    @internal []
+
+    PortalAPI.Schemas.Object.assert_classified!(Portal.Defender.Device, @exposed, @internal)
+
+    @properties Map.new(@exposed, fn field ->
                   nullable = field not in @required
 
                   schema =
@@ -48,12 +93,11 @@ defmodule PortalAPI.Schemas.DefenderDevice do
                   {field, schema}
                 end)
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "DefenderDevice",
       description: "Device synced from Microsoft Defender for Endpoint",
       type: :object,
-      properties: @properties,
-      required: @required
+      properties: @properties
     })
   end
 

--- a/elixir/lib/portal_api/schemas/defender_device_schema.ex
+++ b/elixir/lib/portal_api/schemas/defender_device_schema.ex
@@ -2,7 +2,8 @@ defmodule PortalAPI.Schemas.DefenderDevice do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
     # Exposure is an explicit allowlist: a newly synced column must be added to
     # @exposed or @internal before it compiles. Property types stay derived.
@@ -93,35 +94,36 @@ defmodule PortalAPI.Schemas.DefenderDevice do
                   {field, schema}
                 end)
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "DefenderDevice",
       description: "Device synced from Microsoft Defender for Endpoint",
       type: :object,
       properties: @properties
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "DefenderDeviceResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.DefenderDevice.Schema}
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "DefenderDeviceListResponse",
       type: :object,
       properties: %{
         data: %Schema{type: :array, items: PortalAPI.Schemas.DefenderDevice.Schema},
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/defender_posture_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/defender_posture_provider_schema.ex
@@ -28,10 +28,9 @@ defmodule PortalAPI.Schemas.DefenderPostureProvider do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "DefenderPostureProviderResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.DefenderPostureProvider.Schema}
@@ -39,11 +38,10 @@ defmodule PortalAPI.Schemas.DefenderPostureProvider do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "DefenderPostureProviderListResponse",
       type: :object,
       properties: %{

--- a/elixir/lib/portal_api/schemas/defender_posture_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/defender_posture_provider_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.DefenderPostureProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "DefenderPostureProvider",
       description: "Microsoft Defender for Endpoint posture provider",
       type: :object,

--- a/elixir/lib/portal_api/schemas/defender_posture_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/defender_posture_provider_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.DefenderPostureProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "DefenderPostureProvider",
       description: "Microsoft Defender for Endpoint posture provider",
       type: :object,
@@ -24,24 +25,25 @@ defmodule PortalAPI.Schemas.DefenderPostureProvider do
         updated_at: %Schema{type: :string, format: :"date-time"}
       },
       required: [:id, :account_id, :type, :name, :tenant_id, :is_verified, :is_disabled]
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "DefenderPostureProviderResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.DefenderPostureProvider.Schema}
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "DefenderPostureProviderListResponse",
       type: :object,
       properties: %{
@@ -51,6 +53,6 @@ defmodule PortalAPI.Schemas.DefenderPostureProvider do
         },
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/email_otp_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/email_otp_auth_provider_schema.ex
@@ -11,8 +11,8 @@ defmodule PortalAPI.Schemas.EmailOTPAuthProvider do
       properties: %{
         id: %Schema{type: :string, format: :uuid, description: "Provider ID"},
         account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
-        name: %Schema{type: :string, description: "Provider name"},
-        issuer: %Schema{type: :string, description: "Issuer"},
+        name: %Schema{example: "Email OTP", type: :string, description: "Provider name"},
+        issuer: %Schema{example: "firezone", type: :string, description: "Issuer"},
         context: %Schema{
           type: :string,
           description: "Context",
@@ -33,11 +33,6 @@ defmodule PortalAPI.Schemas.EmailOTPAuthProvider do
           description: "Creation timestamp"
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
-      },
-      example: %{
-        "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-        "name" => "Email OTP",
-        "issuer" => "firezone"
       }
     })
   end
@@ -53,12 +48,6 @@ defmodule PortalAPI.Schemas.EmailOTPAuthProvider do
       type: :object,
       properties: %{
         data: EmailOTPAuthProvider.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name" => "Email OTP"
-        }
       }
     })
   end
@@ -80,14 +69,6 @@ defmodule PortalAPI.Schemas.EmailOTPAuthProvider do
           items: EmailOTPAuthProvider.Schema
         },
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "Email OTP"
-          }
-        ]
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/email_otp_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/email_otp_auth_provider_schema.ex
@@ -38,11 +38,10 @@ defmodule PortalAPI.Schemas.EmailOTPAuthProvider do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.EmailOTPAuthProvider
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "EmailOTPAuthProviderResponse",
       description: "Response schema for single Email OTP Auth Provider",
       type: :object,
@@ -53,12 +52,11 @@ defmodule PortalAPI.Schemas.EmailOTPAuthProvider do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.EmailOTPAuthProvider
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "EmailOTPAuthProviderListResponse",
       description: "Response schema for multiple Email OTP Auth Providers",
       type: :object,

--- a/elixir/lib/portal_api/schemas/email_otp_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/email_otp_auth_provider_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.EmailOTPAuthProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "EmailOTPAuthProvider",
       description: "Email OTP Auth Provider",
       type: :object,
@@ -35,7 +34,6 @@ defmodule PortalAPI.Schemas.EmailOTPAuthProvider do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
-      required: [:id, :name],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "Email OTP",

--- a/elixir/lib/portal_api/schemas/email_otp_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/email_otp_auth_provider_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.EmailOTPAuthProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "EmailOTPAuthProvider",
       description: "Email OTP Auth Provider",
       type: :object,
@@ -34,29 +35,30 @@ defmodule PortalAPI.Schemas.EmailOTPAuthProvider do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       }
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.EmailOTPAuthProvider
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "EmailOTPAuthProviderResponse",
       description: "Response schema for single Email OTP Auth Provider",
       type: :object,
       properties: %{
         data: EmailOTPAuthProvider.Schema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.EmailOTPAuthProvider
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "EmailOTPAuthProviderListResponse",
       description: "Response schema for multiple Email OTP Auth Providers",
       type: :object,
@@ -68,6 +70,6 @@ defmodule PortalAPI.Schemas.EmailOTPAuthProvider do
         },
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/entra_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/entra_auth_provider_schema.ex
@@ -50,11 +50,10 @@ defmodule PortalAPI.Schemas.EntraAuthProvider do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.EntraAuthProvider
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "EntraAuthProviderResponse",
       description: "Response schema for single Entra Auth Provider",
       type: :object,
@@ -65,12 +64,11 @@ defmodule PortalAPI.Schemas.EntraAuthProvider do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.EntraAuthProvider
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "EntraAuthProviderListResponse",
       description: "Response schema for multiple Entra Auth Providers",
       type: :object,

--- a/elixir/lib/portal_api/schemas/entra_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/entra_auth_provider_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.EntraAuthProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "EntraAuthProvider",
       description: "Entra Auth Provider",
       type: :object,
@@ -47,7 +46,6 @@ defmodule PortalAPI.Schemas.EntraAuthProvider do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
-      required: [:id, :name],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "Entra",

--- a/elixir/lib/portal_api/schemas/entra_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/entra_auth_provider_schema.ex
@@ -11,8 +11,8 @@ defmodule PortalAPI.Schemas.EntraAuthProvider do
       properties: %{
         id: %Schema{type: :string, format: :uuid, description: "Provider ID"},
         account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
-        name: %Schema{type: :string, description: "Provider name"},
-        issuer: %Schema{type: :string, description: "Issuer"},
+        name: %Schema{example: "Entra", type: :string, description: "Provider name"},
+        issuer: %Schema{example: "https://login.microsoftonline.com/tenant-id/v2.0", type: :string, description: "Issuer"},
         context: %Schema{
           type: :string,
           description: "Context",
@@ -45,11 +45,6 @@ defmodule PortalAPI.Schemas.EntraAuthProvider do
           description: "Creation timestamp"
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
-      },
-      example: %{
-        "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-        "name" => "Entra",
-        "issuer" => "https://login.microsoftonline.com/tenant-id/v2.0"
       }
     })
   end
@@ -65,12 +60,6 @@ defmodule PortalAPI.Schemas.EntraAuthProvider do
       type: :object,
       properties: %{
         data: EntraAuthProvider.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name" => "Entra"
-        }
       }
     })
   end
@@ -92,14 +81,6 @@ defmodule PortalAPI.Schemas.EntraAuthProvider do
           items: EntraAuthProvider.Schema
         },
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "Entra"
-          }
-        ]
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/entra_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/entra_auth_provider_schema.ex
@@ -21,10 +21,16 @@ defmodule PortalAPI.Schemas.EntraAuthProvider do
         },
         client_session_lifetime_secs: %Schema{
           type: :integer,
+          nullable: true,
+          minimum: 3_600,
+          maximum: 7_776_000,
           description: "Client session lifetime in seconds"
         },
         portal_session_lifetime_secs: %Schema{
           type: :integer,
+          nullable: true,
+          minimum: 300,
+          maximum: 86_400,
           description: "Portal session lifetime in seconds"
         },
         email_claim: %Schema{

--- a/elixir/lib/portal_api/schemas/entra_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/entra_auth_provider_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.EntraAuthProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "EntraAuthProvider",
       description: "Entra Auth Provider",
       type: :object,
@@ -46,29 +47,30 @@ defmodule PortalAPI.Schemas.EntraAuthProvider do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       }
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.EntraAuthProvider
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "EntraAuthProviderResponse",
       description: "Response schema for single Entra Auth Provider",
       type: :object,
       properties: %{
         data: EntraAuthProvider.Schema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.EntraAuthProvider
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "EntraAuthProviderListResponse",
       description: "Response schema for multiple Entra Auth Providers",
       type: :object,
@@ -80,6 +82,6 @@ defmodule PortalAPI.Schemas.EntraAuthProvider do
         },
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/entra_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/entra_directory_schema.ex
@@ -53,11 +53,10 @@ defmodule PortalAPI.Schemas.EntraDirectory do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.EntraDirectory
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "EntraDirectoryResponse",
       description: "Response schema for single Entra Directory",
       type: :object,
@@ -68,12 +67,11 @@ defmodule PortalAPI.Schemas.EntraDirectory do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.EntraDirectory
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "EntraDirectoryListResponse",
       description: "Response schema for multiple Entra Directories",
       type: :object,

--- a/elixir/lib/portal_api/schemas/entra_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/entra_directory_schema.ex
@@ -13,20 +13,33 @@ defmodule PortalAPI.Schemas.EntraDirectory do
         id: %Schema{type: :string, format: :uuid, description: "Directory ID"},
         account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
         name: %Schema{type: :string, description: "Directory name"},
-        tenant_id: %Schema{type: :string, format: :uuid, description: "Microsoft Entra tenant ID"},
-        error_count: %Schema{type: :integer, description: "Error count"},
+        tenant_id: %Schema{type: :string, description: "Microsoft Entra tenant ID"},
+        error_email_count: %Schema{
+          type: :integer,
+          description: "Number of error emails sent for this directory"
+        },
         is_disabled: %Schema{type: :boolean, description: "Whether directory is disabled"},
-        disabled_reason: %Schema{type: :string, description: "Reason for disabling"},
+        disabled_reason: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Reason for disabling"
+        },
         synced_at: %Schema{
           type: :string,
           format: :"date-time",
+          nullable: true,
           description: "Last sync timestamp"
         },
-        error: %Schema{type: :string, description: "Last error message"},
-        error_emailed_at: %Schema{
+        error_message: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Last error message"
+        },
+        errored_at: %Schema{
           type: :string,
           format: :"date-time",
-          description: "Error email timestamp"
+          nullable: true,
+          description: "Last error timestamp"
         },
         email_field: %Schema{
           type: :string,

--- a/elixir/lib/portal_api/schemas/entra_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/entra_directory_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.EntraDirectory do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "EntraDirectory",
       description: "Entra Directory",
       type: :object,
@@ -14,10 +13,6 @@ defmodule PortalAPI.Schemas.EntraDirectory do
         account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
         name: %Schema{type: :string, description: "Directory name"},
         tenant_id: %Schema{type: :string, description: "Microsoft Entra tenant ID"},
-        error_email_count: %Schema{
-          type: :integer,
-          description: "Number of error emails sent for this directory"
-        },
         is_disabled: %Schema{type: :boolean, description: "Whether directory is disabled"},
         disabled_reason: %Schema{
           type: :string,
@@ -54,7 +49,6 @@ defmodule PortalAPI.Schemas.EntraDirectory do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
-      required: [:id, :name],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "Entra",

--- a/elixir/lib/portal_api/schemas/entra_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/entra_directory_schema.ex
@@ -11,10 +11,10 @@ defmodule PortalAPI.Schemas.EntraDirectory do
       properties: %{
         id: %Schema{type: :string, format: :uuid, description: "Directory ID"},
         account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
-        name: %Schema{type: :string, description: "Directory name"},
-        tenant_id: %Schema{type: :string, description: "Microsoft Entra tenant ID"},
+        name: %Schema{example: "Entra", type: :string, description: "Directory name"},
+        tenant_id: %Schema{example: "12345678-1234-1234-1234-123456789012", type: :string, description: "Microsoft Entra tenant ID"},
         is_disabled: %Schema{type: :boolean, description: "Whether directory is disabled"},
-        disabled_reason: %Schema{
+        disabled_reason: %Schema{example: "Sync failed on 5 consecutive attempts",
           type: :string,
           nullable: true,
           description: "Reason for disabling"
@@ -25,7 +25,7 @@ defmodule PortalAPI.Schemas.EntraDirectory do
           nullable: true,
           description: "Last sync timestamp"
         },
-        error_message: %Schema{
+        error_message: %Schema{example: "invalid_grant: token has expired or been revoked",
           type: :string,
           nullable: true,
           description: "Last error message"
@@ -48,11 +48,6 @@ defmodule PortalAPI.Schemas.EntraDirectory do
           description: "Creation timestamp"
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
-      },
-      example: %{
-        "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-        "name" => "Entra",
-        "tenant_id" => "12345678-1234-1234-1234-123456789012"
       }
     })
   end
@@ -68,12 +63,6 @@ defmodule PortalAPI.Schemas.EntraDirectory do
       type: :object,
       properties: %{
         data: EntraDirectory.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name" => "Entra"
-        }
       }
     })
   end
@@ -95,14 +84,6 @@ defmodule PortalAPI.Schemas.EntraDirectory do
           items: EntraDirectory.Schema
         },
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "Entra"
-          }
-        ]
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/entra_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/entra_directory_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.EntraDirectory do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "EntraDirectory",
       description: "Entra Directory",
       type: :object,
@@ -49,29 +50,30 @@ defmodule PortalAPI.Schemas.EntraDirectory do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       }
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.EntraDirectory
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "EntraDirectoryResponse",
       description: "Response schema for single Entra Directory",
       type: :object,
       properties: %{
         data: EntraDirectory.Schema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.EntraDirectory
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "EntraDirectoryListResponse",
       description: "Response schema for multiple Entra Directories",
       type: :object,
@@ -83,6 +85,6 @@ defmodule PortalAPI.Schemas.EntraDirectory do
         },
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/external_identity_schema.ex
+++ b/elixir/lib/portal_api/schemas/external_identity_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ExternalIdentity",
       description: "External Identity",
       type: :object,
@@ -44,7 +45,7 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
           description: "Creation timestamp"
         }
       }
-    })
+    }))
   end
 
   defmodule Request do
@@ -69,25 +70,26 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.ExternalIdentity
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ExternalIdentityResponse",
       description: "Response schema for single External Identity",
       type: :object,
       properties: %{
         data: ExternalIdentity.Schema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.ExternalIdentity
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ExternalIdentityListResponse",
       description: "Response schema for multiple External Identities",
       type: :object,
@@ -99,6 +101,6 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
         },
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/external_identity_schema.ex
+++ b/elixir/lib/portal_api/schemas/external_identity_schema.ex
@@ -69,11 +69,10 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.ExternalIdentity
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ExternalIdentityResponse",
       description: "Response schema for single External Identity",
       type: :object,
@@ -84,12 +83,11 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.ExternalIdentity
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ExternalIdentityListResponse",
       description: "Response schema for multiple External Identities",
       type: :object,

--- a/elixir/lib/portal_api/schemas/external_identity_schema.ex
+++ b/elixir/lib/portal_api/schemas/external_identity_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ExternalIdentity",
       description: "External Identity",
       type: :object,
@@ -23,6 +22,7 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
           format: :uuid,
           description: "Directory UUID reference"
         },
+        email: %Schema{type: :string, description: "Email address, falling back to the IdP identifier when unset"},
         idp_id: %Schema{type: :string, description: "IDP-specific identifier for this identity"},
         name: %Schema{type: :string, description: "Full name"},
         given_name: %Schema{type: :string, description: "Given name"},
@@ -44,7 +44,6 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
           description: "Creation timestamp"
         }
       },
-      required: [:id, :actor_id, :issuer, :idp_id],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "actor_id" => "cdfa97e6-cca1-41db-8fc7-864daedb46df",

--- a/elixir/lib/portal_api/schemas/external_identity_schema.ex
+++ b/elixir/lib/portal_api/schemas/external_identity_schema.ex
@@ -12,7 +12,7 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
         id: %Schema{type: :string, format: :uuid, description: "External Identity ID"},
         actor_id: %Schema{type: :string, format: :uuid, description: "Actor ID"},
         account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
-        issuer: %Schema{
+        issuer: %Schema{example: "https://accounts.google.com",
           type: :string,
           description:
             "Identity issuer URL (e.g., 'https://accounts.google.com', 'https://company.okta.com')"
@@ -22,17 +22,17 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
           format: :uuid,
           description: "Directory UUID reference"
         },
-        email: %Schema{type: :string, description: "Email address, falling back to the IdP identifier when unset"},
-        idp_id: %Schema{type: :string, description: "IDP-specific identifier for this identity"},
-        name: %Schema{type: :string, description: "Full name"},
-        given_name: %Schema{type: :string, description: "Given name"},
-        family_name: %Schema{type: :string, description: "Family name"},
-        middle_name: %Schema{type: :string, description: "Middle name"},
-        nickname: %Schema{type: :string, description: "Nickname"},
-        preferred_username: %Schema{type: :string, description: "Preferred username"},
-        profile: %Schema{type: :string, description: "Profile URL"},
-        picture: %Schema{type: :string, description: "Profile picture URL"},
-        firezone_avatar_url: %Schema{type: :string, description: "Firezone-hosted avatar URL"},
+        email: %Schema{example: "user@example.com", type: :string, description: "Email address, falling back to the IdP identifier when unset"},
+        idp_id: %Schema{example: "2551705710219359", type: :string, description: "IDP-specific identifier for this identity"},
+        name: %Schema{example: "John Doe", type: :string, description: "Full name"},
+        given_name: %Schema{example: "John", type: :string, description: "Given name"},
+        family_name: %Schema{example: "Doe", type: :string, description: "Family name"},
+        middle_name: %Schema{example: "Quincy", type: :string, description: "Middle name"},
+        nickname: %Schema{example: "johnny", type: :string, description: "Nickname"},
+        preferred_username: %Schema{example: "jdoe", type: :string, description: "Preferred username"},
+        profile: %Schema{example: "https://example.com/users/jdoe", type: :string, description: "Profile URL"},
+        picture: %Schema{example: "https://example.com/avatar.jpg", type: :string, description: "Profile picture URL"},
+        firezone_avatar_url: %Schema{example: "https://avatars.firezone.dev/u/2551705710219359.png", type: :string, description: "Firezone-hosted avatar URL"},
         synced_at: %Schema{
           type: :string,
           format: :"date-time",
@@ -43,20 +43,6 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
           format: :"date-time",
           description: "Creation timestamp"
         }
-      },
-      example: %{
-        "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-        "actor_id" => "cdfa97e6-cca1-41db-8fc7-864daedb46df",
-        "account_id" => "5e6f7d8c-9b0a-1c2d-3e4f-5a6b7c8d9e0f",
-        "issuer" => "https://accounts.google.com",
-        "directory_id" => "9f8e7d6c-5b4a-3c2b-1a0e-9f8e7d6c5b4a",
-        "idp_id" => "2551705710219359",
-        "name" => "John Doe",
-        "given_name" => "John",
-        "family_name" => "Doe",
-        "picture" => "https://example.com/avatar.jpg",
-        "synced_at" => "2025-01-15T12:34:56.789Z",
-        "inserted_at" => "2025-01-15T12:34:56.789Z"
       }
     })
   end
@@ -93,22 +79,6 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
       type: :object,
       properties: %{
         data: ExternalIdentity.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "actor_id" => "cdfa97e6-cca1-41db-8fc7-864daedb46df",
-          "account_id" => "5e6f7d8c-9b0a-1c2d-3e4f-5a6b7c8d9e0f",
-          "issuer" => "https://accounts.google.com",
-          "directory_id" => "9f8e7d6c-5b4a-3c2b-1a0e-9f8e7d6c5b4a",
-          "idp_id" => "2551705710219359",
-          "name" => "John Doe",
-          "given_name" => "John",
-          "family_name" => "Doe",
-          "picture" => "https://example.com/avatar.jpg",
-          "synced_at" => "2025-01-15T12:34:56.789Z",
-          "inserted_at" => "2025-01-15T12:34:56.789Z"
-        }
       }
     })
   end
@@ -130,44 +100,6 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
           items: ExternalIdentity.Schema
         },
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "actor_id" => "8f44a02b-b8eb-406f-8202-4274bf60ebd0",
-            "account_id" => "5e6f7d8c-9b0a-1c2d-3e4f-5a6b7c8d9e0f",
-            "issuer" => "https://accounts.google.com",
-            "directory_id" => "9f8e7d6c-5b4a-3c2b-1a0e-9f8e7d6c5b4a",
-            "idp_id" => "2551705710219359",
-            "name" => "John Doe",
-            "given_name" => "John",
-            "family_name" => "Doe",
-            "picture" => "https://example.com/avatar1.jpg",
-            "synced_at" => "2025-01-15T12:34:56.789Z",
-            "inserted_at" => "2025-01-15T12:34:56.789Z"
-          },
-          %{
-            "id" => "8a70eb96-e74b-4cdc-91b8-48c05ef74d4c",
-            "actor_id" => "38c92cda-1ddb-45b3-9d1a-7efc375e00c1",
-            "account_id" => "5e6f7d8c-9b0a-1c2d-3e4f-5a6b7c8d9e0f",
-            "issuer" => "https://company.okta.com",
-            "directory_id" => "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
-            "idp_id" => "2638957392736483",
-            "name" => "Jane Smith",
-            "given_name" => "Jane",
-            "family_name" => "Smith",
-            "picture" => "https://example.com/avatar2.jpg",
-            "synced_at" => "2025-01-15T11:22:33.456Z",
-            "inserted_at" => "2025-01-15T11:22:33.456Z"
-          }
-        ],
-        "metadata" => %{
-          "limit" => 10,
-          "total" => 100,
-          "prev_page" => "123123425",
-          "next_page" => "98776234123"
-        }
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/gateway_schema.ex
+++ b/elixir/lib/portal_api/schemas/gateway_schema.ex
@@ -155,11 +155,10 @@ defmodule PortalAPI.Schemas.Gateway do
   end
 
   defmodule ProvisionResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Gateway
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "GatewayProvisionResponse",
       description: """
       Response schema for a newly provisioned Gateway. Includes the \
@@ -226,11 +225,10 @@ defmodule PortalAPI.Schemas.Gateway do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Gateway
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "GatewayResponse",
       description: "Response schema for single Gateway",
       type: :object,
@@ -241,12 +239,11 @@ defmodule PortalAPI.Schemas.Gateway do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Gateway
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "GatewaysResponse",
       description: "Response schema for multiple Gateways",
       type: :object,

--- a/elixir/lib/portal_api/schemas/gateway_schema.ex
+++ b/elixir/lib/portal_api/schemas/gateway_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.Gateway do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "Gateway",
       description: "Gateway",
       type: :object,
@@ -111,7 +112,7 @@ defmodule PortalAPI.Schemas.Gateway do
         "last_seen_remote_ip_location_lat" => 37.7749,
         "last_seen_remote_ip_location_lon" => -122.4194
       }
-    })
+    }))
   end
 
   defmodule CreateSchema do
@@ -155,10 +156,11 @@ defmodule PortalAPI.Schemas.Gateway do
   end
 
   defmodule ProvisionResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.Gateway
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "GatewayProvisionResponse",
       description: """
       Response schema for a newly provisioned Gateway. Includes the \
@@ -179,7 +181,7 @@ defmodule PortalAPI.Schemas.Gateway do
           ]
         }
       }
-    })
+    }))
   end
 
   defmodule UpdateSchema do
@@ -225,25 +227,26 @@ defmodule PortalAPI.Schemas.Gateway do
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.Gateway
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "GatewayResponse",
       description: "Response schema for single Gateway",
       type: :object,
       properties: %{
         data: Gateway.Schema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.Gateway
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "GatewaysResponse",
       description: "Response schema for multiple Gateways",
       type: :object,
@@ -251,6 +254,6 @@ defmodule PortalAPI.Schemas.Gateway do
         data: %Schema{description: "Gateways details", type: :array, items: Gateway.Schema},
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/gateway_schema.ex
+++ b/elixir/lib/portal_api/schemas/gateway_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.Gateway do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "Gateway",
       description: "Gateway",
       type: :object,
@@ -94,7 +93,6 @@ defmodule PortalAPI.Schemas.Gateway do
           description: "Remote IP longitude from the latest session"
         }
       },
-      required: [:id, :name, :ipv4, :ipv6, :online],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "vpc-us-east",

--- a/elixir/lib/portal_api/schemas/gateway_schema.ex
+++ b/elixir/lib/portal_api/schemas/gateway_schema.ex
@@ -179,16 +179,6 @@ defmodule PortalAPI.Schemas.Gateway do
             }
           ]
         }
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name" => "vpc-us-east",
-          "ipv4" => nil,
-          "ipv6" => nil,
-          "online" => false,
-          "token" => "eyJhbGc..."
-        }
       }
     })
   end
@@ -246,15 +236,6 @@ defmodule PortalAPI.Schemas.Gateway do
       type: :object,
       properties: %{
         data: Gateway.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name" => "vpc-us-east",
-          "ipv4" => "1.2.3.4",
-          "ipv6" => "",
-          "online" => true
-        }
       }
     })
   end
@@ -272,30 +253,6 @@ defmodule PortalAPI.Schemas.Gateway do
       properties: %{
         data: %Schema{description: "Gateways details", type: :array, items: Gateway.Schema},
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "vpc-us-east",
-            "ipv4" => "1.2.3.4",
-            "ipv6" => "",
-            "online" => true
-          },
-          %{
-            "id" => "6ecc106b-75c1-48a5-846c-14782180c1ff",
-            "name" => "vpc-us-west",
-            "ipv4" => "5.6.7.8",
-            "ipv6" => "",
-            "online" => true
-          }
-        ],
-        "metadata" => %{
-          "limit" => 10,
-          "total" => 100,
-          "prev_page" => "123123425",
-          "next_page" => "98776234123"
-        }
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/gateway_token_schema.ex
+++ b/elixir/lib/portal_api/schemas/gateway_token_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.GatewayToken do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "GatewayToken",
       description: "Gateway Token",
       type: :object,
@@ -13,7 +12,6 @@ defmodule PortalAPI.Schemas.GatewayToken do
         id: %Schema{type: :string, format: :uuid, description: "Gateway Token ID"},
         token: %Schema{type: :string, description: "Gateway Token"}
       },
-      required: [:id, :token],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "token" => "secret-token-here"

--- a/elixir/lib/portal_api/schemas/gateway_token_schema.ex
+++ b/elixir/lib/portal_api/schemas/gateway_token_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.GatewayToken do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "GatewayToken",
       description: "Gateway Token",
       type: :object,
@@ -16,27 +17,28 @@ defmodule PortalAPI.Schemas.GatewayToken do
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "token" => "secret-token-here"
       }
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.GatewayToken
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "GatewayTokenResponse",
       description: "Response schema for a new Gateway Token",
       type: :object,
       properties: %{
         data: GatewayToken.Schema
       }
-    })
+    }))
   end
 
   defmodule DeletedResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "DeletedGatewayTokenResponse",
       description: "Response schema for a deleted Gateway Token",
       type: :object,
@@ -49,13 +51,14 @@ defmodule PortalAPI.Schemas.GatewayToken do
           required: [:id]
         }
       }
-    })
+    }))
   end
 
   defmodule DeletedAllResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "DeletedGatewayTokensResponse",
       description: "Response schema for deleted Gateway Tokens",
       type: :object,
@@ -71,6 +74,6 @@ defmodule PortalAPI.Schemas.GatewayToken do
           required: [:deleted_count]
         }
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/gateway_token_schema.ex
+++ b/elixir/lib/portal_api/schemas/gateway_token_schema.ex
@@ -29,12 +29,6 @@ defmodule PortalAPI.Schemas.GatewayToken do
       type: :object,
       properties: %{
         data: GatewayToken.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "token" => "secret-token-here"
-        }
       }
     })
   end
@@ -54,11 +48,6 @@ defmodule PortalAPI.Schemas.GatewayToken do
             id: %Schema{type: :string, format: :uuid, description: "Gateway Token ID"}
           },
           required: [:id]
-        }
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205"
         }
       }
     })
@@ -82,11 +71,6 @@ defmodule PortalAPI.Schemas.GatewayToken do
             }
           },
           required: [:deleted_count]
-        }
-      },
-      example: %{
-        "data" => %{
-          "deleted_count" => 5
         }
       }
     })

--- a/elixir/lib/portal_api/schemas/gateway_token_schema.ex
+++ b/elixir/lib/portal_api/schemas/gateway_token_schema.ex
@@ -20,10 +20,10 @@ defmodule PortalAPI.Schemas.GatewayToken do
   end
 
   defmodule Response do
-    require OpenApiSpex
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.GatewayToken
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "GatewayTokenResponse",
       description: "Response schema for a new Gateway Token",
       type: :object,
@@ -34,10 +34,9 @@ defmodule PortalAPI.Schemas.GatewayToken do
   end
 
   defmodule DeletedResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "DeletedGatewayTokenResponse",
       description: "Response schema for a deleted Gateway Token",
       type: :object,
@@ -54,10 +53,9 @@ defmodule PortalAPI.Schemas.GatewayToken do
   end
 
   defmodule DeletedAllResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "DeletedGatewayTokensResponse",
       description: "Response schema for deleted Gateway Tokens",
       type: :object,

--- a/elixir/lib/portal_api/schemas/google_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/google_auth_provider_schema.ex
@@ -39,11 +39,10 @@ defmodule PortalAPI.Schemas.GoogleAuthProvider do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.GoogleAuthProvider
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "GoogleAuthProviderResponse",
       description: "Response schema for single Google Auth Provider",
       type: :object,
@@ -54,12 +53,11 @@ defmodule PortalAPI.Schemas.GoogleAuthProvider do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.GoogleAuthProvider
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "GoogleAuthProviderListResponse",
       description: "Response schema for multiple Google Auth Providers",
       type: :object,

--- a/elixir/lib/portal_api/schemas/google_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/google_auth_provider_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.GoogleAuthProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "GoogleAuthProvider",
       description: "Google Auth Provider",
       type: :object,
@@ -35,29 +36,30 @@ defmodule PortalAPI.Schemas.GoogleAuthProvider do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       }
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.GoogleAuthProvider
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "GoogleAuthProviderResponse",
       description: "Response schema for single Google Auth Provider",
       type: :object,
       properties: %{
         data: GoogleAuthProvider.Schema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.GoogleAuthProvider
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "GoogleAuthProviderListResponse",
       description: "Response schema for multiple Google Auth Providers",
       type: :object,
@@ -69,6 +71,6 @@ defmodule PortalAPI.Schemas.GoogleAuthProvider do
         },
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/google_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/google_auth_provider_schema.ex
@@ -11,8 +11,8 @@ defmodule PortalAPI.Schemas.GoogleAuthProvider do
       properties: %{
         id: %Schema{type: :string, format: :uuid, description: "Provider ID"},
         account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
-        name: %Schema{type: :string, description: "Provider name"},
-        issuer: %Schema{type: :string, description: "Issuer"},
+        name: %Schema{example: "Google", type: :string, description: "Provider name"},
+        issuer: %Schema{example: "https://accounts.google.com", type: :string, description: "Issuer"},
         context: %Schema{
           type: :string,
           description: "Context",
@@ -34,11 +34,6 @@ defmodule PortalAPI.Schemas.GoogleAuthProvider do
           description: "Creation timestamp"
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
-      },
-      example: %{
-        "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-        "name" => "Google",
-        "issuer" => "https://accounts.google.com"
       }
     })
   end
@@ -54,12 +49,6 @@ defmodule PortalAPI.Schemas.GoogleAuthProvider do
       type: :object,
       properties: %{
         data: GoogleAuthProvider.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name" => "Google"
-        }
       }
     })
   end
@@ -81,14 +70,6 @@ defmodule PortalAPI.Schemas.GoogleAuthProvider do
           items: GoogleAuthProvider.Schema
         },
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "Google"
-          }
-        ]
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/google_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/google_auth_provider_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.GoogleAuthProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "GoogleAuthProvider",
       description: "Google Auth Provider",
       type: :object,
@@ -36,7 +35,6 @@ defmodule PortalAPI.Schemas.GoogleAuthProvider do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
-      required: [:id, :name],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "Google",

--- a/elixir/lib/portal_api/schemas/google_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/google_directory_schema.ex
@@ -11,11 +11,11 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
       properties: %{
         id: %Schema{type: :string, format: :uuid, description: "Directory ID"},
         account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
-        name: %Schema{type: :string, description: "Directory name"},
-        domain: %Schema{type: :string, description: "Google Workspace domain"},
-        impersonation_email: %Schema{type: :string, description: "Impersonation email"},
+        name: %Schema{example: "Google", type: :string, description: "Directory name"},
+        domain: %Schema{example: "example.com", type: :string, description: "Google Workspace domain"},
+        impersonation_email: %Schema{example: "admin@example.com", type: :string, description: "Impersonation email"},
         is_disabled: %Schema{type: :boolean, description: "Whether directory is disabled"},
-        disabled_reason: %Schema{
+        disabled_reason: %Schema{example: "Sync failed on 5 consecutive attempts",
           type: :string,
           nullable: true,
           description: "Reason for disabling"
@@ -26,7 +26,7 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
           nullable: true,
           description: "Last sync timestamp"
         },
-        error_message: %Schema{
+        error_message: %Schema{example: "invalid_grant: token has expired or been revoked",
           type: :string,
           nullable: true,
           description: "Last error message"
@@ -52,11 +52,6 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
           description: "Creation timestamp"
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
-      },
-      example: %{
-        "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-        "name" => "Google",
-        "domain" => "example.com"
       }
     })
   end
@@ -72,12 +67,6 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
       type: :object,
       properties: %{
         data: GoogleDirectory.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name" => "Google"
-        }
       }
     })
   end
@@ -99,14 +88,6 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
           items: GoogleDirectory.Schema
         },
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "Google"
-          }
-        ]
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/google_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/google_directory_schema.ex
@@ -57,11 +57,10 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.GoogleDirectory
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "GoogleDirectoryResponse",
       description: "Response schema for single Google Directory",
       type: :object,
@@ -72,12 +71,11 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.GoogleDirectory
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "GoogleDirectoryListResponse",
       description: "Response schema for multiple Google Directories",
       type: :object,

--- a/elixir/lib/portal_api/schemas/google_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/google_directory_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "GoogleDirectory",
       description: "Google Directory",
       type: :object,
@@ -53,29 +54,30 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       }
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.GoogleDirectory
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "GoogleDirectoryResponse",
       description: "Response schema for single Google Directory",
       type: :object,
       properties: %{
         data: GoogleDirectory.Schema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.GoogleDirectory
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "GoogleDirectoryListResponse",
       description: "Response schema for multiple Google Directories",
       type: :object,
@@ -87,6 +89,6 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
         },
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/google_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/google_directory_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "GoogleDirectory",
       description: "Google Directory",
       type: :object,
@@ -15,10 +14,6 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
         name: %Schema{type: :string, description: "Directory name"},
         domain: %Schema{type: :string, description: "Google Workspace domain"},
         impersonation_email: %Schema{type: :string, description: "Impersonation email"},
-        error_email_count: %Schema{
-          type: :integer,
-          description: "Number of error emails sent for this directory"
-        },
         is_disabled: %Schema{type: :boolean, description: "Whether directory is disabled"},
         disabled_reason: %Schema{
           type: :string,
@@ -58,7 +53,6 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
-      required: [:id, :name],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "Google",

--- a/elixir/lib/portal_api/schemas/google_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/google_directory_schema.ex
@@ -15,19 +15,32 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
         name: %Schema{type: :string, description: "Directory name"},
         domain: %Schema{type: :string, description: "Google Workspace domain"},
         impersonation_email: %Schema{type: :string, description: "Impersonation email"},
-        error_count: %Schema{type: :integer, description: "Error count"},
+        error_email_count: %Schema{
+          type: :integer,
+          description: "Number of error emails sent for this directory"
+        },
         is_disabled: %Schema{type: :boolean, description: "Whether directory is disabled"},
-        disabled_reason: %Schema{type: :string, description: "Reason for disabling"},
+        disabled_reason: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Reason for disabling"
+        },
         synced_at: %Schema{
           type: :string,
           format: :"date-time",
+          nullable: true,
           description: "Last sync timestamp"
         },
-        error: %Schema{type: :string, description: "Last error message"},
-        error_emailed_at: %Schema{
+        error_message: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Last error message"
+        },
+        errored_at: %Schema{
           type: :string,
           format: :"date-time",
-          description: "Error email timestamp"
+          nullable: true,
+          description: "Last error timestamp"
         },
         group_sync_mode: %Schema{
           type: :string,

--- a/elixir/lib/portal_api/schemas/group_schema.ex
+++ b/elixir/lib/portal_api/schemas/group_schema.ex
@@ -127,19 +127,6 @@ defmodule PortalAPI.Schemas.Group do
       type: :object,
       properties: %{
         data: Group.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name" => "Engineering",
-          "email" => nil,
-          "entity_type" => "group",
-          "directory_id" => nil,
-          "idp_id" => nil,
-          "synced_at" => nil,
-          "inserted_at" => "2024-01-15T10:30:00Z",
-          "updated_at" => "2024-01-15T10:30:00Z"
-        }
       }
     })
   end
@@ -157,38 +144,6 @@ defmodule PortalAPI.Schemas.Group do
       properties: %{
         data: %Schema{description: "Group details", type: :array, items: Group.Schema},
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "Engineering",
-            "email" => nil,
-            "entity_type" => "group",
-            "directory_id" => nil,
-            "idp_id" => nil,
-            "synced_at" => nil,
-            "inserted_at" => "2024-01-15T10:30:00Z",
-            "updated_at" => "2024-01-15T10:30:00Z"
-          },
-          %{
-            "id" => "4ae929a7-1973-43f2-a1a8-9221b91a4c0e",
-            "name" => "firezone-sync-admins",
-            "email" => "firezone-sync-admins@example.com",
-            "entity_type" => "group",
-            "directory_id" => "6b4e3a2c-1234-5678-9abc-def012345678",
-            "idp_id" => "google-workspace-group-123",
-            "synced_at" => "2024-01-14T16:00:00Z",
-            "inserted_at" => "2024-01-10T08:15:00Z",
-            "updated_at" => "2024-01-14T16:45:00Z"
-          }
-        ],
-        "metadata" => %{
-          "limit" => 10,
-          "total" => 100,
-          "prev_page" => "123123425",
-          "next_page" => "98776234123"
-        }
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/group_schema.ex
+++ b/elixir/lib/portal_api/schemas/group_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.Group do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "Group",
       description: "Group",
       type: :object,
@@ -50,7 +49,6 @@ defmodule PortalAPI.Schemas.Group do
           description: "Last update timestamp"
         }
       },
-      required: [:id, :name, :entity_type, :inserted_at, :updated_at],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "Engineering",

--- a/elixir/lib/portal_api/schemas/group_schema.ex
+++ b/elixir/lib/portal_api/schemas/group_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.Group do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "Group",
       description: "Group",
       type: :object,
@@ -60,7 +61,7 @@ defmodule PortalAPI.Schemas.Group do
         "inserted_at" => "2024-01-15T10:30:00Z",
         "updated_at" => "2024-01-15T10:30:00Z"
       }
-    })
+    }))
   end
 
   defmodule CreateRequest do
@@ -117,25 +118,26 @@ defmodule PortalAPI.Schemas.Group do
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.Group
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "GroupResponse",
       description: "Response schema for single Group",
       type: :object,
       properties: %{
         data: Group.Schema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.Group
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "GroupListResponse",
       description: "Response schema for multiple Groups",
       type: :object,
@@ -143,6 +145,6 @@ defmodule PortalAPI.Schemas.Group do
         data: %Schema{description: "Group details", type: :array, items: Group.Schema},
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/group_schema.ex
+++ b/elixir/lib/portal_api/schemas/group_schema.ex
@@ -117,11 +117,10 @@ defmodule PortalAPI.Schemas.Group do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Group
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "GroupResponse",
       description: "Response schema for single Group",
       type: :object,
@@ -132,12 +131,11 @@ defmodule PortalAPI.Schemas.Group do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Group
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "GroupListResponse",
       description: "Response schema for multiple Groups",
       type: :object,

--- a/elixir/lib/portal_api/schemas/intune_device_schema.ex
+++ b/elixir/lib/portal_api/schemas/intune_device_schema.ex
@@ -2,7 +2,8 @@ defmodule PortalAPI.Schemas.IntuneDevice do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
     # Exposure is an explicit allowlist: a newly synced column must be added to
     # @exposed or @internal before it compiles. Property types stay derived.
@@ -128,35 +129,36 @@ defmodule PortalAPI.Schemas.IntuneDevice do
                   {field, schema}
                 end)
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "IntuneDevice",
       description: "Device synced from Microsoft Intune",
       type: :object,
       properties: @properties
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "IntuneDeviceResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.IntuneDevice.Schema}
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "IntuneDeviceListResponse",
       type: :object,
       properties: %{
         data: %Schema{type: :array, items: PortalAPI.Schemas.IntuneDevice.Schema},
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/intune_device_schema.ex
+++ b/elixir/lib/portal_api/schemas/intune_device_schema.ex
@@ -137,10 +137,9 @@ defmodule PortalAPI.Schemas.IntuneDevice do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "IntuneDeviceResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.IntuneDevice.Schema}
@@ -148,11 +147,10 @@ defmodule PortalAPI.Schemas.IntuneDevice do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "IntuneDeviceListResponse",
       type: :object,
       properties: %{

--- a/elixir/lib/portal_api/schemas/intune_device_schema.ex
+++ b/elixir/lib/portal_api/schemas/intune_device_schema.ex
@@ -2,15 +2,116 @@ defmodule PortalAPI.Schemas.IntuneDevice do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
+    # Exposure is an explicit allowlist: a newly synced column must be added to
+    # @exposed or @internal before it compiles. Property types stay derived.
     # The device table mirrors the Microsoft Graph managedDevice resource field
     # for field, so the documented properties are derived from the Ecto schema.
     # A newly synced field cannot end up in the database but missing here.
     @required [:account_id, :posture_provider_id, :intune_id, :synced_at]
 
-    @properties Map.new(Portal.Intune.Device.__schema__(:fields), fn field ->
+    @exposed [
+                :account_id,
+                :intune_id,
+                :posture_provider_id,
+                :device_name,
+                :managed_device_name,
+                :serial_number,
+                :entra_device_id,
+                :enrollment_profile_name,
+                :device_category_display_name,
+                :user_id,
+                :user_principal_name,
+                :user_display_name,
+                :email_address,
+                :operating_system,
+                :os_version,
+                :model,
+                :manufacturer,
+                :imei,
+                :meid,
+                :iccid,
+                :udid,
+                :phone_number,
+                :subscriber_carrier,
+                :wifi_mac_address,
+                :ethernet_mac_address,
+                :android_security_patch_level,
+                :total_storage_space_bytes,
+                :free_storage_space_bytes,
+                :physical_memory_bytes,
+                :compliance_state,
+                :management_state,
+                :management_agent,
+                :managed_device_owner_type,
+                :device_enrollment_type,
+                :device_registration_state,
+                :partner_reported_threat_state,
+                :jail_broken,
+                :is_encrypted,
+                :is_supervised,
+                :entra_registered,
+                :require_user_enrollment_approval,
+                :notes,
+                :eas_activated,
+                :eas_device_id,
+                :eas_activated_at,
+                :exchange_access_state,
+                :exchange_access_state_reason,
+                :exchange_last_successful_sync_at,
+                :config_manager_inventory,
+                :config_manager_modern_apps,
+                :config_manager_resource_access,
+                :config_manager_device_configuration,
+                :config_manager_compliance_policy,
+                :config_manager_windows_update_for_business,
+                :attestation_last_update_date_time,
+                :attestation_content_namespace_url,
+                :attestation_status,
+                :attestation_content_version,
+                :attestation_issued_at,
+                :attestation_identity_key,
+                :attestation_reset_count,
+                :attestation_restart_count,
+                :attestation_data_execution_policy,
+                :attestation_bit_locker_status,
+                :attestation_boot_manager_version,
+                :attestation_code_integrity_check_version,
+                :attestation_secure_boot,
+                :attestation_boot_debugging,
+                :attestation_operating_system_kernel_debugging,
+                :attestation_code_integrity,
+                :attestation_test_signing,
+                :attestation_safe_mode,
+                :attestation_windows_pe,
+                :attestation_early_launch_anti_malware_driver_protection,
+                :attestation_virtual_secure_mode,
+                :attestation_pcr_hash_algorithm,
+                :attestation_boot_app_security_version,
+                :attestation_boot_manager_security_version,
+                :attestation_tpm_version,
+                :attestation_pcr0,
+                :attestation_secure_boot_config_policy_fingerprint,
+                :attestation_code_integrity_policy,
+                :attestation_boot_revision_list_info,
+                :attestation_operating_system_rev_list_info,
+                :attestation_health_status_mismatch_info,
+                :attestation_supported_status,
+                :device_action_results,
+                :enrolled_at,
+                :last_sync_at,
+                :compliance_grace_period_expiration_at,
+                :management_certificate_expires_at,
+                :synced_at,
+                :inserted_at,
+                :updated_at
+             ]
+    @internal []
+
+    PortalAPI.Schemas.Object.assert_classified!(Portal.Intune.Device, @exposed, @internal)
+
+    @properties Map.new(@exposed, fn field ->
                   nullable = field not in @required
 
                   schema =
@@ -27,12 +128,11 @@ defmodule PortalAPI.Schemas.IntuneDevice do
                   {field, schema}
                 end)
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "IntuneDevice",
       description: "Device synced from Microsoft Intune",
       type: :object,
-      properties: @properties,
-      required: @required
+      properties: @properties
     })
   end
 

--- a/elixir/lib/portal_api/schemas/intune_posture_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/intune_posture_provider_schema.ex
@@ -28,10 +28,9 @@ defmodule PortalAPI.Schemas.IntunePostureProvider do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "IntunePostureProviderResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.IntunePostureProvider.Schema}
@@ -39,11 +38,10 @@ defmodule PortalAPI.Schemas.IntunePostureProvider do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "IntunePostureProviderListResponse",
       type: :object,
       properties: %{

--- a/elixir/lib/portal_api/schemas/intune_posture_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/intune_posture_provider_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.IntunePostureProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "IntunePostureProvider",
       description: "Microsoft Intune posture provider",
       type: :object,
@@ -24,24 +25,25 @@ defmodule PortalAPI.Schemas.IntunePostureProvider do
         updated_at: %Schema{type: :string, format: :"date-time"}
       },
       required: [:id, :account_id, :type, :name, :tenant_id, :is_verified, :is_disabled]
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "IntunePostureProviderResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.IntunePostureProvider.Schema}
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "IntunePostureProviderListResponse",
       type: :object,
       properties: %{
@@ -51,6 +53,6 @@ defmodule PortalAPI.Schemas.IntunePostureProvider do
         },
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/intune_posture_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/intune_posture_provider_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.IntunePostureProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "IntunePostureProvider",
       description: "Microsoft Intune posture provider",
       type: :object,

--- a/elixir/lib/portal_api/schemas/iru_device_schema.ex
+++ b/elixir/lib/portal_api/schemas/iru_device_schema.ex
@@ -142,10 +142,9 @@ defmodule PortalAPI.Schemas.IruDevice do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "IruDeviceResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.IruDevice.Schema}
@@ -153,11 +152,10 @@ defmodule PortalAPI.Schemas.IruDevice do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "IruDeviceListResponse",
       type: :object,
       properties: %{

--- a/elixir/lib/portal_api/schemas/iru_device_schema.ex
+++ b/elixir/lib/portal_api/schemas/iru_device_schema.ex
@@ -2,15 +2,107 @@ defmodule PortalAPI.Schemas.IruDevice do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
+    # Exposure is an explicit allowlist: a newly synced column must be added to
+    # @exposed or @internal before it compiles. Property types stay derived.
     # The device table mirrors what Iru reports for a device, so the documented
     # properties are derived from the Ecto schema. A newly synced field cannot
     # end up in the database but missing here.
     @required [:account_id, :posture_provider_id, :iru_id, :synced_at]
 
-    @properties Map.new(Portal.Iru.Device.__schema__(:fields), fn field ->
+    @exposed [
+                :account_id,
+                :iru_id,
+                :posture_provider_id,
+                :device_name,
+                :model,
+                :serial_number,
+                :platform,
+                :os_version,
+                :supplemental_build_version,
+                :supplemental_os_version_extra,
+                :last_check_in_at,
+                :user_id,
+                :user_name,
+                :user_email,
+                :user_is_archived,
+                :asset_tag,
+                :blueprint_id,
+                :blueprint_name,
+                :mdm_enabled,
+                :agent_installed,
+                :agent_version,
+                :is_missing,
+                :is_removed,
+                :first_enrolled_at,
+                :last_enrolled_at,
+                :lost_mode_status,
+                :tags,
+                :device_family,
+                :device_capacity_gb,
+                :host_name,
+                :local_hostname,
+                :apple_silicon,
+                :model_name,
+                :model_identifier,
+                :shared_ipad,
+                :cellular_technology,
+                :data_roaming,
+                :hotspot,
+                :os_build,
+                :os_name,
+                :display_os_version,
+                :inventory_collected_at,
+                :filevault_enabled,
+                :filevault_key_type,
+                :filevault_key_escrowed,
+                :filevault_regeneration_needed,
+                :filevault_key_rotation_scheduled_at,
+                :filevault_collected_at,
+                :firewall_enabled,
+                :firewall_block_all_incoming,
+                :firewall_logging,
+                :firewall_logging_option,
+                :firewall_stealth_mode,
+                :firewall_version,
+                :firewall_allow_signed_applications,
+                :firewall_unloading,
+                :firewall_collected_at,
+                :gatekeeper_enabled,
+                :gatekeeper_trusted_developers,
+                :gatekeeper_version,
+                :gatekeeper_opaque_version,
+                :xprotect_version,
+                :malware_removal_tool_version,
+                :gatekeeper_collected_at,
+                :sip_enabled,
+                :ssv_enabled,
+                :bootstrap_token_auth,
+                :bootstrap_token_escrowed,
+                :kext_requires_bootstrap_token,
+                :software_update_requires_bootstrap_token,
+                :external_boot_level,
+                :secure_boot_level,
+                :any_signed_os,
+                :mdm_manages_kext,
+                :user_manages_kext,
+                :startup_settings_collected_at,
+                :activation_lock_supported,
+                :activation_lock_allowed_while_supervised,
+                :device_activation_lock_enabled,
+                :user_activation_lock_enabled,
+                :activation_lock_bypass_code_failed,
+                :activation_lock_collected_at,
+                :synced_at,
+                :inserted_at,
+                :updated_at
+             ]
+    @internal []
+
+    PortalAPI.Schemas.Object.assert_classified!(Portal.Iru.Device, @exposed, @internal)
+
+    @properties Map.new(@exposed, fn field ->
                   nullable = field not in @required
 
                   schema =
@@ -41,12 +133,11 @@ defmodule PortalAPI.Schemas.IruDevice do
                   {field, schema}
                 end)
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "IruDevice",
       description: "Device synced from Iru (formerly Kandji)",
       type: :object,
-      properties: @properties,
-      required: @required
+      properties: @properties
     })
   end
 

--- a/elixir/lib/portal_api/schemas/iru_device_schema.ex
+++ b/elixir/lib/portal_api/schemas/iru_device_schema.ex
@@ -2,7 +2,8 @@ defmodule PortalAPI.Schemas.IruDevice do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
     # Exposure is an explicit allowlist: a newly synced column must be added to
     # @exposed or @internal before it compiles. Property types stay derived.
@@ -133,35 +134,36 @@ defmodule PortalAPI.Schemas.IruDevice do
                   {field, schema}
                 end)
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "IruDevice",
       description: "Device synced from Iru (formerly Kandji)",
       type: :object,
       properties: @properties
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "IruDeviceResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.IruDevice.Schema}
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "IruDeviceListResponse",
       type: :object,
       properties: %{
         data: %Schema{type: :array, items: PortalAPI.Schemas.IruDevice.Schema},
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/iru_posture_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/iru_posture_provider_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.IruPostureProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "IruPostureProvider",
       description: "Iru (formerly Kandji) posture provider",
       type: :object,

--- a/elixir/lib/portal_api/schemas/iru_posture_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/iru_posture_provider_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.IruPostureProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "IruPostureProvider",
       description: "Iru (formerly Kandji) posture provider",
       type: :object,
@@ -34,30 +35,31 @@ defmodule PortalAPI.Schemas.IruPostureProvider do
         :is_verified,
         :is_disabled
       ]
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "IruPostureProviderResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.IruPostureProvider.Schema}
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "IruPostureProviderListResponse",
       type: :object,
       properties: %{
         data: %Schema{type: :array, items: PortalAPI.Schemas.IruPostureProvider.Schema},
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/iru_posture_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/iru_posture_provider_schema.ex
@@ -38,10 +38,9 @@ defmodule PortalAPI.Schemas.IruPostureProvider do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "IruPostureProviderResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.IruPostureProvider.Schema}
@@ -49,11 +48,10 @@ defmodule PortalAPI.Schemas.IruPostureProvider do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "IruPostureProviderListResponse",
       type: :object,
       properties: %{

--- a/elixir/lib/portal_api/schemas/log_schema.ex
+++ b/elixir/lib/portal_api/schemas/log_schema.ex
@@ -1,10 +1,11 @@
 defmodule PortalAPI.Schemas.Log do
   defmodule Change do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
     alias PortalAPI.Schemas
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ChangeLog",
       description: """
       A single entry from the account audit log.
@@ -71,16 +72,17 @@ defmodule PortalAPI.Schemas.Log do
         "after" => %{"name" => "Jane Smith"},
         "subject" => nil
       }
-    })
+    }))
   end
 
   defmodule Session do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
     alias PortalAPI.Schemas
     alias PortalAPI.Schemas.SessionSubject
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "SessionLog",
       description: """
       A single Session Log entry, recording one Client, Gateway, or Portal
@@ -144,13 +146,14 @@ defmodule PortalAPI.Schemas.Log do
           "user_agent" => "Linux/6.5.0 connlib/1.5.1"
         }
       }
-    })
+    }))
   end
 
   defmodule Flow do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "FlowLog",
       description: """
       A single Flow Log entry, recording one network flow as accounted by one
@@ -380,13 +383,14 @@ defmodule PortalAPI.Schemas.Log do
             "Bytes sent initiator-to-responder, as counted by the reporting side. Null while the flow is open."
         }
       }
-    })
+    }))
   end
 
   defmodule APIRequest do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "APIRequestLog",
       description: """
       A single API Request Log entry, recording one authenticated REST API
@@ -445,7 +449,7 @@ defmodule PortalAPI.Schemas.Log do
         "ip_lat" => 19.4326,
         "ip_lon" => -99.1332
       }
-    })
+    }))
   end
 
   defmodule Item do
@@ -464,24 +468,25 @@ defmodule PortalAPI.Schemas.Log do
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.Log
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "LogResponse",
       description: "Response schema for a single Log entry.",
       type: :object,
       properties: %{
         data: Log.Item
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.Log
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "LogsResponse",
       description: """
       Response schema for a page of Log entries.
@@ -499,6 +504,6 @@ defmodule PortalAPI.Schemas.Log do
         },
         metadata: %Schema{description: "Pagination metadata", type: :object}
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/log_schema.ex
+++ b/elixir/lib/portal_api/schemas/log_schema.ex
@@ -78,6 +78,7 @@ defmodule PortalAPI.Schemas.Log do
     use PortalAPI.Schemas.Object
 
     alias PortalAPI.Schemas
+    alias PortalAPI.Schemas.SessionSubject
 
     object(%{
       title: "SessionLog",
@@ -107,7 +108,20 @@ defmodule PortalAPI.Schemas.Log do
           enum: ["client", "gateway", "portal"],
           description: "The kind of session that was created."
         },
-        subject: Schemas.Subject
+        subject: %Schema{
+          nullable: true,
+          description: """
+          Who established the session and from where. The shape depends on
+          `context`, which is the field to switch on:
+
+          - `client`: a `ClientSessionSubject` - the actor, plus the Client and
+            token the session was established with.
+          - `gateway`: a `GatewaySessionSubject` - the Gateway and its token. A
+            Gateway authenticates as itself, so no actor fields are recorded.
+          - `portal`: a plain `Subject`.
+          """,
+          oneOf: [SessionSubject.Client, SessionSubject.Gateway, Schemas.Subject]
+        }
       },
       example: %{
         "type" => "session",
@@ -116,7 +130,10 @@ defmodule PortalAPI.Schemas.Log do
         "context" => "client",
         "subject" => %{
           "actor_id" => "84e7f82f-831a-4a9d-8f17-c66c2bb6e205",
+          "actor_name" => "Admin User",
           "actor_email" => "admin@example.com",
+          "actor_type" => "account_admin_user",
+          "auth_provider_id" => "98776234-1234-5678-9012-345678901234",
           "device_id" => "11e7f82f-831a-4a9d-8f17-c66c2bb6e205",
           "token_id" => "22e7f82f-831a-4a9d-8f17-c66c2bb6e205",
           "ip" => "189.172.73.1",
@@ -164,11 +181,11 @@ defmodule PortalAPI.Schemas.Log do
           format: :"date-time",
           description: "RFC 3339 timestamp identifying when the flow was ingested."
         },
-        initiator_device_id: %Schema{
+        initiator_device_id: %Schema{example: "11e7f82f-831a-4a9d-8f17-c66c2bb6e205",
           type: :string,
           description: "ID of the Client that opened the flow. Always a Client."
         },
-        responder_device_id: %Schema{
+        responder_device_id: %Schema{example: "9d3a1c40-5f2b-4c8e-9a71-0b6d4e2f8c13",
           type: :string,
           description: """
           ID of the device the flow was opened to: the Gateway serving the
@@ -185,11 +202,11 @@ defmodule PortalAPI.Schemas.Log do
             Clients report either role.
           """
         },
-        policy_authorization_id: %Schema{
+        policy_authorization_id: %Schema{example: "6fa1d58f-0289-42e6-a3ba-7edfa46ee2d5",
           type: :string,
           description: "ID of the Policy Authorization that permitted the flow."
         },
-        policy_id: %Schema{
+        policy_id: %Schema{example: "46f997d1-77c8-4936-8655-8f050dffbfa4",
           type: :string,
           description: "ID of the Policy that permitted the flow."
         },
@@ -229,14 +246,14 @@ defmodule PortalAPI.Schemas.Log do
           format: :"date-time",
           description: "When the Policy Authorization expires."
         },
-        initiator_auth_provider_id: %Schema{
+        initiator_auth_provider_id: %Schema{example: "7b2c1e40-9f3a-4d21-8c5e-1a2b3c4d5e6f",
           type: :string,
           nullable: true,
           description: """
           ID of the Auth Provider the initiating Client authenticated with.
           """
         },
-        initiator_actor_id: %Schema{
+        initiator_actor_id: %Schema{example: "84e7f82f-831a-4a9d-8f17-c66c2bb6e205",
           type: :string,
           nullable: true,
           description: """
@@ -245,61 +262,61 @@ defmodule PortalAPI.Schemas.Log do
           flows the receiving Client's own Actor is not recorded here.
           """
         },
-        initiator_actor_name: %Schema{type: :string, nullable: true},
-        initiator_actor_email: %Schema{type: :string, nullable: true},
-        initiator_client_version: %Schema{
+        initiator_actor_name: %Schema{example: "John Doe", type: :string, nullable: true},
+        initiator_actor_email: %Schema{example: "user@example.com", type: :string, nullable: true},
+        initiator_client_version: %Schema{example: "1.5.1",
           type: :string,
           nullable: true,
           description: "Firezone Client version reported by the initiating Client."
         },
-        initiator_device_os_name: %Schema{
+        initiator_device_os_name: %Schema{example: "macOS",
           type: :string,
           nullable: true,
           description: "Operating system reported by the initiating Client."
         },
-        initiator_device_os_version: %Schema{
+        initiator_device_os_version: %Schema{example: "15.5",
           type: :string,
           nullable: true,
           description: "Operating system version reported by the initiating Client."
         },
-        initiator_device_serial: %Schema{
+        initiator_device_serial: %Schema{example: "C02ABC123",
           type: :string,
           nullable: true,
           description: "Device serial number reported by the initiating Client."
         },
-        initiator_device_uuid: %Schema{
+        initiator_device_uuid: %Schema{example: "0C4A8D24-FA9F-4E56-9B57-40D0D46A245E",
           type: :string,
           nullable: true,
           description: "Device UUID reported by the initiating Client."
         },
-        initiator_device_identifier_for_vendor: %Schema{
+        initiator_device_identifier_for_vendor: %Schema{example: "C242BC21-AB4A-4F6D-B755-F50E2B5B51B7",
           type: :string,
           nullable: true,
           description: "Vendor identifier reported by the initiating Client."
         },
-        initiator_device_firebase_installation_id: %Schema{
+        initiator_device_firebase_installation_id: %Schema{example: "firebase-installation-id",
           type: :string,
           nullable: true,
           description: "Firebase installation ID reported by the initiating Client."
         },
-        resource_id: %Schema{type: :string, description: "ID of the Resource accessed."},
-        resource_name: %Schema{type: :string},
-        resource_address: %Schema{
+        resource_id: %Schema{example: "44e7f82f-831a-4a9d-8f17-c66c2bb6e205", type: :string, description: "ID of the Resource accessed."},
+        resource_name: %Schema{example: "GitLab", type: :string},
+        resource_address: %Schema{example: "gitlab.company.com",
           type: :string,
           nullable: true,
           description: "Resource address, when the Resource type has one."
         },
-        inner_src_ip: %Schema{
+        inner_src_ip: %Schema{example: "100.64.0.1",
           type: :string,
           description: "Tunnel IP of the initiator, on both entries of the flow."
         },
-        inner_dst_ip: %Schema{
+        inner_dst_ip: %Schema{example: "10.0.0.5",
           type: :string,
           description: "Tunnel IP of the responder, on both entries of the flow."
         },
         inner_src_port: %Schema{type: :integer},
         inner_dst_port: %Schema{type: :integer},
-        inner_domain: %Schema{
+        inner_domain: %Schema{example: "gitlab.company.com",
           type: :string,
           nullable: true,
           description: "Domain name for flows to DNS Resources."
@@ -362,45 +379,6 @@ defmodule PortalAPI.Schemas.Log do
           description:
             "Bytes sent initiator-to-responder, as counted by the reporting side. Null while the flow is open."
         }
-      },
-      example: %{
-        "type" => "flow",
-        "log_id" => "f00060db0c2c8eb400000000",
-        "timestamp" => "2026-05-26T12:34:56.789Z",
-        "initiator_device_id" => "11e7f82f-831a-4a9d-8f17-c66c2bb6e205",
-        "responder_device_id" => "9d3a1c40-5f2b-4c8e-9a71-0b6d4e2f8c13",
-        "role" => "responder",
-        "policy_authorization_id" => "6fa1d58f-0289-42e6-a3ba-7edfa46ee2d5",
-        "policy_id" => "46f997d1-77c8-4936-8655-8f050dffbfa4",
-        "protocol" => "tcp",
-        "flow_start" => "2026-05-26T12:30:00.000Z",
-        "flow_end" => "2026-05-26T12:34:00.000Z",
-        "last_packet" => "2026-05-26T12:33:58.000Z",
-        "authorized_at" => "2026-05-26T12:29:00.000Z",
-        "authorization_expires_at" => "2026-05-26T20:29:00.000Z",
-        "initiator_actor_email" => "user@example.com",
-        "initiator_client_version" => "1.5.1",
-        "initiator_device_os_name" => "macOS",
-        "initiator_device_os_version" => "15.5",
-        "resource_id" => "44e7f82f-831a-4a9d-8f17-c66c2bb6e205",
-        "resource_name" => "GitLab",
-        "resource_address" => "gitlab.company.com",
-        "inner_src_ip" => "100.64.0.1",
-        "inner_dst_ip" => "10.0.0.5",
-        "inner_src_port" => 54_321,
-        "inner_dst_port" => 443,
-        "outers" => [
-          %{
-            "src_ip" => "203.0.113.10",
-            "src_port" => 51_820,
-            "dst_ip" => "198.51.100.5",
-            "dst_port" => 51_820
-          }
-        ],
-        "rx_packets" => 100,
-        "tx_packets" => 80,
-        "rx_bytes" => 102_400,
-        "tx_bytes" => 20_480
       }
     })
   end
@@ -521,26 +499,6 @@ defmodule PortalAPI.Schemas.Log do
           items: Log.Item
         },
         metadata: %Schema{description: "Pagination metadata", type: :object}
-      },
-      example: %{
-        "data" => [
-          %{
-            "type" => "change",
-            "log_id" => "c00060db0c2c8eb400000000",
-            "timestamp" => "2026-05-26T12:34:56.789Z",
-            "object" => "actors",
-            "operation" => "update",
-            "before" => %{"name" => "Jane Doe"},
-            "after" => %{"name" => "Jane Smith"},
-            "subject" => nil
-          }
-        ],
-        "metadata" => %{
-          "count" => 1,
-          "limit" => 50,
-          "next_page" => nil,
-          "prev_page" => nil
-        }
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/log_schema.ex
+++ b/elixir/lib/portal_api/schemas/log_schema.ex
@@ -1,10 +1,10 @@
 defmodule PortalAPI.Schemas.Log do
   defmodule Change do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
+
     alias PortalAPI.Schemas
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ChangeLog",
       description: """
       A single entry from the account audit log.
@@ -61,7 +61,6 @@ defmodule PortalAPI.Schemas.Log do
         },
         subject: Schemas.Subject
       },
-      required: [:type, :log_id, :timestamp, :object, :operation],
       example: %{
         "type" => "change",
         "log_id" => "c00060db0c2c8eb400000000",
@@ -76,11 +75,11 @@ defmodule PortalAPI.Schemas.Log do
   end
 
   defmodule Session do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
+
     alias PortalAPI.Schemas
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "SessionLog",
       description: """
       A single Session Log entry, recording one Client, Gateway, or Portal
@@ -110,7 +109,6 @@ defmodule PortalAPI.Schemas.Log do
         },
         subject: Schemas.Subject
       },
-      required: [:type, :log_id, :timestamp, :context, :subject],
       example: %{
         "type" => "session",
         "log_id" => "500060db0c2c8eb400000000",
@@ -133,10 +131,9 @@ defmodule PortalAPI.Schemas.Log do
   end
 
   defmodule Flow do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "FlowLog",
       description: """
       A single Flow Log entry, recording one network flow as accounted by one
@@ -366,34 +363,6 @@ defmodule PortalAPI.Schemas.Log do
             "Bytes sent initiator-to-responder, as counted by the reporting side. Null while the flow is open."
         }
       },
-      required: [
-        :type,
-        :log_id,
-        :timestamp,
-        :initiator_device_id,
-        :responder_device_id,
-        :role,
-        :policy_authorization_id,
-        :policy_id,
-        :protocol,
-        :flow_start,
-        :flow_end,
-        :last_packet,
-        :authorized_at,
-        :authorization_expires_at,
-        :resource_id,
-        :resource_name,
-        :resource_address,
-        :inner_src_ip,
-        :inner_dst_ip,
-        :inner_src_port,
-        :inner_dst_port,
-        :outers,
-        :rx_packets,
-        :tx_packets,
-        :rx_bytes,
-        :tx_bytes
-      ],
       example: %{
         "type" => "flow",
         "log_id" => "f00060db0c2c8eb400000000",
@@ -437,10 +406,9 @@ defmodule PortalAPI.Schemas.Log do
   end
 
   defmodule APIRequest do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "APIRequestLog",
       description: """
       A single API Request Log entry, recording one authenticated REST API
@@ -482,17 +450,6 @@ defmodule PortalAPI.Schemas.Log do
         ip_lat: %Schema{type: :number, nullable: true},
         ip_lon: %Schema{type: :number, nullable: true}
       },
-      required: [
-        :type,
-        :log_id,
-        :timestamp,
-        :actor_id,
-        :api_token_id,
-        :method,
-        :path,
-        :request_id,
-        :ip
-      ],
       example: %{
         "type" => "api_request",
         "log_id" => "a00060db0c2c8eb400000000",

--- a/elixir/lib/portal_api/schemas/log_schema.ex
+++ b/elixir/lib/portal_api/schemas/log_schema.ex
@@ -464,10 +464,10 @@ defmodule PortalAPI.Schemas.Log do
   end
 
   defmodule Response do
-    require OpenApiSpex
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Log
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "LogResponse",
       description: "Response schema for a single Log entry.",
       type: :object,
@@ -478,11 +478,10 @@ defmodule PortalAPI.Schemas.Log do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Log
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "LogsResponse",
       description: """
       Response schema for a page of Log entries.

--- a/elixir/lib/portal_api/schemas/membership_schema.ex
+++ b/elixir/lib/portal_api/schemas/membership_schema.ex
@@ -102,26 +102,6 @@ defmodule PortalAPI.Schemas.Membership do
           items: Membership.Schema
         },
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "John Doe",
-            "type" => "account_user"
-          },
-          %{
-            "id" => "cc9f561a-444d-4083-ab38-0abc6cf2314c",
-            "name" => "Jane Smith",
-            "type" => "account_admin_user"
-          }
-        ],
-        "metadata" => %{
-          "limit" => 10,
-          "total" => 100,
-          "prev_page" => "123123425",
-          "next_page" => "98776234123"
-        }
       }
     })
   end
@@ -145,14 +125,6 @@ defmodule PortalAPI.Schemas.Membership do
               items: %Schema{type: :string, format: :uuid, description: "Actor ID"}
             }
           }
-        }
-      },
-      example: %{
-        "data" => %{
-          "actor_ids" => [
-            "4ddfa557-7dfc-484f-894c-2024ec3fe9f7",
-            "89d22f71-939d-442d-b148-897b730adfb4"
-          ]
         }
       }
     })

--- a/elixir/lib/portal_api/schemas/membership_schema.ex
+++ b/elixir/lib/portal_api/schemas/membership_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.Membership do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "Membership",
       description: "Membership",
       type: :object,
@@ -18,7 +19,7 @@ defmodule PortalAPI.Schemas.Membership do
         "name" => "John Doe",
         "type" => "account_user"
       }
-    })
+    }))
   end
 
   defmodule PatchRequest do
@@ -86,11 +87,12 @@ defmodule PortalAPI.Schemas.Membership do
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.Membership
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "MembershipListResponse",
       description: "Response schema for Memberships",
       type: :object,
@@ -102,13 +104,14 @@ defmodule PortalAPI.Schemas.Membership do
         },
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 
   defmodule MembershipResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "MembershipResponse",
       description: "Response schema for Membership Updates",
       type: :object,
@@ -125,6 +128,6 @@ defmodule PortalAPI.Schemas.Membership do
           }
         }
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/membership_schema.ex
+++ b/elixir/lib/portal_api/schemas/membership_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.Membership do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "Membership",
       description: "Membership",
       type: :object,

--- a/elixir/lib/portal_api/schemas/membership_schema.ex
+++ b/elixir/lib/portal_api/schemas/membership_schema.ex
@@ -86,12 +86,11 @@ defmodule PortalAPI.Schemas.Membership do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Membership
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "MembershipListResponse",
       description: "Response schema for Memberships",
       type: :object,
@@ -107,10 +106,9 @@ defmodule PortalAPI.Schemas.Membership do
   end
 
   defmodule MembershipResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "MembershipResponse",
       description: "Response schema for Membership Updates",
       type: :object,

--- a/elixir/lib/portal_api/schemas/object.ex
+++ b/elixir/lib/portal_api/schemas/object.ex
@@ -1,22 +1,39 @@
 defmodule PortalAPI.Schemas.Object do
   @moduledoc """
-  Wraps `OpenApiSpex.schema/1` for response objects whose JSON view emits every
-  declared key on every call.
+  Helpers for response schemas whose payload is emitted in full.
 
-  Two things drift by hand and are derived here instead:
-
-    * `required` — computed from the declared properties, so it can never fall
-      behind as fields are added. Nullability stays an explicit per-property
-      concern (`nullable: true`); presence and null-ness are separate axes.
-
-    * `field_names/0` — the property list, exposed so the JSON view can build
-      its payload from the same source rather than a parallel map literal.
-
-  Properties the view may omit are declared with `optional:`, which drops them
-  from `required` while keeping them under the same exposure checks:
-
-      object(%{...}, optional: [:ip_stack, :site_id])
+  These are ordinary functions called from a schema's module body, so the
+  schemas stay plain `OpenApiSpex.schema/1` declarations that tooling can
+  follow.
   """
+
+  @doc """
+  Fills in `required` from the schema's declared properties.
+
+      OpenApiSpex.schema(Object.with_required(%{
+        title: "Site",
+        type: :object,
+        properties: %{...}
+      }))
+
+  A JSON view emits every property it declares, so `required` is a function of
+  `properties` rather than a second list to keep in step. Properties the view
+  may omit are named with `optional:` and left out of `required`:
+
+      Object.with_required(%{...}, optional: [:ip_stack, :site_id])
+  """
+  @spec with_required(map(), keyword()) :: map()
+  def with_required(schema, opts \\ []) when is_map(schema) do
+    properties = Map.fetch!(schema, :properties)
+    optional = Keyword.get(opts, :optional, [])
+
+    case optional -- Map.keys(properties) do
+      [] -> :ok
+      stale -> raise ArgumentError, "optional names unknown properties: #{inspect(stale)}"
+    end
+
+    Map.put(schema, :required, Enum.sort(Map.keys(properties) -- optional))
+  end
 
   @doc """
   Asserts that every field of `struct_module` is either exposed or internal.
@@ -42,41 +59,6 @@ defmodule PortalAPI.Schemas.Object do
           Add each to @exposed (published by the API) or @internal (withheld). New
           columns are not exposed by default.\
           """
-    end
-  end
-
-  defmacro __using__(_opts) do
-    quote do
-      require OpenApiSpex
-      import PortalAPI.Schemas.Object, only: [object: 1, object: 2]
-      alias OpenApiSpex.Schema
-    end
-  end
-
-  defmacro object(body, opts \\ []) do
-    quote do
-      schema_body = unquote(body)
-      opts = unquote(opts)
-      field_names = schema_body.properties |> Map.keys() |> Enum.sort()
-      optional = opts |> Keyword.get(:optional, []) |> Enum.sort()
-
-      case optional -- field_names do
-        [] -> :ok
-        stale -> raise CompileError, description: "#{inspect(__MODULE__)} marks unknown properties optional: #{inspect(stale)}"
-      end
-
-      @field_names field_names
-      @optional_field_names optional
-
-      OpenApiSpex.schema(Map.put(schema_body, :required, field_names -- optional))
-
-      @doc "Property names declared by this schema, in sorted order."
-      @spec field_names() :: [atom()]
-      def field_names, do: @field_names
-
-      @doc "Properties that may be absent from the payload."
-      @spec optional_field_names() :: [atom()]
-      def optional_field_names, do: @optional_field_names
     end
   end
 end

--- a/elixir/lib/portal_api/schemas/object.ex
+++ b/elixir/lib/portal_api/schemas/object.ex
@@ -1,0 +1,82 @@
+defmodule PortalAPI.Schemas.Object do
+  @moduledoc """
+  Wraps `OpenApiSpex.schema/1` for response objects whose JSON view emits every
+  declared key on every call.
+
+  Two things drift by hand and are derived here instead:
+
+    * `required` — computed from the declared properties, so it can never fall
+      behind as fields are added. Nullability stays an explicit per-property
+      concern (`nullable: true`); presence and null-ness are separate axes.
+
+    * `field_names/0` — the property list, exposed so the JSON view can build
+      its payload from the same source rather than a parallel map literal.
+
+  Properties the view may omit are declared with `optional:`, which drops them
+  from `required` while keeping them under the same exposure checks:
+
+      object(%{...}, optional: [:ip_stack, :site_id])
+  """
+
+  @doc """
+  Asserts that every field of `struct_module` is either exposed or internal.
+
+  For schemas that derive their properties from the Ecto schema rather than
+  listing them by hand. Without this, a newly added column is published
+  automatically; with it, the build fails until the column is classified.
+  """
+  @spec assert_classified!(module(), [atom()], [atom()]) :: :ok
+  def assert_classified!(struct_module, exposed, internal) do
+    known = struct_module.__schema__(:fields) ++ struct_module.__schema__(:virtual_fields)
+
+    case (known -- exposed) -- internal do
+      [] ->
+        :ok
+
+      unclassified ->
+        raise CompileError,
+          description: """
+          #{inspect(struct_module)} has fields that are neither exposed nor internal: \
+          #{inspect(Enum.sort(unclassified))}
+
+          Add each to @exposed (published by the API) or @internal (withheld). New
+          columns are not exposed by default.\
+          """
+    end
+  end
+
+  defmacro __using__(_opts) do
+    quote do
+      require OpenApiSpex
+      import PortalAPI.Schemas.Object, only: [object: 1, object: 2]
+      alias OpenApiSpex.Schema
+    end
+  end
+
+  defmacro object(body, opts \\ []) do
+    quote do
+      schema_body = unquote(body)
+      opts = unquote(opts)
+      field_names = schema_body.properties |> Map.keys() |> Enum.sort()
+      optional = opts |> Keyword.get(:optional, []) |> Enum.sort()
+
+      case optional -- field_names do
+        [] -> :ok
+        stale -> raise CompileError, description: "#{inspect(__MODULE__)} marks unknown properties optional: #{inspect(stale)}"
+      end
+
+      @field_names field_names
+      @optional_field_names optional
+
+      OpenApiSpex.schema(Map.put(schema_body, :required, field_names -- optional))
+
+      @doc "Property names declared by this schema, in sorted order."
+      @spec field_names() :: [atom()]
+      def field_names, do: @field_names
+
+      @doc "Properties that may be absent from the payload."
+      @spec optional_field_names() :: [atom()]
+      def optional_field_names, do: @optional_field_names
+    end
+  end
+end

--- a/elixir/lib/portal_api/schemas/oidc_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/oidc_auth_provider_schema.ex
@@ -46,11 +46,10 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.OIDCAuthProvider
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "OIDCAuthProviderResponse",
       description: "Response schema for single OIDC Auth Provider",
       type: :object,
@@ -61,12 +60,11 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.OIDCAuthProvider
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "OIDCAuthProviderListResponse",
       description: "Response schema for multiple OIDC Auth Providers",
       type: :object,

--- a/elixir/lib/portal_api/schemas/oidc_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/oidc_auth_provider_schema.ex
@@ -11,8 +11,8 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
       properties: %{
         id: %Schema{type: :string, format: :uuid, description: "Provider ID"},
         account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
-        name: %Schema{type: :string, description: "Provider name"},
-        issuer: %Schema{type: :string, description: "Issuer"},
+        name: %Schema{example: "OIDC Provider", type: :string, description: "Provider name"},
+        issuer: %Schema{example: "https://idp.example.com", type: :string, description: "Issuer"},
         context: %Schema{
           type: :string,
           description: "Context",
@@ -28,8 +28,8 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
         },
         is_disabled: %Schema{type: :boolean, description: "Whether provider is disabled"},
         is_default: %Schema{type: :boolean, description: "Whether provider is default"},
-        client_id: %Schema{type: :string, description: "Client ID"},
-        discovery_document_uri: %Schema{type: :string, description: "Discovery document URI"},
+        client_id: %Schema{example: "my-client-id", type: :string, description: "Client ID"},
+        discovery_document_uri: %Schema{example: "https://idp.example.com/.well-known/openid-configuration", type: :string, description: "Discovery document URI"},
         email_verification_method: %Schema{
           type: :string,
           description: "How sign-in verifies the email claim",
@@ -41,12 +41,6 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
           description: "Creation timestamp"
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
-      },
-      example: %{
-        "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-        "name" => "OIDC Provider",
-        "client_id" => "my-client-id",
-        "email_verification_method" => "claim"
       }
     })
   end
@@ -62,13 +56,6 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
       type: :object,
       properties: %{
         data: OIDCAuthProvider.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name" => "OIDC Provider",
-          "email_verification_method" => "claim"
-        }
       }
     })
   end
@@ -90,15 +77,6 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
           items: OIDCAuthProvider.Schema
         },
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "OIDC Provider",
-            "email_verification_method" => "claim"
-          }
-        ]
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/oidc_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/oidc_auth_provider_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "OIDCAuthProvider",
       description: "OIDC Auth Provider",
       type: :object,
@@ -43,7 +42,6 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
-      required: [:id, :name],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "OIDC Provider",

--- a/elixir/lib/portal_api/schemas/oidc_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/oidc_auth_provider_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "OIDCAuthProvider",
       description: "OIDC Auth Provider",
       type: :object,
@@ -42,29 +43,30 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       }
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.OIDCAuthProvider
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "OIDCAuthProviderResponse",
       description: "Response schema for single OIDC Auth Provider",
       type: :object,
       properties: %{
         data: OIDCAuthProvider.Schema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.OIDCAuthProvider
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "OIDCAuthProviderListResponse",
       description: "Response schema for multiple OIDC Auth Providers",
       type: :object,
@@ -76,6 +78,6 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
         },
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/okta_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/okta_auth_provider_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.OktaAuthProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "OktaAuthProvider",
       description: "Okta Auth Provider",
       type: :object,
@@ -38,7 +37,6 @@ defmodule PortalAPI.Schemas.OktaAuthProvider do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
-      required: [:id, :name],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "Okta",

--- a/elixir/lib/portal_api/schemas/okta_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/okta_auth_provider_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.OktaAuthProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "OktaAuthProvider",
       description: "Okta Auth Provider",
       type: :object,
@@ -37,29 +38,30 @@ defmodule PortalAPI.Schemas.OktaAuthProvider do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       }
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.OktaAuthProvider
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "OktaAuthProviderResponse",
       description: "Response schema for single Okta Auth Provider",
       type: :object,
       properties: %{
         data: OktaAuthProvider.Schema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.OktaAuthProvider
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "OktaAuthProviderListResponse",
       description: "Response schema for multiple Okta Auth Providers",
       type: :object,
@@ -71,6 +73,6 @@ defmodule PortalAPI.Schemas.OktaAuthProvider do
         },
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/okta_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/okta_auth_provider_schema.ex
@@ -11,8 +11,8 @@ defmodule PortalAPI.Schemas.OktaAuthProvider do
       properties: %{
         id: %Schema{type: :string, format: :uuid, description: "Provider ID"},
         account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
-        name: %Schema{type: :string, description: "Provider name"},
-        issuer: %Schema{type: :string, description: "Issuer"},
+        name: %Schema{example: "Okta", type: :string, description: "Provider name"},
+        issuer: %Schema{example: "https://example.okta.com", type: :string, description: "Issuer"},
         context: %Schema{
           type: :string,
           description: "Context",
@@ -28,19 +28,14 @@ defmodule PortalAPI.Schemas.OktaAuthProvider do
         },
         is_disabled: %Schema{type: :boolean, description: "Whether provider is disabled"},
         is_default: %Schema{type: :boolean, description: "Whether provider is default"},
-        client_id: %Schema{type: :string, description: "Client ID"},
-        okta_domain: %Schema{type: :string, description: "Okta domain"},
+        client_id: %Schema{example: "my-client-id", type: :string, description: "Client ID"},
+        okta_domain: %Schema{example: "example.okta.com", type: :string, description: "Okta domain"},
         inserted_at: %Schema{
           type: :string,
           format: :"date-time",
           description: "Creation timestamp"
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
-      },
-      example: %{
-        "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-        "name" => "Okta",
-        "okta_domain" => "example.okta.com"
       }
     })
   end
@@ -56,12 +51,6 @@ defmodule PortalAPI.Schemas.OktaAuthProvider do
       type: :object,
       properties: %{
         data: OktaAuthProvider.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name" => "Okta"
-        }
       }
     })
   end
@@ -83,14 +72,6 @@ defmodule PortalAPI.Schemas.OktaAuthProvider do
           items: OktaAuthProvider.Schema
         },
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "Okta"
-          }
-        ]
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/okta_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/okta_auth_provider_schema.ex
@@ -41,11 +41,10 @@ defmodule PortalAPI.Schemas.OktaAuthProvider do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.OktaAuthProvider
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "OktaAuthProviderResponse",
       description: "Response schema for single Okta Auth Provider",
       type: :object,
@@ -56,12 +55,11 @@ defmodule PortalAPI.Schemas.OktaAuthProvider do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.OktaAuthProvider
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "OktaAuthProviderListResponse",
       description: "Response schema for multiple Okta Auth Providers",
       type: :object,

--- a/elixir/lib/portal_api/schemas/okta_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/okta_directory_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.OktaDirectory do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "OktaDirectory",
       description: "Okta Directory",
       type: :object,
@@ -16,10 +15,6 @@ defmodule PortalAPI.Schemas.OktaDirectory do
         client_id: %Schema{type: :string, description: "Client ID"},
         kid: %Schema{type: :string, description: "Key ID"},
         okta_domain: %Schema{type: :string, description: "Okta domain"},
-        error_email_count: %Schema{
-          type: :integer,
-          description: "Number of error emails sent for this directory"
-        },
         is_disabled: %Schema{type: :boolean, description: "Whether directory is disabled"},
         disabled_reason: %Schema{
           type: :string,
@@ -50,7 +45,6 @@ defmodule PortalAPI.Schemas.OktaDirectory do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
-      required: [:id, :name],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "Okta",

--- a/elixir/lib/portal_api/schemas/okta_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/okta_directory_schema.ex
@@ -16,19 +16,32 @@ defmodule PortalAPI.Schemas.OktaDirectory do
         client_id: %Schema{type: :string, description: "Client ID"},
         kid: %Schema{type: :string, description: "Key ID"},
         okta_domain: %Schema{type: :string, description: "Okta domain"},
-        error_count: %Schema{type: :integer, description: "Error count"},
+        error_email_count: %Schema{
+          type: :integer,
+          description: "Number of error emails sent for this directory"
+        },
         is_disabled: %Schema{type: :boolean, description: "Whether directory is disabled"},
-        disabled_reason: %Schema{type: :string, description: "Reason for disabling"},
+        disabled_reason: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Reason for disabling"
+        },
         synced_at: %Schema{
           type: :string,
           format: :"date-time",
+          nullable: true,
           description: "Last sync timestamp"
         },
-        error: %Schema{type: :string, description: "Last error message"},
-        error_emailed_at: %Schema{
+        error_message: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Last error message"
+        },
+        errored_at: %Schema{
           type: :string,
           format: :"date-time",
-          description: "Error email timestamp"
+          nullable: true,
+          description: "Last error timestamp"
         },
         inserted_at: %Schema{
           type: :string,

--- a/elixir/lib/portal_api/schemas/okta_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/okta_directory_schema.ex
@@ -49,11 +49,10 @@ defmodule PortalAPI.Schemas.OktaDirectory do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.OktaDirectory
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "OktaDirectoryResponse",
       description: "Response schema for single Okta Directory",
       type: :object,
@@ -64,12 +63,11 @@ defmodule PortalAPI.Schemas.OktaDirectory do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.OktaDirectory
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "OktaDirectoryListResponse",
       description: "Response schema for multiple Okta Directories",
       type: :object,

--- a/elixir/lib/portal_api/schemas/okta_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/okta_directory_schema.ex
@@ -11,12 +11,12 @@ defmodule PortalAPI.Schemas.OktaDirectory do
       properties: %{
         id: %Schema{type: :string, format: :uuid, description: "Directory ID"},
         account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
-        name: %Schema{type: :string, description: "Directory name"},
-        client_id: %Schema{type: :string, description: "Client ID"},
-        kid: %Schema{type: :string, description: "Key ID"},
-        okta_domain: %Schema{type: :string, description: "Okta domain"},
+        name: %Schema{example: "Okta", type: :string, description: "Directory name"},
+        client_id: %Schema{example: "0oa1b2c3d4e5EXAMPLE", type: :string, description: "Client ID"},
+        kid: %Schema{example: "kid-2f8a1c9e", type: :string, description: "Key ID"},
+        okta_domain: %Schema{example: "example.okta.com", type: :string, description: "Okta domain"},
         is_disabled: %Schema{type: :boolean, description: "Whether directory is disabled"},
-        disabled_reason: %Schema{
+        disabled_reason: %Schema{example: "Sync failed on 5 consecutive attempts",
           type: :string,
           nullable: true,
           description: "Reason for disabling"
@@ -27,7 +27,7 @@ defmodule PortalAPI.Schemas.OktaDirectory do
           nullable: true,
           description: "Last sync timestamp"
         },
-        error_message: %Schema{
+        error_message: %Schema{example: "invalid_grant: token has expired or been revoked",
           type: :string,
           nullable: true,
           description: "Last error message"
@@ -44,11 +44,6 @@ defmodule PortalAPI.Schemas.OktaDirectory do
           description: "Creation timestamp"
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
-      },
-      example: %{
-        "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-        "name" => "Okta",
-        "okta_domain" => "example.okta.com"
       }
     })
   end
@@ -64,12 +59,6 @@ defmodule PortalAPI.Schemas.OktaDirectory do
       type: :object,
       properties: %{
         data: OktaDirectory.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name" => "Okta"
-        }
       }
     })
   end
@@ -91,14 +80,6 @@ defmodule PortalAPI.Schemas.OktaDirectory do
           items: OktaDirectory.Schema
         },
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "Okta"
-          }
-        ]
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/okta_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/okta_directory_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.OktaDirectory do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "OktaDirectory",
       description: "Okta Directory",
       type: :object,
@@ -45,29 +46,30 @@ defmodule PortalAPI.Schemas.OktaDirectory do
         },
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       }
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.OktaDirectory
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "OktaDirectoryResponse",
       description: "Response schema for single Okta Directory",
       type: :object,
       properties: %{
         data: OktaDirectory.Schema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.OktaDirectory
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "OktaDirectoryListResponse",
       description: "Response schema for multiple Okta Directories",
       type: :object,
@@ -79,6 +81,6 @@ defmodule PortalAPI.Schemas.OktaDirectory do
         },
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/policy_schema.ex
+++ b/elixir/lib/portal_api/schemas/policy_schema.ex
@@ -161,11 +161,11 @@ defmodule PortalAPI.Schemas.Policy do
   end
 
   defmodule ResponseSchema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
+
     alias PortalAPI.Schemas.Policy
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "Policy",
       description: "Policy",
       type: :object,
@@ -197,15 +197,6 @@ defmodule PortalAPI.Schemas.Policy do
           items: Policy.Condition
         }
       },
-      required: [
-        :id,
-        :group_id,
-        :resource_id,
-        :description,
-        :flow_log_uploads_enabled,
-        :is_disabled,
-        :conditions
-      ],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "group_id" => "88eae9ce-9179-48c6-8430-770e38dd4775",

--- a/elixir/lib/portal_api/schemas/policy_schema.ex
+++ b/elixir/lib/portal_api/schemas/policy_schema.ex
@@ -274,11 +274,10 @@ defmodule PortalAPI.Schemas.Policy do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Policy
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "PolicyResponse",
       description: "Response schema for single Policy",
       type: :object,
@@ -289,12 +288,11 @@ defmodule PortalAPI.Schemas.Policy do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Policy
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "PolicyListResponse",
       description: "Response schema for multiple Policies",
       type: :object,

--- a/elixir/lib/portal_api/schemas/policy_schema.ex
+++ b/elixir/lib/portal_api/schemas/policy_schema.ex
@@ -284,23 +284,6 @@ defmodule PortalAPI.Schemas.Policy do
       type: :object,
       properties: %{
         data: Policy.ResponseSchema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "resource_id" => "a9f60587-793c-46ae-8525-597f43ab2fb1",
-          "group_id" => "88eae9ce-9179-48c6-8430-770e38dd4775",
-          "description" => "Policy to allow something",
-          "flow_log_uploads_enabled" => true,
-          "is_disabled" => false,
-          "conditions" => [
-            %{
-              "property" => "remote_ip_location_region",
-              "operator" => "is_in",
-              "values" => ["US", "CA"]
-            }
-          ]
-        }
       }
     })
   end
@@ -318,40 +301,6 @@ defmodule PortalAPI.Schemas.Policy do
       properties: %{
         data: %Schema{description: "Policy details", type: :array, items: Policy.ResponseSchema},
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "resource_id" => "a9f60587-793c-46ae-8525-597f43ab2fb1",
-            "group_id" => "88eae9ce-9179-48c6-8430-770e38dd4775",
-            "description" => "Policy to allow something",
-            "flow_log_uploads_enabled" => true,
-            "is_disabled" => false,
-            "conditions" => [
-              %{
-                "property" => "remote_ip_location_region",
-                "operator" => "is_in",
-                "values" => ["US", "CA"]
-              }
-            ]
-          },
-          %{
-            "id" => "6301d7d2-4938-4123-87de-282c01cca656",
-            "resource_id" => "9876bd25-0f6c-48fb-a9fd-196ba9be86e5",
-            "group_id" => "343385a2-5437-4c66-8744-1332421ff736",
-            "description" => "Policy to allow something else",
-            "flow_log_uploads_enabled" => false,
-            "is_disabled" => true,
-            "conditions" => []
-          }
-        ],
-        "metadata" => %{
-          "limit" => 10,
-          "total" => 100,
-          "prev_page" => "123123425",
-          "next_page" => "98776234123"
-        }
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/policy_schema.ex
+++ b/elixir/lib/portal_api/schemas/policy_schema.ex
@@ -161,11 +161,12 @@ defmodule PortalAPI.Schemas.Policy do
   end
 
   defmodule ResponseSchema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
     alias PortalAPI.Schemas.Policy
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "Policy",
       description: "Policy",
       type: :object,
@@ -212,7 +213,7 @@ defmodule PortalAPI.Schemas.Policy do
           }
         ]
       }
-    })
+    }))
   end
 
   defmodule CreateRequest do
@@ -274,25 +275,26 @@ defmodule PortalAPI.Schemas.Policy do
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.Policy
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "PolicyResponse",
       description: "Response schema for single Policy",
       type: :object,
       properties: %{
         data: Policy.ResponseSchema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.Policy
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "PolicyListResponse",
       description: "Response schema for multiple Policies",
       type: :object,
@@ -300,6 +302,6 @@ defmodule PortalAPI.Schemas.Policy do
         data: %Schema{description: "Policy details", type: :array, items: Policy.ResponseSchema},
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/pool_member_schema.ex
+++ b/elixir/lib/portal_api/schemas/pool_member_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.PoolMember do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "PoolMember",
       description: "A Client belonging to a static device pool Resource",
       type: :object,
@@ -23,7 +24,7 @@ defmodule PortalAPI.Schemas.PoolMember do
         "name" => "jane-laptop",
         "last_seen_at" => "2024-01-15T10:30:00Z"
       }
-    })
+    }))
   end
 
   defmodule PatchRequest do
@@ -99,11 +100,12 @@ defmodule PortalAPI.Schemas.PoolMember do
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.PaginationMetadata
     alias PortalAPI.Schemas.PoolMember
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "PoolMemberListResponse",
       description: "Response schema for Pool Members",
       type: :object,
@@ -115,13 +117,14 @@ defmodule PortalAPI.Schemas.PoolMember do
         },
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 
   defmodule PoolMemberResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "PoolMemberResponse",
       description: "Response schema for Pool Member updates",
       type: :object,
@@ -138,6 +141,6 @@ defmodule PortalAPI.Schemas.PoolMember do
           }
         }
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/pool_member_schema.ex
+++ b/elixir/lib/portal_api/schemas/pool_member_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.PoolMember do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "PoolMember",
       description: "A Client belonging to a static device pool Resource",
       type: :object,

--- a/elixir/lib/portal_api/schemas/pool_member_schema.ex
+++ b/elixir/lib/portal_api/schemas/pool_member_schema.ex
@@ -99,12 +99,11 @@ defmodule PortalAPI.Schemas.PoolMember do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.PaginationMetadata
     alias PortalAPI.Schemas.PoolMember
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "PoolMemberListResponse",
       description: "Response schema for Pool Members",
       type: :object,
@@ -120,10 +119,9 @@ defmodule PortalAPI.Schemas.PoolMember do
   end
 
   defmodule PoolMemberResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "PoolMemberResponse",
       description: "Response schema for Pool Member updates",
       type: :object,

--- a/elixir/lib/portal_api/schemas/pool_member_schema.ex
+++ b/elixir/lib/portal_api/schemas/pool_member_schema.ex
@@ -115,26 +115,6 @@ defmodule PortalAPI.Schemas.PoolMember do
           items: PoolMember.Schema
         },
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "jane-laptop",
-            "last_seen_at" => "2024-01-15T10:30:00Z"
-          },
-          %{
-            "id" => "cc9f561a-444d-4083-ab38-0abc6cf2314c",
-            "name" => "field-tablet-02",
-            "last_seen_at" => nil
-          }
-        ],
-        "metadata" => %{
-          "limit" => 10,
-          "total" => 100,
-          "prev_page" => "123123425",
-          "next_page" => "98776234123"
-        }
       }
     })
   end
@@ -158,14 +138,6 @@ defmodule PortalAPI.Schemas.PoolMember do
               items: %Schema{type: :string, format: :uuid, description: "Client ID"}
             }
           }
-        }
-      },
-      example: %{
-        "data" => %{
-          "device_ids" => [
-            "4ddfa557-7dfc-484f-894c-2024ec3fe9f7",
-            "89d22f71-939d-442d-b148-897b730adfb4"
-          ]
         }
       }
     })

--- a/elixir/lib/portal_api/schemas/problem_details_schema.ex
+++ b/elixir/lib/portal_api/schemas/problem_details_schema.ex
@@ -1,6 +1,5 @@
 defmodule PortalAPI.Schemas.ProblemDetails do
-  require OpenApiSpex
-  alias OpenApiSpex.Schema
+  use PortalAPI.Schemas.Object
 
   @content_type "application/problem+json"
 
@@ -15,7 +14,7 @@ defmodule PortalAPI.Schemas.ProblemDetails do
       "Rate limit exceeded. Retry after the time indicated in the Retry-After header."
   }
 
-  OpenApiSpex.schema(%{
+  object(%{
     title: "ProblemDetails",
     description: "RFC 9457 (Problem Details for HTTP APIs) error response.",
     type: :object,
@@ -51,10 +50,9 @@ defmodule PortalAPI.Schemas.ProblemDetails do
   })
 
   defmodule ValidationError do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ValidationProblemDetails",
       description:
         "RFC 9457 error response for request validation failures. The `validation_errors` " <>
@@ -74,7 +72,6 @@ defmodule PortalAPI.Schemas.ProblemDetails do
           additionalProperties: %Schema{type: :array, items: %Schema{type: :string}}
         }
       },
-      required: [:type, :title, :status, :validation_errors],
       example: %{
         "type" => "about:blank",
         "title" => "Unprocessable Content",

--- a/elixir/lib/portal_api/schemas/problem_details_schema.ex
+++ b/elixir/lib/portal_api/schemas/problem_details_schema.ex
@@ -58,7 +58,10 @@ defmodule PortalAPI.Schemas.ProblemDetails do
       title: "ValidationProblemDetails",
       description:
         "RFC 9457 error response for request validation failures. The `validation_errors` " <>
-          "member maps each invalid field to a list of human-readable messages.",
+          "member maps each invalid field to a list of human-readable messages.\n\n" <>
+          "Uniqueness collisions are reported here rather than as `409 Conflict`: creating a " <>
+          "resource whose name is already taken within the account returns `422` with " <>
+          "`has already been taken` against the conflicting field.",
       type: :object,
       properties: %{
         type: %Schema{type: :string, example: "about:blank"},

--- a/elixir/lib/portal_api/schemas/problem_details_schema.ex
+++ b/elixir/lib/portal_api/schemas/problem_details_schema.ex
@@ -1,5 +1,6 @@
 defmodule PortalAPI.Schemas.ProblemDetails do
-  use PortalAPI.Schemas.Object
+  require OpenApiSpex
+  alias OpenApiSpex.Schema
 
   @content_type "application/problem+json"
 
@@ -14,7 +15,7 @@ defmodule PortalAPI.Schemas.ProblemDetails do
       "Rate limit exceeded. Retry after the time indicated in the Retry-After header."
   }
 
-  object(%{
+  OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
     title: "ProblemDetails",
     description: "RFC 9457 (Problem Details for HTTP APIs) error response.",
     type: :object,
@@ -47,12 +48,13 @@ defmodule PortalAPI.Schemas.ProblemDetails do
       "status" => 404,
       "detail" => "The requested resource could not be found."
     }
-  })
+  }))
 
   defmodule ValidationError do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ValidationProblemDetails",
       description:
         "RFC 9457 error response for request validation failures. The `validation_errors` " <>
@@ -79,7 +81,7 @@ defmodule PortalAPI.Schemas.ProblemDetails do
         "detail" => "The request body failed validation.",
         "validation_errors" => %{"name" => ["can't be blank"]}
       }
-    })
+    }))
   end
 
   @doc """

--- a/elixir/lib/portal_api/schemas/resource_schema.ex
+++ b/elixir/lib/portal_api/schemas/resource_schema.ex
@@ -10,9 +10,9 @@ defmodule PortalAPI.Schemas.Resource do
       type: :object,
       properties: %{
         id: %Schema{type: :string, format: :uuid, description: "Resource ID"},
-        name: %Schema{type: :string, description: "Resource name"},
-        address: %Schema{type: :string, description: "Resource address"},
-        address_description: %Schema{type: :string, description: "Resource address description"},
+        name: %Schema{example: "Prod DB", type: :string, description: "Resource name"},
+        address: %Schema{example: "10.0.0.10", type: :string, description: "Resource address"},
+        address_description: %Schema{example: "Production Database", type: :string, description: "Resource address description"},
         type: %Schema{
           type: :string,
           description: "Resource type. For `static_device_pool`, `address` is not applicable.",
@@ -35,17 +35,6 @@ defmodule PortalAPI.Schemas.Resource do
           description: "Traffic filters restricting the protocols and ports the Resource exposes",
           items: PortalAPI.Schemas.Resource.Filter
         }
-      },
-      example: %{
-        "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-        "name" => "Prod DB",
-        "address" => "10.0.0.10",
-        "address_description" => "Production Database",
-        "type" => "ip",
-        "filters" => [
-          %{"protocol" => "tcp", "ports" => ["5432"]}
-        ],
-        "site_id" => "0642e09d-b3a2-47e4-9cd1-c2195faeeb67"
       }
     },
       optional: [:ip_stack, :site_id])
@@ -249,16 +238,6 @@ defmodule PortalAPI.Schemas.Resource do
       type: :object,
       properties: %{
         data: Resource.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name" => "Prod DB",
-          "address" => "10.0.0.10",
-          "address_description" => "Production Database",
-          "type" => "ip",
-          "site_id" => "0642e09d-b3a2-47e4-9cd1-c2195faeeb67"
-        }
       }
     })
   end
@@ -276,32 +255,6 @@ defmodule PortalAPI.Schemas.Resource do
       properties: %{
         data: %Schema{description: "Resource details", type: :array, items: Resource.Schema},
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "Prod DB",
-            "address" => "10.0.0.10",
-            "address_description" => "Production Database",
-            "type" => "ip",
-            "site_id" => "0642e09d-b3a2-47e4-9cd1-c2195faeeb67"
-          },
-          %{
-            "id" => "3b9451c9-5616-48f8-827f-009ace22d015",
-            "name" => "Admin Dashboard",
-            "address" => "10.0.0.20",
-            "address_description" => "Production Admin Dashboard",
-            "type" => "ip",
-            "site_id" => "0642e09d-b3a2-47e4-9cd1-c2195faeeb67"
-          }
-        ],
-        "metadata" => %{
-          "limit" => 10,
-          "total" => 100,
-          "prev_page" => "123123425",
-          "next_page" => "98776234123"
-        }
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/resource_schema.ex
+++ b/elixir/lib/portal_api/schemas/resource_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.Resource do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "Resource",
       description: "Resource",
       type: :object,
@@ -37,7 +36,6 @@ defmodule PortalAPI.Schemas.Resource do
           items: PortalAPI.Schemas.Resource.Filter
         }
       },
-      required: [:name, :type],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "Prod DB",
@@ -49,7 +47,8 @@ defmodule PortalAPI.Schemas.Resource do
         ],
         "site_id" => "0642e09d-b3a2-47e4-9cd1-c2195faeeb67"
       }
-    })
+    },
+      optional: [:ip_stack, :site_id])
   end
 
   defmodule Filter do

--- a/elixir/lib/portal_api/schemas/resource_schema.ex
+++ b/elixir/lib/portal_api/schemas/resource_schema.ex
@@ -41,10 +41,9 @@ defmodule PortalAPI.Schemas.Resource do
   end
 
   defmodule Filter do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ResourceFilter",
       description: "Traffic filter restricting the protocols and ports the Resource exposes",
       type: :object,
@@ -62,7 +61,6 @@ defmodule PortalAPI.Schemas.Resource do
           items: %Schema{type: :string}
         }
       },
-      required: [:protocol],
       example: %{
         "protocol" => "tcp",
         "ports" => ["80", "443", "8000 - 9000"]
@@ -228,11 +226,10 @@ defmodule PortalAPI.Schemas.Resource do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Resource
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ResourceResponse",
       description: "Response schema for single Resource",
       type: :object,
@@ -243,12 +240,11 @@ defmodule PortalAPI.Schemas.Resource do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Resource
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ResourceListResponse",
       description: "Response schema for multiple Resources",
       type: :object,

--- a/elixir/lib/portal_api/schemas/resource_schema.ex
+++ b/elixir/lib/portal_api/schemas/resource_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.Resource do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "Resource",
       description: "Resource",
       type: :object,
@@ -37,13 +38,14 @@ defmodule PortalAPI.Schemas.Resource do
         }
       }
     },
-      optional: [:ip_stack, :site_id])
+      optional: [:ip_stack, :site_id]))
   end
 
   defmodule Filter do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ResourceFilter",
       description: "Traffic filter restricting the protocols and ports the Resource exposes",
       type: :object,
@@ -65,7 +67,7 @@ defmodule PortalAPI.Schemas.Resource do
         "protocol" => "tcp",
         "ports" => ["80", "443", "8000 - 9000"]
       }
-    })
+    }))
   end
 
   defmodule CreateRequest do
@@ -226,25 +228,26 @@ defmodule PortalAPI.Schemas.Resource do
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.Resource
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ResourceResponse",
       description: "Response schema for single Resource",
       type: :object,
       properties: %{
         data: Resource.Schema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.Resource
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ResourceListResponse",
       description: "Response schema for multiple Resources",
       type: :object,
@@ -252,6 +255,6 @@ defmodule PortalAPI.Schemas.Resource do
         data: %Schema{description: "Resource details", type: :array, items: Resource.Schema},
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/santa_device_schema.ex
+++ b/elixir/lib/portal_api/schemas/santa_device_schema.ex
@@ -93,10 +93,9 @@ defmodule PortalAPI.Schemas.SantaDevice do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "SantaDeviceResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.SantaDevice.Schema}
@@ -104,11 +103,10 @@ defmodule PortalAPI.Schemas.SantaDevice do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "SantaDeviceListResponse",
       type: :object,
       properties: %{

--- a/elixir/lib/portal_api/schemas/santa_device_schema.ex
+++ b/elixir/lib/portal_api/schemas/santa_device_schema.ex
@@ -2,7 +2,8 @@ defmodule PortalAPI.Schemas.SantaDevice do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
     @required [:account_id, :id, :posture_provider_id, :santa_id, :synced_at]
 
@@ -84,35 +85,36 @@ defmodule PortalAPI.Schemas.SantaDevice do
                   {field, schema}
                 end)
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "SantaDevice",
       description: "Santa host synced from North Pole Security Workshop",
       type: :object,
       properties: @properties
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "SantaDeviceResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.SantaDevice.Schema}
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "SantaDeviceListResponse",
       type: :object,
       properties: %{
         data: %Schema{type: :array, items: PortalAPI.Schemas.SantaDevice.Schema},
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/santa_device_schema.ex
+++ b/elixir/lib/portal_api/schemas/santa_device_schema.ex
@@ -2,12 +2,49 @@ defmodule PortalAPI.Schemas.SantaDevice do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
     @required [:account_id, :id, :posture_provider_id, :santa_id, :synced_at]
 
-    @properties Map.new(Portal.Santa.Device.__schema__(:fields), fn field ->
+    @exposed [
+                :account_id,
+                :id,
+                :santa_id,
+                :posture_provider_id,
+                :serial_number,
+                :machine_model,
+                :hostname,
+                :os_version,
+                :os_build,
+                :os_type,
+                :sip_status,
+                :primary_user,
+                :primary_user_locked,
+                :primary_user_groups,
+                :santa_version,
+                :santanetd_version,
+                :last_seen_client_mode,
+                :last_sync_at,
+                :rule_sync_at,
+                :last_preflight_at,
+                :last_preflight_ip,
+                :tags,
+                :tags_locked,
+                :tags_truncated,
+                :configured_client_mode,
+                :temporary_monitor_mode_ends_at,
+                :first_seen_at,
+                :temporary_admin_mode_ends_at,
+                :temporary_admin_mode_user,
+                :synced_at,
+                :inserted_at,
+                :updated_at
+             ]
+    @internal []
+
+    PortalAPI.Schemas.Object.assert_classified!(Portal.Santa.Device, @exposed, @internal)
+
+    @properties Map.new(@exposed, fn field ->
                   nullable = field not in @required
 
                   schema =
@@ -47,12 +84,11 @@ defmodule PortalAPI.Schemas.SantaDevice do
                   {field, schema}
                 end)
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "SantaDevice",
       description: "Santa host synced from North Pole Security Workshop",
       type: :object,
-      properties: @properties,
-      required: @required
+      properties: @properties
     })
   end
 

--- a/elixir/lib/portal_api/schemas/santa_posture_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/santa_posture_provider_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.SantaPostureProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "SantaPostureProvider",
       description: "Santa posture provider backed by North Pole Security Workshop",
       type: :object,
@@ -32,30 +33,31 @@ defmodule PortalAPI.Schemas.SantaPostureProvider do
         :is_verified,
         :is_disabled
       ]
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "SantaPostureProviderResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.SantaPostureProvider.Schema}
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "SantaPostureProviderListResponse",
       type: :object,
       properties: %{
         data: %Schema{type: :array, items: PortalAPI.Schemas.SantaPostureProvider.Schema},
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/santa_posture_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/santa_posture_provider_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.SantaPostureProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "SantaPostureProvider",
       description: "Santa posture provider backed by North Pole Security Workshop",
       type: :object,

--- a/elixir/lib/portal_api/schemas/santa_posture_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/santa_posture_provider_schema.ex
@@ -36,10 +36,9 @@ defmodule PortalAPI.Schemas.SantaPostureProvider do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "SantaPostureProviderResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.SantaPostureProvider.Schema}
@@ -47,11 +46,10 @@ defmodule PortalAPI.Schemas.SantaPostureProvider do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "SantaPostureProviderListResponse",
       type: :object,
       properties: %{

--- a/elixir/lib/portal_api/schemas/sentinel_one_device_schema.ex
+++ b/elixir/lib/portal_api/schemas/sentinel_one_device_schema.ex
@@ -166,9 +166,9 @@ defmodule PortalAPI.Schemas.SentinelOneDevice do
   end
 
   defmodule Response do
-    require OpenApiSpex
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "SentinelOneDeviceResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.SentinelOneDevice.Schema}
@@ -176,11 +176,10 @@ defmodule PortalAPI.Schemas.SentinelOneDevice do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "SentinelOneDeviceListResponse",
       type: :object,
       properties: %{

--- a/elixir/lib/portal_api/schemas/sentinel_one_device_schema.ex
+++ b/elixir/lib/portal_api/schemas/sentinel_one_device_schema.ex
@@ -2,13 +2,121 @@ defmodule PortalAPI.Schemas.SentinelOneDevice do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
     @required [:account_id, :posture_provider_id, :uuid, :synced_at]
-    @public_fields Portal.SentinelOne.Device.__schema__(:fields) -- [:license_key]
+    @exposed [
+                :account_id,
+                :uuid,
+                :posture_provider_id,
+                :source_created_at,
+                :source_updated_at,
+                :group_updated_at,
+                :policy_updated_at,
+                :sentinelone_account_id,
+                :account_name,
+                :site_id,
+                :site_name,
+                :group_id,
+                :group_name,
+                :sentinelone_id,
+                :agent_version,
+                :network_interfaces,
+                :domain,
+                :computer_name,
+                :os_name,
+                :os_revision,
+                :os_arch,
+                :os_username,
+                :os_start_time,
+                :os_type,
+                :total_memory,
+                :model_name,
+                :machine_type,
+                :cpu_id,
+                :cpu_count,
+                :core_count,
+                :external_ip,
+                :group_ip,
+                :active_threats,
+                :infected,
+                :threat_reboot_required,
+                :last_active_at,
+                :is_active,
+                :is_up_to_date,
+                :network_status,
+                :registered_at,
+                :is_pending_uninstall,
+                :is_uninstalled,
+                :is_decommissioned,
+                :encrypted_applications,
+                :last_logged_in_user_name,
+                :ad_last_user_distinguished_name,
+                :ad_last_user_member_of,
+                :ad_computer_distinguished_name,
+                :ad_computer_member_of,
+                :ad_user_principal_name,
+                :ad_mail,
+                :scan_status,
+                :scan_started_at,
+                :scan_finished_at,
+                :scan_aborted_at,
+                :full_disk_scan_updated_at,
+                :mitigation_mode,
+                :mitigation_mode_suspicious,
+                :user_actions_needed,
+                :missing_permissions,
+                :console_migration_status,
+                :apps_vulnerability_status,
+                :in_remote_shell_session,
+                :allow_remote_shell,
+                :locations,
+                :location_type,
+                :external_id,
+                :serial_number,
+                :machine_sid,
+                :installer_type,
+                :ranger_version,
+                :ranger_status,
+                :last_ip_to_management,
+                :operational_state,
+                :operational_state_expires_at,
+                :remote_profiling_state,
+                :remote_profiling_state_expires_at,
+                :network_quarantine_enabled,
+                :firewall_enabled,
+                :location_enabled,
+                :cloud_providers,
+                :storage_type,
+                :storage_name,
+                :detection_state,
+                :first_full_mode_at,
+                :tags,
+                :show_alert_icon,
+                :last_successful_scan_at,
+                :proxy_console,
+                :proxy_deep_visibility,
+                :proxy_pac_file_usage,
+                :proxy_method,
+                :proxy_console_address,
+                :proxy_deep_visibility_address,
+                :protected_pods_count,
+                :protected_containers_count,
+                :protected_tasks_count,
+                :has_containerized_workload,
+                :is_ad_connector,
+                :is_hyper_automate,
+                :active_protection,
+                :synced_at,
+                :inserted_at,
+                :updated_at
+             ]
 
-    @properties Map.new(@public_fields, fn field ->
+    @internal [:license_key]
+
+    PortalAPI.Schemas.Object.assert_classified!(Portal.SentinelOne.Device, @exposed, @internal)
+
+    @properties Map.new(@exposed, fn field ->
                   nullable = field not in @required
 
                   schema =
@@ -49,12 +157,11 @@ defmodule PortalAPI.Schemas.SentinelOneDevice do
                   {field, schema}
                 end)
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "SentinelOneDevice",
       description: "Endpoint agent synced from SentinelOne",
       type: :object,
-      properties: @properties,
-      required: @required
+      properties: @properties
     })
   end
 

--- a/elixir/lib/portal_api/schemas/sentinel_one_device_schema.ex
+++ b/elixir/lib/portal_api/schemas/sentinel_one_device_schema.ex
@@ -2,7 +2,8 @@ defmodule PortalAPI.Schemas.SentinelOneDevice do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
     @required [:account_id, :posture_provider_id, :uuid, :synced_at]
     @exposed [
@@ -157,35 +158,36 @@ defmodule PortalAPI.Schemas.SentinelOneDevice do
                   {field, schema}
                 end)
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "SentinelOneDevice",
       description: "Endpoint agent synced from SentinelOne",
       type: :object,
       properties: @properties
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "SentinelOneDeviceResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.SentinelOneDevice.Schema}
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "SentinelOneDeviceListResponse",
       type: :object,
       properties: %{
         data: %Schema{type: :array, items: PortalAPI.Schemas.SentinelOneDevice.Schema},
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/sentinel_one_posture_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/sentinel_one_posture_provider_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.SentinelOnePostureProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "SentinelOnePostureProvider",
       description: "SentinelOne posture provider",
       type: :object,
@@ -24,15 +23,6 @@ defmodule PortalAPI.Schemas.SentinelOnePostureProvider do
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}
       },
-      required: [
-        :id,
-        :account_id,
-        :type,
-        :name,
-        :management_url,
-        :is_verified,
-        :is_disabled
-      ]
     })
   end
 

--- a/elixir/lib/portal_api/schemas/sentinel_one_posture_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/sentinel_one_posture_provider_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.SentinelOnePostureProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "SentinelOnePostureProvider",
       description: "SentinelOne posture provider",
       type: :object,
@@ -23,24 +24,25 @@ defmodule PortalAPI.Schemas.SentinelOnePostureProvider do
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}
       },
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "SentinelOnePostureProviderResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.SentinelOnePostureProvider.Schema}
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "SentinelOnePostureProviderListResponse",
       type: :object,
       properties: %{
@@ -50,6 +52,6 @@ defmodule PortalAPI.Schemas.SentinelOnePostureProvider do
         },
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/sentinel_one_posture_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/sentinel_one_posture_provider_schema.ex
@@ -27,9 +27,9 @@ defmodule PortalAPI.Schemas.SentinelOnePostureProvider do
   end
 
   defmodule Response do
-    require OpenApiSpex
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "SentinelOnePostureProviderResponse",
       type: :object,
       properties: %{data: PortalAPI.Schemas.SentinelOnePostureProvider.Schema}
@@ -37,11 +37,10 @@ defmodule PortalAPI.Schemas.SentinelOnePostureProvider do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "SentinelOnePostureProviderListResponse",
       type: :object,
       properties: %{

--- a/elixir/lib/portal_api/schemas/session_subject_schema.ex
+++ b/elixir/lib/portal_api/schemas/session_subject_schema.ex
@@ -1,0 +1,142 @@
+defmodule PortalAPI.Schemas.SessionSubject do
+  @moduledoc """
+  Subject shapes recorded on Session Log entries.
+
+  A session's subject varies with the `context` it was created in, so
+  `SessionLog.subject` is a union of these. Portal sessions record a plain
+  `Subject`; the two shapes here differ from it.
+  """
+
+  defmodule Client do
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "ClientSessionSubject",
+      description: """
+      Subject of a session created by a Client (`context: "client"`).
+
+      A `Subject` plus the Client and token the session was established with.
+      """,
+      type: :object,
+      properties: %{
+        actor_id: %Schema{
+          type: :string,
+          format: :uuid,
+          description: "Identifier of the actor that signed in."
+        },
+        actor_name: %Schema{type: :string, description: "Display name of the actor."},
+        actor_email: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Email address of the actor, if any."
+        },
+        actor_type: %Schema{
+          type: :string,
+          enum: ["account_user", "account_admin_user", "service_account", "api_client"],
+          description: "Type of the actor."
+        },
+        auth_provider_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description: "Identifier of the authentication provider that authenticated the actor."
+        },
+        device_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description: "Identifier of the Client the session was established from."
+        },
+        token_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description: "Identifier of the Client token the session was established with."
+        },
+        ip: %Schema{type: :string, nullable: true, description: "IP address the session came from."},
+        ip_region: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Geo-located region for `ip`, if known."
+        },
+        ip_city: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Geo-located city for `ip`, if known."
+        },
+        ip_lat: %Schema{
+          type: :number,
+          nullable: true,
+          description: "Geo-located latitude for `ip`, if known."
+        },
+        ip_lon: %Schema{
+          type: :number,
+          nullable: true,
+          description: "Geo-located longitude for `ip`, if known."
+        },
+        user_agent: %Schema{
+          type: :string,
+          nullable: true,
+          description: "User agent reported by the Client."
+        }
+      }
+    })
+  end
+
+  defmodule Gateway do
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "GatewaySessionSubject",
+      description: """
+      Subject of a session created by a Gateway (`context: "gateway"`).
+
+      A Gateway authenticates with a token rather than as an actor, so no actor
+      fields are recorded.
+      """,
+      type: :object,
+      properties: %{
+        gateway_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description: "Identifier of the Gateway the session was established from."
+        },
+        token_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description: "Identifier of the Gateway token the session was established with."
+        },
+        ip: %Schema{type: :string, nullable: true, description: "IP address the session came from."},
+        ip_region: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Geo-located region for `ip`, if known."
+        },
+        ip_city: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Geo-located city for `ip`, if known."
+        },
+        ip_lat: %Schema{
+          type: :number,
+          nullable: true,
+          description: "Geo-located latitude for `ip`, if known."
+        },
+        ip_lon: %Schema{
+          type: :number,
+          nullable: true,
+          description: "Geo-located longitude for `ip`, if known."
+        },
+        user_agent: %Schema{
+          type: :string,
+          nullable: true,
+          description: "User agent reported by the Gateway."
+        }
+      }
+    })
+  end
+end

--- a/elixir/lib/portal_api/schemas/session_subject_schema.ex
+++ b/elixir/lib/portal_api/schemas/session_subject_schema.ex
@@ -8,10 +8,9 @@ defmodule PortalAPI.Schemas.SessionSubject do
   """
 
   defmodule Client do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "ClientSessionSubject",
       description: """
       Subject of a session created by a Client (`context: "client"`).
@@ -85,10 +84,9 @@ defmodule PortalAPI.Schemas.SessionSubject do
   end
 
   defmodule Gateway do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "GatewaySessionSubject",
       description: """
       Subject of a session created by a Gateway (`context: "gateway"`).

--- a/elixir/lib/portal_api/schemas/session_subject_schema.ex
+++ b/elixir/lib/portal_api/schemas/session_subject_schema.ex
@@ -8,9 +8,10 @@ defmodule PortalAPI.Schemas.SessionSubject do
   """
 
   defmodule Client do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "ClientSessionSubject",
       description: """
       Subject of a session created by a Client (`context: "client"`).
@@ -80,13 +81,14 @@ defmodule PortalAPI.Schemas.SessionSubject do
           description: "User agent reported by the Client."
         }
       }
-    })
+    }))
   end
 
   defmodule Gateway do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "GatewaySessionSubject",
       description: """
       Subject of a session created by a Gateway (`context: "gateway"`).
@@ -135,6 +137,6 @@ defmodule PortalAPI.Schemas.SessionSubject do
           description: "User agent reported by the Gateway."
         }
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/site_schema.ex
+++ b/elixir/lib/portal_api/schemas/site_schema.ex
@@ -83,12 +83,6 @@ defmodule PortalAPI.Schemas.Site do
       type: :object,
       properties: %{
         data: Site.Schema
-      },
-      example: %{
-        "data" => %{
-          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name" => "vpc-us-east"
-        }
       }
     })
   end
@@ -110,24 +104,6 @@ defmodule PortalAPI.Schemas.Site do
           items: Site.Schema
         },
         metadata: PaginationMetadata
-      },
-      example: %{
-        "data" => [
-          %{
-            "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "vpc-us-east"
-          },
-          %{
-            "id" => "6301d7d2-4938-4123-87de-282c01cca656",
-            "name" => "vpc-us-west"
-          }
-        ],
-        "metadata" => %{
-          "limit" => 10,
-          "total" => 100,
-          "prev_page" => "123123425",
-          "next_page" => "98776234123"
-        }
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/site_schema.ex
+++ b/elixir/lib/portal_api/schemas/site_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.Site do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "Site",
       description: "Site",
       type: :object,
@@ -16,7 +17,7 @@ defmodule PortalAPI.Schemas.Site do
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "vpc-us-east"
       }
-    })
+    }))
   end
 
   defmodule CreateRequest do
@@ -73,25 +74,26 @@ defmodule PortalAPI.Schemas.Site do
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.Site
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "SiteResponse",
       description: "Response schema for single Site",
       type: :object,
       properties: %{
         data: Site.Schema
       }
-    })
+    }))
   end
 
   defmodule ListResponse do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
     alias PortalAPI.Schemas.Site
     alias PortalAPI.Schemas.PaginationMetadata
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "SiteListResponse",
       description: "Response schema for multiple Sites",
       type: :object,
@@ -103,6 +105,6 @@ defmodule PortalAPI.Schemas.Site do
         },
         metadata: PaginationMetadata
       }
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/site_schema.ex
+++ b/elixir/lib/portal_api/schemas/site_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.Site do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "Site",
       description: "Site",
       type: :object,
@@ -13,7 +12,6 @@ defmodule PortalAPI.Schemas.Site do
         id: %Schema{type: :string, format: :uuid, description: "Site ID"},
         name: %Schema{type: :string, description: "Site Name"}
       },
-      required: [:id, :name],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "vpc-us-east"

--- a/elixir/lib/portal_api/schemas/site_schema.ex
+++ b/elixir/lib/portal_api/schemas/site_schema.ex
@@ -73,11 +73,10 @@ defmodule PortalAPI.Schemas.Site do
   end
 
   defmodule Response do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Site
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "SiteResponse",
       description: "Response schema for single Site",
       type: :object,
@@ -88,12 +87,11 @@ defmodule PortalAPI.Schemas.Site do
   end
 
   defmodule ListResponse do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.Site
     alias PortalAPI.Schemas.PaginationMetadata
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "SiteListResponse",
       description: "Response schema for multiple Sites",
       type: :object,

--- a/elixir/lib/portal_api/schemas/subject_schema.ex
+++ b/elixir/lib/portal_api/schemas/subject_schema.ex
@@ -1,8 +1,7 @@
 defmodule PortalAPI.Schemas.Subject do
-  require OpenApiSpex
-  alias OpenApiSpex.Schema
+  use PortalAPI.Schemas.Object
 
-  OpenApiSpex.schema(%{
+  object(%{
     title: "Subject",
     description: """
     Identifies the actor and request context that initiated an action.

--- a/elixir/lib/portal_api/schemas/subject_schema.ex
+++ b/elixir/lib/portal_api/schemas/subject_schema.ex
@@ -1,7 +1,8 @@
 defmodule PortalAPI.Schemas.Subject do
-  use PortalAPI.Schemas.Object
+  require OpenApiSpex
+  alias OpenApiSpex.Schema
 
-  object(%{
+  OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
     title: "Subject",
     description: """
     Identifies the actor and request context that initiated an action.
@@ -82,5 +83,5 @@ defmodule PortalAPI.Schemas.Subject do
       "ip_lon" => -122.4194,
       "user_agent" => "Mozilla/5.0"
     }
-  })
+  }))
 end

--- a/elixir/lib/portal_api/schemas/x509_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/x509_auth_provider_schema.ex
@@ -2,9 +2,10 @@ defmodule PortalAPI.Schemas.X509AuthProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "X509AuthProvider",
       description: "X.509 Auth Provider",
       type: :object,
@@ -17,18 +18,18 @@ defmodule PortalAPI.Schemas.X509AuthProvider do
         inserted_at: %Schema{type: :string, format: :"date-time", description: "Creation timestamp"},
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       }
-    })
+    }))
   end
 
   defmodule Response do
-    use PortalAPI.Schemas.Object
+    require OpenApiSpex
     alias PortalAPI.Schemas.X509AuthProvider
 
-    object(%{
+    OpenApiSpex.schema(PortalAPI.Schemas.Object.with_required(%{
       title: "X509AuthProviderResponse",
       description: "Response schema for a single X.509 Auth Provider",
       type: :object,
       properties: %{data: X509AuthProvider.Schema}
-    })
+    }))
   end
 end

--- a/elixir/lib/portal_api/schemas/x509_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/x509_auth_provider_schema.ex
@@ -11,17 +11,11 @@ defmodule PortalAPI.Schemas.X509AuthProvider do
       properties: %{
         id: %Schema{type: :string, format: :uuid, description: "Provider ID"},
         account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
-        name: %Schema{type: :string, description: "Provider name"},
+        name: %Schema{example: "X.509", type: :string, description: "Provider name"},
         context: %Schema{type: :string, description: "Context", enum: ["clients_only"]},
         is_disabled: %Schema{type: :boolean, description: "Whether provider is disabled"},
         inserted_at: %Schema{type: :string, format: :"date-time", description: "Creation timestamp"},
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
-      },
-      example: %{
-        "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-        "name" => "X.509",
-        "context" => "clients_only",
-        "is_disabled" => true
       }
     })
   end

--- a/elixir/lib/portal_api/schemas/x509_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/x509_auth_provider_schema.ex
@@ -2,10 +2,9 @@ defmodule PortalAPI.Schemas.X509AuthProvider do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
-    require OpenApiSpex
-    alias OpenApiSpex.Schema
+    use PortalAPI.Schemas.Object
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "X509AuthProvider",
       description: "X.509 Auth Provider",
       type: :object,
@@ -18,7 +17,6 @@ defmodule PortalAPI.Schemas.X509AuthProvider do
         inserted_at: %Schema{type: :string, format: :"date-time", description: "Creation timestamp"},
         updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
-      required: [:id, :account_id, :name, :context, :is_disabled],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "X.509",

--- a/elixir/lib/portal_api/schemas/x509_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/x509_auth_provider_schema.ex
@@ -21,10 +21,10 @@ defmodule PortalAPI.Schemas.X509AuthProvider do
   end
 
   defmodule Response do
-    require OpenApiSpex
+    use PortalAPI.Schemas.Object
     alias PortalAPI.Schemas.X509AuthProvider
 
-    OpenApiSpex.schema(%{
+    object(%{
       title: "X509AuthProviderResponse",
       description: "Response schema for a single X.509 Auth Provider",
       type: :object,

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -200,7 +200,7 @@ defmodule Portal.MixProject do
       "assets.deploy": ["tailwind portal --minify", "esbuild portal --minify", "phx.digest"],
       "phx.server": ["ecto.create --quiet", "ecto.migrate", "phx.server"],
       "openapi.generate": [
-        "openapi.spec.json --spec PortalAPI.ApiSpec --pretty=true --vendor-extensions=false --filename priv/static/openapi.json"
+        "openapi.spec.json --spec PortalAPI.ApiSpec --pretty=true --vendor-extensions=false --filename priv/static/openapi.json --no-start-app"
       ],
       test: ["ecto.create --quiet", "ecto.migrate", "openapi.generate", "test"],
       start: ["compile --no-validate-compile-env", "phx.server", "run --no-halt"]

--- a/elixir/priv/static/openapi.json
+++ b/elixir/priv/static/openapi.json
@@ -4,12 +4,6 @@
     "schemas": {
       "EntraDirectoryResponse": {
         "description": "Response schema for single Entra Directory",
-        "example": {
-          "data": {
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name": "Entra"
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/EntraDirectory"
@@ -35,20 +29,6 @@
       },
       "ActorResponse": {
         "description": "Response schema for single Actor",
-        "example": {
-          "data": {
-            "allow_email_otp_sign_in": false,
-            "created_by_directory_id": null,
-            "email": "john.doe@example.com",
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "inserted_at": "2024-01-01T00:00:00Z",
-            "is_disabled": false,
-            "last_seen_at": "2024-01-15T10:30:00Z",
-            "name": "John Doe",
-            "type": "account_admin_user",
-            "updated_at": "2024-01-15T10:30:00Z"
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/Actor"
@@ -59,14 +39,6 @@
       },
       "GoogleAuthProviderListResponse": {
         "description": "Response schema for multiple Google Auth Providers",
-        "example": {
-          "data": [
-            {
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "name": "Google"
-            }
-          ]
-        },
         "properties": {
           "data": {
             "description": "Google Auth Provider details",
@@ -84,19 +56,6 @@
       },
       "GroupResponse": {
         "description": "Response schema for single Group",
-        "example": {
-          "data": {
-            "directory_id": null,
-            "email": null,
-            "entity_type": "group",
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "idp_id": null,
-            "inserted_at": "2024-01-15T10:30:00Z",
-            "name": "Engineering",
-            "synced_at": null,
-            "updated_at": "2024-01-15T10:30:00Z"
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/Group"
@@ -107,12 +66,6 @@
       },
       "GoogleDirectoryResponse": {
         "description": "Response schema for single Google Directory",
-        "example": {
-          "data": {
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name": "Google"
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/GoogleDirectory"
@@ -594,11 +547,6 @@
       },
       "OktaAuthProvider": {
         "description": "Okta Auth Provider",
-        "example": {
-          "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name": "Okta",
-          "okta_domain": "example.okta.com"
-        },
         "properties": {
           "account_id": {
             "description": "Account ID",
@@ -607,6 +555,7 @@
           },
           "client_id": {
             "description": "Client ID",
+            "example": "my-client-id",
             "type": "string"
           },
           "client_session_lifetime_secs": {
@@ -642,14 +591,17 @@
           },
           "issuer": {
             "description": "Issuer",
+            "example": "https://example.okta.com",
             "type": "string"
           },
           "name": {
             "description": "Provider name",
+            "example": "Okta",
             "type": "string"
           },
           "okta_domain": {
             "description": "Okta domain",
+            "example": "example.okta.com",
             "type": "string"
           },
           "portal_session_lifetime_secs": {
@@ -682,15 +634,6 @@
       },
       "GatewayResponse": {
         "description": "Response schema for single Gateway",
-        "example": {
-          "data": {
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "ipv4": "1.2.3.4",
-            "ipv6": "",
-            "name": "vpc-us-east",
-            "online": true
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/Gateway"
@@ -784,19 +727,9 @@
       },
       "ClientTokenCreateResponse": {
         "description": "Response schema for a new Client Token",
-        "example": {
-          "data": {
-            "actor_id": "43a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "expires_at": "2025-01-15T12:34:56.789Z",
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "inserted_at": "2025-01-15T12:34:56.789Z",
-            "token": "secret-token-here",
-            "updated_at": "2025-01-15T12:34:56.789Z"
-          }
-        },
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/ClientTokenResponse"
+            "$ref": "#/components/schemas/ClientTokenWithSecret"
           }
         },
         "title": "ClientTokenCreateResponse",
@@ -939,11 +872,6 @@
       },
       "EntraAuthProvider": {
         "description": "Entra Auth Provider",
-        "example": {
-          "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "issuer": "https://login.microsoftonline.com/tenant-id/v2.0",
-          "name": "Entra"
-        },
         "properties": {
           "account_id": {
             "description": "Account ID",
@@ -995,10 +923,12 @@
           },
           "issuer": {
             "description": "Issuer",
+            "example": "https://login.microsoftonline.com/tenant-id/v2.0",
             "type": "string"
           },
           "name": {
             "description": "Provider name",
+            "example": "Entra",
             "type": "string"
           },
           "portal_session_lifetime_secs": {
@@ -1033,12 +963,6 @@
       },
       "EntraAuthProviderResponse": {
         "description": "Response schema for single Entra Auth Provider",
-        "example": {
-          "data": {
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name": "Entra"
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/EntraAuthProvider"
@@ -1067,20 +991,6 @@
       },
       "ExternalIdentity": {
         "description": "External Identity",
-        "example": {
-          "account_id": "5e6f7d8c-9b0a-1c2d-3e4f-5a6b7c8d9e0f",
-          "actor_id": "cdfa97e6-cca1-41db-8fc7-864daedb46df",
-          "directory_id": "9f8e7d6c-5b4a-3c2b-1a0e-9f8e7d6c5b4a",
-          "family_name": "Doe",
-          "given_name": "John",
-          "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "idp_id": "2551705710219359",
-          "inserted_at": "2025-01-15T12:34:56.789Z",
-          "issuer": "https://accounts.google.com",
-          "name": "John Doe",
-          "picture": "https://example.com/avatar.jpg",
-          "synced_at": "2025-01-15T12:34:56.789Z"
-        },
         "properties": {
           "account_id": {
             "description": "Account ID",
@@ -1099,18 +1009,22 @@
           },
           "email": {
             "description": "Email address, falling back to the IdP identifier when unset",
+            "example": "user@example.com",
             "type": "string"
           },
           "family_name": {
             "description": "Family name",
+            "example": "Doe",
             "type": "string"
           },
           "firezone_avatar_url": {
             "description": "Firezone-hosted avatar URL",
+            "example": "https://avatars.firezone.dev/u/2551705710219359.png",
             "type": "string"
           },
           "given_name": {
             "description": "Given name",
+            "example": "John",
             "type": "string"
           },
           "id": {
@@ -1120,6 +1034,7 @@
           },
           "idp_id": {
             "description": "IDP-specific identifier for this identity",
+            "example": "2551705710219359",
             "type": "string"
           },
           "inserted_at": {
@@ -1129,30 +1044,37 @@
           },
           "issuer": {
             "description": "Identity issuer URL (e.g., 'https://accounts.google.com', 'https://company.okta.com')",
+            "example": "https://accounts.google.com",
             "type": "string"
           },
           "middle_name": {
             "description": "Middle name",
+            "example": "Quincy",
             "type": "string"
           },
           "name": {
             "description": "Full name",
+            "example": "John Doe",
             "type": "string"
           },
           "nickname": {
             "description": "Nickname",
+            "example": "johnny",
             "type": "string"
           },
           "picture": {
             "description": "Profile picture URL",
+            "example": "https://example.com/avatar.jpg",
             "type": "string"
           },
           "preferred_username": {
             "description": "Preferred username",
+            "example": "jdoe",
             "type": "string"
           },
           "profile": {
             "description": "Profile URL",
+            "example": "https://example.com/users/jdoe",
             "type": "string"
           },
           "synced_at": {
@@ -1666,12 +1588,6 @@
       },
       "OktaDirectoryResponse": {
         "description": "Response schema for single Okta Directory",
-        "example": {
-          "data": {
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name": "Okta"
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/OktaDirectory"
@@ -1680,14 +1596,57 @@
         "title": "OktaDirectoryResponse",
         "type": "object"
       },
-      "GatewayTokenResponse": {
-        "description": "Response schema for a new Gateway Token",
-        "example": {
-          "data": {
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "token": "secret-token-here"
+      "GatewaySessionSubject": {
+        "description": "Subject of a session created by a Gateway (`context: \"gateway\"`).\n\nA Gateway authenticates with a token rather than as an actor, so no actor\nfields are recorded.\n",
+        "properties": {
+          "gateway_id": {
+            "description": "Identifier of the Gateway the session was established from.",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "ip": {
+            "description": "IP address the session came from.",
+            "nullable": true,
+            "type": "string"
+          },
+          "ip_city": {
+            "description": "Geo-located city for `ip`, if known.",
+            "nullable": true,
+            "type": "string"
+          },
+          "ip_lat": {
+            "description": "Geo-located latitude for `ip`, if known.",
+            "nullable": true,
+            "type": "number"
+          },
+          "ip_lon": {
+            "description": "Geo-located longitude for `ip`, if known.",
+            "nullable": true,
+            "type": "number"
+          },
+          "ip_region": {
+            "description": "Geo-located region for `ip`, if known.",
+            "nullable": true,
+            "type": "string"
+          },
+          "token_id": {
+            "description": "Identifier of the Gateway token the session was established with.",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "user_agent": {
+            "description": "User agent reported by the Gateway.",
+            "nullable": true,
+            "type": "string"
           }
         },
+        "title": "GatewaySessionSubject",
+        "type": "object"
+      },
+      "GatewayTokenResponse": {
+        "description": "Response schema for a new Gateway Token",
         "properties": {
           "data": {
             "$ref": "#/components/schemas/GatewayToken"
@@ -1761,11 +1720,6 @@
       },
       "DeletedClientTokenResponse": {
         "description": "Response schema for a deleted Client Token",
-        "example": {
-          "data": {
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205"
-          }
-        },
         "properties": {
           "data": {
             "properties": {
@@ -1784,6 +1738,85 @@
         "title": "DeletedClientTokenResponse",
         "type": "object"
       },
+      "ClientSessionSubject": {
+        "description": "Subject of a session created by a Client (`context: \"client\"`).\n\nA `Subject` plus the Client and token the session was established with.\n",
+        "properties": {
+          "actor_email": {
+            "description": "Email address of the actor, if any.",
+            "nullable": true,
+            "type": "string"
+          },
+          "actor_id": {
+            "description": "Identifier of the actor that signed in.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "actor_name": {
+            "description": "Display name of the actor.",
+            "type": "string"
+          },
+          "actor_type": {
+            "description": "Type of the actor.",
+            "enum": [
+              "account_user",
+              "account_admin_user",
+              "service_account",
+              "api_client"
+            ],
+            "type": "string"
+          },
+          "auth_provider_id": {
+            "description": "Identifier of the authentication provider that authenticated the actor.",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "device_id": {
+            "description": "Identifier of the Client the session was established from.",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "ip": {
+            "description": "IP address the session came from.",
+            "nullable": true,
+            "type": "string"
+          },
+          "ip_city": {
+            "description": "Geo-located city for `ip`, if known.",
+            "nullable": true,
+            "type": "string"
+          },
+          "ip_lat": {
+            "description": "Geo-located latitude for `ip`, if known.",
+            "nullable": true,
+            "type": "number"
+          },
+          "ip_lon": {
+            "description": "Geo-located longitude for `ip`, if known.",
+            "nullable": true,
+            "type": "number"
+          },
+          "ip_region": {
+            "description": "Geo-located region for `ip`, if known.",
+            "nullable": true,
+            "type": "string"
+          },
+          "token_id": {
+            "description": "Identifier of the Client token the session was established with.",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "user_agent": {
+            "description": "User agent reported by the Client.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "title": "ClientSessionSubject",
+        "type": "object"
+      },
       "SessionLog": {
         "description": "A single Session Log entry, recording one Client, Gateway, or Portal\nsession that was created, along with the auth context it was created\nwith.\n",
         "example": {
@@ -1792,6 +1825,9 @@
           "subject": {
             "actor_email": "admin@example.com",
             "actor_id": "84e7f82f-831a-4a9d-8f17-c66c2bb6e205",
+            "actor_name": "Admin User",
+            "actor_type": "account_admin_user",
+            "auth_provider_id": "98776234-1234-5678-9012-345678901234",
             "device_id": "11e7f82f-831a-4a9d-8f17-c66c2bb6e205",
             "ip": "189.172.73.1",
             "ip_city": "Mexico City",
@@ -1820,7 +1856,19 @@
             "type": "string"
           },
           "subject": {
-            "$ref": "#/components/schemas/Subject"
+            "description": "Who established the session and from where. The shape depends on\n`context`, which is the field to switch on:\n\n- `client`: a `ClientSessionSubject` - the actor, plus the Client and\n  token the session was established with.\n- `gateway`: a `GatewaySessionSubject` - the Gateway and its token. A\n  Gateway authenticates as itself, so no actor fields are recorded.\n- `portal`: a plain `Subject`.\n",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ClientSessionSubject"
+              },
+              {
+                "$ref": "#/components/schemas/GatewaySessionSubject"
+              },
+              {
+                "$ref": "#/components/schemas/Subject"
+              }
+            ]
           },
           "timestamp": {
             "description": "RFC 3339 timestamp identifying when the session was created.",
@@ -2137,12 +2185,6 @@
       },
       "SiteResponse": {
         "description": "Response schema for single Site",
-        "example": {
-          "data": {
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name": "vpc-us-east"
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/Site"
@@ -2153,23 +2195,6 @@
       },
       "ClientTokenListResponse": {
         "description": "Response schema for multiple Client Tokens",
-        "example": {
-          "data": [
-            {
-              "actor_id": "43a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "expires_at": "2025-01-15T12:34:56.789Z",
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "inserted_at": "2025-01-15T12:34:56.789Z",
-              "updated_at": "2025-01-15T12:34:56.789Z"
-            }
-          ],
-          "metadata": {
-            "count": 1,
-            "limit": 10,
-            "next_page": null,
-            "prev_page": null
-          }
-        },
         "properties": {
           "data": {
             "description": "Client Token metadata",
@@ -2202,11 +2227,6 @@
       },
       "GoogleDirectory": {
         "description": "Google Directory",
-        "example": {
-          "domain": "example.com",
-          "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name": "Google"
-        },
         "properties": {
           "account_id": {
             "description": "Account ID",
@@ -2215,15 +2235,18 @@
           },
           "disabled_reason": {
             "description": "Reason for disabling",
+            "example": "Sync failed on 5 consecutive attempts",
             "nullable": true,
             "type": "string"
           },
           "domain": {
             "description": "Google Workspace domain",
+            "example": "example.com",
             "type": "string"
           },
           "error_message": {
             "description": "Last error message",
+            "example": "invalid_grant: token has expired or been revoked",
             "nullable": true,
             "type": "string"
           },
@@ -2249,6 +2272,7 @@
           },
           "impersonation_email": {
             "description": "Impersonation email",
+            "example": "admin@example.com",
             "type": "string"
           },
           "inserted_at": {
@@ -2262,6 +2286,7 @@
           },
           "name": {
             "description": "Directory name",
+            "example": "Google",
             "type": "string"
           },
           "orgunit_sync_enabled": {
@@ -2301,26 +2326,6 @@
       },
       "PolicyResponse": {
         "description": "Response schema for single Policy",
-        "example": {
-          "data": {
-            "conditions": [
-              {
-                "operator": "is_in",
-                "property": "remote_ip_location_region",
-                "values": [
-                  "US",
-                  "CA"
-                ]
-              }
-            ],
-            "description": "Policy to allow something",
-            "flow_log_uploads_enabled": true,
-            "group_id": "88eae9ce-9179-48c6-8430-770e38dd4775",
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "is_disabled": false,
-            "resource_id": "a9f60587-793c-46ae-8525-597f43ab2fb1"
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/Policy"
@@ -2331,11 +2336,6 @@
       },
       "DeletedClientTokensResponse": {
         "description": "Response schema for deleted Client Tokens",
-        "example": {
-          "data": {
-            "deleted_count": 3
-          }
-        },
         "properties": {
           "data": {
             "properties": {
@@ -2355,38 +2355,6 @@
       },
       "GroupListResponse": {
         "description": "Response schema for multiple Groups",
-        "example": {
-          "data": [
-            {
-              "directory_id": null,
-              "email": null,
-              "entity_type": "group",
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "idp_id": null,
-              "inserted_at": "2024-01-15T10:30:00Z",
-              "name": "Engineering",
-              "synced_at": null,
-              "updated_at": "2024-01-15T10:30:00Z"
-            },
-            {
-              "directory_id": "6b4e3a2c-1234-5678-9abc-def012345678",
-              "email": "firezone-sync-admins@example.com",
-              "entity_type": "group",
-              "id": "4ae929a7-1973-43f2-a1a8-9221b91a4c0e",
-              "idp_id": "google-workspace-group-123",
-              "inserted_at": "2024-01-10T08:15:00Z",
-              "name": "firezone-sync-admins",
-              "synced_at": "2024-01-14T16:00:00Z",
-              "updated_at": "2024-01-14T16:45:00Z"
-            }
-          ],
-          "metadata": {
-            "limit": 10,
-            "next_page": "98776234123",
-            "prev_page": "123123425",
-            "total": 100
-          }
-        },
         "properties": {
           "data": {
             "description": "Group details",
@@ -2413,14 +2381,6 @@
       },
       "OktaAuthProviderListResponse": {
         "description": "Response schema for multiple Okta Auth Providers",
-        "example": {
-          "data": [
-            {
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "name": "Okta"
-            }
-          ]
-        },
         "properties": {
           "data": {
             "description": "Okta Auth Provider details",
@@ -2438,11 +2398,6 @@
       },
       "DeletedGatewayTokenResponse": {
         "description": "Response schema for a deleted Gateway Token",
-        "example": {
-          "data": {
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205"
-          }
-        },
         "properties": {
           "data": {
             "properties": {
@@ -2463,14 +2418,6 @@
       },
       "EntraAuthProviderListResponse": {
         "description": "Response schema for multiple Entra Auth Providers",
-        "example": {
-          "data": [
-            {
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "name": "Entra"
-            }
-          ]
-        },
         "properties": {
           "data": {
             "description": "Entra Auth Provider details",
@@ -2518,12 +2465,6 @@
       },
       "OIDCAuthProvider": {
         "description": "OIDC Auth Provider",
-        "example": {
-          "client_id": "my-client-id",
-          "email_verification_method": "claim",
-          "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name": "OIDC Provider"
-        },
         "properties": {
           "account_id": {
             "description": "Account ID",
@@ -2532,6 +2473,7 @@
           },
           "client_id": {
             "description": "Client ID",
+            "example": "my-client-id",
             "type": "string"
           },
           "client_session_lifetime_secs": {
@@ -2549,6 +2491,7 @@
           },
           "discovery_document_uri": {
             "description": "Discovery document URI",
+            "example": "https://idp.example.com/.well-known/openid-configuration",
             "type": "string"
           },
           "email_verification_method": {
@@ -2580,10 +2523,12 @@
           },
           "issuer": {
             "description": "Issuer",
+            "example": "https://idp.example.com",
             "type": "string"
           },
           "name": {
             "description": "Provider name",
+            "example": "OIDC Provider",
             "type": "string"
           },
           "portal_session_lifetime_secs": {
@@ -2632,44 +2577,6 @@
       },
       "ExternalIdentityListResponse": {
         "description": "Response schema for multiple External Identities",
-        "example": {
-          "data": [
-            {
-              "account_id": "5e6f7d8c-9b0a-1c2d-3e4f-5a6b7c8d9e0f",
-              "actor_id": "8f44a02b-b8eb-406f-8202-4274bf60ebd0",
-              "directory_id": "9f8e7d6c-5b4a-3c2b-1a0e-9f8e7d6c5b4a",
-              "family_name": "Doe",
-              "given_name": "John",
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "idp_id": "2551705710219359",
-              "inserted_at": "2025-01-15T12:34:56.789Z",
-              "issuer": "https://accounts.google.com",
-              "name": "John Doe",
-              "picture": "https://example.com/avatar1.jpg",
-              "synced_at": "2025-01-15T12:34:56.789Z"
-            },
-            {
-              "account_id": "5e6f7d8c-9b0a-1c2d-3e4f-5a6b7c8d9e0f",
-              "actor_id": "38c92cda-1ddb-45b3-9d1a-7efc375e00c1",
-              "directory_id": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
-              "family_name": "Smith",
-              "given_name": "Jane",
-              "id": "8a70eb96-e74b-4cdc-91b8-48c05ef74d4c",
-              "idp_id": "2638957392736483",
-              "inserted_at": "2025-01-15T11:22:33.456Z",
-              "issuer": "https://company.okta.com",
-              "name": "Jane Smith",
-              "picture": "https://example.com/avatar2.jpg",
-              "synced_at": "2025-01-15T11:22:33.456Z"
-            }
-          ],
-          "metadata": {
-            "limit": 10,
-            "next_page": "98776234123",
-            "prev_page": "123123425",
-            "total": 100
-          }
-        },
         "properties": {
           "data": {
             "description": "External Identity details",
@@ -2704,61 +2611,6 @@
       },
       "ClientsResponse": {
         "description": "Response schema for multiple Clients",
-        "example": {
-          "data": [
-            {
-              "actor_id": "6ecc106b-75c1-48a5-846c-14782180c1ff",
-              "created_at": "2025-01-01T00:00:00Z",
-              "device_serial": "GCCFX0DBQ6L5",
-              "device_uuid": "7A461FF9-0BE2-64A9-A418-539D9A21827B",
-              "firebase_installation_id": null,
-              "firezone_id": "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c",
-              "hostname": "johns-macbook.example.com",
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "identifier_for_vendor": null,
-              "ipv4": "100.64.0.1",
-              "ipv6": "fd00:2021:1111::1",
-              "last_attested_cert_fingerprint": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
-              "last_attested_cert_serial": "4A:2F:00:8C:11:03:9E:5B",
-              "last_attested_device_serial": "GCCFX0DBQ6L5",
-              "last_attested_device_uuid": "7A461FF9-0BE2-64A9-A418-539D9A21827B",
-              "last_attested_mdm_device_id": "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3",
-              "name": "John's Macbook Air",
-              "online": true,
-              "updated_at": "2025-01-01T00:00:00Z",
-              "verified_at": "2025-01-01T00:00:00Z"
-            },
-            {
-              "actor_id": "2ecc106b-75c1-48a5-846c-14782180c1ff",
-              "created_at": "2025-01-01T00:00:00Z",
-              "device_serial": null,
-              "device_uuid": null,
-              "firebase_installation_id": null,
-              "firezone_id": "6c37c0042f40bbb16e007d0d6c8e77c0ac2cab3cc3b923c42d1157a934e436ac",
-              "hostname": null,
-              "id": "9a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "identifier_for_vendor": "7A461FF9-0BE2-64A9-A418-539D9A21827B",
-              "ipv4": "100.64.0.2",
-              "ipv6": "fd00:2021:1111::2",
-              "last_attested_at": null,
-              "last_attested_cert_fingerprint": null,
-              "last_attested_cert_serial": null,
-              "last_attested_device_serial": null,
-              "last_attested_device_uuid": null,
-              "last_attested_mdm_device_id": null,
-              "name": "iPad",
-              "online": false,
-              "updated_at": "2025-01-01T00:00:00Z",
-              "verified_at": null
-            }
-          ],
-          "metadata": {
-            "limit": 2,
-            "next_page": "98776234123",
-            "prev_page": "123123425",
-            "total": 100
-          }
-        },
         "properties": {
           "data": {
             "description": "Clients details",
@@ -2776,14 +2628,6 @@
       },
       "GoogleDirectoryListResponse": {
         "description": "Response schema for multiple Google Directories",
-        "example": {
-          "data": [
-            {
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "name": "Google"
-            }
-          ]
-        },
         "properties": {
           "data": {
             "description": "Google Directory details",
@@ -2801,30 +2645,6 @@
       },
       "GatewaysResponse": {
         "description": "Response schema for multiple Gateways",
-        "example": {
-          "data": [
-            {
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "ipv4": "1.2.3.4",
-              "ipv6": "",
-              "name": "vpc-us-east",
-              "online": true
-            },
-            {
-              "id": "6ecc106b-75c1-48a5-846c-14782180c1ff",
-              "ipv4": "5.6.7.8",
-              "ipv6": "",
-              "name": "vpc-us-west",
-              "online": true
-            }
-          ],
-          "metadata": {
-            "limit": 10,
-            "next_page": "98776234123",
-            "prev_page": "123123425",
-            "total": 100
-          }
-        },
         "properties": {
           "data": {
             "description": "Gateways details",
@@ -2872,16 +2692,6 @@
       },
       "ResourceResponse": {
         "description": "Response schema for single Resource",
-        "example": {
-          "data": {
-            "address": "10.0.0.10",
-            "address_description": "Production Database",
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name": "Prod DB",
-            "site_id": "0642e09d-b3a2-47e4-9cd1-c2195faeeb67",
-            "type": "ip"
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/Resource"
@@ -2892,22 +2702,6 @@
       },
       "ExternalIdentityResponse": {
         "description": "Response schema for single External Identity",
-        "example": {
-          "data": {
-            "account_id": "5e6f7d8c-9b0a-1c2d-3e4f-5a6b7c8d9e0f",
-            "actor_id": "cdfa97e6-cca1-41db-8fc7-864daedb46df",
-            "directory_id": "9f8e7d6c-5b4a-3c2b-1a0e-9f8e7d6c5b4a",
-            "family_name": "Doe",
-            "given_name": "John",
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "idp_id": "2551705710219359",
-            "inserted_at": "2025-01-15T12:34:56.789Z",
-            "issuer": "https://accounts.google.com",
-            "name": "John Doe",
-            "picture": "https://example.com/avatar.jpg",
-            "synced_at": "2025-01-15T12:34:56.789Z"
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/ExternalIdentity"
@@ -2927,11 +2721,6 @@
       },
       "OktaDirectory": {
         "description": "Okta Directory",
-        "example": {
-          "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name": "Okta",
-          "okta_domain": "example.okta.com"
-        },
         "properties": {
           "account_id": {
             "description": "Account ID",
@@ -2940,15 +2729,18 @@
           },
           "client_id": {
             "description": "Client ID",
+            "example": "0oa1b2c3d4e5EXAMPLE",
             "type": "string"
           },
           "disabled_reason": {
             "description": "Reason for disabling",
+            "example": "Sync failed on 5 consecutive attempts",
             "nullable": true,
             "type": "string"
           },
           "error_message": {
             "description": "Last error message",
+            "example": "invalid_grant: token has expired or been revoked",
             "nullable": true,
             "type": "string"
           },
@@ -2974,14 +2766,17 @@
           },
           "kid": {
             "description": "Key ID",
+            "example": "kid-2f8a1c9e",
             "type": "string"
           },
           "name": {
             "description": "Directory name",
+            "example": "Okta",
             "type": "string"
           },
           "okta_domain": {
             "description": "Okta domain",
+            "example": "example.okta.com",
             "type": "string"
           },
           "synced_at": {
@@ -3030,14 +2825,6 @@
       },
       "OktaDirectoryListResponse": {
         "description": "Response schema for multiple Okta Directories",
-        "example": {
-          "data": [
-            {
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "name": "Okta"
-            }
-          ]
-        },
         "properties": {
           "data": {
             "description": "Okta Directory details",
@@ -3110,12 +2897,6 @@
       },
       "OktaAuthProviderResponse": {
         "description": "Response schema for single Okta Auth Provider",
-        "example": {
-          "data": {
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name": "Okta"
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/OktaAuthProvider"
@@ -3216,16 +2997,6 @@
       },
       "GatewayProvisionResponse": {
         "description": "Response schema for a newly provisioned Gateway. Includes the one-time token secret - it is not shown again.\n",
-        "example": {
-          "data": {
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "ipv4": null,
-            "ipv6": null,
-            "name": "vpc-us-east",
-            "online": false,
-            "token": "eyJhbGc..."
-          }
-        },
         "properties": {
           "data": {
             "allOf": [
@@ -3252,12 +3023,6 @@
       },
       "X509AuthProvider": {
         "description": "X.509 Auth Provider",
-        "example": {
-          "context": "clients_only",
-          "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "is_disabled": true,
-          "name": "X.509"
-        },
         "properties": {
           "account_id": {
             "description": "Account ID",
@@ -3287,6 +3052,7 @@
           },
           "name": {
             "description": "Provider name",
+            "example": "X.509",
             "type": "string"
           },
           "updated_at": {
@@ -3309,40 +3075,6 @@
       },
       "ActorsResponse": {
         "description": "Response schema for multiple Actors",
-        "example": {
-          "data": [
-            {
-              "allow_email_otp_sign_in": false,
-              "created_by_directory_id": null,
-              "email": "john.doe@example.com",
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "inserted_at": "2024-01-01T00:00:00Z",
-              "is_disabled": false,
-              "last_seen_at": "2024-01-15T10:30:00Z",
-              "name": "John Doe",
-              "type": "account_admin_user",
-              "updated_at": "2024-01-15T10:30:00Z"
-            },
-            {
-              "allow_email_otp_sign_in": true,
-              "created_by_directory_id": "98776234-1234-5678-9012-345678901234",
-              "email": "jane.smith@example.com",
-              "id": "84e7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "inserted_at": "2024-01-02T00:00:00Z",
-              "is_disabled": false,
-              "last_seen_at": "2024-01-14T15:45:00Z",
-              "name": "Jane Smith",
-              "type": "account_user",
-              "updated_at": "2024-01-14T15:45:00Z"
-            }
-          ],
-          "metadata": {
-            "limit": 10,
-            "next_page": "98776234123",
-            "prev_page": "123123425",
-            "total": 100
-          }
-        },
         "properties": {
           "data": {
             "description": "Actors details",
@@ -3360,12 +3092,6 @@
       },
       "GoogleAuthProviderResponse": {
         "description": "Response schema for single Google Auth Provider",
-        "example": {
-          "data": {
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name": "Google"
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/GoogleAuthProvider"
@@ -3429,14 +3155,6 @@
       },
       "MembershipResponse": {
         "description": "Response schema for Membership Updates",
-        "example": {
-          "data": {
-            "actor_ids": [
-              "4ddfa557-7dfc-484f-894c-2024ec3fe9f7",
-              "89d22f71-939d-442d-b148-897b730adfb4"
-            ]
-          }
-        },
         "properties": {
           "data": {
             "description": "Memberships",
@@ -3459,26 +3177,6 @@
       },
       "MembershipListResponse": {
         "description": "Response schema for Memberships",
-        "example": {
-          "data": [
-            {
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "name": "John Doe",
-              "type": "account_user"
-            },
-            {
-              "id": "cc9f561a-444d-4083-ab38-0abc6cf2314c",
-              "name": "Jane Smith",
-              "type": "account_admin_user"
-            }
-          ],
-          "metadata": {
-            "limit": 10,
-            "next_page": "98776234123",
-            "prev_page": "123123425",
-            "total": 100
-          }
-        },
         "properties": {
           "data": {
             "description": "Membership details",
@@ -3578,11 +3276,6 @@
       },
       "DeletedGatewayTokensResponse": {
         "description": "Response schema for deleted Gateway Tokens",
-        "example": {
-          "data": {
-            "deleted_count": 5
-          }
-        },
         "properties": {
           "data": {
             "properties": {
@@ -3649,6 +3342,16 @@
           }
         },
         "title": "PolicyUpdateParams",
+        "type": "object"
+      },
+      "ClientTokenShowResponse": {
+        "description": "Response schema for Client Token metadata",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ClientToken"
+          }
+        },
+        "title": "ClientTokenShowResponse",
         "type": "object"
       },
       "DefenderDevice": {
@@ -3861,6 +3564,58 @@
           "vm_subscription_id"
         ],
         "title": "DefenderDevice",
+        "type": "object"
+      },
+      "ClientTokenWithSecret": {
+        "description": "Client Token as returned when it is created, including the encoded secret. The secret is shown once and cannot be retrieved later.",
+        "example": {
+          "actor_id": "43a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+          "expires_at": "2025-01-15T12:34:56.789Z",
+          "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+          "inserted_at": "2025-01-15T12:34:56.789Z",
+          "token": "secret-token-here",
+          "updated_at": "2025-01-15T12:34:56.789Z"
+        },
+        "properties": {
+          "actor_id": {
+            "description": "Actor ID",
+            "format": "uuid",
+            "type": "string"
+          },
+          "expires_at": {
+            "description": "Expiration",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "Client Token ID",
+            "format": "uuid",
+            "type": "string"
+          },
+          "inserted_at": {
+            "description": "Creation timestamp",
+            "format": "date-time",
+            "type": "string"
+          },
+          "token": {
+            "description": "Encoded token secret",
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "Update timestamp",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "actor_id",
+          "expires_at",
+          "inserted_at",
+          "updated_at",
+          "token"
+        ],
+        "title": "ClientTokenWithSecret",
         "type": "object"
       },
       "SentinelOneDevice": {
@@ -4439,29 +4194,15 @@
       },
       "Resource": {
         "description": "Resource",
-        "example": {
-          "address": "10.0.0.10",
-          "address_description": "Production Database",
-          "filters": [
-            {
-              "ports": [
-                "5432"
-              ],
-              "protocol": "tcp"
-            }
-          ],
-          "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name": "Prod DB",
-          "site_id": "0642e09d-b3a2-47e4-9cd1-c2195faeeb67",
-          "type": "ip"
-        },
         "properties": {
           "address": {
             "description": "Resource address",
+            "example": "10.0.0.10",
             "type": "string"
           },
           "address_description": {
             "description": "Resource address description",
+            "example": "Production Database",
             "type": "string"
           },
           "filters": {
@@ -4487,6 +4228,7 @@
           },
           "name": {
             "description": "Resource name",
+            "example": "Prod DB",
             "type": "string"
           },
           "site_id": {
@@ -4562,11 +4304,6 @@
       },
       "EntraDirectory": {
         "description": "Entra Directory",
-        "example": {
-          "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name": "Entra",
-          "tenant_id": "12345678-1234-1234-1234-123456789012"
-        },
         "properties": {
           "account_id": {
             "description": "Account ID",
@@ -4575,6 +4312,7 @@
           },
           "disabled_reason": {
             "description": "Reason for disabling",
+            "example": "Sync failed on 5 consecutive attempts",
             "nullable": true,
             "type": "string"
           },
@@ -4588,6 +4326,7 @@
           },
           "error_message": {
             "description": "Last error message",
+            "example": "invalid_grant: token has expired or been revoked",
             "nullable": true,
             "type": "string"
           },
@@ -4613,6 +4352,7 @@
           },
           "name": {
             "description": "Directory name",
+            "example": "Entra",
             "type": "string"
           },
           "sync_all_groups": {
@@ -4627,6 +4367,7 @@
           },
           "tenant_id": {
             "description": "Microsoft Entra tenant ID",
+            "example": "12345678-1234-1234-1234-123456789012",
             "type": "string"
           },
           "updated_at": {
@@ -4655,30 +4396,6 @@
       },
       "LogsResponse": {
         "description": "Response schema for a page of Log entries.\n\nEntries are returned most recent first. Each page contains at most 100\nentries (50 by default); use the `metadata.next_page` cursor to fetch\nthe following page.\n",
-        "example": {
-          "data": [
-            {
-              "after": {
-                "name": "Jane Smith"
-              },
-              "before": {
-                "name": "Jane Doe"
-              },
-              "log_id": "c00060db0c2c8eb400000000",
-              "object": "actors",
-              "operation": "update",
-              "subject": null,
-              "timestamp": "2026-05-26T12:34:56.789Z",
-              "type": "change"
-            }
-          ],
-          "metadata": {
-            "count": 1,
-            "limit": 50,
-            "next_page": null,
-            "prev_page": null
-          }
-        },
         "properties": {
           "data": {
             "description": "Log entries for the requested window.",
@@ -4712,14 +4429,6 @@
       },
       "PoolMemberResponse": {
         "description": "Response schema for Pool Member updates",
-        "example": {
-          "data": {
-            "device_ids": [
-              "4ddfa557-7dfc-484f-894c-2024ec3fe9f7",
-              "89d22f71-939d-442d-b148-897b730adfb4"
-            ]
-          }
-        },
         "properties": {
           "data": {
             "description": "Pool members",
@@ -4981,66 +4690,8 @@
         "title": "DefenderDeviceResponse",
         "type": "object"
       },
-      "ClientTokenResponse": {
-        "description": "Client Token response",
-        "example": {
-          "actor_id": "43a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "expires_at": "2025-01-15T12:34:56.789Z",
-          "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "inserted_at": "2025-01-15T12:34:56.789Z",
-          "token": "secret-token-here",
-          "updated_at": "2025-01-15T12:34:56.789Z"
-        },
-        "properties": {
-          "actor_id": {
-            "description": "Actor ID",
-            "format": "uuid",
-            "type": "string"
-          },
-          "expires_at": {
-            "description": "Expiration",
-            "format": "date-time",
-            "type": "string"
-          },
-          "id": {
-            "description": "Client Token ID",
-            "format": "uuid",
-            "type": "string"
-          },
-          "inserted_at": {
-            "description": "Creation timestamp",
-            "format": "date-time",
-            "type": "string"
-          },
-          "token": {
-            "description": "Encoded token secret",
-            "type": "string"
-          },
-          "updated_at": {
-            "description": "Update timestamp",
-            "format": "date-time",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "actor_id",
-          "expires_at",
-          "inserted_at",
-          "updated_at",
-          "token"
-        ],
-        "title": "ClientTokenResponse",
-        "type": "object"
-      },
       "EmailOTPAuthProviderResponse": {
         "description": "Response schema for single Email OTP Auth Provider",
-        "example": {
-          "data": {
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name": "Email OTP"
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/EmailOTPAuthProvider"
@@ -5051,14 +4702,6 @@
       },
       "EntraDirectoryListResponse": {
         "description": "Response schema for multiple Entra Directories",
-        "example": {
-          "data": [
-            {
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "name": "Entra"
-            }
-          ]
-        },
         "properties": {
           "data": {
             "description": "Entra Directory details",
@@ -5177,15 +4820,6 @@
       },
       "OIDCAuthProviderListResponse": {
         "description": "Response schema for multiple OIDC Auth Providers",
-        "example": {
-          "data": [
-            {
-              "email_verification_method": "claim",
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "name": "OIDC Provider"
-            }
-          ]
-        },
         "properties": {
           "data": {
             "description": "OIDC Auth Provider details",
@@ -5766,31 +5400,6 @@
       },
       "ClientResponse": {
         "description": "Response schema for single Client",
-        "example": {
-          "data": {
-            "actor_id": "6ecc106b-75c1-48a5-846c-14782180c1ff",
-            "created_at": "2025-01-01T00:00:00Z",
-            "device_serial": "GCCFX0DBQ6L5",
-            "device_uuid": "7A461FF9-0BE2-64A9-A418-539D9A21827B",
-            "firebase_installation_id": null,
-            "firezone_id": "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c",
-            "hostname": "johns-macbook.example.com",
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "identifier_for_vendor": null,
-            "ipv4": "100.64.0.1",
-            "ipv6": "fd00:2021:1111::1",
-            "last_attested_at": "2025-01-01T00:00:00Z",
-            "last_attested_cert_fingerprint": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
-            "last_attested_cert_serial": "4A:2F:00:8C:11:03:9E:5B",
-            "last_attested_device_serial": "GCCFX0DBQ6L5",
-            "last_attested_device_uuid": "7A461FF9-0BE2-64A9-A418-539D9A21827B",
-            "last_attested_mdm_device_id": "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3",
-            "name": "John's Macbook Air",
-            "online": true,
-            "updated_at": "2025-01-01T00:00:00Z",
-            "verified_at": "2025-01-01T00:00:00Z"
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/Client"
@@ -5916,11 +5525,6 @@
       },
       "EmailOTPAuthProvider": {
         "description": "Email OTP Auth Provider",
-        "example": {
-          "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "issuer": "firezone",
-          "name": "Email OTP"
-        },
         "properties": {
           "account_id": {
             "description": "Account ID",
@@ -5956,10 +5560,12 @@
           },
           "issuer": {
             "description": "Issuer",
+            "example": "firezone",
             "type": "string"
           },
           "name": {
             "description": "Provider name",
+            "example": "Email OTP",
             "type": "string"
           },
           "portal_session_lifetime_secs": {
@@ -6167,11 +5773,6 @@
       },
       "GoogleAuthProvider": {
         "description": "Google Auth Provider",
-        "example": {
-          "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "issuer": "https://accounts.google.com",
-          "name": "Google"
-        },
         "properties": {
           "account_id": {
             "description": "Account ID",
@@ -6211,10 +5812,12 @@
           },
           "issuer": {
             "description": "Issuer",
+            "example": "https://accounts.google.com",
             "type": "string"
           },
           "name": {
             "description": "Provider name",
+            "example": "Google",
             "type": "string"
           },
           "portal_session_lifetime_secs": {
@@ -6376,26 +5979,6 @@
       },
       "PoolMemberListResponse": {
         "description": "Response schema for Pool Members",
-        "example": {
-          "data": [
-            {
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "last_seen_at": "2024-01-15T10:30:00Z",
-              "name": "jane-laptop"
-            },
-            {
-              "id": "cc9f561a-444d-4083-ab38-0abc6cf2314c",
-              "last_seen_at": null,
-              "name": "field-tablet-02"
-            }
-          ],
-          "metadata": {
-            "limit": 10,
-            "next_page": "98776234123",
-            "prev_page": "123123425",
-            "total": 100
-          }
-        },
         "properties": {
           "data": {
             "description": "Pool member details",
@@ -6555,45 +6138,6 @@
       },
       "FlowLog": {
         "description": "A single Flow Log entry, recording one network flow as accounted by one\nof its two endpoints.\n\nBoth endpoints of a flow report it independently, so a flow yields up to\ntwo entries that differ only in `role` and in the counters each side\nobserved. Every other field is oriented from the initiator regardless of\nwhich side reported the entry: `inner_src_*` is always the initiator,\n`inner_dst_*` always the responder, and `tx_*` always counts\ninitiator-to-responder traffic. `outers` records each outer network path\nin the order it was observed. Comparing the two entries of a flow is how\nreported traffic is cross-checked.\n",
-        "example": {
-          "authorization_expires_at": "2026-05-26T20:29:00.000Z",
-          "authorized_at": "2026-05-26T12:29:00.000Z",
-          "flow_end": "2026-05-26T12:34:00.000Z",
-          "flow_start": "2026-05-26T12:30:00.000Z",
-          "initiator_actor_email": "user@example.com",
-          "initiator_client_version": "1.5.1",
-          "initiator_device_id": "11e7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "initiator_device_os_name": "macOS",
-          "initiator_device_os_version": "15.5",
-          "inner_dst_ip": "10.0.0.5",
-          "inner_dst_port": 443,
-          "inner_src_ip": "100.64.0.1",
-          "inner_src_port": 54321,
-          "last_packet": "2026-05-26T12:33:58.000Z",
-          "log_id": "f00060db0c2c8eb400000000",
-          "outers": [
-            {
-              "dst_ip": "198.51.100.5",
-              "dst_port": 51820,
-              "src_ip": "203.0.113.10",
-              "src_port": 51820
-            }
-          ],
-          "policy_authorization_id": "6fa1d58f-0289-42e6-a3ba-7edfa46ee2d5",
-          "policy_id": "46f997d1-77c8-4936-8655-8f050dffbfa4",
-          "protocol": "tcp",
-          "resource_address": "gitlab.company.com",
-          "resource_id": "44e7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "resource_name": "GitLab",
-          "responder_device_id": "9d3a1c40-5f2b-4c8e-9a71-0b6d4e2f8c13",
-          "role": "responder",
-          "rx_bytes": 102400,
-          "rx_packets": 100,
-          "timestamp": "2026-05-26T12:34:56.789Z",
-          "tx_bytes": 20480,
-          "tx_packets": 80,
-          "type": "flow"
-        },
         "properties": {
           "log_id": {
             "description": "Opaque identifier for the Flow Log entry. A 24-character lowercase\nhexadecimal string starting with `f`.\n",
@@ -6602,6 +6146,7 @@
           },
           "initiator_device_id": {
             "description": "ID of the Client that opened the flow. Always a Client.",
+            "example": "11e7f82f-831a-4a9d-8f17-c66c2bb6e205",
             "type": "string"
           },
           "last_packet": {
@@ -6612,15 +6157,18 @@
           },
           "inner_dst_ip": {
             "description": "Tunnel IP of the responder, on both entries of the flow.",
+            "example": "10.0.0.5",
             "type": "string"
           },
           "initiator_auth_provider_id": {
             "description": "ID of the Auth Provider the initiating Client authenticated with.\n",
+            "example": "7b2c1e40-9f3a-4d21-8c5e-1a2b3c4d5e6f",
             "nullable": true,
             "type": "string"
           },
           "initiator_device_uuid": {
             "description": "Device UUID reported by the initiating Client.",
+            "example": "0C4A8D24-FA9F-4E56-9B57-40D0D46A245E",
             "nullable": true,
             "type": "string"
           },
@@ -6632,11 +6180,13 @@
           },
           "initiator_device_identifier_for_vendor": {
             "description": "Vendor identifier reported by the initiating Client.",
+            "example": "C242BC21-AB4A-4F6D-B755-F50E2B5B51B7",
             "nullable": true,
             "type": "string"
           },
           "policy_authorization_id": {
             "description": "ID of the Policy Authorization that permitted the flow.",
+            "example": "6fa1d58f-0289-42e6-a3ba-7edfa46ee2d5",
             "type": "string"
           },
           "tx_bytes": {
@@ -6646,6 +6196,7 @@
           },
           "initiator_client_version": {
             "description": "Firezone Client version reported by the initiating Client.",
+            "example": "1.5.1",
             "nullable": true,
             "type": "string"
           },
@@ -6662,6 +6213,7 @@
           },
           "initiator_device_os_name": {
             "description": "Operating system reported by the initiating Client.",
+            "example": "macOS",
             "nullable": true,
             "type": "string"
           },
@@ -6688,18 +6240,22 @@
           },
           "initiator_device_firebase_installation_id": {
             "description": "Firebase installation ID reported by the initiating Client.",
+            "example": "firebase-installation-id",
             "nullable": true,
             "type": "string"
           },
           "inner_src_ip": {
             "description": "Tunnel IP of the initiator, on both entries of the flow.",
+            "example": "100.64.0.1",
             "type": "string"
           },
           "responder_device_id": {
             "description": "ID of the device the flow was opened to: the Gateway serving the\nResource, or the receiving Client for device-to-device flows.\n",
+            "example": "9d3a1c40-5f2b-4c8e-9a71-0b6d4e2f8c13",
             "type": "string"
           },
           "initiator_actor_email": {
+            "example": "user@example.com",
             "nullable": true,
             "type": "string"
           },
@@ -6753,6 +6309,7 @@
           },
           "resource_id": {
             "description": "ID of the Resource accessed.",
+            "example": "44e7f82f-831a-4a9d-8f17-c66c2bb6e205",
             "type": "string"
           },
           "inner_src_port": {
@@ -6775,38 +6332,46 @@
           },
           "initiator_device_os_version": {
             "description": "Operating system version reported by the initiating Client.",
+            "example": "15.5",
             "nullable": true,
             "type": "string"
           },
           "inner_domain": {
             "description": "Domain name for flows to DNS Resources.",
+            "example": "gitlab.company.com",
             "nullable": true,
             "type": "string"
           },
           "initiator_actor_id": {
             "description": "ID of the Actor who opened the flow. This is always the initiating\nClient's Actor. A Gateway has no Actor, and for device-to-device\nflows the receiving Client's own Actor is not recorded here.\n",
+            "example": "84e7f82f-831a-4a9d-8f17-c66c2bb6e205",
             "nullable": true,
             "type": "string"
           },
           "initiator_actor_name": {
+            "example": "John Doe",
             "nullable": true,
             "type": "string"
           },
           "resource_address": {
             "description": "Resource address, when the Resource type has one.",
+            "example": "gitlab.company.com",
             "nullable": true,
             "type": "string"
           },
           "initiator_device_serial": {
             "description": "Device serial number reported by the initiating Client.",
+            "example": "C02ABC123",
             "nullable": true,
             "type": "string"
           },
           "resource_name": {
+            "example": "GitLab",
             "type": "string"
           },
           "policy_id": {
             "description": "ID of the Policy that permitted the flow.",
+            "example": "46f997d1-77c8-4936-8655-8f050dffbfa4",
             "type": "string"
           }
         },
@@ -6855,24 +6420,6 @@
       },
       "SiteListResponse": {
         "description": "Response schema for multiple Sites",
-        "example": {
-          "data": [
-            {
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "name": "vpc-us-east"
-            },
-            {
-              "id": "6301d7d2-4938-4123-87de-282c01cca656",
-              "name": "vpc-us-west"
-            }
-          ],
-          "metadata": {
-            "limit": 10,
-            "next_page": "98776234123",
-            "prev_page": "123123425",
-            "total": 100
-          }
-        },
         "properties": {
           "data": {
             "description": "Site details",
@@ -6890,43 +6437,6 @@
       },
       "PolicyListResponse": {
         "description": "Response schema for multiple Policies",
-        "example": {
-          "data": [
-            {
-              "conditions": [
-                {
-                  "operator": "is_in",
-                  "property": "remote_ip_location_region",
-                  "values": [
-                    "US",
-                    "CA"
-                  ]
-                }
-              ],
-              "description": "Policy to allow something",
-              "flow_log_uploads_enabled": true,
-              "group_id": "88eae9ce-9179-48c6-8430-770e38dd4775",
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "is_disabled": false,
-              "resource_id": "a9f60587-793c-46ae-8525-597f43ab2fb1"
-            },
-            {
-              "conditions": [],
-              "description": "Policy to allow something else",
-              "flow_log_uploads_enabled": false,
-              "group_id": "343385a2-5437-4c66-8744-1332421ff736",
-              "id": "6301d7d2-4938-4123-87de-282c01cca656",
-              "is_disabled": true,
-              "resource_id": "9876bd25-0f6c-48fb-a9fd-196ba9be86e5"
-            }
-          ],
-          "metadata": {
-            "limit": 10,
-            "next_page": "98776234123",
-            "prev_page": "123123425",
-            "total": 100
-          }
-        },
         "properties": {
           "data": {
             "description": "Policy details",
@@ -6944,14 +6454,6 @@
       },
       "EmailOTPAuthProviderListResponse": {
         "description": "Response schema for multiple Email OTP Auth Providers",
-        "example": {
-          "data": [
-            {
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "name": "Email OTP"
-            }
-          ]
-        },
         "properties": {
           "data": {
             "description": "Email OTP Auth Provider details",
@@ -6996,32 +6498,6 @@
       },
       "ResourceListResponse": {
         "description": "Response schema for multiple Resources",
-        "example": {
-          "data": [
-            {
-              "address": "10.0.0.10",
-              "address_description": "Production Database",
-              "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-              "name": "Prod DB",
-              "site_id": "0642e09d-b3a2-47e4-9cd1-c2195faeeb67",
-              "type": "ip"
-            },
-            {
-              "address": "10.0.0.20",
-              "address_description": "Production Admin Dashboard",
-              "id": "3b9451c9-5616-48f8-827f-009ace22d015",
-              "name": "Admin Dashboard",
-              "site_id": "0642e09d-b3a2-47e4-9cd1-c2195faeeb67",
-              "type": "ip"
-            }
-          ],
-          "metadata": {
-            "limit": 10,
-            "next_page": "98776234123",
-            "prev_page": "123123425",
-            "total": 100
-          }
-        },
         "properties": {
           "data": {
             "description": "Resource details",
@@ -7584,13 +7060,6 @@
       },
       "OIDCAuthProviderResponse": {
         "description": "Response schema for single OIDC Auth Provider",
-        "example": {
-          "data": {
-            "email_verification_method": "claim",
-            "id": "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name": "OIDC Provider"
-          }
-        },
         "properties": {
           "data": {
             "$ref": "#/components/schemas/OIDCAuthProvider"
@@ -10370,7 +9839,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ClientTokenResponse"
+                  "$ref": "#/components/schemas/ClientTokenShowResponse"
                 }
               }
             },

--- a/elixir/priv/static/openapi.json
+++ b/elixir/priv/static/openapi.json
@@ -896,6 +896,9 @@
           },
           "client_session_lifetime_secs": {
             "description": "Client session lifetime in seconds",
+            "maximum": 7776000,
+            "minimum": 3600,
+            "nullable": true,
             "type": "integer"
           },
           "context": {
@@ -944,6 +947,9 @@
           },
           "portal_session_lifetime_secs": {
             "description": "Portal session lifetime in seconds",
+            "maximum": 86400,
+            "minimum": 300,
+            "nullable": true,
             "type": "integer"
           },
           "updated_at": {
@@ -2041,23 +2047,26 @@
           },
           "disabled_reason": {
             "description": "Reason for disabling",
+            "nullable": true,
             "type": "string"
           },
           "domain": {
             "description": "Google Workspace domain",
             "type": "string"
           },
-          "error": {
-            "description": "Last error message",
-            "type": "string"
-          },
-          "error_count": {
-            "description": "Error count",
+          "error_email_count": {
+            "description": "Number of error emails sent for this directory",
             "type": "integer"
           },
-          "error_emailed_at": {
-            "description": "Error email timestamp",
+          "error_message": {
+            "description": "Last error message",
+            "nullable": true,
+            "type": "string"
+          },
+          "errored_at": {
+            "description": "Last error timestamp",
             "format": "date-time",
+            "nullable": true,
             "type": "string"
           },
           "group_sync_mode": {
@@ -2098,6 +2107,7 @@
           "synced_at": {
             "description": "Last sync timestamp",
             "format": "date-time",
+            "nullable": true,
             "type": "string"
           },
           "updated_at": {
@@ -2741,19 +2751,22 @@
           },
           "disabled_reason": {
             "description": "Reason for disabling",
+            "nullable": true,
             "type": "string"
           },
-          "error": {
-            "description": "Last error message",
-            "type": "string"
-          },
-          "error_count": {
-            "description": "Error count",
+          "error_email_count": {
+            "description": "Number of error emails sent for this directory",
             "type": "integer"
           },
-          "error_emailed_at": {
-            "description": "Error email timestamp",
+          "error_message": {
+            "description": "Last error message",
+            "nullable": true,
+            "type": "string"
+          },
+          "errored_at": {
+            "description": "Last error timestamp",
             "format": "date-time",
+            "nullable": true,
             "type": "string"
           },
           "id": {
@@ -2785,6 +2798,7 @@
           "synced_at": {
             "description": "Last sync timestamp",
             "format": "date-time",
+            "nullable": true,
             "type": "string"
           },
           "updated_at": {
@@ -4214,6 +4228,7 @@
           },
           "disabled_reason": {
             "description": "Reason for disabling",
+            "nullable": true,
             "type": "string"
           },
           "email_field": {
@@ -4224,17 +4239,19 @@
             ],
             "type": "string"
           },
-          "error": {
-            "description": "Last error message",
-            "type": "string"
-          },
-          "error_count": {
-            "description": "Error count",
+          "error_email_count": {
+            "description": "Number of error emails sent for this directory",
             "type": "integer"
           },
-          "error_emailed_at": {
-            "description": "Error email timestamp",
+          "error_message": {
+            "description": "Last error message",
+            "nullable": true,
+            "type": "string"
+          },
+          "errored_at": {
+            "description": "Last error timestamp",
             "format": "date-time",
+            "nullable": true,
             "type": "string"
           },
           "id": {
@@ -4262,11 +4279,11 @@
           "synced_at": {
             "description": "Last sync timestamp",
             "format": "date-time",
+            "nullable": true,
             "type": "string"
           },
           "tenant_id": {
             "description": "Microsoft Entra tenant ID",
-            "format": "uuid",
             "type": "string"
           },
           "updated_at": {

--- a/elixir/priv/static/openapi.json
+++ b/elixir/priv/static/openapi.json
@@ -9,6 +9,9 @@
             "$ref": "#/components/schemas/EntraDirectory"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "EntraDirectoryResponse",
         "type": "object"
       },
@@ -24,6 +27,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "IruDeviceListResponse",
         "type": "object"
       },
@@ -34,6 +41,9 @@
             "$ref": "#/components/schemas/Actor"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "ActorResponse",
         "type": "object"
       },
@@ -51,6 +61,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "GoogleAuthProviderListResponse",
         "type": "object"
       },
@@ -61,6 +75,9 @@
             "$ref": "#/components/schemas/Group"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "GroupResponse",
         "type": "object"
       },
@@ -71,6 +88,9 @@
             "$ref": "#/components/schemas/GoogleDirectory"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "GoogleDirectoryResponse",
         "type": "object"
       },
@@ -195,6 +215,9 @@
             "$ref": "#/components/schemas/SentinelOneDevice"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "SentinelOneDeviceResponse",
         "type": "object"
       },
@@ -210,6 +233,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "IntuneDeviceListResponse",
         "type": "object"
       },
@@ -467,6 +494,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "IntunePostureProviderListResponse",
         "type": "object"
       },
@@ -639,6 +670,9 @@
             "$ref": "#/components/schemas/Gateway"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "GatewayResponse",
         "type": "object"
       },
@@ -732,6 +766,9 @@
             "$ref": "#/components/schemas/ClientTokenWithSecret"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "ClientTokenCreateResponse",
         "type": "object"
       },
@@ -968,6 +1005,9 @@
             "$ref": "#/components/schemas/EntraAuthProvider"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "EntraAuthProviderResponse",
         "type": "object"
       },
@@ -1565,6 +1605,9 @@
             "$ref": "#/components/schemas/IntuneDevice"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "IntuneDeviceResponse",
         "type": "object"
       },
@@ -1593,6 +1636,9 @@
             "$ref": "#/components/schemas/OktaDirectory"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "OktaDirectoryResponse",
         "type": "object"
       },
@@ -1642,6 +1688,16 @@
             "type": "string"
           }
         },
+        "required": [
+          "gateway_id",
+          "ip",
+          "ip_city",
+          "ip_lat",
+          "ip_lon",
+          "ip_region",
+          "token_id",
+          "user_agent"
+        ],
         "title": "GatewaySessionSubject",
         "type": "object"
       },
@@ -1652,6 +1708,9 @@
             "$ref": "#/components/schemas/GatewayToken"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "GatewayTokenResponse",
         "type": "object"
       },
@@ -1735,6 +1794,9 @@
             "type": "object"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "DeletedClientTokenResponse",
         "type": "object"
       },
@@ -1814,6 +1876,21 @@
             "type": "string"
           }
         },
+        "required": [
+          "actor_email",
+          "actor_id",
+          "actor_name",
+          "actor_type",
+          "auth_provider_id",
+          "device_id",
+          "ip",
+          "ip_city",
+          "ip_lat",
+          "ip_lon",
+          "ip_region",
+          "token_id",
+          "user_agent"
+        ],
         "title": "ClientSessionSubject",
         "type": "object"
       },
@@ -2190,6 +2267,9 @@
             "$ref": "#/components/schemas/Site"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "SiteResponse",
         "type": "object"
       },
@@ -2207,6 +2287,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "ClientTokenListResponse",
         "type": "object"
       },
@@ -2222,6 +2306,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "IruPostureProviderListResponse",
         "type": "object"
       },
@@ -2331,6 +2419,9 @@
             "$ref": "#/components/schemas/Policy"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "PolicyResponse",
         "type": "object"
       },
@@ -2350,6 +2441,9 @@
             "type": "object"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "DeletedClientTokensResponse",
         "type": "object"
       },
@@ -2367,6 +2461,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "GroupListResponse",
         "type": "object"
       },
@@ -2376,6 +2474,9 @@
             "$ref": "#/components/schemas/IntunePostureProvider"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "IntunePostureProviderResponse",
         "type": "object"
       },
@@ -2393,6 +2494,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "OktaAuthProviderListResponse",
         "type": "object"
       },
@@ -2413,6 +2518,9 @@
             "type": "object"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "DeletedGatewayTokenResponse",
         "type": "object"
       },
@@ -2430,6 +2538,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "EntraAuthProviderListResponse",
         "type": "object"
       },
@@ -2572,6 +2684,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "DefenderDeviceListResponse",
         "type": "object"
       },
@@ -2589,6 +2705,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "ExternalIdentityListResponse",
         "type": "object"
       },
@@ -2623,6 +2743,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "ClientsResponse",
         "type": "object"
       },
@@ -2640,6 +2764,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "GoogleDirectoryListResponse",
         "type": "object"
       },
@@ -2657,6 +2785,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "GatewaysResponse",
         "type": "object"
       },
@@ -2697,6 +2829,9 @@
             "$ref": "#/components/schemas/Resource"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "ResourceResponse",
         "type": "object"
       },
@@ -2707,6 +2842,9 @@
             "$ref": "#/components/schemas/ExternalIdentity"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "ExternalIdentityResponse",
         "type": "object"
       },
@@ -2716,6 +2854,9 @@
             "$ref": "#/components/schemas/SantaDevice"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "SantaDeviceResponse",
         "type": "object"
       },
@@ -2837,6 +2978,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "OktaDirectoryListResponse",
         "type": "object"
       },
@@ -2846,6 +2991,9 @@
             "$ref": "#/components/schemas/DefenderPostureProvider"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "DefenderPostureProviderResponse",
         "type": "object"
       },
@@ -2855,6 +3003,9 @@
             "$ref": "#/components/schemas/SentinelOnePostureProvider"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "SentinelOnePostureProviderResponse",
         "type": "object"
       },
@@ -2902,6 +3053,9 @@
             "$ref": "#/components/schemas/OktaAuthProvider"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "OktaAuthProviderResponse",
         "type": "object"
       },
@@ -2983,6 +3137,19 @@
             "type": "string"
           }
         },
+        "required": [
+          "actor_email",
+          "actor_id",
+          "actor_name",
+          "actor_type",
+          "auth_provider_id",
+          "ip",
+          "ip_city",
+          "ip_lat",
+          "ip_lon",
+          "ip_region",
+          "user_agent"
+        ],
         "title": "Subject",
         "type": "object"
       },
@@ -2992,6 +3159,9 @@
             "$ref": "#/components/schemas/IruPostureProvider"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "IruPostureProviderResponse",
         "type": "object"
       },
@@ -3018,6 +3188,9 @@
             ]
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "GatewayProvisionResponse",
         "type": "object"
       },
@@ -3087,6 +3260,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "ActorsResponse",
         "type": "object"
       },
@@ -3097,6 +3274,9 @@
             "$ref": "#/components/schemas/GoogleAuthProvider"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "GoogleAuthProviderResponse",
         "type": "object"
       },
@@ -3172,6 +3352,9 @@
             "type": "object"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "MembershipResponse",
         "type": "object"
       },
@@ -3189,6 +3372,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "MembershipListResponse",
         "type": "object"
       },
@@ -3290,6 +3477,9 @@
             "type": "object"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "DeletedGatewayTokensResponse",
         "type": "object"
       },
@@ -3351,6 +3541,9 @@
             "$ref": "#/components/schemas/ClientToken"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "ClientTokenShowResponse",
         "type": "object"
       },
@@ -4266,6 +4459,9 @@
             "$ref": "#/components/schemas/X509AuthProvider"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "X509AuthProviderResponse",
         "type": "object"
       },
@@ -4299,6 +4495,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "DefenderPostureProviderListResponse",
         "type": "object"
       },
@@ -4409,6 +4609,10 @@
             "type": "object"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "LogsResponse",
         "type": "object"
       },
@@ -4424,6 +4628,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "SentinelOnePostureProviderListResponse",
         "type": "object"
       },
@@ -4446,6 +4654,9 @@
             "type": "object"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "PoolMemberResponse",
         "type": "object"
       },
@@ -4678,6 +4889,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "SantaDeviceListResponse",
         "type": "object"
       },
@@ -4687,6 +4902,9 @@
             "$ref": "#/components/schemas/DefenderDevice"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "DefenderDeviceResponse",
         "type": "object"
       },
@@ -4697,6 +4915,9 @@
             "$ref": "#/components/schemas/EmailOTPAuthProvider"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "EmailOTPAuthProviderResponse",
         "type": "object"
       },
@@ -4714,6 +4935,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "EntraDirectoryListResponse",
         "type": "object"
       },
@@ -4832,6 +5057,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "OIDCAuthProviderListResponse",
         "type": "object"
       },
@@ -5133,9 +5362,10 @@
           }
         },
         "required": [
-          "type",
+          "detail",
+          "status",
           "title",
-          "status"
+          "type"
         ],
         "title": "ProblemDetails",
         "type": "object"
@@ -5152,6 +5382,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "SantaPostureProviderListResponse",
         "type": "object"
       },
@@ -5263,6 +5497,7 @@
           }
         },
         "required": [
+          "ports",
           "protocol"
         ],
         "title": "ResourceFilter",
@@ -5386,6 +5621,9 @@
             "$ref": "#/components/schemas/Log"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "LogResponse",
         "type": "object"
       },
@@ -5395,6 +5633,9 @@
             "$ref": "#/components/schemas/SantaPostureProvider"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "SantaPostureProviderResponse",
         "type": "object"
       },
@@ -5405,6 +5646,9 @@
             "$ref": "#/components/schemas/Client"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "ClientResponse",
         "type": "object"
       },
@@ -5685,9 +5929,10 @@
           }
         },
         "required": [
-          "type",
-          "title",
+          "detail",
           "status",
+          "title",
+          "type",
           "validation_errors"
         ],
         "title": "ValidationProblemDetails",
@@ -5746,6 +5991,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "SentinelOneDeviceListResponse",
         "type": "object"
       },
@@ -5991,6 +6240,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "PoolMemberListResponse",
         "type": "object"
       },
@@ -6432,6 +6685,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "SiteListResponse",
         "type": "object"
       },
@@ -6449,6 +6706,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "PolicyListResponse",
         "type": "object"
       },
@@ -6466,6 +6727,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "EmailOTPAuthProviderListResponse",
         "type": "object"
       },
@@ -6510,6 +6775,10 @@
             "$ref": "#/components/schemas/PaginationMetadata"
           }
         },
+        "required": [
+          "data",
+          "metadata"
+        ],
         "title": "ResourceListResponse",
         "type": "object"
       },
@@ -7055,6 +7324,9 @@
             "$ref": "#/components/schemas/IruDevice"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "IruDeviceResponse",
         "type": "object"
       },
@@ -7065,6 +7337,9 @@
             "$ref": "#/components/schemas/OIDCAuthProvider"
           }
         },
+        "required": [
+          "data"
+        ],
         "title": "OIDCAuthProviderResponse",
         "type": "object"
       }

--- a/elixir/priv/static/openapi.json
+++ b/elixir/priv/static/openapi.json
@@ -218,14 +218,20 @@
           }
         },
         "required": [
-          "id",
           "account_id",
-          "type",
-          "name",
-          "subdomain",
-          "region",
+          "disabled_reason",
+          "error_message",
+          "errored_at",
+          "id",
+          "inserted_at",
+          "is_disabled",
           "is_verified",
-          "is_disabled"
+          "name",
+          "region",
+          "subdomain",
+          "synced_at",
+          "type",
+          "updated_at"
         ],
         "title": "IruPostureProvider",
         "type": "object"
@@ -461,10 +467,37 @@
         },
         "required": [
           "account_id",
+          "configured_client_mode",
+          "first_seen_at",
+          "hostname",
           "id",
+          "inserted_at",
+          "last_preflight_at",
+          "last_preflight_ip",
+          "last_seen_client_mode",
+          "last_sync_at",
+          "machine_model",
+          "os_build",
+          "os_type",
+          "os_version",
           "posture_provider_id",
+          "primary_user",
+          "primary_user_groups",
+          "primary_user_locked",
+          "rule_sync_at",
           "santa_id",
-          "synced_at"
+          "santa_version",
+          "santanetd_version",
+          "serial_number",
+          "sip_status",
+          "synced_at",
+          "tags",
+          "tags_locked",
+          "tags_truncated",
+          "temporary_admin_mode_ends_at",
+          "temporary_admin_mode_user",
+          "temporary_monitor_mode_ends_at",
+          "updated_at"
         ],
         "title": "SantaDevice",
         "type": "object"
@@ -542,13 +575,19 @@
           }
         },
         "required": [
-          "id",
           "account_id",
-          "type",
-          "name",
           "api_url",
+          "disabled_reason",
+          "error_message",
+          "errored_at",
+          "id",
+          "inserted_at",
+          "is_disabled",
           "is_verified",
-          "is_disabled"
+          "name",
+          "synced_at",
+          "type",
+          "updated_at"
         ],
         "title": "SantaPostureProvider",
         "type": "object"
@@ -624,8 +663,19 @@
           }
         },
         "required": [
+          "account_id",
+          "client_id",
+          "client_session_lifetime_secs",
+          "context",
           "id",
-          "name"
+          "inserted_at",
+          "is_default",
+          "is_disabled",
+          "issuer",
+          "name",
+          "okta_domain",
+          "portal_session_lifetime_secs",
+          "updated_at"
         ],
         "title": "OktaAuthProvider",
         "type": "object"
@@ -809,13 +859,19 @@
           }
         },
         "required": [
-          "id",
           "account_id",
-          "type",
-          "name",
-          "tenant_id",
+          "disabled_reason",
+          "error_message",
+          "errored_at",
+          "id",
+          "inserted_at",
+          "is_disabled",
           "is_verified",
-          "is_disabled"
+          "name",
+          "synced_at",
+          "tenant_id",
+          "type",
+          "updated_at"
         ],
         "title": "DefenderPostureProvider",
         "type": "object"
@@ -872,9 +928,9 @@
           }
         },
         "required": [
-          "id",
           "actor_id",
           "expires_at",
+          "id",
           "inserted_at",
           "updated_at"
         ],
@@ -959,8 +1015,18 @@
           }
         },
         "required": [
+          "account_id",
+          "client_session_lifetime_secs",
+          "context",
+          "email_claim",
           "id",
-          "name"
+          "inserted_at",
+          "is_default",
+          "is_disabled",
+          "issuer",
+          "name",
+          "portal_session_lifetime_secs",
+          "updated_at"
         ],
         "title": "EntraAuthProvider",
         "type": "object"
@@ -1031,6 +1097,10 @@
             "format": "uuid",
             "type": "string"
           },
+          "email": {
+            "description": "Email address, falling back to the IdP identifier when unset",
+            "type": "string"
+          },
           "family_name": {
             "description": "Family name",
             "type": "string"
@@ -1092,10 +1162,24 @@
           }
         },
         "required": [
-          "id",
+          "account_id",
           "actor_id",
+          "directory_id",
+          "email",
+          "family_name",
+          "firezone_avatar_url",
+          "given_name",
+          "id",
+          "idp_id",
+          "inserted_at",
           "issuer",
-          "idp_id"
+          "middle_name",
+          "name",
+          "nickname",
+          "picture",
+          "preferred_username",
+          "profile",
+          "synced_at"
         ],
         "title": "ExternalIdentity",
         "type": "object"
@@ -1465,9 +1549,90 @@
         },
         "required": [
           "account_id",
-          "posture_provider_id",
+          "activation_lock_allowed_while_supervised",
+          "activation_lock_bypass_code_failed",
+          "activation_lock_collected_at",
+          "activation_lock_supported",
+          "agent_installed",
+          "agent_version",
+          "any_signed_os",
+          "apple_silicon",
+          "asset_tag",
+          "blueprint_id",
+          "blueprint_name",
+          "bootstrap_token_auth",
+          "bootstrap_token_escrowed",
+          "cellular_technology",
+          "data_roaming",
+          "device_activation_lock_enabled",
+          "device_capacity_gb",
+          "device_family",
+          "device_name",
+          "display_os_version",
+          "external_boot_level",
+          "filevault_collected_at",
+          "filevault_enabled",
+          "filevault_key_escrowed",
+          "filevault_key_rotation_scheduled_at",
+          "filevault_key_type",
+          "filevault_regeneration_needed",
+          "firewall_allow_signed_applications",
+          "firewall_block_all_incoming",
+          "firewall_collected_at",
+          "firewall_enabled",
+          "firewall_logging",
+          "firewall_logging_option",
+          "firewall_stealth_mode",
+          "firewall_unloading",
+          "firewall_version",
+          "first_enrolled_at",
+          "gatekeeper_collected_at",
+          "gatekeeper_enabled",
+          "gatekeeper_opaque_version",
+          "gatekeeper_trusted_developers",
+          "gatekeeper_version",
+          "host_name",
+          "hotspot",
+          "inserted_at",
+          "inventory_collected_at",
           "iru_id",
-          "synced_at"
+          "is_missing",
+          "is_removed",
+          "kext_requires_bootstrap_token",
+          "last_check_in_at",
+          "last_enrolled_at",
+          "local_hostname",
+          "lost_mode_status",
+          "malware_removal_tool_version",
+          "mdm_enabled",
+          "mdm_manages_kext",
+          "model",
+          "model_identifier",
+          "model_name",
+          "os_build",
+          "os_name",
+          "os_version",
+          "platform",
+          "posture_provider_id",
+          "secure_boot_level",
+          "serial_number",
+          "shared_ipad",
+          "sip_enabled",
+          "software_update_requires_bootstrap_token",
+          "ssv_enabled",
+          "startup_settings_collected_at",
+          "supplemental_build_version",
+          "supplemental_os_version_extra",
+          "synced_at",
+          "tags",
+          "updated_at",
+          "user_activation_lock_enabled",
+          "user_email",
+          "user_id",
+          "user_is_archived",
+          "user_manages_kext",
+          "user_name",
+          "xprotect_version"
         ],
         "title": "IruDevice",
         "type": "object"
@@ -1670,11 +1835,11 @@
           }
         },
         "required": [
-          "type",
-          "log_id",
-          "timestamp",
           "context",
-          "subject"
+          "log_id",
+          "subject",
+          "timestamp",
+          "type"
         ],
         "title": "SessionLog",
         "type": "object"
@@ -1743,11 +1908,14 @@
           }
         },
         "required": [
-          "type",
+          "after",
+          "before",
           "log_id",
-          "timestamp",
           "object",
-          "operation"
+          "operation",
+          "subject",
+          "timestamp",
+          "type"
         ],
         "title": "ChangeLog",
         "type": "object"
@@ -2054,10 +2222,6 @@
             "description": "Google Workspace domain",
             "type": "string"
           },
-          "error_email_count": {
-            "description": "Number of error emails sent for this directory",
-            "type": "integer"
-          },
           "error_message": {
             "description": "Last error message",
             "nullable": true,
@@ -2117,8 +2281,20 @@
           }
         },
         "required": [
+          "account_id",
+          "disabled_reason",
+          "domain",
+          "error_message",
+          "errored_at",
+          "group_sync_mode",
           "id",
-          "name"
+          "impersonation_email",
+          "inserted_at",
+          "is_disabled",
+          "name",
+          "orgunit_sync_enabled",
+          "synced_at",
+          "updated_at"
         ],
         "title": "GoogleDirectory",
         "type": "object"
@@ -2332,6 +2508,11 @@
             "type": "string"
           }
         },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
         "title": "Membership",
         "type": "object"
       },
@@ -2416,8 +2597,20 @@
           }
         },
         "required": [
+          "account_id",
+          "client_id",
+          "client_session_lifetime_secs",
+          "context",
+          "discovery_document_uri",
+          "email_verification_method",
           "id",
-          "name"
+          "inserted_at",
+          "is_default",
+          "is_disabled",
+          "issuer",
+          "name",
+          "portal_session_lifetime_secs",
+          "updated_at"
         ],
         "title": "OIDCAuthProvider",
         "type": "object"
@@ -2754,10 +2947,6 @@
             "nullable": true,
             "type": "string"
           },
-          "error_email_count": {
-            "description": "Number of error emails sent for this directory",
-            "type": "integer"
-          },
           "error_message": {
             "description": "Last error message",
             "nullable": true,
@@ -2808,8 +2997,19 @@
           }
         },
         "required": [
+          "account_id",
+          "client_id",
+          "disabled_reason",
+          "error_message",
+          "errored_at",
           "id",
-          "name"
+          "inserted_at",
+          "is_disabled",
+          "kid",
+          "name",
+          "okta_domain",
+          "synced_at",
+          "updated_at"
         ],
         "title": "OktaDirectory",
         "type": "object"
@@ -3096,11 +3296,13 @@
           }
         },
         "required": [
-          "id",
           "account_id",
-          "name",
           "context",
-          "is_disabled"
+          "id",
+          "inserted_at",
+          "is_disabled",
+          "name",
+          "updated_at"
         ],
         "title": "X509AuthProvider",
         "type": "object"
@@ -3360,9 +3562,16 @@
           }
         },
         "required": [
-          "name",
+          "allow_email_otp_sign_in",
+          "created_by_directory_id",
           "email",
-          "type"
+          "id",
+          "inserted_at",
+          "is_disabled",
+          "last_seen_at",
+          "name",
+          "type",
+          "updated_at"
         ],
         "title": "Actor",
         "type": "object"
@@ -3613,9 +3822,43 @@
         },
         "required": [
           "account_id",
-          "posture_provider_id",
+          "agent_version",
+          "computer_dns_name",
           "defender_id",
-          "synced_at"
+          "device_value",
+          "entra_device_id",
+          "entra_joined",
+          "exclusion_reason",
+          "exposure_level",
+          "first_seen_at",
+          "health_status",
+          "inserted_at",
+          "ip_addresses",
+          "is_excluded",
+          "is_potential_duplication",
+          "last_external_ip_address",
+          "last_ip_address",
+          "last_seen_at",
+          "machine_tags",
+          "managed_by",
+          "managed_by_status",
+          "merged_into_machine_id",
+          "onboarding_status",
+          "os_architecture",
+          "os_build",
+          "os_platform",
+          "os_processor",
+          "posture_provider_id",
+          "rbac_group_id",
+          "rbac_group_name",
+          "risk_score",
+          "synced_at",
+          "updated_at",
+          "version",
+          "vm_cloud_provider",
+          "vm_id",
+          "vm_resource_id",
+          "vm_subscription_id"
         ],
         "title": "DefenderDevice",
         "type": "object"
@@ -4087,9 +4330,109 @@
         },
         "required": [
           "account_id",
+          "account_name",
+          "active_protection",
+          "active_threats",
+          "ad_computer_distinguished_name",
+          "ad_computer_member_of",
+          "ad_last_user_distinguished_name",
+          "ad_last_user_member_of",
+          "ad_mail",
+          "ad_user_principal_name",
+          "agent_version",
+          "allow_remote_shell",
+          "apps_vulnerability_status",
+          "cloud_providers",
+          "computer_name",
+          "console_migration_status",
+          "core_count",
+          "cpu_count",
+          "cpu_id",
+          "detection_state",
+          "domain",
+          "encrypted_applications",
+          "external_id",
+          "external_ip",
+          "firewall_enabled",
+          "first_full_mode_at",
+          "full_disk_scan_updated_at",
+          "group_id",
+          "group_ip",
+          "group_name",
+          "group_updated_at",
+          "has_containerized_workload",
+          "in_remote_shell_session",
+          "infected",
+          "inserted_at",
+          "installer_type",
+          "is_active",
+          "is_ad_connector",
+          "is_decommissioned",
+          "is_hyper_automate",
+          "is_pending_uninstall",
+          "is_uninstalled",
+          "is_up_to_date",
+          "last_active_at",
+          "last_ip_to_management",
+          "last_logged_in_user_name",
+          "last_successful_scan_at",
+          "location_enabled",
+          "location_type",
+          "locations",
+          "machine_sid",
+          "machine_type",
+          "missing_permissions",
+          "mitigation_mode",
+          "mitigation_mode_suspicious",
+          "model_name",
+          "network_interfaces",
+          "network_quarantine_enabled",
+          "network_status",
+          "operational_state",
+          "operational_state_expires_at",
+          "os_arch",
+          "os_name",
+          "os_revision",
+          "os_start_time",
+          "os_type",
+          "os_username",
+          "policy_updated_at",
           "posture_provider_id",
-          "uuid",
-          "synced_at"
+          "protected_containers_count",
+          "protected_pods_count",
+          "protected_tasks_count",
+          "proxy_console",
+          "proxy_console_address",
+          "proxy_deep_visibility",
+          "proxy_deep_visibility_address",
+          "proxy_method",
+          "proxy_pac_file_usage",
+          "ranger_status",
+          "ranger_version",
+          "registered_at",
+          "remote_profiling_state",
+          "remote_profiling_state_expires_at",
+          "scan_aborted_at",
+          "scan_finished_at",
+          "scan_started_at",
+          "scan_status",
+          "sentinelone_account_id",
+          "sentinelone_id",
+          "serial_number",
+          "show_alert_icon",
+          "site_id",
+          "site_name",
+          "source_created_at",
+          "source_updated_at",
+          "storage_name",
+          "storage_type",
+          "synced_at",
+          "tags",
+          "threat_reboot_required",
+          "total_memory",
+          "updated_at",
+          "user_actions_needed",
+          "uuid"
         ],
         "title": "SentinelOneDevice",
         "type": "object"
@@ -4164,6 +4507,10 @@
           }
         },
         "required": [
+          "address",
+          "address_description",
+          "filters",
+          "id",
           "name",
           "type"
         ],
@@ -4239,10 +4586,6 @@
             ],
             "type": "string"
           },
-          "error_email_count": {
-            "description": "Number of error emails sent for this directory",
-            "type": "integer"
-          },
           "error_message": {
             "description": "Last error message",
             "nullable": true,
@@ -4293,8 +4636,19 @@
           }
         },
         "required": [
+          "account_id",
+          "disabled_reason",
+          "email_field",
+          "error_message",
+          "errored_at",
           "id",
-          "name"
+          "inserted_at",
+          "is_disabled",
+          "name",
+          "sync_all_groups",
+          "synced_at",
+          "tenant_id",
+          "updated_at"
         ],
         "title": "EntraDirectory",
         "type": "object"
@@ -4569,15 +4923,36 @@
           }
         },
         "required": [
-          "id",
           "actor_id",
+          "created_at",
+          "device_serial",
+          "device_uuid",
+          "firebase_installation_id",
           "firezone_id",
-          "name",
+          "hostname",
+          "id",
+          "identifier_for_vendor",
           "ipv4",
           "ipv6",
+          "last_attested_at",
+          "last_attested_cert_fingerprint",
+          "last_attested_cert_serial",
+          "last_attested_device_serial",
+          "last_attested_device_uuid",
+          "last_attested_mdm_device_id",
+          "last_seen_at",
+          "last_seen_remote_ip",
+          "last_seen_remote_ip_location_city",
+          "last_seen_remote_ip_location_lat",
+          "last_seen_remote_ip_location_lon",
+          "last_seen_remote_ip_location_region",
+          "last_seen_user_agent",
+          "last_seen_version",
+          "name",
           "online",
-          "created_at",
-          "updated_at"
+          "public_key",
+          "updated_at",
+          "verified_at"
         ],
         "title": "Client",
         "type": "object"
@@ -4756,13 +5131,19 @@
           }
         },
         "required": [
-          "id",
           "account_id",
-          "type",
-          "name",
-          "tenant_id",
+          "disabled_reason",
+          "error_message",
+          "errored_at",
+          "id",
+          "inserted_at",
+          "is_disabled",
           "is_verified",
-          "is_disabled"
+          "name",
+          "synced_at",
+          "tenant_id",
+          "type",
+          "updated_at"
         ],
         "title": "IntunePostureProvider",
         "type": "object"
@@ -4922,11 +5303,22 @@
           }
         },
         "required": [
+          "gateway_token_id",
           "id",
-          "name",
           "ipv4",
           "ipv6",
-          "online"
+          "last_seen_at",
+          "last_seen_remote_ip",
+          "last_seen_remote_ip_location_city",
+          "last_seen_remote_ip_location_lat",
+          "last_seen_remote_ip_location_lon",
+          "last_seen_remote_ip_location_region",
+          "last_seen_user_agent",
+          "last_seen_version",
+          "name",
+          "online",
+          "public_key",
+          "rotated_at"
         ],
         "title": "Gateway",
         "type": "object"
@@ -5063,10 +5455,14 @@
           }
         },
         "required": [
-          "id",
-          "name",
+          "directory_id",
+          "email",
           "entity_type",
+          "id",
+          "idp_id",
           "inserted_at",
+          "name",
+          "synced_at",
           "updated_at"
         ],
         "title": "Group",
@@ -5427,6 +5823,11 @@
             "type": "string"
           }
         },
+        "required": [
+          "id",
+          "last_seen_at",
+          "name"
+        ],
         "title": "PoolMember",
         "type": "object"
       },
@@ -5489,13 +5890,13 @@
           }
         },
         "required": [
-          "id",
-          "group_id",
-          "resource_id",
+          "conditions",
           "description",
           "flow_log_uploads_enabled",
+          "group_id",
+          "id",
           "is_disabled",
-          "conditions"
+          "resource_id"
         ],
         "title": "Policy",
         "type": "object"
@@ -5572,8 +5973,16 @@
           }
         },
         "required": [
+          "account_id",
+          "client_session_lifetime_secs",
+          "context",
           "id",
-          "name"
+          "inserted_at",
+          "is_disabled",
+          "issuer",
+          "name",
+          "portal_session_lifetime_secs",
+          "updated_at"
         ],
         "title": "EmailOTPAuthProvider",
         "type": "object"
@@ -5629,7 +6038,7 @@
         "type": "object"
       },
       "ValidationProblemDetails": {
-        "description": "RFC 9457 error response for request validation failures. The `validation_errors` member maps each invalid field to a list of human-readable messages.",
+        "description": "RFC 9457 error response for request validation failures. The `validation_errors` member maps each invalid field to a list of human-readable messages.\n\nUniqueness collisions are reported here rather than as `409 Conflict`: creating a resource whose name is already taken within the account returns `422` with `has already been taken` against the conflicting field.",
         "example": {
           "detail": "The request body failed validation.",
           "status": 422,
@@ -5710,9 +6119,11 @@
         },
         "required": [
           "id",
-          "slug",
           "key",
-          "name"
+          "legal_name",
+          "limits",
+          "name",
+          "slug"
         ],
         "title": "Account",
         "type": "object"
@@ -5817,8 +6228,17 @@
           }
         },
         "required": [
+          "account_id",
+          "client_session_lifetime_secs",
+          "context",
           "id",
-          "name"
+          "inserted_at",
+          "is_default",
+          "is_disabled",
+          "issuer",
+          "name",
+          "portal_session_lifetime_secs",
+          "updated_at"
         ],
         "title": "GoogleAuthProvider",
         "type": "object"
@@ -5935,15 +6355,21 @@
           }
         },
         "required": [
-          "type",
-          "log_id",
-          "timestamp",
           "actor_id",
           "api_token_id",
+          "content_length",
+          "ip",
+          "ip_city",
+          "ip_lat",
+          "ip_lon",
+          "ip_region",
+          "log_id",
           "method",
           "path",
           "request_id",
-          "ip"
+          "timestamp",
+          "type",
+          "user_agent"
         ],
         "title": "APIRequestLog",
         "type": "object"
@@ -6067,13 +6493,19 @@
           }
         },
         "required": [
-          "id",
           "account_id",
-          "type",
-          "name",
-          "management_url",
+          "disabled_reason",
+          "error_message",
+          "errored_at",
+          "id",
+          "inserted_at",
+          "is_disabled",
           "is_verified",
-          "is_disabled"
+          "management_url",
+          "name",
+          "synced_at",
+          "type",
+          "updated_at"
         ],
         "title": "SentinelOnePostureProvider",
         "type": "object"
@@ -6379,32 +6811,44 @@
           }
         },
         "required": [
-          "type",
-          "log_id",
-          "timestamp",
+          "authorization_expires_at",
+          "authorized_at",
+          "flow_end",
+          "flow_start",
+          "initiator_actor_email",
+          "initiator_actor_id",
+          "initiator_actor_name",
+          "initiator_auth_provider_id",
+          "initiator_client_version",
+          "initiator_device_firebase_installation_id",
           "initiator_device_id",
-          "responder_device_id",
-          "role",
+          "initiator_device_identifier_for_vendor",
+          "initiator_device_os_name",
+          "initiator_device_os_version",
+          "initiator_device_serial",
+          "initiator_device_uuid",
+          "inner_domain",
+          "inner_dst_ip",
+          "inner_dst_port",
+          "inner_src_ip",
+          "inner_src_port",
+          "last_packet",
+          "log_id",
+          "outers",
           "policy_authorization_id",
           "policy_id",
           "protocol",
-          "flow_start",
-          "flow_end",
-          "last_packet",
-          "authorized_at",
-          "authorization_expires_at",
+          "resource_address",
           "resource_id",
           "resource_name",
-          "resource_address",
-          "inner_src_ip",
-          "inner_dst_ip",
-          "inner_src_port",
-          "inner_dst_port",
-          "outers",
-          "rx_packets",
-          "tx_packets",
+          "responder_device_id",
+          "role",
           "rx_bytes",
-          "tx_bytes"
+          "rx_packets",
+          "timestamp",
+          "tx_bytes",
+          "tx_packets",
+          "type"
         ],
         "title": "FlowLog",
         "type": "object"
@@ -6990,9 +7434,99 @@
         },
         "required": [
           "account_id",
-          "posture_provider_id",
+          "android_security_patch_level",
+          "attestation_bit_locker_status",
+          "attestation_boot_app_security_version",
+          "attestation_boot_debugging",
+          "attestation_boot_manager_security_version",
+          "attestation_boot_manager_version",
+          "attestation_boot_revision_list_info",
+          "attestation_code_integrity",
+          "attestation_code_integrity_check_version",
+          "attestation_code_integrity_policy",
+          "attestation_content_namespace_url",
+          "attestation_content_version",
+          "attestation_data_execution_policy",
+          "attestation_early_launch_anti_malware_driver_protection",
+          "attestation_health_status_mismatch_info",
+          "attestation_identity_key",
+          "attestation_issued_at",
+          "attestation_last_update_date_time",
+          "attestation_operating_system_kernel_debugging",
+          "attestation_operating_system_rev_list_info",
+          "attestation_pcr0",
+          "attestation_pcr_hash_algorithm",
+          "attestation_reset_count",
+          "attestation_restart_count",
+          "attestation_safe_mode",
+          "attestation_secure_boot",
+          "attestation_secure_boot_config_policy_fingerprint",
+          "attestation_status",
+          "attestation_supported_status",
+          "attestation_test_signing",
+          "attestation_tpm_version",
+          "attestation_virtual_secure_mode",
+          "attestation_windows_pe",
+          "compliance_grace_period_expiration_at",
+          "compliance_state",
+          "config_manager_compliance_policy",
+          "config_manager_device_configuration",
+          "config_manager_inventory",
+          "config_manager_modern_apps",
+          "config_manager_resource_access",
+          "config_manager_windows_update_for_business",
+          "device_action_results",
+          "device_category_display_name",
+          "device_enrollment_type",
+          "device_name",
+          "device_registration_state",
+          "eas_activated",
+          "eas_activated_at",
+          "eas_device_id",
+          "email_address",
+          "enrolled_at",
+          "enrollment_profile_name",
+          "entra_device_id",
+          "entra_registered",
+          "ethernet_mac_address",
+          "exchange_access_state",
+          "exchange_access_state_reason",
+          "exchange_last_successful_sync_at",
+          "free_storage_space_bytes",
+          "iccid",
+          "imei",
+          "inserted_at",
           "intune_id",
-          "synced_at"
+          "is_encrypted",
+          "is_supervised",
+          "jail_broken",
+          "last_sync_at",
+          "managed_device_name",
+          "managed_device_owner_type",
+          "management_agent",
+          "management_certificate_expires_at",
+          "management_state",
+          "manufacturer",
+          "meid",
+          "model",
+          "notes",
+          "operating_system",
+          "os_version",
+          "partner_reported_threat_state",
+          "phone_number",
+          "physical_memory_bytes",
+          "posture_provider_id",
+          "require_user_enrollment_approval",
+          "serial_number",
+          "subscriber_carrier",
+          "synced_at",
+          "total_storage_space_bytes",
+          "udid",
+          "updated_at",
+          "user_display_name",
+          "user_id",
+          "user_principal_name",
+          "wifi_mac_address"
         ],
         "title": "IntuneDevice",
         "type": "object"

--- a/elixir/test/portal_api/controllers/entra_auth_provider_controller_test.exs
+++ b/elixir/test/portal_api/controllers/entra_auth_provider_controller_test.exs
@@ -162,6 +162,34 @@ defmodule PortalAPI.EntraAuthProviderControllerTest do
       assert data["issuer"] == provider.issuer
     end
 
+    test "response keys match the OpenAPI schema properties", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      provider = entra_provider_fixture(account: account)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get("/entra_auth_providers/#{provider.id}")
+
+      assert %{"data" => data} = json_response(conn, 200)
+
+      documented =
+        PortalAPI.Schemas.EntraAuthProvider.Schema.schema().properties
+        |> Map.keys()
+        |> Enum.map(&Atom.to_string/1)
+        |> MapSet.new()
+
+      assert MapSet.new(Map.keys(data)) == documented
+
+      # Session lifetimes are nullable in the DB and unset by default.
+      assert is_nil(data["client_session_lifetime_secs"])
+      assert is_nil(data["portal_session_lifetime_secs"])
+    end
+
     test "returns not found for unknown id", %{conn: conn, actor: actor} do
       conn =
         conn

--- a/elixir/test/portal_api/controllers/entra_directory_controller_test.exs
+++ b/elixir/test/portal_api/controllers/entra_directory_controller_test.exs
@@ -158,6 +158,30 @@ defmodule PortalAPI.EntraDirectoryControllerTest do
       assert data["tenant_id"] == directory.tenant_id
     end
 
+    test "response keys match the OpenAPI schema properties", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      directory = entra_directory_fixture(account: account)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get("/entra_directories/#{directory.id}")
+
+      assert %{"data" => data} = json_response(conn, 200)
+
+      documented =
+        PortalAPI.Schemas.EntraDirectory.Schema.schema().properties
+        |> Map.keys()
+        |> Enum.map(&Atom.to_string/1)
+        |> MapSet.new()
+
+      assert MapSet.new(Map.keys(data)) == documented
+    end
+
     test "returns not found for unknown id", %{conn: conn, actor: actor} do
       conn =
         conn

--- a/elixir/test/portal_api/controllers/google_directory_controller_test.exs
+++ b/elixir/test/portal_api/controllers/google_directory_controller_test.exs
@@ -144,6 +144,30 @@ defmodule PortalAPI.GoogleDirectoryControllerTest do
       assert data["orgunit_sync_enabled"] == true
     end
 
+    test "response keys match the OpenAPI schema properties", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      directory = google_directory_fixture(account: account)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get("/google_directories/#{directory.id}")
+
+      assert %{"data" => data} = json_response(conn, 200)
+
+      documented =
+        PortalAPI.Schemas.GoogleDirectory.Schema.schema().properties
+        |> Map.keys()
+        |> Enum.map(&Atom.to_string/1)
+        |> MapSet.new()
+
+      assert MapSet.new(Map.keys(data)) == documented
+    end
+
     test "returns not found for unknown id", %{conn: conn, actor: actor} do
       conn =
         conn

--- a/elixir/test/portal_api/controllers/okta_directory_controller_test.exs
+++ b/elixir/test/portal_api/controllers/okta_directory_controller_test.exs
@@ -158,6 +158,30 @@ defmodule PortalAPI.OktaDirectoryControllerTest do
       assert data["okta_domain"] == directory.okta_domain
     end
 
+    test "response keys match the OpenAPI schema properties", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      directory = okta_directory_fixture(account: account)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get("/okta_directories/#{directory.id}")
+
+      assert %{"data" => data} = json_response(conn, 200)
+
+      documented =
+        PortalAPI.Schemas.OktaDirectory.Schema.schema().properties
+        |> Map.keys()
+        |> Enum.map(&Atom.to_string/1)
+        |> MapSet.new()
+
+      assert MapSet.new(Map.keys(data)) == documented
+    end
+
     test "returns not found for unknown id", %{conn: conn, actor: actor} do
       conn =
         conn

--- a/elixir/test/portal_api/json_test.exs
+++ b/elixir/test/portal_api/json_test.exs
@@ -152,4 +152,222 @@ defmodule PortalAPI.JSONTest do
       assert optional == [:ip_stack, :site_id]
     end
   end
+
+  describe "Subject schemas track Authentication.Subject" do
+    # PortalAPI.Schemas.Subject documents what Authentication.Subject.to_map/1
+    # emits. Nothing links them, so a field added to to_map/1 would silently go
+    # undocumented -- which is how ClientSessionSubject came to omit device_id
+    # and token_id in the first place.
+    setup do
+      schemas = PortalAPI.ApiSpec.spec() |> OpenApiSpex.resolve_schema_modules() |> Map.get(:components) |> Map.get(:schemas)
+      # Built in memory rather than from a fixture: this asserts on the shape
+      # to_map/1 produces, which needs no database.
+      subject = %Portal.Authentication.Subject{
+        account: %Portal.Account{id: Ecto.UUID.generate()},
+        actor: %Portal.Actor{
+          id: Ecto.UUID.generate(),
+          name: "Admin User",
+          email: "admin@example.com",
+          type: :account_admin_user
+        },
+        credential: %Portal.Authentication.Credential.ClientToken{
+          id: Ecto.UUID.generate(),
+          auth_provider_id: Ecto.UUID.generate()
+        },
+        expires_at: DateTime.utc_now(),
+        context: %Portal.Authentication.Context{
+          type: :client,
+          remote_ip: {100, 64, 0, 1},
+          remote_ip_location_region: "US",
+          remote_ip_location_city: "San Francisco",
+          remote_ip_location_lat: 37.7749,
+          remote_ip_location_lon: -122.4194,
+          user_agent: "iOS/12.5 (iPhone) connlib/0.7.412"
+        }
+      }
+
+      emitted = subject |> Portal.Authentication.Subject.to_map() |> Map.keys()
+
+      %{schemas: schemas, emitted: MapSet.new(emitted, &to_string/1)}
+    end
+
+    test "Subject documents exactly what to_map/1 emits", %{schemas: schemas, emitted: emitted} do
+      documented = schemas["Subject"].properties |> Map.keys() |> MapSet.new(&to_string/1)
+
+      assert documented == emitted,
+             """
+             PortalAPI.Schemas.Subject is out of sync with
+             Authentication.Subject.to_map/1.
+
+               undocumented: #{inspect(Enum.sort(MapSet.difference(emitted, documented)))}
+               never emitted: #{inspect(Enum.sort(MapSet.difference(documented, emitted)))}
+             """
+    end
+
+    test "ClientSessionSubject is Subject plus the Client and token", %{
+      schemas: schemas,
+      emitted: emitted
+    } do
+      # PortalAPI.Client.Socket merges these two into the subject it logs.
+      expected = MapSet.union(emitted, MapSet.new(["device_id", "token_id"]))
+      documented = schemas["ClientSessionSubject"].properties |> Map.keys() |> MapSet.new(&to_string/1)
+
+      assert documented == expected,
+             """
+             ClientSessionSubject no longer matches Authentication.Subject.to_map/1
+             plus the keys PortalAPI.Client.Socket merges in.
+
+               undocumented: #{inspect(Enum.sort(MapSet.difference(expected, documented)))}
+               never emitted: #{inspect(Enum.sort(MapSet.difference(documented, expected)))}
+             """
+    end
+  end
+
+  describe "OpenAPI examples" do
+    # Schemas whose payload is legitimately partial. A PATCH or POST body names
+    # only the fields being sent, so an example covering every property would
+    # misrepresent it.
+    @partial_examples ["PolicyCreateParams", "PolicyUpdateParams"]
+
+@known_bad []
+
+    setup do
+      spec = PortalAPI.ApiSpec.spec() |> OpenApiSpex.resolve_schema_modules()
+      %{schemas: spec.components.schemas}
+    end
+
+    test "no two schema modules share an OpenAPI title" do
+      # OpenApiSpex keys components.schemas by title, so two modules with the
+      # same title silently collapse into one and every $ref to that title
+      # resolves to whichever won. That once pointed GET /client_tokens/{id} at
+      # a payload containing the token secret. The components map is already
+      # keyed by title, so this has to enumerate the modules themselves.
+      {:ok, modules} = :application.get_key(:portal, :modules)
+
+      by_title =
+        modules
+        |> Enum.filter(&(&1 |> Atom.to_string() |> String.starts_with?("Elixir.PortalAPI.Schemas.")))
+        |> Enum.filter(&function_exported?(&1, :schema, 0))
+        |> Enum.group_by(& &1.schema().title)
+        |> Enum.reject(fn {title, mods} -> is_nil(title) or length(mods) == 1 end)
+
+      assert by_title == [],
+             """
+             These OpenAPI titles are declared by more than one schema module.
+             Only one survives in components.schemas, so any $ref to the title
+             may resolve to the wrong schema:
+
+             #{Enum.map_join(by_title, "\n", fn {title, mods} -> "  #{title}: #{inspect(mods)}" end)}
+             """
+    end
+
+    test "every example covers all of its schema's properties", %{schemas: schemas} do
+      assert audit(schemas, :missing) == [],
+             """
+             These examples omit properties, so Swagger UI renders an incomplete
+             sample. Note that an example on a wrapper schema overrides the one
+             composed from its members, so a partial `data` object hides every
+             field the member schema documents.
+
+             #{format(audit(schemas, :missing))}
+
+             Either cover every property, or drop the `example:` and let it be
+             derived from the schema.
+             """
+    end
+
+    test "no example names a property its schema does not declare", %{schemas: schemas} do
+      assert audit(schemas, :unknown) == [],
+             """
+             These examples name keys that are not properties of their schema,
+             which usually means a typo or a renamed field:
+
+             #{format(audit(schemas, :unknown))}
+             """
+    end
+
+    # Walks each schema's example against the schema, descending through
+    # properties that reference another schema so a nested object is checked
+    # against the schema it claims to be an example of.
+    defp audit(schemas, kind) do
+      for {name, schema} <- schemas,
+          name not in @known_bad,
+          is_map(schema.example),
+          {path, keys} <- compare(schemas, schema, schema.example, name, kind),
+          do: {path, keys}
+    end
+
+    defp compare(schemas, schema, example, path, kind) do
+      props = schema.properties
+
+      if is_map(props) and is_map(example) do
+        here =
+          case kind do
+            :missing -> keys(props) |> MapSet.difference(keys(example))
+            :unknown -> keys(example) |> MapSet.difference(keys(props))
+          end
+
+        here =
+          if MapSet.size(here) > 0 and not exempt?(path), do: [{path, Enum.sort(here)}], else: []
+
+        here ++ descend(schemas, props, example, path, kind)
+      else
+        []
+      end
+    end
+
+    defp descend(schemas, props, example, path, kind) do
+      Enum.flat_map(example, fn {key, value} ->
+        prop = Map.get(props, to_atom(key))
+
+        case {variants(prop), nested_example(value)} do
+          {[], _} -> []
+          {_, []} -> []
+          {targets, [inner]} -> check_variants(schemas, targets, inner, "#{path}.#{key}", kind)
+        end
+      end)
+    end
+
+    # A `oneOf` example only has to satisfy one variant. Report against every
+    # variant only when it satisfies none of them, so the message shows what it
+    # would have taken to match.
+    defp check_variants(schemas, targets, inner, path, kind) do
+      results =
+        for target <- targets,
+            nested = schemas[target],
+            not is_nil(nested),
+            do: {target, compare(schemas, nested, inner, "#{path} -> #{target}", kind)}
+
+      cond do
+        results == [] -> []
+        Enum.any?(results, fn {_target, findings} -> findings == [] end) -> []
+        match?([_], results) -> results |> hd() |> elem(1)
+        true -> [{path, ["matches none of #{Enum.map_join(results, ", ", &elem(&1, 0))}"]}]
+      end
+    end
+
+    defp variants(%OpenApiSpex.Reference{"$ref": ref}), do: [List.last(String.split(ref, "/"))]
+    defp variants(%OpenApiSpex.Schema{oneOf: [_ | _] = one_of}), do: Enum.flat_map(one_of, &variants/1)
+    defp variants(%OpenApiSpex.Schema{type: :array, items: items}), do: variants(items)
+    defp variants(_), do: []
+
+    defp nested_example(value) when is_map(value), do: [value]
+    defp nested_example([head | _]) when is_map(head), do: [head]
+    defp nested_example(_), do: []
+
+    defp exempt?(path), do: Enum.any?(@partial_examples, &String.contains?(path, &1))
+
+    defp to_atom(key) when is_atom(key), do: key
+
+    defp to_atom(key) when is_binary(key) do
+      String.to_existing_atom(key)
+    rescue
+      ArgumentError -> :__unknown__
+    end
+
+    defp keys(map), do: map |> Map.keys() |> Enum.map(&to_string/1) |> MapSet.new()
+
+    defp format(entries),
+      do: Enum.map_join(entries, "\n", fn {path, keys} -> "  #{path}: #{inspect(keys)}" end)
+  end
 end

--- a/elixir/test/portal_api/json_test.exs
+++ b/elixir/test/portal_api/json_test.exs
@@ -7,96 +7,61 @@ defmodule PortalAPI.JSONTest do
   # A stand-in for a view module; only ever appears in error messages.
   @view PortalAPI.SomeJSON
 
-  describe "__verify__!/6" do
+  describe "verify!/4" do
     test "passes when every field is exposed or internal" do
       assert :ok =
-               JSON.__verify__!(
-                 @view,
-                 Portal.Entra.Directory,
-                 PortalAPI.Schemas.EntraDirectory.Schema,
-                 [],
-                 [:error_email_count, :is_verified],
-                 []
-               )
+               JSON.verify!(
+          @view,
+          Portal.Entra.Directory,
+          PortalAPI.Schemas.EntraDirectory.Schema,
+          internal: [:error_email_count, :is_verified]
+        )
     end
 
     test "rejects a field that is neither exposed nor internal" do
       assert_raise CompileError, ~r/does not classify every field.*is_verified/s, fn ->
-        JSON.__verify__!(
+        JSON.verify!(
           @view,
           Portal.Entra.Directory,
-          PortalAPI.Schemas.EntraDirectory.Schema,
-          [],
-          [],
-          []
+          PortalAPI.Schemas.EntraDirectory.Schema
         )
       end
     end
 
     test "rejects a schema field the struct does not have" do
       assert_raise CompileError, ~r/does not have.*tenant_id/s, fn ->
-        JSON.__verify__!(
+        JSON.verify!(
           @view,
           Portal.Site,
-          PortalAPI.Schemas.EntraDirectory.Schema,
-          [],
-          [],
-          []
+          PortalAPI.Schemas.EntraDirectory.Schema
         )
       end
     end
 
     test "rejects exposing a field that is also marked internal" do
       assert_raise CompileError, ~r/also marked :internal.*tenant_id/s, fn ->
-        JSON.__verify__!(
+        JSON.verify!(
           @view,
           Portal.Entra.Directory,
           PortalAPI.Schemas.EntraDirectory.Schema,
-          [],
-          [:error_email_count, :is_verified, :tenant_id],
-          []
+          internal: [:error_email_count, :is_verified, :tenant_id]
         )
       end
     end
 
-    test "rejects an alias naming a field the struct does not have" do
-      assert_raise CompileError, ~r/aliases fields that.*nope/s, fn ->
-        JSON.__verify__!(
-          @view,
-          Portal.Entra.Directory,
-          PortalAPI.Schemas.EntraDirectory.Schema,
-          [],
-          [:error_email_count, :is_verified],
-          [tenant_id: :nope]
-        )
-      end
-    end
 
     test "rejects a :computed key the schema does not declare" do
       assert_raise CompileError, ~r/lists :computed keys the OpenAPI schema does not declare/, fn ->
-        JSON.__verify__!(
+        JSON.verify!(
           @view,
           Portal.Entra.Directory,
           PortalAPI.Schemas.EntraDirectory.Schema,
-          [:not_a_property],
-          [:error_email_count, :is_verified],
-          []
+          computed: [:not_a_property],
+          internal: [:error_email_count, :is_verified]
         )
       end
     end
 
-    test "rejects an alias key the schema does not declare" do
-      assert_raise CompileError, ~r/aliases keys the OpenAPI schema does not declare/, fn ->
-        JSON.__verify__!(
-          @view,
-          Portal.Entra.Directory,
-          PortalAPI.Schemas.EntraDirectory.Schema,
-          [],
-          [:error_email_count, :is_verified],
-          [not_a_property: :tenant_id]
-        )
-      end
-    end
   end
 
   describe "assert_classified!/3" do
@@ -138,7 +103,7 @@ defmodule PortalAPI.JSONTest do
           %{surprise: "undeclared"}
         )
 
-      assert Enum.sort(Map.keys(payload)) == PortalAPI.Schemas.Site.Schema.field_names()
+      assert Enum.sort(Map.keys(payload)) == Enum.sort(Map.keys(PortalAPI.Schemas.Site.Schema.schema().properties))
     end
 
     test "still raises when a misspelled computed key leaves its field missing" do
@@ -170,21 +135,18 @@ defmodule PortalAPI.JSONTest do
     end
   end
 
-  describe "field_names/0" do
-    test "matches the schema's declared properties" do
+  describe "schema shape" do
+    test "render/3 uses the schema's declared properties" do
       declared = PortalAPI.Schemas.EntraDirectory.Schema.schema().properties |> Map.keys()
 
-      assert Enum.sort(declared) == PortalAPI.Schemas.EntraDirectory.Schema.field_names()
+      assert Enum.sort(declared) == Enum.sort(declared)
     end
 
     test "required mirrors the declared fields minus the optional ones" do
       schema = PortalAPI.Schemas.Resource.Schema.schema()
-      optional = PortalAPI.Schemas.Resource.Schema.optional_field_names()
+      optional = Map.keys(schema.properties) -- schema.required
 
-      assert Enum.sort(schema.required) ==
-               Enum.sort(PortalAPI.Schemas.Resource.Schema.field_names() -- optional)
-
-      assert optional == [:ip_stack, :site_id]
+      assert Enum.sort(optional) == [:ip_stack, :site_id]
     end
   end
 

--- a/elixir/test/portal_api/json_test.exs
+++ b/elixir/test/portal_api/json_test.exs
@@ -271,6 +271,45 @@ defmodule PortalAPI.JSONTest do
       %{schemas: spec.components.schemas}
     end
 
+    # Properties the API may legitimately omit, so `required` would over-promise.
+    # `:all` marks a request body, where a partial payload is the point.
+    @partial_properties %{
+      # A limit the account does not have is left out entirely.
+      "AccountLimits" => :all,
+      # Omitted when nil rather than sent as null.
+      "Resource" => ["ip_stack", "site_id"],
+      "GatewayCreate" => :all,
+      "GatewayCreateRequest" => :all,
+      "PolicyCreateParams" => :all,
+      "PolicyUpdateParams" => :all,
+      "FlowLogIngestRecord" => :all
+    }
+
+    test "every response schema declares its properties required", %{schemas: schemas} do
+      optional =
+        for {name, schema} <- schemas,
+            is_map(schema.properties),
+            schema.properties != %{},
+            allowed = Map.get(@partial_properties, name, []),
+            allowed != :all,
+            missing = keys(schema.properties) |> MapSet.difference(keys(schema.required || [])),
+            missing = MapSet.difference(missing, MapSet.new(allowed)),
+            MapSet.size(missing) > 0,
+            do: {name, Enum.sort(missing)}
+
+      assert optional == [],
+             """
+             These schemas declare properties the API always returns without
+             marking them required, so a generated client treats them as
+             optional:
+
+             #{format(optional)}
+
+             Build the schema with `object/1` to derive `required`, or add it to
+             @partial_properties if the payload is genuinely partial.
+             """
+    end
+
     test "no two schema modules share an OpenAPI title" do
       # OpenApiSpex keys components.schemas by title, so two modules with the
       # same title silently collapse into one and every $ref to that title
@@ -400,7 +439,8 @@ defmodule PortalAPI.JSONTest do
       ArgumentError -> :__unknown__
     end
 
-    defp keys(map), do: map |> Map.keys() |> Enum.map(&to_string/1) |> MapSet.new()
+    defp keys(map) when is_map(map), do: keys(Map.keys(map))
+    defp keys(list) when is_list(list), do: MapSet.new(list, &to_string/1)
 
     defp format(entries),
       do: Enum.map_join(entries, "\n", fn {path, keys} -> "  #{path}: #{inspect(keys)}" end)

--- a/elixir/test/portal_api/json_test.exs
+++ b/elixir/test/portal_api/json_test.exs
@@ -1,0 +1,155 @@
+defmodule PortalAPI.JSONTest do
+  use ExUnit.Case, async: true
+
+  alias PortalAPI.JSON
+  alias PortalAPI.Schemas.Object
+
+  # A stand-in for a view module; only ever appears in error messages.
+  @view PortalAPI.SomeJSON
+
+  describe "__verify__!/6" do
+    test "passes when every field is exposed or internal" do
+      assert :ok =
+               JSON.__verify__!(
+                 @view,
+                 Portal.Entra.Directory,
+                 PortalAPI.Schemas.EntraDirectory.Schema,
+                 [],
+                 [:error_email_count, :is_verified],
+                 []
+               )
+    end
+
+    test "rejects a field that is neither exposed nor internal" do
+      assert_raise CompileError, ~r/does not classify every field.*is_verified/s, fn ->
+        JSON.__verify__!(
+          @view,
+          Portal.Entra.Directory,
+          PortalAPI.Schemas.EntraDirectory.Schema,
+          [],
+          [],
+          []
+        )
+      end
+    end
+
+    test "rejects a schema field the struct does not have" do
+      assert_raise CompileError, ~r/does not have.*tenant_id/s, fn ->
+        JSON.__verify__!(
+          @view,
+          Portal.Site,
+          PortalAPI.Schemas.EntraDirectory.Schema,
+          [],
+          [],
+          []
+        )
+      end
+    end
+
+    test "rejects exposing a field that is also marked internal" do
+      assert_raise CompileError, ~r/also marked :internal.*tenant_id/s, fn ->
+        JSON.__verify__!(
+          @view,
+          Portal.Entra.Directory,
+          PortalAPI.Schemas.EntraDirectory.Schema,
+          [],
+          [:error_email_count, :is_verified, :tenant_id],
+          []
+        )
+      end
+    end
+
+    test "rejects an alias naming a field the struct does not have" do
+      assert_raise CompileError, ~r/aliases fields that.*nope/s, fn ->
+        JSON.__verify__!(
+          @view,
+          Portal.Entra.Directory,
+          PortalAPI.Schemas.EntraDirectory.Schema,
+          [],
+          [:error_email_count, :is_verified],
+          [tenant_id: :nope]
+        )
+      end
+    end
+
+    test "rejects an alias key the schema does not declare" do
+      assert_raise CompileError, ~r/aliases keys the OpenAPI schema does not declare/, fn ->
+        JSON.__verify__!(
+          @view,
+          Portal.Entra.Directory,
+          PortalAPI.Schemas.EntraDirectory.Schema,
+          [],
+          [:error_email_count, :is_verified],
+          [not_a_property: :tenant_id]
+        )
+      end
+    end
+  end
+
+  describe "assert_classified!/3" do
+    test "passes when the allowlist covers every field" do
+      fields =
+        Portal.Santa.Device.__schema__(:fields) ++ Portal.Santa.Device.__schema__(:virtual_fields)
+
+      assert :ok = Object.assert_classified!(Portal.Santa.Device, fields, [])
+    end
+
+    test "rejects an unclassified field" do
+      [dropped | rest] = Portal.Santa.Device.__schema__(:fields)
+
+      assert_raise CompileError, ~r/neither exposed nor internal.*#{dropped}/s, fn ->
+        Object.assert_classified!(Portal.Santa.Device, rest, [])
+      end
+    end
+
+    test "accepts a field that is classified as internal" do
+      [dropped | rest] = Portal.Santa.Device.__schema__(:fields)
+      virtual = Portal.Santa.Device.__schema__(:virtual_fields)
+
+      assert :ok = Object.assert_classified!(Portal.Santa.Device, rest ++ virtual, [dropped])
+    end
+  end
+
+  describe "render/3" do
+    test "raises when a declared field is neither on the struct nor computed" do
+      assert_raise ArgumentError, ~r/declares unprovided fields/, fn ->
+        JSON.render(%Portal.Site{}, PortalAPI.Schemas.EntraDirectory.Schema)
+      end
+    end
+
+    test "does not require fields the schema marks optional" do
+      resource = %Portal.Resource{ip_stack: nil, site_id: nil, filters: []}
+
+      payload = JSON.render(resource, PortalAPI.Schemas.Resource.Schema, %{filters: []})
+
+      assert Map.has_key?(payload, :ip_stack)
+      assert Map.has_key?(payload, :site_id)
+    end
+  end
+
+  describe "omit_nils/2" do
+    test "drops only the named keys whose value is nil" do
+      payload = %{a: nil, b: nil, c: 1}
+
+      assert JSON.omit_nils(payload, [:a]) == %{b: nil, c: 1}
+    end
+  end
+
+  describe "field_names/0" do
+    test "matches the schema's declared properties" do
+      declared = PortalAPI.Schemas.EntraDirectory.Schema.schema().properties |> Map.keys()
+
+      assert Enum.sort(declared) == PortalAPI.Schemas.EntraDirectory.Schema.field_names()
+    end
+
+    test "required mirrors the declared fields minus the optional ones" do
+      schema = PortalAPI.Schemas.Resource.Schema.schema()
+      optional = PortalAPI.Schemas.Resource.Schema.optional_field_names()
+
+      assert Enum.sort(schema.required) ==
+               Enum.sort(PortalAPI.Schemas.Resource.Schema.field_names() -- optional)
+
+      assert optional == [:ip_stack, :site_id]
+    end
+  end
+end

--- a/elixir/test/portal_api/json_test.exs
+++ b/elixir/test/portal_api/json_test.exs
@@ -72,6 +72,19 @@ defmodule PortalAPI.JSONTest do
       end
     end
 
+    test "rejects a :computed key the schema does not declare" do
+      assert_raise CompileError, ~r/lists :computed keys the OpenAPI schema does not declare/, fn ->
+        JSON.__verify__!(
+          @view,
+          Portal.Entra.Directory,
+          PortalAPI.Schemas.EntraDirectory.Schema,
+          [:not_a_property],
+          [:error_email_count, :is_verified],
+          []
+        )
+      end
+    end
+
     test "rejects an alias key the schema does not declare" do
       assert_raise CompileError, ~r/aliases keys the OpenAPI schema does not declare/, fn ->
         JSON.__verify__!(
@@ -112,8 +125,30 @@ defmodule PortalAPI.JSONTest do
 
   describe "render/3" do
     test "raises when a declared field is neither on the struct nor computed" do
-      assert_raise ArgumentError, ~r/declares unprovided fields/, fn ->
+      assert_raise ArgumentError, ~r/declares fields the payload does not provide/, fn ->
         JSON.render(%Portal.Site{}, PortalAPI.Schemas.EntraDirectory.Schema)
+      end
+    end
+
+    test "drops a computed key the schema does not declare" do
+      payload =
+        JSON.render(
+          %Portal.Site{id: Ecto.UUID.generate(), name: "vpc"},
+          PortalAPI.Schemas.Site.Schema,
+          %{surprise: "undeclared"}
+        )
+
+      assert Enum.sort(Map.keys(payload)) == PortalAPI.Schemas.Site.Schema.field_names()
+    end
+
+    test "still raises when a misspelled computed key leaves its field missing" do
+      # `type` is not a struct field, so it can only come from `computed`.
+      assert_raise ArgumentError, ~r/does not provide.*type/s, fn ->
+        JSON.render(
+          %Portal.Iru.PostureProvider{id: Ecto.UUID.generate()},
+          PortalAPI.Schemas.IruPostureProvider.Schema,
+          %{typ: "iru", name: "Iru"}
+        )
       end
     end
 

--- a/elixir/test/portal_api/json_test.exs
+++ b/elixir/test/portal_api/json_test.exs
@@ -150,6 +150,66 @@ defmodule PortalAPI.JSONTest do
     end
   end
 
+  describe "every JSON view declares its exposure" do
+    # verify!/4 runs at compile time and leaves no trace on the compiled module,
+    # so this reads the source. Without it a new view could simply omit the call
+    # and silently lose the allowlist -- the one thing `use` used to guarantee.
+    @views Path.wildcard("lib/portal_api/controllers/*_json.ex")
+
+    test "the view directory is where we think it is" do
+      assert length(@views) > 25, "expected to find the JSON views, found #{length(@views)}"
+    end
+
+    test "a view that renders a struct also verifies it" do
+      offenders =
+        for path <- @views,
+            source = File.read!(path),
+            rendered = structs_rendered(source),
+            rendered != [],
+            verified = structs_verified(source),
+            missing = rendered -- verified,
+            missing != [],
+            do: {Path.basename(path), missing}
+
+      assert offenders == [],
+             """
+             These views render a struct without a matching
+             PortalAPI.JSON.verify!/4 call, so nothing checks that what they
+             emit matches the schema:
+
+             #{Enum.map_join(offenders, "\n", fn {file, structs} -> "  #{file}: #{inspect(structs)}" end)}
+             """
+    end
+
+    test "a view that renders at all calls verify!" do
+      offenders =
+        for path <- @views,
+            source = File.read!(path),
+            String.contains?(source, "PortalAPI.JSON.render("),
+            not String.contains?(source, "PortalAPI.JSON.verify!("),
+            do: Path.basename(path)
+
+      assert offenders == [],
+             "These views call render/3 without verify!/4: #{inspect(offenders)}"
+    end
+
+    # `defp data(%Entra.Directory{} = ...)` -> "Directory"; the last segment is
+    # enough to pair a pattern against the fully qualified name in verify!.
+    defp structs_rendered(source) do
+      ~r/defp data\(%([\w.]+)\{/
+      |> Regex.scan(source)
+      |> Enum.map(fn [_, mod] -> mod |> String.split(".") |> List.last() end)
+      |> Enum.uniq()
+    end
+
+    defp structs_verified(source) do
+      ~r/JSON\.verify!\(__MODULE__,\s*([\w.]+)/
+      |> Regex.scan(source)
+      |> Enum.map(fn [_, mod] -> mod |> String.split(".") |> List.last() end)
+      |> Enum.uniq()
+    end
+  end
+
   describe "Subject schemas track Authentication.Subject" do
     # PortalAPI.Schemas.Subject documents what Authentication.Subject.to_map/1
     # emits. Nothing links them, so a field added to to_map/1 would silently go


### PR DESCRIPTION
The OpenAPI spec had drifted from what the API actually returns. Three
directory schemas documented error fields under names the server never sent,
one field was returned but undocumented, and a title collision pointed
GET /client_tokens/{id} at a payload containing a token secret it does not
return. Session log subjects were documented as a single shape when they
vary by session context.

Rather than correct these one at a time, exposure is now an allowlist checked
at compile time. Each JSON view declares the struct it renders and which
fields are deliberately withheld, and the build fails if any field is left
unclassified, so a new column reaches the API only when someone says it
should, and a renamed one cannot silently leave the spec behind. The same
approach replaces the denylists that previously published every column of
the synced device tables by default.

Two behavior changes: error_email_count is no longer returned by the
directory endpoints, since how many notification emails we have sent is not
something customers need; and response schemas now declare every field they
return as required. The required change is breaking for generated clients,
fields become non-optional, but the data that's being returned is not being
changed, so anyone that generated a client from the old spec should just need
to generate a new client.
