### PR TITLE
chore(apple): collect MetricKit diagnostics

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -24,7 +24,7 @@ struct FirezoneApp: App {
 
   init() {
     // Initialize Telemetry as early as possible
-    Telemetry.start()
+    Telemetry.start(enableMetricKit: true)
 
     installCertificateParser()
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -18,7 +18,7 @@ public enum Telemetry {
     }
   }
 
-  public static func start(enableAppHangTracking: Bool = true) {
+  public static func start(enableAppHangTracking: Bool = true, enableMetricKit: Bool = false) {
     guard !BundleHelper.noTelemetry else {
       Log.info("Telemetry is switched off for this build")
 
@@ -32,6 +32,7 @@ public enum Telemetry {
       options.releaseName = releaseName()
       options.dist = distributionType()
       options.enableAppHangTracking = enableAppHangTracking
+      options.enableMetricKit = enableMetricKit
       options.enableLogs = true
     }
   }


### PR DESCRIPTION
Enable MetricKit's system-provided hang, CPU, and disk-write diagnostics in the Apple UI app alongside existing app-hang tracking. This gives us comparison data to validate MetricKit before retiring the legacy detector.
