### PR TITLE
fix(portal): revoke OAuth credentials when consent narrows

### DIFF
--- a/elixir/lib/portal/oauth.ex
+++ b/elixir/lib/portal/oauth.ex
@@ -130,7 +130,9 @@ defmodule Portal.OAuth do
 
   The grant is upserted rather than inserted so that re-approving a client with
   different scopes replaces what it had, instead of leaving two rows that
-  disagree about what was allowed.
+  disagree about what was allowed. Removing a previously granted scope also
+  revokes the client's outstanding codes and token pairs, so they cannot keep
+  using the wider grant.
   """
   def consent(%Request{} = request, %Subject{} = subject) do
     with :ok <- validate_granted_scopes(request) do
@@ -308,10 +310,12 @@ defmodule Portal.OAuth do
   defp upsert_grant(%Request{} = request, %Subject{} = subject) do
     case Database.fetch_grant(request.client.id, subject) do
       {:ok, grant} ->
-        grant
-        |> change()
-        |> put_change(:scopes, request.scopes)
-        |> Database.update_grant(subject)
+        with :ok <- revoke_credentials_if_scopes_removed(grant, request.scopes) do
+          grant
+          |> change()
+          |> put_change(:scopes, request.scopes)
+          |> Database.update_grant(subject)
+        end
 
       :error ->
         %OAuthGrant{}
@@ -324,6 +328,14 @@ defmodule Portal.OAuth do
           ~w[actor_id oauth_client_id scopes]a
         )
         |> Database.insert_grant(subject)
+    end
+  end
+
+  defp revoke_credentials_if_scopes_removed(%OAuthGrant{} = grant, scopes) do
+    if MapSet.subset?(MapSet.new(grant.scopes), MapSet.new(scopes)) do
+      :ok
+    else
+      Database.delete_credentials(grant)
     end
   end
 
@@ -496,9 +508,8 @@ defmodule Portal.OAuth do
       secret_hash: access_hash,
       refresh_secret_salt: refresh_salt,
       refresh_secret_hash: refresh_hash,
-      # Taken from the grant rather than carried over, so approving the same
-      # client again with fewer permissions reaches the token it is already
-      # holding instead of waiting out its refresh window.
+      # Taken from the current grant rather than carried over, so rotation
+      # cannot retain permissions that are no longer present on the grant.
       scopes: token.oauth_grant.scopes,
       expires_at: DateTime.add(now, @access_ttl_seconds, :second),
       refresh_expires_at: DateTime.add(now, @refresh_ttl_seconds, :second),
@@ -572,7 +583,8 @@ defmodule Portal.OAuth do
     def fetch_grant(oauth_client_id, subject) do
       from(grants in OAuthGrant,
         where: grants.actor_id == ^subject.actor.id,
-        where: grants.oauth_client_id == ^oauth_client_id
+        where: grants.oauth_client_id == ^oauth_client_id,
+        lock: "FOR UPDATE"
       )
       |> Safe.scoped(subject)
       |> Safe.one()
@@ -592,6 +604,24 @@ defmodule Portal.OAuth do
       changeset
       |> Safe.scoped(subject)
       |> Safe.update()
+    end
+
+    def delete_credentials(%OAuthGrant{} = grant) do
+      from(codes in OAuthAuthorizationCode,
+        where: codes.account_id == ^grant.account_id,
+        where: codes.oauth_grant_id == ^grant.id
+      )
+      |> Safe.unscoped()
+      |> Safe.delete_all()
+
+      from(tokens in OAuthToken,
+        where: tokens.account_id == ^grant.account_id,
+        where: tokens.oauth_grant_id == ^grant.id
+      )
+      |> Safe.unscoped()
+      |> Safe.delete_all()
+
+      :ok
     end
 
     def insert_code(changeset, subject) do

--- a/elixir/test/portal/oauth_test.exs
+++ b/elixir/test/portal/oauth_test.exs
@@ -301,6 +301,46 @@ defmodule Portal.OAuthTest do
       assert grant.scopes == ["policies:read", "policies:write"]
     end
 
+    test "re-consenting with fewer scopes revokes the existing token pair", context do
+      resource = OAuth.resource_uri()
+      code = consent(context, "policies:read policies:write", resource)
+
+      assert {:ok, issued} = OAuth.exchange(exchange_params(context, code), resource)
+
+      mcp_context = Portal.Authentication.Context.build({127, 0, 0, 1}, "testing", [], :mcp)
+
+      assert {:ok, subject} =
+               Portal.Authentication.authenticate(issued.access_token, mcp_context)
+
+      assert subject.credential.scopes == ["policies:read", "policies:write"]
+
+      narrowed_code = consent(context, "policies:read", resource)
+
+      assert {:error, :invalid_token} =
+               Portal.Authentication.authenticate(issued.access_token, mcp_context)
+
+      assert {:error, "invalid_grant", _description} =
+               OAuth.refresh(refresh_params(context, issued.refresh_token), resource)
+
+      assert {:ok, narrowed} =
+               OAuth.exchange(exchange_params(context, narrowed_code), resource)
+
+      assert narrowed.scope == "policies:read"
+    end
+
+    test "re-consenting with fewer scopes revokes outstanding authorization codes", context do
+      broad_code = consent(context, "policies:read policies:write")
+      narrowed_code = consent(context, "policies:read")
+
+      assert {:error, "invalid_grant", _description} =
+               OAuth.exchange(exchange_params(context, broad_code), @resource)
+
+      assert {:ok, narrowed} =
+               OAuth.exchange(exchange_params(context, narrowed_code), @resource)
+
+      assert narrowed.scope == "policies:read"
+    end
+
     test "refuses to record scopes outside the validated request", context do
       {:ok, request} =
         OAuth.validate_request(
@@ -492,11 +532,11 @@ defmodule Portal.OAuthTest do
     end
   end
 
-  defp consent(context, scope \\ "policies:read") do
-    params = %{params(context.client) | "scope" => scope}
+  defp consent(context, scope \\ "policies:read", resource \\ @resource) do
+    params = %{params(context.client) | "scope" => scope, "resource" => resource}
 
     {:ok, request} =
-      OAuth.validate_request(params, context.client, redirect_uri(), @resource)
+      OAuth.validate_request(params, context.client, redirect_uri(), resource)
 
     request = %{request | scopes: request.requested_scopes}
     {:ok, code} = OAuth.consent(request, context.subject)


### PR DESCRIPTION
Narrowing an existing OAuth grant updated the stored scopes but left previously issued, broader credentials valid. This allowed an access token to retain permissions the user had just removed.

This change:

- revokes existing OAuth token pairs when re-consent removes any scope
- invalidates outstanding authorization codes for the wider grant
- locks the grant while replacing consent so concurrent consent updates serialize
- preserves existing credentials when scopes are unchanged or only expanded

## Testing

- `mix test test/portal/oauth_test.exs` (43 passed)
- `mix test test/portal_web/controllers/oauth_controller_test.exs` (48 passed)