### PR TITLE
fix(portal): preserve connection state on JSON parse errors

### DIFF
--- a/elixir/lib/portal_api/parsers/json.ex
+++ b/elixir/lib/portal_api/parsers/json.ex
@@ -1,0 +1,65 @@
+defmodule PortalAPI.Parsers.JSON do
+  @moduledoc """
+  JSON parser that carries the latest connection when decoding fails.
+
+  Plug.Parsers.JSON raises after reading the body without including the updated
+  connection. Error responses must use that connection, especially on keep-alive
+  requests where the adapter tracks the bytes already consumed.
+  """
+  @behaviour Plug.Parsers
+
+  @impl true
+  def init(opts) do
+    # Retain Plug's validation of the configured decoder.
+    Plug.Parsers.JSON.init(opts)
+    opts
+  end
+
+  @impl true
+  def parse(conn, "application", subtype, _headers, opts) do
+    if subtype == "json" or String.ends_with?(subtype, "+json") do
+      {module, function, args} = Keyword.get(opts, :body_reader, {Plug.Conn, :read_body, []})
+      decode(apply(module, function, [conn, opts | args]), opts)
+    else
+      {:next, conn}
+    end
+  end
+
+  def parse(conn, _type, _subtype, _headers, _opts), do: {:next, conn}
+
+  defp decode({:ok, "", conn}, _opts), do: {:ok, %{}, conn}
+
+  defp decode({:ok, body, conn}, opts) do
+    decoder = Keyword.fetch!(opts, :json_decoder)
+    {module, function, args} = if is_atom(decoder), do: {decoder, :decode!, []}, else: decoder
+
+    terms =
+      try do
+        apply(module, function, [body | args])
+      rescue
+        exception ->
+          error = Plug.Parsers.ParseError.exception(exception: exception)
+          Plug.Conn.WrapperError.reraise(conn, :error, error, __STACKTRACE__)
+      end
+
+    params =
+      if is_map(terms) and not Keyword.get(opts, :nest_all_json, false),
+        do: terms,
+        else: %{"_json" => terms}
+
+    {:ok, params, conn}
+  end
+
+  defp decode({:more, _body, conn}, _opts) do
+    # Plug.Parsers otherwise discards this updated conn when raising for size.
+    Plug.Conn.WrapperError.reraise(
+      conn,
+      :error,
+      Plug.Parsers.RequestTooLargeError.exception([]),
+      []
+    )
+  end
+
+  defp decode({:error, :timeout}, _opts), do: raise(Plug.TimeoutError)
+  defp decode({:error, _}, _opts), do: raise(Plug.BadRequestError)
+end

--- a/elixir/lib/portal_api/plugs/mcp_parse_body.ex
+++ b/elixir/lib/portal_api/plugs/mcp_parse_body.ex
@@ -20,12 +20,19 @@ defmodule PortalAPI.Plugs.MCPParseBody do
   def call(conn, opts) do
     Plug.Parsers.call(conn, opts)
   rescue
-    Plug.Parsers.ParseError ->
-      body = MCP.error(nil, MCP.parse_error(), "Parse error")
+    exception in Plug.Conn.WrapperError ->
+      case exception do
+        %{kind: :error, reason: %Plug.Parsers.ParseError{}, conn: conn} -> parse_error(conn)
+        _ -> reraise(exception, __STACKTRACE__)
+      end
+  end
 
-      conn
-      |> put_resp_content_type("application/json")
-      |> send_resp(400, Phoenix.json_library().encode_to_iodata!(body))
-      |> halt()
+  defp parse_error(conn) do
+    body = MCP.error(nil, MCP.parse_error(), "Parse error")
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(400, Phoenix.json_library().encode_to_iodata!(body))
+    |> halt()
   end
 end

--- a/elixir/lib/portal_api/plugs/parse_body.ex
+++ b/elixir/lib/portal_api/plugs/parse_body.ex
@@ -13,7 +13,14 @@ defmodule PortalAPI.Plugs.ParseBody do
   def call(conn, opts) do
     Plug.Parsers.call(conn, opts)
   rescue
-    Plug.Parsers.ParseError ->
-      PortalAPI.ProblemDetails.send(conn, 400, "The request body could not be parsed.")
+    exception in Plug.Conn.WrapperError ->
+      case exception do
+        %{kind: :error, reason: %Plug.Parsers.ParseError{}, conn: conn} -> parse_error(conn)
+        _ -> reraise(exception, __STACKTRACE__)
+      end
+  end
+
+  defp parse_error(conn) do
+    PortalAPI.ProblemDetails.send(conn, 400, "The request body could not be parsed.")
   end
 end

--- a/elixir/lib/portal_api/router.ex
+++ b/elixir/lib/portal_api/router.ex
@@ -10,7 +10,7 @@ defmodule PortalAPI.Router do
     plug PortalAPI.Plugs.RateLimit
 
     plug PortalAPI.Plugs.ParseBody,
-      parsers: [:json],
+      parsers: [PortalAPI.Parsers.JSON],
       pass: ["*/*"],
       json_decoder: Phoenix.json_library()
 
@@ -58,7 +58,7 @@ defmodule PortalAPI.Router do
     plug PortalAPI.Plugs.RequestLog, mcp: true
 
     plug PortalAPI.Plugs.MCPParseBody,
-      parsers: [:json],
+      parsers: [PortalAPI.Parsers.JSON],
       pass: ["*/*"],
       json_decoder: Phoenix.json_library(),
       length: 1_000_000

--- a/elixir/test/portal_api/plugs/parse_body_test.exs
+++ b/elixir/test/portal_api/plugs/parse_body_test.exs
@@ -1,0 +1,95 @@
+defmodule PortalAPI.Plugs.ParseBodyTest do
+  use ExUnit.Case, async: true
+
+  alias PortalAPI.Plugs.{MCPParseBody, ParseBody}
+
+  # Mark the conn returned by the body reader so rescuing with the pre-read conn
+  # fails these tests even with Plug.Test's more permissive adapter.
+  def read_body(conn, opts) do
+    case Plug.Conn.read_body(conn, opts) do
+      {status, body, conn} -> {status, body, Plug.Conn.assign(conn, :body_read, true)}
+      error -> error
+    end
+  end
+
+  defp parse(plug, body, opts \\ []) do
+    opts =
+      Keyword.merge(
+        [
+          parsers: [PortalAPI.Parsers.JSON],
+          pass: ["*/*"],
+          json_decoder: Phoenix.json_library(),
+          body_reader: {__MODULE__, :read_body, []}
+        ],
+        opts
+      )
+
+    conn =
+      Plug.Test.conn(:post, "/", body)
+      |> Plug.Conn.put_req_header("content-type", "application/json")
+
+    plug.call(conn, plug.init(opts))
+  end
+
+  test "REST malformed JSON uses the conn returned by the body reader" do
+    for body <- [<<0>>, <<255>>, "{", "[1,"] do
+      conn = parse(ParseBody, body)
+
+      assert conn.status == 400
+      assert conn.halted
+      assert conn.assigns.body_read
+
+      assert Plug.Conn.get_resp_header(conn, "content-type") ==
+               ["application/problem+json; charset=utf-8"]
+
+      assert JSON.decode!(conn.resp_body)["detail"] == "The request body could not be parsed."
+    end
+  end
+
+  test "MCP malformed JSON retains its JSON-RPC response and the updated conn" do
+    conn = parse(MCPParseBody, <<0>>)
+
+    assert conn.status == 400
+    assert conn.halted
+    assert conn.assigns.body_read
+
+    assert JSON.decode!(conn.resp_body) == %{
+             "jsonrpc" => "2.0",
+             "id" => nil,
+             "error" => %{"code" => -32700, "message" => "Parse error"}
+           }
+  end
+
+  test "valid JSON keeps Plug's map, scalar, array, and empty-body semantics" do
+    for plug <- [ParseBody, MCPParseBody],
+        {body, expected} <- [
+          {~s({"name":"test"}), %{"name" => "test"}},
+          {"[1,2]", %{"_json" => [1, 2]}},
+          {"null", %{"_json" => nil}},
+          {"1", %{"_json" => 1}},
+          {"", %{}}
+        ] do
+      conn = parse(plug, body)
+      refute conn.halted
+      assert conn.assigns.body_read
+      assert conn.body_params == expected
+    end
+  end
+
+  test "supports MFA decoders and nesting JSON maps" do
+    conn =
+      parse(ParseBody, ~s({"name":"test"}),
+        json_decoder: {JSON, :decode!, []},
+        nest_all_json: true
+      )
+
+    assert conn.body_params == %{"_json" => %{"name" => "test"}}
+  end
+
+  test "oversized bodies retain the updated conn and their 413 exception" do
+    error = assert_raise Plug.Conn.WrapperError, fn -> parse(ParseBody, "[1,2,3]", length: 2) end
+    assert %Plug.Parsers.RequestTooLargeError{} = error.reason
+    assert error.conn.assigns.body_read
+    assert Plug.Exception.status(error.reason) == 413
+  end
+end


### PR DESCRIPTION
Malformed JSON requests return 500 instead of the documented 400 after upgrading to Bandit main. The OpenAPI fuzz job found this across 25 REST operations with a one-byte NUL body. Bandit's new stale-conn guard exposes our parser error handlers reusing the connection from before `read_body/2`.

Use a shared JSON parser that wraps decoding failures with the updated connection, and have the REST and MCP handlers use that connection for their existing problem-details and JSON-RPC responses. Preserve the updated connection for oversized bodies as well, retaining the 413 error. This PR is based on main and contains no Bandit dependency changes.

---

Fixes the [API fuzz failure](https://github.com/firezone/firezone/actions/runs/34039879207/job/101506010326?pr=15121) exposed by #15121.
