### PR TITLE
feat(portal): enable Trust Anchors, gate X.509 auth separately

### DIFF
--- a/elixir/lib/portal/crl/scheduler.ex
+++ b/elixir/lib/portal/crl/scheduler.ex
@@ -20,11 +20,7 @@ defmodule Portal.Crl.Scheduler do
   def perform(%Oban.Job{}) do
     Logger.debug("Scheduling certificate revocation list refresh jobs")
 
-    if Portal.Features.enabled?(:trust_anchors) do
-      Database.queue_sync_jobs()
-    else
-      {:ok, :skipped}
-    end
+    Database.queue_sync_jobs()
   end
 
   defmodule Database do

--- a/elixir/lib/portal/crl/sync.ex
+++ b/elixir/lib/portal/crl/sync.ex
@@ -31,8 +31,7 @@ defmodule Portal.Crl.Sync do
           "distribution_point" => distribution_point
         }
       }) do
-    with true <- Portal.Features.enabled?(:trust_anchors),
-         {:ok, issuer} <- Base.decode64(encoded_issuer),
+    with {:ok, issuer} <- Base.decode64(encoded_issuer),
          endpoint when not is_nil(endpoint) <-
            Database.fetch_endpoint(account_id, issuer, distribution_point) do
       refresh(endpoint)

--- a/elixir/lib/portal/features.ex
+++ b/elixir/lib/portal/features.ex
@@ -2,8 +2,8 @@ defmodule Portal.Features do
   # credo:disable-for-this-file Credo.Check.Warning.MissingChangesetFunction
   use Ecto.Schema
 
-  @features [:trust_anchors, :device_posture]
-  @type feature :: :trust_anchors | :device_posture
+  @features [:x509_auth, :device_posture]
+  @type feature :: :x509_auth | :device_posture
 
   @primary_key false
 

--- a/elixir/lib/portal/ocsp/scheduler.ex
+++ b/elixir/lib/portal/ocsp/scheduler.ex
@@ -14,11 +14,7 @@ defmodule Portal.Ocsp.Scheduler do
   def perform(%Oban.Job{}) do
     Logger.debug("Scheduling OCSP refresh jobs")
 
-    if Portal.Features.enabled?(:trust_anchors) do
-      Database.queue_sync_jobs()
-    else
-      {:ok, :skipped}
-    end
+    Database.queue_sync_jobs()
   end
 
   defmodule Database do

--- a/elixir/lib/portal/ocsp/sync.ex
+++ b/elixir/lib/portal/ocsp/sync.ex
@@ -30,8 +30,7 @@ defmodule Portal.Ocsp.Sync do
           "distribution_point" => distribution_point
         } = args
       }) do
-    with true <- Portal.Features.enabled?(:trust_anchors),
-         {:ok, issuer} <- Base.decode64(encoded_issuer),
+    with {:ok, issuer} <- Base.decode64(encoded_issuer),
          endpoint when not is_nil(endpoint) <-
            Database.fetch_endpoint(account_id, issuer, distribution_point) do
       refresh(endpoint, Map.get(args, "serial"))
@@ -55,19 +54,17 @@ defmodule Portal.Ocsp.Sync do
   """
   @spec enqueue_check(Ecto.UUID.t(), binary(), String.t()) :: :ok
   def enqueue_check(account_id, issuer, serial) do
-    if Portal.Features.enabled?(:trust_anchors) do
-      Database.ocsp_distribution_points(account_id, issuer)
-      |> Enum.each(fn distribution_point ->
-        %{
-          account_id: account_id,
-          issuer: Base.encode64(issuer),
-          distribution_point: distribution_point,
-          serial: serial
-        }
-        |> new(unique: [period: {1, :hour}, states: Oban.Job.states() -- [:discarded]])
-        |> Oban.insert()
-      end)
-    end
+    Database.ocsp_distribution_points(account_id, issuer)
+    |> Enum.each(fn distribution_point ->
+      %{
+        account_id: account_id,
+        issuer: Base.encode64(issuer),
+        distribution_point: distribution_point,
+        serial: serial
+      }
+      |> new(unique: [period: {1, :hour}, states: Oban.Job.states() -- [:discarded]])
+      |> Oban.insert()
+    end)
 
     :ok
   end

--- a/elixir/lib/portal_api/client/device_trust.ex
+++ b/elixir/lib/portal_api/client/device_trust.ex
@@ -198,7 +198,8 @@ defmodule PortalAPI.Client.DeviceTrust do
         %{der: der, leaf: leaf, account_id: account_id, identity: identity},
         context
       ) do
-    with {:ok, account, auth_provider} <- Database.fetch_x509_account(account_id),
+    with :ok <- ensure_x509_auth_feature_enabled(),
+         {:ok, account, auth_provider} <- Database.fetch_x509_account(account_id),
          {:ok, anchors} <- fetch_anchors(account.id),
          :ok <- validate_leaf(leaf, der, anchors),
          :ok <- ensure_account_enabled(account),
@@ -333,14 +334,17 @@ defmodule PortalAPI.Client.DeviceTrust do
   end
 
   defp fetch_anchors(subject) do
-    anchors =
-      if Portal.Features.enabled?(:trust_anchors),
-        do: Database.fetch_anchors(subject),
-        else: []
-
-    case anchors do
+    case Database.fetch_anchors(subject) do
       [] -> {:error, :no_trust_anchors}
       anchors -> {:ok, anchors}
+    end
+  end
+
+  defp ensure_x509_auth_feature_enabled do
+    if Portal.Features.enabled?(:x509_auth) do
+      :ok
+    else
+      {:error, :x509_authentication_not_found}
     end
   end
 

--- a/elixir/lib/portal_api/controllers/x509_auth_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/x509_auth_provider_controller.ex
@@ -21,7 +21,7 @@ defmodule PortalAPI.X509AuthProviderController do
   # coveralls-ignore-stop
 
   def show(conn, _params) do
-    if Portal.Features.enabled?(:trust_anchors) do
+    if Portal.Features.enabled?(:x509_auth) do
       with {:ok, provider} <- Database.fetch_provider(conn.assigns.subject) do
         json(conn, JSON.encode(provider))
       else

--- a/elixir/lib/portal_web/components/navigation_components.ex
+++ b/elixir/lib/portal_web/components/navigation_components.ex
@@ -4,11 +4,6 @@ defmodule PortalWeb.NavigationComponents do
   import PortalWeb.CoreComponents
 
   @doc """
-  Returns whether the global `trust_anchors` rollout flag is enabled.
-  """
-  def trust_anchors_enabled?, do: Portal.Features.enabled?(:trust_anchors)
-
-  @doc """
   Returns whether the global `device_posture` rollout flag is enabled.
   """
   def device_posture_enabled?, do: Portal.Features.enabled?(:device_posture)
@@ -207,7 +202,6 @@ defmodule PortalWeb.NavigationComponents do
               current_path={@current_path}
               navigate={~p"/#{@account}/resources"}
               icon="ri-server-line"
-              badge="NEW"
             >
               Resources
             </.sidebar_item>
@@ -297,7 +291,6 @@ defmodule PortalWeb.NavigationComponents do
               navigate={~p"/#{@account}/logs/change_logs"}
               match="/#{@account.slug}/logs"
               icon="ri-file-list-3-line"
-              badge="NEW"
             >
               Logs
             </.sidebar_item>
@@ -321,9 +314,15 @@ defmodule PortalWeb.NavigationComponents do
           <.icon name="ri-settings-3-line" class="w-4 h-4 shrink-0" />
           <span
             data-sidebar-label
-            class="whitespace-nowrap transition-[max-width,opacity] duration-200 max-w-xs opacity-100"
+            class="whitespace-nowrap transition-[max-width,opacity] duration-200 max-w-xs opacity-100 flex-1"
           >
             Settings
+          </span>
+          <span
+            data-sidebar-badge
+            class="ml-auto px-1 py-px rounded text-[9px] font-semibold tracking-wider bg-brand-muted text-brand"
+          >
+            NEW
           </span>
         </.link>
       </div>
@@ -406,7 +405,6 @@ defmodule PortalWeb.NavigationComponents do
   """
   attr :account, :any, required: true
   attr :current_path, :string, required: true
-  attr :trust_anchors_enabled?, :boolean, default: false
   attr :device_posture_enabled?, :boolean, default: false
   slot :actions
 
@@ -527,11 +525,11 @@ defmodule PortalWeb.NavigationComponents do
           REST API
         </.settings_tab>
         <.settings_tab
-          :if={@trust_anchors_enabled?}
           current_path={@current_path}
           navigate={~p"/#{@account}/settings/trust_anchors"}
           tab_path="settings/trust_anchors"
           icon="ri-shield-check-fill"
+          badge="NEW"
         >
           Trust Anchors
         </.settings_tab>
@@ -544,6 +542,7 @@ defmodule PortalWeb.NavigationComponents do
   attr :current_path, :string, required: true
   attr :tab_path, :string, required: true
   attr :icon, :string, required: true
+  attr :badge, :string, default: nil
   slot :inner_block, required: true
 
   defp settings_tab(assigns) do
@@ -562,6 +561,13 @@ defmodule PortalWeb.NavigationComponents do
     >
       <.icon name={@icon} class="w-4 h-4 shrink-0" />
       {render_slot(@inner_block)}
+      <span
+        :if={@badge}
+        data-settings-tab-badge
+        class="px-1 py-px rounded text-[9px] font-semibold tracking-wider bg-brand-muted text-brand"
+      >
+        {@badge}
+      </span>
     </.link>
     """
   end

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -1284,7 +1284,7 @@ defmodule PortalWeb.Policies do
       ]
 
       schemas =
-        if Portal.Features.enabled?(:trust_anchors) do
+        if Portal.Features.enabled?(:x509_auth) do
           [Portal.X509.AuthProvider | schemas]
         else
           schemas
@@ -1298,7 +1298,7 @@ defmodule PortalWeb.Policies do
     end
 
     def x509_auth_provider_id(subject) do
-      if Portal.Features.enabled?(:trust_anchors) do
+      if Portal.Features.enabled?(:x509_auth) do
         Portal.X509.AuthProvider
         |> Safe.scoped(subject)
         |> Safe.one()

--- a/elixir/lib/portal_web/live/settings/account.ex
+++ b/elixir/lib/portal_web/live/settings/account.ex
@@ -25,7 +25,6 @@ defmodule PortalWeb.Settings.Account do
         users_count: Database.count_users_for_account(subject),
         active_users_count: Database.count_1m_active_users_for_account(subject),
         sites_count: Database.count_groups_for_account(subject),
-        trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?(),
         device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
       )
 
@@ -38,7 +37,6 @@ defmodule PortalWeb.Settings.Account do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       >
         <:actions>

--- a/elixir/lib/portal_web/live/settings/api_clients/index.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/index.ex
@@ -110,7 +110,6 @@ defmodule PortalWeb.Settings.ApiClients.Index do
       |> assign(selected_actor: nil)
       |> assign(form: nil, encoded_token: nil)
       |> assign(pending_confirm: nil, open_actor_actions_id: nil)
-      |> assign(trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?())
       |> assign(device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?())
 
     {:ok, socket}
@@ -176,7 +175,6 @@ defmodule PortalWeb.Settings.ApiClients.Index do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -52,7 +52,7 @@ defmodule PortalWeb.Settings.Authentication do
     socket =
       assign(socket,
         page_title: "Authentication",
-        trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?(),
+        x509_auth_enabled?: Portal.Features.enabled?(:x509_auth),
         device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
       )
 
@@ -608,7 +608,7 @@ defmodule PortalWeb.Settings.Authentication do
     providers =
       Database.list_all_providers(
         socket.assigns.subject,
-        socket.assigns.trust_anchors_enabled?
+        socket.assigns.x509_auth_enabled?
       )
       |> Database.enrich_with_session_counts(socket.assigns.subject)
 
@@ -627,7 +627,6 @@ defmodule PortalWeb.Settings.Authentication do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 

--- a/elixir/lib/portal_web/live/settings/device_posture.ex
+++ b/elixir/lib/portal_web/live/settings/device_posture.ex
@@ -99,7 +99,6 @@ defmodule PortalWeb.Settings.DevicePosture do
      socket
      |> assign(
        page_title: "Device Posture",
-       trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?(),
        device_posture_enabled?: true,
        type: nil,
        provider: nil,
@@ -647,7 +646,6 @@ defmodule PortalWeb.Settings.DevicePosture do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -47,7 +47,6 @@ defmodule PortalWeb.Settings.DirectorySync do
     socket =
       assign(socket,
         page_title: "Directory Sync",
-        trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?(),
         device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
       )
 
@@ -570,7 +569,6 @@ defmodule PortalWeb.Settings.DirectorySync do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 

--- a/elixir/lib/portal_web/live/settings/dns.ex
+++ b/elixir/lib/portal_web/live/settings/dns.ex
@@ -10,7 +10,6 @@ defmodule PortalWeb.Settings.DNS do
       socket
       |> assign(page_title: "DNS")
       |> assign(dns_account: account)
-      |> assign(trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?())
       |> assign(device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?())
 
     {:ok, socket}
@@ -39,7 +38,6 @@ defmodule PortalWeb.Settings.DNS do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 

--- a/elixir/lib/portal_web/live/settings/log_sinks.ex
+++ b/elixir/lib/portal_web/live/settings/log_sinks.ex
@@ -75,7 +75,6 @@ defmodule PortalWeb.Settings.LogSinks do
         submit_failed?: false,
         sentinel_verification_ref: nil,
         s3_setup_tab: "console",
-        trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?(),
         device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
       )
 
@@ -309,7 +308,6 @@ defmodule PortalWeb.Settings.LogSinks do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 

--- a/elixir/lib/portal_web/live/settings/notifications.ex
+++ b/elixir/lib/portal_web/live/settings/notifications.ex
@@ -7,7 +7,6 @@ defmodule PortalWeb.Settings.Notifications do
       assign(socket,
         page_title: "Notifications",
         form: to_form(build_changeset(socket.assigns.account)),
-        trust_anchors_enabled?: PortalWeb.NavigationComponents.trust_anchors_enabled?(),
         device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?()
       )
 
@@ -20,7 +19,6 @@ defmodule PortalWeb.Settings.Notifications do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 

--- a/elixir/lib/portal_web/live/settings/trust_anchors/index.ex
+++ b/elixir/lib/portal_web/live/settings/trust_anchors/index.ex
@@ -128,34 +128,27 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
   end
 
   def mount(_params, _session, socket) do
-    trust_anchors_enabled? = PortalWeb.NavigationComponents.trust_anchors_enabled?()
+    trust_anchors = Database.list_trust_anchors(socket.assigns.subject)
 
-    if trust_anchors_enabled? do
-      trust_anchors = Database.list_trust_anchors(socket.assigns.subject)
+    socket =
+      socket
+      |> assign(page_title: "Trust Anchors")
+      |> assign(trust_anchors: trust_anchors)
+      |> assign_revocation_health(trust_anchors)
+      |> assign(selected_trust_anchor: nil)
+      |> assign(form: nil, input_mode: :paste)
+      |> assign(confirm_delete?: false)
+      |> assign(revocation: [])
+      |> assign(panel_tab: :overview, expanded_endpoint: nil)
+      |> assign(device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?())
+      |> allow_upload(:cert_file,
+        accept: ~w(.pem .crt .cer .der .txt),
+        max_entries: @max_upload_entries,
+        max_file_size: @max_upload_size,
+        auto_upload: true
+      )
 
-      socket =
-        socket
-        |> assign(page_title: "Trust Anchors")
-        |> assign(trust_anchors: trust_anchors)
-        |> assign_revocation_health(trust_anchors)
-        |> assign(selected_trust_anchor: nil)
-        |> assign(form: nil, input_mode: :paste)
-        |> assign(confirm_delete?: false)
-        |> assign(revocation: [])
-        |> assign(panel_tab: :overview, expanded_endpoint: nil)
-        |> assign(trust_anchors_enabled?: trust_anchors_enabled?)
-        |> assign(device_posture_enabled?: PortalWeb.NavigationComponents.device_posture_enabled?())
-        |> allow_upload(:cert_file,
-          accept: ~w(.pem .crt .cer .der .txt),
-          max_entries: @max_upload_entries,
-          max_file_size: @max_upload_size,
-          auto_upload: true
-        )
-
-      {:ok, socket}
-    else
-      {:ok, push_navigate(socket, to: ~p"/#{socket.assigns.account}/settings/account")}
-    end
+    {:ok, socket}
   end
 
   def handle_params(_params, _uri, %{assigns: %{live_action: :new}} = socket) do
@@ -214,7 +207,6 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
       <.settings_nav
         account={@account}
         current_path={@current_path}
-        trust_anchors_enabled?={@trust_anchors_enabled?}
         device_posture_enabled?={@device_posture_enabled?}
       />
 
@@ -227,6 +219,7 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
             </span>
           </div>
           <div class="flex items-center gap-2">
+            <.docs_action path="/device-trust" />
             <.link
               patch={~p"/#{@account}/settings/trust_anchors/new"}
               class="flex items-center gap-1 px-2.5 py-1 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
@@ -323,7 +316,10 @@ defmodule PortalWeb.Settings.TrustAnchors.Index do
         <div :if={@live_action == :new && @form} class="flex flex-col h-full overflow-hidden">
           <div class="shrink-0 px-5 pt-4 pb-3 border-b border-border bg-elevated">
             <div class="flex items-center justify-between gap-3">
-              <h2 class="text-sm font-semibold text-heading">New Trust Anchor</h2>
+              <div class="flex items-center gap-2">
+                <h2 class="text-sm font-semibold text-heading">New Trust Anchor</h2>
+                <.docs_action path="/device-trust" />
+              </div>
               <.icon_button icon="ri-close-line" title="Close (Esc)" phx-click="close_panel" />
             </div>
           </div>

--- a/elixir/priv/repo/migrations/20260907000000_rename_trust_anchors_feature_to_x509_auth.exs
+++ b/elixir/priv/repo/migrations/20260907000000_rename_trust_anchors_feature_to_x509_auth.exs
@@ -1,0 +1,10 @@
+defmodule Portal.Repo.Migrations.RenameTrustAnchorsFeatureToX509Auth do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      "UPDATE features SET feature = 'x509_auth' WHERE feature = 'trust_anchors'",
+      "UPDATE features SET feature = 'trust_anchors' WHERE feature = 'x509_auth'"
+    )
+  end
+end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -1758,7 +1758,7 @@ defmodule Portal.Repo.Seeds do
     Repo.query!(
       """
       INSERT INTO features (feature, enabled)
-      VALUES ('trust_anchors', true), ('device_posture', true)
+      VALUES ('x509_auth', true), ('device_posture', true)
       ON CONFLICT (feature) DO UPDATE SET enabled = true
       """
     )

--- a/elixir/test/portal/crl/scheduler_test.exs
+++ b/elixir/test/portal/crl/scheduler_test.exs
@@ -3,28 +3,12 @@ defmodule Portal.Crl.SchedulerTest do
 
   import Portal.AccountFixtures
   import Portal.DeviceTrustFixtures
-  import Portal.FeaturesFixtures
 
   alias Portal.Crl.Scheduler
   alias Portal.Crypto.X509
 
   setup do
-    enable_feature(:trust_anchors)
     %{account: account_fixture(), pki: pki()}
-  end
-
-  describe "perform/1 when the trust_anchors feature is off" do
-    test "nothing is queued, so endpoints are left exactly as they are", %{
-      account: account,
-      pki: pki
-    } do
-      endpoint_fixture(account, pki.ca_der)
-      Portal.Repo.delete_all(Portal.Features)
-
-      assert Scheduler.perform(%Oban.Job{}) == {:ok, :skipped}
-
-      assert all_sync_jobs() == []
-    end
   end
 
   describe "perform/1" do

--- a/elixir/test/portal/crl/sync_test.exs
+++ b/elixir/test/portal/crl/sync_test.exs
@@ -4,7 +4,6 @@ defmodule Portal.Crl.SyncTest do
 
   import Portal.AccountFixtures
   import Portal.TrustAnchorFixtures
-  import Portal.FeaturesFixtures
   import Portal.DeviceTrustFixtures
   import ExUnit.CaptureLog
 
@@ -17,7 +16,6 @@ defmodule Portal.Crl.SyncTest do
 
   setup do
     account = account_fixture()
-    enable_feature(:trust_anchors)
     pki = pki()
     trust_anchor_fixture(account: account, certs: [pki.ca_der])
 

--- a/elixir/test/portal/features_test.exs
+++ b/elixir/test/portal/features_test.exs
@@ -3,7 +3,7 @@ defmodule Portal.FeaturesTest do
 
   import Portal.FeaturesFixtures
 
-  for feature <- [:trust_anchors, :device_posture] do
+  for feature <- [:x509_auth, :device_posture] do
     test "enabled?/1 reads the #{feature} global rollout flag" do
       disable_feature(unquote(feature))
       refute Portal.Features.enabled?(unquote(feature))

--- a/elixir/test/portal/ocsp/sync_test.exs
+++ b/elixir/test/portal/ocsp/sync_test.exs
@@ -3,7 +3,6 @@ defmodule Portal.Ocsp.SyncTest do
 
   import Portal.AccountFixtures
   import Portal.TrustAnchorFixtures
-  import Portal.FeaturesFixtures
   import Portal.DeviceTrustFixtures
   import ExUnit.CaptureLog
 
@@ -14,7 +13,6 @@ defmodule Portal.Ocsp.SyncTest do
 
   setup do
     account = account_fixture()
-    enable_feature(:trust_anchors)
     pki = pki()
     trust_anchor_fixture(account: account, certs: [pki.ca_der])
 

--- a/elixir/test/portal_api/client/device_trust_test.exs
+++ b/elixir/test/portal_api/client/device_trust_test.exs
@@ -5,7 +5,6 @@ defmodule PortalAPI.Client.DeviceTrustTest do
   import Portal.AccountFixtures
   import Portal.SubjectFixtures
   import Portal.TrustAnchorFixtures
-  import Portal.FeaturesFixtures
   import Portal.DeviceTrustFixtures
 
   alias PortalAPI.Client.DeviceTrust
@@ -29,23 +28,10 @@ defmodule PortalAPI.Client.DeviceTrustTest do
       subject: subject,
       pki: pki
     } do
-      enable_feature(:trust_anchors)
       trust_anchor_fixture(account: account, certs: [pki.ca_der])
 
       assert DeviceTrust.attest(connect_info(leaf(pki, :rsa)), subject) ==
                {:error, :not_attestation_host}
-    end
-
-    test "does not attest when the feature is off", %{
-      account: account,
-      subject: subject,
-      pki: pki
-    } do
-      configure_attestation_host()
-      trust_anchor_fixture(account: account, certs: [pki.ca_der])
-
-      assert DeviceTrust.attest(connect_info(leaf(pki, :rsa)), subject) ==
-               {:error, :no_trust_anchors}
     end
 
     test "reports no anchors when the account has none uploaded", %{
@@ -53,43 +39,9 @@ defmodule PortalAPI.Client.DeviceTrustTest do
       pki: pki
     } do
       configure_attestation_host()
-      enable_feature(:trust_anchors)
 
       assert DeviceTrust.attest(connect_info(leaf(pki, :rsa)), subject) ==
                {:error, :no_trust_anchors}
-    end
-  end
-
-  describe "attest/2 when the trust_anchors feature is off" do
-    setup do
-      configure_attestation_host()
-      start_revocation_endpoint_queue()
-
-      account = account_fixture()
-      pki = pki()
-      trust_anchor_fixture(account: account, certs: [pki.ca_der])
-      subject = subject_fixture(account: account)
-
-      %{account: account, pki: pki, subject: subject}
-    end
-
-    test "the certificate is refused rather than trusted unchecked", %{
-      pki: pki,
-      subject: subject
-    } do
-      connect_info = connect_info(leaf(pki, :rsa))
-
-      assert DeviceTrust.attest(connect_info, subject) == {:error, :no_trust_anchors}
-    end
-
-    test "nothing is recorded about the certificate's CA", %{pki: pki, subject: subject} do
-      assert {:error, :no_trust_anchors} =
-               DeviceTrust.attest(connect_info(leaf(pki, :with_crl)), subject)
-
-      Portal.Queue.flush(:revocation_endpoint_queue)
-
-      assert Repo.all(Portal.RevocationEndpoint) == []
-      assert all_enqueued(worker: Portal.Ocsp.Sync) == []
     end
   end
 
@@ -99,7 +51,6 @@ defmodule PortalAPI.Client.DeviceTrustTest do
       start_revocation_endpoint_queue()
 
       account = account_fixture()
-      enable_feature(:trust_anchors)
       pki = pki()
       trust_anchor_fixture(account: account, certs: [pki.ca_der])
       subject = subject_fixture(account: account)

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -912,13 +912,13 @@ defmodule PortalAPI.Client.SocketTest do
                {:error, :x509_user_type_not_allowed}
     end
 
-    test "returns a trust-anchor error when trust anchors are globally disabled", %{
+    test "refuses X.509 authentication when the feature is globally disabled", %{
       account: account,
       actor: actor,
       pki: pki
     } do
       _provider = x509_provider_fixture(account: account, is_disabled: false)
-      disable_feature(:trust_anchors)
+      disable_feature(:x509_auth)
 
       connect_info =
         build_connect_info(
@@ -927,7 +927,7 @@ defmodule PortalAPI.Client.SocketTest do
         )
 
       assert connect(Socket, connect_attrs([]), connect_info: connect_info) ==
-               {:error, :no_trust_anchors}
+               {:error, :x509_authentication_not_found}
     end
 
     test "refuses a connect through the mutual-TLS host without a certificate", %{token: token} do
@@ -1724,7 +1724,7 @@ defmodule PortalAPI.Client.SocketTest do
     Portal.Config.put_env_override(:portal, :mtls_external_url, "https://mtls.firezone.test/")
 
     account = account_fixture()
-    enable_feature(:trust_anchors)
+    enable_feature(:x509_auth)
     pki = pki()
     trust_anchor_fixture(account: account, certs: [pki.ca_der])
 

--- a/elixir/test/portal_api/controllers/x509_auth_provider_controller_test.exs
+++ b/elixir/test/portal_api/controllers/x509_auth_provider_controller_test.exs
@@ -7,7 +7,7 @@ defmodule PortalAPI.X509AuthProviderControllerTest do
   import Portal.FeaturesFixtures
 
   setup do
-    enable_feature(:trust_anchors)
+    enable_feature(:x509_auth)
     account = account_fixture()
     actor = api_client_fixture(account: account)
 
@@ -54,13 +54,13 @@ defmodule PortalAPI.X509AuthProviderControllerTest do
       assert json_response(conn, 404)
     end
 
-    test "is unavailable when trust anchors are globally disabled", %{
+    test "is unavailable when X.509 authentication is globally disabled", %{
       conn: conn,
       account: account,
       actor: actor
     } do
       _provider = x509_provider_fixture(account: account)
-      disable_feature(:trust_anchors)
+      disable_feature(:x509_auth)
 
       conn = conn |> authorize_conn(actor) |> get("/x509_auth_provider")
 

--- a/elixir/test/portal_web/components/navigation_components_test.exs
+++ b/elixir/test/portal_web/components/navigation_components_test.exs
@@ -3,7 +3,6 @@ defmodule PortalWeb.NavigationComponentsTest do
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
-  import Portal.FeaturesFixtures
 
   setup do
     account = account_fixture()
@@ -41,34 +40,28 @@ defmodule PortalWeb.NavigationComponentsTest do
   end
 
   describe "settings_nav trust anchors tab" do
-    test "hidden when trust_anchors feature is disabled", %{
-      conn: conn,
-      account: account,
-      actor: actor
-    } do
-      disable_feature(:trust_anchors)
-
-      {:ok, _lv, html} =
-        conn
-        |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/account")
-
-      refute html =~ "Trust Anchors"
-    end
-
-    test "shown when trust_anchors feature is enabled", %{
-      conn: conn,
-      account: account,
-      actor: actor
-    } do
-      enable_feature(:trust_anchors)
-
-      {:ok, _lv, html} =
+    test "is shown with a NEW badge", %{conn: conn, account: account, actor: actor} do
+      {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/account")
 
       assert html =~ "Trust Anchors"
+      assert has_element?(lv, "a[href='/#{account.slug}/settings/trust_anchors'] [data-settings-tab-badge]", "NEW")
+    end
+  end
+
+  describe "sidebar badges" do
+    test "only Settings and Devices carry a NEW badge", %{conn: conn, account: account, actor: actor} do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/account")
+
+      assert has_element?(lv, "a[href='/#{account.slug}/settings/account'] [data-sidebar-badge]", "NEW")
+      assert has_element?(lv, "a[href='/#{account.slug}/devices'] [data-sidebar-badge]", "NEW")
+      refute has_element?(lv, "a[href='/#{account.slug}/resources'] [data-sidebar-badge]")
+      refute has_element?(lv, "a[href='/#{account.slug}/logs/change_logs'] [data-sidebar-badge]")
     end
   end
 end

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -877,7 +877,7 @@ defmodule PortalWeb.PoliciesTest do
       account: account,
       actor: actor
     } do
-      enable_feature(:trust_anchors)
+      enable_feature(:x509_auth)
       x509_provider = x509_provider_fixture(account: account, is_disabled: false)
       group = group_fixture(account: account)
       resource = resource_fixture(account: account)
@@ -907,7 +907,7 @@ defmodule PortalWeb.PoliciesTest do
       account: account,
       actor: actor
     } do
-      enable_feature(:trust_anchors)
+      enable_feature(:x509_auth)
       x509_provider = x509_provider_fixture(account: account, is_disabled: false)
       _anchor = trust_anchor_fixture(account: account)
       group = group_fixture(account: account)
@@ -1186,7 +1186,7 @@ defmodule PortalWeb.PoliciesTest do
       account: account,
       actor: actor
     } do
-      enable_feature(:trust_anchors)
+      enable_feature(:x509_auth)
       x509_provider = x509_provider_fixture(account: account, is_disabled: false)
       group = group_fixture(account: account)
       resource = resource_fixture(account: account)

--- a/elixir/test/portal_web/live/settings/authentication_test.exs
+++ b/elixir/test/portal_web/live/settings/authentication_test.exs
@@ -176,7 +176,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       actor: actor,
       conn: conn
     } do
-      enable_feature(:trust_anchors)
+      enable_feature(:x509_auth)
       provider = x509_provider_fixture(account: account)
 
       {:ok, lv, html} =
@@ -208,7 +208,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       actor: actor,
       conn: conn
     } do
-      enable_feature(:trust_anchors)
+      enable_feature(:x509_auth)
       _provider = x509_provider_fixture(account: account)
       _anchor = trust_anchor_fixture(account: account)
 
@@ -221,7 +221,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       refute html =~ "No devices will be able to use this authentication provider"
     end
 
-    test "hides X.509 when trust anchors are globally disabled", %{
+    test "hides X.509 when X.509 authentication is globally disabled", %{
       account: account,
       actor: actor,
       conn: conn
@@ -1384,7 +1384,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       actor: actor,
       conn: conn
     } do
-      enable_feature(:trust_anchors)
+      enable_feature(:x509_auth)
       provider = x509_provider_fixture(account: account)
 
       {:ok, lv, _html} =

--- a/elixir/test/portal_web/live/settings/trust_anchors/index_test.exs
+++ b/elixir/test/portal_web/live/settings/trust_anchors/index_test.exs
@@ -4,7 +4,6 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
   import Portal.AccountFixtures
   import Portal.ActorFixtures
   import Portal.TrustAnchorFixtures
-  import Portal.FeaturesFixtures
 
   alias Portal.TrustAnchor
   alias Portal.Crypto.X509
@@ -64,7 +63,6 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
   setup do
     account = account_fixture()
     actor = admin_actor_fixture(account: account)
-    enable_feature(:trust_anchors)
     %{account: account, actor: actor}
   end
 
@@ -83,32 +81,23 @@ defmodule PortalWeb.Settings.TrustAnchors.IndexTest do
   end
 
   describe "index (default action)" do
-    test "redirects to account settings when trust_anchors feature is disabled", %{
-      conn: conn,
-      account: account,
-      actor: actor
-    } do
-      disable_feature(:trust_anchors)
-
-      assert {:error, {:live_redirect, %{to: to}}} =
-               conn
-               |> authorize_conn(actor)
-               |> live(~p"/#{account}/settings/trust_anchors")
-
-      assert to == ~p"/#{account}/settings/account"
-    end
-
     test "renders empty state when no trust anchors", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      {:ok, _lv, html} =
+      {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/trust_anchors")
 
       assert html =~ "Trust Anchors"
+
+      assert has_element?(
+               lv,
+               "a[href='https://www.firezone.dev/kb/device-trust?utm_source=product#']"
+             )
+
       assert html =~ "No trust anchors yet"
     end
 


### PR DESCRIPTION
Trust Anchors is now on for every account. The `trust_anchors` feature flag used to hide the Settings tab, the page, device attestation, and the CRL/OCSP revocation jobs. None of that is gated any more.

X.509 auth providers are not ready yet, so they stay hidden. The flag row is renamed in place to `x509_auth` and now gates only the X.509 provider surface: the row on Settings > Authentication, the X.509 option in policy conditions, the `GET /x509_auth_provider` endpoint, and X.509 client authentication at connect. Production keeps its current `false` value, so nothing new is exposed. A client that presents an X.509 identity certificate while the flag is off now gets `x509_authentication_not_found` instead of `no_trust_anchors`.

Device posture is untouched and still behind its own flag.

Also adds a NEW badge to the Settings sidebar item and the Trust Anchors tab, removes the NEW badge from Resources and Logs, and adds a docs link to `/kb/device-trust` on the Trust Anchors page. That docs page is not published yet.
