### PR TITLE
chore(x509): drop the tunnel hint from the Windows tasks

### DIFF
--- a/mise-tasks/x509/install-windows.ps1
+++ b/mise-tasks/x509/install-windows.ps1
@@ -80,6 +80,3 @@ if (-not $provider -or $provider.Line -notmatch 'Key Storage Provider') {
     Write-Warning 'Delete it from Cert:\LocalMachine\My and import it again with certutil instead:'
     Write-Warning ('  certutil -f -p ' + $p12Password + ' -csp "Microsoft Software Key Storage Provider" -importpfx My ' + $p12Path)
 }
-
-Write-Output ''
-Write-Output "'firezone-client-tunnel.exe x509' prints what the Client makes of the store."

--- a/mise-tasks/x509/uninstall-windows.ps1
+++ b/mise-tasks/x509/uninstall-windows.ps1
@@ -127,5 +127,3 @@ foreach ($certificate in $certificates) {
 Write-Output ''
 Write-Output 'A connected Tunnel service holds the certificate until it restarts, so restart it'
 Write-Output 'to see the change.'
-Write-Output ''
-Write-Output "'firezone-client-tunnel.exe x509' prints what the Client makes of the store."


### PR DESCRIPTION
The Windows install and uninstall tasks still closed by naming the Tunnel service's `x509` subcommand. They provision the store for every client, so the pointer goes, as it already did from the Linux tasks.

Related: #14972