### PR TITLE
fix(android): report the user's device name to the portal

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -574,7 +574,11 @@ class TunnelService : VpnService() {
         }
 
         val userName = Settings.Global.getString(contentResolver, Settings.Global.DEVICE_NAME)
-        return if (userName.isNullOrBlank()) Build.MODEL else userName
+        if (!userName.isNullOrBlank()) {
+            return userName
+        }
+
+        return Build.MODEL
     }
 
     sealed class TunnelCommand {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -15,6 +15,7 @@ import android.os.Binder
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
+import android.provider.Settings
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.installations.FirebaseInstallations
 import com.squareup.moshi.Moshi
@@ -567,12 +568,13 @@ class TunnelService : VpnService() {
     }
 
     private fun getDeviceName(): String {
-        val deviceName = appRestrictions.getString("deviceName")
-        return if (deviceName.isNullOrBlank() || deviceName == "null") {
-            Build.MODEL
-        } else {
-            deviceName
+        val managedName = appRestrictions.getString("deviceName")
+        if (!managedName.isNullOrBlank() && managedName != "null") {
+            return managedName
         }
+
+        val userName = Settings.Global.getString(contentResolver, Settings.Global.DEVICE_NAME)
+        return if (userName.isNullOrBlank()) Build.MODEL else userName
     }
 
     sealed class TunnelCommand {


### PR DESCRIPTION
It looks like we can report the Android device name to the portal using the more identifiable and expect "DEVICE_NAME" key. This is used to (a) better support the use case of accessing your own devices and (b) to make the device more identifiable to admins for posture conditions.

---

Related: #15125 