### PR TITLE
fix(portal): return valid provisioned gateway token

### DIFF
--- a/elixir/lib/portal/authentication.ex
+++ b/elixir/lib/portal/authentication.ex
@@ -464,15 +464,23 @@ defmodule Portal.Authentication do
     end
   end
 
-  defp verify_secret_hash(token, nonce, fragment) do
-    expected_hash = Portal.Crypto.hash(:sha3_256, nonce <> fragment <> token.secret_salt)
+  defp verify_secret_hash(
+         %{secret_salt: secret_salt, secret_hash: secret_hash},
+         nonce,
+         fragment
+       )
+       when is_binary(secret_salt) and is_binary(secret_hash) and is_binary(nonce) and
+              is_binary(fragment) do
+    expected_hash = Portal.Crypto.hash(:sha3_256, nonce <> fragment <> secret_salt)
 
-    if Plug.Crypto.secure_compare(expected_hash, token.secret_hash) do
+    if Plug.Crypto.secure_compare(expected_hash, secret_hash) do
       :ok
     else
       :error
     end
   end
+
+  defp verify_secret_hash(_token, _nonce, _fragment), do: :error
 
   # Authentication
 

--- a/elixir/lib/portal_api/controllers/gateway_controller.ex
+++ b/elixir/lib/portal_api/controllers/gateway_controller.ex
@@ -135,13 +135,17 @@ defmodule PortalAPI.GatewayController do
     name = get_in(params, ["gateway", "name"])
 
     with {:ok, site} <- Database.fetch_site(site_id, subject),
-         {:ok, gateway, token, _encoded_token} <- Database.provision_gateway(site, name, subject) do
+         {:ok, gateway, _token, encoded_token} <- Database.provision_gateway(site, name, subject) do
       gateway = Presence.Devices.preload_presence([gateway]) |> List.first()
 
       conn
       |> put_status(:created)
       |> put_resp_header("location", ~p"/sites/#{site_id}/gateways/#{gateway}")
-      |> json(JSON.encode(%{gateway | provisioned_token: token}, schema: PortalAPI.Schemas.Gateway.Schema))
+      |> json(
+        JSON.encode(%{gateway | provisioned_token: encoded_token},
+          schema: PortalAPI.Schemas.Gateway.Schema
+        )
+      )
     else
       error -> Error.handle(conn, error)
     end

--- a/elixir/lib/portal_api/schemas/gateway_schema.ex
+++ b/elixir/lib/portal_api/schemas/gateway_schema.ex
@@ -168,6 +168,13 @@ defmodule PortalAPI.Schemas.Gateway do
       %{online: device.online?, rotated_at: device.gateway_token_rotated_at}
     end
 
+    def map(%Portal.Device{provisioned_token: token} = device, map) when is_binary(token) do
+      device
+      |> Map.put(:provisioned_token, nil)
+      |> map(map)
+      |> Map.put(:token, token)
+    end
+
     def map(%Portal.Device{provisioned_token: token} = device, map) do
       device
       |> Map.put(:provisioned_token, nil)

--- a/elixir/test/portal/authentication_test.exs
+++ b/elixir/test/portal/authentication_test.exs
@@ -776,6 +776,17 @@ defmodule Portal.AuthenticationTest do
   end
 
   describe "verify_gateway_token/1 with single-owner tokens" do
+    test "rejects a signed token with a nil secret fragment" do
+      gateway = gateway_fixture()
+      token = gateway_token_fixture(gateway: gateway)
+      config = Portal.Config.fetch_env!(:portal, Portal.Tokens)
+      key_base = Keyword.fetch!(config, :key_base)
+      salt = Keyword.fetch!(config, :salt) <> "gateway"
+      malformed = "." <> Plug.Crypto.sign(key_base, salt, {token.account_id, token.id, nil})
+
+      assert {:error, :invalid_token} = verify_gateway_token(malformed)
+    end
+
     test "verifies an active single-owner token" do
       gateway = gateway_fixture()
       token = gateway_token_fixture(gateway: gateway)

--- a/elixir/test/portal_api/controllers/gateway_controller_test.exs
+++ b/elixir/test/portal_api/controllers/gateway_controller_test.exs
@@ -51,6 +51,8 @@ defmodule PortalAPI.GatewayControllerTest do
 
       refute is_nil(id)
       refute is_nil(token)
+      assert {:ok, gateway_token} = Portal.Authentication.verify_gateway_token(token)
+      assert gateway_token.device_id == id
 
       assert [{"location", location}] =
                Enum.filter(conn.resp_headers, fn {k, _} -> k == "location" end)

--- a/elixir/test/portal_web/live/sites_test.exs
+++ b/elixir/test/portal_web/live/sites_test.exs
@@ -533,6 +533,13 @@ defmodule PortalWeb.SitesTest do
       html = render_click(lv, "deploy_gateway")
       assert html =~ "Deploy a Gateway"
 
+      encoded_token =
+        html
+        |> Floki.parse_fragment!()
+        |> Floki.find("#deploy-code-debian-token-code")
+        |> Floki.text()
+        |> String.trim()
+
       gateway =
         Repo.get_by!(Device, account_id: account.id, site_id: site.id, type: :gateway)
 
@@ -541,6 +548,8 @@ defmodule PortalWeb.SitesTest do
       token = Repo.get_by!(GatewayToken, account_id: account.id, device_id: gateway.id)
       assert is_nil(token.site_id)
       assert is_nil(token.rotated_at)
+      assert {:ok, verified_token} = Portal.Authentication.verify_gateway_token(encoded_token)
+      assert verified_token.id == token.id
     end
 
     test "deploy flips to connected when its gateway joins the account presence", %{


### PR DESCRIPTION
- return the already encoded gateway token from the REST gateway provisioning endpoint instead of re-encoding a struct whose virtual secret fragment has been scrubbed
- reject signed credentials with malformed secret fields as `:invalid_token` instead of raising during binary construction
- add regressions that authenticate tokens emitted by both REST API and Web UI gateway provisioning paths