### PR TITLE
fix(portal): fix MCP handshake and consent details

### DIFF
--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -395,7 +395,7 @@ config :argon2_elixir, t_cost: 1, m_cost: 8
 
 config :geolix,
   databases: [
-    %{id: :city, adapter: Geolix.Adapter.Fake, data: %{}}
+    %{id: :city, adapter: Portal.Test.GeoAdapter, data: %{}}
   ]
 
 default_assert_receive_timeout = 1_000

--- a/elixir/lib/portal_api/controllers/mcp_controller.ex
+++ b/elixir/lib/portal_api/controllers/mcp_controller.ex
@@ -23,7 +23,7 @@ defmodule PortalAPI.MCPController do
   @base64_prefix "=?base64?"
   @base64_suffix "?="
 
-  plug :validate_origin
+  plug(:validate_origin)
 
   @spec handle(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def handle(conn, _params) do
@@ -51,8 +51,7 @@ defmodule PortalAPI.MCPController do
       MCP.error(
         nil,
         MCP.invalid_request(),
-        "The MCP endpoint accepts POST only. Protocol revision #{MCP.protocol_version()} " <>
-          "removed the GET stream and the DELETE session teardown."
+        "The MCP endpoint accepts POST only; it does not offer an SSE stream or sessions."
       )
     )
   end
@@ -61,15 +60,43 @@ defmodule PortalAPI.MCPController do
     conn = PortalAPI.Plugs.MCPRequestLog.identify(conn, method, params)
 
     with :ok <- validate_params(params),
-         :ok <- validate_protocol_version(conn, params),
-         :ok <- validate_header(conn, "mcp-method", method, "Mcp-Method"),
-         :ok <- validate_name_header(conn, method, params),
-         :ok <- validate_client_capabilities(params) do
+         :ok <- validate_protocol(conn, method, params) do
       dispatch(conn, id, method, params)
     else
       {:error, status, code, message, data} ->
         send_rpc(conn, status, MCP.error(id, code, message, data))
     end
+  end
+
+  # Streamable HTTP clients negotiate once via initialize. No session is needed:
+  # subsequent requests identify the negotiated revision in the version header.
+  defp dispatch(conn, id, "initialize", %{
+         "protocolVersion" => version,
+         "capabilities" => capabilities,
+         "clientInfo" => %{"name" => name, "version" => client_version}
+       })
+       when is_binary(version) and is_map(capabilities) and is_binary(name) and
+              is_binary(client_version) do
+    version = if MCP.legacy_version?(version), do: version, else: MCP.legacy_protocol_version()
+
+    send_rpc(
+      conn,
+      200,
+      MCP.result(id, %{
+        protocolVersion: version,
+        capabilities: %{tools: %{}},
+        serverInfo: MCP.server_info(),
+        instructions: MCP.instructions()
+      })
+    )
+  end
+
+  defp dispatch(conn, id, "initialize", _params) do
+    send_rpc(conn, 400, MCP.error(id, MCP.invalid_params(), "Invalid initialize parameters."))
+  end
+
+  defp dispatch(conn, id, "ping", _params) do
+    send_rpc(conn, 200, MCP.result(id, %{}))
   end
 
   defp dispatch(conn, id, "server/discover", _params) do
@@ -223,10 +250,36 @@ defmodule PortalAPI.MCPController do
     Map.get(body, "params", %{})
   end
 
-  defp validate_params(%{"_meta" => meta}) when is_map(meta), do: :ok
+  defp validate_params(params) when is_map(params) do
+    if is_map(Map.get(params, "_meta", %{})), do: :ok, else: invalid_params()
+  end
 
-  defp validate_params(_params) do
+  defp validate_params(_params), do: invalid_params()
+
+  defp invalid_params do
     {:error, 400, MCP.invalid_params(), "`params` and `params._meta` must be JSON objects.", nil}
+  end
+
+  defp validate_protocol(_conn, "initialize", _params), do: :ok
+
+  defp validate_protocol(conn, method, params) do
+    # A modern metadata envelope must still pass every modern routing check.
+    modern? = Map.has_key?(Map.get(params, "_meta", %{}), MCP.protocol_version_key())
+
+    case {modern?, get_req_header(conn, "mcp-protocol-version")} do
+      {false, [version]} when version in ["2025-03-26", "2025-06-18", "2025-11-25"] ->
+        :ok
+
+      {false, []} when method != "server/discover" ->
+        :ok
+
+      _ ->
+        with :ok <- validate_protocol_version(conn, params),
+             :ok <- validate_header(conn, "mcp-method", method, "Mcp-Method"),
+             :ok <- validate_name_header(conn, method, params) do
+          validate_client_capabilities(params)
+        end
+    end
   end
 
   defp validate_header(conn, header, expected, label) do
@@ -358,11 +411,12 @@ defmodule PortalAPI.MCPController do
         userinfo: nil
       }
       when is_binary(scheme) and is_binary(host) and path in [nil, ""] ->
-        String.downcase(scheme) == (conn.scheme |> Atom.to_string() |> String.downcase()) and
+        String.downcase(scheme) == conn.scheme |> Atom.to_string() |> String.downcase() and
           String.downcase(host) == String.downcase(conn.host) and
           effective_port(scheme, port) == conn.port
 
-      _other -> false
+      _other ->
+        false
     end
   end
 

--- a/elixir/lib/portal_api/controllers/mcp_controller.ex
+++ b/elixir/lib/portal_api/controllers/mcp_controller.ex
@@ -23,7 +23,7 @@ defmodule PortalAPI.MCPController do
   @base64_prefix "=?base64?"
   @base64_suffix "?="
 
-  plug(:validate_origin)
+  plug :validate_origin
 
   @spec handle(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def handle(conn, _params) do
@@ -411,12 +411,11 @@ defmodule PortalAPI.MCPController do
         userinfo: nil
       }
       when is_binary(scheme) and is_binary(host) and path in [nil, ""] ->
-        String.downcase(scheme) == conn.scheme |> Atom.to_string() |> String.downcase() and
+        String.downcase(scheme) == (conn.scheme |> Atom.to_string() |> String.downcase()) and
           String.downcase(host) == String.downcase(conn.host) and
           effective_port(scheme, port) == conn.port
 
-      _other ->
-        false
+      _other -> false
     end
   end
 

--- a/elixir/lib/portal_api/mcp.ex
+++ b/elixir/lib/portal_api/mcp.ex
@@ -2,11 +2,9 @@ defmodule PortalAPI.MCP do
   @moduledoc """
   Model Context Protocol server for the Firezone REST API.
 
-  Implements revision `2026-07-28`, which is stateless: there is no
-  `initialize` handshake and no session, every request carries its own protocol
-  version and client capabilities in `_meta`, and the transport is a single
-  POST endpoint. That maps onto a plain Phoenix controller with no supervised
-  state of its own.
+  Implements stateless revision `2026-07-28` and the initialize handshake for
+  Streamable HTTP revisions `2025-03-26`, `2025-06-18`, and `2025-11-25`.
+  Both use a single POST endpoint without server-side session state.
 
   Tools are derived from the same `OpenApiSpex` operation specs that generate
   `openapi.json`, and every tool call is dispatched back through
@@ -16,7 +14,8 @@ defmodule PortalAPI.MCP do
   """
 
   @protocol_version "2026-07-28"
-  @supported_versions [@protocol_version]
+  @legacy_versions ["2025-11-25", "2025-06-18", "2025-03-26"]
+  @supported_versions [@protocol_version | @legacy_versions]
 
   @meta_prefix "io.modelcontextprotocol/"
   @protocol_version_key @meta_prefix <> "protocolVersion"
@@ -42,6 +41,9 @@ defmodule PortalAPI.MCP do
 
   @doc "Every protocol revision this server accepts on a request."
   def supported_versions, do: @supported_versions
+
+  def legacy_protocol_version, do: hd(@legacy_versions)
+  def legacy_version?(version), do: version in @legacy_versions
 
   def supported_version?(version), do: version in @supported_versions
 

--- a/elixir/lib/portal_web/components/page_components.ex
+++ b/elixir/lib/portal_web/components/page_components.ex
@@ -152,7 +152,7 @@ defmodule PortalWeb.PageComponents do
       </div>
 
       <div class="mt-3 pt-3 border-t border-border">
-        <p class="text-xs font-medium text-subtle uppercase tracking-wide mb-1.5">
+        <p class="text-xs font-medium text-body uppercase tracking-wide mb-1.5">
           Verified address
         </p>
 
@@ -163,28 +163,32 @@ defmodule PortalWeb.PageComponents do
           </span>
         </p>
 
-        <p :if={@client.resolved_ips != []} class="mt-1.5 text-xs font-mono text-subtle break-all">
-          Served from {Enum.map_join(@client.resolved_ips, ", ", &to_string/1)}{origin_location(
-            @client
-          )}
-        </p>
+        <div :if={@client.resolved_ips != []} class="mt-1.5 text-xs text-body">
+          <p>Served from</p>
+          <ul class="mt-1 space-y-1">
+            <li :for={ip <- @client.resolved_ips} class="break-all">
+              <span class="font-mono">{to_string(ip)}</span>{origin_location(ip)}
+            </li>
+          </ul>
+        </div>
       </div>
 
-      <p class="mt-3 text-xs text-subtle leading-relaxed">
+      <p class="mt-3 text-xs text-body leading-relaxed">
         Only this address is checked. The name and icon are supplied by the app
-        itself. If you do not recognise it, close this window.
+        itself. If you do not recognize it, close this window.
       </p>
     </div>
     """
   end
 
-  defp origin_location(%{resolved_ip_location_region: nil}), do: ""
-
-  defp origin_location(%{resolved_ip_location_region: region, resolved_ip_location_city: nil}),
-    do: " · #{region}"
-
-  defp origin_location(%{resolved_ip_location_region: region, resolved_ip_location_city: city}),
-    do: " · #{city}, #{region}"
+  defp origin_location(%Postgrex.INET{address: address}) do
+    case Portal.Geo.locate(address, []) do
+      {nil, nil, _coordinates} -> " · Location unavailable"
+      {region, nil, _coordinates} -> " · #{region}"
+      {nil, city, _coordinates} -> " · #{city}"
+      {region, city, _coordinates} -> " · #{city}, #{region}"
+    end
+  end
 
   @doc """
   The tile identifying an OAuth client by its icon, falling back to its initial.

--- a/elixir/test/portal_api/controllers/mcp_controller_test.exs
+++ b/elixir/test/portal_api/controllers/mcp_controller_test.exs
@@ -16,6 +16,101 @@ defmodule PortalAPI.MCPControllerTest do
     %{account: account, actor: actor}
   end
 
+  describe "Streamable HTTP compatibility" do
+    test "initializes, lists tools, and calls a tool without modern metadata", %{
+      conn: conn,
+      actor: actor
+    } do
+      conn = authorize_mcp_conn(conn, actor, ["actors:read"])
+
+      for version <- ["2025-03-26", "2025-06-18", "2025-11-25"] do
+        initialized =
+          legacy_rpc(conn, "initialize", %{
+            "protocolVersion" => version,
+            "capabilities" => %{},
+            "clientInfo" => %{"name" => "test-client", "version" => "1.0"}
+          })
+
+        assert %{
+                 "result" => %{
+                   "protocolVersion" => ^version,
+                   "capabilities" => %{"tools" => %{}},
+                   "serverInfo" => %{"name" => "firezone"}
+                 }
+               } = json_response(initialized, 200)
+
+        assert get_resp_header(initialized, "mcp-session-id") == []
+
+        notification =
+          conn
+          |> put_req_header("content-type", "application/json")
+          |> put_req_header("mcp-protocol-version", version)
+          |> post(
+            "/mcp",
+            Jason.encode!(%{"jsonrpc" => "2.0", "method" => "notifications/initialized"})
+          )
+
+        assert response(notification, 202) == ""
+
+        versioned = put_req_header(conn, "mcp-protocol-version", version)
+
+        assert %{"result" => %{"tools" => [_ | _]}} =
+                 versioned |> legacy_rpc("tools/list") |> json_response(200)
+
+        assert %{"result" => %{"isError" => false}} =
+                 versioned
+                 |> legacy_rpc("tools/call", %{"name" => "list_actors", "arguments" => %{}})
+                 |> json_response(200)
+
+        assert %{"result" => %{}} = versioned |> legacy_rpc("ping") |> json_response(200)
+      end
+    end
+
+    test "negotiates a supported revision for an unknown client revision", %{
+      conn: conn,
+      actor: actor
+    } do
+      response =
+        conn
+        |> authorize_mcp_conn(actor)
+        |> legacy_rpc("initialize", %{
+          "protocolVersion" => "unknown",
+          "capabilities" => %{},
+          "clientInfo" => %{"name" => "test-client", "version" => "1.0"}
+        })
+        |> json_response(200)
+
+      assert response["result"]["protocolVersion"] == MCP.legacy_protocol_version()
+    end
+
+    test "rejects malformed params and initialization fields", %{conn: conn, actor: actor} do
+      for params <- [nil, [], %{}, %{"_meta" => nil}, %{"protocolVersion" => 123}] do
+        response =
+          conn
+          |> authorize_mcp_conn(actor)
+          |> legacy_rpc("initialize", params)
+          |> json_response(400)
+
+        assert response["error"]["code"] == MCP.invalid_params()
+      end
+    end
+
+    test "allows omitted version and params for older clients", %{conn: conn, actor: actor} do
+      assert %{"result" => %{"tools" => _}} =
+               conn |> authorize_mcp_conn(actor) |> legacy_rpc("tools/list") |> json_response(200)
+    end
+  end
+
+  defp legacy_rpc(conn, method, params \\ :omitted) do
+    body = %{"jsonrpc" => "2.0", "id" => 1, "method" => method}
+    body = if params == :omitted, do: body, else: Map.put(body, "params", params)
+
+    conn
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("accept", "application/json, text/event-stream")
+    |> post("/mcp", Jason.encode!(body))
+  end
+
   describe "transport" do
     test "hides every MCP method when the global feature is disabled", %{conn: conn} do
       disable_feature(:mcp)

--- a/elixir/test/portal_web/controllers/oauth_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oauth_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule PortalWeb.OAuthControllerTest do
-  use PortalWeb.ConnCase, async: true
+  use PortalWeb.ConnCase, async: false
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
@@ -580,11 +580,29 @@ defmodule PortalWeb.OAuthControllerTest do
       account: account,
       actor: actor
     } do
+      ipv4 = {104, 18, 0, 1}
+      ipv6 = {0x2606, 0x4700, 0, 0, 0, 0, 0, 0x1111}
+      unknown = {192, 0, 2, 1}
+
+      on_exit(fn -> Geolix.Adapter.Fake.Storage.set(:city, {%{}, %{}}) end)
+
+      Geolix.Adapter.Fake.Storage.set(:city, {
+        %{
+          ipv4 => %{
+            country: %{iso_code: "US"},
+            city: %{names: %{en: "San Francisco"}},
+            location: %{}
+          },
+          ipv6 => %{country: %{iso_code: "AU"}}
+        },
+        %{}
+      })
+
       client =
         oauth_client_fixture(
-          resolved_ips: [%Postgrex.INET{address: {104, 18, 0, 1}}],
-          resolved_ip_location_region: "US",
-          resolved_ip_location_city: "San Francisco"
+          resolved_ips: Enum.map([ipv4, ipv6, unknown], &%Postgrex.INET{address: &1}),
+          resolved_ip_location_region: "GB",
+          resolved_ip_location_city: "Stale location"
         )
 
       conn =
@@ -595,7 +613,12 @@ defmodule PortalWeb.OAuthControllerTest do
       response = html_response(conn, 200)
 
       assert response =~ "104.18.0.1"
-      assert response =~ "San Francisco, US"
+      rows = response |> Floki.parse_document!() |> Floki.find("li") |> Enum.map(&Floki.text/1)
+      assert Enum.any?(rows, &(&1 =~ "104.18.0.1" and &1 =~ "San Francisco, US"))
+      assert Enum.any?(rows, &(&1 =~ "2606:4700::1111" and &1 =~ "AU"))
+      assert Enum.any?(rows, &(&1 =~ "192.0.2.1" and &1 =~ "Location unavailable"))
+      refute response =~ "Stale location"
+      assert response =~ "do not recognize it"
       assert response =~ "Verified address"
       assert response =~ URI.parse(client.client_id).host
 

--- a/elixir/test/portal_web/controllers/oauth_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oauth_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule PortalWeb.OAuthControllerTest do
-  use PortalWeb.ConnCase, async: false
+  use PortalWeb.ConnCase, async: true
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
@@ -584,18 +584,13 @@ defmodule PortalWeb.OAuthControllerTest do
       ipv6 = {0x2606, 0x4700, 0, 0, 0, 0, 0, 0x1111}
       unknown = {192, 0, 2, 1}
 
-      on_exit(fn -> Geolix.Adapter.Fake.Storage.set(:city, {%{}, %{}}) end)
-
-      Geolix.Adapter.Fake.Storage.set(:city, {
-        %{
-          ipv4 => %{
-            country: %{iso_code: "US"},
-            city: %{names: %{en: "San Francisco"}},
-            location: %{}
-          },
-          ipv6 => %{country: %{iso_code: "AU"}}
+      Portal.Test.GeoAdapter.put_data(%{
+        ipv4 => %{
+          country: %{iso_code: "US"},
+          city: %{names: %{en: "San Francisco"}},
+          location: %{}
         },
-        %{}
+        ipv6 => %{country: %{iso_code: "AU"}}
       })
 
       client =

--- a/elixir/test/support/geo_adapter.ex
+++ b/elixir/test/support/geo_adapter.ex
@@ -1,0 +1,31 @@
+defmodule Portal.Test.GeoAdapter do
+  @moduledoc """
+  Geolix fake adapter with process-local fixtures for asynchronous tests.
+
+  Lookups without local fixtures use the existing fake database. Fixtures apply
+  to the calling process only and disappear when that test process exits.
+  """
+  @behaviour Geolix.Adapter
+
+  def put_data(data) when is_map(data) do
+    Process.put(__MODULE__, data)
+    :ok
+  end
+
+  @impl true
+  def lookup(ip, opts, database) do
+    case Process.get(__MODULE__) do
+      nil -> Geolix.Adapter.Fake.lookup(ip, opts, database)
+      data -> Map.get(data, ip)
+    end
+  end
+
+  @impl true
+  defdelegate database_workers(database), to: Geolix.Adapter.Fake
+  @impl true
+  defdelegate load_database(database), to: Geolix.Adapter.Fake
+  @impl true
+  defdelegate metadata(database), to: Geolix.Adapter.Fake
+  @impl true
+  defdelegate unload_database(database), to: Geolix.Adapter.Fake
+end


### PR DESCRIPTION
MCP clients that start with `initialize` currently fail with a `-32602` error because the endpoint requires the newer protocol's metadata envelope. Add initialization, version negotiation, and subsequent tool-request compatibility for Streamable HTTP revisions 2025-03-26, 2025-06-18, and 2025-11-25 while preserving the newer protocol's validation.

Improve the OAuth consent box with darker secondary text, American spelling of “recognize,” and a separate row for each served-from IP. Resolve each address through `Portal.Geo`, showing its own location or “Location unavailable.”

Validation: 111 tests passed across the MCP controller, OAuth controller, MCP security, and MCP rate-limit suites. Regression coverage includes initialization through tool calls, malformed initialization requests, and distinct IPv4/IPv6 locations. Live MCP reconnection has not been verified.

---
