### PR TITLE
fix(portal): treat Google 412 as a deleted user

### DIFF
--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -547,8 +547,8 @@ defmodule Portal.Google.APIClient do
   Fetches multiple users by Google user ID using the Google API Batch endpoint.
 
   Chunks `user_ids` into groups of #{@batch_size} and issues one multipart HTTP POST
-  per chunk. Users that return 404 (deleted from Google Workspace) are silently
-  skipped. Returns `{:ok, [user_map]}` or `{:error, reason}` on transport/HTTP failure.
+  per chunk. Users that return 404 or 412 (deleted from Google Workspace) are
+  silently skipped. Returns `{:ok, [user_map]}` or `{:error, reason}` on transport/HTTP failure.
   """
   @spec batch_get_users(String.t(), [String.t()]) :: {:ok, [map()]} | {:error, term()}
   def batch_get_users(_access_token, []), do: {:ok, []}
@@ -683,9 +683,9 @@ defmodule Portal.Google.APIClient do
     #   HTTP/1.1 200 OK\r\n<response headers>\r\n\r\n<JSON body>
     with [_outer_headers, nested] <- String.split(part, "\r\n\r\n", parts: 2),
          [status_and_headers, json_body] <- String.split(nested, "\r\n\r\n", parts: 2),
-         status when status in [200, 403, 404] <- extract_http_status(status_and_headers) do
+         status when status in [200, 403, 404, 412] <- extract_http_status(status_and_headers) do
       case status do
-        404 ->
+        status when status in [404, 412] ->
           {:ok, []}
 
         403 ->
@@ -695,7 +695,7 @@ defmodule Portal.Google.APIClient do
           decode_json_user(json_body)
       end
     else
-      status when is_integer(status) and status not in [200, 403, 404] ->
+      status when is_integer(status) and status not in [200, 403, 404, 412] ->
         log_batch_parse_issue("Failing batch users response part with unexpected status",
           status: status
         )

--- a/elixir/lib/portal/google/webhook_sync.ex
+++ b/elixir/lib/portal/google/webhook_sync.ex
@@ -85,7 +85,8 @@ defmodule Portal.Google.WebhookSync do
           remove_identity(directory, identity)
         end
 
-      {:ok, %Req.Response{status: 404}} ->
+      # Google answers 412 "User is deleted." for a user in the 20-day undelete window.
+      {:ok, %Req.Response{status: status}} when status in [404, 412] ->
         remove_identity(directory, identity)
 
       {:ok, response} ->

--- a/elixir/test/portal/google/api_client_test.exs
+++ b/elixir/test/portal/google/api_client_test.exs
@@ -1136,6 +1136,24 @@ defmodule Portal.Google.APIClientTest do
       assert {:ok, []} = APIClient.batch_get_users(@test_access_token, ["deleted-user"])
     end
 
+    test "skips soft-deleted 412 users in batch response" do
+      Req.Test.expect(APIClient, fn conn ->
+        boundary = "deleted_boundary"
+
+        body =
+          build_batch_body(boundary, [
+            {"HTTP/1.1 412 Precondition Failed",
+             JSON.encode!(%{"error" => %{"code" => 412, "message" => "User is deleted."}})}
+          ])
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:ok, []} = APIClient.batch_get_users(@test_access_token, ["deleted-user"])
+    end
+
     test "handles iodata response body for multipart parsing" do
       Req.Test.expect(APIClient, fn conn ->
         boundary = "iodata_boundary"

--- a/elixir/test/portal/google/webhook_sync_test.exs
+++ b/elixir/test/portal/google/webhook_sync_test.exs
@@ -152,6 +152,38 @@ defmodule Portal.Google.WebhookSyncTest do
       refute Repo.get_by(ExternalIdentity, id: identity.id)
     end
 
+    test "removes a user Google soft-deleted", %{directory: directory} = ctx do
+      identity = directory_identity(ctx, "user-1")
+
+      Req.Test.stub(APIClient, fn conn ->
+        if conn.request_path == "/token" do
+          Req.Test.json(conn, %{"access_token" => "token", "expires_in" => 3600})
+        else
+          conn
+          |> Plug.Conn.put_status(412)
+          |> Req.Test.json(%{
+            "error" => %{
+              "code" => 412,
+              "message" => "User is deleted.",
+              "errors" => [
+                %{
+                  "domain" => "global",
+                  "location" => "If-Match",
+                  "locationType" => "header",
+                  "message" => "User is deleted.",
+                  "reason" => "conditionNotMet"
+                }
+              ]
+            }
+          })
+        end
+      end)
+
+      assert :ok = perform_job(WebhookSync, args(directory, "user-1"))
+
+      refute Repo.get_by(ExternalIdentity, id: identity.id)
+    end
+
     test "keeps an actor that still has other identities", %{directory: directory} = ctx do
       identity = directory_identity(ctx, "user-1")
       actor = mark_created_by_directory(identity.actor_id, directory)


### PR DESCRIPTION
When a Google Workspace user is deleted, Google keeps the user for 20 days so an admin can undelete them. In that window the Directory API does not answer `users.get` with 404. It answers 412 `conditionNotMet` with the message "User is deleted.". The same 412 shows up as a part status inside a batch users request.

The webhook sync only handled 404, so a notification for a deleted user raised and the job retried until it gave up. The batch users parser also failed the whole chunk on a 412 part, which aborted a full sync when a deleted user was still a group member.

The webhook sync now treats 412 the same as 404 and removes the identity. The batch parser now skips a 412 part the same as a 404 part.

Fixes #15168 