### PR TITLE
ci: silence ShellCheck on bats stderr variable

### DIFF
--- a/scripts/tests/bats/firezone_shim.bats
+++ b/scripts/tests/bats/firezone_shim.bats
@@ -22,6 +22,7 @@ MOCK
 
     [ "$status" -eq 0 ]
     [ "$output" = "gateway stdout" ]
+    # shellcheck disable=SC2154 # `run --separate-stderr` assigns it
     [[ "$stderr" == *"deprecated"* ]]
     [[ "$stderr" == *'`firezone-gateway authenticate --replace`'* ]]
     [ "$(cat "$GATEWAY_CALLS_LOG")" = "authenticate --replace" ]


### PR DESCRIPTION
ShellCheck knows bats assigns `output` and `status` but not `stderr`, which `run --separate-stderr` sets, so the `global-linter` check fails on `main` and on every pull request since the shim test landed.

Related: #15070