### PR TITLE
fix(api): reject a page limit outside 1 to 100

### DIFF
--- a/elixir/lib/portal/repo/paginator.ex
+++ b/elixir/lib/portal/repo/paginator.ex
@@ -305,6 +305,7 @@ defmodule Portal.Repo.Paginator do
 
   @doc false
   def max_encoded_cursor_bytes, do: @max_encoded_cursor_bytes
+  def max_limit, do: @max_limit
 
   @doc false
   def encode_cursor(direction, cursor_fields, schema) do

--- a/elixir/lib/portal_api/controllers/actor_controller.ex
+++ b/elixir/lib/portal_api/controllers/actor_controller.ex
@@ -16,7 +16,7 @@ defmodule PortalAPI.ActorController do
   operation :index,
     summary: "List Actors",
     parameters: [
-      limit: [in: :query, description: "Limit Users returned", type: :integer, example: 10],
+      limit: [in: :query, description: "Limit Users returned", schema: PortalAPI.Pagination.limit_schema(), example: 10],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string],
       name: [in: :query, description: "Filter to Actors with this exact name", type: :string],
       email: [in: :query, description: "Filter to Actors with this exact email", type: :string],

--- a/elixir/lib/portal_api/controllers/client_controller.ex
+++ b/elixir/lib/portal_api/controllers/client_controller.ex
@@ -20,7 +20,7 @@ defmodule PortalAPI.ClientController do
       limit: [
         in: :query,
         description: "Limit Clients returned",
-        type: :integer,
+        schema: PortalAPI.Pagination.limit_schema(),
         example: 10
       ],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string],

--- a/elixir/lib/portal_api/controllers/client_token_controller.ex
+++ b/elixir/lib/portal_api/controllers/client_token_controller.ex
@@ -20,7 +20,7 @@ defmodule PortalAPI.ClientTokenController do
         type: :string,
         example: "00000000-0000-0000-0000-000000000000"
       ],
-      limit: [in: :query, description: "Limit Client Tokens returned", type: :integer],
+      limit: [in: :query, description: "Limit Client Tokens returned", schema: PortalAPI.Pagination.limit_schema()],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string]
     ],
     responses:

--- a/elixir/lib/portal_api/controllers/defender_device_controller.ex
+++ b/elixir/lib/portal_api/controllers/defender_device_controller.ex
@@ -24,7 +24,7 @@ defmodule PortalAPI.DefenderDeviceController do
   operation :index,
     summary: "List synced Defender devices",
     parameters: [
-      limit: [in: :query, description: "Limit devices returned", type: :integer],
+      limit: [in: :query, description: "Limit devices returned", schema: PortalAPI.Pagination.limit_schema()],
       page_cursor: [in: :query, description: "Next/previous page cursor", type: :string]
     ],
     responses:

--- a/elixir/lib/portal_api/controllers/defender_posture_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/defender_posture_provider_controller.ex
@@ -24,7 +24,7 @@ defmodule PortalAPI.DefenderPostureProviderController do
   operation :index,
     summary: "List Defender posture providers",
     parameters: [
-      limit: [in: :query, description: "Limit providers returned", type: :integer],
+      limit: [in: :query, description: "Limit providers returned", schema: PortalAPI.Pagination.limit_schema()],
       page_cursor: [in: :query, description: "Next/previous page cursor", type: :string]
     ],
     responses:

--- a/elixir/lib/portal_api/controllers/email_otp_auth_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/email_otp_auth_provider_controller.ex
@@ -17,7 +17,7 @@ defmodule PortalAPI.EmailOTPAuthProviderController do
       limit: [
         in: :query,
         description: "Limit Email OTP Auth Providers returned",
-        type: :integer,
+        schema: PortalAPI.Pagination.limit_schema(),
         example: 10
       ],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string],

--- a/elixir/lib/portal_api/controllers/entra_auth_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/entra_auth_provider_controller.ex
@@ -17,7 +17,7 @@ defmodule PortalAPI.EntraAuthProviderController do
       limit: [
         in: :query,
         description: "Limit Entra Auth Providers returned",
-        type: :integer,
+        schema: PortalAPI.Pagination.limit_schema(),
         example: 10
       ],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string],

--- a/elixir/lib/portal_api/controllers/entra_directory_controller.ex
+++ b/elixir/lib/portal_api/controllers/entra_directory_controller.ex
@@ -17,7 +17,7 @@ defmodule PortalAPI.EntraDirectoryController do
       limit: [
         in: :query,
         description: "Limit Entra Directories returned",
-        type: :integer,
+        schema: PortalAPI.Pagination.limit_schema(),
         example: 10
       ],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string],

--- a/elixir/lib/portal_api/controllers/external_identity_controller.ex
+++ b/elixir/lib/portal_api/controllers/external_identity_controller.ex
@@ -14,7 +14,7 @@ defmodule PortalAPI.ExternalIdentityController do
     summary: "List External Identities for an Actor",
     parameters: [
       actor_id: [in: :path, description: "Actor ID", type: :string],
-      limit: [in: :query, description: "Limit External Identities returned", type: :integer],
+      limit: [in: :query, description: "Limit External Identities returned", schema: PortalAPI.Pagination.limit_schema()],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string]
     ],
     responses:

--- a/elixir/lib/portal_api/controllers/gateway_controller.ex
+++ b/elixir/lib/portal_api/controllers/gateway_controller.ex
@@ -21,7 +21,7 @@ defmodule PortalAPI.GatewayController do
         type: :string,
         example: "00000000-0000-0000-0000-000000000000"
       ],
-      limit: [in: :query, description: "Limit Gateways returned", type: :integer, example: 10],
+      limit: [in: :query, description: "Limit Gateways returned", schema: PortalAPI.Pagination.limit_schema(), example: 10],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string],
       name: [in: :query, description: "Filter to the Gateway with this exact name", type: :string],
       ipv4: [in: :query, description: "Filter to the Gateway with this exact tunnel IPv4 address", type: :string],

--- a/elixir/lib/portal_api/controllers/google_auth_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/google_auth_provider_controller.ex
@@ -17,7 +17,7 @@ defmodule PortalAPI.GoogleAuthProviderController do
       limit: [
         in: :query,
         description: "Limit Google Auth Providers returned",
-        type: :integer,
+        schema: PortalAPI.Pagination.limit_schema(),
         example: 10
       ],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string],

--- a/elixir/lib/portal_api/controllers/google_directory_controller.ex
+++ b/elixir/lib/portal_api/controllers/google_directory_controller.ex
@@ -17,7 +17,7 @@ defmodule PortalAPI.GoogleDirectoryController do
       limit: [
         in: :query,
         description: "Limit Google Directories returned",
-        type: :integer,
+        schema: PortalAPI.Pagination.limit_schema(),
         example: 10
       ],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string],

--- a/elixir/lib/portal_api/controllers/group_controller.ex
+++ b/elixir/lib/portal_api/controllers/group_controller.ex
@@ -16,7 +16,7 @@ defmodule PortalAPI.GroupController do
   operation :index,
     summary: "List Groups",
     parameters: [
-      limit: [in: :query, description: "Limit Groups returned", type: :integer, example: 10],
+      limit: [in: :query, description: "Limit Groups returned", schema: PortalAPI.Pagination.limit_schema(), example: 10],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string],
       name: [in: :query, description: "Filter to Groups with this exact name", type: :string],
       directory_id: [

--- a/elixir/lib/portal_api/controllers/intune_device_controller.ex
+++ b/elixir/lib/portal_api/controllers/intune_device_controller.ex
@@ -24,7 +24,7 @@ defmodule PortalAPI.IntuneDeviceController do
   operation :index,
     summary: "List synced Intune devices",
     parameters: [
-      limit: [in: :query, description: "Limit devices returned", type: :integer],
+      limit: [in: :query, description: "Limit devices returned", schema: PortalAPI.Pagination.limit_schema()],
       page_cursor: [in: :query, description: "Next/previous page cursor", type: :string]
     ],
     responses:

--- a/elixir/lib/portal_api/controllers/intune_posture_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/intune_posture_provider_controller.ex
@@ -24,7 +24,7 @@ defmodule PortalAPI.IntunePostureProviderController do
   operation :index,
     summary: "List Intune posture providers",
     parameters: [
-      limit: [in: :query, description: "Limit providers returned", type: :integer],
+      limit: [in: :query, description: "Limit providers returned", schema: PortalAPI.Pagination.limit_schema()],
       page_cursor: [in: :query, description: "Next/previous page cursor", type: :string]
     ],
     responses:

--- a/elixir/lib/portal_api/controllers/iru_device_controller.ex
+++ b/elixir/lib/portal_api/controllers/iru_device_controller.ex
@@ -24,7 +24,7 @@ defmodule PortalAPI.IruDeviceController do
   operation :index,
     summary: "List synced Iru devices",
     parameters: [
-      limit: [in: :query, description: "Limit devices returned", type: :integer],
+      limit: [in: :query, description: "Limit devices returned", schema: PortalAPI.Pagination.limit_schema()],
       page_cursor: [in: :query, description: "Next/previous page cursor", type: :string]
     ],
     responses:

--- a/elixir/lib/portal_api/controllers/iru_posture_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/iru_posture_provider_controller.ex
@@ -24,7 +24,7 @@ defmodule PortalAPI.IruPostureProviderController do
   operation :index,
     summary: "List Iru posture providers",
     parameters: [
-      limit: [in: :query, description: "Limit providers returned", type: :integer],
+      limit: [in: :query, description: "Limit providers returned", schema: PortalAPI.Pagination.limit_schema()],
       page_cursor: [in: :query, description: "Next/previous page cursor", type: :string]
     ],
     responses:

--- a/elixir/lib/portal_api/controllers/log_controller.ex
+++ b/elixir/lib/portal_api/controllers/log_controller.ex
@@ -77,11 +77,9 @@ defmodule PortalAPI.LogController do
       limit: [
         in: :query,
         description: """
-        Maximum number of Logs to return per page. Defaults to 50.
-        Values greater than 100 are capped to 100, and values less than 1
-        are raised to 1.
+        Maximum number of Logs to return per page, from 1 to 100. Defaults to 50.
         """,
-        type: :integer,
+        schema: PortalAPI.Pagination.limit_schema(),
         example: 50
       ],
       page_cursor: [

--- a/elixir/lib/portal_api/controllers/membership_controller.ex
+++ b/elixir/lib/portal_api/controllers/membership_controller.ex
@@ -21,7 +21,7 @@ defmodule PortalAPI.MembershipController do
       limit: [
         in: :query,
         description: "Limit Memberships returned",
-        type: :integer,
+        schema: PortalAPI.Pagination.limit_schema(),
         example: 10
       ],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string]

--- a/elixir/lib/portal_api/controllers/oidc_auth_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/oidc_auth_provider_controller.ex
@@ -17,7 +17,7 @@ defmodule PortalAPI.OIDCAuthProviderController do
       limit: [
         in: :query,
         description: "Limit OIDC Auth Providers returned",
-        type: :integer,
+        schema: PortalAPI.Pagination.limit_schema(),
         example: 10
       ],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string],

--- a/elixir/lib/portal_api/controllers/okta_auth_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/okta_auth_provider_controller.ex
@@ -17,7 +17,7 @@ defmodule PortalAPI.OktaAuthProviderController do
       limit: [
         in: :query,
         description: "Limit Okta Auth Providers returned",
-        type: :integer,
+        schema: PortalAPI.Pagination.limit_schema(),
         example: 10
       ],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string],

--- a/elixir/lib/portal_api/controllers/okta_directory_controller.ex
+++ b/elixir/lib/portal_api/controllers/okta_directory_controller.ex
@@ -17,7 +17,7 @@ defmodule PortalAPI.OktaDirectoryController do
       limit: [
         in: :query,
         description: "Limit Okta Directories returned",
-        type: :integer,
+        schema: PortalAPI.Pagination.limit_schema(),
         example: 10
       ],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string],

--- a/elixir/lib/portal_api/controllers/pagination.ex
+++ b/elixir/lib/portal_api/controllers/pagination.ex
@@ -2,6 +2,12 @@ defmodule PortalAPI.Pagination do
   alias Portal.Repo.Paginator
   alias Portal.Repo.Paginator.Metadata
 
+  @max_limit Paginator.max_limit()
+
+  def limit_schema do
+    %OpenApiSpex.Schema{type: :integer, minimum: 1, maximum: @max_limit}
+  end
+
   @spec params_to_list_opts(map()) :: {:ok, keyword()} | {:error, :bad_request, reason: String.t()}
   def params_to_list_opts(params) do
     with {:ok, page} <- params_to_page(params) do
@@ -43,7 +49,8 @@ defmodule PortalAPI.Pagination do
 
   defp parse_limit(limit) when is_binary(limit) do
     case Integer.parse(limit) do
-      {int, ""} -> {:ok, int}
+      {int, ""} when int >= 1 and int <= @max_limit -> {:ok, int}
+      {_int, ""} -> {:error, :bad_request, reason: "limit must be between 1 and #{@max_limit}"}
       _ -> {:error, :bad_request, reason: "limit must be an integer"}
     end
   end

--- a/elixir/lib/portal_api/controllers/policy_controller.ex
+++ b/elixir/lib/portal_api/controllers/policy_controller.ex
@@ -14,7 +14,7 @@ defmodule PortalAPI.PolicyController do
   operation :index,
     summary: "List Policies",
     parameters: [
-      limit: [in: :query, description: "Limit Policies returned", type: :integer, example: 10],
+      limit: [in: :query, description: "Limit Policies returned", schema: PortalAPI.Pagination.limit_schema(), example: 10],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string],
       group_id: [in: :query, description: "Filter to Policies granting this Group", type: :string],
       resource_id: [

--- a/elixir/lib/portal_api/controllers/pool_member_controller.ex
+++ b/elixir/lib/portal_api/controllers/pool_member_controller.ex
@@ -24,7 +24,7 @@ defmodule PortalAPI.PoolMemberController do
         description: "Resource ID",
         example: "00000000-0000-0000-0000-000000000000"
       ],
-      limit: [in: :query, description: "Limit Pool Members returned", type: :integer, example: 10],
+      limit: [in: :query, description: "Limit Pool Members returned", schema: PortalAPI.Pagination.limit_schema(), example: 10],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string]
     ],
     responses:

--- a/elixir/lib/portal_api/controllers/resource_controller.ex
+++ b/elixir/lib/portal_api/controllers/resource_controller.ex
@@ -14,7 +14,7 @@ defmodule PortalAPI.ResourceController do
   operation :index,
     summary: "List Resources",
     parameters: [
-      limit: [in: :query, description: "Limit Resources returned", type: :integer, example: 10],
+      limit: [in: :query, description: "Limit Resources returned", schema: PortalAPI.Pagination.limit_schema(), example: 10],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string],
       name: [
         in: :query,

--- a/elixir/lib/portal_api/controllers/santa_device_controller.ex
+++ b/elixir/lib/portal_api/controllers/santa_device_controller.ex
@@ -24,7 +24,7 @@ defmodule PortalAPI.SantaDeviceController do
   operation :index,
     summary: "List synced Santa devices",
     parameters: [
-      limit: [in: :query, description: "Limit devices returned", type: :integer],
+      limit: [in: :query, description: "Limit devices returned", schema: PortalAPI.Pagination.limit_schema()],
       page_cursor: [in: :query, description: "Next/previous page cursor", type: :string]
     ],
     responses:

--- a/elixir/lib/portal_api/controllers/santa_posture_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/santa_posture_provider_controller.ex
@@ -24,7 +24,7 @@ defmodule PortalAPI.SantaPostureProviderController do
   operation :index,
     summary: "List Santa posture providers",
     parameters: [
-      limit: [in: :query, description: "Limit providers returned", type: :integer],
+      limit: [in: :query, description: "Limit providers returned", schema: PortalAPI.Pagination.limit_schema()],
       page_cursor: [in: :query, description: "Next/previous page cursor", type: :string]
     ],
     responses:

--- a/elixir/lib/portal_api/controllers/sentinel_one_device_controller.ex
+++ b/elixir/lib/portal_api/controllers/sentinel_one_device_controller.ex
@@ -24,7 +24,7 @@ defmodule PortalAPI.SentinelOneDeviceController do
   operation :index,
     summary: "List synced SentinelOne devices",
     parameters: [
-      limit: [in: :query, description: "Limit devices returned", type: :integer],
+      limit: [in: :query, description: "Limit devices returned", schema: PortalAPI.Pagination.limit_schema()],
       page_cursor: [in: :query, description: "Next/previous page cursor", type: :string]
     ],
     responses:

--- a/elixir/lib/portal_api/controllers/sentinel_one_posture_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/sentinel_one_posture_provider_controller.ex
@@ -24,7 +24,7 @@ defmodule PortalAPI.SentinelOnePostureProviderController do
   operation :index,
     summary: "List SentinelOne posture providers",
     parameters: [
-      limit: [in: :query, description: "Limit providers returned", type: :integer],
+      limit: [in: :query, description: "Limit providers returned", schema: PortalAPI.Pagination.limit_schema()],
       page_cursor: [in: :query, description: "Next/previous page cursor", type: :string]
     ],
     responses:

--- a/elixir/lib/portal_api/controllers/site_controller.ex
+++ b/elixir/lib/portal_api/controllers/site_controller.ex
@@ -17,7 +17,7 @@ defmodule PortalAPI.SiteController do
       limit: [
         in: :query,
         description: "Limit Sites returned",
-        type: :integer,
+        schema: PortalAPI.Pagination.limit_schema(),
         example: 10
       ],
       page_cursor: [in: :query, description: "Next/Prev page cursor", type: :string],

--- a/elixir/priv/static/openapi.json
+++ b/elixir/priv/static/openapi.json
@@ -7158,6 +7158,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -7418,6 +7420,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -8610,6 +8614,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -8717,6 +8723,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -8956,6 +8964,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -9814,6 +9824,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -10327,6 +10339,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -10443,6 +10457,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -10672,6 +10688,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -11419,6 +11437,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -12267,6 +12287,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -12783,6 +12805,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -12890,6 +12914,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -13344,6 +13370,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -13461,6 +13489,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -13874,6 +13904,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -14329,6 +14361,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -15064,6 +15098,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -15294,6 +15330,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -15846,6 +15884,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -15964,6 +16004,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -16831,6 +16873,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -17691,6 +17735,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -17985,6 +18031,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -18092,6 +18140,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -18355,12 +18405,14 @@
             }
           },
           {
-            "description": "Maximum number of Logs to return per page. Defaults to 50.\nValues greater than 100 are capped to 100, and values less than 1\nare raised to 1.\n",
+            "description": "Maximum number of Logs to return per page, from 1 to 100. Defaults to 50.\n",
             "example": 50,
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -18508,6 +18560,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -18760,6 +18814,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -18988,6 +19044,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },
@@ -19474,6 +19532,8 @@
             "name": "limit",
             "required": false,
             "schema": {
+              "maximum": 100,
+              "minimum": 1,
               "type": "integer"
             }
           },

--- a/elixir/test/portal_api/controllers/actor_controller_test.exs
+++ b/elixir/test/portal_api/controllers/actor_controller_test.exs
@@ -107,6 +107,18 @@ defmodule PortalAPI.ActorControllerTest do
       assert %{"type" => "about:blank", "status" => 400} = json_response(conn, 400)
     end
 
+    test "returns error for a limit outside 1 to 100", %{conn: conn, actor: actor} do
+      for limit <- ["0", "-1", "101"] do
+        conn =
+          conn
+          |> authorize_conn(actor)
+          |> put_req_header("content-type", "application/json")
+          |> get("/actors", limit: limit)
+
+        assert %{"type" => "about:blank", "status" => 400} = json_response(conn, 400)
+      end
+    end
+
     test "filters by exact name match", %{conn: conn, account: account, actor: actor} do
       target = actor_fixture(account: account, name: "alice", type: :account_user)
       _other = actor_fixture(account: account, name: "bob", type: :account_user)


### PR DESCRIPTION
The API fuzz job failed on #15057 because a list request with a negative `limit` returned 200. The paginator silently clamped any integer into the 1 to 100 range, and the OpenAPI spec declared `limit` as a bare integer, so nothing said a page size of -4194305 was wrong.

Every list operation now declares `limit` with a minimum of 1 and a maximum of 100 from one shared schema, and the request validation plug rejects anything outside that range with a 400 before the controller runs. The pagination parser applies the same check as a backstop.

Related: #15057
