### PR TITLE
fix(ci): skip irrelevant OpenAPI breaking-change checks

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -1,6 +1,12 @@
 name: Elixir
 on:
   workflow_call:
+    inputs:
+      check_openapi_breaking_changes:
+        description: Whether the pull request changes files under elixir/.
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   unit-test:
@@ -151,11 +157,11 @@ jobs:
       # does not fail the job: there is no API versioning strategy yet, so a
       # breaking change is a review decision rather than a build error.
       - name: Fetch base OpenAPI spec
-        if: github.base_ref != ''
+        if: github.base_ref != '' && inputs.check_openapi_breaking_changes
         run: git show "origin/${{ github.base_ref }}:elixir/priv/static/openapi.json" > ../base-openapi.json
       - name: Check for breaking OpenAPI changes
         id: oasdiff
-        if: github.base_ref != ''
+        if: github.base_ref != '' && inputs.check_openapi_breaking_changes
         uses: oasdiff/oasdiff-action/breaking@45c956ed8138f7f18f0425d34e3d66730b805cb2 # v0.1.9
         with:
           base: base-openapi.json
@@ -167,7 +173,7 @@ jobs:
           github-token: ""
       - name: Build the OpenAPI changelog
         id: changelog
-        if: github.base_ref != ''
+        if: github.base_ref != '' && inputs.check_openapi_breaking_changes
         uses: oasdiff/oasdiff-action/changelog@45c956ed8138f7f18f0425d34e3d66730b805cb2 # v0.1.9
         with:
           base: base-openapi.json
@@ -180,7 +186,7 @@ jobs:
       # in the review rather than buried in a job summary. The full changelog
       # rides along collapsed, so the detail is one click away.
       - name: Comment on breaking OpenAPI changes
-        if: github.base_ref != '' && github.event.pull_request.number
+        if: github.base_ref != '' && inputs.check_openapi_breaking_changes && github.event.pull_request.number
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -212,6 +218,6 @@ jobs:
             --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -n1)
           if [[ -n "$existing" ]]; then
             gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -f body="$body" >/dev/null
-          elif [[ -n "$BREAKING" ]] || [[ "$changelog" != "No API changes." ]]; then
+          elif [[ -n "$BREAKING" ]]; then
             gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="$body" >/dev/null
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       jobs_to_run: ${{ steps.plan.outputs.jobs_to_run }}
+      elixir_changed: ${{ steps.plan.outputs.elixir_changed }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Plan jobs to run
@@ -42,6 +43,7 @@ jobs:
           # For workflow_dispatch or workflow_call, run all jobs
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "workflow_call" ]; then
             echo "jobs_to_run=$jobs" >> "$GITHUB_OUTPUT"
+            echo "elixir_changed=true" >> "$GITHUB_OUTPUT"
 
             exit 0;
           fi
@@ -49,6 +51,7 @@ jobs:
           # For main branch runs, run all jobs
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref_name }}" = "main" ]; then
             echo "jobs_to_run=$jobs" >> "$GITHUB_OUTPUT"
+            echo "elixir_changed=true" >> "$GITHUB_OUTPUT"
 
             exit 0;
           fi
@@ -72,6 +75,12 @@ jobs:
 
             echo "Changed files:"
             cat changed_files.txt
+          fi
+
+          if grep -q '^elixir/' changed_files.txt; then
+            echo "elixir_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "elixir_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
           # Run all jobs if CI configuration changes
@@ -348,6 +357,8 @@ jobs:
     needs: planner
     if: contains(needs.planner.outputs.jobs_to_run, 'elixir')
     uses: ./.github/workflows/_elixir.yml
+    with:
+      check_openapi_breaking_changes: ${{ needs.planner.outputs.elixir_changed == 'true' }}
     secrets: inherit
     permissions:
       checks: write # dorny/test-reporter


### PR DESCRIPTION
Skips the OpenAPI breaking-change comparison for PRs that do not modify `elixir/`, and only posts a PR comment when the comparison finds a breaking change.