### PR TITLE
feat(snownet): buffer candidates for unknown connections

### DIFF
--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1,4 +1,5 @@
 mod allocations;
+mod buffered_candidates;
 mod connection_state;
 mod connections;
 mod inflight_stun_requests;
@@ -11,6 +12,7 @@ use crate::allocation::{self, Allocation, RelaySocket, Socket};
 use crate::buffer::{BufferProvider, Reservation, TransmitBuffer};
 use crate::index::IndexLfsr;
 use crate::node::allocations::Allocations;
+use crate::node::buffered_candidates::BufferedCandidates;
 use crate::node::connection_state::{ConnectionState, PeerSocket};
 use crate::node::connections::Connections;
 use crate::node::inflight_stun_requests::InflightStunRequests;
@@ -96,6 +98,7 @@ pub struct Node<TId, RId> {
     allocations: Allocations<RId>,
 
     connections: Connections<TId, RId>,
+    buffered_candidates: BufferedCandidates<TId>,
     inflight_stun_requests: InflightStunRequests<TId>,
 
     pending_events: VecDeque<Event<TId>>,
@@ -206,6 +209,7 @@ where
             allocations,
             inflight_stun_requests: Default::default(),
             connections: Default::default(),
+            buffered_candidates: Default::default(),
             buffer_pool: BufferPool::new(ip_packet::MAX_FZ_PAYLOAD, "snownet"),
             connection_count: otel_instruments::connection_count(),
             unix_now: now,
@@ -231,6 +235,7 @@ where
         self.buffered_transmits.clear();
         self.pending_events.clear();
         self.inflight_stun_requests.clear();
+        self.buffered_candidates.clear();
 
         if self.connections.all_iceless() {
             let num_iceless = self.connections.reset_for_roam(now);
@@ -399,6 +404,10 @@ where
 
         self.connections.insert_established(cid, index, connection);
 
+        for candidate in self.buffered_candidates.drain(&cid).collect::<Vec<_>>() {
+            self.add_remote_candidate(cid, candidate, now);
+        }
+
         Ok(())
     }
 
@@ -485,7 +494,8 @@ where
         self.last_now = now;
 
         let Ok(c) = self.connections.get_mut(&cid, now) else {
-            tracing::warn!(%candidate, "Received candidate for unknown connection");
+            tracing::debug!(%candidate, "Buffering candidate for unknown connection");
+            self.buffered_candidates.push(cid, candidate, now);
             return;
         };
 
@@ -521,7 +531,11 @@ where
         self.last_now = now;
 
         let Ok(c) = self.connections.get_mut(&cid, now) else {
-            tracing::debug!(ignored_candidate = %candidate, "Unknown connection");
+            if self.buffered_candidates.remove(&cid, &candidate) {
+                tracing::debug!(%candidate, "Removed buffered candidate for unknown connection");
+            } else {
+                tracing::debug!(ignored_candidate = %candidate, "Unknown connection");
+            }
             return;
         };
 
@@ -631,6 +645,7 @@ where
         iter::empty()
             .chain(queued_io)
             .chain(self.connections.poll_timeout())
+            .chain(self.buffered_candidates.poll_timeout())
             .chain(self.allocations.poll_timeout())
             .min_by_key(|(instant, _)| *instant)
     }
@@ -699,6 +714,7 @@ where
         );
         self.connections
             .handle_timeout(&mut self.pending_events, now);
+        self.buffered_candidates.handle_timeout(now);
         self.inflight_stun_requests.handle_timeout(now);
     }
 

--- a/rust/libs/connlib/snownet/src/node/buffered_candidates.rs
+++ b/rust/libs/connlib/snownet/src/node/buffered_candidates.rs
@@ -1,0 +1,156 @@
+use std::{
+    collections::BTreeMap,
+    fmt,
+    time::{Duration, Instant},
+};
+
+/// Remote candidates for connections we have not been told about (yet).
+///
+/// A new connection and its candidates are signalled independently through the portal,
+/// so a remote's candidates can overtake the message that creates the connection locally.
+/// They are held here until the connection is created or they expire.
+pub(crate) struct BufferedCandidates<TId> {
+    inner: BTreeMap<TId, Vec<(Instant, String)>>,
+}
+
+impl<TId> BufferedCandidates<TId>
+where
+    TId: Copy + Ord + fmt::Display,
+{
+    const TIMEOUT: Duration = Duration::from_secs(10);
+    const MAX_PER_CONNECTION: usize = 32;
+
+    pub(crate) fn push(&mut self, cid: TId, candidate: String, now: Instant) {
+        let candidates = self.inner.entry(cid).or_default();
+
+        if candidates.len() >= Self::MAX_PER_CONNECTION {
+            let (_, dropped) = candidates.remove(0);
+
+            tracing::debug!(%cid, candidate = %dropped, "Dropping oldest buffered candidate");
+        }
+
+        candidates.push((now, candidate));
+    }
+
+    /// Removes a buffered candidate, returning whether it was present.
+    pub(crate) fn remove(&mut self, cid: &TId, candidate: &str) -> bool {
+        let Some(candidates) = self.inner.get_mut(cid) else {
+            return false;
+        };
+
+        let num_removed = candidates.extract_if(.., |(_, c)| c == candidate).count();
+
+        if candidates.is_empty() {
+            self.inner.remove(cid);
+        }
+
+        num_removed > 0
+    }
+
+    pub(crate) fn drain(&mut self, cid: &TId) -> impl Iterator<Item = String> + use<TId> {
+        self.inner
+            .remove(cid)
+            .into_iter()
+            .flatten()
+            .map(|(_, candidate)| candidate)
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    pub(crate) fn poll_timeout(&self) -> Option<(Instant, &'static str)> {
+        self.inner
+            .values()
+            .filter_map(|candidates| candidates.first())
+            .map(|(received_at, _)| (*received_at + Self::TIMEOUT, "buffered candidates"))
+            .min_by_key(|(instant, _)| *instant)
+    }
+
+    pub(crate) fn handle_timeout(&mut self, now: Instant) {
+        for (cid, candidates) in self.inner.iter_mut() {
+            for (_, candidate) in candidates.extract_if(.., |(received_at, _)| {
+                now.duration_since(*received_at) >= Self::TIMEOUT
+            }) {
+                tracing::debug!(%cid, %candidate, "Discarding buffered candidate for unknown connection");
+            }
+        }
+
+        self.inner
+            .extract_if(.., |_, candidates| candidates.is_empty())
+            .for_each(drop);
+    }
+}
+
+impl<TId> Default for BufferedCandidates<TId> {
+    fn default() -> Self {
+        Self {
+            inner: BTreeMap::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drains_candidates_in_order_of_arrival() {
+        let mut buffer = BufferedCandidates::<u32>::default();
+        let now = Instant::now();
+
+        buffer.push(1, "first".to_owned(), now);
+        buffer.push(1, "second".to_owned(), now);
+        buffer.push(2, "other".to_owned(), now);
+
+        assert_eq!(buffer.drain(&1).collect::<Vec<_>>(), ["first", "second"]);
+        assert_eq!(buffer.drain(&1).count(), 0);
+        assert_eq!(buffer.drain(&2).collect::<Vec<_>>(), ["other"]);
+    }
+
+    #[test]
+    fn expires_candidates_after_timeout() {
+        let mut buffer = BufferedCandidates::<u32>::default();
+        let now = Instant::now();
+
+        buffer.push(1, "early".to_owned(), now);
+        buffer.push(1, "late".to_owned(), now + Duration::from_secs(5));
+
+        let (timeout, _) = buffer.poll_timeout().unwrap();
+        assert_eq!(timeout, now + BufferedCandidates::<u32>::TIMEOUT);
+
+        buffer.handle_timeout(timeout);
+
+        assert_eq!(buffer.drain(&1).collect::<Vec<_>>(), ["late"]);
+        assert_eq!(buffer.poll_timeout(), None);
+    }
+
+    #[test]
+    fn caps_candidates_per_connection() {
+        let mut buffer = BufferedCandidates::<u32>::default();
+        let now = Instant::now();
+
+        for i in 0..=BufferedCandidates::<u32>::MAX_PER_CONNECTION {
+            buffer.push(1, i.to_string(), now);
+        }
+
+        let candidates = buffer.drain(&1).collect::<Vec<_>>();
+        assert_eq!(
+            candidates.len(),
+            BufferedCandidates::<u32>::MAX_PER_CONNECTION
+        );
+        assert_eq!(candidates.first().unwrap(), "1");
+    }
+
+    #[test]
+    fn removes_candidate() {
+        let mut buffer = BufferedCandidates::<u32>::default();
+        let now = Instant::now();
+
+        buffer.push(1, "candidate".to_owned(), now);
+
+        assert!(buffer.remove(&1, "candidate"));
+        assert!(!buffer.remove(&1, "candidate"));
+        assert_eq!(buffer.poll_timeout(), None);
+    }
+}

--- a/rust/tests/fuzz/src/sut.rs
+++ b/rust/tests/fuzz/src/sut.rs
@@ -1229,6 +1229,21 @@ impl TunnelTest {
                         error,
                     })?;
 
+                // The gateway's candidates and the portal's `flow_created` reply travel
+                // independently, so the client may receive them before it knows about
+                // the connection.
+                while let Some(event) = gateway.exec_mut(|g| g.sut.poll_event()) {
+                    on_gateway_event(
+                        gateway_id,
+                        event,
+                        &mut self.clients,
+                        gateway,
+                        &self.relays,
+                        &ref_state.global_dns_records,
+                        now,
+                    );
+                }
+
                 let client = self.clients.get_mut(&src).unwrap();
                 client
                     .exec_mut(|c| {


### PR DESCRIPTION
A connection and its remote candidates are signalled independently through the portal, so a peer's candidates can arrive before the message that creates the connection locally. Today we drop them with a warning and rely on later candidates (or optimistic ones) to still establish the connection. This holds candidates for unknown connections for a short while and replays them once the connection is created, so the early ones are not lost.

The simulator now delivers the gateway's candidates to the client before the client learns about the connection, mirroring that ordering.