### PR TITLE
fix(ci): clarify store release changelog text

### DIFF
--- a/.github/workflows/submit-android-release.yml
+++ b/.github/workflows/submit-android-release.yml
@@ -113,7 +113,7 @@ jobs:
             printf "| Source | [\`%s\`](https://github.com/%s/commit/%s) |\n" "$SOURCE_SHA" "$GITHUB_REPOSITORY" "$SOURCE_SHA"
             printf "| Play release | \`%s@%s\` |\n" "$VERSION_NAME" "$SOURCE_SHA"
             printf "| Version code | \`%s\` |\n" "$VERSION_CODE"
-            echo "| What's New | [Android changelog](https://www.firezone.dev/changelog#tab-android) |"
+            echo "| What's New | See our full changelog at https://www.firezone.dev/changelog#tab-android. |"
             echo
             echo "### Store listing assets"
             echo

--- a/.github/workflows/submit-apple-release.yml
+++ b/.github/workflows/submit-apple-release.yml
@@ -293,7 +293,7 @@ jobs:
             echo
             echo "- Source: [\`${short_sha}\`](https://github.com/${GITHUB_REPOSITORY}/commit/${SOURCE_SHA})"
             echo "- Build: \`${BUILD_NUMBER}\`"
-            echo "- What's New: [Apple changelog]($changelog)"
+            echo "- What's New: $changelog"
             echo "- [Open Firezone in App Store Connect](https://appstoreconnect.apple.com/apps/${ASC_APP_ID}/distribution)"
             echo
             if [[ "$VERSION_PHASE" == submitted ]]; then

--- a/scripts/upload/play-store.sh
+++ b/scripts/upload/play-store.sh
@@ -71,7 +71,7 @@ update_track() {
     releases=$(jq --compact-output --null-input \
         --arg name "$RELEASE_NAME" \
         --arg version_code "$version_code" \
-        --arg changelog "$CHANGELOG_URL" \
+        --arg changelog "See our full changelog at $CHANGELOG_URL." \
         '[{
             name: $name,
             versionCodes: [$version_code],

--- a/swift/apple/app-store/metadata/en-US.json
+++ b/swift/apple/app-store/metadata/en-US.json
@@ -1,3 +1,3 @@
 {
-  "whatsNew": "https://www.firezone.dev/changelog#tab-apple"
+  "whatsNew": "See our full changelog at https://www.firezone.dev/changelog#tab-apple."
 }


### PR DESCRIPTION
Use "See our full changelog at ..." in the App Store and Google Play release notes, linking to the corresponding platform tab. Keep workflow summaries consistent with the submitted text.