### PR TITLE
fix(portal): preserve conn state on request body errors

### DIFF
--- a/elixir/lib/portal_api/controllers/integrations/azure_communication_services/webhook_controller.ex
+++ b/elixir/lib/portal_api/controllers/integrations/azure_communication_services/webhook_controller.ex
@@ -22,14 +22,9 @@ defmodule PortalAPI.Integrations.AzureCommunicationServices.WebhookController do
       {:more, _, conn} ->
         send_resp(conn, 413, "Request Entity Too Large")
 
-      # coveralls-ignore-start
-      # Defensive: catches read_body/1 transport failures such as {:error, :timeout}
-      # or {:error, :closed}. These are impractical to trigger in tests, so this
-      # clause is excluded from coverage.
       {:error, reason} ->
         Logger.error("ACS Event Grid webhook body could not be read", reason: inspect(reason))
         send_resp(conn, 500, "Internal Error")
-        # coveralls-ignore-stop
     end
   end
 

--- a/elixir/lib/portal_api/controllers/integrations/azure_communication_services/webhook_controller.ex
+++ b/elixir/lib/portal_api/controllers/integrations/azure_communication_services/webhook_controller.ex
@@ -5,9 +5,36 @@ defmodule PortalAPI.Integrations.AzureCommunicationServices.WebhookController do
   require Logger
 
   def handle_webhook(conn, _params) do
-    with [event_type] <- get_req_header(conn, "aeg-event-type"),
-         {:ok, body, conn} <- read_body(conn),
-         {:ok, events} <- decode_events(body) do
+    case get_req_header(conn, "aeg-event-type") do
+      [event_type] ->
+        handle_body(conn, event_type)
+
+      [] ->
+        send_resp(conn, 400, "Bad Request: missing aeg-event-type header")
+    end
+  end
+
+  defp handle_body(conn, event_type) do
+    case read_body(conn) do
+      {:ok, body, conn} ->
+        dispatch_body(conn, event_type, body)
+
+      {:more, _, conn} ->
+        send_resp(conn, 413, "Request Entity Too Large")
+
+      # coveralls-ignore-start
+      # Defensive: catches read_body/1 transport failures such as {:error, :timeout}
+      # or {:error, :closed}. These are impractical to trigger in tests, so this
+      # clause is excluded from coverage.
+      {:error, reason} ->
+        Logger.error("ACS Event Grid webhook body could not be read", reason: inspect(reason))
+        send_resp(conn, 500, "Internal Error")
+        # coveralls-ignore-stop
+    end
+  end
+
+  defp dispatch_body(conn, event_type, body) do
+    with {:ok, events} <- decode_events(body) do
       case dispatch_event_type(conn, event_type, events) do
         {:error, :invalid_secret} ->
           send_resp(conn, 401, "Unauthorized")
@@ -23,29 +50,8 @@ defmodule PortalAPI.Integrations.AzureCommunicationServices.WebhookController do
           conn
       end
     else
-      [] ->
-        send_resp(conn, 400, "Bad Request: missing aeg-event-type header")
-
-      # coveralls-ignore-start
-      # Defensive: only triggered by a payload exceeding read_body/2's default
-      # 8MB length, which Event Grid never sends. Allocating such a body in
-      # tests is wasteful, so this guard is excluded from coverage.
-      {:more, _, _} ->
-        send_resp(conn, 413, "Request Entity Too Large")
-
-      # coveralls-ignore-stop
-
       {:error, :invalid_json} ->
         send_resp(conn, 400, "Bad Request: invalid JSON")
-
-      # coveralls-ignore-start
-      # Defensive: catches read_body/1 transport failures such as {:error, :timeout}
-      # or {:error, :closed}. These are impractical to trigger in tests, so this
-      # clause is excluded from coverage.
-      {:error, reason} ->
-        Logger.error("ACS Event Grid webhook failed", reason: inspect(reason))
-        send_resp(conn, 500, "Internal Error")
-        # coveralls-ignore-stop
     end
   end
 

--- a/elixir/lib/portal_api/controllers/integrations/entra/webhook_controller.ex
+++ b/elixir/lib/portal_api/controllers/integrations/entra/webhook_controller.ex
@@ -24,15 +24,25 @@ defmodule PortalAPI.Integrations.Entra.WebhookController do
   end
 
   defp handle_notifications(conn, directory_id) do
-    with {:ok, body, conn} <- read_body(conn, length: @max_body_bytes),
-         {:ok, %{"value" => notifications}} when is_list(notifications) <- JSON.decode(body),
+    case read_body(conn, length: @max_body_bytes) do
+      {:ok, body, conn} ->
+        handle_notification_body(conn, directory_id, body)
+
+      {:more, _, conn} ->
+        send_resp(conn, 413, "Request Entity Too Large")
+
+      {:error, reason} ->
+        Logger.info("Entra webhook body could not be read", reason: inspect(reason))
+        send_resp(conn, 400, "Bad Request")
+    end
+  end
+
+  defp handle_notification_body(conn, directory_id, body) do
+    with {:ok, %{"value" => notifications}} when is_list(notifications) <- JSON.decode(body),
          true <- length(notifications) <= @max_notifications do
       :ok = Entra.Webhooks.handle_notifications(directory_id, notifications)
       send_resp(conn, 202, "")
     else
-      {:more, _, _} ->
-        send_resp(conn, 413, "Request Entity Too Large")
-
       false ->
         send_resp(conn, 413, "Request Entity Too Large: too many notifications")
 

--- a/elixir/lib/portal_api/controllers/integrations/stripe/webhook_controller.ex
+++ b/elixir/lib/portal_api/controllers/integrations/stripe/webhook_controller.ex
@@ -7,9 +7,24 @@ defmodule PortalAPI.Integrations.Stripe.WebhookController do
   @scheme "v1"
 
   def handle_webhook(conn, _params) do
-    with [signature_header] <- get_req_header(conn, "stripe-signature"),
-         {:ok, body, conn} <- read_body(conn, length: 1_000_000),
-         {:ok, {timestamp, signatures}} <- fetch_timestamp_and_signatures(signature_header),
+    case get_req_header(conn, "stripe-signature") do
+      [signature_header] ->
+        case read_body(conn, length: 1_000_000) do
+          {:ok, body, conn} -> handle_body(conn, signature_header, body)
+          {:more, _, conn} -> send_resp(conn, 413, "Request Entity Too Large")
+
+          {:error, reason} ->
+            Logger.error("Stripe webhook body could not be read", reason: inspect(reason))
+            send_resp(conn, 500, "Internal Error")
+        end
+
+      [] ->
+        send_resp(conn, 400, "Bad Request: missing signature header")
+    end
+  end
+
+  defp handle_body(conn, signature_header, body) do
+    with {:ok, {timestamp, signatures}} <- fetch_timestamp_and_signatures(signature_header),
          :ok <- verify_timestamp(timestamp, @tolerance),
          secret = Billing.fetch_webhook_signing_secret!(),
          :ok <- verify_signatures(signatures, timestamp, body, secret),
@@ -17,18 +32,6 @@ defmodule PortalAPI.Integrations.Stripe.WebhookController do
          :ok <- Billing.handle_events([payload]) do
       send_resp(conn, 200, "")
     else
-      [] ->
-        send_resp(conn, 400, "Bad Request: missing signature header")
-
-      # coveralls-ignore-start
-      # Plug.Conn.read_body/2 never returns {:error, :too_large}; an oversized
-      # body yields {:more, _, _} which falls through to the catch-all below.
-      # This defensive clause is kept in case the adapter contract changes.
-      {:error, :too_large} ->
-        send_resp(conn, 413, "Request Entity Too Large")
-
-      # coveralls-ignore-stop
-
       {:error, :missing_timestamp} ->
         send_resp(conn, 400, "Bad Request: missing timestamp")
 

--- a/elixir/lib/portal_api/router.ex
+++ b/elixir/lib/portal_api/router.ex
@@ -91,8 +91,10 @@ defmodule PortalAPI.Router do
     plug PortalAPI.Plugs.IngestionRateLimit
     plug PortalAPI.Plugs.FlowLogAuth
 
+    # Preserve the post-read conn when malformed or oversized JSON raises so
+    # RescueRouterErrors can send the error without reusing stale adapter state.
     plug Plug.Parsers,
-      parsers: [:json],
+      parsers: [PortalAPI.Parsers.JSON],
       pass: ["*/*"],
       json_decoder: Phoenix.json_library(),
       length: 10_000_000

--- a/elixir/test/portal_api/controllers/integrations/webhook_bandit_test.exs
+++ b/elixir/test/portal_api/controllers/integrations/webhook_bandit_test.exs
@@ -1,0 +1,67 @@
+defmodule PortalAPI.Integrations.WebhookBanditTest do
+  use ExUnit.Case, async: true
+
+  # Plug.Test does not enforce Bandit's connection usage counter. Exercise the
+  # controllers over HTTP so discarding the conn returned by read_body raises.
+  defmodule WebhookPlug do
+    def init(opts), do: opts
+
+    def call(conn, _opts) do
+      controller =
+        case conn.request_path do
+          "/entra" -> PortalAPI.Integrations.Entra.WebhookController
+          "/stripe" -> PortalAPI.Integrations.Stripe.WebhookController
+          "/acs" -> PortalAPI.Integrations.AzureCommunicationServices.WebhookController
+        end
+
+      controller.handle_webhook(conn, %{})
+    end
+  end
+
+  setup do
+    server =
+      start_supervised!({Bandit,
+       plug: WebhookPlug, ip: {127, 0, 0, 1}, port: 0, startup_log: false})
+
+    {:ok, {_address, port}} = ThousandIsland.listener_info(server)
+    %{url: "http://127.0.0.1:#{port}"}
+  end
+
+  for {name, path, headers, body, status, response} <- [
+        {"Entra invalid JSON", "/entra", [], "{", 400, "Bad Request: invalid JSON"},
+        {"Entra missing notifications", "/entra", [], "{}", 400,
+         "Bad Request: missing notifications"},
+        {"Entra oversized batch", "/entra", [], JSON.encode!(%{value: List.duplicate(%{}, 1001)}),
+         413, "Request Entity Too Large: too many notifications"},
+        {"Stripe missing timestamp", "/stripe", [{"stripe-signature", "v1=invalid"}], "{}",
+         400, "Bad Request: missing timestamp"},
+        {"Stripe expired signature", "/stripe", [{"stripe-signature", "t=0,v1=invalid"}], "{}",
+         400, "Bad Request: expired signature"},
+        {"ACS invalid JSON", "/acs", [{"aeg-event-type", "Notification"}], "{", 400,
+         "Bad Request: invalid JSON"}
+      ] do
+    test name, %{url: url} do
+      response =
+        Finch.build(:post, url <> unquote(path), unquote(headers), unquote(body))
+        |> Finch.request!(Req.Finch)
+
+      assert response.status == unquote(status)
+      assert response.body == unquote(response)
+    end
+  end
+
+  for {path, headers, size} <- [
+        {"/entra", [], 1_100_000},
+        {"/stripe", [{"stripe-signature", "v1=invalid"}], 1_100_000},
+        {"/acs", [{"aeg-event-type", "Notification"}], 8_100_000}
+      ] do
+    test "#{path} rejects an oversized body using the updated conn", %{url: url} do
+      response =
+        Finch.build(:post, url <> unquote(path), unquote(headers), String.duplicate("x", unquote(size)))
+        |> Finch.request!(Req.Finch)
+
+      assert response.status == 413
+      assert response.body == "Request Entity Too Large"
+    end
+  end
+end

--- a/elixir/test/portal_api/controllers/integrations/webhook_bandit_test.exs
+++ b/elixir/test/portal_api/controllers/integrations/webhook_bandit_test.exs
@@ -7,6 +7,10 @@ defmodule PortalAPI.Integrations.WebhookBanditTest do
     def init(opts), do: opts
 
     def call(conn, _opts) do
+      Portal.Config.put_env_override(:portal, Portal.AzureCommunicationServices,
+        event_grid_webhook_signing_secret: "acs-secret"
+      )
+
       controller =
         case conn.request_path do
           "/entra" -> PortalAPI.Integrations.Entra.WebhookController
@@ -24,7 +28,7 @@ defmodule PortalAPI.Integrations.WebhookBanditTest do
        plug: WebhookPlug, ip: {127, 0, 0, 1}, port: 0, startup_log: false})
 
     {:ok, {_address, port}} = ThousandIsland.listener_info(server)
-    %{url: "http://127.0.0.1:#{port}"}
+    %{url: "http://127.0.0.1:#{port}", port: port}
   end
 
   for {name, path, headers, body, status, response} <- [
@@ -35,10 +39,23 @@ defmodule PortalAPI.Integrations.WebhookBanditTest do
          413, "Request Entity Too Large: too many notifications"},
         {"Stripe missing timestamp", "/stripe", [{"stripe-signature", "v1=invalid"}], "{}",
          400, "Bad Request: missing timestamp"},
+        {"Stripe missing signatures", "/stripe", [{"stripe-signature", "t=0"}], "{}",
+         400, "Bad Request: missing signatures"},
         {"Stripe expired signature", "/stripe", [{"stripe-signature", "t=0,v1=invalid"}], "{}",
          400, "Bad Request: expired signature"},
         {"ACS invalid JSON", "/acs", [{"aeg-event-type", "Notification"}], "{", 400,
-         "Bad Request: invalid JSON"}
+         "Bad Request: invalid JSON"},
+        {"ACS invalid secret", "/acs", [{"aeg-event-type", "Notification"}], "[]", 401,
+         "Unauthorized"},
+        {"ACS invalid validation event", "/acs", [{"aeg-event-type", "SubscriptionValidation"}],
+         "[]", 400, "Bad Request: invalid validation event"},
+        {"ACS unsupported event", "/acs", [{"aeg-event-type", "Unknown"}], "[]", 400,
+         "Bad Request: unsupported aeg-event-type"},
+        {"ACS unsubscribe", "/acs", [{"aeg-event-type", "Unsubscribe"}], "[]", 200, ""},
+        {"ACS dispatch failure", "/acs",
+         [{"aeg-event-type", "Notification"}, {"aeg-sas-key", "acs-secret"}],
+         JSON.encode!([%{eventType: "Microsoft.Communication.EmailDeliveryReportReceived", data: "not-a-map"}]),
+         500, "Internal Error"}
       ] do
     test name, %{url: url} do
       response =
@@ -62,6 +79,64 @@ defmodule PortalAPI.Integrations.WebhookBanditTest do
 
       assert response.status == 413
       assert response.body == "Request Entity Too Large"
+    end
+  end
+
+  test "Stripe rejects an invalid signature after reading the body", %{url: url} do
+    timestamp = System.system_time(:second)
+
+    response =
+      Finch.build(:post, url <> "/stripe", [{"stripe-signature", "t=#{timestamp},v1=invalid"}], "{}")
+      |> Finch.request!(Req.Finch)
+
+    assert response.status == 400
+    assert response.body == "Bad Request: invalid signature"
+  end
+
+  test "Stripe returns its fallback response for signed invalid JSON", %{url: url} do
+    timestamp = System.system_time(:second)
+    body = "{"
+    secret = Portal.Billing.fetch_webhook_signing_secret!()
+    signature = PortalAPI.Integrations.Stripe.WebhookController.sign(timestamp, secret, body)
+
+    response =
+      Finch.build(:post, url <> "/stripe", [{"stripe-signature", "t=#{timestamp},v1=#{signature}"}], body)
+      |> Finch.request!(Req.Finch)
+
+    assert response.status == 500
+    # Bandit also returns 500 on a stale conn; check the controller's body.
+    assert response.body == "Internal Error"
+  end
+
+  for {path, headers, body} <- [
+        {"/entra", "", "{"},
+        {"/stripe", "stripe-signature: v1=invalid\r\n", "{}"},
+        {"/acs", "aeg-event-type: Notification\r\n", "{"}
+      ] do
+    test "#{path} preserves the next request on the same connection", %{port: port} do
+      {:ok, socket} = :gen_tcp.connect(~c"127.0.0.1", port, [:binary, active: false], 5_000)
+      on_exit(fn -> :gen_tcp.close(socket) end)
+
+      :ok = :gen_tcp.send(socket, [
+        "POST ", unquote(path), " HTTP/1.1\r\nHost: localhost\r\n",
+        unquote(headers), "Content-Length: ", Integer.to_string(byte_size(unquote(body))),
+        "\r\n\r\n", unquote(body),
+        "POST /entra?validationToken=still-alive HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+      ])
+
+      response = receive_until_closed(socket, "")
+      assert response =~ "HTTP/1.1 400"
+      assert response =~ "HTTP/1.1 200"
+      assert String.ends_with?(response, "still-alive")
+      refute response =~ "HTTP/1.1 500"
+    end
+  end
+
+  defp receive_until_closed(socket, acc) do
+    case :gen_tcp.recv(socket, 0, 5_000) do
+      {:ok, data} -> receive_until_closed(socket, acc <> data)
+      {:error, :closed} -> acc
+      {:error, reason} -> flunk("HTTP connection failed: #{inspect(reason)}")
     end
   end
 end

--- a/elixir/test/portal_api/controllers/integrations/webhook_body_error_test.exs
+++ b/elixir/test/portal_api/controllers/integrations/webhook_body_error_test.exs
@@ -1,0 +1,36 @@
+defmodule PortalAPI.Integrations.WebhookBodyErrorTest do
+  use ExUnit.Case, async: true
+
+  # Unlike successful and partial reads, Plug's {:error, reason} result has
+  # no updated conn. Inject that adapter result without racing a socket timeout.
+  defmodule ReadErrorAdapter do
+    def read_req_body(%{read_error: reason}, _opts), do: {:error, reason}
+    defdelegate send_resp(state, status, headers, body), to: Plug.Adapters.Test.Conn
+  end
+
+  for {controller, headers, status, body} <- [
+        {PortalAPI.Integrations.Entra.WebhookController, [], 400, "Bad Request"},
+        {PortalAPI.Integrations.Stripe.WebhookController, [{"stripe-signature", "v1=invalid"}],
+         500, "Internal Error"},
+        {PortalAPI.Integrations.AzureCommunicationServices.WebhookController,
+         [{"aeg-event-type", "Notification"}], 500, "Internal Error"}
+      ],
+      reason <- [:timeout, :closed] do
+    test "#{inspect(controller)} handles #{reason} while reading the body" do
+      conn = Plug.Test.conn(:post, "/", "{}")
+      {Plug.Adapters.Test.Conn, state} = conn.adapter
+
+      conn = %{
+        conn
+        | adapter: {ReadErrorAdapter, Map.put(state, :read_error, unquote(reason))},
+          req_headers: unquote(headers)
+      }
+
+      conn = unquote(controller).handle_webhook(conn, %{})
+
+      assert conn.state == :sent
+      assert conn.status == unquote(status)
+      assert conn.resp_body == unquote(body)
+    end
+  end
+end

--- a/elixir/test/portal_api/ingestion_http2_test.exs
+++ b/elixir/test/portal_api/ingestion_http2_test.exs
@@ -1,0 +1,139 @@
+defmodule PortalAPI.IngestionHTTP2Test do
+  use Portal.DataCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.FlowLogFixtures
+
+  alias Mint.HTTP2
+
+  # Configure only the test listener and sandbox ownership. Dispatch, routing,
+  # authentication, parsing, and error rendering all use the real endpoints.
+  defmodule EndpointPlug do
+    def init(opts), do: opts
+
+    def call(conn, {owner, ip}) do
+      Ecto.Adapters.SQL.Sandbox.allow(Portal.Repo, owner, self())
+      Portal.Config.put_env_override(:portal, :flow_logs_api_url, "http://127.0.0.1")
+      Portal.Config.put_env_override(:portal, Portal.Endpoint, https: nil)
+
+      conn
+      |> Map.put(:remote_ip, ip)
+      |> Portal.Endpoint.call(Portal.Endpoint.init([]))
+    end
+  end
+
+  setup do
+    account = account_fixture()
+    token = Portal.FlowLogToken.mint(account, flow_log_token_claims(), DateTime.utc_now())
+    counter = System.unique_integer([:positive, :monotonic])
+    ip = {10, rem(div(counter, 65_536), 256), rem(div(counter, 256), 256), rem(counter, 256)}
+
+    server = start_supervised!({Bandit,
+      plug: {EndpointPlug, {self(), ip}}, ip: {127, 0, 0, 1}, port: 0, startup_log: false})
+    {:ok, {_address, port}} = ThousandIsland.listener_info(server)
+    {:ok, conn} = HTTP2.connect(:http, "127.0.0.1", port, mode: :passive)
+
+    on_exit(fn -> HTTP2.close(conn) end)
+    %{http: conn, token: token}
+  end
+
+  for {name, body} <- [
+    {"malformed JSON", "{"},
+    {"invalid UTF-8", <<255>>},
+    {"truncated array", "[1,"}
+  ] do
+    test "authenticated #{name} returns 400 and preserves the HTTP/2 connection", ctx do
+      {conn, response} = request(ctx.http, ctx.token, unquote(body))
+      assert_problem(response, 400)
+      assert_next_request(conn, ctx.token)
+    end
+  end
+
+  test "authenticated oversized body returns 413 and preserves the HTTP/2 connection", ctx do
+    {conn, response} = request(ctx.http, ctx.token, String.duplicate(" ", 10_000_001))
+    assert_problem(response, 413)
+    assert_next_request(conn, ctx.token)
+  end
+
+  test "a body at the 10 MB limit is accepted", ctx do
+    json = ~s({"flow_logs":[]})
+    body = json <> String.duplicate(" ", 10_000_000 - byte_size(json))
+    {conn, response} = request(ctx.http, ctx.token, body)
+    assert response.status == 200
+    assert JSON.decode!(response.body) == %{"data" => %{"status" => "ok"}}
+    assert_next_request(conn, ctx.token)
+  end
+
+  test "unauthenticated malformed JSON is rejected before parsing", ctx do
+    {conn, response} = request(ctx.http, nil, "{")
+    assert_problem(response, 401)
+    assert_next_request(conn, ctx.token)
+  end
+
+  for body <- ["", "null", "[]", "{}", ~s({"flow_logs":false})] do
+    test "valid JSON shape #{inspect(body)} reaches controller validation", ctx do
+      {conn, response} = request(ctx.http, ctx.token, unquote(body))
+      assert_problem(response, 400)
+      assert JSON.decode!(response.body)["detail"] == "Expected a \"flow_logs\" array"
+      assert_next_request(conn, ctx.token)
+    end
+  end
+
+  defp assert_next_request(conn, token) do
+    {conn, response} = request(conn, token, ~s({"flow_logs":[]}))
+    assert response.status == 200
+    assert JSON.decode!(response.body) == %{"data" => %{"status" => "ok"}}
+    assert HTTP2.open?(conn)
+  end
+
+  defp assert_problem(response, status) do
+    assert response.status == status
+    assert {"content-type", "application/problem+json; charset=utf-8"} in response.headers
+    assert JSON.decode!(response.body)["status"] == status
+  end
+
+  defp request(conn, token, body) do
+    headers = [{"content-type", "application/json"}, {"content-length", to_string(byte_size(body))}]
+    headers = if token, do: [{"authorization", "Bearer " <> token} | headers], else: headers
+    {:ok, conn, ref} = HTTP2.request(conn, "POST", "/ingestion/flow_logs", headers, :stream)
+    {conn, events} = upload(conn, ref, body, [])
+    {conn, events} = receive_response(conn, ref, events)
+
+    response = Enum.reduce(events, %{status: nil, headers: [], body: ""}, fn
+      {:status, ^ref, status}, response -> %{response | status: status}
+      {:headers, ^ref, headers}, response -> %{response | headers: response.headers ++ headers}
+      {:data, ^ref, data}, response -> %{response | body: response.body <> data}
+      _, response -> response
+    end)
+    {conn, response}
+  end
+
+  defp upload(conn, ref, "", events) do
+    {:ok, conn} = HTTP2.stream_request_body(conn, ref, :eof)
+    {conn, events}
+  end
+
+  defp upload(conn, ref, body, events) do
+    size = min(HTTP2.get_window_size(conn, :connection), HTTP2.get_window_size(conn, {:request, ref}))
+
+    if size > 0 do
+      size = min(size, byte_size(body))
+      chunk = binary_part(body, 0, size)
+      rest = binary_part(body, size, byte_size(body) - size)
+      {:ok, conn} = HTTP2.stream_request_body(conn, ref, chunk)
+      upload(conn, ref, rest, events)
+    else
+      {:ok, conn, received} = HTTP2.recv(conn, 0, 5_000)
+      upload(conn, ref, body, events ++ received)
+    end
+  end
+
+  defp receive_response(conn, ref, events) do
+    if {:done, ref} in events do
+      {conn, events}
+    else
+      {:ok, conn, received} = HTTP2.recv(conn, 0, 5_000)
+      receive_response(conn, ref, events ++ received)
+    end
+  end
+end


### PR DESCRIPTION
Malformed or oversized request bodies can discard the connection returned by `read_body`, causing error responses to raise Bandit's stale-connection exception. This affects flow-log ingestion's standard JSON parser and error branches in Entra, Stripe, and Azure Communication Services webhooks.

Use the existing connection-preserving JSON parser for `/ingestion/flow_logs`, retaining its 10 MB limit and authentication/rate limiting before parsing. Refactor webhook body reads into `case` branches that pass the updated connection through validation and dispatch, including partial reads. Oversized Stripe bodies now return 413.

Regression tests reproduce the reported HTTP/2 stack before the fix and pass afterward. They cover malformed and oversized bodies, the 10 MB boundary, authentication ordering, webhook errors, read failures, and subsequent requests on the same connection. All 126 focused tests pass.

---

Related: #15123
