### PR TITLE
fix(portal): queue the first sync for a new Okta directory

### DIFF
--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -2181,32 +2181,12 @@ defmodule PortalWeb.Settings.DirectorySync do
   defp forget_subscriptions_on_tenant_change(changeset, _directory), do: changeset
 
   defp queue_initial_sync(
-         {:ok, %Entra.Directory{is_verified: true, is_disabled: false} = directory} = result,
+         {:ok, %{is_verified: true, is_disabled: false} = directory} = result,
          %{assigns: %{account: %{features: %{idp_sync: true}}}}
        ) do
     args = %{"account_id" => directory.account_id, "directory_id" => directory.id}
 
-    case Oban.insert(Entra.Sync.new(args)) do
-      {:ok, _job} ->
-        result
-
-      {:error, reason} ->
-        Logger.info("Failed to enqueue initial directory sync job",
-          id: directory.id,
-          reason: inspect(reason)
-        )
-
-        result
-    end
-  end
-
-  defp queue_initial_sync(
-         {:ok, %Google.Directory{is_verified: true, is_disabled: false} = directory} = result,
-         %{assigns: %{account: %{features: %{idp_sync: true}}}}
-       ) do
-    args = %{"account_id" => directory.account_id, "directory_id" => directory.id}
-
-    case Oban.insert(Google.Sync.new(args)) do
+    case Oban.insert(sync_module(directory).new(args)) do
       {:ok, _job} ->
         result
 

--- a/elixir/test/portal_web/live/settings/directory_sync_test.exs
+++ b/elixir/test/portal_web/live/settings/directory_sync_test.exs
@@ -73,7 +73,7 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
       assert render(lv) =~ "Verified, click to continue"
     end
 
-    test "opens the panel after an okta directory is created", %{
+    test "queues the first sync and opens the panel after an okta directory is created", %{
       conn: conn,
       account: account,
       actor: actor
@@ -104,8 +104,14 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
       render_hook(lv, "submit_directory", %{})
 
       directory = Portal.Repo.get_by!(Portal.Okta.Directory, account_id: account.id, name: "Okta")
+      assert directory.is_verified
       assert_patch(lv, ~p"/#{account}/settings/directory_sync/okta/#{directory.id}/hook")
       assert render(lv) =~ "Waiting for Okta to verify"
+
+      assert_enqueued(
+        worker: Portal.Okta.Sync,
+        args: %{account_id: account.id, directory_id: directory.id}
+      )
     end
 
     test "re-verifies the event hook from the row menu", %{


### PR DESCRIPTION
Creating a verified Entra or Google directory queued a full sync right away. Creating an Okta directory did not, so a new Okta directory showed no users or groups until the two-hourly sync ran, or until the admin clicked Sync Now.

A new Okta directory now queues its first sync the moment it is saved, the same as the other two. The two provider-specific branches became one, keyed on the directory's sync module.

Related: #15149
