### PR TITLE
chore(portal): rename the Require Attestation condition labels

### DIFF
--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -1444,7 +1444,7 @@ defmodule PortalWeb.Policies.Components do
     do: "Device must be verified"
 
   defp condition_values_display(%{property: :device_attested}, _providers, _account),
-    do: "Device must be attested"
+    do: "Devices must have a trusted X.509 client certificate"
 
   defp condition_values_display(
          %{property: :auth_provider_id, values: values},
@@ -2281,7 +2281,7 @@ defmodule PortalWeb.Policies.Components do
 
   @spec condition_type_label(atom()) :: String.t()
   def condition_type_label(:client_verified), do: "Require Verified Device"
-  def condition_type_label(:device_attested), do: "Require attestation"
+  def condition_type_label(:device_attested), do: "Require Attestation"
   def condition_type_label(:auth_provider_id), do: "Authentication Provider"
   def condition_type_label(:remote_ip_location_region), do: "Device Location"
   def condition_type_label(:remote_ip), do: "IP Range"

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -1444,7 +1444,7 @@ defmodule PortalWeb.Policies.Components do
     do: "Device must be verified"
 
   defp condition_values_display(%{property: :device_attested}, _providers, _account),
-    do: "Devices must have a trusted X.509 client certificate"
+    do: "Devices must have a trusted X.509 certificate"
 
   defp condition_values_display(
          %{property: :auth_provider_id, values: values},

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -2311,6 +2311,44 @@ defmodule PortalAPI.Client.ChannelTest do
       assert Enum.any?(resources, &(&1.id == resource.id))
     end
 
+    test "for client updates keeps this connection's attestation", %{
+      client: client,
+      actor: actor,
+      account: account,
+      subject: subject
+    } do
+      identity_fixture(actor: actor, account: account)
+      group = group_fixture(account: account)
+      site = site_fixture(account: account)
+      resource = dns_resource_fixture(account: account, site: site, ip_stack: :ipv4_only)
+
+      policy_fixture(
+        account: account,
+        group: group,
+        resource: resource,
+        conditions: [%{property: :device_attested, operator: :is, values: ["true"]}]
+      )
+
+      membership_fixture(account: account, actor: actor, group: group)
+
+      client = verify_device(client)
+      socket = join_channel(client, subject, attested?: true)
+      assert_push "init", %{resources: resources}
+      assert Enum.any?(resources, &(&1.id == resource.id))
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: 100,
+        op: :update,
+        old_struct: broadcast_struct(client),
+        struct: broadcast_struct(%{client | verified_at: nil})
+      })
+
+      assert %{assigns: %{client: updated}} = :sys.get_state(socket.channel_pid)
+      assert updated.attested?
+      assert updated.verified_at == nil
+      refute_push "resource_deleted", _payload
+    end
+
     test "for client address updates resends init with the new tunnel IPs", %{
       client: client,
       subject: subject,

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -1351,7 +1351,7 @@ defmodule PortalWeb.PoliciesTest do
 
       render_click(lv, "toggle_conditions_dropdown")
       html = render_click(lv, "add_condition", %{"type" => "device_attested"})
-      assert html =~ "Require attestation"
+      assert html =~ "Require Attestation"
     end
 
     test "saves device_attested condition to DB", %{conn: conn, account: account, actor: actor} do
@@ -1414,7 +1414,7 @@ defmodule PortalWeb.PoliciesTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/policies/#{policy.id}/edit")
 
-      assert html =~ "Require attestation"
+      assert html =~ "Require Attestation"
     end
   end
 


### PR DESCRIPTION
The "Require attestation" policy condition is now titled "Require Attestation", and its summary in the policy view reads "Devices must have a trusted X.509 client certificate" instead of "Device must be attested". This makes it clear what the condition checks.

This also adds a test that a device update from CDC in the client channel keeps the connection's attested flag, so the condition keeps granting access after the device row changes.

Related: #15173
