### PR TITLE
fix(ci): judge screenshots against the merge commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,10 +254,13 @@ jobs:
         run: |
           set -euo pipefail
 
+          # The clients built the merge commit, not the branch checked out here.
+          git fetch --depth=1 origin "$GITHUB_SHA"
+
           # `mise exec` puts `uv` on PATH: the shims the mise action sets up are
           # regenerated before it installs, not after.
           mise exec -- uv run scripts/prepare-store-screenshots.py
-          mise exec -- uv run scripts/settle-screenshots.py \
+          mise exec -- uv run scripts/settle-screenshots.py --baseline "$GITHUB_SHA" \
             rust/gui-client/screenshots kotlin/android/screenshots swift/apple/screenshots
       - name: Set up GnuPG for the screenshot commit
         uses: ./.github/actions/setup-gpg

--- a/scripts/settle-screenshots.py
+++ b/scripts/settle-screenshots.py
@@ -15,8 +15,14 @@ the same way, a further 13 steps apart.
 
 Nobody can see either, but git can, and left alone they put a re-render commit on
 every pull request that touches the clients.
+
+A render is judged against the commit the clients built, which on a pull request
+is its merge commit rather than the branch. A screen that main re-rendered after
+the branch was cut looks different from the branch's copy and the same as main's,
+and the branch's copy is what stays.
 """
 
+import argparse
 import subprocess
 import sys
 from io import BytesIO
@@ -35,10 +41,10 @@ PATCH_TOLERANCE = 14
 PATCH_FRACTION = 0.01
 
 
-def committed(path: str) -> bytes | None:
-    """The file as HEAD has it, or None for one that HEAD does not carry."""
+def committed(revision: str, path: str) -> bytes | None:
+    """The file as `revision` has it, or None for one that it does not carry."""
     result = subprocess.run(
-        ["git", "show", f"HEAD:{path}"], capture_output=True, check=False
+        ["git", "show", f"{revision}:{path}"], capture_output=True, check=False
     )
 
     return result.stdout if result.returncode == 0 else None
@@ -67,24 +73,34 @@ def looks_the_same(path: str, before: bytes) -> bool:
     return steps <= PATCH_TOLERANCE and moved <= PATCH_FRACTION * pixels
 
 
-def main(directories: list[str]) -> int:
-    changed = subprocess.run(
-        ["git", "diff", "--name-only", "--", *directories],
-        capture_output=True,
-        text=True,
-        check=True,
+def listed(*arguments: str) -> list[str]:
+    """The paths a git command prints, one per line."""
+    return subprocess.run(
+        ["git", *arguments], capture_output=True, text=True, check=True
     ).stdout.split()
+
+
+def main(baseline: str, directories: list[str]) -> int:
+    # A screen that main added after the branch was cut arrives as a file HEAD
+    # does not track, and would otherwise be committed as the branch's own.
+    changed = listed("diff", "--name-only", "--", *directories) + listed(
+        "ls-files", "--others", "--exclude-standard", "--", *directories
+    )
 
     restored = []
     for path in changed:
         if not path.endswith(".png"):
             continue
 
-        before = committed(path)
+        before = committed(baseline, path)
         if before is None or not looks_the_same(path, before):
             continue
 
-        Path(path).write_bytes(before)
+        ours = committed("HEAD", path)
+        if ours is None:
+            Path(path).unlink()
+        else:
+            Path(path).write_bytes(ours)
         restored.append(path)
 
     for path in restored:
@@ -96,4 +112,13 @@ def main(directories: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--baseline",
+        default="HEAD",
+        help="the commit whose pictures a render is judged against",
+    )
+    parser.add_argument("directories", nargs="+")
+    arguments = parser.parse_args()
+
+    sys.exit(main(arguments.baseline, arguments.directories))


### PR DESCRIPTION
The client jobs render the pull request's merge commit, while `commit-screenshots` checks out the branch and compares the renders to the branch's pictures. A screen that `main` re-rendered after the branch was cut therefore looked changed on every such branch, and `main`'s picture was committed to it as the branch's own: #15049 changed only CI and received `main`'s three Android permission screens that way.

The settle script now takes the commit the clients rendered as its baseline and leaves the branch's own copy in place when a render looks the same as that commit's picture. A screen `main` added after the branch was cut arrives as an untracked file, so those are checked too and removed rather than committed.

Related: #15049