### PR TITLE
fix(clients): keep error details out of the disconnect alert

### DIFF
--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Connlib.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Connlib.kt
@@ -16,7 +16,9 @@ class FakeDisconnectError(
     private val signInRequired: Boolean,
     private val text: String = "session ended",
 ) : DisconnectError(NoHandle) {
-    override fun message(): String = text
+    override fun userMessage(): String = text
+
+    override fun logMessage(): String = text
 
     override fun requiresSignIn(): Boolean = signInRequired
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -718,13 +718,13 @@ class TunnelService : VpnService() {
                                 }
 
                                 is Event.Disconnected -> {
-                                    Log.i(TAG, "Disconnected by connlib: ${event.error.message()}")
+                                    Log.i(TAG, "Disconnected by connlib: ${event.error.logMessage()}")
 
                                     if (event.error.requiresSignIn()) {
                                         tokenStore.clear()
                                     }
 
-                                    stopReason = StopReason.Disconnected(event.error.message())
+                                    stopReason = StopReason.Disconnected(event.error.userMessage())
                                 }
 
                                 is Event.GatewayVersionMismatch -> {

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -236,8 +236,14 @@ impl ConnlibError {
 
 #[uniffi::export]
 impl DisconnectError {
-    pub fn message(&self) -> String {
-        self.0.to_string()
+    /// Returns the sentence to show the user.
+    pub fn user_message(&self) -> String {
+        self.0.user_message()
+    }
+
+    /// Returns the error with its full cause chain, for the logs.
+    pub fn log_message(&self) -> String {
+        self.0.log_message()
     }
 
     /// Returns whether the stored token must be discarded and the user sent through sign-in again.

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -672,10 +672,11 @@ impl<I: GuiIntegration> Controller<I> {
                 }
             }
             service::ServerMsg::OnDisconnect {
-                error_msg,
+                user_msg,
+                log_msg,
                 requires_sign_in,
             } => {
-                tracing::error!("Connlib disconnected: {error_msg}");
+                tracing::error!("Connlib disconnected: {log_msg}");
 
                 if requires_sign_in {
                     self.sign_out().await?;
@@ -683,7 +684,7 @@ impl<I: GuiIntegration> Controller<I> {
                     self.disconnect().await?;
                 }
 
-                dialog::error(&error_msg)?;
+                dialog::error(&user_msg)?;
             }
             service::ServerMsg::ConnectedToPortal(connected) => {
                 if connected.actor_name.is_empty() {

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -96,7 +96,8 @@ pub enum ServerMsg {
     ConnectResult(Result<(), String>),
     DisconnectedGracefully,
     OnDisconnect {
-        error_msg: String,
+        user_msg: String,
+        log_msg: String,
         requires_sign_in: bool,
     },
     AllGatewaysOffline {
@@ -674,7 +675,8 @@ impl<'a> Handler<'a> {
                 self.reset_telemetry_environment();
                 self.dns_controller.deactivate()?;
                 self.send_ipc(ServerMsg::OnDisconnect {
-                    error_msg: error.to_string(),
+                    user_msg: error.user_message(),
+                    log_msg: error.log_message(),
                     requires_sign_in: error.requires_sign_in(),
                 })
                 .await?

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -529,7 +529,7 @@ fn try_main() -> Result<()> {
             };
 
             match event {
-                client_shared::Event::Disconnected(error) => break Err(anyhow!(error).context("Firezone disconnected")),
+                client_shared::Event::Disconnected(error) => break Err(anyhow!(error.log_message()).context("Firezone disconnected")),
                 client_shared::Event::ResourcesUpdated(_) => {
                     // On every Resources update, flush DNS to mitigate <https://github.com/firezone/firezone/issues/5052>
                     dns_controller.flush()?;

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -1034,11 +1034,11 @@ mod tests {
 
         assert_eq!(
             error.user_message(),
-            "This device could not sign in with its certificate."
+            "This device could not sign in with its certificate"
         );
         assert_eq!(
             error.log_message(),
-            "Connection to portal failed: This device could not sign in with its certificate.: the keystore failed to sign: The requested operation is not supported. (0x80090029)"
+            "Connection to portal failed: This device could not sign in with its certificate: the keystore failed to sign: The requested operation is not supported. (0x80090029)"
         );
     }
 
@@ -1050,11 +1050,11 @@ mod tests {
 
         assert_eq!(
             error.user_message(),
-            "The connection to the Firezone Portal was lost and could not be restored."
+            "The connection to the Firezone Portal was lost and could not be restored"
         );
         assert_eq!(
             error.log_message(),
-            "Connection to portal failed: The connection to the Firezone Portal was lost and could not be restored.: websocket connection failed"
+            "Connection to portal failed: The connection to the Firezone Portal was lost and could not be restored: websocket connection failed"
         );
     }
 

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -119,6 +119,23 @@ impl From<anyhow::Error> for DisconnectError {
 }
 
 impl DisconnectError {
+    /// Returns the sentence to show the user.
+    ///
+    /// Only [`phoenix_channel::Error`] is worded for a user. Anything else that ends a session
+    /// is an internal failure, which the user is told about without the diagnostics.
+    pub fn user_message(&self) -> String {
+        let Some(e) = self.0.any_downcast_ref::<phoenix_channel::Error>() else {
+            return "Firezone ran into an unrecoverable error.".to_owned();
+        };
+
+        e.to_string()
+    }
+
+    /// Returns the error with its full cause chain, for the logs.
+    pub fn log_message(&self) -> String {
+        format!("{:#}", self.0)
+    }
+
     /// Returns whether the stored token must be discarded and the user sent through sign-in again.
     ///
     /// This does not report whether the failure was authentication-related in general.
@@ -1002,4 +1019,62 @@ fn parse_portal_domain(domain: &str) -> Option<dns_types::DomainName> {
             tracing::warn!(%domain, "Portal sent malformed device pool domain: {}", logging::err_with_src(e));
         })
         .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signing_failure_names_the_certificate_but_not_the_keystore() {
+        let error = portal_failure(phoenix_channel::Error::ClientCertificateSigningFailed(
+            "the keystore failed to sign: The requested operation is not supported. (0x80090029)"
+                .into(),
+        ));
+
+        assert_eq!(
+            error.user_message(),
+            "This device could not sign in with its certificate."
+        );
+        assert_eq!(
+            error.log_message(),
+            "Connection to portal failed: This device could not sign in with its certificate.: the keystore failed to sign: The requested operation is not supported. (0x80090029)"
+        );
+    }
+
+    #[test]
+    fn lost_connection_names_the_portal_but_not_the_last_attempt() {
+        let error = portal_failure(phoenix_channel::Error::MaxRetriesReached {
+            final_error: "websocket connection failed".into(),
+        });
+
+        assert_eq!(
+            error.user_message(),
+            "The connection to the Firezone Portal was lost and could not be restored."
+        );
+        assert_eq!(
+            error.log_message(),
+            "Connection to portal failed: The connection to the Firezone Portal was lost and could not be restored.: websocket connection failed"
+        );
+    }
+
+    #[test]
+    fn failures_without_a_message_for_the_user_are_reported_as_unrecoverable() {
+        let error = DisconnectError::from(
+            anyhow::Error::msg("failed to write to TUN device").context("connlib crashed"),
+        );
+
+        assert_eq!(
+            error.user_message(),
+            "Firezone ran into an unrecoverable error."
+        );
+        assert_eq!(
+            error.log_message(),
+            "connlib crashed: failed to write to TUN device"
+        );
+    }
+
+    fn portal_failure(error: phoenix_channel::Error) -> DisconnectError {
+        DisconnectError(anyhow::Error::new(error).context("Connection to portal failed"))
+    }
 }

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -216,31 +216,36 @@ const CERTIFICATE_REJECTION_CODES: &[&str] = &[
 /// Every variant's `Display` output is shown to the user verbatim: as a notification on mobile
 /// and as a dialog on desktop.
 ///
-/// These are product copy, not log lines. Word them for someone who has never seen this code,
-/// and keep whatever diagnostic detail we have at the end so it never leads the sentence.
+/// These are product copy, not log lines. Word them for someone who has never seen this code.
+/// Diagnostics we cannot word for a user go into the variant's source, which only the logs render.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Your Firezone sign-in has expired. Sign in again to reconnect.")]
     InvalidToken,
     /// The portal refused to authenticate us for a reason we cannot act on specifically.
+    ///
+    /// The reason it names is its own wording for the user.
     #[error("The Firezone Portal rejected this device's sign-in: {0}")]
     AuthenticationFailed(String),
-    #[error("This device could not sign in with its certificate: {0}")]
-    ClientCertificateSigningFailed(String),
+    #[error("This device could not sign in with its certificate.")]
+    ClientCertificateSigningFailed(#[source] BoxError),
     /// The portal refused the X.509 client certificate we presented.
     ///
     /// It words its rejections for the user, so anything we wrap around one only repeats it.
     #[error("{0}")]
     CertificateRejected(String),
-    #[error(
-        "The connection to the Firezone Portal was lost and could not be restored: {final_error}"
-    )]
-    MaxRetriesReached { final_error: String },
-    #[error("The Firezone Portal refused to start a session for this device: {0}")]
-    LoginFailed(String),
-    #[error("Firezone ran into an unrecoverable error: {0}")]
-    FatalIo(io::Error),
+    #[error("The connection to the Firezone Portal was lost and could not be restored.")]
+    MaxRetriesReached {
+        #[source]
+        final_error: BoxError,
+    },
+    #[error("The Firezone Portal refused to start a session for this device.")]
+    LoginFailed(#[source] BoxError),
+    #[error("Firezone ran into an unrecoverable error.")]
+    FatalIo(#[source] io::Error),
 }
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 impl Error {
     /// Returns whether the stored token must be discarded and the user sent through sign-in again.
@@ -704,7 +709,9 @@ where
                         if let Some(message) = e.client_certificate_signing_error() =>
                     {
                         self.state = State::Closed;
-                        return Poll::Ready(Err(Error::ClientCertificateSigningFailed(message)));
+                        return Poll::Ready(Err(Error::ClientCertificateSigningFailed(
+                            message.into(),
+                        )));
                     }
                     Poll::Ready(Err(e)) => {
                         let backoff = match e.parse_retry_after_header() {
@@ -717,11 +724,13 @@ where
                                         &self.make_initial_backoff
                                     });
 
-                                backoff
-                                    .next_backoff()
-                                    .ok_or_else(|| Error::MaxRetriesReached {
-                                        final_error: e.to_string(),
-                                    })?
+                                let Some(duration) = backoff.next_backoff() else {
+                                    return Poll::Ready(Err(Error::MaxRetriesReached {
+                                        final_error: Box::new(e),
+                                    }));
+                                };
+
+                                duration
                             }
                         };
                         self.state = State::Closed;
@@ -886,7 +895,9 @@ where
                             if message.topic == self.login
                                 && pending_join_requests.contains_key(&req_id)
                             {
-                                return Poll::Ready(Err(Error::LoginFailed(reason.to_string())));
+                                return Poll::Ready(Err(Error::LoginFailed(
+                                    reason.to_string().into(),
+                                )));
                             }
 
                             match reason {

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -218,6 +218,7 @@ const CERTIFICATE_REJECTION_CODES: &[&str] = &[
 ///
 /// These are product copy, not log lines. Word them for someone who has never seen this code.
 /// Diagnostics we cannot word for a user go into the variant's source, which only the logs render.
+/// A message with a source ends without a full stop, so that the chain reads as one sentence.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Your Firezone sign-in has expired. Sign in again to reconnect.")]
@@ -227,21 +228,21 @@ pub enum Error {
     /// The reason it names is its own wording for the user.
     #[error("The Firezone Portal rejected this device's sign-in: {0}")]
     AuthenticationFailed(String),
-    #[error("This device could not sign in with its certificate.")]
+    #[error("This device could not sign in with its certificate")]
     ClientCertificateSigningFailed(#[source] BoxError),
     /// The portal refused the X.509 client certificate we presented.
     ///
     /// It words its rejections for the user, so anything we wrap around one only repeats it.
     #[error("{0}")]
     CertificateRejected(String),
-    #[error("The connection to the Firezone Portal was lost and could not be restored.")]
+    #[error("The connection to the Firezone Portal was lost and could not be restored")]
     MaxRetriesReached {
         #[source]
         final_error: BoxError,
     },
-    #[error("The Firezone Portal refused to start a session for this device.")]
+    #[error("The Firezone Portal refused to start a session for this device")]
     LoginFailed(#[source] BoxError),
-    #[error("Firezone ran into an unrecoverable error.")]
+    #[error("Firezone ran into an unrecoverable error")]
     FatalIo(#[source] io::Error),
 }
 

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -558,10 +558,10 @@ actor Adapter {
       }
 
     case .disconnected(let error):
-      let errorMessage = error.message()
+      let userMessage = error.userMessage()
       let requiresSignIn = error.requiresSignIn()
       Log.info(
-        "Received Disconnected event (requiresSignIn=\(requiresSignIn)): " + errorMessage)
+        "Received Disconnected event (requiresSignIn=\(requiresSignIn)): " + error.logMessage())
 
       // iOS shows the notification from the tunnel process because the UI
       // process isn't guaranteed to be alive; macOS handles it from the UI.
@@ -569,13 +569,13 @@ actor Adapter {
         // Only a session ended by an unusable token can be restored by signing in again.
         // Offering it for anything else sends the user somewhere that cannot help them.
         if requiresSignIn {
-          SessionNotification.showDisconnectedNotificationiOS(errorMessage)
+          SessionNotification.showDisconnectedNotificationiOS(userMessage)
         } else {
-          SessionNotification.showDisconnectedNotificationWithoutSignIniOS(errorMessage)
+          SessionNotification.showDisconnectedNotificationWithoutSignIniOS(userMessage)
         }
       #endif
 
-      let sendableError = SendableError(errorMessage, requiresSignIn: requiresSignIn)
+      let sendableError = SendableError(userMessage, requiresSignIn: requiresSignIn)
       providerCommandSender.send(.cancelWithError(sendableError))
 
     case .allGatewaysOffline(let resourceId):


### PR DESCRIPTION
When connlib disconnects, the error reached the user with its whole cause chain attached, keystore internals and OS error codes included: a Windows signing failure read "This device could not sign in with its certificate: the keystore failed to sign: The requested operation is not supported. (0x80090029)" in the alert.

The error now answers two questions separately. `user_message()` is the sentence a person can act on: `phoenix_channel::Error` is the one type worded for a user, so it is that type's `Display` when the chain carries one and a generic sentence otherwise. `log_message()` is the full chain. Diagnostics move out of the variant text into `#[source]` fields, so `Display` stays user copy while `{:#}` still renders everything for the log; the portal's own wording in `AuthenticationFailed` and `CertificateRejected` stays where it is, since the portal writes those for the user.

The FFI error exposes only the two accessors, so every Swift and Kotlin call site had to choose, and the GUI's IPC disconnect message carries both strings: the dialog and the notifications show the user message, the logs on every platform keep the chain.