### PR TITLE
fix(portal): normalize IPv4-mapped addresses at every entry

### DIFF
--- a/elixir/lib/portal/changeset.ex
+++ b/elixir/lib/portal/changeset.ex
@@ -3,7 +3,6 @@ defmodule Portal.Changeset do
   This module extend `Ecto.Changeset`'s with custom validations and polymorphic embeds.
   """
   import Ecto.Changeset
-  import Bitwise
   alias Ecto.Changeset
 
   @special_use_ipv4_cidrs [
@@ -334,17 +333,13 @@ defmodule Portal.Changeset do
   end
 
   # IPv4-mapped IPv6 addresses (::ffff:w.x.y.z)
-  def private_ip?({0, 0, 0, 0, 0, 0xFFFF, w, x}), do: private_ip?(to_ipv4_tuple(w, x))
+  def private_ip?({0, 0, 0, 0, 0, 0xFFFF, _, _} = ip), do: private_ip?(Portal.Types.IP.unmap(ip))
   def private_ip?({_, _, _, _} = ip), do: private_ip_in_cidrs?(ip, @special_use_ipv4_cidrs)
 
   def private_ip?({_, _, _, _, _, _, _, _} = ip),
     do: private_ip_in_cidrs?(ip, @special_use_ipv6_cidrs)
 
   def private_ip?(_), do: false
-
-  defp to_ipv4_tuple(w, x) do
-    {w >>> 8, band(w, 0x00FF), x >>> 8, band(x, 0x00FF)}
-  end
 
   defp private_ip_in_cidrs?(ip, cidrs) do
     inet = %Postgrex.INET{address: ip}

--- a/elixir/lib/portal/remote_ip/x_forwarded_for_parser.ex
+++ b/elixir/lib/portal/remote_ip/x_forwarded_for_parser.ex
@@ -36,7 +36,7 @@ defmodule Portal.RemoteIp.XForwardedForParser do
 
     case :inet.parse_strict_address(to_charlist(trimmed)) do
       {:ok, ip} ->
-        [ip]
+        [Portal.Types.IP.unmap(ip)]
 
       {:error, _} ->
         trimmed
@@ -47,7 +47,7 @@ defmodule Portal.RemoteIp.XForwardedForParser do
 
   defp parse_normalized_ip(candidate) do
     case :inet.parse_strict_address(to_charlist(candidate)) do
-      {:ok, ip} -> [ip]
+      {:ok, ip} -> [Portal.Types.IP.unmap(ip)]
       {:error, _} -> []
     end
   end

--- a/elixir/lib/portal/sockets.ex
+++ b/elixir/lib/portal/sockets.ex
@@ -8,4 +8,23 @@ defmodule Portal.Sockets do
 
   @spec socket_id(Ecto.UUID.t()) :: socket_id()
   def socket_id(id) when is_binary(id), do: "socket:#{id}"
+
+  @doc """
+  Resolves the client address of a WebSocket from its connect info.
+
+  Sockets get their headers before `Portal.Endpoint` can rewrite the connection,
+  so the forwarded address is resolved here, with the peer address as fallback,
+  and IPv4-mapped IPv6 addresses are normalized to IPv4.
+  """
+  @spec remote_ip(map()) :: :inet.ip_address()
+  def remote_ip(connect_info) do
+    x_headers = Map.get(connect_info, :x_headers)
+
+    forwarded_ip =
+      if is_list(x_headers) and x_headers != [] do
+        RemoteIp.from(x_headers, Portal.Endpoint.real_ip_opts())
+      end
+
+    Portal.Types.IP.unmap(forwarded_ip || connect_info.peer_data.address)
+  end
 end

--- a/elixir/lib/portal/types/ip.ex
+++ b/elixir/lib/portal/types/ip.ex
@@ -2,6 +2,9 @@ defmodule Portal.Types.IP do
   @moduledoc """
   Ecto type implementation for IP's based on `Postgrex.INET` type,
   it always ignores netmask by setting it to `nil`.
+
+  IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`) are normalized to IPv4 on
+  cast, dump and load.
   """
   @behaviour Ecto.Type
 
@@ -16,13 +19,13 @@ defmodule Portal.Types.IP do
 
   def equal?(left, right), do: left == right
 
-  def cast(tuple) when tuple_size(tuple) == 4, do: {:ok, %Postgrex.INET{address: tuple}}
-  def cast(tuple) when tuple_size(tuple) == 8, do: {:ok, %Postgrex.INET{address: tuple}}
-  def cast(%Postgrex.INET{} = inet), do: {:ok, inet}
+  def cast(tuple) when tuple_size(tuple) == 4, do: {:ok, normalize(%Postgrex.INET{address: tuple})}
+  def cast(tuple) when tuple_size(tuple) == 8, do: {:ok, normalize(%Postgrex.INET{address: tuple})}
+  def cast(%Postgrex.INET{} = inet), do: {:ok, normalize(inet)}
 
   def cast(binary) when is_binary(binary) do
     with {:ok, address} <- Portal.Types.IPPort.cast_address(binary) do
-      {:ok, %Postgrex.INET{address: address, netmask: nil}}
+      {:ok, normalize(%Postgrex.INET{address: address, netmask: nil})}
     else
       {:error, reason} ->
         {:error, message: "#{binary} is invalid: #{reason}"}
@@ -31,12 +34,12 @@ defmodule Portal.Types.IP do
 
   def cast(_), do: :error
 
-  def dump(%Postgrex.INET{} = inet), do: {:ok, inet}
-  def dump(tuple) when tuple_size(tuple) == 4, do: {:ok, %Postgrex.INET{address: tuple}}
-  def dump(tuple) when tuple_size(tuple) == 8, do: {:ok, %Postgrex.INET{address: tuple}}
+  def dump(%Postgrex.INET{} = inet), do: {:ok, normalize(inet)}
+  def dump(tuple) when tuple_size(tuple) == 4, do: {:ok, normalize(%Postgrex.INET{address: tuple})}
+  def dump(tuple) when tuple_size(tuple) == 8, do: {:ok, normalize(%Postgrex.INET{address: tuple})}
   def dump(_), do: :error
 
-  def load(%Postgrex.INET{} = inet), do: {:ok, inet}
+  def load(%Postgrex.INET{} = inet), do: {:ok, normalize(inet)}
   def load(_), do: :error
 
   def type(address) when tuple_size(address) == 4, do: :ipv4
@@ -51,4 +54,11 @@ defmodule Portal.Types.IP do
   end
 
   def unmap(address), do: address
+
+  defp normalize(%Postgrex.INET{address: {0, 0, 0, 0, 0, 0xFFFF, _, _} = address, netmask: netmask} = inet)
+       when netmask in [nil, 128] do
+    %{inet | address: unmap(address), netmask: nil}
+  end
+
+  defp normalize(%Postgrex.INET{} = inet), do: inet
 end

--- a/elixir/lib/portal_api/sockets.ex
+++ b/elixir/lib/portal_api/sockets.ex
@@ -162,18 +162,9 @@ defmodule PortalAPI.Sockets do
     )
   end
 
-  def auth_context(%{user_agent: user_agent, x_headers: x_headers, peer_data: peer_data}, type) do
-    remote_ip = real_ip(x_headers, peer_data)
+  def auth_context(%{user_agent: user_agent, x_headers: x_headers} = connect_info, type) do
+    remote_ip = Portal.Sockets.remote_ip(connect_info)
     Portal.Authentication.Context.build(remote_ip, user_agent, x_headers, type)
-  end
-
-  defp real_ip(x_headers, peer_data) do
-    real_ip =
-      if is_list(x_headers) and x_headers != [] do
-        RemoteIp.from(x_headers, Portal.Endpoint.real_ip_opts())
-      end
-
-    real_ip || peer_data.address
   end
 
   @session_field_limits %{

--- a/elixir/lib/portal_api/sockets/rate_limit.ex
+++ b/elixir/lib/portal_api/sockets/rate_limit.ex
@@ -39,17 +39,10 @@ defmodule PortalAPI.Sockets.RateLimit do
   def retry_after_seconds, do: @retry_after_seconds
 
   defp build_key(connect_info, token) do
-    ip = extract_ip(connect_info)
+    ip = Portal.Sockets.remote_ip(connect_info)
     token_hash = hash_authorization(connect_info, token)
     "socket:#{ip_to_string(ip)}:#{token_hash}"
   end
-
-  defp extract_ip(%{x_headers: x_headers, peer_data: peer_data})
-       when is_list(x_headers) and x_headers != [] do
-    RemoteIp.from(x_headers, Portal.Endpoint.real_ip_opts()) || peer_data.address
-  end
-
-  defp extract_ip(%{peer_data: peer_data}), do: peer_data.address
 
   defp hash_authorization(_connect_info, token) when is_binary(token) do
     :crypto.hash(:sha256, token) |> Base.encode16(case: :lower) |> binary_part(0, 16)

--- a/elixir/lib/portal_api/sockets/rate_limit.ex
+++ b/elixir/lib/portal_api/sockets/rate_limit.ex
@@ -60,6 +60,5 @@ defmodule PortalAPI.Sockets.RateLimit do
 
   defp hash_authorization(_connect_info, _token), do: "none"
 
-  defp ip_to_string(ip) when is_tuple(ip), do: :inet.ntoa(ip) |> to_string()
-  defp ip_to_string(ip), do: to_string(ip)
+  defp ip_to_string(ip), do: :inet.ntoa(ip) |> to_string()
 end

--- a/elixir/lib/portal_web/authentication.ex
+++ b/elixir/lib/portal_web/authentication.ex
@@ -9,15 +9,10 @@ defmodule PortalWeb.Authentication do
   Returns the real IP address of the client.
   """
   def real_ip(socket) do
-    peer_data = Phoenix.LiveView.get_connect_info(socket, :peer_data)
-    x_headers = Phoenix.LiveView.get_connect_info(socket, :x_headers)
-
-    real_ip =
-      if is_list(x_headers) and x_headers != [] do
-        RemoteIp.from(x_headers, Portal.Endpoint.real_ip_opts())
-      end
-
-    real_ip || peer_data.address
+    Portal.Sockets.remote_ip(%{
+      peer_data: Phoenix.LiveView.get_connect_info(socket, :peer_data),
+      x_headers: Phoenix.LiveView.get_connect_info(socket, :x_headers)
+    })
   end
 
   @doc """

--- a/elixir/test/portal/remote_ip/x_forwarded_for_parser_test.exs
+++ b/elixir/test/portal/remote_ip/x_forwarded_for_parser_test.exs
@@ -39,6 +39,15 @@ defmodule Portal.RemoteIp.XForwardedForParserTest do
                [{1, 2, 3, 4}, {5, 6, 7, 8}]
     end
 
+    test "normalizes IPv4-mapped IPv6 addresses to IPv4" do
+      assert XForwardedForParser.parse("::ffff:107.197.104.68") == [{107, 197, 104, 68}]
+      assert XForwardedForParser.parse("::ffff:107.197.104.68:53859") == [{107, 197, 104, 68}]
+      assert XForwardedForParser.parse("[::ffff:107.197.104.68]:53859") == [{107, 197, 104, 68}]
+
+      assert XForwardedForParser.parse("::ffff:107.197.104.68, ::ffff:10.115.8.5") ==
+               [{107, 197, 104, 68}, {10, 115, 8, 5}]
+    end
+
     test "filters out truly invalid values" do
       assert XForwardedForParser.parse("not-an-ip") == []
     end

--- a/elixir/test/portal/sockets_test.exs
+++ b/elixir/test/portal/sockets_test.exs
@@ -1,0 +1,46 @@
+defmodule Portal.SocketsTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Sockets
+
+  @mapped {0, 0, 0, 0, 0, 0xFFFF, 0x6BC5, 0x6844}
+  @ipv4 {107, 197, 104, 68}
+
+  describe "remote_ip/1" do
+    test "uses the peer address when there are no forwarding headers" do
+      assert Sockets.remote_ip(%{peer_data: %{address: @ipv4}, x_headers: []}) == @ipv4
+      assert Sockets.remote_ip(%{peer_data: %{address: @ipv4}}) == @ipv4
+    end
+
+    test "normalizes an IPv4-mapped IPv6 peer address to IPv4" do
+      assert Sockets.remote_ip(%{peer_data: %{address: @mapped}, x_headers: []}) == @ipv4
+    end
+
+    test "prefers the forwarded address over the peer address" do
+      connect_info = %{
+        peer_data: %{address: {10, 0, 0, 1}},
+        x_headers: [{"x-forwarded-for", "107.197.104.68"}]
+      }
+
+      assert Sockets.remote_ip(connect_info) == @ipv4
+    end
+
+    test "normalizes an IPv4-mapped IPv6 forwarded address to IPv4" do
+      connect_info = %{
+        peer_data: %{address: {10, 0, 0, 1}},
+        x_headers: [{"x-forwarded-for", "::ffff:107.197.104.68:53859"}]
+      }
+
+      assert Sockets.remote_ip(connect_info) == @ipv4
+    end
+
+    test "skips IPv4-mapped private proxy hops in the forwarded chain" do
+      connect_info = %{
+        peer_data: %{address: {10, 0, 0, 1}},
+        x_headers: [{"x-forwarded-for", "6.6.6.6, ::ffff:203.0.113.5, ::ffff:10.0.0.1"}]
+      }
+
+      assert Sockets.remote_ip(connect_info) == {203, 0, 113, 5}
+    end
+  end
+end

--- a/elixir/test/portal/types/ip_test.exs
+++ b/elixir/test/portal/types/ip_test.exs
@@ -3,15 +3,61 @@ defmodule Portal.Types.IPTest do
 
   alias Portal.Types.IP
 
+  @mapped {0, 0, 0, 0, 0, 0xFFFF, 0x6BC5, 0x6844}
+  @ipv4 {107, 197, 104, 68}
+
   describe "unmap/1" do
     test "converts an IPv4-mapped IPv6 address to IPv4" do
-      assert IP.unmap({0, 0, 0, 0, 0, 0xFFFF, 0x6BC5, 0x6844}) == {107, 197, 104, 68}
+      assert IP.unmap(@mapped) == @ipv4
     end
 
     test "leaves other addresses unchanged" do
-      assert IP.unmap({107, 197, 104, 68}) == {107, 197, 104, 68}
+      assert IP.unmap(@ipv4) == @ipv4
       assert IP.unmap({0x2601, 0, 0, 0, 0, 0, 0, 1}) == {0x2601, 0, 0, 0, 0, 0, 0, 1}
       assert IP.unmap(nil) == nil
+    end
+  end
+
+  describe "cast/1" do
+    test "normalizes an IPv4-mapped IPv6 address to IPv4" do
+      assert IP.cast(@mapped) == {:ok, %Postgrex.INET{address: @ipv4}}
+      assert IP.cast("::ffff:107.197.104.68") == {:ok, %Postgrex.INET{address: @ipv4}}
+      assert IP.cast(%Postgrex.INET{address: @mapped}) == {:ok, %Postgrex.INET{address: @ipv4}}
+
+      assert IP.cast(%Postgrex.INET{address: @mapped, netmask: 128}) ==
+               {:ok, %Postgrex.INET{address: @ipv4}}
+    end
+
+    test "keeps an IPv4-mapped block that is not a single host" do
+      block = %Postgrex.INET{address: {0, 0, 0, 0, 0, 0xFFFF, 0, 0}, netmask: 96}
+      assert IP.cast(block) == {:ok, block}
+    end
+
+    test "leaves other addresses unchanged" do
+      assert IP.cast(@ipv4) == {:ok, %Postgrex.INET{address: @ipv4}}
+
+      assert IP.cast({0x2601, 0, 0, 0, 0, 0, 0, 1}) ==
+               {:ok, %Postgrex.INET{address: {0x2601, 0, 0, 0, 0, 0, 0, 1}}}
+    end
+  end
+
+  describe "dump/1" do
+    test "normalizes an IPv4-mapped IPv6 address to IPv4" do
+      assert IP.dump(@mapped) == {:ok, %Postgrex.INET{address: @ipv4}}
+      assert IP.dump(%Postgrex.INET{address: @mapped}) == {:ok, %Postgrex.INET{address: @ipv4}}
+    end
+  end
+
+  describe "load/1" do
+    test "normalizes an IPv4-mapped IPv6 address stored before normalization" do
+      assert IP.load(%Postgrex.INET{address: @mapped}) == {:ok, %Postgrex.INET{address: @ipv4}}
+
+      assert IP.load(%Postgrex.INET{address: @mapped, netmask: 128}) ==
+               {:ok, %Postgrex.INET{address: @ipv4}}
+    end
+
+    test "leaves other addresses unchanged" do
+      assert IP.load(%Postgrex.INET{address: @ipv4}) == {:ok, %Postgrex.INET{address: @ipv4}}
     end
   end
 end

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -127,6 +127,22 @@ defmodule PortalAPI.Client.SocketTest do
       assert connect(Socket, attrs, connect_info: connect_info) == {:error, :invalid_token}
     end
 
+    test "stores an IPv4-mapped IPv6 peer address as IPv4" do
+      token = client_token_fixture()
+      encoded_token = encode_token(token)
+      {a, b, c, d} = @client_remote_ip
+      mapped_ip = {0, 0, 0, 0, 0, 0xFFFF, a * 256 + b, c * 256 + d}
+
+      attrs = connect_attrs(token: encoded_token)
+      connect_info = build_connect_info(ip: mapped_ip, token: encoded_token)
+
+      assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
+      assert client = Map.fetch!(socket.assigns, :client)
+
+      assert client.last_seen_remote_ip == @client_remote_ip
+      assert client.last_seen_remote_ip_location_city == "Kyiv"
+    end
+
     test "creates a new client for user identity" do
       token = client_token_fixture()
       encoded_token = encode_token(token)

--- a/elixir/test/portal_api/sockets/rate_limit_test.exs
+++ b/elixir/test/portal_api/sockets/rate_limit_test.exs
@@ -81,6 +81,15 @@ defmodule PortalAPI.Sockets.RateLimitTest do
       assert RateLimit.check(connect_info_2) == {:error, :rate_limit}
     end
 
+    test "shares a bucket between an IPv4 peer and its IPv4-mapped IPv6 form" do
+      token = unique_token()
+      {a, b, c, d} = ip = unique_ip()
+      mapped_ip = {0, 0, 0, 0, 0, 0xFFFF, a * 256 + b, c * 256 + d}
+
+      assert RateLimit.check(build_connect_info(ip, token)) == :ok
+      assert RateLimit.check(build_connect_info(mapped_ip, token)) == {:error, :rate_limit}
+    end
+
     test "handles missing x-authorization header" do
       connect_info = %{
         peer_data: %{address: unique_ip()},


### PR DESCRIPTION
On a dual-stack listener, IPv4 peers show up as IPv4-mapped IPv6 addresses (`::ffff:1.2.3.4`). #15013 unmapped them on the HTTP path and in the auth context, but three paths still let them through: WebSocket peer data comes straight from the adapter, so client, gateway and relay sockets still saw the mapped form. The X-Forwarded-For parser handed mapped hops to the remote_ip library, which only matches blocks of the same protocol, so a mapped private proxy hop could be picked as the client address. And rows stored before #15013 came back mapped on read, which broke IP range policy conditions and display for those rows.

Mapped addresses are now normalized to IPv4 at every entry: the `Portal.Types.IP` Ecto type on cast, dump and load, the X-Forwarded-For parser before hops are classified, and one shared `Portal.Sockets.remote_ip/1` helper that the API sockets, the socket rate limiter and the LiveView hook all use. Geolocation, relay selection and IP range policies now always see the IPv4 address.

Related: #15013
