### PR TITLE
fix(x509): sign TLS handshakes with SHA-256 only

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/x509/KeyChainTlsIdentity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/x509/KeyChainTlsIdentity.kt
@@ -77,18 +77,15 @@ internal class KeyChainTlsIdentity(
             }
 
         /**
-         * The RSA schemes a [modulusBits]-bit key has room for, strongest first.
+         * The SHA-256 RSA schemes a [modulusBits]-bit key has room for, PSS first.
          *
+         * SHA-256 is the one digest every TPM profile mandates and every TLS server has to accept.
          * PSS needs the digest, a salt of the same length and two more bytes; PKCS#1 v1.5 needs the
          * digest, its 19-byte DigestInfo header and at least 11 bytes of padding.
          */
         private fun rsaSchemes(modulusBits: Int): List<TlsSignatureScheme> =
             listOfNotNull(
-                TlsSignatureScheme.RSA_PSS_SHA512.takeIf { modulusBits >= 8 * (64 + 64 + 2) },
-                TlsSignatureScheme.RSA_PSS_SHA384.takeIf { modulusBits >= 8 * (48 + 48 + 2) },
                 TlsSignatureScheme.RSA_PSS_SHA256.takeIf { modulusBits >= 8 * (32 + 32 + 2) },
-                TlsSignatureScheme.RSA_PKCS1_SHA512.takeIf { modulusBits >= 8 * (64 + 19 + 11) },
-                TlsSignatureScheme.RSA_PKCS1_SHA384.takeIf { modulusBits >= 8 * (48 + 19 + 11) },
                 TlsSignatureScheme.RSA_PKCS1_SHA256.takeIf { modulusBits >= 8 * (32 + 19 + 11) },
             ).ifEmpty {
                 throw X509IdentityException(

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/x509/KeyChainTlsIdentityTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/x509/KeyChainTlsIdentityTest.kt
@@ -12,16 +12,12 @@ import java.security.spec.ECGenParameterSpec
 
 class KeyChainTlsIdentityTest {
     @Test
-    fun `offers every RSA scheme a 2048-bit key has room for`() {
+    fun `offers PSS ahead of PKCS#1 for a 2048-bit RSA key`() {
         val keyPair = rsaKeyPair(2048)
 
         assertEquals(
             listOf(
-                TlsSignatureScheme.RSA_PSS_SHA512,
-                TlsSignatureScheme.RSA_PSS_SHA384,
                 TlsSignatureScheme.RSA_PSS_SHA256,
-                TlsSignatureScheme.RSA_PKCS1_SHA512,
-                TlsSignatureScheme.RSA_PKCS1_SHA384,
                 TlsSignatureScheme.RSA_PKCS1_SHA256,
             ),
             KeyChainTlsIdentity.signatureSchemes(keyPair.public),
@@ -29,17 +25,11 @@ class KeyChainTlsIdentityTest {
     }
 
     @Test
-    fun `drops the RSA schemes a 1024-bit key has no room for`() {
-        val keyPair = rsaKeyPair(1024)
+    fun `drops the PSS scheme a 512-bit key has no room for`() {
+        val keyPair = rsaKeyPair(512)
 
         assertEquals(
-            listOf(
-                TlsSignatureScheme.RSA_PSS_SHA384,
-                TlsSignatureScheme.RSA_PSS_SHA256,
-                TlsSignatureScheme.RSA_PKCS1_SHA512,
-                TlsSignatureScheme.RSA_PKCS1_SHA384,
-                TlsSignatureScheme.RSA_PKCS1_SHA256,
-            ),
+            listOf(TlsSignatureScheme.RSA_PKCS1_SHA256),
             KeyChainTlsIdentity.signatureSchemes(keyPair.public),
         )
     }

--- a/rust/libs/x509-keystore/src/linux.rs
+++ b/rust/libs/x509-keystore/src/linux.rs
@@ -158,11 +158,7 @@ fn sign_with_key(
 ) -> Result<Vec<u8>, SigningError> {
     let signature = match scheme {
         SignatureScheme::RSA_PSS_SHA256 => session.sign(&Mechanism::Sha256RsaPkcsPss, key, message),
-        SignatureScheme::RSA_PSS_SHA384 => session.sign(&Mechanism::Sha384RsaPkcsPss, key, message),
-        SignatureScheme::RSA_PSS_SHA512 => session.sign(&Mechanism::Sha512RsaPkcsPss, key, message),
         SignatureScheme::RSA_PKCS1_SHA256 => session.sign(&Mechanism::Sha256RsaPkcs, key, message),
-        SignatureScheme::RSA_PKCS1_SHA384 => session.sign(&Mechanism::Sha384RsaPkcs, key, message),
-        SignatureScheme::RSA_PKCS1_SHA512 => session.sign(&Mechanism::Sha512RsaPkcs, key, message),
         SignatureScheme::ECDSA_NISTP256_SHA256 => {
             session.sign(&Mechanism::Ecdsa, key, &Sha256::digest(message))
         }

--- a/rust/libs/x509-keystore/src/linux/rpc.rs
+++ b/rust/libs/x509-keystore/src/linux/rpc.rs
@@ -453,11 +453,7 @@ impl Drop for Session {
 #[derive(Debug)]
 pub(crate) enum Mechanism {
     Sha256RsaPkcs,
-    Sha384RsaPkcs,
-    Sha512RsaPkcs,
     Sha256RsaPkcsPss,
-    Sha384RsaPkcsPss,
-    Sha512RsaPkcsPss,
     Ecdsa,
 }
 
@@ -471,31 +467,15 @@ impl Mechanism {
     /// version it negotiated names.
     fn encode(&self, buffer: &mut Vec<u8>, protocol_version: u8) {
         const CKM_SHA256_RSA_PKCS: u32 = 0x0000_0040;
-        const CKM_SHA384_RSA_PKCS: u32 = 0x0000_0041;
-        const CKM_SHA512_RSA_PKCS: u32 = 0x0000_0042;
         const CKM_SHA256_RSA_PKCS_PSS: u32 = 0x0000_0043;
-        const CKM_SHA384_RSA_PKCS_PSS: u32 = 0x0000_0044;
-        const CKM_SHA512_RSA_PKCS_PSS: u32 = 0x0000_0045;
         const CKM_ECDSA: u32 = 0x0000_1041;
         const CKM_SHA256: u64 = 0x0000_0250;
-        const CKM_SHA384: u64 = 0x0000_0260;
-        const CKM_SHA512: u64 = 0x0000_0270;
         const MGF1_SHA256: u64 = 0x0000_0002;
-        const MGF1_SHA384: u64 = 0x0000_0003;
-        const MGF1_SHA512: u64 = 0x0000_0004;
 
         let (mechanism, pss) = match self {
             Self::Sha256RsaPkcs => (CKM_SHA256_RSA_PKCS, None),
-            Self::Sha384RsaPkcs => (CKM_SHA384_RSA_PKCS, None),
-            Self::Sha512RsaPkcs => (CKM_SHA512_RSA_PKCS, None),
             Self::Sha256RsaPkcsPss => {
                 (CKM_SHA256_RSA_PKCS_PSS, Some((CKM_SHA256, MGF1_SHA256, 32)))
-            }
-            Self::Sha384RsaPkcsPss => {
-                (CKM_SHA384_RSA_PKCS_PSS, Some((CKM_SHA384, MGF1_SHA384, 48)))
-            }
-            Self::Sha512RsaPkcsPss => {
-                (CKM_SHA512_RSA_PKCS_PSS, Some((CKM_SHA512, MGF1_SHA512, 64)))
             }
             Self::Ecdsa => (CKM_ECDSA, None),
         };

--- a/rust/libs/x509-keystore/src/linux/tests.rs
+++ b/rust/libs/x509-keystore/src/linux/tests.rs
@@ -23,9 +23,8 @@ use cryptoki::{
     types::{AuthPin, Ulong},
 };
 use ring::signature::{
-    ECDSA_P256_SHA256_ASN1, RSA_PKCS1_2048_8192_SHA256, RSA_PKCS1_2048_8192_SHA384,
-    RSA_PKCS1_2048_8192_SHA512, RSA_PSS_2048_8192_SHA256, RSA_PSS_2048_8192_SHA384,
-    RSA_PSS_2048_8192_SHA512, UnparsedPublicKey, VerificationAlgorithm,
+    ECDSA_P256_SHA256_ASN1, RSA_PKCS1_2048_8192_SHA256, RSA_PSS_2048_8192_SHA256,
+    UnparsedPublicKey, VerificationAlgorithm,
 };
 use rustls::SignatureAlgorithm;
 use secrecy::ExposeSecret as _;
@@ -572,11 +571,7 @@ fn assert_signs_every_advertised_scheme(identity: &Identity, certificate: &[u8])
 fn verification_algorithm(scheme: SignatureScheme) -> &'static dyn VerificationAlgorithm {
     match scheme {
         SignatureScheme::RSA_PSS_SHA256 => &RSA_PSS_2048_8192_SHA256,
-        SignatureScheme::RSA_PSS_SHA384 => &RSA_PSS_2048_8192_SHA384,
-        SignatureScheme::RSA_PSS_SHA512 => &RSA_PSS_2048_8192_SHA512,
         SignatureScheme::RSA_PKCS1_SHA256 => &RSA_PKCS1_2048_8192_SHA256,
-        SignatureScheme::RSA_PKCS1_SHA384 => &RSA_PKCS1_2048_8192_SHA384,
-        SignatureScheme::RSA_PKCS1_SHA512 => &RSA_PKCS1_2048_8192_SHA512,
         SignatureScheme::ECDSA_NISTP256_SHA256 => &ECDSA_P256_SHA256_ASN1,
         unexpected => panic!("no `ring` verifier for {unexpected:?}"),
     }

--- a/rust/libs/x509-keystore/src/sign.rs
+++ b/rust/libs/x509-keystore/src/sign.rs
@@ -61,14 +61,12 @@ impl<S: Signer> PrivateKey for Key<S> {
 }
 
 /// The schemes a key of `algorithm` signs with, most preferred first.
+///
+/// RSA keys sign with SHA-256 alone: it is the only digest every TPM profile mandates and every TLS server has to accept.
 fn signature_schemes(algorithm: SigningAlgorithm) -> &'static [SignatureScheme] {
     match algorithm {
         SigningAlgorithm::RsaSha256 => &[
-            SignatureScheme::RSA_PSS_SHA512,
-            SignatureScheme::RSA_PSS_SHA384,
             SignatureScheme::RSA_PSS_SHA256,
-            SignatureScheme::RSA_PKCS1_SHA512,
-            SignatureScheme::RSA_PKCS1_SHA384,
             SignatureScheme::RSA_PKCS1_SHA256,
         ],
         SigningAlgorithm::EcdsaSha256 => &[SignatureScheme::ECDSA_NISTP256_SHA256],

--- a/rust/libs/x509-keystore/src/windows.rs
+++ b/rust/libs/x509-keystore/src/windows.rs
@@ -16,16 +16,15 @@ use windows::{
         },
         Security::Cryptography::{
             BCRYPT_PKCS1_PADDING_INFO, BCRYPT_PSS_PADDING_INFO, BCRYPT_SHA256_ALGORITHM,
-            BCRYPT_SHA384_ALGORITHM, BCRYPT_SHA512_ALGORITHM, CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL,
-            CERT_CHAIN_DISABLE_AIA, CERT_CHAIN_PARA, CERT_CONTEXT, CERT_KEY_SPEC,
-            CERT_OPEN_STORE_FLAGS, CERT_QUERY_ENCODING_TYPE, CERT_STORE_OPEN_EXISTING_FLAG,
-            CERT_STORE_PROV_SYSTEM_W, CERT_STORE_READONLY_FLAG, CERT_SYSTEM_STORE_LOCAL_MACHINE,
-            CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG, CRYPT_ACQUIRE_SILENT_FLAG, CertCloseStore,
-            CertDuplicateCertificateContext, CertEnumCertificatesInStore, CertFreeCertificateChain,
-            CertFreeCertificateContext, CertGetCertificateChain, CertOpenStore,
-            CryptAcquireCertificatePrivateKey, HCERTSTORE, HCRYPTPROV_OR_NCRYPT_KEY_HANDLE,
-            NCRYPT_FLAGS, NCRYPT_HANDLE, NCRYPT_KEY_HANDLE, NCRYPT_PAD_PKCS1_FLAG,
-            NCRYPT_PAD_PSS_FLAG, NCryptFreeObject, NCryptSignHash,
+            CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL, CERT_CHAIN_DISABLE_AIA, CERT_CHAIN_PARA,
+            CERT_CONTEXT, CERT_KEY_SPEC, CERT_OPEN_STORE_FLAGS, CERT_QUERY_ENCODING_TYPE,
+            CERT_STORE_OPEN_EXISTING_FLAG, CERT_STORE_PROV_SYSTEM_W, CERT_STORE_READONLY_FLAG,
+            CERT_SYSTEM_STORE_LOCAL_MACHINE, CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG,
+            CRYPT_ACQUIRE_SILENT_FLAG, CertCloseStore, CertDuplicateCertificateContext,
+            CertEnumCertificatesInStore, CertFreeCertificateChain, CertFreeCertificateContext,
+            CertGetCertificateChain, CertOpenStore, CryptAcquireCertificatePrivateKey, HCERTSTORE,
+            HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, NCRYPT_FLAGS, NCRYPT_HANDLE, NCRYPT_KEY_HANDLE,
+            NCRYPT_PAD_PKCS1_FLAG, NCRYPT_PAD_PSS_FLAG, NCryptFreeObject, NCryptSignHash,
         },
     },
     core::w,
@@ -118,39 +117,11 @@ unsafe fn sign_with_certificate(
                 &Sha256::digest(message),
             )
         },
-        SignatureScheme::RSA_PSS_SHA384 => unsafe {
-            sign_rsa_pss(
-                key.handle,
-                BCRYPT_SHA384_ALGORITHM,
-                &Sha384::digest(message),
-            )
-        },
-        SignatureScheme::RSA_PSS_SHA512 => unsafe {
-            sign_rsa_pss(
-                key.handle,
-                BCRYPT_SHA512_ALGORITHM,
-                &Sha512::digest(message),
-            )
-        },
         SignatureScheme::RSA_PKCS1_SHA256 => unsafe {
             sign_rsa_pkcs1(
                 key.handle,
                 BCRYPT_SHA256_ALGORITHM,
                 &Sha256::digest(message),
-            )
-        },
-        SignatureScheme::RSA_PKCS1_SHA384 => unsafe {
-            sign_rsa_pkcs1(
-                key.handle,
-                BCRYPT_SHA384_ALGORITHM,
-                &Sha384::digest(message),
-            )
-        },
-        SignatureScheme::RSA_PKCS1_SHA512 => unsafe {
-            sign_rsa_pkcs1(
-                key.handle,
-                BCRYPT_SHA512_ALGORITHM,
-                &Sha512::digest(message),
             )
         },
         SignatureScheme::ECDSA_NISTP256_SHA256 => unsafe {

--- a/rust/libs/x509-keystore/src/windows/tests.rs
+++ b/rust/libs/x509-keystore/src/windows/tests.rs
@@ -12,9 +12,8 @@ use std::{
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use ring::signature::{
-    ECDSA_P256_SHA256_ASN1, RSA_PKCS1_2048_8192_SHA256, RSA_PKCS1_2048_8192_SHA384,
-    RSA_PKCS1_2048_8192_SHA512, RSA_PSS_2048_8192_SHA256, RSA_PSS_2048_8192_SHA384,
-    RSA_PSS_2048_8192_SHA512, UnparsedPublicKey, VerificationAlgorithm,
+    ECDSA_P256_SHA256_ASN1, RSA_PKCS1_2048_8192_SHA256, RSA_PSS_2048_8192_SHA256,
+    UnparsedPublicKey, VerificationAlgorithm,
 };
 use rustls::SignatureAlgorithm;
 use x509_parser::prelude::{FromDer as _, X509Certificate};
@@ -190,11 +189,7 @@ fn assert_signs_every_advertised_scheme(identity: &Identity, certificate: &[u8])
 fn verification_algorithm(scheme: SignatureScheme) -> &'static dyn VerificationAlgorithm {
     match scheme {
         SignatureScheme::RSA_PSS_SHA256 => &RSA_PSS_2048_8192_SHA256,
-        SignatureScheme::RSA_PSS_SHA384 => &RSA_PSS_2048_8192_SHA384,
-        SignatureScheme::RSA_PSS_SHA512 => &RSA_PSS_2048_8192_SHA512,
         SignatureScheme::RSA_PKCS1_SHA256 => &RSA_PKCS1_2048_8192_SHA256,
-        SignatureScheme::RSA_PKCS1_SHA384 => &RSA_PKCS1_2048_8192_SHA384,
-        SignatureScheme::RSA_PKCS1_SHA512 => &RSA_PKCS1_2048_8192_SHA512,
         SignatureScheme::ECDSA_NISTP256_SHA256 => &ECDSA_P256_SHA256_ASN1,
         unexpected => panic!("no `ring` verifier for {unexpected:?}"),
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Keychain/X509Identity.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Keychain/X509Identity.swift
@@ -124,10 +124,9 @@ public final class X509ClientIdentity: @unchecked Sendable {
 
 /// Loads the identity referenced by `NEVPNProtocol.identityReference`.
 public enum X509Identity {
+  /// SHA-256 is the one digest every TPM profile mandates and every TLS server has to accept.
   /// PSS first: TLS 1.3 accepts only PSS, and TLS 1.2 accepts either padding.
-  private static let rsaSchemes: [X509SignatureScheme] = [
-    .rsaPssSha512, .rsaPssSha384, .rsaPssSha256, .rsaPkcs1Sha512, .rsaPkcs1Sha384, .rsaPkcs1Sha256,
-  ]
+  private static let rsaSchemes: [X509SignatureScheme] = [.rsaPssSha256, .rsaPkcs1Sha256]
 
   // Bridged here rather than in the `case` patterns below, where `as String` would parse
   // as a cast of the value being matched instead of a bridge of the constant.

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/X509IdentityTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/X509IdentityTests.swift
@@ -18,11 +18,7 @@ struct X509IdentityTests {
 
     let schemes = try X509Identity.signatureSchemes(for: key)
 
-    #expect(
-      schemes == [
-        .rsaPssSha512, .rsaPssSha384, .rsaPssSha256,
-        .rsaPkcs1Sha512, .rsaPkcs1Sha384, .rsaPkcs1Sha256,
-      ])
+    #expect(schemes == [.rsaPssSha256, .rsaPkcs1Sha256])
   }
 
   @Test("An elliptic-curve key advertises only the scheme for its curve")


### PR DESCRIPTION
Firezone clients advertise the TLS signature schemes their device certificate's key can sign with, and the RSA lists led with SHA-512. A TPM-held RSA key is not obliged to do that: the TCG PC Client Platform TPM Profile mandates SHA-256 for RSASSA and RSAPSS in every revision, leaves SHA-512 optional, and only made SHA-384 mandatory in its 2020 revisions. A firmware TPM refused the very first request with `NTE_NOT_SUPPORTED` and the handshake died there, even though the same key signs PSS and PKCS#1 with SHA-256 without complaint.

Every platform now offers `rsa_pss_rsae_sha256` followed by `rsa_pkcs1_sha256` and nothing else. That loses nothing against a conforming server: RFC 8446 makes `rsa_pss_rsae_sha256` mandatory to implement, TLS 1.2 servers accept `rsa_pkcs1_sha256`, and the portal offers both. ECDSA keys are unaffected, since TLS pairs each curve with its own digest.