### PR TITLE
fix(ci): skip OpenAPI comment when nothing changed

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -190,6 +190,9 @@ jobs:
           BREAKING=$(head -c 12000 ../openapi-breaking.txt 2>/dev/null || true)
           # Comment bodies are capped at 64 KiB; keep room for the rest.
           changelog=$(head -c 48000 ../openapi-changelog.md 2>/dev/null || true)
+          # oasdiff writes these placeholders instead of leaving the files empty.
+          [[ "$BREAKING" == "No breaking changes" ]] && BREAKING=""
+          [[ "$changelog" == "No changelog changes" ]] && changelog=""
           if [[ -z "$changelog" ]]; then
             changelog="No API changes."
           elif [[ $(wc -c < ../openapi-changelog.md) -gt 48000 ]]; then


### PR DESCRIPTION
The oasdiff action writes `No breaking changes` and `No changelog changes` to its output files instead of leaving them empty, so the comment step treated every PR as having API changes and posted the "Breaking OpenAPI changes" comment even when the spec was untouched. Treat those placeholders as empty so the comment only appears when there is something to review.