### PR TITLE
fix: log disk-full flow-log spool failures on debug

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -478,14 +478,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atomicwrites"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef1bb8d1b645fe38d51dfc331d720fb5fc2c94b440c76cc79c80ff265ca33e3"
+name = "atomicfs"
+version = "0.1.0"
 dependencies = [
- "rustix 0.38.44",
  "tempfile",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -748,7 +744,7 @@ name = "bin-shared"
 version = "0.1.0"
 dependencies = [
  "anyhow-ext",
- "atomicwrites",
+ "atomicfs",
  "axum",
  "bufferpool",
  "clap",
@@ -2761,7 +2757,7 @@ name = "flow-log-writer"
 version = "0.1.0"
 dependencies = [
  "anyhow-ext",
- "atomicwrites",
+ "atomicfs",
  "base64 0.23.1",
  "chrono",
  "flow-log-spool",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "gui-client/src-tauri",
     "headless-client",
     "libs/anyhow-ext",
+    "libs/atomicfs",
     "libs/backoff",
     "libs/bin-shared",
     "libs/client-shared",
@@ -72,7 +73,7 @@ admx-macro = { path = "gui-client/src-admx-macro" }
 anyhow = { package = "anyhow-ext", path = "libs/anyhow-ext" }
 arbitrary = "1.4.2"
 arboard = { version = "3.6.1", default-features = false }
-atomicwrites = "0.4.4"
+atomicfs = { path = "libs/atomicfs" }
 axum = { version = "0.8.8", default-features = false }
 aya = { git = "https://github.com/aya-rs/aya" }
 aya-build = { git = "https://github.com/aya-rs/aya" }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -343,7 +343,11 @@ impl Eventloop {
                     && let Err(e) =
                         flow_log_writer::write_token(&self.flow_logs_dir, token.as_str())
                 {
-                    tracing::warn!("Failed to persist flow-log ingest token: {e:#}");
+                    if flow_log_writer::is_disk_full(&e) {
+                        tracing::debug!("Failed to persist flow-log ingest token: {e:#}");
+                    } else {
+                        tracing::warn!("Failed to persist flow-log ingest token: {e:#}");
+                    }
                 }
 
                 if let Err(snownet::NoTurnServers {}) = tunnel.state_mut().create_authorization(

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -339,14 +339,15 @@ impl Eventloop {
             IngressMessages::CreateAuthorization(msg) => {
                 let token = &msg.flow_logs_ingest_token;
 
-                if token.claims().uploads_enabled
-                    && let Err(e) =
-                        flow_log_writer::write_token(&self.flow_logs_dir, token.as_str())
-                {
-                    if flow_log_writer::is_disk_full(&e) {
-                        tracing::debug!("Failed to persist flow-log ingest token: {e:#}");
-                    } else {
-                        tracing::warn!("Failed to persist flow-log ingest token: {e:#}");
+                if token.claims().uploads_enabled {
+                    match flow_log_writer::write_token(&self.flow_logs_dir, token.as_str()) {
+                        Ok(()) => {}
+                        Err(e) if is_disk_full(&e) => {
+                            tracing::debug!("Failed to persist flow-log ingest token: {e:#}");
+                        }
+                        Err(e) => {
+                            tracing::warn!("Failed to persist flow-log ingest token: {e:#}");
+                        }
                     }
                 }
 
@@ -430,13 +431,19 @@ impl Eventloop {
                     .state_mut()
                     .set_flow_logs_enabled(flow_logs.upload_enabled() || self.local_flow_logs);
 
-                if let Err(e) = flow_log_upload::configure_uploads(
+                match flow_log_upload::configure_uploads(
                     &self.flow_logs_dir,
                     &flow_logs.api_url,
                     flow_logs.upload_interval_secs,
                     flow_logs.upload_batch_size,
                 ) {
-                    tracing::warn!("Failed to persist flow-log upload config: {e:#}");
+                    Ok(()) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::StorageFull => {
+                        tracing::debug!("Failed to persist flow-log upload config: {e:#}");
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed to persist flow-log upload config: {e:#}");
+                    }
                 }
 
                 tunnel
@@ -544,6 +551,11 @@ impl Eventloop {
 
 /// Performs a single recursive DNS lookup against the upstream resolver, recording
 /// its duration with `dns.question.type` and `dns.response.code` attributes.
+fn is_disk_full(e: &anyhow::Error) -> bool {
+    e.any_downcast_ref::<std::io::Error>()
+        .is_some_and(|io| io.kind() == std::io::ErrorKind::StorageFull)
+}
+
 async fn resolve_record(
     resolver: &TokioResolver,
     dns_lookup_duration: &opentelemetry::metrics::Histogram<f64>,

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -340,13 +340,18 @@ impl Eventloop {
                 let token = &msg.flow_logs_ingest_token;
 
                 if token.claims().uploads_enabled {
-                    match flow_log_writer::write_token(&self.flow_logs_dir, token.as_str()) {
+                    match flow_log_writer::write_token(&self.flow_logs_dir, token.as_str())
+                        .context("Failed to persist flow-log ingest token")
+                    {
                         Ok(()) => {}
-                        Err(e) if is_disk_full(&e) => {
-                            tracing::debug!("Failed to persist flow-log ingest token: {e:#}");
+                        Err(e)
+                            if e.any_downcast_ref::<std::io::Error>()
+                                .is_some_and(|io| io.kind() == std::io::ErrorKind::StorageFull) =>
+                        {
+                            tracing::debug!("{e:#}");
                         }
                         Err(e) => {
-                            tracing::warn!("Failed to persist flow-log ingest token: {e:#}");
+                            tracing::warn!("{e:#}");
                         }
                     }
                 }
@@ -436,13 +441,18 @@ impl Eventloop {
                     &flow_logs.api_url,
                     flow_logs.upload_interval_secs,
                     flow_logs.upload_batch_size,
-                ) {
+                )
+                .context("Failed to persist flow-log upload config")
+                {
                     Ok(()) => {}
-                    Err(e) if e.kind() == std::io::ErrorKind::StorageFull => {
-                        tracing::debug!("Failed to persist flow-log upload config: {e:#}");
+                    Err(e)
+                        if e.any_downcast_ref::<std::io::Error>()
+                            .is_some_and(|io| io.kind() == std::io::ErrorKind::StorageFull) =>
+                    {
+                        tracing::debug!("{e:#}");
                     }
                     Err(e) => {
-                        tracing::warn!("Failed to persist flow-log upload config: {e:#}");
+                        tracing::warn!("{e:#}");
                     }
                 }
 
@@ -551,11 +561,6 @@ impl Eventloop {
 
 /// Performs a single recursive DNS lookup against the upstream resolver, recording
 /// its duration with `dns.question.type` and `dns.response.code` attributes.
-fn is_disk_full(e: &anyhow::Error) -> bool {
-    e.any_downcast_ref::<std::io::Error>()
-        .is_some_and(|io| io.kind() == std::io::ErrorKind::StorageFull)
-}
-
 async fn resolve_record(
     resolver: &TokioResolver,
     dns_lookup_duration: &opentelemetry::metrics::Histogram<f64>,

--- a/rust/gui-client/src-tauri/src/controller/ran_before.rs
+++ b/rust/gui-client/src-tauri/src/controller/ran_before.rs
@@ -6,7 +6,7 @@ use tokio::fs;
 
 /// Returns true if the flag is set
 pub(crate) async fn get() -> Result<bool> {
-    // Just check if the file exists. We don't use `atomicwrites` to write it,
+    // Just check if the file exists. We don't use `atomicfs` to write it,
     // so the content itself may be corrupt.
     Ok(fs::try_exists(path()?).await?)
 }

--- a/rust/libs/atomicfs/Cargo.toml
+++ b/rust/libs/atomicfs/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "atomicfs"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/libs/atomicfs/src/lib.rs
+++ b/rust/libs/atomicfs/src/lib.rs
@@ -16,29 +16,14 @@ use std::path::Path;
 ///
 /// The atomic counterpart to [`std::fs::write`].
 pub fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> io::Result<()> {
-    write_with(path.as_ref(), contents.as_ref(), true)
-}
-
-/// Atomically writes `contents` to `path`, failing with [`io::ErrorKind::AlreadyExists`]
-/// if a file is already there.
-///
-/// The atomic counterpart to [`File::create_new`] followed by a write.
-pub fn write_new(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> io::Result<()> {
-    write_with(path.as_ref(), contents.as_ref(), false)
-}
-
-fn write_with(path: &Path, contents: &[u8], overwrite: bool) -> io::Result<()> {
+    let path = path.as_ref();
     let dir = path.parent().filter(|dir| !dir.as_os_str().is_empty());
     let dir = dir.unwrap_or(Path::new("."));
 
     let mut file = tempfile::NamedTempFile::new_in(dir)?;
-    file.write_all(contents)?;
+    file.write_all(contents.as_ref())?;
     file.as_file().sync_all()?;
-    if overwrite {
-        file.persist(path)?;
-    } else {
-        file.persist_noclobber(path)?;
-    }
+    file.persist(path)?;
 
     // The rename is only durable once the directory entry is on disk too.
     #[cfg(unix)]
@@ -62,19 +47,6 @@ mod tests {
         write(&path, b"two").unwrap();
         assert_eq!(std::fs::read(&path).unwrap(), b"two");
 
-        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
-    }
-
-    #[test]
-    fn write_new_refuses_to_clobber() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("file");
-
-        write_new(&path, b"one").unwrap();
-        let e = write_new(&path, b"two").unwrap_err();
-
-        assert_eq!(e.kind(), io::ErrorKind::AlreadyExists);
-        assert_eq!(std::fs::read(&path).unwrap(), b"one");
         assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
     }
 

--- a/rust/libs/atomicfs/src/lib.rs
+++ b/rust/libs/atomicfs/src/lib.rs
@@ -1,0 +1,105 @@
+//! Atomic and durable counterparts to the write operations in [`std::fs`].
+//!
+//! Each function writes to a temporary file in the target's directory, fsyncs it
+//! and renames it into place, so a reader never observes a partial file and a
+//! crash or power loss mid-write leaves the previous contents intact.
+//!
+//! Files are created with mode `0600` on Unix.
+
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+use std::fs::File;
+use std::io::{self, Write as _};
+use std::path::Path;
+
+/// Atomically writes `contents` to `path`, replacing any existing file.
+///
+/// The atomic counterpart to [`std::fs::write`].
+pub fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> io::Result<()> {
+    write_with(path.as_ref(), contents.as_ref(), true)
+}
+
+/// Atomically writes `contents` to `path`, failing with [`io::ErrorKind::AlreadyExists`]
+/// if a file is already there.
+///
+/// The atomic counterpart to [`File::create_new`] followed by a write.
+pub fn write_new(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> io::Result<()> {
+    write_with(path.as_ref(), contents.as_ref(), false)
+}
+
+fn write_with(path: &Path, contents: &[u8], overwrite: bool) -> io::Result<()> {
+    let dir = path.parent().filter(|dir| !dir.as_os_str().is_empty());
+    let dir = dir.unwrap_or(Path::new("."));
+
+    let mut file = tempfile::NamedTempFile::new_in(dir)?;
+    file.write_all(contents)?;
+    file.as_file().sync_all()?;
+    if overwrite {
+        file.persist(path)?;
+    } else {
+        file.persist_noclobber(path)?;
+    }
+
+    // The rename is only durable once the directory entry is on disk too.
+    #[cfg(unix)]
+    File::open(dir)?.sync_all()?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writes_and_overwrites() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file");
+
+        write(&path, b"one").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"one");
+
+        write(&path, b"two").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"two");
+
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn write_new_refuses_to_clobber() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file");
+
+        write_new(&path, b"one").unwrap();
+        let e = write_new(&path, b"two").unwrap_err();
+
+        assert_eq!(e.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(std::fs::read(&path).unwrap(), b"one");
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn missing_directory_is_an_io_error() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let e = write(dir.path().join("missing").join("file"), b"x").unwrap_err();
+
+        assert_eq!(e.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file");
+
+        write(&path, b"secret").unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}

--- a/rust/libs/atomicfs/src/lib.rs
+++ b/rust/libs/atomicfs/src/lib.rs
@@ -8,7 +8,6 @@
 
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
-use std::fs::File;
 use std::io::{self, Write as _};
 use std::path::Path;
 
@@ -27,7 +26,7 @@ pub fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> io::Result<(
 
     // The rename is only durable once the directory entry is on disk too.
     #[cfg(unix)]
-    File::open(dir)?.sync_all()?;
+    std::fs::File::open(dir)?.sync_all()?;
 
     Ok(())
 }

--- a/rust/libs/bin-shared/Cargo.toml
+++ b/rust/libs/bin-shared/Cargo.toml
@@ -11,7 +11,7 @@ test = [] # APIs only exposed for testing.
 
 [dependencies]
 anyhow = { workspace = true }
-atomicwrites = { workspace = true }
+atomicfs = { workspace = true }
 axum = { workspace = true, features = ["http1", "tokio"] }
 clap = { workspace = true, features = ["derive", "env"] }
 dns-types = { workspace = true }
@@ -36,7 +36,6 @@ tun = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-atomicwrites = { workspace = true }
 hmac = { workspace = true }
 libc = { workspace = true }
 netlink-packet-core = { workspace = true }

--- a/rust/libs/bin-shared/src/device_id.rs
+++ b/rust/libs/bin-shared/src/device_id.rs
@@ -109,7 +109,7 @@ fn get_or_create_at(path: &Path, app_id: &str) -> Result<DeviceId> {
     let content =
         serde_json::to_string(&j).context("Impossible: Failed to serialize firezone-id")?;
 
-    atomicfs::write_new(path, content).context("Failed to write firezone-id file")?;
+    atomicfs::write(path, content).context("Failed to write firezone-id file")?;
 
     tracing::debug!(%id, "Saved device ID to disk");
     set_id_permissions(path).context("Couldn't set permissions on Firezone ID file")?;

--- a/rust/libs/bin-shared/src/device_id.rs
+++ b/rust/libs/bin-shared/src/device_id.rs
@@ -1,11 +1,9 @@
 //! Generate a persistent device ID, stores it to disk, and reads it back.
 
 use anyhow::{Context as _, Result};
-use atomicwrites::{AtomicFile, OverwriteBehavior};
 use sha2::Digest;
 use std::{
     fs,
-    io::Write,
     path::{Path, PathBuf},
 };
 
@@ -111,9 +109,7 @@ fn get_or_create_at(path: &Path, app_id: &str) -> Result<DeviceId> {
     let content =
         serde_json::to_string(&j).context("Impossible: Failed to serialize firezone-id")?;
 
-    let file = AtomicFile::new(path, OverwriteBehavior::DisallowOverwrite);
-    file.write(|f| f.write_all(content.as_bytes()))
-        .context("Failed to write firezone-id file")?;
+    atomicfs::write_new(path, content).context("Failed to write firezone-id file")?;
 
     tracing::debug!(%id, "Saved device ID to disk");
     set_id_permissions(path).context("Couldn't set permissions on Firezone ID file")?;

--- a/rust/libs/bin-shared/src/dns_control/linux/etc_resolv_conf.rs
+++ b/rust/libs/bin-shared/src/dns_control/linux/etc_resolv_conf.rs
@@ -1,8 +1,7 @@
 use anyhow::{Context, Result, bail};
 use dns_types::DomainName;
 use std::{
-    fs,
-    io::{self, Write},
+    fs, io,
     net::IpAddr,
     path::{Path, PathBuf},
 };
@@ -82,16 +81,7 @@ fn configure_at_paths(
     // - If we crashed, and MAGIC_HEADER is still present, we already called `revert` above.
     // - If we crashed, but the user rewrote the file, our backup is out of date
     // - If we didn't crash, we should have reverted, so the backup is not needed.
-    //
-    // `atomicwrites` handles the fsync and rename-into-place tricks to resist file corruption
-    // if we lose power during the write.
-    let backup_file = atomicwrites::AtomicFile::new(
-        &paths.backup,
-        atomicwrites::OverwriteBehavior::AllowOverwrite,
-    );
-    backup_file
-        .write(|f| f.write_all(text.as_bytes()))
-        .context("Failed to back up `resolv.conf`")?;
+    atomicfs::write(&paths.backup, &text).context("Failed to back up `resolv.conf`")?;
 
     let mut new_resolv_conf = parsed;
 

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -875,7 +875,11 @@ fn persist_ingest_token(spool_root: Option<&std::path::Path>, token: &IngestToke
     }
 
     if let Err(e) = flow_log_writer::write_token(spool_root, token.as_str()) {
-        tracing::warn!("Failed to persist flow-log ingest token: {e:#}");
+        if flow_log_writer::is_disk_full(&e) {
+            tracing::debug!("Failed to persist flow-log ingest token: {e:#}");
+        } else {
+            tracing::warn!("Failed to persist flow-log ingest token: {e:#}");
+        }
     }
 }
 

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -555,13 +555,18 @@ impl Eventloop {
                         &flow_logs.api_url,
                         flow_logs.upload_interval_secs,
                         flow_logs.upload_batch_size,
-                    ) {
+                    )
+                    .context("Failed to persist flow-log upload config")
+                    {
                         Ok(()) => {}
-                        Err(e) if e.kind() == std::io::ErrorKind::StorageFull => {
-                            tracing::debug!("Failed to persist flow-log upload config: {e:#}");
+                        Err(e)
+                            if e.any_downcast_ref::<std::io::Error>()
+                                .is_some_and(|io| io.kind() == std::io::ErrorKind::StorageFull) =>
+                        {
+                            tracing::debug!("{e:#}");
                         }
                         Err(e) => {
-                            tracing::warn!("Failed to persist flow-log upload config: {e:#}");
+                            tracing::warn!("{e:#}");
                         }
                     }
                 }
@@ -880,20 +885,20 @@ fn persist_ingest_token(spool_root: Option<&std::path::Path>, token: &IngestToke
         return;
     }
 
-    match flow_log_writer::write_token(spool_root, token.as_str()) {
+    match flow_log_writer::write_token(spool_root, token.as_str())
+        .context("Failed to persist flow-log ingest token")
+    {
         Ok(()) => {}
-        Err(e) if is_disk_full(&e) => {
-            tracing::debug!("Failed to persist flow-log ingest token: {e:#}");
+        Err(e)
+            if e.any_downcast_ref::<std::io::Error>()
+                .is_some_and(|io| io.kind() == std::io::ErrorKind::StorageFull) =>
+        {
+            tracing::debug!("{e:#}");
         }
         Err(e) => {
-            tracing::warn!("Failed to persist flow-log ingest token: {e:#}");
+            tracing::warn!("{e:#}");
         }
     }
-}
-
-fn is_disk_full(e: &anyhow::Error) -> bool {
-    e.any_downcast_ref::<std::io::Error>()
-        .is_some_and(|io| io.kind() == std::io::ErrorKind::StorageFull)
 }
 
 async fn phoenix_channel_event_loop(

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -549,15 +549,21 @@ impl Eventloop {
                         || self.local_flow_logs,
                 );
 
-                if let Some(spool_root) = &self.flow_logs_dir
-                    && let Err(e) = flow_log_upload::configure_uploads(
+                if let Some(spool_root) = &self.flow_logs_dir {
+                    match flow_log_upload::configure_uploads(
                         spool_root,
                         &flow_logs.api_url,
                         flow_logs.upload_interval_secs,
                         flow_logs.upload_batch_size,
-                    )
-                {
-                    tracing::warn!("Failed to persist flow-log upload config: {e:#}");
+                    ) {
+                        Ok(()) => {}
+                        Err(e) if e.kind() == std::io::ErrorKind::StorageFull => {
+                            tracing::debug!("Failed to persist flow-log upload config: {e:#}");
+                        }
+                        Err(e) => {
+                            tracing::warn!("Failed to persist flow-log upload config: {e:#}");
+                        }
+                    }
                 }
 
                 let state = tunnel.state_mut();
@@ -874,13 +880,20 @@ fn persist_ingest_token(spool_root: Option<&std::path::Path>, token: &IngestToke
         return;
     }
 
-    if let Err(e) = flow_log_writer::write_token(spool_root, token.as_str()) {
-        if flow_log_writer::is_disk_full(&e) {
+    match flow_log_writer::write_token(spool_root, token.as_str()) {
+        Ok(()) => {}
+        Err(e) if is_disk_full(&e) => {
             tracing::debug!("Failed to persist flow-log ingest token: {e:#}");
-        } else {
+        }
+        Err(e) => {
             tracing::warn!("Failed to persist flow-log ingest token: {e:#}");
         }
     }
+}
+
+fn is_disk_full(e: &anyhow::Error) -> bool {
+    e.any_downcast_ref::<std::io::Error>()
+        .is_some_and(|io| io.kind() == std::io::ErrorKind::StorageFull)
 }
 
 async fn phoenix_channel_event_loop(

--- a/rust/libs/flow-log-writer/Cargo.toml
+++ b/rust/libs/flow-log-writer/Cargo.toml
@@ -6,7 +6,7 @@ license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-atomicwrites = { workspace = true }
+atomicfs = { workspace = true }
 base64 = { workspace = true, features = ["std"] }
 chrono = { workspace = true }
 flow-log-spool = { workspace = true }

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -62,7 +62,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::Context as _;
+use anyhow::{Context as _, ErrorExt as _};
 use base64::Engine as _;
 use chrono::DateTime;
 use flow_log_spool::serialize;
@@ -425,13 +425,16 @@ fn write_report(root: &Path, report: &Report) {
         "{:010}-{}.{suffix}.json",
         report.flow_start, report.identity
     ));
-    match atomicfs::write(&path, &contents) {
+    match atomicfs::write(&path, &contents).context("Failed to write flow-log report") {
         Ok(()) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::StorageFull => {
-            tracing::debug!(path = %path.display(), "Failed to write flow-log report: {e}");
+        Err(e)
+            if e.any_downcast_ref::<std::io::Error>()
+                .is_some_and(|io| io.kind() == std::io::ErrorKind::StorageFull) =>
+        {
+            tracing::debug!(path = %path.display(), "{e:#}");
         }
         Err(e) => {
-            tracing::warn!(path = %path.display(), "Failed to write flow-log report: {e}");
+            tracing::warn!(path = %path.display(), "{e:#}");
         }
     }
 }

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -53,7 +53,6 @@
 
 use std::{
     hash::{Hash as _, Hasher as _},
-    io::Write as _,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -64,7 +63,6 @@ use std::{
 };
 
 use anyhow::Context as _;
-use atomicwrites::{AtomicFile, OverwriteBehavior};
 use base64::Engine as _;
 use chrono::DateTime;
 use flow_log_spool::serialize;
@@ -454,14 +452,7 @@ fn flow_identity(fields: &serde_json::Map<String, serde_json::Value>) -> String 
 }
 
 fn write_file_secure(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
-    // `AtomicFile` writes to a temp file, fsyncs it, then renames into place, so a
-    // reader never observes a partial file and a written file is durable.
-    AtomicFile::new(path, OverwriteBehavior::AllowOverwrite)
-        .write(|f| {
-            set_owner_only(f)?;
-            f.write_all(bytes)
-        })
-        .map_err(std::io::Error::from)
+    atomicfs::write(path, bytes)
         .with_context(|| format!("Failed to atomically write {}", path.display()))
 }
 
@@ -508,7 +499,7 @@ fn create_dir_secure(path: &Path) -> std::io::Result<()> {
     // The spool holds Bearer tokens, so lock each authorization directory down to
     // `LocalSystem` and `BUILTIN\Administrators` (the accounts the Gateway / Tunnel
     // service runs as), the equivalent of `0700` on Unix. `OICI` makes the token and
-    // report files inside inherit the same access, so `set_owner_only` is a no-op.
+    // report files inside inherit the same access.
     windows_security::SecurityDescriptor::from_sddl("D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)")
         .and_then(|descriptor| descriptor.apply_to_path(path))
         .map_err(|e| std::io::Error::other(format!("{e:#}")))
@@ -517,24 +508,6 @@ fn create_dir_secure(path: &Path) -> std::io::Result<()> {
 #[cfg(not(any(unix, windows)))]
 fn create_dir_secure(path: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(path)
-}
-
-#[cfg(unix)]
-fn set_owner_only(f: &std::fs::File) -> std::io::Result<()> {
-    use std::os::unix::fs::PermissionsExt as _;
-
-    f.set_permissions(std::fs::Permissions::from_mode(0o600))
-}
-
-// On Windows the files inherit their directory's DACL (see `create_dir_secure`), so
-// there is nothing to do here.
-#[cfg(not(unix))]
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "signature must match the unix version"
-)]
-fn set_owner_only(_f: &std::fs::File) -> std::io::Result<()> {
-    Ok(())
 }
 
 #[cfg(test)]

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -153,8 +153,8 @@ pub fn write_token(spool_root: &Path, token: &str) -> anyhow::Result<()> {
         .context("Token has a missing or invalid policy_authorization_id")?;
 
     let dir = spool_root.join(&role).join(&authz_id);
-    create_dir_secure(&dir)?;
-    write_file_secure(&dir.join("token"), token.as_bytes())?;
+    create_dir_secure(&dir).context("Failed to create authorization directory")?;
+    atomicfs::write(dir.join("token"), token).context("Failed to write token file")?;
 
     Ok(())
 }
@@ -398,35 +398,42 @@ fn writer_loop(root: &Path, rx: &mpsc::Receiver<Command>) {
             Command::Shutdown => break,
         };
 
-        if let Err(e) = write_report(root, &report) {
-            if is_disk_full(&e) {
-                tracing::debug!("Failed to write flow-log report: {e:#}");
-            } else {
-                tracing::warn!("Failed to write flow-log report: {e:#}");
-            }
-        }
+        write_report(root, &report);
     }
 }
 
-fn write_report(root: &Path, report: &Report) -> anyhow::Result<()> {
+fn write_report(root: &Path, report: &Report) {
     let dir = root.join(&report.role).join(&report.authz_id);
 
     if !dir.join("token").exists() {
         tracing::debug!(authz_id = %report.authz_id, "No ingest token on disk for authorization; not spooling report");
 
-        return Ok(());
+        return;
     }
 
-    let contents = serialize(&serde_json::Value::Object(report.payload.clone()))?;
+    let contents = match serialize(&serde_json::Value::Object(report.payload.clone())) {
+        Ok(contents) => contents,
+        Err(e) => {
+            tracing::warn!("Failed to serialize flow-log report: {e:#}");
+
+            return;
+        }
+    };
 
     let suffix = if report.completed { "end" } else { "start" };
     let path = dir.join(format!(
         "{:010}-{}.{suffix}.json",
         report.flow_start, report.identity
     ));
-    write_file_secure(&path, &contents)?;
-
-    Ok(())
+    match atomicfs::write(&path, &contents) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::StorageFull => {
+            tracing::debug!(path = %path.display(), "Failed to write flow-log report: {e}");
+        }
+        Err(e) => {
+            tracing::warn!(path = %path.display(), "Failed to write flow-log report: {e}");
+        }
+    }
 }
 
 /// A stable hash of the fields identifying a flow within an authorization.
@@ -449,23 +456,6 @@ fn flow_identity(fields: &serde_json::Map<String, serde_json::Value>) -> String 
     }
 
     format!("{:016x}", hasher.finish())
-}
-
-fn write_file_secure(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
-    atomicfs::write(path, bytes)
-        .with_context(|| format!("Failed to atomically write {}", path.display()))
-}
-
-/// Whether a spool write failed because the disk is full.
-///
-/// A full disk is an operator problem the spool cannot fix, so callers log it on
-/// `DEBUG` instead of `WARN` and carry on.
-pub fn is_disk_full(e: &anyhow::Error) -> bool {
-    e.chain().any(|cause| {
-        cause
-            .downcast_ref::<std::io::Error>()
-            .is_some_and(|io| io.kind() == std::io::ErrorKind::StorageFull)
-    })
 }
 
 /// A policy-authorization id must be a hyphenated UUID; reject anything else so it
@@ -611,27 +601,6 @@ mod tests {
 
         assert!(write_token(dir.path(), &format!("h.{payload}.s")).is_err());
         assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
-    }
-
-    #[test]
-    fn atomic_write_error_keeps_io_error_kind() {
-        let dir = tempfile::tempdir().unwrap();
-        let e = write_file_secure(&dir.path().join("missing").join("file"), b"x").unwrap_err();
-
-        assert!(
-            e.chain()
-                .any(|c| c.downcast_ref::<std::io::Error>().is_some()),
-            "{e:#}"
-        );
-        assert!(!is_disk_full(&e));
-    }
-
-    #[test]
-    fn detects_disk_full_through_context() {
-        let e = anyhow::Error::from(std::io::Error::from(std::io::ErrorKind::StorageFull))
-            .context("Failed to atomically write");
-
-        assert!(is_disk_full(&e));
     }
 
     #[test]

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -401,7 +401,11 @@ fn writer_loop(root: &Path, rx: &mpsc::Receiver<Command>) {
         };
 
         if let Err(e) = write_report(root, &report) {
-            tracing::warn!("Failed to write flow-log report: {e:#}");
+            if is_disk_full(&e) {
+                tracing::debug!("Failed to write flow-log report: {e:#}");
+            } else {
+                tracing::warn!("Failed to write flow-log report: {e:#}");
+            }
         }
     }
 }
@@ -457,7 +461,20 @@ fn write_file_secure(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
             set_owner_only(f)?;
             f.write_all(bytes)
         })
+        .map_err(std::io::Error::from)
         .with_context(|| format!("Failed to atomically write {}", path.display()))
+}
+
+/// Whether a spool write failed because the disk is full.
+///
+/// A full disk is an operator problem the spool cannot fix, so callers log it on
+/// `DEBUG` instead of `WARN` and carry on.
+pub fn is_disk_full(e: &anyhow::Error) -> bool {
+    e.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|io| io.kind() == std::io::ErrorKind::StorageFull)
+    })
 }
 
 /// A policy-authorization id must be a hyphenated UUID; reject anything else so it
@@ -621,6 +638,27 @@ mod tests {
 
         assert!(write_token(dir.path(), &format!("h.{payload}.s")).is_err());
         assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn atomic_write_error_keeps_io_error_kind() {
+        let dir = tempfile::tempdir().unwrap();
+        let e = write_file_secure(&dir.path().join("missing").join("file"), b"x").unwrap_err();
+
+        assert!(
+            e.chain()
+                .any(|c| c.downcast_ref::<std::io::Error>().is_some()),
+            "{e:#}"
+        );
+        assert!(!is_disk_full(&e));
+    }
+
+    #[test]
+    fn detects_disk_full_through_context() {
+        let e = anyhow::Error::from(std::io::Error::from(std::io::ErrorKind::StorageFull))
+            .context("Failed to atomically write");
+
+        assert!(is_disk_full(&e));
     }
 
     #[test]

--- a/rust/libs/known-dirs/src/platform/linux.rs
+++ b/rust/libs/known-dirs/src/platform/linux.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 /// Path for Tunnel service config that the Tunnel service can write
 ///
-/// All writes should use `atomicwrites`.
+/// All writes should use `atomicfs`.
 ///
 /// On Linux, `/var/lib/$BUNDLE_ID/config/firezone-id`
 ///

--- a/rust/libs/known-dirs/src/platform/windows.rs
+++ b/rust/libs/known-dirs/src/platform/windows.rs
@@ -17,7 +17,7 @@ pub fn app_local_data_dir() -> Result<PathBuf> {
 
 /// Path for Tunnel service config that the Tunnel service can write
 ///
-/// All writes should use `atomicwrites`.
+/// All writes should use `atomicfs`.
 ///
 /// On Windows, `C:/ProgramData/$BUNDLE_ID/config`
 pub fn tunnel_service_config() -> Option<PathBuf> {


### PR DESCRIPTION
A full disk is an operator problem the flow-log spool cannot fix, yet every flow start and end tried to spool a report while the disk stayed full and logged the failure on `WARN`. Because the message embeds a unique file path, Sentry turned each one into a new issue across the GUI, Apple and Gateway projects. Those failures are now logged on `DEBUG` and the writer carries on as before.

Detecting the error kind was not possible with `atomicwrites`: its error type only implements the deprecated `cause`, so `anyhow` chains never reach the underlying `io::Error`. What we need from that crate is small (a temp file in the target directory, fsync, rename into place), and `tempfile` already provides the temp file and the cross-platform rename. The new in-tree `atomicfs` crate builds on that and exposes a single `write` function mirroring `std::fs::write` that returns a plain `io::Result`. All three former `atomicwrites` call sites use it and the dependency is removed from the workspace. Files are created owner-only, which the flow-log spool wanted anyway, so its own permission fixup goes away. The device ID file is now overwritten if it exists but failed to parse, instead of erroring out.