### PR TITLE
fix(apple): refresh store screenshot selection and sizes

### DIFF
--- a/.github/workflows/submit-apple-release.yml
+++ b/.github/workflows/submit-apple-release.yml
@@ -189,6 +189,20 @@ jobs:
               --device-type APP_IPAD_PRO_3GEN_129 \
               --replace \
               --confirm
+
+            # Remove smaller iPhone overrides so Apple scales the 6.9-inch screenshots.
+            asc screenshots list \
+              --app "$ASC_APP_ID" \
+              --version "$version" \
+              --platform IOS \
+              --locale en-US \
+              --output json \
+              | jq -r '.sets[]
+                  | select(.set.attributes.screenshotDisplayType | startswith("APP_IPHONE_") and . != "APP_IPHONE_67")
+                  | .screenshots[]?.id' \
+              | while IFS= read -r screenshot_id; do
+                  asc screenshots delete --id "$screenshot_id" --confirm
+                done
           else
             asc screenshots upload \
               --app "$ASC_APP_ID" \

--- a/.github/workflows/submit-apple-release.yml
+++ b/.github/workflows/submit-apple-release.yml
@@ -190,7 +190,7 @@ jobs:
               --replace \
               --confirm
 
-            # Remove smaller iPhone overrides so Apple scales the 6.9-inch screenshots.
+            # Remove other size overrides so Apple scales the screenshots we upload.
             asc screenshots list \
               --app "$ASC_APP_ID" \
               --version "$version" \
@@ -198,7 +198,9 @@ jobs:
               --locale en-US \
               --output json \
               | jq -r '.sets[]
-                  | select(.set.attributes.screenshotDisplayType | startswith("APP_IPHONE_") and . != "APP_IPHONE_67")
+                  | select(.set.attributes.screenshotDisplayType
+                      | (startswith("APP_IPHONE_") and . != "APP_IPHONE_67")
+                        or (startswith("APP_IPAD_") and . != "APP_IPAD_PRO_3GEN_129"))
                   | .screenshots[]?.id' \
               | while IFS= read -r screenshot_id; do
                   asc screenshots delete --id "$screenshot_id" --confirm

--- a/kotlin/android/screenshots/play-store.txt
+++ b/kotlin/android/screenshots/play-store.txt
@@ -1,7 +1,7 @@
 kotlin/android/screenshots/sign-in.png
 kotlin/android/screenshots/session-screen.png
-kotlin/android/screenshots/session-screen-favorites.png
 kotlin/android/screenshots/resource-details.png
+kotlin/android/screenshots/session-screen-favorites.png
 kotlin/android/screenshots/resource-details-internet.png
 kotlin/android/screenshots/device-details.png
 kotlin/android/screenshots/settings-general.png

--- a/swift/apple/app-store/screenshots-ios.txt
+++ b/swift/apple/app-store/screenshots-ios.txt
@@ -1,6 +1,5 @@
 welcome-light.png
 session-light.png
-session-menu-light.png
 resource-details-light.png
 resource-details-internet-light.png
 device-details-light.png


### PR DESCRIPTION
Remove obsolete iPhone and iPad screenshots after uploading their replacements so Apple scales the maintained sizes instead of retaining stale size-specific images. Cleanup is limited to the prepared iOS version and English (US) localization; app previews are unchanged.

Put sign-in, the resource list, and resource details first in the iPhone and iPad store selection, and remove the account pop-over screenshot.