### PR TITLE
feat(gui-client): install a firezone.cmd wrapper on Windows

### DIFF
--- a/rust/gui-client/src-tauri/tauri.conf.json
+++ b/rust/gui-client/src-tauri/tauri.conf.json
@@ -43,12 +43,14 @@
           "RemoveOldFirezoneService",
           "FirezoneClientTunnelService",
           "SparsePackageMsix",
-          "RegisterSparseExe"
+          "RegisterSparseExe",
+          "FirezoneCli"
         ],
         "dialogImagePath": "./win_files/install_dialog.png",
         "fragmentPaths": [
           "./win_files/service.wxs",
-          "./win_files/sparse-package.wxs"
+          "./win_files/sparse-package.wxs",
+          "./win_files/cli.wxs"
         ],
         "template": "./win_files/main.wxs"
       }

--- a/rust/gui-client/src-tauri/win_files/cli.wxs
+++ b/rust/gui-client/src-tauri/win_files/cli.wxs
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Installs the `firezone.cmd` wrapper into its own `cli` directory and puts
+  that directory on the system PATH. It must not sit next to `Firezone.exe`
+  because `PATHEXT` resolves `.exe` before `.cmd`, and `Firezone.exe` is a
+  GUI-subsystem binary the shell would not wait for.
+-->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <DirectoryRef Id="INSTALLDIR">
+      <Directory Id="CliFolder" Name="cli">
+        <Component Id="FirezoneCli" Guid="6f3f2c1e-0f2a-4a4e-9c6b-2d9d0c5b7a11">
+          <File Id="FirezoneCliCmd" Name="firezone.cmd"
+                Source="../../../../gui-client/src-tauri/win_files/firezone.cmd" KeyPath="yes" />
+          <Environment Id="FirezoneCliPath" Name="PATH" Value="[INSTALLDIR]cli"
+                       Part="last" Action="set" System="yes" Permanent="no" />
+        </Component>
+      </Directory>
+    </DirectoryRef>
+  </Fragment>
+</Wix>

--- a/rust/gui-client/src-tauri/win_files/firezone.cmd
+++ b/rust/gui-client/src-tauri/win_files/firezone.cmd
@@ -1,0 +1,3 @@
+@echo off
+"%~dp0..\Firezone.exe" %*
+exit /b %ERRORLEVEL%

--- a/scripts/tests/gui-client-install-windows-msi.ps1
+++ b/scripts/tests/gui-client-install-windows-msi.ps1
@@ -62,6 +62,21 @@ if (($machinePath -split ";") -notcontains "$installDir\cli") {
     exit 1
 }
 
+Write-Output '==> Checking `firezone --help` runs through the wrapper...'
+# The MSI edited the machine PATH after this process started, so pick it up.
+$env:Path = "$machinePath;" + [Environment]::GetEnvironmentVariable("Path", "User")
+$help = firezone --help | Out-String
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "``firezone --help`` exited with ${LASTEXITCODE}: $help"
+    exit 1
+}
+# Matched case-insensitively, so this accepts `Firezone.exe` until the CLI
+# names itself `firezone` in its help output.
+if ($help -notmatch "Usage: firezone") {
+    Write-Error "``firezone --help`` printed no usage line: $help"
+    exit 1
+}
+
 Write-Output "==> Checking the tunnel service is running..."
 $null = sc.exe query FirezoneClientTunnelService | Select-String "RUNNING"
 if ($LASTEXITCODE -ne 0) {

--- a/scripts/tests/gui-client-install-windows-msi.ps1
+++ b/scripts/tests/gui-client-install-windows-msi.ps1
@@ -51,6 +51,17 @@ Assert-ValidSignature "$installDir\Firezone.exe"
 Assert-ValidSignature "$installDir\firezone-client-tunnel.exe"
 Assert-ValidSignature "$installDir\register-sparse.exe"
 
+Write-Output "==> Checking the firezone.cmd wrapper is installed and on PATH..."
+if (-not (Test-Path -LiteralPath "$installDir\cli\firezone.cmd")) {
+    Write-Error "Expected $installDir\cli\firezone.cmd to exist"
+    exit 1
+}
+$machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+if (($machinePath -split ";") -notcontains "$installDir\cli") {
+    Write-Error "Machine PATH does not contain $installDir\cli: $machinePath"
+    exit 1
+}
+
 Write-Output "==> Checking the tunnel service is running..."
 $null = sc.exe query FirezoneClientTunnelService | Select-String "RUNNING"
 if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
The unified CLI is meant to be invoked as `firezone`, but `Firezone.exe` is a GUI-subsystem binary that an interactive shell does not wait for. The MSI now ships a `firezone.cmd` batch wrapper, which makes `cmd.exe` and PowerShell wait for the exe and return its exit code. It lives in a `cli` subdirectory rather than next to `Firezone.exe` because `PATHEXT` would otherwise resolve `firezone` to the exe, and only that subdirectory is appended to the system `PATH`.

Related: #15071
Related: #15074