### PR TITLE
fix(portal): show firezone-gateway authenticate on deploy page

### DIFF
--- a/elixir/lib/portal_web/live/sites/components.ex
+++ b/elixir/lib/portal_web/live/sites/components.ex
@@ -1893,7 +1893,7 @@ defmodule PortalWeb.Sites.Components do
 
   defp gateway_debian_authenticate do
     """
-    sudo firezone gateway authenticate
+    sudo firezone-gateway authenticate
     """
   end
 

--- a/elixir/test/portal_web/live/sites_test.exs
+++ b/elixir/test/portal_web/live/sites_test.exs
@@ -311,7 +311,7 @@ defmodule PortalWeb.SitesTest do
 
       # Currently defaults to Debian/Ubuntu instructions
       assert html =~ "Add the Firezone APT repository"
-      assert html =~ "sudo firezone gateway authenticate"
+      assert html =~ "sudo firezone-gateway authenticate"
       assert html =~ "Use this token when prompted"
 
       html = render_click(lv, "deploy_tab_selected", %{"tab" => "systemd-instructions"})


### PR DESCRIPTION
The Gateway deploy page now shows the command the new Gateway release ships, `sudo firezone-gateway authenticate`, now that the management CLI lives in the `firezone-gateway` daemon.

Related: #15070
Related: #15074