### PR TITLE
fix(ci): correct Apple submission authentication

### DIFF
--- a/.github/workflows/submit-apple-release.yml
+++ b/.github/workflows/submit-apple-release.yml
@@ -23,7 +23,7 @@ concurrency:
 env:
   ASC_APP_ID: "6443661826"
   ASC_PLATFORM: ${{ inputs.platform == 'iOS' && 'IOS' || 'MAC_OS' }}
-  ASC_KEY_TYPE: individual
+  ASC_KEY_TYPE: team
   ASC_STRICT_AUTH: "1"
   ASC_TELEMETRY_DISABLED: "1"
   # mark:next-apple-version
@@ -138,6 +138,7 @@ jobs:
         working-directory: swift/apple
         env:
           ASC_KEY_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}
           ASC_PRIVATE_KEY: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY }}
         run: |
           version="${RELEASE_NAME#apple-client-}"
@@ -150,6 +151,7 @@ jobs:
               --app "$ASC_APP_ID" \
               --version "$version" \
               --platform "$ASC_PLATFORM" \
+              --release-type MANUAL \
               --copy-metadata-from "$source"
           fi
           source ../../scripts/upload/apple-version.sh
@@ -161,6 +163,7 @@ jobs:
         working-directory: swift/apple
         env:
           ASC_KEY_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}
           ASC_PRIVATE_KEY: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY }}
         run: |
           version="${RELEASE_NAME#apple-client-}"
@@ -203,6 +206,7 @@ jobs:
         working-directory: swift/apple
         env:
           ASC_KEY_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}
           ASC_PRIVATE_KEY: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY }}
           BUILD_NUMBER: ${{ steps.release.outputs.build_number }}
         run: |
@@ -231,6 +235,20 @@ jobs:
             echo "build_id=$build_id"
             echo "phase=$version_phase"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Check App Store submission readiness
+        if: steps.build.outputs.phase != 'submitted'
+        working-directory: swift/apple
+        env:
+          ASC_KEY_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY }}
+        run: |
+          asc validate \
+            --app "$ASC_APP_ID" \
+            --version "${RELEASE_NAME#apple-client-}" \
+            --platform "$ASC_PLATFORM" \
+            --output table
 
       - name: Summarize the candidate
         env:
@@ -319,6 +337,7 @@ jobs:
         working-directory: swift/apple
         env:
           ASC_KEY_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}
           ASC_PRIVATE_KEY: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY }}
           BUILD_ID: ${{ needs.prepare.outputs.build_id }}
         run: |

--- a/.github/workflows/submit-apple-release.yml
+++ b/.github/workflows/submit-apple-release.yml
@@ -138,7 +138,7 @@ jobs:
         working-directory: swift/apple
         env:
           ASC_KEY_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY_ID }}
-          ASC_PRIVATE_KEY_B64: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY }}
+          ASC_PRIVATE_KEY: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY }}
         run: |
           version="${RELEASE_NAME#apple-client-}"
           target=$(asc versions list --app "$ASC_APP_ID" --version "$version" --platform "$ASC_PLATFORM" --output json)
@@ -161,7 +161,7 @@ jobs:
         working-directory: swift/apple
         env:
           ASC_KEY_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY_ID }}
-          ASC_PRIVATE_KEY_B64: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY }}
+          ASC_PRIVATE_KEY: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY }}
         run: |
           version="${RELEASE_NAME#apple-client-}"
           if [[ "$ASC_PLATFORM" == IOS ]]; then
@@ -203,7 +203,7 @@ jobs:
         working-directory: swift/apple
         env:
           ASC_KEY_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY_ID }}
-          ASC_PRIVATE_KEY_B64: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY }}
+          ASC_PRIVATE_KEY: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY }}
           BUILD_NUMBER: ${{ steps.release.outputs.build_number }}
         run: |
           source ../../scripts/upload/apple-version.sh
@@ -319,7 +319,7 @@ jobs:
         working-directory: swift/apple
         env:
           ASC_KEY_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY_ID }}
-          ASC_PRIVATE_KEY_B64: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY }}
+          ASC_PRIVATE_KEY: ${{ secrets.APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY }}
           BUILD_ID: ${{ needs.prepare.outputs.build_id }}
         run: |
           source ../../scripts/upload/apple-version.sh

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -65,8 +65,10 @@ is left unchanged. A fresh Swift dispatch generates a new build number.
 
 Required secrets in the `main`-only `app-store` GitHub Environment:
 
-- `APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY_ID`
-- `APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY`
+- `APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY_ID` (team key)
+- `APPLE_APP_STORE_CONNECT_APP_MANAGER_API_KEY` (raw `.p8` contents)
+
+The workflow also uses the repository secret `APPLE_APP_STORE_CONNECT_ISSUER_ID`.
 
 Do not configure required reviewers on `app-store`; `app-store-review` is the
 approval gate.


### PR DESCRIPTION
Use the App Manager team key in its original PEM format with the existing issuer ID. The previous configuration tried to decode it as Base64 and authenticate as an individual key.

Create versions with manual release explicitly and run the CLI submission-readiness report before requesting approval, surfacing supported metadata, screenshot, build, and review-detail blockers together. Approval and final publication remain manual.