### PR TITLE
fix(portal): name the directory sync column Last Full Sync

### DIFF
--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -625,7 +625,7 @@ defmodule PortalWeb.Settings.DirectorySync do
                       Groups
                     </th>
                     <th class="px-6 py-2.5 text-left text-[10px] font-semibold tracking-widest uppercase text-subtle w-40">
-                      Last Synced
+                      Last Full Sync
                     </th>
                     <th class="px-6 py-2.5 w-14"></th>
                   </tr>
@@ -853,7 +853,7 @@ defmodule PortalWeb.Settings.DirectorySync do
                       Groups
                     </th>
                     <th class="px-6 py-2.5 text-left text-[10px] font-semibold tracking-widest uppercase text-subtle w-40">
-                      Last Synced
+                      Last Full Sync
                     </th>
                     <th class="px-6 py-2.5 w-14"></th>
                   </tr>


### PR DESCRIPTION
The directory sync table called its time column Last Synced. Since webhooks now apply changes between syncs, that time is the last full sync, and the column now says so.

Related: #15067
