### PR TITLE
feat(apple): ship the CLI as firezone with a PATH wrapper

### DIFF
--- a/scripts/build/macos-pkg-scripts/postinstall
+++ b/scripts/build/macos-pkg-scripts/postinstall
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Puts the headless client on the PATH. The installer passes the install location as $2.
+
+set -euo pipefail
+
+mkdir -p /usr/local/bin
+ln -sf "$2/Firezone.app/Contents/Resources/firezone" /usr/local/bin/firezone
+ln -sf "$2/Firezone.app/Contents/Resources/firezone-cli" /usr/local/bin/firezone-cli

--- a/scripts/build/macos-standalone.sh
+++ b/scripts/build/macos-standalone.sh
@@ -15,6 +15,7 @@ dmg_dir="$temp_dir/dmg"
 dmg_path="$temp_dir/Firezone.dmg"
 staging_dmg_path="$temp_dir/staging.dmg"
 staging_pkg_path="$temp_dir/staging.pkg"
+component_pkg_path="$temp_dir/component.pkg"
 git_sha=${GITHUB_SHA:-$(git rev-parse HEAD)}
 # CI sets this for every build that is not a release, so nothing it builds reports.
 no_telemetry=${FIREZONE_NO_TELEMETRY:-false}
@@ -54,11 +55,17 @@ xcodebuild build \
     -sdk macosx \
     -destination 'platform=macOS'
 
-# We also publish a pkg file for MDMs that don't like our DMG (Intune error 0x87D30139)
+# We also publish a pkg file for MDMs that don't like our DMG (Intune error 0x87D30139).
+# pkgbuild rather than productbuild --component so that the package can carry the
+# postinstall script that puts the headless client on the PATH.
+pkgbuild \
+    --component "$temp_dir/Firezone.app" \
+    --install-location /Applications \
+    --scripts scripts/build/macos-pkg-scripts \
+    "$component_pkg_path"
 productbuild \
     --sign "$installer_code_sign_identity" \
-    --component "$temp_dir/Firezone.app" \
-    /Applications \
+    --package "$component_pkg_path" \
     "$staging_pkg_path"
 
 # Create disk image

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -54,7 +54,8 @@
 		FZ0CLI012E80000000000009 /* SignOutCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E80000000000017 /* SignOutCommand.swift */; platformFilters = (macos, ); };
 		FZ0CLI012E8000000000000A /* ExtensionCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E80000000000018 /* ExtensionCommand.swift */; platformFilters = (macos, ); };
 		FZ0CLI012E80000000000007 /* TunnelSupervisor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E80000000000015 /* TunnelSupervisor.swift */; platformFilters = (macos, ); };
-		FZ0CLI012E8000000000000B /* firezone-cli.sh in Resources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E80000000000019 /* firezone-cli.sh */; platformFilters = (macos, ); };
+		FZ0CLI012E8000000000000B /* firezone-cli in Resources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E80000000000019 /* firezone-cli */; platformFilters = (macos, ); };
+		FZ0CLI012E8000000000000C /* firezone in Resources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E8000000000001A /* firezone */; platformFilters = (macos, ); };
 		FZ0CLI012E80000000000003 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = FZ0CLI012E80000000000030 /* ArgumentParser */; platformFilters = (macos, ); };
 		FZUIT0012E90000000000001 /* AppScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZUIT0012E90000000000010 /* AppScreenshotTests.swift */; };
 		FZUIT0012E90000000000002 /* ScreenshotDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZUIT0012E90000000000012 /* ScreenshotDelivery.swift */; };
@@ -163,7 +164,8 @@
 		FZ0CLI012E80000000000017 /* SignOutCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutCommand.swift; sourceTree = "<group>"; };
 		FZ0CLI012E80000000000018 /* ExtensionCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionCommand.swift; sourceTree = "<group>"; };
 		FZ0CLI012E80000000000015 /* TunnelSupervisor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelSupervisor.swift; sourceTree = "<group>"; };
-		FZ0CLI012E80000000000019 /* firezone-cli.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "firezone-cli.sh"; sourceTree = "<group>"; };
+		FZ0CLI012E80000000000019 /* firezone-cli */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "firezone-cli"; sourceTree = "<group>"; };
+		FZ0CLI012E8000000000001A /* firezone */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = firezone; sourceTree = "<group>"; };
 		FZUIT0012E90000000000010 /* AppScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScreenshotTests.swift; sourceTree = "<group>"; };
 		FZUIT0012E90000000000012 /* ScreenshotDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotDelivery.swift; sourceTree = "<group>"; };
 		FZUIT0012E90000000000013 /* IOSScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSScreenshotTests.swift; sourceTree = "<group>"; };
@@ -356,7 +358,8 @@
 				FZ0CLI012E80000000000017 /* SignOutCommand.swift */,
 				FZ0CLI012E80000000000018 /* ExtensionCommand.swift */,
 				FZ0CLI012E80000000000015 /* TunnelSupervisor.swift */,
-				FZ0CLI012E80000000000019 /* firezone-cli.sh */,
+				FZ0CLI012E8000000000001A /* firezone */,
+				FZ0CLI012E80000000000019 /* firezone-cli */,
 			);
 			path = CLI;
 			sourceTree = "<group>";
@@ -562,7 +565,8 @@
 				8DFDEAC72D2CEBA500615095 /* PrivacyInfo.xcprivacy in Resources */,
 				8DCC022A28D512AE007E12D2 /* Preview Assets.xcassets in Resources */,
 				8DCC022628D512AE007E12D2 /* Assets.xcassets in Resources */,
-				FZ0CLI012E8000000000000B /* firezone-cli.sh in Resources */,
+				FZ0CLI012E8000000000000C /* firezone in Resources */,
+				FZ0CLI012E8000000000000B /* firezone-cli in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		FZ0CLI012E80000000000009 /* SignOutCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E80000000000017 /* SignOutCommand.swift */; platformFilters = (macos, ); };
 		FZ0CLI012E8000000000000A /* ExtensionCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E80000000000018 /* ExtensionCommand.swift */; platformFilters = (macos, ); };
 		FZ0CLI012E80000000000007 /* TunnelSupervisor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E80000000000015 /* TunnelSupervisor.swift */; platformFilters = (macos, ); };
+		FZ0CLI012E8000000000000B /* firezone-cli.sh in Resources */ = {isa = PBXBuildFile; fileRef = FZ0CLI012E80000000000019 /* firezone-cli.sh */; platformFilters = (macos, ); };
 		FZ0CLI012E80000000000003 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = FZ0CLI012E80000000000030 /* ArgumentParser */; platformFilters = (macos, ); };
 		FZUIT0012E90000000000001 /* AppScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZUIT0012E90000000000010 /* AppScreenshotTests.swift */; };
 		FZUIT0012E90000000000002 /* ScreenshotDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = FZUIT0012E90000000000012 /* ScreenshotDelivery.swift */; };
@@ -162,6 +163,7 @@
 		FZ0CLI012E80000000000017 /* SignOutCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutCommand.swift; sourceTree = "<group>"; };
 		FZ0CLI012E80000000000018 /* ExtensionCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionCommand.swift; sourceTree = "<group>"; };
 		FZ0CLI012E80000000000015 /* TunnelSupervisor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelSupervisor.swift; sourceTree = "<group>"; };
+		FZ0CLI012E80000000000019 /* firezone-cli.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "firezone-cli.sh"; sourceTree = "<group>"; };
 		FZUIT0012E90000000000010 /* AppScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScreenshotTests.swift; sourceTree = "<group>"; };
 		FZUIT0012E90000000000012 /* ScreenshotDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotDelivery.swift; sourceTree = "<group>"; };
 		FZUIT0012E90000000000013 /* IOSScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSScreenshotTests.swift; sourceTree = "<group>"; };
@@ -354,6 +356,7 @@
 				FZ0CLI012E80000000000017 /* SignOutCommand.swift */,
 				FZ0CLI012E80000000000018 /* ExtensionCommand.swift */,
 				FZ0CLI012E80000000000015 /* TunnelSupervisor.swift */,
+				FZ0CLI012E80000000000019 /* firezone-cli.sh */,
 			);
 			path = CLI;
 			sourceTree = "<group>";
@@ -559,6 +562,7 @@
 				8DFDEAC72D2CEBA500615095 /* PrivacyInfo.xcprivacy in Resources */,
 				8DCC022A28D512AE007E12D2 /* Preview Assets.xcassets in Resources */,
 				8DCC022628D512AE007E12D2 /* Assets.xcassets in Resources */,
+				FZ0CLI012E8000000000000B /* firezone-cli.sh in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/swift/apple/Firezone/Application/main.swift
+++ b/swift/apple/Firezone/Application/main.swift
@@ -25,13 +25,14 @@ import Foundation
   }
 
   // The headless client is this same binary, reached through a symlink sitting next to
-  // it in Contents/MacOS. Running it that way means it keeps the app's bundle identity,
-  // and so can see the VPN configuration and system extension that belong to the app. A
-  // separate bundle could not: NETunnelProviderManager only hands an app the
-  // configurations that app itself created.
-  if URL(fileURLWithPath: CommandLine.arguments.first ?? "").lastPathComponent
-    == "firezone-cli"
-  {
+  // it in Contents/MacOS or through the wrapper scripts in Contents/Resources. Running
+  // it that way means it keeps the app's bundle identity, and so can see the VPN
+  // configuration and system extension that belong to the app. A separate bundle could
+  // not: NETunnelProviderManager only hands an app the configurations that app itself
+  // created. The comparison is case-sensitive on purpose: the app's own executable is
+  // `Firezone`.
+  let invokedAs = URL(fileURLWithPath: CommandLine.arguments.first ?? "").lastPathComponent
+  if invokedAs == "firezone" || invokedAs == "firezone-cli" {
     // Reached through a symlink from outside the bundle, macOS gives us no bundle at
     // all, and with it no identity, no VPN configuration and no system extension. Say
     // so, rather than failing later on something that reads as unrelated.
@@ -39,17 +40,26 @@ import Foundation
       FileHandle.standardError.write(
         Data(
           """
-          Run firezone-cli from inside Firezone.app, for example
-          /Applications/Firezone.app/Contents/MacOS/firezone-cli.
+          Run firezone through the wrapper script inside Firezone.app, for example
+          /Applications/Firezone.app/Contents/Resources/firezone.
 
-          A symlink to it from somewhere else does not work, because it leaves the
-          client without the app's identity. To have it on your PATH, install the
-          wrapper script that ships with the app:
+          A symlink to the binary in Contents/MacOS does not work, because it leaves the
+          client without the app's identity. To have it on your PATH, symlink the
+          wrapper script instead:
 
-            sudo install /Applications/Firezone.app/Contents/Resources/firezone-cli.sh /usr/local/bin/firezone-cli
+            sudo ln -sf /Applications/Firezone.app/Contents/Resources/firezone /usr/local/bin/firezone
 
           """.utf8))
       exit(1)
+    }
+
+    if invokedAs == "firezone-cli" {
+      FileHandle.standardError.write(
+        Data(
+          """
+          warning: firezone-cli is deprecated and will be removed in a future release; use firezone instead
+
+          """.utf8))
     }
 
     await runHeadlessClient(FirezoneCLI.self)

--- a/swift/apple/Firezone/Application/main.swift
+++ b/swift/apple/Firezone/Application/main.swift
@@ -42,8 +42,11 @@ import Foundation
           Run firezone-cli from inside Firezone.app, for example
           /Applications/Firezone.app/Contents/MacOS/firezone-cli.
 
-          Putting that directory on your PATH works. A symlink to it from somewhere
-          else does not, because it leaves the client without the app's identity.
+          A symlink to it from somewhere else does not work, because it leaves the
+          client without the app's identity. To have it on your PATH, install the
+          wrapper script that ships with the app:
+
+            sudo install /Applications/Firezone.app/Contents/Resources/firezone-cli.sh /usr/local/bin/firezone-cli
 
           """.utf8))
       exit(1)

--- a/swift/apple/Firezone/CLI/FirezoneCLI.swift
+++ b/swift/apple/Firezone/CLI/FirezoneCLI.swift
@@ -11,7 +11,7 @@ import NetworkExtension
 
 struct FirezoneCLI: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
-    commandName: "firezone-cli",
+    commandName: "firezone",
     abstract: "Firezone headless Client",
     version: versionString,
     subcommands: [Connect.self, SignOut.self, Extension.self],

--- a/swift/apple/Firezone/CLI/SignIn.swift
+++ b/swift/apple/Firezone/CLI/SignIn.swift
@@ -31,7 +31,7 @@ enum SignIn {
   /// What to do about not having a token, written out so it can be followed as-is.
   static func instructions(authBaseURL: String, accountSlug: String) -> String {
     let url = signInURL(authBaseURL: authBaseURL, accountSlug: accountSlug)
-    let command = CommandLine.arguments.first ?? "firezone-cli"
+    let command = CommandLine.arguments.first ?? "firezone"
 
     return """
       No token found. To sign in:

--- a/swift/apple/Firezone/CLI/firezone
+++ b/swift/apple/Firezone/CLI/firezone
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Installed into /usr/local/bin. A symlink to the binary would not do: macOS derives an
+# app's bundle from the path its binary was launched through, so a link from outside the
+# bundle leaves the client without the app's identity. Starting it at its real path keeps
+# it; `-a` only names it.
+exec -a firezone /Applications/Firezone.app/Contents/MacOS/firezone-cli "$@"

--- a/swift/apple/Firezone/CLI/firezone-cli
+++ b/swift/apple/Firezone/CLI/firezone-cli
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Deprecated alias of `firezone`, kept so existing scripts keep working.
+exec /Applications/Firezone.app/Contents/MacOS/firezone-cli "$@"

--- a/swift/apple/Firezone/CLI/firezone-cli.sh
+++ b/swift/apple/Firezone/CLI/firezone-cli.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Installed into /usr/local/bin as firezone-cli. A symlink would not do: macOS derives an
+# app's bundle from the path its binary was launched through, so a link from outside the
+# bundle leaves the client without the app's identity. Starting the binary at its real
+# path keeps it.
+exec /Applications/Firezone.app/Contents/MacOS/firezone-cli "$@"

--- a/swift/apple/Firezone/CLI/firezone-cli.sh
+++ b/swift/apple/Firezone/CLI/firezone-cli.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-# Installed into /usr/local/bin as firezone-cli. A symlink would not do: macOS derives an
-# app's bundle from the path its binary was launched through, so a link from outside the
-# bundle leaves the client without the app's identity. Starting the binary at its real
-# path keeps it.
-exec /Applications/Firezone.app/Contents/MacOS/firezone-cli "$@"

--- a/swift/apple/README.md
+++ b/swift/apple/README.md
@@ -163,15 +163,19 @@ mise run //swift/apple:<task>   # e.g. mise run //swift/apple:build
 
 ### Headless client
 
-`firezone-cli` is the macOS Client run from a terminal. It is not a separate
+`firezone` is the macOS Client run from a terminal. It is not a separate
 program: it is the app's own binary, reached through a symlink beside it at
 `Firezone.app/Contents/MacOS/firezone-cli`, and it picks the command line path
-when started under that name. Being the same bundle is what lets it use the VPN
-configuration and system extension the app set up, which a second bundle could
-not do. That also rules out a symlink from outside the bundle, which is why the
-app ships `Contents/Resources/firezone-cli.sh`, a wrapper that `exec`s the
-binary at its real path and is meant to be installed into `/usr/local/bin`. For
-a development build, `mise run cli` finds the binary for you:
+when started under that name or as `firezone`. Being the same bundle is what
+lets it use the VPN configuration and system extension the app set up, which a
+second bundle could not do. That also rules out a symlink to the binary from
+outside the bundle, which is why the app ships `Contents/Resources/firezone`, a
+wrapper that `exec`s the binary at its real path. The standalone `.pkg` symlinks
+it into `/usr/local/bin`; other installs do the same by hand with
+`sudo ln -sf /Applications/Firezone.app/Contents/Resources/firezone /usr/local/bin/firezone`.
+`Contents/Resources/firezone-cli` is the previous name, kept as a deprecated
+alias that prints a warning. For a development build, `mise run cli` finds the
+binary for you:
 
 ```sh
 mise run cli -- --help
@@ -179,8 +183,8 @@ mise run cli -- extension status
 mise run cli -- connect --account-slug my-account
 ```
 
-`connect` is the default, so plain `firezone-cli` brings the tunnel up and stays
-in the foreground until you stop it. `sign-out` drops the stored token.
+`connect` is the default, so plain `firezone` brings the tunnel up and stays in
+the foreground until you stop it. `sign-out` drops the stored token.
 
 It talks to the same system extension as the GUI and will not start without it.
 `extension status` reports whether that extension is installed and matches the
@@ -204,7 +208,7 @@ terminal echo off, and a token typed at a prompt would stay in the scrollback.
 Pipe one in instead, which is what it tells you to do when it hasn't got one:
 
 ```sh
-pbpaste | firezone-cli
+pbpaste | firezone
 ```
 
 Anything you don't set keeps whatever the app stored, since both share one VPN

--- a/swift/apple/README.md
+++ b/swift/apple/README.md
@@ -168,7 +168,10 @@ program: it is the app's own binary, reached through a symlink beside it at
 `Firezone.app/Contents/MacOS/firezone-cli`, and it picks the command line path
 when started under that name. Being the same bundle is what lets it use the VPN
 configuration and system extension the app set up, which a second bundle could
-not do. `mise run cli` finds it for you:
+not do. That also rules out a symlink from outside the bundle, which is why the
+app ships `Contents/Resources/firezone-cli.sh`, a wrapper that `exec`s the
+binary at its real path and is meant to be installed into `/usr/local/bin`. For
+a development build, `mise run cli` finds the binary for you:
 
 ```sh
 mise run cli -- --help

--- a/swift/apple/mise-tasks/cli.sh
+++ b/swift/apple/mise-tasks/cli.sh
@@ -27,8 +27,8 @@ if [ ! -x "$CLI_PATH" ]; then
 fi
 
 echo "Binary: $CLI_PATH"
-printf 'Running: firezone-cli'
+printf 'Running: firezone'
 printf ' %q' "$@"
 printf '\n'
 echo "---"
-exec "$CLI_PATH" "$@"
+exec -a firezone "$CLI_PATH" "$@"


### PR DESCRIPTION
The macOS filesystem is case-insensitive by default and our app is already called Firezone which means we cannot have a `firezone` CLI right next to it. The CLI target is therefore called `firezone-cli` but that isn't super clean. Sym-link it as `firezone` itself doesn't work because with a symlink, the app looses its bundle identity and then refuses to to start.

The fix for this is to provide a wrapper script the `exec`s the `firezone-cli` binary and have people symlink that script. For the case of a managed installation via the PKG artifact, this is handled automatically in a postinstall script now. For AppStore or manual installs, users will have to symlink the scripts themselves to `/usr/bin` or add the Firezone directory to their path.

Related: #15074