### PR TITLE
chore(rust): bump toolchain to 1.98.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787246814,
-        "narHash": "sha256-pEd4/iPY3Zm/EhhHmeB1QnIWXJSLx7gJzD/05mm2MCo=",
+        "lastModified": 1788456718,
+        "narHash": "sha256-TxHC0sBjV2pmsBLKAX02JTXlye/EOLt6Do+WNtGofGw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c84e121aaede7ef8c7bd9fb5154ccc1599e07816",
+        "rev": "0b20a18e84d9164464739189c2b2a1b00f6f0e4b",
         "type": "github"
       },
       "original": {

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -62,7 +62,7 @@ COPY ${PACKAGE} .
 FROM runtime AS dev
 
 ARG PACKAGE
-ARG RUST_VERSION="1.98.0" # Keep in sync with `rust-toolchain.toml`
+ARG RUST_VERSION="1.98.1" # Keep in sync with `rust-toolchain.toml`
 
 WORKDIR /app
 

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.98.0" # Keep in sync with `Dockerfile`
+channel = "1.98.1" # Keep in sync with `Dockerfile`
 components = ["rust-src", "rust-analyzer", "clippy"]
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Updates the Rust toolchain to 1.98.1 for local, CI, Docker, and Nix builds.

The pinned `rust-overlay` revision is refreshed so Nix can resolve the patch release.