### PR TITLE
fix(ci): grant CD pull request permission

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -135,6 +135,7 @@ jobs:
     secrets: inherit
     permissions:
       checks: write # dorny/test-reporter
+      pull-requests: write # breaking OpenAPI changes comment
 
   swift:
     uses: ./.github/workflows/_swift.yml


### PR DESCRIPTION
The [Continuous Delivery workflow](https://github.com/firezone/firezone/actions/runs/33823855373) cannot instantiate the reusable Elixir workflow because its caller does not grant `pull-requests: write`.

Grant the permission at the caller so CD can start and publish main-branch artifacts, including the QA loadtest binaries.