### PR TITLE
fix(snownet): drop ufrag mapping of failed connections

### DIFF
--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -65,6 +65,7 @@ where
                 .insert(conn.tunnel.remote_static_public().to_bytes(), now);
             self.disconnected_ids.insert(id, now);
             if let Some(ufrag) = conn.agent.local_ufrag() {
+                self.established_by_local_ufrag.remove(ufrag);
                 self.disconnected_ufrags.insert(ufrag.to_owned(), now);
             }
         }


### PR DESCRIPTION
`Connections::handle_timeout` removes failed connections from `established` and records them in the `disconnected_*` maps, but leaves their entry in `established_by_local_ufrag`. That entry is only cleaned up in `remove_established`, so every ICE-failed connection leaks its ufrag mapping for the lifetime of the node. Late STUN binding requests for such a ufrag also resolve to an id that no longer exists, so they are reported as "No connection for id" instead of "No connection for ufrag" and lose the recent-disconnect hint.