### PR TITLE
fix(apple): swipe away banners before a screenshot

### DIFF
--- a/swift/apple/FirezoneUITests/ScreenshotDelivery.swift
+++ b/swift/apple/FirezoneUITests/ScreenshotDelivery.swift
@@ -105,7 +105,7 @@ extension XCTestCase {
 
       print("banner: dismissing \"\(banner.label)\" before \(fileName)")
       banner.swipeUp()
-      _ = banner.waitForNonExistence(withTimeout: 5)
+      _ = banner.waitForNonExistence(timeout: 5)
     #endif
   }
 

--- a/swift/apple/FirezoneUITests/ScreenshotDelivery.swift
+++ b/swift/apple/FirezoneUITests/ScreenshotDelivery.swift
@@ -61,6 +61,10 @@ extension XCTestCase {
     for _ in 1...attempts {
       Thread.sleep(forTimeInterval: 1.0)
 
+      // A dismissed banner leaves the next capture differing from the last,
+      // which starts the count over.
+      dismissBanner(before: fileName)
+
       let current = element.screenshot()
       let currentPNG = current.pngRepresentation
       sizes.append(currentPNG.count)
@@ -85,6 +89,24 @@ extension XCTestCase {
     XCTFail("\(fileName) never held still, across \(attempts) captures")
 
     return previous
+  }
+
+  /// Swipes away a banner SpringBoard has laid over the app, and says so.
+  ///
+  /// The simulator posts its own: a "Ready for Apple Intelligence" notice once
+  /// made it into a capture. A banner holds still for longer than the captures
+  /// take to agree, so it has to be looked for rather than waited out.
+  private func dismissBanner(before fileName: String) {
+    #if os(iOS)
+      let banner = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        .otherElements["Notification"]
+
+      guard banner.exists else { return }
+
+      print("banner: dismissing \"\(banner.label)\" before \(fileName)")
+      banner.swipeUp()
+      _ = banner.waitForNonExistence(withTimeout: 5)
+    #endif
   }
 
   /// Says in the run's log how a capture came to rest: a screen that agreed at

--- a/swift/apple/mise-tasks/boot-simulator.sh
+++ b/swift/apple/mise-tasks/boot-simulator.sh
@@ -43,15 +43,6 @@ xcrun simctl spawn "${udid}" defaults write \
 xcrun simctl spawn "${udid}" defaults write \
   com.apple.Accessibility DarkerSystemColorsEnabled -bool true
 
-# A banner drawn over the app is photographed with it: the gallery once carried a
-# "Ready for Apple Intelligence" notice across the navigation bar. Best effort,
-# because the keys have moved between releases and a capture waits a banner out.
-xcrun simctl spawn "${udid}" defaults write com.apple.springboard SBEnableDoNotDisturb -bool true \
-  2>/dev/null || echo "::warning::Could not turn on Do Not Disturb via SpringBoard"
-xcrun simctl spawn "${udid}" defaults write com.apple.donotdisturb.DoNotDisturbSettings \
-  dndThroughUnlockEnabled -bool true \
-  2>/dev/null || echo "::warning::Could not turn on Do Not Disturb via its settings"
-
 echo "${udid}"
 
 if [ -n "${GITHUB_ENV:-}" ]; then


### PR DESCRIPTION
The simulator's own "Ready for Apple Intelligence" notice made it into a capture: a banner holds still for longer than the settle check waits, and the Do Not Disturb keys the boot task wrote date from iOS 14 and no longer take on the iOS 26 runtime. The test runner now asks SpringBoard for a banner before every capture and swipes it away, whatever posted it, and the boot task stops pretending to turn Do Not Disturb on.

Related: #15039