### PR TITLE
fix(portal): render errors with the conn after a body read

### DIFF
--- a/elixir/lib/portal/conn.ex
+++ b/elixir/lib/portal/conn.ex
@@ -1,0 +1,24 @@
+defmodule Portal.Conn do
+  @moduledoc """
+  Keeps the current `Plug.Conn` attached to an exception.
+
+  Phoenix renders an exception with the conn it held before the failing plug or
+  action ran. Once that code has read the request body, the earlier conn is
+  stale and Bandit refuses to send a response on it. Run the work that follows
+  a body read through `wrap_errors/2` so the error reaches Phoenix with the
+  conn the read returned.
+  """
+
+  @spec wrap_errors(Plug.Conn.t(), (Plug.Conn.t() -> result)) :: result when result: term()
+  def wrap_errors(%Plug.Conn{} = conn, fun) when is_function(fun, 1) do
+    fun.(conn)
+  rescue
+    exception in Plug.Conn.WrapperError ->
+      reraise(exception, __STACKTRACE__)
+  catch
+    kind, reason ->
+      stack = __STACKTRACE__
+      wrapper = %Plug.Conn.WrapperError{conn: conn, kind: kind, reason: reason, stack: stack}
+      :erlang.raise(:error, wrapper, stack)
+  end
+end

--- a/elixir/lib/portal/parsers/json.ex
+++ b/elixir/lib/portal/parsers/json.ex
@@ -1,4 +1,4 @@
-defmodule PortalAPI.Parsers.JSON do
+defmodule Portal.Parsers.JSON do
   @moduledoc """
   JSON parser that carries the latest connection when decoding fails.
 

--- a/elixir/lib/portal/parsers/urlencoded.ex
+++ b/elixir/lib/portal/parsers/urlencoded.ex
@@ -1,0 +1,44 @@
+defmodule Portal.Parsers.URLENCODED do
+  @moduledoc """
+  Form parser that carries the latest connection when decoding fails.
+
+  Plug.Parsers.URLENCODED raises after reading the body without including the
+  updated connection, and Plug.Parsers drops it for oversized bodies. Error
+  responses must use that connection.
+  """
+  @behaviour Plug.Parsers
+
+  @impl true
+  def init(opts) do
+    opts = Keyword.put_new(opts, :length, 1_000_000)
+    Keyword.pop(opts, :body_reader, {Plug.Conn, :read_body, []})
+  end
+
+  @impl true
+  def parse(conn, "application", "x-www-form-urlencoded", _headers, {{mod, fun, args}, opts}) do
+    case apply(mod, fun, [conn, opts | args]) do
+      {:ok, body, conn} ->
+        Portal.Conn.wrap_errors(conn, fn conn ->
+          validate_utf8 = Keyword.get(opts, :validate_utf8, true)
+          params = Plug.Conn.Query.decode(body, [], Plug.Parsers.BadEncodingError, validate_utf8)
+          {:ok, params, conn}
+        end)
+
+      {:more, _data, conn} ->
+        Plug.Conn.WrapperError.reraise(
+          conn,
+          :error,
+          Plug.Parsers.RequestTooLargeError.exception([]),
+          []
+        )
+
+      {:error, :timeout} ->
+        raise Plug.TimeoutError
+
+      {:error, _} ->
+        raise Plug.BadRequestError
+    end
+  end
+
+  def parse(conn, _type, _subtype, _headers, _opts), do: {:next, conn}
+end

--- a/elixir/lib/portal_api/controllers/integrations/azure_communication_services/webhook_controller.ex
+++ b/elixir/lib/portal_api/controllers/integrations/azure_communication_services/webhook_controller.ex
@@ -17,7 +17,7 @@ defmodule PortalAPI.Integrations.AzureCommunicationServices.WebhookController do
   defp handle_body(conn, event_type) do
     case read_body(conn) do
       {:ok, body, conn} ->
-        dispatch_body(conn, event_type, body)
+        Portal.Conn.wrap_errors(conn, &dispatch_body(&1, event_type, body))
 
       {:more, _, conn} ->
         send_resp(conn, 413, "Request Entity Too Large")

--- a/elixir/lib/portal_api/controllers/integrations/entra/webhook_controller.ex
+++ b/elixir/lib/portal_api/controllers/integrations/entra/webhook_controller.ex
@@ -26,7 +26,7 @@ defmodule PortalAPI.Integrations.Entra.WebhookController do
   defp handle_notifications(conn, directory_id) do
     case read_body(conn, length: @max_body_bytes) do
       {:ok, body, conn} ->
-        handle_notification_body(conn, directory_id, body)
+        Portal.Conn.wrap_errors(conn, &handle_notification_body(&1, directory_id, body))
 
       {:more, _, conn} ->
         send_resp(conn, 413, "Request Entity Too Large")

--- a/elixir/lib/portal_api/controllers/integrations/google/webhook_controller.ex
+++ b/elixir/lib/portal_api/controllers/integrations/google/webhook_controller.ex
@@ -16,8 +16,7 @@ defmodule PortalAPI.Integrations.Google.WebhookController do
 
     case read_body(conn, length: @max_body_bytes) do
       {:ok, body, conn} ->
-        :ok = Google.Webhooks.handle_notification(conn.query_params["directory_id"], headers, decode(body))
-        send_resp(conn, 200, "")
+        Portal.Conn.wrap_errors(conn, &handle_body(&1, headers, body))
 
       {:more, _, conn} ->
         send_resp(conn, 413, "Request Entity Too Large")
@@ -26,6 +25,11 @@ defmodule PortalAPI.Integrations.Google.WebhookController do
         Logger.info("Google webhook rejected", reason: inspect(reason))
         send_resp(conn, 400, "Bad Request")
     end
+  end
+
+  defp handle_body(conn, headers, body) do
+    :ok = Google.Webhooks.handle_notification(conn.query_params["directory_id"], headers, decode(body))
+    send_resp(conn, 200, "")
   end
 
   # Google sends an empty body for the initial sync message.

--- a/elixir/lib/portal_api/controllers/integrations/stripe/webhook_controller.ex
+++ b/elixir/lib/portal_api/controllers/integrations/stripe/webhook_controller.ex
@@ -10,8 +10,11 @@ defmodule PortalAPI.Integrations.Stripe.WebhookController do
     case get_req_header(conn, "stripe-signature") do
       [signature_header] ->
         case read_body(conn, length: 1_000_000) do
-          {:ok, body, conn} -> handle_body(conn, signature_header, body)
-          {:more, _, conn} -> send_resp(conn, 413, "Request Entity Too Large")
+          {:ok, body, conn} ->
+            Portal.Conn.wrap_errors(conn, &handle_body(&1, signature_header, body))
+
+          {:more, _, conn} ->
+            send_resp(conn, 413, "Request Entity Too Large")
 
           {:error, reason} ->
             Logger.error("Stripe webhook body could not be read", reason: inspect(reason))

--- a/elixir/lib/portal_api/router.ex
+++ b/elixir/lib/portal_api/router.ex
@@ -3,21 +3,20 @@ defmodule PortalAPI.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
-    # Authentication and the account limiter use only request metadata. Keep
-    # them ahead of the body parser so rejected requests never buffer or decode
-    # an attacker-controlled JSON body.
     plug PortalAPI.Plugs.Auth
     plug PortalAPI.Plugs.RateLimit
-
-    plug PortalAPI.Plugs.ParseBody,
-      parsers: [PortalAPI.Parsers.JSON],
-      pass: ["*/*"],
-      json_decoder: Phoenix.json_library()
-
     plug PortalAPI.Plugs.RequestLog
     plug PortalAPI.Plugs.Scope
     plug PortalAPI.Plugs.ValidateUUIDParams
     plug OpenApiSpex.Plug.PutApiSpec, module: PortalAPI.ApiSpec
+
+    # The plugs above use only request metadata, so a rejected request never
+    # buffers an attacker-controlled body. The parser is also last because
+    # Phoenix renders a pipeline error with the conn from before the body read.
+    plug PortalAPI.Plugs.ParseBody,
+      parsers: [Portal.Parsers.JSON],
+      pass: ["*/*"],
+      json_decoder: Phoenix.json_library()
   end
 
   pipeline :public do
@@ -57,7 +56,7 @@ defmodule PortalAPI.Router do
     plug PortalAPI.Plugs.RequestLog, mcp: true
 
     plug PortalAPI.Plugs.MCPParseBody,
-      parsers: [PortalAPI.Parsers.JSON],
+      parsers: [Portal.Parsers.JSON],
       pass: ["*/*"],
       json_decoder: Phoenix.json_library(),
       length: 1_000_000
@@ -94,7 +93,7 @@ defmodule PortalAPI.Router do
     # Preserve the post-read conn when malformed or oversized JSON raises so
     # RescueRouterErrors can send the error without reusing stale adapter state.
     plug Plug.Parsers,
-      parsers: [PortalAPI.Parsers.JSON],
+      parsers: [Portal.Parsers.JSON],
       pass: ["*/*"],
       json_decoder: Phoenix.json_library(),
       length: 10_000_000

--- a/elixir/lib/portal_ops/endpoint.ex
+++ b/elixir/lib/portal_ops/endpoint.ex
@@ -41,7 +41,7 @@ defmodule PortalOps.Endpoint do
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 
   plug Plug.Parsers,
-    parsers: [:urlencoded, :multipart],
+    parsers: [Portal.Parsers.URLENCODED],
     pass: ["*/*"]
 
   plug Plug.Session, @session_cookie

--- a/elixir/lib/portal_web/endpoint.ex
+++ b/elixir/lib/portal_web/endpoint.ex
@@ -57,7 +57,7 @@ defmodule PortalWeb.Endpoint do
   end
 
   plug Plug.Parsers,
-    parsers: [:urlencoded, :multipart, :json],
+    parsers: [Portal.Parsers.URLENCODED, Portal.Parsers.JSON],
     pass: ["*/*"],
     json_decoder: Phoenix.json_library()
 

--- a/elixir/test/portal/conn_test.exs
+++ b/elixir/test/portal/conn_test.exs
@@ -1,0 +1,46 @@
+defmodule Portal.ConnTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Conn
+
+  setup do
+    %{conn: Plug.Test.conn(:post, "/", "") |> Plug.Conn.assign(:current, true)}
+  end
+
+  test "returns the function result", %{conn: conn} do
+    assert Conn.wrap_errors(conn, &{:ok, &1}) == {:ok, conn}
+  end
+
+  for kind <- [:error, :exit, :throw] do
+    test "wraps a #{kind} with the conn it was given", %{conn: conn} do
+      error =
+        assert_raise Plug.Conn.WrapperError, fn ->
+          Conn.wrap_errors(conn, fn _conn -> fail(unquote(kind)) end)
+        end
+
+      assert error.conn.assigns.current
+      assert error.kind == unquote(kind)
+      assert error.reason == fail_reason(unquote(kind))
+    end
+  end
+
+  test "keeps the conn of an error that was already wrapped", %{conn: conn} do
+    inner = Plug.Conn.assign(conn, :inner, true)
+
+    error =
+      assert_raise Plug.Conn.WrapperError, fn ->
+        Conn.wrap_errors(conn, fn _conn ->
+          Conn.wrap_errors(inner, fn _conn -> raise "boom" end)
+        end)
+      end
+
+    assert error.conn.assigns.inner
+  end
+
+  defp fail(:error), do: raise("boom")
+  defp fail(:exit), do: exit(:boom)
+  defp fail(:throw), do: throw(:boom)
+
+  defp fail_reason(:error), do: %RuntimeError{message: "boom"}
+  defp fail_reason(_kind), do: :boom
+end

--- a/elixir/test/portal/parsers/bandit_test.exs
+++ b/elixir/test/portal/parsers/bandit_test.exs
@@ -1,0 +1,62 @@
+defmodule Portal.Parsers.BanditTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.EndpointServer
+
+  @form "application/x-www-form-urlencoded"
+  @json "application/json"
+
+  describe "PortalWeb.Endpoint" do
+    setup do
+      %{port: EndpointServer.start()}
+    end
+
+    for {name, content_type, body, status, reason} <- [
+          {"invalid UTF-8 form", @form, "a=%FF", 400, "Bad Request"},
+          {"oversized form", @form, String.duplicate("a", 1_000_001), 413,
+           "Request Entity Too Large"},
+          {"malformed JSON", @json, "{", 400, "Bad Request"},
+          {"oversized JSON", @json, String.duplicate(" ", 8_000_001), 413,
+           "Request Entity Too Large"}
+        ] do
+      test "#{name} renders #{status} with the conn returned by the body read", %{port: port} do
+        response =
+          EndpointServer.send_raw(
+            port,
+            EndpointServer.raw_request(
+              "POST",
+              "/",
+              [{"Content-Type", unquote(content_type)}],
+              unquote(body),
+              "localhost"
+            )
+          )
+
+        assert response =~ "HTTP/1.1 #{unquote(status)}"
+        assert String.ends_with?(response, unquote(reason))
+      end
+    end
+  end
+
+  describe "PortalOps.Endpoint" do
+    setup do
+      %{port: EndpointServer.start(endpoint: PortalOps.Endpoint)}
+    end
+
+    for {name, body, status, reason} <- [
+          {"invalid UTF-8 form", "a=%FF", 400, "Bad Request"},
+          {"oversized form", String.duplicate("a", 1_000_001), 413, "Request Entity Too Large"}
+        ] do
+      test "#{name} renders #{status} with the conn returned by the body read", %{port: port} do
+        response =
+          EndpointServer.send_raw(
+            port,
+            EndpointServer.raw_request("POST", "/", [{"Content-Type", @form}], unquote(body))
+          )
+
+        assert response =~ "HTTP/1.1 #{unquote(status)}"
+        assert String.ends_with?(response, unquote(reason))
+      end
+    end
+  end
+end

--- a/elixir/test/portal/parsers/urlencoded_test.exs
+++ b/elixir/test/portal/parsers/urlencoded_test.exs
@@ -1,0 +1,48 @@
+defmodule Portal.Parsers.URLENCODEDTest do
+  use ExUnit.Case, async: true
+
+  # Mark the conn returned by the body reader so a wrapper carrying the
+  # pre-read conn fails these tests even with Plug.Test's permissive adapter.
+  def read_body(conn, opts) do
+    case Plug.Conn.read_body(conn, opts) do
+      {status, body, conn} -> {status, body, Plug.Conn.assign(conn, :body_read, true)}
+      error -> error
+    end
+  end
+
+  defp parse(body, opts \\ []) do
+    opts =
+      Keyword.merge(
+        [
+          parsers: [Portal.Parsers.URLENCODED],
+          pass: ["*/*"],
+          body_reader: {__MODULE__, :read_body, []}
+        ],
+        opts
+      )
+
+    Plug.Test.conn(:post, "/", body)
+    |> Plug.Conn.put_req_header("content-type", "application/x-www-form-urlencoded")
+    |> Plug.Parsers.call(Plug.Parsers.init(opts))
+  end
+
+  test "decodes a valid body" do
+    conn = parse("a=1&b[]=2")
+    assert conn.assigns.body_read
+    assert conn.body_params == %{"a" => "1", "b" => ["2"]}
+  end
+
+  test "an invalid UTF-8 body carries the updated conn and a 400 exception" do
+    error = assert_raise Plug.Conn.WrapperError, fn -> parse("a=%FF") end
+    assert %Plug.Parsers.BadEncodingError{} = error.reason
+    assert error.conn.assigns.body_read
+    assert Plug.Exception.status(error.reason) == 400
+  end
+
+  test "an oversized body carries the updated conn and a 413 exception" do
+    error = assert_raise Plug.Conn.WrapperError, fn -> parse("a=1&b=2", length: 2) end
+    assert %Plug.Parsers.RequestTooLargeError{} = error.reason
+    assert error.conn.assigns.body_read
+    assert Plug.Exception.status(error.reason) == 413
+  end
+end

--- a/elixir/test/portal_api/controllers/integrations/webhook_bandit_test.exs
+++ b/elixir/test/portal_api/controllers/integrations/webhook_bandit_test.exs
@@ -1,66 +1,69 @@
 defmodule PortalAPI.Integrations.WebhookBanditTest do
   use ExUnit.Case, async: true
 
-  # Plug.Test does not enforce Bandit's connection usage counter. Exercise the
-  # controllers over HTTP so discarding the conn returned by read_body raises.
-  defmodule WebhookPlug do
-    def init(opts), do: opts
+  alias Portal.EndpointServer
 
-    def call(conn, _opts) do
-      Portal.Config.put_env_override(:portal, Portal.AzureCommunicationServices,
-        event_grid_webhook_signing_secret: "acs-secret"
+  @acs_secret "acs-secret"
+  @entra "/integrations/entra/webhooks"
+  @stripe "/integrations/stripe/webhooks"
+  @acs "/integrations/azure_communication_services/webhooks"
+  @google "/integrations/google/webhooks"
+  @report %{
+    eventType: "Microsoft.Communication.EmailDeliveryReportReceived",
+    data: %{messageId: "message", recipient: "user@example.com", status: "Bounced"}
+  }
+
+  # The request process is never allowed into the SQL sandbox, so the first
+  # database call after a body read raises like a lost database connection.
+  setup do
+    handler = {__MODULE__, make_ref()}
+    :telemetry.attach(handler, [:bandit, :request, :exception], &__MODULE__.forward/4, self())
+    on_exit(fn -> :telemetry.detach(handler) end)
+
+    port =
+      EndpointServer.start(
+        prepare: fn conn ->
+          Portal.Config.put_env_override(:portal, :rest_api_url, "http://127.0.0.1")
+
+          Portal.Config.put_env_override(:portal, Portal.AzureCommunicationServices,
+            event_grid_webhook_signing_secret: @acs_secret
+          )
+
+          conn
+        end
       )
 
-      controller =
-        case conn.request_path do
-          "/entra" -> PortalAPI.Integrations.Entra.WebhookController
-          "/stripe" -> PortalAPI.Integrations.Stripe.WebhookController
-          "/acs" -> PortalAPI.Integrations.AzureCommunicationServices.WebhookController
-        end
-
-      controller.handle_webhook(conn, %{})
-    end
-  end
-
-  setup do
-    server =
-      start_supervised!({Bandit,
-       plug: WebhookPlug, ip: {127, 0, 0, 1}, port: 0, startup_log: false})
-
-    {:ok, {_address, port}} = ThousandIsland.listener_info(server)
-    %{url: "http://127.0.0.1:#{port}", port: port}
+    %{port: port}
   end
 
   for {name, path, headers, body, status, response} <- [
-        {"Entra invalid JSON", "/entra", [], "{", 400, "Bad Request: invalid JSON"},
-        {"Entra missing notifications", "/entra", [], "{}", 400,
+        {"Entra invalid JSON", @entra, [], "{", 400, "Bad Request: invalid JSON"},
+        {"Entra missing notifications", @entra, [], "{}", 400,
          "Bad Request: missing notifications"},
-        {"Entra oversized batch", "/entra", [], JSON.encode!(%{value: List.duplicate(%{}, 1001)}),
+        {"Entra oversized batch", @entra, [], JSON.encode!(%{value: List.duplicate(%{}, 1001)}),
          413, "Request Entity Too Large: too many notifications"},
-        {"Stripe missing timestamp", "/stripe", [{"stripe-signature", "v1=invalid"}], "{}",
-         400, "Bad Request: missing timestamp"},
-        {"Stripe missing signatures", "/stripe", [{"stripe-signature", "t=0"}], "{}",
-         400, "Bad Request: missing signatures"},
-        {"Stripe expired signature", "/stripe", [{"stripe-signature", "t=0,v1=invalid"}], "{}",
+        {"Stripe missing timestamp", @stripe, [{"stripe-signature", "v1=invalid"}], "{}", 400,
+         "Bad Request: missing timestamp"},
+        {"Stripe missing signatures", @stripe, [{"stripe-signature", "t=0"}], "{}", 400,
+         "Bad Request: missing signatures"},
+        {"Stripe expired signature", @stripe, [{"stripe-signature", "t=0,v1=invalid"}], "{}",
          400, "Bad Request: expired signature"},
-        {"ACS invalid JSON", "/acs", [{"aeg-event-type", "Notification"}], "{", 400,
+        {"ACS invalid JSON", @acs, [{"aeg-event-type", "Notification"}], "{", 400,
          "Bad Request: invalid JSON"},
-        {"ACS invalid secret", "/acs", [{"aeg-event-type", "Notification"}], "[]", 401,
+        {"ACS invalid secret", @acs, [{"aeg-event-type", "Notification"}], "[]", 401,
          "Unauthorized"},
-        {"ACS invalid validation event", "/acs", [{"aeg-event-type", "SubscriptionValidation"}],
+        {"ACS invalid validation event", @acs, [{"aeg-event-type", "SubscriptionValidation"}],
          "[]", 400, "Bad Request: invalid validation event"},
-        {"ACS unsupported event", "/acs", [{"aeg-event-type", "Unknown"}], "[]", 400,
+        {"ACS unsupported event", @acs, [{"aeg-event-type", "Unknown"}], "[]", 400,
          "Bad Request: unsupported aeg-event-type"},
-        {"ACS unsubscribe", "/acs", [{"aeg-event-type", "Unsubscribe"}], "[]", 200, ""},
-        {"ACS dispatch failure", "/acs",
-         [{"aeg-event-type", "Notification"}, {"aeg-sas-key", "acs-secret"}],
-         JSON.encode!([%{eventType: "Microsoft.Communication.EmailDeliveryReportReceived", data: "not-a-map"}]),
-         500, "Internal Error"}
+        {"ACS unsubscribe", @acs, [{"aeg-event-type", "Unsubscribe"}], "[]", 200, ""},
+        {"ACS dispatch failure", @acs,
+         [{"aeg-event-type", "Notification"}, {"aeg-sas-key", @acs_secret}],
+         JSON.encode!([%{eventType: @report.eventType, data: "not-a-map"}]), 500,
+         "Internal Error"}
       ] do
-    test name, %{url: url} do
-      response =
-        Finch.build(:post, url <> unquote(path), unquote(headers), unquote(body))
-        |> Finch.request!(Req.Finch)
+    test name, %{port: port} do
+      response = EndpointServer.request(port, :post, unquote(path), unquote(headers), unquote(body))
 
       assert response.status == unquote(status)
       assert response.body == unquote(response)
@@ -68,63 +71,88 @@ defmodule PortalAPI.Integrations.WebhookBanditTest do
   end
 
   for {path, headers, size} <- [
-        {"/entra", [], 1_100_000},
-        {"/stripe", [{"stripe-signature", "v1=invalid"}], 1_100_000},
-        {"/acs", [{"aeg-event-type", "Notification"}], 8_100_000}
+        {@entra, [], 1_100_000},
+        {@stripe, [{"stripe-signature", "v1=invalid"}], 1_100_000},
+        {@acs, [{"aeg-event-type", "Notification"}], 8_100_000}
       ] do
-    test "#{path} rejects an oversized body using the updated conn", %{url: url} do
+    test "#{path} rejects an oversized body using the updated conn", %{port: port} do
       response =
-        Finch.build(:post, url <> unquote(path), unquote(headers), String.duplicate("x", unquote(size)))
-        |> Finch.request!(Req.Finch)
+        EndpointServer.request(
+          port,
+          :post,
+          unquote(path),
+          unquote(headers),
+          String.duplicate("x", unquote(size))
+        )
 
       assert response.status == 413
       assert response.body == "Request Entity Too Large"
     end
   end
 
-  test "Stripe rejects an invalid signature after reading the body", %{url: url} do
-    timestamp = System.system_time(:second)
-
-    response =
-      Finch.build(:post, url <> "/stripe", [{"stripe-signature", "t=#{timestamp},v1=invalid"}], "{}")
-      |> Finch.request!(Req.Finch)
+  test "Stripe rejects an invalid signature after reading the body", %{port: port} do
+    headers = [{"stripe-signature", "t=#{System.system_time(:second)},v1=invalid"}]
+    response = EndpointServer.request(port, :post, @stripe, headers, "{}")
 
     assert response.status == 400
     assert response.body == "Bad Request: invalid signature"
   end
 
-  test "Stripe returns its fallback response for signed invalid JSON", %{url: url} do
-    timestamp = System.system_time(:second)
-    body = "{"
-    secret = Portal.Billing.fetch_webhook_signing_secret!()
-    signature = PortalAPI.Integrations.Stripe.WebhookController.sign(timestamp, secret, body)
-
-    response =
-      Finch.build(:post, url <> "/stripe", [{"stripe-signature", "t=#{timestamp},v1=#{signature}"}], body)
-      |> Finch.request!(Req.Finch)
+  test "Stripe returns its fallback response for signed invalid JSON", %{port: port} do
+    response = EndpointServer.request(port, :post, @stripe, stripe_headers("{"), "{")
 
     assert response.status == 500
-    # Bandit also returns 500 on a stale conn; check the controller's body.
     assert response.body == "Internal Error"
   end
 
+  for {name, path, headers, body, exception} <- [
+        {"Stripe", @stripe, :stripe, "{}", FunctionClauseError},
+        {"Entra", @entra <> "?directory_id=#{Ecto.UUID.generate()}", [],
+         JSON.encode!(%{value: [%{clientState: "state"}]}), DBConnection.OwnershipError},
+        {"Google", @google <> "?directory_id=#{Ecto.UUID.generate()}",
+         [{"x-goog-resource-state", "update"}], JSON.encode!(%{id: "user"}),
+         DBConnection.OwnershipError},
+        {"ACS", @acs, [{"aeg-event-type", "Notification"}, {"aeg-sas-key", @acs_secret}],
+         JSON.encode!([@report]), DBConnection.OwnershipError}
+      ] do
+    test "#{name} renders an exception raised after the body was read", %{port: port} do
+      headers =
+        case unquote(headers) do
+          :stripe -> stripe_headers(unquote(body))
+          headers -> headers
+        end
+
+      response = EndpointServer.request(port, :post, unquote(path), headers, unquote(body))
+
+      assert response.status == 500
+
+      assert JSON.decode!(response.body) == %{
+               "type" => "about:blank",
+               "title" => "Internal Server Error",
+               "status" => 500
+             }
+
+      assert_receive {:bandit_exception, %{exception: %{__struct__: unquote(exception)}}}
+    end
+  end
+
   for {path, headers, body} <- [
-        {"/entra", "", "{"},
-        {"/stripe", "stripe-signature: v1=invalid\r\n", "{}"},
-        {"/acs", "aeg-event-type: Notification\r\n", "{"}
+        {@entra, [], "{"},
+        {@stripe, [{"stripe-signature", "v1=invalid"}], "{}"},
+        {@acs, [{"aeg-event-type", "Notification"}], "{"}
       ] do
     test "#{path} preserves the next request on the same connection", %{port: port} do
-      {:ok, socket} = :gen_tcp.connect(~c"127.0.0.1", port, [:binary, active: false], 5_000)
-      on_exit(fn -> :gen_tcp.close(socket) end)
+      response =
+        EndpointServer.send_raw(port, [
+          EndpointServer.raw_request("POST", unquote(path), unquote(headers), unquote(body)),
+          EndpointServer.raw_request(
+            "POST",
+            @entra <> "?validationToken=still-alive",
+            [{"Connection", "close"}],
+            ""
+          )
+        ])
 
-      :ok = :gen_tcp.send(socket, [
-        "POST ", unquote(path), " HTTP/1.1\r\nHost: localhost\r\n",
-        unquote(headers), "Content-Length: ", Integer.to_string(byte_size(unquote(body))),
-        "\r\n\r\n", unquote(body),
-        "POST /entra?validationToken=still-alive HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
-      ])
-
-      response = receive_until_closed(socket, "")
       assert response =~ "HTTP/1.1 400"
       assert response =~ "HTTP/1.1 200"
       assert String.ends_with?(response, "still-alive")
@@ -132,11 +160,12 @@ defmodule PortalAPI.Integrations.WebhookBanditTest do
     end
   end
 
-  defp receive_until_closed(socket, acc) do
-    case :gen_tcp.recv(socket, 0, 5_000) do
-      {:ok, data} -> receive_until_closed(socket, acc <> data)
-      {:error, :closed} -> acc
-      {:error, reason} -> flunk("HTTP connection failed: #{inspect(reason)}")
-    end
+  def forward(_event, _measurements, metadata, pid), do: send(pid, {:bandit_exception, metadata})
+
+  defp stripe_headers(body) do
+    timestamp = System.system_time(:second)
+    secret = Portal.Billing.fetch_webhook_signing_secret!()
+    signature = PortalAPI.Integrations.Stripe.WebhookController.sign(timestamp, secret, body)
+    [{"stripe-signature", "t=#{timestamp},v1=#{signature}"}]
   end
 end

--- a/elixir/test/portal_api/plugs/parse_body_test.exs
+++ b/elixir/test/portal_api/plugs/parse_body_test.exs
@@ -16,7 +16,7 @@ defmodule PortalAPI.Plugs.ParseBodyTest do
     opts =
       Keyword.merge(
         [
-          parsers: [PortalAPI.Parsers.JSON],
+          parsers: [Portal.Parsers.JSON],
           pass: ["*/*"],
           json_decoder: Phoenix.json_library(),
           body_reader: {__MODULE__, :read_body, []}

--- a/elixir/test/support/endpoint_server.ex
+++ b/elixir/test/support/endpoint_server.ex
@@ -1,0 +1,83 @@
+defmodule Portal.EndpointServer do
+  @moduledoc """
+  Serves an endpoint over a real Bandit listener. `Plug.Test` never enforces
+  Bandit's connection usage counter, so only a request over a socket shows a
+  response that was sent on a stale conn.
+  """
+
+  import ExUnit.Callbacks, only: [start_supervised!: 1]
+
+  defmodule Dispatch do
+    @behaviour Plug
+
+    @impl Plug
+    def init(opts), do: opts
+
+    @impl Plug
+    def call(conn, {endpoint, prepare}) do
+      Portal.Config.put_env_override(:portal, Portal.Endpoint, https: nil)
+      conn |> prepare.() |> endpoint.call(endpoint.init([]))
+    end
+  end
+
+  @doc """
+  Starts the listener and returns its port. `:prepare` runs in the request
+  process before the endpoint, for per-process config overrides.
+  """
+  def start(opts \\ []) do
+    endpoint = Keyword.get(opts, :endpoint, Portal.Endpoint)
+    prepare = Keyword.get(opts, :prepare, & &1)
+
+    server =
+      start_supervised!(
+        {Bandit,
+         plug: {Dispatch, {endpoint, prepare}},
+         ip: {127, 0, 0, 1},
+         port: 0,
+         startup_log: false,
+         http_options: [log_exceptions_with_status_codes: []]}
+      )
+
+    {:ok, {_address, port}} = ThousandIsland.listener_info(server)
+    port
+  end
+
+  def request(port, method, path, headers, body) do
+    %Finch.Response{} =
+      Finch.build(method, "http://127.0.0.1:#{port}#{path}", headers, body)
+      |> Finch.request!(Req.Finch)
+  end
+
+  @doc "Sends raw HTTP/1.1 bytes and returns everything written back before the server closes."
+  def send_raw(port, data) do
+    {:ok, socket} = :gen_tcp.connect(~c"127.0.0.1", port, [:binary, active: false], 5_000)
+    :ok = :gen_tcp.send(socket, data)
+    response = receive_until_closed(socket, "")
+    :gen_tcp.close(socket)
+    response
+  end
+
+  def raw_request(method, path, headers, body, host \\ "127.0.0.1") do
+    [
+      method,
+      " ",
+      path,
+      " HTTP/1.1\r\nHost: ",
+      host,
+      "\r\n",
+      Enum.map(headers, fn {name, value} -> [name, ": ", value, "\r\n"] end),
+      "Content-Length: ",
+      Integer.to_string(IO.iodata_length(body)),
+      "\r\n\r\n",
+      body
+    ]
+  end
+
+  defp receive_until_closed(socket, acc) do
+    case :gen_tcp.recv(socket, 0, 5_000) do
+      {:ok, data} -> receive_until_closed(socket, acc <> data)
+      {:error, :closed} -> acc
+      {:error, reason} -> raise "HTTP connection failed: #{inspect(reason)}"
+    end
+  end
+end


### PR DESCRIPTION
Stripe webhooks were still failing with Bandit's "Stale conn" error after #15127. That PR fixed the controllers' own error branches, but not exceptions. Phoenix renders an exception with the conn it held before the failing action or plug ran. After a body read that conn is stale, Bandit refuses to send on it, and the client got a bare 500 while the original exception was never logged.

The same problem existed in three places: the four webhook controllers, the API pipeline plugs that ran after the body parser, and the stock Plug parsers in the web and ops endpoints, which turned a malformed or oversized body into a bare 500 instead of a 400 or 413.

Every error path now carries the post-read conn. The webhook controllers run their post-read work through a small wrapper, the API pipeline parses the body last, and the web and ops endpoints use conn-preserving form and JSON parsers. Multipart parsing is dropped from those endpoints because nothing posts multipart forms and Plug's multipart parser cannot be wrapped.

Tests now run the real endpoints over a Bandit socket, which is the only way to catch this. They cover a handler raising after the body read for each webhook, and malformed and oversized bodies for the web and ops endpoints.

Related: #15123, #15127