### PR TITLE
fix(x509): uninstall only certificates from the test CA

### DIFF
--- a/mise-tasks/x509/uninstall-linux.sh
+++ b/mise-tasks/x509/uninstall-linux.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # confusing failure further down.
 host_os="$(uname -s)"
 if [ "$host_os" != "Linux" ]; then
-    echo "error: this task removes a PKCS#11 token, but this is ${host_os}." >&2
+    echo "error: this task removes from a PKCS#11 token, but this is ${host_os}." >&2
     echo "'mise tasks' lists the task for this platform." >&2
     exit 1
 fi
@@ -19,6 +19,15 @@ fi
 PIN_PATH="/etc/firezone/pkcs11-pin"
 TOKEN_LABEL="Firezone"
 
+# The PIN `//:x509:install-linux` initialises the token with. Nothing here guards anything: the
+# token holds a throwaway test key.
+PKCS11_PIN="123456"
+
+# A real deployment's certificates carry the same subject common name as ours, so only the CA a
+# certificate chains to makes it this task's to delete, and nothing here falls back to the name:
+# leaving one of ours behind costs a line of output, deleting an MDM's costs a machine its identity.
+CA_CRT="${XDG_CACHE_HOME:-${HOME}/.cache}/firezone/x509/ca.crt"
+
 as_root() {
     if [ "$(id -u)" -eq 0 ]; then
         "$@"
@@ -27,41 +36,162 @@ as_root() {
     fi
 }
 
-command -v softhsm2-util >/dev/null || {
-    echo "error: softhsm2-util is required (Debian: apt install softhsm2; Fedora: dnf install softhsm)" >&2
+softhsm_module() {
+    local candidate
+
+    if [ -n "${SOFTHSM2_MODULE:-}" ]; then
+        printf '%s\n' "$SOFTHSM2_MODULE"
+        return 0
+    fi
+
+    # Debian keeps the module under softhsm/, Fedora under pkcs11/ and without the 2.
+    for candidate in \
+        /usr/lib/softhsm/libsofthsm2.so \
+        /usr/lib64/softhsm/libsofthsm2.so \
+        /usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so \
+        /usr/lib/aarch64-linux-gnu/softhsm/libsofthsm2.so \
+        /usr/lib64/pkcs11/libsofthsm2.so \
+        /usr/lib64/pkcs11/libsofthsm.so \
+        /usr/lib/pkcs11/libsofthsm2.so \
+        /usr/lib/pkcs11/libsofthsm.so \
+        /usr/local/lib/softhsm/libsofthsm2.so; do
+        if [ -f "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+command -v softhsm2-util >/dev/null && command -v pkcs11-tool >/dev/null || {
+    echo "error: softhsm2-util and pkcs11-tool are required (Debian: apt install softhsm2 opensc; Fedora: dnf install softhsm opensc)" >&2
     exit 1
 }
 
+# A certificate can be issued on one machine and only its PKCS#12 carried to another, so a
+# machine can hold one of ours without ever holding the CA. Then the person running this is the
+# only one who can tell the certificates apart, and there has to be a terminal to ask them at.
+if [ ! -f "$CA_CRT" ] && [ ! -t 0 ]; then
+    echo "error: no test CA in ${CA_CRT%/*}, so nothing here can tell a test certificate from any" >&2
+    echo "other under that common name; run 'mise run //:x509:create-ca', or 'mise run //:x509:import-ca'" >&2
+    echo "if another machine has the CA, or run this task from a terminal to choose by hand" >&2
+    exit 1
+fi
+
 if [ "$(id -u)" -ne 0 ]; then
     if ! command -v sudo >/dev/null; then
-        echo "error: removing the system SoftHSM token and ${PIN_PATH} needs root, and sudo is" >&2
-        echo "not installed; run this task as root instead" >&2
+        echo "error: emptying the system SoftHSM token and removing ${PIN_PATH} needs root, and" >&2
+        echo "sudo is not installed; run this task as root instead" >&2
         exit 1
     fi
 
     # Elevating now means a refusal is its own error, rather than every check below reading
     # as "there was nothing there".
     if ! sudo true; then
-        echo "error: sudo could not elevate, and removing the system SoftHSM token and" >&2
+        echo "error: sudo could not elevate, and emptying the system SoftHSM token and removing" >&2
         echo "${PIN_PATH} needs root" >&2
         exit 1
     fi
 fi
 
+module="$(softhsm_module)" || {
+    echo "error: no SoftHSM PKCS#11 module found; set SOFTHSM2_MODULE to its path" >&2
+    exit 1
+}
+
 # SoftHSM prefers a per-user configuration over the system one, and `sudo` decides for itself
 # whose home directory it looks in, so the system one is named outright.
 system_softhsm=(env "SOFTHSM2_CONF=${SOFTHSM_CONF}")
 
+work="$(mktemp -d)"
+# shellcheck disable=SC2064 # `work` is expanded now on purpose; the trap outlives the variable.
+trap "rm -rf '${work}'" EXIT
+
+token() {
+    as_root "${system_softhsm[@]}" pkcs11-tool --module "$module" --token-label "$TOKEN_LABEL" \
+        --login --pin "$PKCS11_PIN" "$@"
+}
+
+# Enough of the certificate to recognise it by, since the answer is the only thing standing
+# between it and deletion.
+confirm_delete() {
+    echo
+    openssl x509 -in "${work}/cert.pem" -noout -subject -issuer -enddate -fingerprint -sha256 |
+        sed 's/^/    /'
+    read -r -p "    Delete ${1}? [y/N] " reply
+
+    case "$reply" in
+    [yY] | [yY][eE][sS]) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+# A machine that never ran the install task has no token, which is not a failure. Anything else
+# pkcs11-tool reports is one, and it says so on stderr rather than in its exit status.
+list_status=0
+listing="$(token --list-objects --type cert 2>&1)" || list_status=$?
+
+if [ "$list_status" -ne 0 ] && ! printf '%s' "$listing" | grep -qi "no slot"; then
+    echo "error: could not read the ${TOKEN_LABEL} token:" >&2
+    printf '%s\n' "$listing" >&2
+    exit 1
+fi
+
+if [ "$list_status" -ne 0 ]; then
+    listing=""
+elif [ -f "$CA_CRT" ]; then
+    echo "==> Removing certificates the test CA issued from the ${TOKEN_LABEL} token..."
+else
+    echo "==> No test CA in ${CA_CRT%/*}, so which of these are the test ones is yours to say."
+fi
+
+# A certificate and the key pair it belongs to share a CKA_ID, which is how both are named.
+for id in $(printf '%s\n' "$listing" | awk '/^[[:blank:]]*ID:/ { print $2 }'); do
+    token --read-object --type cert --id "$id" 2>/dev/null |
+        openssl x509 -inform der -out "${work}/cert.pem"
+
+    if [ -f "$CA_CRT" ]; then
+        # An expired certificate is still ours and still wants deleting, hence `-no_check_time`.
+        if ! openssl verify -CAfile "$CA_CRT" -no_check_time "${work}/cert.pem" >/dev/null 2>&1; then
+            issuer="$(openssl x509 -in "${work}/cert.pem" -noout -issuer | sed 's/^issuer=//')"
+            echo "    Kept ${id}, which the test CA did not issue: ${issuer}"
+            continue
+        fi
+    elif ! confirm_delete "$id"; then
+        echo "    Kept ${id}."
+        continue
+    fi
+
+    token --delete-object --type cert --id "$id" >/dev/null
+    # A certificate can sit on a token on its own, so its key pair is not always there.
+    token --delete-object --type privkey --id "$id" >/dev/null 2>&1 || true
+    token --delete-object --type pubkey --id "$id" >/dev/null 2>&1 || true
+    echo "    Removed ${id} and its key pair."
+done
+
+# Whatever is left on the token needs the token and the PIN that opens it, so the two go only
+# once nothing is. A token that is not there lists nothing and reads the same as an empty one.
+remaining="$(token --list-objects 2>/dev/null || true)"
+
+if [ -n "$remaining" ]; then
+    echo
+    echo "The ${TOKEN_LABEL} token and ${PIN_PATH} stay, because what is still on the token needs"
+    echo "both. A connected Tunnel service holds its PKCS#11 session until it restarts, so restart it"
+    echo "to see the change."
+
+    exit 0
+fi
+
 echo "==> Deleting the ${TOKEN_LABEL} token..."
-# A machine that never ran the install task has no token, which is not a failure. Anything
-# else softhsm2-util reports is one, and it says so on stderr rather than in its exit status.
 delete_status=0
 delete_output="$(as_root "${system_softhsm[@]}" softhsm2-util --delete-token \
     --token "$TOKEN_LABEL" 2>&1)" || delete_status=$?
 
 if [ "$delete_status" -eq 0 ]; then
     echo "    Deleted."
-elif printf '%s' "$delete_output" | grep -qi "could not be found\|not found"; then
+elif [ "$list_status" -ne 0 ]; then
+    # The listing found no token, so softhsm2-util had none to delete either, whatever it says.
     echo "    No ${TOKEN_LABEL} token was in ${SOFTHSM_CONF}'s store."
 else
     echo "error: could not delete the ${TOKEN_LABEL} token:" >&2

--- a/mise-tasks/x509/uninstall-windows.ps1
+++ b/mise-tasks/x509/uninstall-windows.ps1
@@ -17,12 +17,31 @@ if (-not $onWindows) {
 }
 
 # `//:x509:gen-certificate` issues the certificate under this common name, which is how the
-# Client finds it and how this task knows which certificates it put there.
+# Client finds it and how this task narrows the store down. A real deployment's certificates
+# carry it too, so only the CA a certificate chains to makes it this task's to delete, and
+# nothing here falls back to the name: leaving one of ours behind costs a line of output,
+# deleting an MDM's costs a machine its identity.
 #
 # The CA the certificate was issued from has its own tasks and its own lifetime, so it stays
 # where it is even though `//:x509:install-windows` carries it into the store alongside this
 # certificate.
 $commonName = 'dev.firezone.device-trust'
+
+# Resolved the way `//:x509:install-windows` resolves it, so the two tasks agree on the path.
+$cacheHome = if ($env:XDG_CACHE_HOME) { $env:XDG_CACHE_HOME } else { Join-Path $HOME '.cache' }
+$caPath = Join-Path $cacheHome 'firezone\x509\ca.crt'
+
+# A certificate can be issued on one machine and only its PKCS#12 carried to another, so a
+# machine can hold one of ours without ever holding the CA. Then the person running this is the
+# only one who can tell the certificates apart, and there has to be a terminal to ask them at.
+if (-not (Test-Path -LiteralPath $caPath -PathType Leaf) -and [Console]::IsInputRedirected) {
+    [Console]::Error.WriteLine("error: no test CA at $caPath, so nothing here can tell a test")
+    [Console]::Error.WriteLine("certificate from any other under $commonName. Run 'mise run //:x509:create-ca',")
+    [Console]::Error.WriteLine("or 'mise run //:x509:import-ca' if another machine has the CA, or run")
+    [Console]::Error.WriteLine('this task from a terminal to choose by hand.')
+
+    exit 1
+}
 
 # The install task writes into the machine store, so that is where the removal happens, and
 # emptying it needs the same elevation filling it did.
@@ -34,10 +53,50 @@ if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administra
     exit 1
 }
 
+# The file constructor reads PEM as well as DER, in Windows PowerShell and in PowerShell 7.
+$ca = if (Test-Path -LiteralPath $caPath -PathType Leaf) {
+    [Security.Cryptography.X509Certificates.X509Certificate2]::new($caPath)
+}
+
+# The CA is a trust anchor the portal knows and this machine does not, so the chain is built
+# against it rather than the machine's own roots, and a certificate of ours that has expired is
+# still ours to delete.
+function Test-IssuedByTestCa {
+    param($Certificate)
+
+    $chain = [Security.Cryptography.X509Certificates.X509Chain]::new()
+    $chain.ChainPolicy.RevocationMode = [Security.Cryptography.X509Certificates.X509RevocationMode]::NoCheck
+    $unknownRoot = [Security.Cryptography.X509Certificates.X509VerificationFlags]::AllowUnknownCertificateAuthority
+    $expired = [Security.Cryptography.X509Certificates.X509VerificationFlags]::IgnoreNotTimeValid
+    $chain.ChainPolicy.VerificationFlags = $unknownRoot -bor $expired
+    $chain.ChainPolicy.ExtraStore.Add($ca) | Out-Null
+
+    # `Build` reports every fault those two flags do not excuse, an issuer whose signature does
+    # not verify included, so a certificate that merely names the CA does not pass here.
+    $chain.Build($Certificate) -and
+    $chain.ChainElements[$chain.ChainElements.Count - 1].Certificate.Thumbprint -eq $ca.Thumbprint
+}
+
+# Enough of the certificate to recognise it by, since the answer is the only thing standing
+# between it and deletion. `Write-Host` keeps it off the pipeline, which is the answer itself.
+function Confirm-Delete {
+    param($Certificate)
+
+    Write-Host ''
+    Write-Host ('    Subject    ' + $Certificate.Subject)
+    Write-Host ('    Issuer     ' + $Certificate.Issuer)
+    Write-Host ('    Thumbprint ' + $Certificate.Thumbprint)
+    Write-Host ('    Expires    ' + $Certificate.NotAfter.ToString('u'))
+
+    (Read-Host '    Delete it? [y/N]') -match '^y(es)?$'
+}
+
 Write-Output "==> Removing certificates for $commonName from Cert:\LocalMachine\My..."
 
-# Matched on the common name rather than a thumbprint, because a machine that ran the install
-# task more than once holds one certificate per run and all of them are throwaway test material.
+if (-not $ca) {
+    Write-Output "    No test CA at $caPath, so which of these are the test ones is yours to say."
+}
+
 # `GetNameInfo` reads the CN out of the subject, so a certificate whose subject merely contains
 # that name somewhere is left alone: this task deletes private keys as an administrator.
 $certificates = @(
@@ -48,17 +107,25 @@ $certificates = @(
 
 if ($certificates.Count -eq 0) {
     Write-Output '    None were in the store.'
-} else {
-    foreach ($certificate in $certificates) {
-        # `-DeleteKey` takes the private key with the certificate, whichever provider holds it,
-        # so the key does not outlive the certificate it was imported with.
-        Remove-Item -Path $certificate.PSPath -Force -DeleteKey
-        Write-Output ('    Removed ' + $certificate.Thumbprint)
+}
+
+foreach ($certificate in $certificates) {
+    $ours = if ($ca) { Test-IssuedByTestCa $certificate } else { Confirm-Delete $certificate }
+
+    if (-not $ours) {
+        Write-Output ('    Kept ' + $certificate.Thumbprint + ', issued by ' + $certificate.Issuer)
+
+        continue
     }
+
+    # `-DeleteKey` takes the private key with the certificate, whichever provider holds it,
+    # so the key does not outlive the certificate it was imported with.
+    Remove-Item -Path $certificate.PSPath -Force -DeleteKey
+    Write-Output ('    Removed ' + $certificate.Thumbprint)
 }
 
 Write-Output ''
-Write-Output 'The Client has no identity to find now. A connected Tunnel service holds the'
-Write-Output 'certificate until it restarts, so restart it to see the change.'
+Write-Output 'A connected Tunnel service holds the certificate until it restarts, so restart it'
+Write-Output 'to see the change.'
 Write-Output ''
 Write-Output "'firezone-client-tunnel.exe x509' prints what the Client makes of the store."


### PR DESCRIPTION
The uninstall tasks matched on the common name `dev.firezone.device-trust`, which a real deployment's certificates carry too, so on a machine that also holds an MDM-issued certificate they would have deleted it, private key included. They now decide by the test CA instead: a certificate is removed only when it chains cryptographically to the CA in `~/.cache/firezone/x509/ca.crt`, checked against the CA's key rather than its name, and anything else under that common name is left alone and listed. On Linux that means removing the matching objects from the token rather than the whole token, which goes, with its PIN file, only once nothing remains on it.

Without a `ca.crt` the tasks cannot tell the test certificates apart, since the certificate may have been issued on another machine, so on a terminal they print each candidate with its issuer, fingerprint and expiry and ask per certificate, and without a terminal they refuse rather than guess.

The Linux task also treated a machine that never ran the install task as a failure: `softhsm2-util` reports a missing token as "Could not find a token", which the message match did not cover.

Related: #14991