### PR TITLE
fix(android): use the Intune track name for submissions

### DIFF
--- a/.github/workflows/submit-android-release.yml
+++ b/.github/workflows/submit-android-release.yml
@@ -64,11 +64,13 @@ jobs:
         with:
           ref: ${{ steps.release.outputs.source_sha }}
 
-      - name: Select store screenshots
+      - name: Select submission inputs
         run: |
-          # Use the submission's selection without changing the build's screenshot files.
+          # Use the submission's script and selection, with screenshot files from the build.
           git fetch --depth=1 origin "$GITHUB_SHA"
-          git restore --source="$GITHUB_SHA" --worktree -- kotlin/android/screenshots/play-store.txt
+          git restore --source="$GITHUB_SHA" --worktree -- \
+            scripts/upload/play-store.sh \
+            kotlin/android/screenshots/play-store.txt
 
       - uses: ./.github/actions/setup-mise
         with:
@@ -167,11 +169,13 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.source_sha }}
 
-      - name: Select store screenshots
+      - name: Select submission inputs
         run: |
-          # Match the selection shown before approval, with image files from the build.
+          # Match the script and selection used before approval, with image files from the build.
           git fetch --depth=1 origin "$GITHUB_SHA"
-          git restore --source="$GITHUB_SHA" --worktree -- kotlin/android/screenshots/play-store.txt
+          git restore --source="$GITHUB_SHA" --worktree -- \
+            scripts/upload/play-store.sh \
+            kotlin/android/screenshots/play-store.txt
 
       - uses: ./.github/actions/setup-mise
         with:

--- a/scripts/upload/play-store.sh
+++ b/scripts/upload/play-store.sh
@@ -18,8 +18,7 @@ mapfile -t SCREENSHOTS < "$REPO_ROOT/kotlin/android/screenshots/play-store.txt"
 readonly -a SCREENSHOTS
 
 case "$COMMAND" in
-    Intune) TARGET_TRACK="4699772446953372201" ;;
-    inspect | internal | production) TARGET_TRACK="$COMMAND" ;;
+    inspect | internal | production | Intune) TARGET_TRACK="$COMMAND" ;;
     *)
         echo "Unknown command: $COMMAND" >&2
         exit 1


### PR DESCRIPTION
Use `Intune` as the Google Play API track name instead of the numeric Play Console identifier, which returns a track-not-found error.

Load the upload script and screenshot selection from the submission commit in both preparation and submission. This lets workflow fixes apply to an existing draft without rebuilding it, while screenshot content and the release artifact remain tied to the draft build.