### PR TITLE
fix(ci): isolate Swift CI concurrency groups

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && 'apple-release-main' || github.run_id }}
+  group: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && 'apple-release-main' || format('apple-ci-{0}', github.run_id) }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Give ordinary Swift CI runs a platform-specific concurrency group. Reusable workflows share the caller's run ID, so using that ID alone can serialize unrelated platform builds within the same CI run.

Keep the existing Apple release lock unchanged so draft builds and App Store submissions remain serialized.
