### PR TITLE
fix(ci): select store screenshots from the submission commit

### DIFF
--- a/.github/workflows/submit-android-release.yml
+++ b/.github/workflows/submit-android-release.yml
@@ -64,6 +64,12 @@ jobs:
         with:
           ref: ${{ steps.release.outputs.source_sha }}
 
+      - name: Select store screenshots
+        run: |
+          # Use the submission's selection without changing the build's screenshot files.
+          git fetch --depth=1 origin "$GITHUB_SHA"
+          git restore --source="$GITHUB_SHA" --worktree -- kotlin/android/screenshots/play-store.txt
+
       - uses: ./.github/actions/setup-mise
         with:
           install_args: --cd kotlin/android github:tamtom/play-console-cli
@@ -160,6 +166,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.prepare.outputs.source_sha }}
+
+      - name: Select store screenshots
+        run: |
+          # Match the selection shown before approval, with image files from the build.
+          git fetch --depth=1 origin "$GITHUB_SHA"
+          git restore --source="$GITHUB_SHA" --worktree -- kotlin/android/screenshots/play-store.txt
 
       - uses: ./.github/actions/setup-mise
         with:

--- a/.github/workflows/submit-apple-release.yml
+++ b/.github/workflows/submit-apple-release.yml
@@ -91,6 +91,11 @@ jobs:
 
       - name: Stage App Store inputs
         run: |
+          # Use the submission's selection without changing the build's screenshot files.
+          git fetch --depth=1 origin "$GITHUB_SHA"
+          git restore --source="$GITHUB_SHA" --worktree -- \
+            swift/apple/app-store/screenshots-ios.txt \
+            swift/apple/app-store/screenshots-macos.txt
           if [[ ! -f scripts/upload/apple-version.sh ]]; then
             echo "This draft predates the submission workflow. Run Swift from main and QA the new draft first." >&2
             exit 1


### PR DESCRIPTION
Use screenshot manifests from the commit that started the Apple or Android submission workflow, while retaining image files from the draft build commit. This allows changing the store screenshot selection without rebuilding an already-tested app.

Android preparation and submission restore the same manifest, so the upload selection matches the approval summary. Missing images still fail preparation or submission.