### PR TITLE
fix(portal): raise the directory sync lock checkout timeout

### DIFF
--- a/elixir/lib/portal/directory_sync/lock.ex
+++ b/elixir/lib/portal/directory_sync/lock.ex
@@ -17,25 +17,31 @@ defmodule Portal.DirectorySync.Lock do
   defmodule Database do
     alias Portal.Safe
 
+    # DBConnection disconnects the checkout, and with it the running sync, at this deadline.
+    @checkout_timeout :timer.minutes(10)
+
     def try_run(key, fun) do
       Safe.unscoped()
-      |> Safe.checkout(fn ->
-        {:ok, %{rows: [[acquired?]]}} =
-          Safe.unscoped()
-          |> Safe.query("SELECT pg_try_advisory_lock(hashtextextended($1, 0))", [key])
+      |> Safe.checkout(
+        fn ->
+          {:ok, %{rows: [[acquired?]]}} =
+            Safe.unscoped()
+            |> Safe.query("SELECT pg_try_advisory_lock(hashtextextended($1, 0))", [key])
 
-        if acquired? do
-          try do
-            {:ok, fun.()}
-          after
-            {:ok, _} =
-              Safe.unscoped()
-              |> Safe.query("SELECT pg_advisory_unlock(hashtextextended($1, 0))", [key])
+          if acquired? do
+            try do
+              {:ok, fun.()}
+            after
+              {:ok, _} =
+                Safe.unscoped()
+                |> Safe.query("SELECT pg_advisory_unlock(hashtextextended($1, 0))", [key])
+            end
+          else
+            :busy
           end
-        else
-          :busy
-        end
-      end)
+        end,
+        timeout: @checkout_timeout
+      )
     end
   end
 end


### PR DESCRIPTION
Directory syncs for Entra and Google run inside one checked-out database connection. That connection holds the advisory lock for the directory. DBConnection put a deadline of 15 seconds on the checkout. A sync that ran longer than 15 seconds lost its connection, and the job failed with a "checked out the connection for longer than 15000ms" error.

The checkout now has a deadline of 10 minutes.

Related: #15067
