### PR TITLE
fix(x509): sign over TLS 1.2 when the key cannot do RSA-PSS

### DIFF
--- a/rust/libs/connlib/phoenix-channel/Cargo.toml
+++ b/rust/libs/connlib/phoenix-channel/Cargo.toml
@@ -17,7 +17,7 @@ libc = { workspace = true }
 logging = { workspace = true }
 os_info = { workspace = true }
 rand = { workspace = true }
-rustls = { workspace = true }
+rustls = { workspace = true, features = ["tls12"] }
 secrecy = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/rust/libs/connlib/phoenix-channel/src/tls.rs
+++ b/rust/libs/connlib/phoenix-channel/src/tls.rs
@@ -13,18 +13,38 @@ use x509_credential::ClientCertificate;
 ///
 /// # Errors
 ///
-/// Returns a [`rustls::Error`] if the crypto provider does not support the default protocol versions.
+/// Returns a [`rustls::Error`] if the crypto provider does not support the protocol versions we ask for.
 pub(crate) fn client_config(
     certificate: &ClientCertificate,
 ) -> Result<Arc<rustls::ClientConfig>, rustls::Error> {
     let config = rustls::ClientConfig::builder_with_provider(Arc::new(
         rustls::crypto::ring::default_provider(),
     ))
-    .with_safe_default_protocol_versions()?
+    .with_protocol_versions(protocol_versions(certificate))?
     .with_root_certificates(root_store())
     .with_client_cert_resolver(certificate.resolver());
 
     Ok(Arc::new(config))
+}
+
+/// The TLS versions offered to the portal when presenting `certificate`.
+///
+/// TLS 1.3 signs the handshake with schemes not every keystore can produce, most notably RSA-PSS with a digest-length salt, which TPM firmware refuses.
+/// Such a certificate authenticates over TLS 1.2 alone, so the version it needs follows from the schemes its key advertises.
+fn protocol_versions(
+    certificate: &ClientCertificate,
+) -> &'static [&'static rustls::SupportedProtocolVersion] {
+    const TLS12_ONLY: &[&rustls::SupportedProtocolVersion] = &[&rustls::version::TLS12];
+
+    if certificate.supports_tls13() {
+        return rustls::DEFAULT_VERSIONS;
+    }
+
+    tracing::info!(
+        "Offering TLS 1.2 only: the keystore cannot sign a TLS 1.3 handshake with this certificate's key"
+    );
+
+    TLS12_ONLY
 }
 
 /// The roots bundled with the binary.
@@ -50,4 +70,53 @@ fn root_store() -> rustls::RootCertStore {
     tracing::debug!(%added, %ignored, "Loaded native root certificates");
 
     store
+}
+
+#[cfg(test)]
+mod tests {
+    use rustls::{SignatureAlgorithm, SignatureScheme, pki_types::CertificateDer};
+    use x509_credential::{PrivateKey, SigningError};
+
+    use super::*;
+
+    #[test]
+    fn a_key_that_cannot_sign_a_tls13_handshake_restricts_the_connection_to_tls12() {
+        let certificate = certificate(vec![SignatureScheme::RSA_PKCS1_SHA256]);
+
+        assert_eq!(protocol_versions(&certificate), [&rustls::version::TLS12]);
+    }
+
+    #[test]
+    fn any_other_key_keeps_the_default_versions() {
+        let certificate = certificate(vec![SignatureScheme::RSA_PSS_SHA256]);
+
+        assert_eq!(protocol_versions(&certificate), rustls::DEFAULT_VERSIONS);
+    }
+
+    fn certificate(schemes: Vec<SignatureScheme>) -> ClientCertificate {
+        ClientCertificate::new(
+            vec![CertificateDer::from(vec![1, 2, 3])],
+            Arc::new(StubKey { schemes }),
+        )
+        .expect("a single-element chain should be accepted")
+    }
+
+    #[derive(Debug)]
+    struct StubKey {
+        schemes: Vec<SignatureScheme>,
+    }
+
+    impl PrivateKey for StubKey {
+        fn supported_schemes(&self) -> Vec<SignatureScheme> {
+            self.schemes.clone()
+        }
+
+        fn algorithm(&self) -> SignatureAlgorithm {
+            SignatureAlgorithm::RSA
+        }
+
+        fn sign(&self, _: SignatureScheme, _: &[u8]) -> Result<Vec<u8>, SigningError> {
+            unimplemented!("these tests never complete a handshake")
+        }
+    }
 }

--- a/rust/libs/x509-credential/src/lib.rs
+++ b/rust/libs/x509-credential/src/lib.rs
@@ -18,7 +18,10 @@ use rustls::{
 /// Constructing a `phoenix_channel::LoginUrl` with a certificate dials the portal's mTLS endpoint instead of the regular one.
 /// This carries the client identity alone: how the portal's own certificate is verified belongs to `phoenix-channel`, so presenting a certificate cannot change it.
 #[derive(Debug, Clone)]
-pub struct ClientCertificate(Arc<CertifiedKey>);
+pub struct ClientCertificate {
+    certified_key: Arc<CertifiedKey>,
+    key: Arc<dyn PrivateKey>,
+}
 
 impl ClientCertificate {
     /// Builds a client identity from a DER-encoded certificate chain and a platform-held key.
@@ -34,16 +37,41 @@ impl ClientCertificate {
             return Err(EmptyCertificateChain);
         }
 
-        let certified_key = CertifiedKey::new(chain, Arc::new(PlatformSigningKey(key)));
+        let certified_key = CertifiedKey::new(chain, Arc::new(PlatformSigningKey(key.clone())));
 
-        Ok(Self(Arc::new(certified_key)))
+        Ok(Self {
+            certified_key: Arc::new(certified_key),
+            key,
+        })
     }
 
     /// Offers this certificate whenever the portal asks for a client identity.
     pub fn resolver(&self) -> Arc<dyn ResolvesClientCert> {
-        Arc::new(SingleCertAndKey::from(self.0.clone()))
+        Arc::new(SingleCertAndKey::from(self.certified_key.clone()))
+    }
+
+    /// Whether this identity can authenticate over TLS 1.3.
+    ///
+    /// A key that signs with none of the schemes TLS 1.3 admits can only present itself over TLS 1.2, so a connection offering it has to negotiate that version.
+    pub fn supports_tls13(&self) -> bool {
+        self.key
+            .supported_schemes()
+            .iter()
+            .any(|scheme| !REFUSED_BY_TLS13.contains(scheme))
     }
 }
+
+/// The signature schemes a TLS 1.3 handshake cannot carry.
+///
+/// RFC 8446, section 4.2.3 leaves the PKCS#1 v1.5 schemes to certificate signatures and outlaws SHA-1 in handshake signatures altogether.
+/// It states the rule as a denylist, so a scheme it does not name is admissible.
+const REFUSED_BY_TLS13: &[SignatureScheme] = &[
+    SignatureScheme::RSA_PKCS1_SHA1,
+    SignatureScheme::RSA_PKCS1_SHA256,
+    SignatureScheme::RSA_PKCS1_SHA384,
+    SignatureScheme::RSA_PKCS1_SHA512,
+    SignatureScheme::ECDSA_SHA1_Legacy,
+];
 
 /// A private key that is held by a platform keystore.
 ///
@@ -151,7 +179,7 @@ mod tests {
         .expect("mock key should produce a client certificate");
 
         let signer = certificate
-            .0
+            .certified_key
             .key
             .choose_scheme(&[
                 SignatureScheme::ECDSA_NISTP256_SHA256,
@@ -209,7 +237,7 @@ mod tests {
         )
         .expect("failing key should produce a client certificate");
         let signer = certificate
-            .0
+            .certified_key
             .key
             .choose_scheme(&[SignatureScheme::ECDSA_NISTP256_SHA256])
             .expect("ECDSA NIST P-256 should be mutually supported");
@@ -229,6 +257,45 @@ mod tests {
             matches!(signing_error, SigningError::AccessDenied(_)),
             "got {signing_error:?}"
         );
+    }
+
+    #[test]
+    fn a_key_without_the_pss_schemes_rules_out_tls13() {
+        let certificate = ClientCertificate::new(
+            vec![CertificateDer::from(vec![1, 2, 3])],
+            Arc::new(MockKey {
+                schemes: vec![
+                    SignatureScheme::RSA_PKCS1_SHA512,
+                    SignatureScheme::RSA_PKCS1_SHA384,
+                    SignatureScheme::RSA_PKCS1_SHA256,
+                ],
+            }),
+        )
+        .expect("mock key should produce a client certificate");
+
+        assert!(!certificate.supports_tls13());
+    }
+
+    #[test]
+    fn an_rsa_pss_or_ecdsa_key_authenticates_over_tls13() {
+        let rsa_pss = ClientCertificate::new(
+            vec![CertificateDer::from(vec![1, 2, 3])],
+            Arc::new(MockKey {
+                schemes: vec![
+                    SignatureScheme::RSA_PSS_SHA256,
+                    SignatureScheme::RSA_PKCS1_SHA256,
+                ],
+            }),
+        )
+        .expect("mock key should produce a client certificate");
+        let ecdsa = ClientCertificate::new(
+            vec![CertificateDer::from(vec![1, 2, 3])],
+            Arc::new(FailingKey),
+        )
+        .expect("failing key should produce a client certificate");
+
+        assert!(rsa_pss.supports_tls13());
+        assert!(ecdsa.supports_tls13());
     }
 
     #[derive(Debug)]

--- a/rust/libs/x509-keystore/src/sign.rs
+++ b/rust/libs/x509-keystore/src/sign.rs
@@ -96,15 +96,19 @@ impl<S: Signer> PrivateKey for Key<S> {
 }
 
 /// The schemes a key of `algorithm` signs with, most preferred first.
+///
+/// The RSA schemes are ordered by digest rather than by padding, SHA-256 first, because a TPM
+/// commonly implements SHA-1 and SHA-256 alone: a key held by one refuses a SHA-512 signature
+/// outright, and only the first scheme the peer also offers is ever tried.
 fn signature_schemes(algorithm: SigningAlgorithm) -> &'static [SignatureScheme] {
     match algorithm {
         SigningAlgorithm::RsaSha256 => &[
-            SignatureScheme::RSA_PSS_SHA512,
-            SignatureScheme::RSA_PSS_SHA384,
             SignatureScheme::RSA_PSS_SHA256,
-            SignatureScheme::RSA_PKCS1_SHA512,
-            SignatureScheme::RSA_PKCS1_SHA384,
             SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::RSA_PKCS1_SHA512,
         ],
         SigningAlgorithm::EcdsaSha256 => &[SignatureScheme::ECDSA_NISTP256_SHA256],
         SigningAlgorithm::EcdsaSha384 => &[SignatureScheme::ECDSA_NISTP384_SHA384],

--- a/rust/libs/x509-keystore/src/sign.rs
+++ b/rust/libs/x509-keystore/src/sign.rs
@@ -24,18 +24,53 @@ pub(crate) trait Signer: std::fmt::Debug + Send + Sync {
 pub(crate) struct Key<S> {
     /// What the parsed certificate says the key signs with.
     algorithm: SigningAlgorithm,
+    schemes: Vec<SignatureScheme>,
     signer: S,
 }
 
 impl<S> Key<S> {
     pub(crate) fn new(algorithm: SigningAlgorithm, signer: S) -> Self {
-        Self { algorithm, signer }
+        Self {
+            algorithm,
+            schemes: signature_schemes(algorithm).to_vec(),
+            signer,
+        }
+    }
+
+    /// Returns the key with the RSA-PSS schemes taken out of what it advertises.
+    ///
+    /// rustls signs with the first advertised scheme the peer offers, so a keystore that cannot
+    /// produce RSA-PSS signatures has to stop offering them: it would otherwise refuse in the
+    /// middle of the handshake, where the connection has no way left to recover.
+    pub(crate) fn without_rsa_pss(self) -> Self {
+        let Self {
+            algorithm,
+            schemes,
+            signer,
+        } = self;
+        let schemes = schemes
+            .into_iter()
+            .filter(|scheme| {
+                !matches!(
+                    scheme,
+                    SignatureScheme::RSA_PSS_SHA256
+                        | SignatureScheme::RSA_PSS_SHA384
+                        | SignatureScheme::RSA_PSS_SHA512
+                )
+            })
+            .collect();
+
+        Self {
+            algorithm,
+            schemes,
+            signer,
+        }
     }
 }
 
 impl<S: Signer> PrivateKey for Key<S> {
     fn supported_schemes(&self) -> Vec<SignatureScheme> {
-        signature_schemes(self.algorithm).to_vec()
+        self.schemes.clone()
     }
 
     fn algorithm(&self) -> SignatureAlgorithm {

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -11,21 +11,27 @@ use sha2::{Digest as _, Sha256, Sha384, Sha512};
 use windows::{
     Win32::{
         Foundation::{
-            E_ACCESSDENIED, NTE_BAD_KEYSET, NTE_NO_KEY, NTE_NOT_FOUND, NTE_PERM,
+            E_ACCESSDENIED, NTE_BAD_KEYSET, NTE_NO_KEY, NTE_NOT_FOUND, NTE_NOT_SUPPORTED, NTE_PERM,
             NTE_SILENT_CONTEXT, NTE_USER_CANCELLED, SCARD_W_CANCELLED_BY_USER,
         },
-        Security::Cryptography::{
-            BCRYPT_PKCS1_PADDING_INFO, BCRYPT_PSS_PADDING_INFO, BCRYPT_SHA256_ALGORITHM,
-            BCRYPT_SHA384_ALGORITHM, BCRYPT_SHA512_ALGORITHM, CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL,
-            CERT_CHAIN_DISABLE_AIA, CERT_CHAIN_PARA, CERT_CONTEXT, CERT_KEY_SPEC,
-            CERT_OPEN_STORE_FLAGS, CERT_QUERY_ENCODING_TYPE, CERT_STORE_OPEN_EXISTING_FLAG,
-            CERT_STORE_PROV_SYSTEM_W, CERT_STORE_READONLY_FLAG, CERT_SYSTEM_STORE_LOCAL_MACHINE,
-            CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG, CRYPT_ACQUIRE_SILENT_FLAG, CertCloseStore,
-            CertDuplicateCertificateContext, CertEnumCertificatesInStore, CertFreeCertificateChain,
-            CertFreeCertificateContext, CertGetCertificateChain, CertOpenStore,
-            CryptAcquireCertificatePrivateKey, HCERTSTORE, HCRYPTPROV_OR_NCRYPT_KEY_HANDLE,
-            NCRYPT_FLAGS, NCRYPT_HANDLE, NCRYPT_KEY_HANDLE, NCRYPT_PAD_PKCS1_FLAG,
-            NCRYPT_PAD_PSS_FLAG, NCryptFreeObject, NCryptSignHash,
+        Security::{
+            Cryptography::{
+                BCRYPT_PKCS1_PADDING_INFO, BCRYPT_PSS_PADDING_INFO, BCRYPT_SHA256_ALGORITHM,
+                BCRYPT_SHA384_ALGORITHM, BCRYPT_SHA512_ALGORITHM,
+                CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL, CERT_CHAIN_DISABLE_AIA, CERT_CHAIN_PARA,
+                CERT_CONTEXT, CERT_KEY_SPEC, CERT_NCRYPT_KEY_SPEC, CERT_OPEN_STORE_FLAGS,
+                CERT_QUERY_ENCODING_TYPE, CERT_STORE_OPEN_EXISTING_FLAG, CERT_STORE_PROV_SYSTEM_W,
+                CERT_STORE_READONLY_FLAG, CERT_SYSTEM_STORE_LOCAL_MACHINE, CRYPT_ACQUIRE_FLAGS,
+                CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG, CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG,
+                CRYPT_ACQUIRE_SILENT_FLAG, CertCloseStore, CertDuplicateCertificateContext,
+                CertEnumCertificatesInStore, CertFreeCertificateChain, CertFreeCertificateContext,
+                CertGetCertificateChain, CertOpenStore, CryptAcquireCertificatePrivateKey,
+                CryptReleaseContext, HCERTSTORE, HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, NCRYPT_FLAGS,
+                NCRYPT_HANDLE, NCRYPT_KEY_HANDLE, NCRYPT_PAD_PKCS1_FLAG, NCRYPT_PAD_PSS_FLAG,
+                NCRYPT_PCP_PSS_SALT_SIZE_PROPERTY, NCRYPT_TPM_PSS_SALT_SIZE_HASHSIZE,
+                NCryptFreeObject, NCryptGetProperty, NCryptSignHash,
+            },
+            OBJECT_SECURITY_INFORMATION,
         },
     },
     core::w,
@@ -63,12 +69,16 @@ pub(crate) fn identity(subject_cn: &str) -> Result<Option<Identity>, Error> {
         .cloned()
         .map(CertificateDer::from)
         .collect();
-    let key = Arc::new(sign::Key::new(
+    let key = sign::Key::new(
         certificate.algorithm,
         CngKey {
             context: Arc::new(CertificateContext(signing_context)),
         },
-    ));
+    );
+    let key = Arc::new(match certificate.signs_rsa_pss {
+        true => key,
+        false => key.without_rsa_pss(),
+    });
 
     tracing::debug!(
         store = STORE.1,
@@ -108,54 +118,55 @@ unsafe fn sign_with_certificate(
     scheme: SignatureScheme,
     message: &[u8],
 ) -> Result<Vec<u8>, SigningError> {
-    let key = unsafe { acquire_key(context) }.map_err(classify_signing_error)?;
+    let key = unsafe { acquire_key(context, CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG) }
+        .map_err(|error| classify_signing_error(error, scheme))?;
 
-    match scheme {
+    let signature = match scheme {
         SignatureScheme::RSA_PSS_SHA256 => unsafe {
             sign_rsa_pss(
-                key.handle,
+                key.ncrypt(),
                 BCRYPT_SHA256_ALGORITHM,
                 &Sha256::digest(message),
             )
         },
         SignatureScheme::RSA_PSS_SHA384 => unsafe {
             sign_rsa_pss(
-                key.handle,
+                key.ncrypt(),
                 BCRYPT_SHA384_ALGORITHM,
                 &Sha384::digest(message),
             )
         },
         SignatureScheme::RSA_PSS_SHA512 => unsafe {
             sign_rsa_pss(
-                key.handle,
+                key.ncrypt(),
                 BCRYPT_SHA512_ALGORITHM,
                 &Sha512::digest(message),
             )
         },
         SignatureScheme::RSA_PKCS1_SHA256 => unsafe {
             sign_rsa_pkcs1(
-                key.handle,
+                key.ncrypt(),
                 BCRYPT_SHA256_ALGORITHM,
                 &Sha256::digest(message),
             )
         },
         SignatureScheme::RSA_PKCS1_SHA384 => unsafe {
             sign_rsa_pkcs1(
-                key.handle,
+                key.ncrypt(),
                 BCRYPT_SHA384_ALGORITHM,
                 &Sha384::digest(message),
             )
         },
         SignatureScheme::RSA_PKCS1_SHA512 => unsafe {
             sign_rsa_pkcs1(
-                key.handle,
+                key.ncrypt(),
                 BCRYPT_SHA512_ALGORITHM,
                 &Sha512::digest(message),
             )
         },
         SignatureScheme::ECDSA_NISTP256_SHA256 => unsafe {
             sign_hash(
-                key.handle,
+                key.ncrypt(),
                 None,
                 &Sha256::digest(message),
                 NCRYPT_FLAGS::default(),
@@ -163,7 +174,7 @@ unsafe fn sign_with_certificate(
         },
         SignatureScheme::ECDSA_NISTP384_SHA384 => unsafe {
             sign_hash(
-                key.handle,
+                key.ncrypt(),
                 None,
                 &Sha384::digest(message),
                 NCRYPT_FLAGS::default(),
@@ -171,21 +182,26 @@ unsafe fn sign_with_certificate(
         },
         SignatureScheme::ECDSA_NISTP521_SHA512 => unsafe {
             sign_hash(
-                key.handle,
+                key.ncrypt(),
                 None,
                 &Sha512::digest(message),
                 NCRYPT_FLAGS::default(),
             )
         },
-        _ => Err(SigningError::UnsupportedScheme(scheme)),
+        _ => return Err(SigningError::UnsupportedScheme(scheme)),
     }
+    .map_err(|error| classify_signing_error(error, scheme))?;
+
+    Ok(signature)
 }
 
-/// Names the cause behind a failed CNG key operation.
+/// Names the cause behind a failed CNG key operation on `scheme`.
 ///
 /// Windows reports a declined confirmation prompt and a missing key-usage permission as different
 /// codes, but both mean the same to us: the keystore is there and refuses to use the key.
-fn classify_signing_error(error: windows_core::Error) -> SigningError {
+/// `NTE_NOT_SUPPORTED` is how a provider turns down the padding rather than the key, which its own
+/// message ("The requested operation is not supported") leaves for the reader to work out.
+fn classify_signing_error(error: windows_core::Error, scheme: SignatureScheme) -> SigningError {
     let reason = error.to_string();
 
     match error.code() {
@@ -197,6 +213,7 @@ fn classify_signing_error(error: windows_core::Error) -> SigningError {
         NTE_USER_CANCELLED => SigningError::AccessDenied(reason),
         SCARD_W_CANCELLED_BY_USER => SigningError::AccessDenied(reason),
         E_ACCESSDENIED => SigningError::AccessDenied(reason),
+        NTE_NOT_SUPPORTED => SigningError::UnsupportedScheme(scheme),
         _ => SigningError::Keystore(reason),
     }
 }
@@ -205,7 +222,7 @@ unsafe fn sign_rsa_pss(
     key: NCRYPT_KEY_HANDLE,
     hash_algorithm: windows_core::PCWSTR,
     hash: &[u8],
-) -> Result<Vec<u8>, SigningError> {
+) -> windows_core::Result<Vec<u8>> {
     let padding = BCRYPT_PSS_PADDING_INFO {
         pszAlgId: hash_algorithm,
         cbSalt: hash.len() as u32,
@@ -226,7 +243,7 @@ unsafe fn sign_rsa_pkcs1(
     key: NCRYPT_KEY_HANDLE,
     hash_algorithm: windows_core::PCWSTR,
     hash: &[u8],
-) -> Result<Vec<u8>, SigningError> {
+) -> windows_core::Result<Vec<u8>> {
     let padding = BCRYPT_PKCS1_PADDING_INFO {
         pszAlgId: hash_algorithm,
     };
@@ -247,10 +264,9 @@ unsafe fn sign_hash(
     padding: Option<*const c_void>,
     hash: &[u8],
     flags: NCRYPT_FLAGS,
-) -> Result<Vec<u8>, SigningError> {
+) -> windows_core::Result<Vec<u8>> {
     let mut needed = 0;
-    unsafe { NCryptSignHash(key, padding, hash, None, &mut needed, flags) }
-        .map_err(classify_signing_error)?;
+    unsafe { NCryptSignHash(key, padding, hash, None, &mut needed, flags) }?;
 
     let mut signature = vec![0; needed as usize];
     let mut written = 0;
@@ -263,8 +279,7 @@ unsafe fn sign_hash(
             &mut written,
             flags,
         )
-    }
-    .map_err(classify_signing_error)?;
+    }?;
     signature.truncate(written as usize);
 
     Ok(signature)
@@ -276,6 +291,8 @@ struct Certificate {
     chain: Vec<Vec<u8>>,
     metadata: ParsedCertificate,
     algorithm: SigningAlgorithm,
+    /// Whether the provider will produce RSA-PSS signatures; vacuously true for an ECDSA key.
+    signs_rsa_pss: bool,
 }
 
 impl CandidateCertificate for Certificate {
@@ -356,7 +373,7 @@ unsafe fn enumerate_store(
             );
             continue;
         };
-        if let Err(error) = unsafe { acquire_key(context) } {
+        if let Err(error) = unsafe { acquire_key(context, CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG) } {
             tracing::debug!(
                 store = label,
                 fingerprint = %metadata.fingerprint,
@@ -365,6 +382,15 @@ unsafe fn enumerate_store(
             );
             continue;
         }
+
+        let signs_rsa_pss = match algorithm {
+            SigningAlgorithm::RsaSha256 => unsafe {
+                provider_signs_rsa_pss(context, &metadata.fingerprint)
+            },
+            SigningAlgorithm::EcdsaSha256 => true,
+            SigningAlgorithm::EcdsaSha384 => true,
+            SigningAlgorithm::EcdsaSha512 => true,
+        };
 
         let chain = match unsafe { certificate_chain(context) } {
             Ok(chain) => chain,
@@ -392,6 +418,7 @@ unsafe fn enumerate_store(
             chain,
             metadata,
             algorithm,
+            signs_rsa_pss,
         });
     }
 
@@ -421,6 +448,79 @@ unsafe fn open_store(location: u32) -> Result<HCERTSTORE> {
     }
 
     Ok(store)
+}
+
+/// Whether the provider holding the certificate's key produces the RSA-PSS signatures TLS 1.3
+/// asks for.
+///
+/// TLS 1.3 mandates a salt as long as the digest, which two kinds of provider cannot deliver: a
+/// TPM that salts differently, and a legacy CryptoAPI provider, which has no RSA-PSS at all. Both
+/// answer a signing request with `NTE_NOT_SUPPORTED`, so the answer is worked out here, from what
+/// they say about themselves rather than from a signature nobody asked for.
+///
+/// Anything else keeps RSA-PSS: no property tells us, and a handshake that fails is a better
+/// answer than a guess that quietly gives up TLS 1.3.
+unsafe fn provider_signs_rsa_pss(context: *mut CERT_CONTEXT, fingerprint: &str) -> bool {
+    let key = match unsafe { acquire_key(context, CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG) } {
+        Ok(key) => key,
+        Err(error) => {
+            tracing::debug!(
+                store = STORE.1,
+                fingerprint,
+                %error,
+                "Assuming RSA-PSS: the provider of this certificate's key did not answer"
+            );
+
+            return true;
+        }
+    };
+
+    if key.key_spec != CERT_NCRYPT_KEY_SPEC {
+        tracing::info!(
+            store = STORE.1,
+            fingerprint,
+            "A legacy CryptoAPI provider holds this certificate's key, which rules out RSA-PSS and with it TLS 1.3"
+        );
+
+        return false;
+    }
+
+    let Some(salt_size) = (unsafe { tpm_pss_salt_size(key.ncrypt()) }) else {
+        return true;
+    };
+    if salt_size == NCRYPT_TPM_PSS_SALT_SIZE_HASHSIZE {
+        return true;
+    }
+
+    tracing::info!(
+        store = STORE.1,
+        fingerprint,
+        salt_size,
+        "The TPM holding this certificate's key salts RSA-PSS differently than TLS 1.3 requires"
+    );
+
+    false
+}
+
+/// The salt size the TPM holding `key` signs RSA-PSS with, if a TPM holds it at all.
+///
+/// Only the Platform Crypto Provider carries this property, so a key without it is one the TPM
+/// never saw rather than one whose provider failed to answer.
+unsafe fn tpm_pss_salt_size(key: NCRYPT_KEY_HANDLE) -> Option<u32> {
+    let mut value = 0u32.to_ne_bytes();
+    let mut written = 0;
+    unsafe {
+        NCryptGetProperty(
+            NCRYPT_HANDLE(key.0),
+            NCRYPT_PCP_PSS_SALT_SIZE_PROPERTY,
+            Some(&mut value),
+            &mut written,
+            OBJECT_SECURITY_INFORMATION::default(),
+        )
+    }
+    .ok()?;
+
+    Some(u32::from_ne_bytes(value))
 }
 
 /// Collects the leaf and every issuer Windows can resolve from its local caches.
@@ -514,32 +614,52 @@ impl Drop for CertificateContext {
 }
 
 struct AcquiredKey {
-    handle: NCRYPT_KEY_HANDLE,
+    handle: HCRYPTPROV_OR_NCRYPT_KEY_HANDLE,
+    /// Which of the two key APIs answered, which also decides how the handle is released.
+    key_spec: CERT_KEY_SPEC,
     must_free: bool,
+}
+
+impl AcquiredKey {
+    /// The handle CNG signs with, which is what [`acquire_key`] answers with unless it fell back
+    /// to CryptoAPI.
+    fn ncrypt(&self) -> NCRYPT_KEY_HANDLE {
+        NCRYPT_KEY_HANDLE(self.handle.0)
+    }
 }
 
 impl Drop for AcquiredKey {
     fn drop(&mut self) {
-        if self.must_free {
-            unsafe {
+        if !self.must_free {
+            return;
+        }
+
+        match self.key_spec {
+            CERT_NCRYPT_KEY_SPEC => unsafe {
                 let _ = NCryptFreeObject(NCRYPT_HANDLE(self.handle.0));
-            }
+            },
+            _ => unsafe {
+                let _ = CryptReleaseContext(self.handle.0, 0);
+            },
         }
     }
 }
 
-/// Opens the certificate's CNG key without ever showing UI.
+/// Opens the certificate's private key through `flags`, without ever showing UI.
 ///
 /// The Tunnel service runs without a desktop, so a key that insists on a confirmation prompt is
 /// reported as [`SigningError::AccessDenied`] rather than hanging the connection.
-unsafe fn acquire_key(context: *mut CERT_CONTEXT) -> windows_core::Result<AcquiredKey> {
+unsafe fn acquire_key(
+    context: *mut CERT_CONTEXT,
+    flags: CRYPT_ACQUIRE_FLAGS,
+) -> windows_core::Result<AcquiredKey> {
     let mut handle = HCRYPTPROV_OR_NCRYPT_KEY_HANDLE::default();
     let mut key_spec = CERT_KEY_SPEC::default();
     let mut must_free = windows_core::BOOL(0);
     unsafe {
         CryptAcquireCertificatePrivateKey(
             context,
-            CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG | CRYPT_ACQUIRE_SILENT_FLAG,
+            flags | CRYPT_ACQUIRE_SILENT_FLAG,
             None,
             &mut handle,
             Some(&mut key_spec),
@@ -548,7 +668,8 @@ unsafe fn acquire_key(context: *mut CERT_CONTEXT) -> windows_core::Result<Acquir
     }?;
 
     Ok(AcquiredKey {
-        handle: NCRYPT_KEY_HANDLE(handle.0),
+        handle,
+        key_spec,
         must_free: must_free.as_bool(),
     })
 }

--- a/rust/libs/x509-keystore/src/windows/mint-certificate.ps1
+++ b/rust/libs/x509-keystore/src/windows/mint-certificate.ps1
@@ -13,7 +13,11 @@ param(
 
     [Parameter(Mandatory)]
     [ValidateSet('Rsa', 'EcdsaP256')]
-    [string]$Algorithm
+    [string]$Algorithm,
+
+    [Parameter(Mandatory)]
+    [ValidateSet('SoftwareKsp', 'LegacyCsp')]
+    [string]$KeyStorage
 )
 
 $ErrorActionPreference = 'Stop'
@@ -23,10 +27,16 @@ $parameters = @{
     Type              = 'Custom'
     Subject           = "CN=$SubjectCn"
     CertStoreLocation = 'Cert:\LocalMachine\My'
-    Provider          = 'Microsoft Software Key Storage Provider'
     KeyExportPolicy   = 'NonExportable'
     KeyUsage          = 'DigitalSignature'
     TextExtension     = @('2.5.29.37={text}1.3.6.1.5.5.7.3.2')
+}
+
+# The legacy CryptoAPI providers implement no RSA-PSS at all, which is what makes a key in one
+# stand in for a key in a TPM: both refuse the padding a TLS 1.3 handshake is signed with.
+switch ($KeyStorage) {
+    'SoftwareKsp' { $parameters.Provider = 'Microsoft Software Key Storage Provider' }
+    'LegacyCsp' { $parameters.Provider = 'Microsoft Enhanced RSA and AES Cryptographic Provider' }
 }
 
 switch ($Algorithm) {

--- a/rust/libs/x509-keystore/src/windows/mint-certificate.ps1
+++ b/rust/libs/x509-keystore/src/windows/mint-certificate.ps1
@@ -34,9 +34,16 @@ $parameters = @{
 
 # The legacy CryptoAPI providers implement no RSA-PSS at all, which is what makes a key in one
 # stand in for a key in a TPM: both refuse the padding a TLS 1.3 handshake is signed with.
+#
+# A CryptoAPI provider is addressed by its name and a provider type, and naming a key
+# specification is what makes the cmdlet resolve the type: without one it asks for the provider
+# type CryptoAPI has no definition for, and fails with NTE_PROV_TYPE_NOT_DEF.
 switch ($KeyStorage) {
     'SoftwareKsp' { $parameters.Provider = 'Microsoft Software Key Storage Provider' }
-    'LegacyCsp' { $parameters.Provider = 'Microsoft Enhanced RSA and AES Cryptographic Provider' }
+    'LegacyCsp' {
+        $parameters.Provider = 'Microsoft Enhanced RSA and AES Cryptographic Provider'
+        $parameters.KeySpec = 'KeyExchange'
+    }
 }
 
 switch ($Algorithm) {

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -38,12 +38,12 @@ fn signs_with_the_cng_key_of_an_rsa_certificate() {
     assert_eq!(
         identity.key.supported_schemes(),
         vec![
-            SignatureScheme::RSA_PSS_SHA512,
-            SignatureScheme::RSA_PSS_SHA384,
             SignatureScheme::RSA_PSS_SHA256,
-            SignatureScheme::RSA_PKCS1_SHA512,
-            SignatureScheme::RSA_PKCS1_SHA384,
             SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::RSA_PKCS1_SHA512,
         ]
     );
     assert_signs_every_advertised_scheme(&identity, &minted.der);
@@ -67,9 +67,9 @@ fn a_certificate_whose_key_a_legacy_provider_holds_advertises_no_rsa_pss() {
     assert_eq!(
         identity.key.supported_schemes(),
         vec![
-            SignatureScheme::RSA_PKCS1_SHA512,
-            SignatureScheme::RSA_PKCS1_SHA384,
             SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
         ]
     );
     assert_signs_every_advertised_scheme(&identity, &minted.der);

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -27,7 +27,7 @@ use crate::DetailField;
 fn signs_with_the_cng_key_of_an_rsa_certificate() {
     let _serialized = serialize_certificate_store_access();
     let subject_cn = unique_subject_cn("rsa");
-    let minted = mint_certificate(&subject_cn, KeyAlgorithm::Rsa);
+    let minted = mint_certificate(&subject_cn, KeyAlgorithm::Rsa, KeyStorage::SoftwareKsp);
 
     let identity = super::identity(&subject_cn)
         .expect("the Windows certificate stores should be readable")
@@ -35,6 +35,43 @@ fn signs_with_the_cng_key_of_an_rsa_certificate() {
 
     assert_eq!(leaf_of(&identity), minted.der);
     assert_eq!(identity.key.algorithm(), SignatureAlgorithm::RSA);
+    assert_eq!(
+        identity.key.supported_schemes(),
+        vec![
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA256,
+        ]
+    );
+    assert_signs_every_advertised_scheme(&identity, &minted.der);
+}
+
+/// The `Microsoft Enhanced RSA and AES Cryptographic Provider` is a CryptoAPI provider, whose keys
+/// CNG can sign PKCS#1 v1.5 with but never RSA-PSS. That is the refusal a TPM-held key answers a
+/// TLS 1.3 handshake with, on a runner that has no TPM to provision a key in.
+#[test]
+#[ignore = "Writes to the LocalMachine certificate store"]
+fn a_certificate_whose_key_a_legacy_provider_holds_advertises_no_rsa_pss() {
+    let _serialized = serialize_certificate_store_access();
+    let subject_cn = unique_subject_cn("legacy-csp");
+    let minted = mint_certificate(&subject_cn, KeyAlgorithm::Rsa, KeyStorage::LegacyCsp);
+
+    let identity = super::identity(&subject_cn)
+        .expect("the Windows certificate stores should be readable")
+        .expect("the minted certificate should be selected as the client identity");
+
+    assert_eq!(leaf_of(&identity), minted.der);
+    assert_eq!(
+        identity.key.supported_schemes(),
+        vec![
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA256,
+        ]
+    );
     assert_signs_every_advertised_scheme(&identity, &minted.der);
 }
 
@@ -43,7 +80,11 @@ fn signs_with_the_cng_key_of_an_rsa_certificate() {
 fn signs_with_the_cng_key_of_an_ecdsa_certificate() {
     let _serialized = serialize_certificate_store_access();
     let subject_cn = unique_subject_cn("ecdsa");
-    let minted = mint_certificate(&subject_cn, KeyAlgorithm::EcdsaP256);
+    let minted = mint_certificate(
+        &subject_cn,
+        KeyAlgorithm::EcdsaP256,
+        KeyStorage::SoftwareKsp,
+    );
 
     let identity = super::identity(&subject_cn)
         .expect("the Windows certificate stores should be readable")
@@ -63,7 +104,7 @@ fn signs_with_the_cng_key_of_an_ecdsa_certificate() {
 fn describes_the_minted_certificate_it_loads() {
     let _serialized = serialize_certificate_store_access();
     let subject_cn = unique_subject_cn("describe");
-    let _minted = mint_certificate(&subject_cn, KeyAlgorithm::Rsa);
+    let _minted = mint_certificate(&subject_cn, KeyAlgorithm::Rsa, KeyStorage::SoftwareKsp);
 
     let identity = super::identity(&subject_cn)
         .expect("the Windows certificate stores should be readable")
@@ -94,20 +135,26 @@ fn reports_no_identity_when_no_certificate_matches() {
 
 #[test]
 fn names_the_cause_behind_a_cng_failure() {
+    let scheme = SignatureScheme::RSA_PSS_SHA256;
+
     assert!(matches!(
-        classify_signing_error(NTE_NO_KEY.into()),
+        classify_signing_error(NTE_NO_KEY.into(), scheme),
         SigningError::KeyUnavailable(_)
     ));
     assert!(matches!(
-        classify_signing_error(NTE_SILENT_CONTEXT.into()),
+        classify_signing_error(NTE_SILENT_CONTEXT.into(), scheme),
         SigningError::AccessDenied(_)
     ));
     assert!(matches!(
-        classify_signing_error(SCARD_W_CANCELLED_BY_USER.into()),
+        classify_signing_error(SCARD_W_CANCELLED_BY_USER.into(), scheme),
         SigningError::AccessDenied(_)
     ));
     assert!(matches!(
-        classify_signing_error(windows::Win32::Foundation::E_UNEXPECTED.into()),
+        classify_signing_error(NTE_NOT_SUPPORTED.into(), scheme),
+        SigningError::UnsupportedScheme(SignatureScheme::RSA_PSS_SHA256)
+    ));
+    assert!(matches!(
+        classify_signing_error(windows::Win32::Foundation::E_UNEXPECTED.into(), scheme),
         SigningError::Keystore(_)
     ));
 }
@@ -212,6 +259,12 @@ enum KeyAlgorithm {
     EcdsaP256,
 }
 
+/// Where a minted certificate's private key lives, which decides what it can sign with.
+enum KeyStorage {
+    SoftwareKsp,
+    LegacyCsp,
+}
+
 /// The script that mints a certificate, resolved at compile time so the tests do not depend on the
 /// working directory.
 const MINT_CERTIFICATE_SCRIPT: &str = concat!(
@@ -220,10 +273,21 @@ const MINT_CERTIFICATE_SCRIPT: &str = concat!(
 );
 
 /// Creates a certificate for `subject_cn` that satisfies Firezone's rules for a client identity.
-fn mint_certificate(subject_cn: &str, algorithm: KeyAlgorithm) -> MintedCertificate {
+fn mint_certificate(
+    subject_cn: &str,
+    algorithm: KeyAlgorithm,
+    storage: KeyStorage,
+) -> MintedCertificate {
     let output = powershell(
         MINT_CERTIFICATE_SCRIPT,
-        &["-SubjectCn", subject_cn, "-Algorithm", algorithm.argument()],
+        &[
+            "-SubjectCn",
+            subject_cn,
+            "-Algorithm",
+            algorithm.argument(),
+            "-KeyStorage",
+            storage.argument(),
+        ],
     )
     .unwrap_or_else(|error| panic!("PowerShell should mint a certificate: {error:#}"));
 
@@ -251,6 +315,16 @@ impl KeyAlgorithm {
         match self {
             Self::Rsa => "Rsa",
             Self::EcdsaP256 => "EcdsaP256",
+        }
+    }
+}
+
+impl KeyStorage {
+    /// Returns the value [`MINT_CERTIFICATE_SCRIPT`] expects for its `-KeyStorage` parameter.
+    fn argument(&self) -> &'static str {
+        match self {
+            Self::SoftwareKsp => "SoftwareKsp",
+            Self::LegacyCsp => "LegacyCsp",
         }
     }
 }


### PR DESCRIPTION
An Intune-provisioned RSA certificate on a Windows machine with a firmware TPM cannot sign in: the key lives in the Microsoft Platform Crypto Provider, TLS 1.3 mandates RSA-PSS with a digest-length salt for `rsa_pss_rsae_*`, and consumer TPM firmware signs PSS only with the maximum salt or not at all, so `NCryptSignHash` answers `NTE_NOT_SUPPORTED`. Intune issues no ECC keys for Windows, so this is the key every customer on modern hardware gets.

The keystore now learns at selection time whether a key can sign PSS, from properties rather than a trial signature: the Platform Crypto Provider reports its PSS salt size, and a key held by a legacy CSP shows itself through the key spec `CryptAcquireCertificatePrivateKey` returns when asked to prefer rather than require CNG. A key that cannot do PSS offers only the PKCS#1 schemes, and a certificate whose key offers no scheme a TLS 1.3 handshake can use is negotiated over TLS 1.2, where `rsa_pkcs1_sha256` is still allowed. ECDSA keys and software-KSP RSA keys are unaffected. The portal accepts TLS 1.2 today.