### PR TITLE
fix(apple): isolate tunnel IPC on main actor

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -204,6 +204,7 @@ public enum IPCClient {
   /// Polling opts out: cycle-starting from the poll loop would wake the extension
   /// without a tunnel behind it, and the stop that follows churns the VPN status,
   /// which starts the loop over again.
+  @MainActor
   private static func sendProviderMessage(
     session: any TunnelSessionProtocol,
     message: ProviderMessage,
@@ -229,6 +230,7 @@ public enum IPCClient {
   /// On macOS, the tunnel needs to be in a connected, connecting, or reasserting state for the utun to be removed
   /// upon stopTunnel. We do this by ensuring the tunnel is "started" prior to any IPC call. If so, we return true
   /// so that the caller may stop the tunnel afterwards.
+  @MainActor
   private static func maybeCycleStart(_ session: any TunnelSessionProtocol) async throws -> Bool {
     if session.status == .invalid {
       throw Error.invalidStatus(session.status)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnelSession.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnelSession.swift
@@ -13,9 +13,9 @@
   /// Answers the app's messages from state a scenario or a test sets, and moves through
   /// the statuses a start or stop would.
   ///
-  /// `@unchecked Sendable`: the protocol is `Sendable`, but the mock is only ever driven
-  /// from the main actor.
-  final class MockTunnelSession: TunnelSessionProtocol, @unchecked Sendable {
+  /// The app drives tunnel sessions from the main actor.
+  @MainActor
+  final class MockTunnelSession: @preconcurrency TunnelSessionProtocol {
     private(set) var status: NEVPNStatus
 
     /// What the next poll reports; `nil` resources are a portal that has not sent `init`.


### PR DESCRIPTION
Provider-message handling enters through `@MainActor` APIs, but the private async helpers were nonisolated and could run on the generic executor. This allowed concurrent mutation of the mock message array, causing the intermittent `SIGSEGV` in the [Swift coverage job](https://github.com/firezone/firezone/actions/runs/33599103333/job/100148640023).

Keep the helper functions and `MockTunnelSession` isolated to the main actor, removing the mock’s unchecked `Sendable` conformance and making its existing isolation assumption explicit.