### PR TITLE
fix(apple): use light-mode screenshots in the App Store

### DIFF
--- a/swift/apple/app-store/screenshots-macos.txt
+++ b/swift/apple/app-store/screenshots-macos.txt
@@ -1,10 +1,5 @@
 first-time-light.png
-first-time-dark.png
 settings-general-light.png
-settings-general-dark.png
 settings-advanced-light.png
-settings-advanced-dark.png
 x509-filled-light.png
-x509-filled-dark.png
 grant-vpn-light.png
-grant-vpn-dark.png


### PR DESCRIPTION
Select only light-mode screenshots for the macOS App Store listing. Keep the dark-mode screenshots in the repository for manual verification. The iOS selection already contains only light-mode screenshots.