### PR TITLE
fix(android): await the screens in the auth flow e2e test

### DIFF
--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/AuthFlowE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/AuthFlowE2eTest.kt
@@ -25,9 +25,11 @@ import dev.firezone.android.core.presentation.MainActivity
 import dev.firezone.android.features.auth.AUTH_CALLBACK_SCHEME
 import dev.firezone.android.features.auth.PendingAuthSession
 import dev.firezone.android.features.auth.ui.AuthActivity
+import dev.firezone.android.features.session.ui.SessionActivity
 import dev.firezone.android.tunnel.FakeSession
 import dev.firezone.android.tunnel.FakeSessionFactory
 import dev.firezone.android.tunnel.TestRestrictions
+import dev.firezone.android.tunnel.awaitResumed
 import dev.firezone.android.tunnel.finishAllActivities
 import dev.firezone.android.tunnel.grantNotificationPermission
 import dev.firezone.android.tunnel.grantVpnConsent
@@ -89,6 +91,7 @@ class AuthFlowE2eTest {
             assertFalse(pendingAuthSession.hasPendingRequest())
             intended(authTabIntent())
             intended(mainActivityHandoffIntent())
+            awaitSessionScreen()
         }
 
     @Test
@@ -98,6 +101,7 @@ class AuthFlowE2eTest {
 
             launchAuthActivity()
 
+            awaitResumed(MainActivity::class.java)
             intended(mainActivityReturnIntent())
             val captured = checkNotNull(attempt.get())
             assertTrue(pendingAuthSession.hasPendingRequest())
@@ -114,6 +118,7 @@ class AuthFlowE2eTest {
             assertFalse(pendingAuthSession.hasPendingRequest())
             intended(authTabIntent())
             intended(mainActivityHandoffIntent())
+            awaitSessionScreen()
         }
 
     private fun stubAuthTab(resultCode: Int): AtomicReference<AuthAttempt> {
@@ -159,6 +164,10 @@ class AuthFlowE2eTest {
             .build()
 
     private suspend fun awaitSession(): FakeSession = withTimeout(TIMEOUT_MS) { FakeSessionFactory.awaitSession() }
+
+    // Where the handoff lands. A test that returns before it does leaves the launch in flight, and
+    // it then arrives after the Hilt component is torn down and takes the whole process with it.
+    private fun awaitSessionScreen() = awaitResumed(SessionActivity::class.java)
 
     private fun authTabIntent(): Matcher<Intent> =
         allOf(

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
@@ -1,6 +1,7 @@
 // Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
 package dev.firezone.android.tunnel
 
+import android.app.Activity
 import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
@@ -71,6 +72,35 @@ fun finishAllActivities() {
 
         Thread.sleep(50)
     }
+}
+
+// An activity the app hands off to is still in flight in `system_server` when `startActivity`
+// returns, and Espresso's `intended` only drains the main looper before checking, so a test has to
+// wait for the screen itself before asserting anything about how it got there.
+fun awaitResumed(activity: Class<out Activity>) {
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(20)
+
+    while (!isResumed(activity)) {
+        if (System.nanoTime() > deadline) {
+            throw AssertionError("Timed out waiting for ${activity.simpleName} to be on screen, showing ${resumedActivity()}")
+        }
+
+        Thread.sleep(50)
+    }
+}
+
+private fun isResumed(activity: Class<out Activity>): Boolean {
+    var resumed = false
+
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+        resumed =
+            ActivityLifecycleMonitorRegistry
+                .getInstance()
+                .getActivitiesInStage(Stage.RESUMED)
+                .any { activity.isInstance(it) }
+    }
+
+    return resumed
 }
 
 // Names what the user would be looking at, which is what tells a screen that has not arrived yet


### PR DESCRIPTION
`AuthFlowE2eTest` launches `AuthActivity` through the application context and asserts the handoff to `MainActivity` right away. Espresso's `intended` only drains the main looper before it checks, so when the launch is still queued in `system_server`, nothing has been recorded yet and the assertion fails. The activity then goes on to open the auth tab while the next test is already recording, which makes that test see two auth-tab intents. Both tests also end with the handoff to `MainActivity` still in flight, so the splash screen starts `SessionActivity` after the Hilt component has been torn down and the process crashes, hiding the results of every test class after it.

Wait for the screen a step lands on before asserting how it got there, and end each test on the session screen so nothing is left in flight.

Related: #14888