### PR TITLE
ci(winget): fail when komac drops an installer

### DIFF
--- a/.github/actions/winget-releaser/action.yml
+++ b/.github/actions/winget-releaser/action.yml
@@ -112,6 +112,21 @@ runs:
         GITHUB_TOKEN: ${{ inputs.token }}
       shell: pwsh
     - run: |
+        # komac update drops installers that have no counterpart in the previous version's manifest; fail instead of publishing a partial manifest.
+        $Out = Join-Path $env:RUNNER_TEMP 'winget-dry-run'
+        komac update '${{ inputs.identifier }}' --version '${{ steps.version-and-urls.outputs.version }}' --dry-run --output $Out --urls ${{ steps.version-and-urls.outputs.urls }}
+        if (-not $?) { exit 1 }
+        $Manifest = (Get-ChildItem -Path $Out -Recurse -Filter '*.installer.yaml' | Get-Content -Raw) -join "`n"
+        $Missing = '${{ steps.version-and-urls.outputs.urls }}'.Split(' ') | Where-Object { -not $Manifest.Contains($_) }
+        if ($Missing) {
+          Write-Output "::error::Installers missing from the generated manifest: $($Missing -join ', '). Seed a manifest that contains them once; komac will carry them forward from there."
+          exit 1
+        }
+      env:
+        KOMAC_FORK_OWNER: ${{ inputs.fork-user }}
+        GITHUB_TOKEN: ${{ inputs.token }}
+      shell: pwsh
+    - run: |
         $ReplaceFlag = $Null
         $ReleaseNotesUrlFlag = $Null
         if (${{ inputs.max-versions-to-keep }} -eq 1) {


### PR DESCRIPTION
The GUI client release already ships a Windows arm64 MSI, and the winget job already passes it to komac. But `komac update` only keeps installers that have a match in the previous version's manifest. A new architecture is silently dropped, so winget kept publishing x64 only.

The arm64 installer has to be seeded once by hand in microsoft/winget-pkgs. From the release after that, komac carries both architectures forward on its own.

This PR makes the job fail loudly when komac drops an installer, instead of publishing a partial manifest.

Related: #14762

---

Fixes https://github.com/firezone/firezone/issues/2992