### PR TITLE
ci(swift): skip screenshots on release dispatch from main

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -69,6 +69,8 @@ jobs:
   # SDK it was built with, so the macOS screens are drawn on every release CI can run.
   screenshots-macos:
     name: macos-${{ matrix.release }}-screenshots
+    # A release dispatch from main only needs the builds, not the screenshots.
+    if: "${{ !(github.event_name == 'workflow_dispatch' && github.ref_name == 'main') }}"
     runs-on: macos-${{ matrix.release }}
     strategy:
       fail-fast: false
@@ -140,6 +142,8 @@ jobs:
   # and photographed on each simulator in parallel below.
   build-ios-screenshots:
     name: ios-screenshots-build
+    # A release dispatch from main only needs the builds, not the screenshots.
+    if: "${{ !(github.event_name == 'workflow_dispatch' && github.ref_name == 'main') }}"
     runs-on: macos-26
     env:
       XCODE_VERSION: "26.2"


### PR DESCRIPTION
The screenshot jobs exist to review UI changes on pull requests. A `workflow_dispatch` from `main` is a release build and gains nothing from them, so skip them there to shorten the release run.