### PR TITLE
feat(portal): add Require attestation policy condition

### DIFF
--- a/elixir/lib/portal/cache/cacheable/policy.ex
+++ b/elixir/lib/portal/cache/cacheable/policy.ex
@@ -14,7 +14,7 @@ defmodule Portal.Cache.Cacheable.Policy do
             | :provider_id
             | :current_utc_datetime
             | :client_verified
-            | :client_attested,
+            | :device_attested,
           operator:
             :contains
             | :does_not_contain

--- a/elixir/lib/portal/cache/cacheable/policy.ex
+++ b/elixir/lib/portal/cache/cacheable/policy.ex
@@ -13,7 +13,8 @@ defmodule Portal.Cache.Cacheable.Policy do
             | :remote_ip
             | :provider_id
             | :current_utc_datetime
-            | :client_verified,
+            | :client_verified
+            | :client_attested,
           operator:
             :contains
             | :does_not_contain

--- a/elixir/lib/portal/policies/condition.ex
+++ b/elixir/lib/portal/policies/condition.ex
@@ -11,7 +11,8 @@ defmodule Portal.Policies.Condition do
             | :remote_ip
             | :auth_provider_id
             | :current_utc_datetime
-            | :client_verified,
+            | :client_verified
+            | :client_attested,
           operator:
             :contains
             | :does_not_contain
@@ -31,6 +32,7 @@ defmodule Portal.Policies.Condition do
         auth_provider_id
         current_utc_datetime
         client_verified
+        client_attested
       ]a
 
     field :operator, Ecto.Enum, values: ~w[
@@ -72,6 +74,7 @@ defmodule Portal.Policies.Condition do
   def valid_operators_for_property(:auth_provider_id), do: [:is_in, :is_not_in]
   def valid_operators_for_property(:current_utc_datetime), do: [:is_in_day_of_week_time_ranges]
   def valid_operators_for_property(:client_verified), do: [:is]
+  def valid_operators_for_property(:client_attested), do: [:is]
 
   defp validate_operator(changeset) do
     case fetch_field(changeset, :property) do
@@ -105,6 +108,13 @@ defmodule Portal.Policies.Condition do
         changeset
         |> validate_required(:operator)
         |> validate_inclusion(:operator, valid_operators_for_property(:client_verified))
+        |> validate_length(:values, min: 1, max: 1)
+        |> validate_list(:values, :boolean)
+
+      {_data_or_changes, :client_attested} ->
+        changeset
+        |> validate_required(:operator)
+        |> validate_inclusion(:operator, valid_operators_for_property(:client_attested))
         |> validate_length(:values, min: 1, max: 1)
         |> validate_list(:values, :boolean)
 

--- a/elixir/lib/portal/policies/condition.ex
+++ b/elixir/lib/portal/policies/condition.ex
@@ -12,7 +12,7 @@ defmodule Portal.Policies.Condition do
             | :auth_provider_id
             | :current_utc_datetime
             | :client_verified
-            | :client_attested,
+            | :device_attested,
           operator:
             :contains
             | :does_not_contain
@@ -32,7 +32,7 @@ defmodule Portal.Policies.Condition do
         auth_provider_id
         current_utc_datetime
         client_verified
-        client_attested
+        device_attested
       ]a
 
     field :operator, Ecto.Enum, values: ~w[
@@ -74,7 +74,7 @@ defmodule Portal.Policies.Condition do
   def valid_operators_for_property(:auth_provider_id), do: [:is_in, :is_not_in]
   def valid_operators_for_property(:current_utc_datetime), do: [:is_in_day_of_week_time_ranges]
   def valid_operators_for_property(:client_verified), do: [:is]
-  def valid_operators_for_property(:client_attested), do: [:is]
+  def valid_operators_for_property(:device_attested), do: [:is]
 
   defp validate_operator(changeset) do
     case fetch_field(changeset, :property) do
@@ -111,10 +111,10 @@ defmodule Portal.Policies.Condition do
         |> validate_length(:values, min: 1, max: 1)
         |> validate_list(:values, :boolean)
 
-      {_data_or_changes, :client_attested} ->
+      {_data_or_changes, :device_attested} ->
         changeset
         |> validate_required(:operator)
-        |> validate_inclusion(:operator, valid_operators_for_property(:client_attested))
+        |> validate_inclusion(:operator, valid_operators_for_property(:device_attested))
         |> validate_length(:values, min: 1, max: 1)
         |> validate_list(:values, :boolean)
 

--- a/elixir/lib/portal/policies/evaluator.ex
+++ b/elixir/lib/portal/policies/evaluator.ex
@@ -169,6 +169,34 @@ defmodule Portal.Policies.Evaluator do
 
   def fetch_conformation_expiration(
         %{
+          property: :client_attested,
+          operator: :is,
+          values: ["true"]
+        },
+        %Device{type: :client, attested?: attested?},
+        _auth_provider_id
+      ) do
+    if attested? do
+      {:ok, nil}
+    else
+      :error
+    end
+  end
+
+  def fetch_conformation_expiration(
+        %{
+          property: :client_attested,
+          operator: :is,
+          values: _other
+        },
+        %Device{type: :client},
+        _auth_provider_id
+      ) do
+    {:ok, nil}
+  end
+
+  def fetch_conformation_expiration(
+        %{
           property: :current_utc_datetime,
           operator: :is_in_day_of_week_time_ranges,
           values: values

--- a/elixir/lib/portal/policies/evaluator.ex
+++ b/elixir/lib/portal/policies/evaluator.ex
@@ -169,7 +169,7 @@ defmodule Portal.Policies.Evaluator do
 
   def fetch_conformation_expiration(
         %{
-          property: :client_attested,
+          property: :device_attested,
           operator: :is,
           values: ["true"]
         },
@@ -185,7 +185,7 @@ defmodule Portal.Policies.Evaluator do
 
   def fetch_conformation_expiration(
         %{
-          property: :client_attested,
+          property: :device_attested,
           operator: :is,
           values: _other
         },

--- a/elixir/lib/portal_api/schemas/policy_schema.ex
+++ b/elixir/lib/portal_api/schemas/policy_schema.ex
@@ -28,6 +28,10 @@ defmodule PortalAPI.Schemas.Policy do
         IANA timezone name, e.g. `"M/09:00-17:00/America/New_York"`.
       * `client_verified` with `is`: `values` is a single-element list
         containing `"true"` or `"false"`.
+      * `client_attested` with `is`: `values` is a single-element list
+        containing `"true"` or `"false"`. `"true"` requires the Client to
+        have presented a valid X.509 certificate from one of the account's
+        trust anchors on its current connection.
       """,
       type: :object,
       properties: %{
@@ -40,7 +44,8 @@ defmodule PortalAPI.Schemas.Policy do
             "remote_ip",
             "auth_provider_id",
             "current_utc_datetime",
-            "client_verified"
+            "client_verified",
+            "client_attested"
           ]
         },
         operator: %Schema{

--- a/elixir/lib/portal_api/schemas/policy_schema.ex
+++ b/elixir/lib/portal_api/schemas/policy_schema.ex
@@ -28,7 +28,7 @@ defmodule PortalAPI.Schemas.Policy do
         IANA timezone name, e.g. `"M/09:00-17:00/America/New_York"`.
       * `client_verified` with `is`: `values` is a single-element list
         containing `"true"` or `"false"`.
-      * `client_attested` with `is`: `values` is a single-element list
+      * `device_attested` with `is`: `values` is a single-element list
         containing `"true"` or `"false"`. `"true"` requires the Client to
         have presented a valid X.509 certificate from one of the account's
         trust anchors on its current connection.
@@ -45,7 +45,7 @@ defmodule PortalAPI.Schemas.Policy do
             "auth_provider_id",
             "current_utc_datetime",
             "client_verified",
-            "client_attested"
+            "device_attested"
           ]
         },
         operator: %Schema{

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -18,7 +18,7 @@ defmodule PortalWeb.Policies.Components do
     :remote_ip,
     :auth_provider_id,
     :client_verified,
-    :client_attested,
+    :device_attested,
     :current_utc_datetime
   ]
 
@@ -1382,7 +1382,7 @@ defmodule PortalWeb.Policies.Components do
 
   @spec condition_short_label(atom()) :: String.t()
   def condition_short_label(:client_verified), do: "Verified"
-  def condition_short_label(:client_attested), do: "Attested"
+  def condition_short_label(:device_attested), do: "Attested"
   def condition_short_label(:auth_provider_id), do: "Auth"
   def condition_short_label(:remote_ip_location_region), do: "Location"
   def condition_short_label(:remote_ip), do: "IP Range"
@@ -1415,7 +1415,7 @@ defmodule PortalWeb.Policies.Components do
     do:
       "inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0 text-success bg-success-light"
 
-  defp condition_type_badge_class(:client_attested),
+  defp condition_type_badge_class(:device_attested),
     do:
       "inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0 text-success bg-success-light"
 
@@ -1443,7 +1443,7 @@ defmodule PortalWeb.Policies.Components do
   defp condition_values_display(%{property: :client_verified}, _providers, _account),
     do: "Device must be verified"
 
-  defp condition_values_display(%{property: :client_attested}, _providers, _account),
+  defp condition_values_display(%{property: :device_attested}, _providers, _account),
     do: "Device must be attested"
 
   defp condition_values_display(
@@ -1623,7 +1623,7 @@ defmodule PortalWeb.Policies.Components do
     """
   end
 
-  defp condition(%{property: :client_attested} = assigns) do
+  defp condition(%{property: :device_attested} = assigns) do
     ~H"""
     <span :if={@values != []} class="mr-1">
       <span>by clients that are</span>
@@ -2266,7 +2266,7 @@ defmodule PortalWeb.Policies.Components do
       :remote_ip,
       :auth_provider_id,
       :client_verified,
-      :client_attested
+      :device_attested
     ]
 
   def available_conditions(_resource),
@@ -2275,13 +2275,13 @@ defmodule PortalWeb.Policies.Components do
       :remote_ip,
       :auth_provider_id,
       :client_verified,
-      :client_attested,
+      :device_attested,
       :current_utc_datetime
     ]
 
   @spec condition_type_label(atom()) :: String.t()
   def condition_type_label(:client_verified), do: "Require Verified Device"
-  def condition_type_label(:client_attested), do: "Require attestation"
+  def condition_type_label(:device_attested), do: "Require attestation"
   def condition_type_label(:auth_provider_id), do: "Authentication Provider"
   def condition_type_label(:remote_ip_location_region), do: "Device Location"
   def condition_type_label(:remote_ip), do: "IP Range"
@@ -2305,7 +2305,7 @@ defmodule PortalWeb.Policies.Components do
   def grant_condition_card(assigns) do
     ~H"""
     <.grant_client_verified_condition_card :if={@type == :client_verified} type={@type} />
-    <.grant_client_attested_condition_card :if={@type == :client_attested} type={@type} />
+    <.grant_device_attested_condition_card :if={@type == :device_attested} type={@type} />
     <.grant_ip_range_condition_card
       :if={@type == :remote_ip}
       type={@type}
@@ -2390,23 +2390,23 @@ defmodule PortalWeb.Policies.Components do
 
   attr :type, :atom, required: true
 
-  defp grant_client_attested_condition_card(assigns) do
+  defp grant_device_attested_condition_card(assigns) do
     ~H"""
     <div class="rounded-lg border border-border overflow-hidden">
       <.grant_condition_card_header type={@type} />
       <input
         type="hidden"
-        name="policy[conditions][client_attested][property]"
-        value="client_attested"
+        name="policy[conditions][device_attested][property]"
+        value="device_attested"
       />
       <input
         type="hidden"
-        name="policy[conditions][client_attested][operator]"
+        name="policy[conditions][device_attested][operator]"
         value="is"
       />
       <input
         type="hidden"
-        name="policy[conditions][client_attested][values][]"
+        name="policy[conditions][device_attested][values][]"
         value="true"
       />
     </div>

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -18,6 +18,7 @@ defmodule PortalWeb.Policies.Components do
     :remote_ip,
     :auth_provider_id,
     :client_verified,
+    :client_attested,
     :current_utc_datetime
   ]
 
@@ -1381,6 +1382,7 @@ defmodule PortalWeb.Policies.Components do
 
   @spec condition_short_label(atom()) :: String.t()
   def condition_short_label(:client_verified), do: "Verified"
+  def condition_short_label(:client_attested), do: "Attested"
   def condition_short_label(:auth_provider_id), do: "Auth"
   def condition_short_label(:remote_ip_location_region), do: "Location"
   def condition_short_label(:remote_ip), do: "IP Range"
@@ -1413,6 +1415,10 @@ defmodule PortalWeb.Policies.Components do
     do:
       "inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0 text-success bg-success-light"
 
+  defp condition_type_badge_class(:client_attested),
+    do:
+      "inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0 text-success bg-success-light"
+
   defp condition_type_badge_class(:auth_provider_id),
     do:
       "inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0 text-badge-dns-text bg-badge-dns"
@@ -1436,6 +1442,9 @@ defmodule PortalWeb.Policies.Components do
   @spec condition_values_display(map(), list(), any()) :: String.t()
   defp condition_values_display(%{property: :client_verified}, _providers, _account),
     do: "Device must be verified"
+
+  defp condition_values_display(%{property: :client_attested}, _providers, _account),
+    do: "Device must be attested"
 
   defp condition_values_display(
          %{property: :auth_provider_id, values: values},
@@ -1610,6 +1619,16 @@ defmodule PortalWeb.Policies.Components do
       <span>by clients that are</span>
       <span :if={@values == ["true"]}>verified</span>
       <span :if={@values == ["false"]}>not verified</span>
+    </span>
+    """
+  end
+
+  defp condition(%{property: :client_attested} = assigns) do
+    ~H"""
+    <span :if={@values != []} class="mr-1">
+      <span>by clients that are</span>
+      <span :if={@values == ["true"]}>attested</span>
+      <span :if={@values == ["false"]}>not attested</span>
     </span>
     """
   end
@@ -2242,7 +2261,13 @@ defmodule PortalWeb.Policies.Components do
 
   @spec available_conditions(map() | nil) :: [atom()]
   def available_conditions(%{type: :internet}),
-    do: [:remote_ip_location_region, :remote_ip, :auth_provider_id, :client_verified]
+    do: [
+      :remote_ip_location_region,
+      :remote_ip,
+      :auth_provider_id,
+      :client_verified,
+      :client_attested
+    ]
 
   def available_conditions(_resource),
     do: [
@@ -2250,11 +2275,13 @@ defmodule PortalWeb.Policies.Components do
       :remote_ip,
       :auth_provider_id,
       :client_verified,
+      :client_attested,
       :current_utc_datetime
     ]
 
   @spec condition_type_label(atom()) :: String.t()
   def condition_type_label(:client_verified), do: "Require Verified Device"
+  def condition_type_label(:client_attested), do: "Require attestation"
   def condition_type_label(:auth_provider_id), do: "Authentication Provider"
   def condition_type_label(:remote_ip_location_region), do: "Device Location"
   def condition_type_label(:remote_ip), do: "IP Range"
@@ -2278,6 +2305,7 @@ defmodule PortalWeb.Policies.Components do
   def grant_condition_card(assigns) do
     ~H"""
     <.grant_client_verified_condition_card :if={@type == :client_verified} type={@type} />
+    <.grant_client_attested_condition_card :if={@type == :client_attested} type={@type} />
     <.grant_ip_range_condition_card
       :if={@type == :remote_ip}
       type={@type}
@@ -2354,6 +2382,31 @@ defmodule PortalWeb.Policies.Components do
       <input
         type="hidden"
         name="policy[conditions][client_verified][values][]"
+        value="true"
+      />
+    </div>
+    """
+  end
+
+  attr :type, :atom, required: true
+
+  defp grant_client_attested_condition_card(assigns) do
+    ~H"""
+    <div class="rounded-lg border border-border overflow-hidden">
+      <.grant_condition_card_header type={@type} />
+      <input
+        type="hidden"
+        name="policy[conditions][client_attested][property]"
+        value="client_attested"
+      />
+      <input
+        type="hidden"
+        name="policy[conditions][client_attested][operator]"
+        value="is"
+      />
+      <input
+        type="hidden"
+        name="policy[conditions][client_attested][values][]"
         value="true"
       />
     </div>

--- a/elixir/priv/static/openapi.json
+++ b/elixir/priv/static/openapi.json
@@ -5658,7 +5658,7 @@
         "type": "object"
       },
       "PolicyCondition": {
-        "description": "A condition that must be satisfied for the Policy to grant access.\n\nAll conditions on a Policy must evaluate to true for access to be\ngranted. A condition is made up of a `property`, an `operator`, and a\nlist of `values`. The valid operators and the meaning of `values`\ndepend on the `property`:\n\n* `remote_ip_location_region` with `is_in` / `is_not_in`: `values` are\n  ISO 3166-1 alpha-2 country codes, e.g. `[\"US\", \"CA\"]`.\n* `remote_ip` with `is_in_cidr` / `is_not_in_cidr`: `values` are CIDR\n  ranges (IPv4 or IPv6), e.g. `[\"10.0.0.0/8\", \"2607:f8b0::/32\"]`.\n* `auth_provider_id` with `is_in` / `is_not_in`: `values` are\n  authentication provider IDs (UUIDs).\n* `current_utc_datetime` with `is_in_day_of_week_time_ranges`: each\n  value is a `DAY/TIME_RANGES/TIMEZONE` string where `DAY` is one of\n  `M T W R F S U` (Monday through Sunday), `TIME_RANGES` is a\n  comma-separated list of `HH:MM-HH:MM` ranges, and `TIMEZONE` is an\n  IANA timezone name, e.g. `\"M/09:00-17:00/America/New_York\"`.\n* `client_verified` with `is`: `values` is a single-element list\n  containing `\"true\"` or `\"false\"`.\n* `client_attested` with `is`: `values` is a single-element list\n  containing `\"true\"` or `\"false\"`. `\"true\"` requires the Client to\n  have presented a valid X.509 certificate from one of the account's\n  trust anchors on its current connection.\n",
+        "description": "A condition that must be satisfied for the Policy to grant access.\n\nAll conditions on a Policy must evaluate to true for access to be\ngranted. A condition is made up of a `property`, an `operator`, and a\nlist of `values`. The valid operators and the meaning of `values`\ndepend on the `property`:\n\n* `remote_ip_location_region` with `is_in` / `is_not_in`: `values` are\n  ISO 3166-1 alpha-2 country codes, e.g. `[\"US\", \"CA\"]`.\n* `remote_ip` with `is_in_cidr` / `is_not_in_cidr`: `values` are CIDR\n  ranges (IPv4 or IPv6), e.g. `[\"10.0.0.0/8\", \"2607:f8b0::/32\"]`.\n* `auth_provider_id` with `is_in` / `is_not_in`: `values` are\n  authentication provider IDs (UUIDs).\n* `current_utc_datetime` with `is_in_day_of_week_time_ranges`: each\n  value is a `DAY/TIME_RANGES/TIMEZONE` string where `DAY` is one of\n  `M T W R F S U` (Monday through Sunday), `TIME_RANGES` is a\n  comma-separated list of `HH:MM-HH:MM` ranges, and `TIMEZONE` is an\n  IANA timezone name, e.g. `\"M/09:00-17:00/America/New_York\"`.\n* `client_verified` with `is`: `values` is a single-element list\n  containing `\"true\"` or `\"false\"`.\n* `device_attested` with `is`: `values` is a single-element list\n  containing `\"true\"` or `\"false\"`. `\"true\"` requires the Client to\n  have presented a valid X.509 certificate from one of the account's\n  trust anchors on its current connection.\n",
         "properties": {
           "operator": {
             "description": "How the values are compared against the property",
@@ -5681,7 +5681,7 @@
               "auth_provider_id",
               "current_utc_datetime",
               "client_verified",
-              "client_attested"
+              "device_attested"
             ],
             "example": "remote_ip_location_region",
             "type": "string"

--- a/elixir/priv/static/openapi.json
+++ b/elixir/priv/static/openapi.json
@@ -5658,7 +5658,7 @@
         "type": "object"
       },
       "PolicyCondition": {
-        "description": "A condition that must be satisfied for the Policy to grant access.\n\nAll conditions on a Policy must evaluate to true for access to be\ngranted. A condition is made up of a `property`, an `operator`, and a\nlist of `values`. The valid operators and the meaning of `values`\ndepend on the `property`:\n\n* `remote_ip_location_region` with `is_in` / `is_not_in`: `values` are\n  ISO 3166-1 alpha-2 country codes, e.g. `[\"US\", \"CA\"]`.\n* `remote_ip` with `is_in_cidr` / `is_not_in_cidr`: `values` are CIDR\n  ranges (IPv4 or IPv6), e.g. `[\"10.0.0.0/8\", \"2607:f8b0::/32\"]`.\n* `auth_provider_id` with `is_in` / `is_not_in`: `values` are\n  authentication provider IDs (UUIDs).\n* `current_utc_datetime` with `is_in_day_of_week_time_ranges`: each\n  value is a `DAY/TIME_RANGES/TIMEZONE` string where `DAY` is one of\n  `M T W R F S U` (Monday through Sunday), `TIME_RANGES` is a\n  comma-separated list of `HH:MM-HH:MM` ranges, and `TIMEZONE` is an\n  IANA timezone name, e.g. `\"M/09:00-17:00/America/New_York\"`.\n* `client_verified` with `is`: `values` is a single-element list\n  containing `\"true\"` or `\"false\"`.\n",
+        "description": "A condition that must be satisfied for the Policy to grant access.\n\nAll conditions on a Policy must evaluate to true for access to be\ngranted. A condition is made up of a `property`, an `operator`, and a\nlist of `values`. The valid operators and the meaning of `values`\ndepend on the `property`:\n\n* `remote_ip_location_region` with `is_in` / `is_not_in`: `values` are\n  ISO 3166-1 alpha-2 country codes, e.g. `[\"US\", \"CA\"]`.\n* `remote_ip` with `is_in_cidr` / `is_not_in_cidr`: `values` are CIDR\n  ranges (IPv4 or IPv6), e.g. `[\"10.0.0.0/8\", \"2607:f8b0::/32\"]`.\n* `auth_provider_id` with `is_in` / `is_not_in`: `values` are\n  authentication provider IDs (UUIDs).\n* `current_utc_datetime` with `is_in_day_of_week_time_ranges`: each\n  value is a `DAY/TIME_RANGES/TIMEZONE` string where `DAY` is one of\n  `M T W R F S U` (Monday through Sunday), `TIME_RANGES` is a\n  comma-separated list of `HH:MM-HH:MM` ranges, and `TIMEZONE` is an\n  IANA timezone name, e.g. `\"M/09:00-17:00/America/New_York\"`.\n* `client_verified` with `is`: `values` is a single-element list\n  containing `\"true\"` or `\"false\"`.\n* `client_attested` with `is`: `values` is a single-element list\n  containing `\"true\"` or `\"false\"`. `\"true\"` requires the Client to\n  have presented a valid X.509 certificate from one of the account's\n  trust anchors on its current connection.\n",
         "properties": {
           "operator": {
             "description": "How the values are compared against the property",
@@ -5680,7 +5680,8 @@
               "remote_ip",
               "auth_provider_id",
               "current_utc_datetime",
-              "client_verified"
+              "client_verified",
+              "client_attested"
             ],
             "example": "remote_ip_location_region",
             "type": "string"

--- a/elixir/test/portal/policies/condition/evaluator_test.exs
+++ b/elixir/test/portal/policies/condition/evaluator_test.exs
@@ -324,12 +324,12 @@ defmodule Portal.Policies.EvaluatorTest do
     end
   end
 
-  describe "fetch_conformation_expiration/3 with client_attested" do
+  describe "fetch_conformation_expiration/3 with device_attested" do
     test "is with values [\"true\"] returns ok when the connection attested" do
       attested_client = %Portal.Device{type: :client, attested?: true}
 
       condition = %{
-        property: :client_attested,
+        property: :device_attested,
         operator: :is,
         values: ["true"]
       }
@@ -341,7 +341,7 @@ defmodule Portal.Policies.EvaluatorTest do
       unattested_client = %Portal.Device{type: :client, attested?: false}
 
       condition = %{
-        property: :client_attested,
+        property: :device_attested,
         operator: :is,
         values: ["true"]
       }
@@ -358,7 +358,7 @@ defmodule Portal.Policies.EvaluatorTest do
       }
 
       condition = %{
-        property: :client_attested,
+        property: :device_attested,
         operator: :is,
         values: ["true"]
       }
@@ -371,7 +371,7 @@ defmodule Portal.Policies.EvaluatorTest do
       unattested_client = %Portal.Device{type: :client, attested?: false}
 
       condition = %{
-        property: :client_attested,
+        property: :device_attested,
         operator: :is,
         values: ["false"]
       }

--- a/elixir/test/portal/policies/condition/evaluator_test.exs
+++ b/elixir/test/portal/policies/condition/evaluator_test.exs
@@ -324,6 +324,63 @@ defmodule Portal.Policies.EvaluatorTest do
     end
   end
 
+  describe "fetch_conformation_expiration/3 with client_attested" do
+    test "is with values [\"true\"] returns ok when the connection attested" do
+      attested_client = %Portal.Device{type: :client, attested?: true}
+
+      condition = %{
+        property: :client_attested,
+        operator: :is,
+        values: ["true"]
+      }
+
+      assert fetch_conformation_expiration(condition, attested_client, nil) == {:ok, nil}
+    end
+
+    test "is with values [\"true\"] returns error when the connection did not attest" do
+      unattested_client = %Portal.Device{type: :client, attested?: false}
+
+      condition = %{
+        property: :client_attested,
+        operator: :is,
+        values: ["true"]
+      }
+
+      assert fetch_conformation_expiration(condition, unattested_client, nil) == :error
+    end
+
+    test "is with values [\"true\"] ignores past attestation of the device row" do
+      client = %Portal.Device{
+        type: :client,
+        attested?: false,
+        last_attested_at: DateTime.utc_now(),
+        verified_at: DateTime.utc_now()
+      }
+
+      condition = %{
+        property: :client_attested,
+        operator: :is,
+        values: ["true"]
+      }
+
+      assert fetch_conformation_expiration(condition, client, nil) == :error
+    end
+
+    test "is with values other than [\"true\"] always returns ok" do
+      attested_client = %Portal.Device{type: :client, attested?: true}
+      unattested_client = %Portal.Device{type: :client, attested?: false}
+
+      condition = %{
+        property: :client_attested,
+        operator: :is,
+        values: ["false"]
+      }
+
+      assert fetch_conformation_expiration(condition, attested_client, nil) == {:ok, nil}
+      assert fetch_conformation_expiration(condition, unattested_client, nil) == {:ok, nil}
+    end
+  end
+
   describe "fetch_conformation_expiration/3 with remote_ip_location_region" do
     test "returns error when region is nil regardless of operator" do
       client = %Portal.Device{type: :client, last_seen_remote_ip_location_region: nil}

--- a/elixir/test/portal/policies/condition_test.exs
+++ b/elixir/test/portal/policies/condition_test.exs
@@ -176,4 +176,38 @@ defmodule Portal.Policies.ConditionTest do
       assert cs.errors[:values]
     end
   end
+
+  describe "changeset/3 with client_attested" do
+    test "valid with is and true" do
+      cs = changeset(%{property: :client_attested, operator: :is, values: ["true"]})
+      assert cs.valid?
+    end
+
+    test "valid with is and false" do
+      cs = changeset(%{property: :client_attested, operator: :is, values: ["false"]})
+      assert cs.valid?
+    end
+
+    test "invalid operator returns error" do
+      cs = changeset(%{property: :client_attested, operator: :is_in, values: ["true"]})
+      assert cs.errors[:operator]
+    end
+
+    test "non-boolean value returns error" do
+      cs = changeset(%{property: :client_attested, operator: :is, values: ["yes"]})
+      assert cs.errors[:values]
+    end
+
+    test "more than one value returns length error" do
+      cs =
+        changeset(%{property: :client_attested, operator: :is, values: ["true", "false"]})
+
+      assert cs.errors[:values]
+    end
+
+    test "empty values list returns length error" do
+      cs = changeset(%{property: :client_attested, operator: :is, values: []})
+      assert cs.errors[:values]
+    end
+  end
 end

--- a/elixir/test/portal/policies/condition_test.exs
+++ b/elixir/test/portal/policies/condition_test.exs
@@ -177,36 +177,36 @@ defmodule Portal.Policies.ConditionTest do
     end
   end
 
-  describe "changeset/3 with client_attested" do
+  describe "changeset/3 with device_attested" do
     test "valid with is and true" do
-      cs = changeset(%{property: :client_attested, operator: :is, values: ["true"]})
+      cs = changeset(%{property: :device_attested, operator: :is, values: ["true"]})
       assert cs.valid?
     end
 
     test "valid with is and false" do
-      cs = changeset(%{property: :client_attested, operator: :is, values: ["false"]})
+      cs = changeset(%{property: :device_attested, operator: :is, values: ["false"]})
       assert cs.valid?
     end
 
     test "invalid operator returns error" do
-      cs = changeset(%{property: :client_attested, operator: :is_in, values: ["true"]})
+      cs = changeset(%{property: :device_attested, operator: :is_in, values: ["true"]})
       assert cs.errors[:operator]
     end
 
     test "non-boolean value returns error" do
-      cs = changeset(%{property: :client_attested, operator: :is, values: ["yes"]})
+      cs = changeset(%{property: :device_attested, operator: :is, values: ["yes"]})
       assert cs.errors[:values]
     end
 
     test "more than one value returns length error" do
       cs =
-        changeset(%{property: :client_attested, operator: :is, values: ["true", "false"]})
+        changeset(%{property: :device_attested, operator: :is, values: ["true", "false"]})
 
       assert cs.errors[:values]
     end
 
     test "empty values list returns length error" do
-      cs = changeset(%{property: :client_attested, operator: :is, values: []})
+      cs = changeset(%{property: :device_attested, operator: :is, values: []})
       assert cs.errors[:values]
     end
   end

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -53,7 +53,8 @@ defmodule PortalAPI.Client.ChannelTest do
         last_seen_remote_ip_location_lat: subject.context.remote_ip_location_lat,
         last_seen_remote_ip_location_lon: subject.context.remote_ip_location_lon,
         last_seen_version: client_version,
-        last_seen_at: DateTime.utc_now()
+        last_seen_at: DateTime.utc_now(),
+        attested?: Keyword.get(opts, :attested?, false)
     }
 
     {:ok, _reply, socket} =
@@ -2246,6 +2247,68 @@ defmodule PortalAPI.Client.ChannelTest do
       # Client is no longer verified, resource should be deleted
       assert_push "resource_deleted", payload
       assert payload == resource.id
+    end
+
+    test "for client_attested conditions grants only the connection that attested",
+         %{
+           client: client,
+           actor: actor,
+           account: account,
+           subject: subject
+         } do
+      identity_fixture(actor: actor, account: account)
+      group = group_fixture(account: account)
+      site = site_fixture(account: account)
+
+      resource =
+        dns_resource_fixture(
+          account: account,
+          site: site,
+          ip_stack: :ipv4_only
+        )
+
+      policy_fixture(
+        account: account,
+        group: group,
+        resource: resource,
+        conditions: [
+          %{
+            property: :client_attested,
+            operator: :is,
+            values: ["true"]
+          }
+        ]
+      )
+
+      membership =
+        membership_fixture(
+          account: account,
+          actor: actor,
+          group: group
+        )
+
+      # A device that attested on an earlier connection but not on this one
+      # does not satisfy the condition: only the live session counts.
+      client = verify_device(client)
+
+      unattested_socket = join_channel(client, subject, attested?: false)
+      assert_push "init", %{resources: resources}
+      refute Enum.any?(resources, &(&1.id == resource.id))
+
+      send(unattested_socket.channel_pid, %Changes.Change{
+        lsn: 100,
+        op: :insert,
+        struct: membership
+      })
+
+      refute_push "resource_created_or_updated", _payload
+
+      Process.unlink(unattested_socket.channel_pid)
+      Process.exit(unattested_socket.channel_pid, :shutdown)
+
+      join_channel(client, subject, attested?: true)
+      assert_push "init", %{resources: resources}
+      assert Enum.any?(resources, &(&1.id == resource.id))
     end
 
     test "for client address updates resends init with the new tunnel IPs", %{

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -2249,7 +2249,7 @@ defmodule PortalAPI.Client.ChannelTest do
       assert payload == resource.id
     end
 
-    test "for client_attested conditions grants only the connection that attested",
+    test "for device_attested conditions grants only the connection that attested",
          %{
            client: client,
            actor: actor,
@@ -2273,7 +2273,7 @@ defmodule PortalAPI.Client.ChannelTest do
         resource: resource,
         conditions: [
           %{
-            property: :client_attested,
+            property: :device_attested,
             operator: :is,
             values: ["true"]
           }

--- a/elixir/test/portal_api/controllers/policy_controller_test.exs
+++ b/elixir/test/portal_api/controllers/policy_controller_test.exs
@@ -333,6 +333,64 @@ defmodule PortalAPI.PolicyControllerTest do
              ]
     end
 
+    test "creates a policy with a client_attested condition", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      resource = resource_fixture(account: account)
+      group = group_fixture(account: account)
+
+      attrs = %{
+        "group_id" => group.id,
+        "resource_id" => resource.id,
+        "conditions" => [
+          %{"property" => "client_attested", "operator" => "is", "values" => ["true"]}
+        ]
+      }
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/policies", policy: attrs)
+
+      assert resp = json_response(conn, 201)
+
+      assert resp["data"]["conditions"] == [
+               %{
+                 "property" => "client_attested",
+                 "operator" => "is",
+                 "values" => ["true"]
+               }
+             ]
+    end
+
+    test "rejects a client_attested condition with an unsupported operator", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      resource = resource_fixture(account: account)
+      group = group_fixture(account: account)
+
+      attrs = %{
+        "group_id" => group.id,
+        "resource_id" => resource.id,
+        "conditions" => [
+          %{"property" => "client_attested", "operator" => "is_in", "values" => ["true"]}
+        ]
+      }
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/policies", policy: attrs)
+
+      assert json_response(conn, 422)
+    end
+
     test "creates a policy with auth_provider_id and time conditions", %{
       conn: conn,
       account: account,
@@ -810,6 +868,38 @@ defmodule PortalAPI.PolicyControllerTest do
       assert json_response(conn, 200)["data"]["conditions"] == [
                %{
                  "property" => "client_verified",
+                 "operator" => "is",
+                 "values" => ["true"]
+               }
+             ]
+    end
+
+    test "updates a policy to require an attested client", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      policy =
+        policy_with_conditions_fixture(%{
+          account: account,
+          conditions: [%{property: :client_verified, operator: :is, values: ["true"]}]
+        })
+
+      attrs = %{
+        "conditions" => [
+          %{"property" => "client_attested", "operator" => "is", "values" => ["true"]}
+        ]
+      }
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/policies/#{policy.id}", policy: attrs)
+
+      assert json_response(conn, 200)["data"]["conditions"] == [
+               %{
+                 "property" => "client_attested",
                  "operator" => "is",
                  "values" => ["true"]
                }

--- a/elixir/test/portal_api/controllers/policy_controller_test.exs
+++ b/elixir/test/portal_api/controllers/policy_controller_test.exs
@@ -333,7 +333,7 @@ defmodule PortalAPI.PolicyControllerTest do
              ]
     end
 
-    test "creates a policy with a client_attested condition", %{
+    test "creates a policy with a device_attested condition", %{
       conn: conn,
       account: account,
       actor: actor
@@ -345,7 +345,7 @@ defmodule PortalAPI.PolicyControllerTest do
         "group_id" => group.id,
         "resource_id" => resource.id,
         "conditions" => [
-          %{"property" => "client_attested", "operator" => "is", "values" => ["true"]}
+          %{"property" => "device_attested", "operator" => "is", "values" => ["true"]}
         ]
       }
 
@@ -359,14 +359,14 @@ defmodule PortalAPI.PolicyControllerTest do
 
       assert resp["data"]["conditions"] == [
                %{
-                 "property" => "client_attested",
+                 "property" => "device_attested",
                  "operator" => "is",
                  "values" => ["true"]
                }
              ]
     end
 
-    test "rejects a client_attested condition with an unsupported operator", %{
+    test "rejects a device_attested condition with an unsupported operator", %{
       conn: conn,
       account: account,
       actor: actor
@@ -378,7 +378,7 @@ defmodule PortalAPI.PolicyControllerTest do
         "group_id" => group.id,
         "resource_id" => resource.id,
         "conditions" => [
-          %{"property" => "client_attested", "operator" => "is_in", "values" => ["true"]}
+          %{"property" => "device_attested", "operator" => "is_in", "values" => ["true"]}
         ]
       }
 
@@ -887,7 +887,7 @@ defmodule PortalAPI.PolicyControllerTest do
 
       attrs = %{
         "conditions" => [
-          %{"property" => "client_attested", "operator" => "is", "values" => ["true"]}
+          %{"property" => "device_attested", "operator" => "is", "values" => ["true"]}
         ]
       }
 
@@ -899,7 +899,7 @@ defmodule PortalAPI.PolicyControllerTest do
 
       assert json_response(conn, 200)["data"]["conditions"] == [
                %{
-                 "property" => "client_attested",
+                 "property" => "device_attested",
                  "operator" => "is",
                  "values" => ["true"]
                }

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -1339,7 +1339,7 @@ defmodule PortalWeb.PoliciesTest do
       assert html =~ "Require Verified Device"
     end
 
-    test "manages client_attested condition", %{conn: conn, account: account, actor: actor} do
+    test "manages device_attested condition", %{conn: conn, account: account, actor: actor} do
       group = group_fixture(account: account)
       resource = resource_fixture(account: account)
       policy = policy_fixture(group: group, resource: resource)
@@ -1350,11 +1350,11 @@ defmodule PortalWeb.PoliciesTest do
         |> live(~p"/#{account}/policies/#{policy.id}/edit")
 
       render_click(lv, "toggle_conditions_dropdown")
-      html = render_click(lv, "add_condition", %{"type" => "client_attested"})
+      html = render_click(lv, "add_condition", %{"type" => "device_attested"})
       assert html =~ "Require attestation"
     end
 
-    test "saves client_attested condition to DB", %{conn: conn, account: account, actor: actor} do
+    test "saves device_attested condition to DB", %{conn: conn, account: account, actor: actor} do
       group = group_fixture(account: account)
       resource = resource_fixture(account: account)
       policy = policy_fixture(group: group, resource: resource)
@@ -1365,7 +1365,7 @@ defmodule PortalWeb.PoliciesTest do
         |> live(~p"/#{account}/policies/#{policy.id}/edit")
 
       render_click(lv, "toggle_conditions_dropdown")
-      render_click(lv, "add_condition", %{"type" => "client_attested"})
+      render_click(lv, "add_condition", %{"type" => "device_attested"})
 
       html =
         lv
@@ -1384,11 +1384,11 @@ defmodule PortalWeb.PoliciesTest do
 
       assert Enum.any?(
                policy.conditions,
-               &(&1.property == :client_attested and &1.values == ["true"])
+               &(&1.property == :device_attested and &1.values == ["true"])
              )
     end
 
-    test "renders client_attested condition from saved policy", %{
+    test "renders device_attested condition from saved policy", %{
       conn: conn,
       account: account,
       actor: actor
@@ -1402,7 +1402,7 @@ defmodule PortalWeb.PoliciesTest do
           resource: resource,
           conditions: [
             %{
-              property: :client_attested,
+              property: :device_attested,
               operator: :is,
               values: ["true"]
             }

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -1338,6 +1338,84 @@ defmodule PortalWeb.PoliciesTest do
 
       assert html =~ "Require Verified Device"
     end
+
+    test "manages client_attested condition", %{conn: conn, account: account, actor: actor} do
+      group = group_fixture(account: account)
+      resource = resource_fixture(account: account)
+      policy = policy_fixture(group: group, resource: resource)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies/#{policy.id}/edit")
+
+      render_click(lv, "toggle_conditions_dropdown")
+      html = render_click(lv, "add_condition", %{"type" => "client_attested"})
+      assert html =~ "Require attestation"
+    end
+
+    test "saves client_attested condition to DB", %{conn: conn, account: account, actor: actor} do
+      group = group_fixture(account: account)
+      resource = resource_fixture(account: account)
+      policy = policy_fixture(group: group, resource: resource)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies/#{policy.id}/edit")
+
+      render_click(lv, "toggle_conditions_dropdown")
+      render_click(lv, "add_condition", %{"type" => "client_attested"})
+
+      html =
+        lv
+        |> form("[phx-submit='submit_policy_form']",
+          policy: %{
+            group_id: group.id,
+            resource_id: resource.id,
+            description: "With client attested condition"
+          }
+        )
+        |> render_submit()
+
+      assert html =~ "updated successfully"
+
+      policy = Repo.get_by!(Policy, id: policy.id, account_id: account.id)
+
+      assert Enum.any?(
+               policy.conditions,
+               &(&1.property == :client_attested and &1.values == ["true"])
+             )
+    end
+
+    test "renders client_attested condition from saved policy", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      group = group_fixture(account: account)
+      resource = resource_fixture(account: account)
+
+      policy =
+        policy_fixture(
+          group: group,
+          resource: resource,
+          conditions: [
+            %{
+              property: :client_attested,
+              operator: :is,
+              values: ["true"]
+            }
+          ]
+        )
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies/#{policy.id}/edit")
+
+      assert html =~ "Require attestation"
+    end
   end
 
   describe ":show action authorizations tab" do


### PR DESCRIPTION
Adds a new policy condition, "Require attestation". It works like "Require Verified Device", but instead of checking whether an admin verified the device, it checks whether the Client presented a valid X.509 certificate from one of the account's trust anchors on its current WebSocket connection.

The check reads the live connection state, so a device that attested on an earlier connection but connected without a certificate this time does not pass.

The condition is available in the policy form for every resource type and through the REST API as the `device_attested` property with the `is` operator.
