### PR TITLE
ci: report what a screenshot re-render adds to the repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      pull-requests: write # the storage report comment
       security-events: write # trivy SARIF upload from setup-mise
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -266,6 +267,7 @@ jobs:
           key: ${{ secrets.RELEASE_PR_BOT_GPG_KEY }}
           email: github-bot@firezone.dev
       - name: Push the re-rendered screenshots
+        id: push
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: |
@@ -290,12 +292,26 @@ jobs:
             git fetch origin "$HEAD_REF"
             git rebase "origin/$HEAD_REF"
             if git push origin "HEAD:$HEAD_REF"; then
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           done
 
           echo "Could not push the screenshots after three attempts." >&2
           exit 1
+      - name: Report what the re-render adds to the repository
+        if: steps.push.outputs.pushed == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          count=$(git diff --name-only HEAD~1 HEAD | wc -l)
+          on_disk=$(git diff --name-only HEAD~1 HEAD | xargs git ls-tree -r -l HEAD -- | awk '{ sum += $4 } END { print sum }')
+          # What the push carried: the new objects, delta-compressed against the parent.
+          stored=$( (echo HEAD; echo ^HEAD~1) | git pack-objects --thin --revs --stdout | wc -c )
+
+          gh pr comment "$PR_NUMBER" --body "Re-rendered $count screenshots: $(numfmt --to=iec-i --suffix=B "$on_disk") of PNGs, stored in git as $(numfmt --to=iec-i --suffix=B "$stored")."
 
   shell:
     name: shell-tests


### PR DESCRIPTION
After the bot pushes a re-render, the commit-screenshots job now comments on the pull request with the number of images, their size on disk, and what the push actually carried: the new objects delta-compressed against the parent commit, measured as a thin pack. That is the number the byte-aligned encoding is meant to keep small, so it should be visible where each re-render lands.

Related: #15120