### PR TITLE
fix(portal): retry Google batch parts that fail with a 5xx

### DIFF
--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -24,6 +24,7 @@ defmodule Portal.Google.APIClient do
   ]
   @token_cache Portal.Google.TokenCache
   @max_retries 5
+  @transient_statuses [408, 429, 500, 502, 503, 504]
 
   @doc """
   Gets a delegated Google Workspace access token using deployment credentials.
@@ -573,15 +574,16 @@ defmodule Portal.Google.APIClient do
     end
   end
 
-  # The batch endpoint answers 200 even when parts are throttled, so Req's retry
-  # never sees those. Re-sending the whole chunk is cheaper than tracking parts.
+  # The batch endpoint answers 200 even when parts are throttled or fail with a
+  # 5xx, so Req's retry never sees those. Re-sending the whole chunk is cheaper
+  # than tracking parts.
   defp get_users_chunk(access_token, chunk, retry_count \\ 0) do
     case do_batch_get_users(access_token, chunk) do
-      {:throttled, _response} when retry_count < @max_retries ->
+      {:retry, _response} when retry_count < @max_retries ->
         Process.sleep(batch_retry_delay(retry_count))
         get_users_chunk(access_token, chunk, retry_count + 1)
 
-      {:throttled, response} ->
+      {:retry, response} ->
         {:error, response}
 
       result ->
@@ -653,8 +655,8 @@ defmodule Portal.Google.APIClient do
         {:ok, users} ->
           {:cont, {:ok, Enum.reverse(users, acc)}}
 
-        {:throttled, _} = throttled ->
-          {:halt, throttled}
+        {:retry, _} = retry ->
+          {:halt, retry}
 
         {:error, _} = error ->
           {:halt, error}
@@ -695,6 +697,9 @@ defmodule Portal.Google.APIClient do
           decode_json_user(json_body)
       end
     else
+      status when status in @transient_statuses ->
+        {:retry, %Req.Response{status: status, body: %{"error" => "Batch users part failed"}}}
+
       status when is_integer(status) and status not in [200, 403, 404, 412] ->
         log_batch_parse_issue("Failing batch users response part with unexpected status",
           status: status
@@ -721,8 +726,7 @@ defmodule Portal.Google.APIClient do
 
   defp parse_forbidden_batch_part(json_body) do
     if usage_limits_error?(String.trim(json_body)) do
-      {:throttled,
-       %Req.Response{status: 403, body: %{"error" => "Batch users part throttled"}}}
+      {:retry, %Req.Response{status: 403, body: %{"error" => "Batch users part throttled"}}}
     else
       log_batch_parse_issue("Failing batch users response part with unexpected status",
         status: 403
@@ -845,7 +849,6 @@ defmodule Portal.Google.APIClient do
   # strategies miss it. A custom predicate replaces them, hence the repetition.
   # https://developers.google.com/workspace/admin/directory/v1/limits
   @usage_limits_domain "usageLimits"
-  @transient_statuses [408, 429, 500, 502, 503, 504]
   @transient_transport_reasons [:timeout, :econnrefused, :closed]
   @transient_http_reasons [:unprocessed, :pool_not_available]
 

--- a/elixir/test/portal/google/api_client_test.exs
+++ b/elixir/test/portal/google/api_client_test.exs
@@ -1212,12 +1212,11 @@ defmodule Portal.Google.APIClientTest do
 
     test "returns error for unexpected per-part status in batch response" do
       Req.Test.expect(APIClient, fn conn ->
-        boundary = "server_error_part_boundary"
+        boundary = "teapot_part_boundary"
 
         body =
           build_batch_body(boundary, [
-            {"HTTP/1.1 500 Internal Server Error",
-             JSON.encode!(%{"error" => %{"message" => "boom"}})}
+            {"HTTP/1.1 418 I'm a teapot", JSON.encode!(%{"error" => %{"message" => "boom"}})}
           ])
 
         conn
@@ -1225,7 +1224,7 @@ defmodule Portal.Google.APIClientTest do
         |> Plug.Conn.send_resp(200, body)
       end)
 
-      assert {:error, %Req.Response{status: 500}} =
+      assert {:error, %Req.Response{status: 418}} =
                APIClient.batch_get_users(@test_access_token, ["user1"])
     end
 
@@ -1284,6 +1283,66 @@ defmodule Portal.Google.APIClientTest do
       end)
 
       assert {:error, %Req.Response{status: 403}} =
+               APIClient.batch_get_users(@test_access_token, ["user1"])
+
+      assert :counters.get(attempts, 1) == 6
+    end
+
+    test "retries the whole chunk when a part fails with a 5xx" do
+      Portal.Config.put_env_override(:portal, APIClient,
+        req_opts: [retry_delay: 0, plug: {Req.Test, APIClient}]
+      )
+
+      attempts = :counters.new(1, [:atomics])
+
+      Req.Test.expect(APIClient, 2, fn conn ->
+        :counters.add(attempts, 1, 1)
+        boundary = "server_error_part_boundary"
+
+        second_part =
+          case :counters.get(attempts, 1) do
+            1 -> {"HTTP/1.1 500 Internal Server Error", JSON.encode!(%{"error" => "boom"})}
+            2 -> {"HTTP/1.1 200 OK", JSON.encode!(active_google_user(%{"id" => "user2"}))}
+          end
+
+        body =
+          build_batch_body(boundary, [
+            {"HTTP/1.1 200 OK", JSON.encode!(active_google_user(%{"id" => "user1"}))},
+            second_part
+          ])
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:ok, users} = APIClient.batch_get_users(@test_access_token, ["user1", "user2"])
+      assert Enum.map(users, & &1["id"]) == ["user1", "user2"]
+      assert :counters.get(attempts, 1) == 2
+    end
+
+    test "surfaces the error when a 5xx part outlasts the retries" do
+      Portal.Config.put_env_override(:portal, APIClient,
+        req_opts: [retry_delay: 0, plug: {Req.Test, APIClient}]
+      )
+
+      attempts = :counters.new(1, [:atomics])
+
+      Req.Test.stub(APIClient, fn conn ->
+        :counters.add(attempts, 1, 1)
+        boundary = "always_failing_boundary"
+
+        body =
+          build_batch_body(boundary, [
+            {"HTTP/1.1 503 Service Unavailable", JSON.encode!(%{"error" => "boom"})}
+          ])
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:error, %Req.Response{status: 503}} =
                APIClient.batch_get_users(@test_access_token, ["user1"])
 
       assert :counters.get(attempts, 1) == 6

--- a/elixir/test/portal/google/sync_test.exs
+++ b/elixir/test/portal/google/sync_test.exs
@@ -1209,6 +1209,10 @@ defmodule Portal.Google.SyncTest do
     end
 
     test "keeps identities when a batch part fails" do
+      Portal.Config.put_env_override(:portal, APIClient,
+        req_opts: [retry_delay: 0, plug: {Req.Test, APIClient}]
+      )
+
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 


### PR DESCRIPTION
The Google batch users endpoint answers 200 even when one part inside the batch failed. Google sometimes answers a single part with a 500. The parser passed that status straight through, so one bad part failed the whole chunk, and the full sync raised and waited for its next scheduled run.

A throttled part already made the client re-send the whole chunk with backoff. A part with a transient status (408, 429, or 5xx) now takes the same retry path. The error still surfaces when the retries run out.

Related: #15169
