### PR TITLE
chore(portal): update dev config to include API HTTP port

### DIFF
--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -3,6 +3,7 @@ import Config
 # Local vars
 web_port = System.get_env("PHOENIX_WEB_PORT", "13443") |> String.to_integer()
 api_port = System.get_env("PHOENIX_API_PORT", "13001") |> String.to_integer()
+api_http_port = System.get_env("PHOENIX_API_HTTP_PORT", "13081") |> String.to_integer()
 mtls_port = System.get_env("PHOENIX_MTLS_PORT", "13003") |> String.to_integer()
 ops_port = System.get_env("PHOENIX_OPS_PORT", "13002") |> String.to_integer()
 certfile_path = System.get_env("CERTFILE_PATH", "priv/cert/selfsigned.pem")
@@ -309,6 +310,7 @@ config :portal, Portal.Endpoint,
 
 config :portal, PortalAPI.Endpoint,
   url: [scheme: "https", host: "localhost", port: api_port],
+  http: [port: api_http_port],
   https: [
     port: api_port,
     certfile: certfile_path,


### PR DESCRIPTION
The API endpoint started using HTTPS.  When running a local gateway in a docker container it was very difficult to get it to connect properly without having to build a custom docker image.  Allowing the local dev instance to listen on HTTP rather than HTTPS makes testing local gateway connections much easier.