### PR TITLE
refactor(gui-client): flatten and hide the command tree

### DIFF
--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -148,23 +148,17 @@ fn try_main(cli: Cli, rt: &Runtime, log_guard: &mut Option<LogGuard>) -> Result<
         }
 
         // All commands below _don't_ end up running the GUI because they return early.
-        Some(Cmd::Debug {
-            command: DebugCommand::Replicate6791,
-        }) => {
+        Some(Cmd::Replicate6791) => {
             firezone_gui_client::auth::replicate_6791()?;
 
             return Ok(());
         }
-        Some(Cmd::Debug {
-            command: DebugCommand::SetAutostart(SetAutostartArgs { enabled }),
-        }) => {
+        Some(Cmd::SetAutostart(SetAutostartArgs { enabled })) => {
             rt.block_on(firezone_gui_client::gui::set_autostart(enabled))?;
 
             return Ok(());
         }
-        Some(Cmd::Debug {
-            command: DebugCommand::SingleInstance,
-        }) => {
+        Some(Cmd::SingleInstance) => {
             rt.block_on(debug_single_instance())?;
 
             return Ok(());
@@ -366,19 +360,12 @@ impl Cli {
 
 #[derive(clap::Subcommand)]
 enum Cmd {
-    Debug {
-        #[command(subcommand)]
-        command: DebugCommand,
-    },
-    Elevated,
     OpenDeepLink(DeepLink),
-    /// SmokeTest gets its own subcommand for historical reasons.
-    SmokeTest,
-}
-
-#[derive(clap::Subcommand)]
-enum DebugCommand {
+    #[command(hide = true)]
+    Elevated,
+    #[command(hide = true)]
     Replicate6791,
+    #[command(hide = true)]
     SetAutostart(SetAutostartArgs),
     /// Drive only the launch-lock + GUI IPC handshake — no controller, no
     /// auth, no tunnel-service IPC, no Tauri UI. Two invocations exercise
@@ -389,7 +376,10 @@ enum DebugCommand {
     /// - Second invocation: sees the lock held, connects to the pipe,
     ///   sends `NewInstance`, awaits the `Ack`, prints
     ///   `second-instance: …`, and exits.
+    #[command(hide = true)]
     SingleInstance,
+    #[command(hide = true)]
+    SmokeTest,
 }
 
 #[derive(clap::Parser)]

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -586,9 +586,9 @@ pub enum SingleInstance {
     /// Another instance was already running. We connected to its GUI
     /// IPC pipe, sent `ClientMsg::NewInstance`, awaited the `Ack`,
     /// and closed our end. Production callers bail with
-    /// [`AlreadyRunning`] here; the `debug single-instance`
-    /// subcommand uses it as a successful end state for the
-    /// second-instance side of the smoke test.
+    /// [`AlreadyRunning`] here; the `single-instance` subcommand uses
+    /// it as a successful end state for the second-instance side of
+    /// the smoke test.
     SecondHandedOff,
 }
 
@@ -633,7 +633,7 @@ pub async fn establish_single_instance() -> Result<SingleInstance> {
 /// [`ClientMsg`], send a `ServerMsg::Ack`, and return the message
 /// so the caller can log / assert on it.
 ///
-/// Used by the `debug single-instance` subcommand to exercise the
+/// Used by the `single-instance` subcommand to exercise the
 /// pipe-server side of the launch-lock hand-off without standing up
 /// the controller or any other normal-runtime machinery. Production
 /// code uses the same `ipc::Server` + framed reader/writer types

--- a/rust/tests/gui-smoke-test/src/main.rs
+++ b/rust/tests/gui-smoke-test/src/main.rs
@@ -133,7 +133,7 @@ fn binary_allowlist_rejection_test(app: &App) -> Result<()> {
     Ok(())
 }
 
-/// Spawn two `debug single-instance` invocations back-to-back and
+/// Spawn two `single-instance` invocations back-to-back and
 /// assert that:
 ///
 /// - The first acquires the launch lock and binds the GUI IPC pipe.
@@ -150,7 +150,7 @@ fn single_instance_test(app: &App) -> Result<()> {
     );
 
     let first = app
-        .gui_command(&["debug", "single-instance"])?
+        .gui_command(&["single-instance"])?
         .stdout(subprocess::Redirection::Pipe)
         .start()?;
 
@@ -159,7 +159,7 @@ fn single_instance_test(app: &App) -> Result<()> {
     std::thread::sleep(Duration::from_millis(500));
 
     let second = app
-        .gui_command(&["debug", "single-instance"])?
+        .gui_command(&["single-instance"])?
         .stdout(subprocess::Redirection::Pipe)
         .start()?;
     let second_capture = second
@@ -198,9 +198,7 @@ fn single_instance_test(app: &App) -> Result<()> {
 
 fn manual_tests(app: &App) -> Result<()> {
     tracing::info!("=== manual: replicate #6791 ===");
-    app.gui_command(&["debug", "replicate6791"])?
-        .start()?
-        .wait()?;
+    app.gui_command(&["replicate6791"])?.start()?.wait()?;
     tracing::info!("=== manual: replicate #6791 complete ===");
 
     tracing::info!("=== manual: --quit-after 10s ===");

--- a/scripts/tests/expect-pipe-denied-lua-windows.ps1
+++ b/scripts/tests/expect-pipe-denied-lua-windows.ps1
@@ -13,7 +13,7 @@
 # thread; the kernel then performs the named-pipe access check
 # against the impersonation token.
 #
-# Safe against single-client pipes like `debug single-instance`:
+# Safe against single-client pipes like `single-instance`:
 # the kernel performs the DACL check *before* the server's
 # `ConnectNamedPipe` returns, so a denied open never consumes the
 # accept slot.


### PR DESCRIPTION
The client's commands sat in two levels, with the development-only ones behind a `debug` namespace, and every one of them was advertised in `--help` even though `open-deep-link` is the only one anyone is meant to type. They are one flat set now, and it is the only one still listed.

Related: #15074