### PR TITLE
fix(connlib): hold ICE candidates back during roam reconnect

### DIFF
--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -315,6 +315,11 @@ impl Eventloop {
                     return Ok(ControlFlow::Continue(()));
                 };
 
+                // Resetting the tunnel yields fresh ICE candidates right away, while the portal
+                // connection is only re-established below. Mark the portal as disconnected first
+                // so those candidates are held back and flushed once we are connected again,
+                // instead of being sent into a socket that is still connecting and dropped.
+                tunnel.state_mut().set_portal_connected(false);
                 tunnel.reset(&reason, now);
                 tunnel_bypass_resolver::reset_sockets();
                 telemetry::reset_ingest();

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -315,10 +315,6 @@ impl Eventloop {
                     return Ok(ControlFlow::Continue(()));
                 };
 
-                // Resetting the tunnel yields fresh ICE candidates right away, while the portal
-                // connection is only re-established below. Mark the portal as disconnected first
-                // so those candidates are held back and flushed once we are connected again,
-                // instead of being sent into a socket that is still connecting and dropped.
                 tunnel.state_mut().set_portal_connected(false);
                 tunnel.reset(&reason, now);
                 tunnel_bypass_resolver::reset_sockets();


### PR DESCRIPTION
Resetting the tunnel on a roam yields the new ICE candidates immediately, but the portal connection is only re-established afterwards. Nothing told connlib that the portal was going away, so the candidates were emitted right away, hit the still-connecting phoenix channel and were dropped with `Not connected`. Existing iceless connections never learned the client's new addresses and only recovered once the WireGuard tunnel expired after `REKEY_ATTEMPT_TIME`, turning a roam into a ~100s outage.

The hold-back logic in `ClientState` already covers this, it just never engaged because `set_portal_connected(false)` was only called on portal-initiated hiccups. Marking the portal as disconnected before the reset makes the candidates wait for the reconnect and get flushed on the connected edge.