### PR TITLE
feat(gui-client): install a firezone wrapper on Linux

### DIFF
--- a/rust/gui-client/src-tauri/linux_package/firezone
+++ b/rust/gui-client/src-tauri/linux_package/firezone
@@ -1,0 +1,3 @@
+#!/bin/sh
+# `firezone` CLI entry point for the GUI Client.
+exec /usr/bin/firezone-client-gui "$@"

--- a/rust/gui-client/src-tauri/tauri.conf.json
+++ b/rust/gui-client/src-tauri/tauri.conf.json
@@ -18,6 +18,7 @@
           "/usr/lib/systemd/system/firezone-client-tunnel.service": "./linux_package/firezone-client-tunnel.service",
           "/usr/lib/sysusers.d/firezone-client-tunnel.conf": "./linux_package/sysusers.conf",
           "/usr/bin/firezone-client-tunnel": "../../target/release/firezone-client-tunnel",
+          "/usr/bin/firezone": "./linux_package/firezone",
           "/usr/share/metainfo/dev.firezone.client.metainfo.xml": "./linux_package/dev.firezone.client.metainfo.xml"
         },
         "desktopTemplate": "./linux_package/firezone-client-gui.desktop"
@@ -30,6 +31,7 @@
           "/usr/lib/systemd/system/firezone-client-tunnel.service": "./linux_package/firezone-client-tunnel.service",
           "/usr/lib/sysusers.d/firezone-client-tunnel.conf": "./linux_package/sysusers.conf",
           "/usr/bin/firezone-client-tunnel": "../../target/release/firezone-client-tunnel",
+          "/usr/bin/firezone": "./linux_package/firezone",
           "/usr/share/metainfo/dev.firezone.client.metainfo.xml": "./linux_package/dev.firezone.client.metainfo.xml"
         },
         "desktopTemplate": "./linux_package/firezone-client-gui.desktop"

--- a/scripts/nix/packages/firezone-gui-client/package.nix
+++ b/scripts/nix/packages/firezone-gui-client/package.nix
@@ -105,6 +105,9 @@ fzLib.buildRustPackage (
         mv $out/bin/firezone-gui-client $out/bin/firezone-client-gui
       fi
 
+      # `firezone` CLI entry point, mirroring linux_package/firezone.
+      makeWrapper $out/bin/firezone-client-gui $out/bin/firezone
+
       install -Dm644 gui-client/src-tauri/icons/32x32.png \
         $out/share/icons/hicolor/32x32/apps/firezone-client-gui.png
       install -Dm644 gui-client/src-tauri/icons/128x128.png \

--- a/scripts/tests/gui-client-install-linux-deb.sh
+++ b/scripts/tests/gui-client-install-linux-deb.sh
@@ -26,10 +26,10 @@ stat /usr/share/icons/hicolor/512x512/apps/firezone-client-gui.png
 
 # Make sure the binary got built, packaged, and installed, and at least
 # knows its own name
-firezone-client-gui --help | grep "Usage: firezone-client-gui"
+firezone-client-gui --help | grep "Usage: firezone"
 
 # Make sure the `firezone` wrapper forwards to the GUI binary
-firezone --help | grep "Usage: firezone-client-gui"
+firezone --help | grep "Usage: firezone"
 
 # Make sure the Tunnel service is running
 systemctl status "$SERVICE_NAME" || debug_exit

--- a/scripts/tests/gui-client-install-linux-deb.sh
+++ b/scripts/tests/gui-client-install-linux-deb.sh
@@ -21,12 +21,15 @@ dpkg --listfiles firezone-client-gui
 dpkg --info "$DEB_PATH"
 
 # Confirm that both binaries and at least one icon were installed
-which firezone-client-gui firezone-client-tunnel
+which firezone-client-gui firezone-client-tunnel firezone
 stat /usr/share/icons/hicolor/512x512/apps/firezone-client-gui.png
 
 # Make sure the binary got built, packaged, and installed, and at least
 # knows its own name
 firezone-client-gui --help | grep "Usage: firezone-client-gui"
+
+# Make sure the `firezone` wrapper forwards to the GUI binary
+firezone --help | grep "Usage: firezone-client-gui"
 
 # Make sure the Tunnel service is running
 systemctl status "$SERVICE_NAME" || debug_exit


### PR DESCRIPTION
Firezone is unifying the CLI entry point across Clients under the `firezone` name. On Linux, the GUI Client's deb, rpm and Nix packages now ship a `firezone` script that `exec`s `firezone-client-gui`, so the running process exe stays the one the tunnel service's peer check expects. The Gateway `.deb` currently also installs `/usr/bin/firezone` as a deprecation shim, so the two packages cannot be co-installed until that shim is removed.

Related: #15074