### PR TITLE
test(gateway): mark installer version for release bumps

### DIFF
--- a/scripts/tests/bats/gateway_systemd_install.bats
+++ b/scripts/tests/bats/gateway_systemd_install.bats
@@ -191,6 +191,7 @@ refute_file_contains() {
     [ -f "$(init_script)" ]
 
     grep -q '^ARTIFACT_BASE_URL="https://www.firezone.dev/dl/firezone-gateway"$' "$(init_script)"
+    # mark:current-gateway-version
     grep -q '^GATEWAY_VERSION="1.6.0"$' "$(init_script)"
     grep -q 'download_url="$ARTIFACT_BASE_URL/$GATEWAY_VERSION/$arch"' "$(init_script)"
     [ "$(grep -Ec 'expected_sha256="[0-9a-f]{64}"' "$(init_script)")" -eq 3 ]


### PR DESCRIPTION
Mark the gateway installer's version assertion so release bumps update it automatically and avoid shell test failures from a stale expected version.

Related: #15153
