### PR TITLE
fix(gui-client): attach to the parent console on Windows

### DIFF
--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -118,6 +118,8 @@ features = [
     "Win32_System_Threading",
     # `ProcessIdToSessionId` for the GUI-pipe cross-session check.
     "Win32_System_RemoteDesktop",
+    # `AttachConsole` so release builds print to the terminal they were launched from.
+    "Win32_System_Console",
     # WinRT `Windows.Foundation.Uri` and
     # `Windows.Management.Deployment.PackageManager` for the
     # `register-sparse.exe` WiX custom action.

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -26,6 +26,9 @@ enum LogGuard {
 }
 
 fn main() -> ExitCode {
+    #[cfg(all(target_os = "windows", not(debug_assertions)))]
+    attach_parent_console();
+
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("Failed to install default crypto provider");
@@ -64,6 +67,18 @@ fn main() -> ExitCode {
     telemetry::stop();
 
     exit_code
+}
+
+/// Attaches to the console of the parent process so subcommand output and the stdout log layer are visible when launched from a terminal.
+///
+/// Must run before the logger is set up because ANSI detection inspects stdout.
+/// Failure means there is no parent console (e.g. launched from the Start menu), which is the normal GUI launch.
+#[cfg(all(target_os = "windows", not(debug_assertions)))]
+fn attach_parent_console() {
+    use windows::Win32::System::Console::{ATTACH_PARENT_PROCESS, AttachConsole};
+
+    // SAFETY: `AttachConsole` has no memory-safety preconditions.
+    let _ = unsafe { AttachConsole(ATTACH_PARENT_PROCESS) };
 }
 
 fn try_main(cli: Cli, rt: &Runtime, log_guard: &mut Option<LogGuard>) -> Result<()> {


### PR DESCRIPTION
Release builds of the GUI client are GUI-subsystem executables and never get a console, so subcommand output, `--help` and the stdout log layer were silently discarded. Attaching to the parent process's console before the logger starts makes that output visible when the client is launched from a terminal. Launching from the Start menu has no parent console, so the attach fails silently and nothing changes there.

Related: #15074