### PR TITLE
fix(ci): allow Apple submission to read draft releases

### DIFF
--- a/.github/workflows/submit-apple-release.yml
+++ b/.github/workflows/submit-apple-release.yml
@@ -32,6 +32,9 @@ env:
 jobs:
   prepare:
     if: ${{ github.ref_name == 'main' }}
+    permissions:
+      contents: write # GitHub requires push access to read draft releases.
+      security-events: write
     environment:
       name: app-store
       url: https://appstoreconnect.apple.com/apps/6443661826/distribution
@@ -281,6 +284,9 @@ jobs:
 
   submit:
     needs: [prepare, review]
+    permissions:
+      contents: write # Revalidating the draft also requires push access.
+      security-events: write
     environment:
       name: app-store
       url: https://appstoreconnect.apple.com/apps/6443661826/distribution


### PR DESCRIPTION
GitHub hides draft releases from callers without push access, causing Apple submission to fail with `release not found` even when the draft exists. Grant `contents: write` only to the jobs that resolve and revalidate the draft, retaining the permissionless approval job and existing store approval gates.