### PR TITLE
feat(android): prototype a `firezone status` management CLI

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -49,6 +49,7 @@ val jacocoCli by configurations.creating
 
 android {
     buildFeatures {
+        aidl = true
         buildConfig = true
         resValues = true
     }

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -344,9 +344,7 @@ dependencies {
     // Security
     implementation("androidx.security:security-crypto:1.1.0")
 
-    // Management CLI. `clikt-core` is the clikt artifact without the `mordant` terminal renderer,
-    // which nothing behind `app_process` can use anyway.
-    implementation("com.github.ajalt.clikt:clikt-core:5.1.0")
+    // The CLI's hidden framework interfaces, declared at `app/src/frameworkStubs`.
     compileOnly(files(frameworkStubs))
 
     // JUnit

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -257,6 +257,27 @@ abstract class CollectClasses
         }
     }
 
+// Hand-written declarations of the hidden framework interfaces the CLI talks to. The boot
+// classpath always wins at runtime, so the device never loads these; the jar exists only to give
+// the compiler types to check against, and every signature in it has to match the platform's
+// exactly or the call fails with `NoSuchMethodError` on the device.
+val compileFrameworkStubs =
+    tasks.register<JavaCompile>("compileFrameworkStubs") {
+        source(layout.projectDirectory.dir("src/frameworkStubs/java"))
+        classpath = files(androidComponents.sdkComponents.bootClasspath)
+        destinationDirectory = layout.buildDirectory.dir("frameworkStubs/classes")
+        options.release = 17
+    }
+
+// AGP resolves a compile classpath through an artifact view that accepts only jars, so handing it
+// the class directory instead would drop the stubs without a word.
+val frameworkStubs =
+    tasks.register<Jar>("frameworkStubs") {
+        from(compileFrameworkStubs.map { it.destinationDirectory })
+        archiveFileName = "framework-stubs.jar"
+        destinationDirectory = layout.buildDirectory.dir("frameworkStubs")
+    }
+
 dependencies {
     // The `nodeps` jar is already shaded, so its declared dependencies would only add jars for the
     // report step to pick the wrong one from.
@@ -326,6 +347,7 @@ dependencies {
     // Management CLI. `clikt-core` is the clikt artifact without the `mordant` terminal renderer,
     // which nothing behind `app_process` can use anyway.
     implementation("com.github.ajalt.clikt:clikt-core:5.1.0")
+    compileOnly(files(frameworkStubs))
 
     // JUnit
     testImplementation("junit:junit:4.13.2")

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -323,6 +323,10 @@ dependencies {
     // Security
     implementation("androidx.security:security-crypto:1.1.0")
 
+    // Management CLI. `clikt-core` is the clikt artifact without the `mordant` terminal renderer,
+    // which nothing behind `app_process` can use anyway.
+    implementation("com.github.ajalt.clikt:clikt-core:5.1.0")
+
     // JUnit
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.3.0")

--- a/kotlin/android/app/proguard-rules.pro
+++ b/kotlin/android/app/proguard-rules.pro
@@ -45,3 +45,10 @@
     public static void main(java.lang.String[]);
 }
 -keep class dev.firezone.android.cli.IFirezoneCli$Stub { *; }
+
+# The CLI calls hidden framework interfaces through hand-written `compileOnly` stubs
+# (`app/src/frameworkStubs`), so they are absent from the APK and present on every device's boot
+# classpath.
+-dontwarn android.app.ContentProviderHolder
+-dontwarn android.app.IActivityManager
+-dontwarn android.content.IContentProvider

--- a/kotlin/android/app/proguard-rules.pro
+++ b/kotlin/android/app/proguard-rules.pro
@@ -38,3 +38,10 @@
 # Persisted to SharedPreferences via Gson by constant name; renaming the
 # constants would corrupt existing installs on update.
 -keep class dev.firezone.android.core.data.ResourceState { *; }
+
+# Nothing in the app references the CLI: `app_process` resolves its entry point by name from the
+# shell wrapper, and the AIDL stub behind it is only ever entered from a binder transaction.
+-keep class dev.firezone.android.cli.Main {
+    public static void main(java.lang.String[]);
+}
+-keep class dev.firezone.android.cli.IFirezoneCli$Stub { *; }

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/CliE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/CliE2eTest.kt
@@ -4,22 +4,24 @@ package dev.firezone.android.e2e
 import android.content.SharedPreferences
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.data.TokenStore
 import dev.firezone.android.tunnel.ACCOUNT_SLUG
 import dev.firezone.android.tunnel.ACTOR_NAME
 import dev.firezone.android.tunnel.FakeSessionFactory
+import dev.firezone.android.tunnel.TUN_IPV4
+import dev.firezone.android.tunnel.TUN_IPV6
 import dev.firezone.android.tunnel.TestRestrictions
-import dev.firezone.android.tunnel.engineeringWiki
 import dev.firezone.android.tunnel.finishAllActivities
 import dev.firezone.android.tunnel.grantNotificationPermission
 import dev.firezone.android.tunnel.grantVpnConsent
 import dev.firezone.android.tunnel.shellOutput
 import dev.firezone.android.tunnel.startTunnelService
 import dev.firezone.android.tunnel.stopTunnelService
+import dev.firezone.android.tunnel.tunInterfaceUpdated
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -36,6 +38,9 @@ class CliE2eTest {
 
     @Inject
     internal lateinit var tokenStore: TokenStore
+
+    @Inject
+    lateinit var repository: Repository
 
     @Inject
     lateinit var preferences: SharedPreferences
@@ -62,22 +67,35 @@ class CliE2eTest {
         val session = runBlocking { withTimeout(TIMEOUT_MS) { FakeSessionFactory.awaitSession() } }
 
         session.emit(Event.ConnectedToPortal(accountSlug = ACCOUNT_SLUG, actorName = ACTOR_NAME))
-        session.emit(
-            Event.ResourcesUpdated(
-                resources = listOf(engineeringWiki),
-                connectedDevices = emptyList(),
+        session.emit(tunInterfaceUpdated())
+
+        val status = awaitStatus("the tunnel addresses to reach the CLI") { it.contains(TUN_IPV6) }
+
+        assertEquals(
+            listOf(
+                "signed-in: yes",
+                "account: $ACCOUNT_SLUG",
+                "actor: $ACTOR_NAME",
+                "tunnel-ipv4: $TUN_IPV4",
+                "tunnel-ipv6: $TUN_IPV6",
             ),
+            status.trim().lines(),
         )
+    }
 
-        val status = awaitStatus("the resource to reach the CLI") { it.contains("Engineering wiki") }
+    // Whether we are signed in and which account we belong to outlive the tunnel, so the CLI has
+    // to answer both without one.
+    @Test
+    fun statusReportsTheAccountWhileTheTunnelIsDown() {
+        tokenStore.save(TOKEN)
+        runBlocking { repository.saveAccountSlug(ACCOUNT_SLUG).collect {} }
 
-        assertTrue(status, status.contains("Tunnel: UP"))
-        assertTrue(status, status.contains("Signed in as: $ACTOR_NAME"))
+        assertEquals(listOf("signed-in: yes", "account: $ACCOUNT_SLUG"), status().trim().lines())
     }
 
     @Test
-    fun statusReportsTheTunnelIsDownWhenItIsNotRunning() {
-        assertEquals("Tunnel: DOWN", status().trim())
+    fun statusReportsBeingSignedOutWhenThereIsNoToken() {
+        assertEquals(listOf("signed-in: no"), status().trim().lines())
     }
 
     private fun awaitStatus(

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/CliE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/CliE2eTest.kt
@@ -15,14 +15,12 @@ import dev.firezone.android.tunnel.TestRestrictions
 import dev.firezone.android.tunnel.finishAllActivities
 import dev.firezone.android.tunnel.grantNotificationPermission
 import dev.firezone.android.tunnel.grantVpnConsent
-import dev.firezone.android.tunnel.revokeVpnConsent
 import dev.firezone.android.tunnel.shellOutput
 import dev.firezone.android.tunnel.startTunnelService
 import dev.firezone.android.tunnel.stopTunnelService
 import dev.firezone.android.tunnel.tunInterfaceUpdated
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -60,15 +58,6 @@ class CliE2eTest {
         stopTunnelService()
         preferences.edit().clear().commit()
         TestRestrictions.bundle.clear()
-    }
-
-    // `TunInterfaceUpdated` makes the service establish a real interface, and the framework binds
-    // it to dispatch `onRevoke`. That binding outlives `stopService`, and a bound service never
-    // leaves `getRunningServices`, so every later test would wait for a stop that cannot happen.
-    @After
-    fun tearDown() {
-        revokeVpnConsent()
-        stopTunnelService()
     }
 
     @Test

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/CliE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/CliE2eTest.kt
@@ -15,12 +15,14 @@ import dev.firezone.android.tunnel.TestRestrictions
 import dev.firezone.android.tunnel.finishAllActivities
 import dev.firezone.android.tunnel.grantNotificationPermission
 import dev.firezone.android.tunnel.grantVpnConsent
+import dev.firezone.android.tunnel.revokeVpnConsent
 import dev.firezone.android.tunnel.shellOutput
 import dev.firezone.android.tunnel.startTunnelService
 import dev.firezone.android.tunnel.stopTunnelService
 import dev.firezone.android.tunnel.tunInterfaceUpdated
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -58,6 +60,15 @@ class CliE2eTest {
         stopTunnelService()
         preferences.edit().clear().commit()
         TestRestrictions.bundle.clear()
+    }
+
+    // `TunInterfaceUpdated` makes the service establish a real interface, and the framework binds
+    // it to dispatch `onRevoke`. That binding outlives `stopService`, and a bound service never
+    // leaves `getRunningServices`, so every later test would wait for a stop that cannot happen.
+    @After
+    fun tearDown() {
+        revokeVpnConsent()
+        stopTunnelService()
     }
 
     @Test

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/CliE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/CliE2eTest.kt
@@ -1,0 +1,127 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.e2e
+
+import android.content.SharedPreferences
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dev.firezone.android.core.data.TokenStore
+import dev.firezone.android.tunnel.ACCOUNT_SLUG
+import dev.firezone.android.tunnel.ACTOR_NAME
+import dev.firezone.android.tunnel.FakeSessionFactory
+import dev.firezone.android.tunnel.TestRestrictions
+import dev.firezone.android.tunnel.engineeringWiki
+import dev.firezone.android.tunnel.finishAllActivities
+import dev.firezone.android.tunnel.grantNotificationPermission
+import dev.firezone.android.tunnel.grantVpnConsent
+import dev.firezone.android.tunnel.shellOutput
+import dev.firezone.android.tunnel.startTunnelService
+import dev.firezone.android.tunnel.stopTunnelService
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import uniffi.connlib.Event
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+// End-to-end the way an operator runs the CLI: the wrapper script on the device, the app's own
+// APK under `app_process`, and a binder hop into whatever the tunnel is currently doing.
+@HiltAndroidTest
+class CliE2eTest {
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    internal lateinit var tokenStore: TokenStore
+
+    @Inject
+    lateinit var preferences: SharedPreferences
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+        grantVpnConsent()
+        grantNotificationPermission()
+        // Order matters: ending the last test's sessions lets its service finish, and finishing
+        // its activities releases the binding that would otherwise keep the service alive.
+        FakeSessionFactory.reset()
+        finishAllActivities()
+        stopTunnelService()
+        preferences.edit().clear().commit()
+        TestRestrictions.bundle.clear()
+    }
+
+    @Test
+    fun statusReachesTheShell() {
+        tokenStore.save(TOKEN)
+        startTunnelService()
+
+        val session = runBlocking { withTimeout(TIMEOUT_MS) { FakeSessionFactory.awaitSession() } }
+
+        session.emit(Event.ConnectedToPortal(accountSlug = ACCOUNT_SLUG, actorName = ACTOR_NAME))
+        session.emit(
+            Event.ResourcesUpdated(
+                resources = listOf(engineeringWiki),
+                connectedDevices = emptyList(),
+            ),
+        )
+
+        val status = awaitStatus("the resource to reach the CLI") { it.contains("Engineering wiki") }
+
+        assertTrue(status, status.contains("Tunnel: UP"))
+        assertTrue(status, status.contains("Signed in as: $ACTOR_NAME"))
+    }
+
+    @Test
+    fun statusReportsTheTunnelIsDownWhenItIsNotRunning() {
+        assertEquals("Tunnel: DOWN", status().trim())
+    }
+
+    private fun awaitStatus(
+        what: String,
+        condition: (String) -> Boolean,
+    ): String {
+        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(TIMEOUT_MS)
+
+        while (true) {
+            val status = status()
+
+            if (condition(status)) {
+                return status
+            }
+
+            if (System.nanoTime() > deadline) {
+                throw AssertionError("Timed out waiting for $what, the CLI last said:\n$status")
+            }
+
+            Thread.sleep(500)
+        }
+    }
+
+    // A single token, because `shellOutput` tokenizes rather than running a shell. Everything the
+    // CLI needs a shell for lives in the wrapper script instead.
+    private fun status(): String {
+        val output =
+            try {
+                shellOutput("$CLI status")
+            } catch (e: Exception) {
+                throw AssertionError("Could not run $CLI. $PUSHED_BY", e)
+            }
+
+        if (output.isBlank()) {
+            throw AssertionError("$CLI printed nothing. $PUSHED_BY")
+        }
+
+        return output
+    }
+
+    private companion object {
+        const val TOKEN = "stored-token"
+        const val TIMEOUT_MS = 20_000L
+        const val CLI = "/data/local/tmp/firezone"
+        const val PUSHED_BY = "kotlin/android/mise-tasks/emulator-tests.sh pushes it, so run the suite through that."
+    }
+}

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/CliE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/CliE2eTest.kt
@@ -22,6 +22,7 @@ import dev.firezone.android.tunnel.tunInterfaceUpdated
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -96,6 +97,15 @@ class CliE2eTest {
     @Test
     fun statusReportsBeingSignedOutWhenThereIsNoToken() {
         assertEquals(listOf("signed-in: no"), status().trim().lines())
+    }
+
+    // The usage text is generated from the command list, so this is what catches a command that
+    // was added without a description, and the only path that reads the parser's own output.
+    @Test
+    fun theHelpListsTheCommands() {
+        val help = shellOutput("$CLI --help")
+
+        assertTrue(help, help.contains("status"))
     }
 
     private fun awaitStatus(

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Connlib.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Connlib.kt
@@ -1,9 +1,11 @@
 // Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
 package dev.firezone.android.tunnel
 
+import uniffi.connlib.Cidr
 import uniffi.connlib.ConnectedDevice
 import uniffi.connlib.DisconnectError
 import uniffi.connlib.DnsResource
+import uniffi.connlib.Event
 import uniffi.connlib.InternetResource
 import uniffi.connlib.NoHandle
 import uniffi.connlib.Resource
@@ -26,6 +28,18 @@ class FakeDisconnectError(
 // The deployment the screenshot fixtures describe, so the galleries and these tests tell one story.
 const val ACTOR_NAME = "Jane Doe"
 const val ACCOUNT_SLUG = "example-corp"
+const val TUN_IPV4 = "100.64.7.41"
+const val TUN_IPV6 = "fd00:2021:1111::29"
+
+fun tunInterfaceUpdated() =
+    Event.TunInterfaceUpdated(
+        ipv4 = TUN_IPV4,
+        ipv6 = TUN_IPV6,
+        dns = listOf("100.100.111.1"),
+        searchDomain = null,
+        ipv4Routes = listOf(Cidr(address = "100.64.0.0", prefix = 11u)),
+        ipv6Routes = listOf(Cidr(address = "fd00:2021:1111::", prefix = 48u)),
+    )
 
 val engineeringWiki =
     Resource.Dns(

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/FakeSession.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/FakeSession.kt
@@ -1,6 +1,7 @@
 // Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
 package dev.firezone.android.tunnel
 
+import android.os.ParcelFileDescriptor
 import kotlinx.coroutines.channels.Channel
 import uniffi.connlib.AndroidSessionConfig
 import uniffi.connlib.ClientTlsIdentity
@@ -13,6 +14,11 @@ class FakeSession(
     val tlsIdentity: ClientTlsIdentity?,
 ) : TunnelSession {
     private val events = Channel<Event>(Channel.UNLIMITED)
+
+    // connlib owns the descriptor it is handed. Leaving it open keeps the interface the
+    // service established alive, and the framework holds the service bound while one is up,
+    // which no amount of stopping the service undoes.
+    private var tun: ParcelFileDescriptor? = null
 
     val commands = Channel<String>(Channel.UNLIMITED)
 
@@ -52,10 +58,14 @@ class FakeSession(
 
     override fun setTun(fd: Int) {
         commands.trySend("setTun")
+        tun?.close()
+        tun = ParcelFileDescriptor.adoptFd(fd)
     }
 
     override fun close() {
         events.close()
         commands.close()
+        tun?.close()
+        tun = null
     }
 }

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
@@ -20,6 +20,12 @@ fun grantVpnConsent() {
     shell("appops set ${packageName()} ACTIVATE_VPN allow")
 }
 
+// The framework watches this op and revokes a VPN whose consent is withdrawn, which is the only
+// lever a test has on an interface the app has already established.
+fun revokeVpnConsent() {
+    shell("appops set ${packageName()} ACTIVATE_VPN deny")
+}
+
 // Without it the splash screen sends the app to the permission prompt instead of the session, and
 // nothing the tunnel posts on disconnect ever reaches the shade.
 fun grantNotificationPermission() {
@@ -184,5 +190,15 @@ private fun describeTunnelService(context: Context): String {
             .firstOrNull { it.service.className == TunnelService::class.java.name }
             ?: return "no record"
 
-    return "started=${info.started}, clients=${info.clientCount}, foreground=${info.foreground}"
+    return "started=${info.started}, clients=${info.clientCount}, foreground=${info.foreground}, " +
+        "bound by ${boundBy()}"
 }
+
+// `clientCount` says how many bindings hold the service open but not whose, and an established
+// VPN is bound by the framework itself rather than by anything a test can finish.
+private fun boundBy(): String =
+    shellOutput("dumpsys activity services ${packageName()}")
+        .lines()
+        .filter { it.contains("Connection") }
+        .joinToString("; ") { it.trim() }
+        .ifEmpty { "nothing the dump names" }

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
@@ -20,12 +20,6 @@ fun grantVpnConsent() {
     shell("appops set ${packageName()} ACTIVATE_VPN allow")
 }
 
-// The framework watches this op and revokes a VPN whose consent is withdrawn, which is the only
-// lever a test has on an interface the app has already established.
-fun revokeVpnConsent() {
-    shell("appops set ${packageName()} ACTIVATE_VPN deny")
-}
-
 // Without it the splash screen sends the app to the permission prompt instead of the session, and
 // nothing the tunnel posts on disconnect ever reaches the shade.
 fun grantNotificationPermission() {

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
@@ -170,8 +170,7 @@ private fun packageName() = InstrumentationRegistry.getInstrumentation().targetC
 
 // `executeShellCommand` does not run a shell: it splits the line on whitespace and executes that,
 // so quotes, pipes, redirects and `VAR=value` prefixes reach the program as literal arguments.
-fun shellOutput(command: String): String =
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).executeShellCommand(command)
+fun shellOutput(command: String): String = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).executeShellCommand(command)
 
 private fun shell(command: String) {
     shellOutput(command)

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Instrumentation.kt
@@ -168,8 +168,13 @@ fun photographScreen(name: String) {
 
 private fun packageName() = InstrumentationRegistry.getInstrumentation().targetContext.packageName
 
-private fun shell(command: String) {
+// `executeShellCommand` does not run a shell: it splits the line on whitespace and executes that,
+// so quotes, pipes, redirects and `VAR=value` prefixes reach the program as literal arguments.
+fun shellOutput(command: String): String =
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).executeShellCommand(command)
+
+private fun shell(command: String) {
+    shellOutput(command)
 }
 
 @Suppress("DEPRECATION")

--- a/kotlin/android/app/src/frameworkStubs/java/android/app/ContentProviderHolder.java
+++ b/kotlin/android/app/src/frameworkStubs/java/android/app/ContentProviderHolder.java
@@ -1,0 +1,7 @@
+package android.app;
+
+import android.content.IContentProvider;
+
+public class ContentProviderHolder {
+    public IContentProvider provider;
+}

--- a/kotlin/android/app/src/frameworkStubs/java/android/app/IActivityManager.java
+++ b/kotlin/android/app/src/frameworkStubs/java/android/app/IActivityManager.java
@@ -1,0 +1,12 @@
+package android.app;
+
+import android.os.IBinder;
+import android.os.IInterface;
+import android.os.RemoteException;
+
+public interface IActivityManager extends IInterface {
+    ContentProviderHolder getContentProviderExternal(String name, int userId, IBinder token, String tag)
+            throws RemoteException;
+
+    void removeContentProviderExternalAsUser(String name, IBinder token, int userId) throws RemoteException;
+}

--- a/kotlin/android/app/src/frameworkStubs/java/android/content/IContentProvider.java
+++ b/kotlin/android/app/src/frameworkStubs/java/android/content/IContentProvider.java
@@ -1,0 +1,10 @@
+package android.content;
+
+import android.os.Bundle;
+import android.os.IInterface;
+import android.os.RemoteException;
+
+public interface IContentProvider extends IInterface {
+    Bundle call(AttributionSource attributionSource, String authority, String method, String arg, Bundle extras)
+            throws RemoteException;
+}

--- a/kotlin/android/app/src/main/AndroidManifest.xml
+++ b/kotlin/android/app/src/main/AndroidManifest.xml
@@ -100,6 +100,12 @@
         </service>
 
         <provider
+            android:name="dev.firezone.android.cli.CliProvider"
+            android:authorities="dev.firezone.android.cli"
+            android:exported="true"
+            android:grantUriPermissions="false" />
+
+        <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"
             android:exported="false"

--- a/kotlin/android/app/src/main/aidl/dev/firezone/android/cli/IFirezoneCli.aidl
+++ b/kotlin/android/app/src/main/aidl/dev/firezone/android/cli/IFirezoneCli.aidl
@@ -1,0 +1,7 @@
+package dev.firezone.android.cli;
+
+interface IFirezoneCli {
+    int protocolVersion();
+
+    String status();
+}

--- a/kotlin/android/app/src/main/aidl/dev/firezone/android/cli/IFirezoneCli.aidl
+++ b/kotlin/android/app/src/main/aidl/dev/firezone/android/cli/IFirezoneCli.aidl
@@ -1,7 +1,9 @@
 package dev.firezone.android.cli;
 
+import dev.firezone.android.cli.Status;
+
 interface IFirezoneCli {
     int protocolVersion();
 
-    String status();
+    Status status();
 }

--- a/kotlin/android/app/src/main/aidl/dev/firezone/android/cli/Status.aidl
+++ b/kotlin/android/app/src/main/aidl/dev/firezone/android/cli/Status.aidl
@@ -1,0 +1,3 @@
+package dev.firezone.android.cli;
+
+parcelable Status;

--- a/kotlin/android/app/src/main/java/dev/firezone/android/cli/CliProvider.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/cli/CliProvider.kt
@@ -1,0 +1,150 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.cli
+
+import android.content.ComponentName
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.database.Cursor
+import android.net.Uri
+import android.os.Binder
+import android.os.Bundle
+import android.os.IBinder
+import android.os.Process
+import dev.firezone.android.tunnel.TunnelService
+import dev.firezone.android.tunnel.model.Resource
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+internal const val CLI_AUTHORITY = "dev.firezone.android.cli"
+internal const val HANDSHAKE_METHOD = "handshake"
+internal const val BINDER_KEY = "binder"
+
+private const val PROTOCOL_VERSION = 1
+private const val BIND_TIMEOUT_MS = 5_000L
+private const val TUNNEL_DOWN = "Tunnel: DOWN"
+
+// The CLI runs outside the app and has no `Context` to reach the tunnel with. A provider is the
+// one component the shell can address without one, so the handshake hands it a binder instead.
+class CliProvider : ContentProvider() {
+    private val cli =
+        object : IFirezoneCli.Stub() {
+            override fun protocolVersion(): Int = PROTOCOL_VERSION
+
+            override fun status(): String = report(context!!)
+        }
+
+    override fun onCreate(): Boolean = true
+
+    override fun call(
+        method: String,
+        arg: String?,
+        extras: Bundle?,
+    ): Bundle {
+        val uid = Binder.getCallingUid()
+
+        if (uid != Process.SHELL_UID && uid != Process.ROOT_UID) {
+            throw SecurityException("uid $uid may not talk to the Firezone CLI")
+        }
+
+        if (method != HANDSHAKE_METHOD) {
+            throw IllegalArgumentException("Unknown method '$method'")
+        }
+
+        return Bundle().apply { putBinder(BINDER_KEY, cli) }
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(
+        uri: Uri,
+        values: ContentValues?,
+    ): Uri? = null
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = 0
+
+    override fun delete(
+        uri: Uri,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = 0
+
+    private fun report(context: Context): String {
+        if (!TunnelService.isRunning(context)) {
+            return TUNNEL_DOWN
+        }
+
+        val connection = TunnelConnection()
+
+        // Flags 0 rather than `BIND_AUTO_CREATE`: asking after the tunnel must never be what
+        // starts it.
+        if (!context.bindService(Intent(context, TunnelService::class.java), connection, 0)) {
+            throw IllegalStateException("The tunnel service is running but refused the binding")
+        }
+
+        try {
+            val service =
+                connection.await()
+                    ?: throw IllegalStateException("The tunnel service did not answer within ${BIND_TIMEOUT_MS}ms")
+
+            return describe(service)
+        } finally {
+            context.unbindService(connection)
+        }
+    }
+
+    private fun describe(service: TunnelService): String =
+        buildString {
+            appendLine("Tunnel: ${service.serviceState.value}")
+
+            service.actorNameState.value?.let { appendLine("Signed in as: $it") }
+
+            val resources = service.resourcesState.value
+            appendLine("Resources: ${resources.size}")
+            resources.forEach { appendLine("  ${describe(it)}") }
+
+            val devices = service.connectedDevicesState.value
+            if (devices.isNotEmpty()) {
+                appendLine("Connected devices: ${devices.size}")
+                devices.forEach { appendLine("  ${it.name} (${it.tunIpv4})") }
+            }
+        }.trimEnd()
+
+    private fun describe(resource: Resource): String = resource.address?.let { "${resource.name} ($it)" } ?: resource.name
+
+    // The AIDL call arrives on a binder thread, which is the only one allowed to wait here:
+    // `onServiceConnected` is dispatched on the main thread.
+    private class TunnelConnection : ServiceConnection {
+        private val connected = CountDownLatch(1)
+
+        @Volatile
+        private var service: TunnelService? = null
+
+        override fun onServiceConnected(
+            name: ComponentName?,
+            binder: IBinder?,
+        ) {
+            service = (binder as TunnelService.LocalBinder).getService()
+            connected.countDown()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {}
+
+        fun await(): TunnelService? = if (connected.await(BIND_TIMEOUT_MS, TimeUnit.MILLISECONDS)) service else null
+    }
+}

--- a/kotlin/android/app/src/main/java/dev/firezone/android/cli/CliProvider.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/cli/CliProvider.kt
@@ -12,8 +12,13 @@ import android.net.Uri
 import android.os.Binder
 import android.os.Bundle
 import android.os.IBinder
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.data.TokenStore
 import dev.firezone.android.tunnel.TunnelService
-import dev.firezone.android.tunnel.model.Resource
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -28,7 +33,16 @@ private const val PROTOCOL_VERSION = 1
 private const val SHELL_UID = 2000
 private const val ROOT_UID = 0
 private const val BIND_TIMEOUT_MS = 5_000L
-private const val TUNNEL_DOWN = "Tunnel: DOWN"
+
+// Providers are created before `Application.onCreate`, so `@AndroidEntryPoint` cannot inject one.
+// The graph is up by the time a transaction arrives, which is why this is resolved per call.
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+internal interface CliEntryPoint {
+    fun tokenStore(): TokenStore
+
+    fun repository(): Repository
+}
 
 // The CLI runs outside the app and has no `Context` to reach the tunnel with. A provider is the
 // one component the shell can address without one, so the handshake hands it a binder instead.
@@ -37,7 +51,7 @@ class CliProvider : ContentProvider() {
         object : IFirezoneCli.Stub() {
             override fun protocolVersion(): Int = PROTOCOL_VERSION
 
-            override fun status(): String = report(context!!)
+            override fun status(): Status = report(context!!)
         }
 
     override fun onCreate(): Boolean = true
@@ -88,9 +102,22 @@ class CliProvider : ContentProvider() {
         selectionArgs: Array<out String>?,
     ): Int = 0
 
-    private fun report(context: Context): String {
+    private fun report(context: Context): Status {
+        val app = EntryPointAccessors.fromApplication(context, CliEntryPoint::class.java)
+        val config = app.repository().getConfigSync()
+        val signedIn = app.tokenStore().get() != null
+        val accountSlug = config.accountSlug.ifEmpty { null }
+
+        // Who we are signed in as and which addresses we hold are the only fields the service
+        // knows, so nothing else pays for the binding.
         if (!TunnelService.isRunning(context)) {
-            return TUNNEL_DOWN
+            return Status(
+                signedIn = signedIn,
+                accountSlug = accountSlug,
+                actorName = null,
+                tunnelIpv4 = null,
+                tunnelIpv6 = null,
+            )
         }
 
         val connection = TunnelConnection()
@@ -106,30 +133,17 @@ class CliProvider : ContentProvider() {
                 connection.await()
                     ?: throw IllegalStateException("The tunnel service did not answer within ${BIND_TIMEOUT_MS}ms")
 
-            return describe(service)
+            return Status(
+                signedIn = signedIn,
+                accountSlug = accountSlug,
+                actorName = service.actorNameState.value,
+                tunnelIpv4 = service.tunnelIpv4State.value,
+                tunnelIpv6 = service.tunnelIpv6State.value,
+            )
         } finally {
             context.unbindService(connection)
         }
     }
-
-    private fun describe(service: TunnelService): String =
-        buildString {
-            appendLine("Tunnel: ${service.serviceState.value}")
-
-            service.actorNameState.value?.let { appendLine("Signed in as: $it") }
-
-            val resources = service.resourcesState.value
-            appendLine("Resources: ${resources.size}")
-            resources.forEach { appendLine("  ${describe(it)}") }
-
-            val devices = service.connectedDevicesState.value
-            if (devices.isNotEmpty()) {
-                appendLine("Connected devices: ${devices.size}")
-                devices.forEach { appendLine("  ${it.name} (${it.tunIpv4})") }
-            }
-        }.trimEnd()
-
-    private fun describe(resource: Resource): String = resource.address?.let { "${resource.name} ($it)" } ?: resource.name
 
     // The AIDL call arrives on a binder thread, which is the only one allowed to wait here:
     // `onServiceConnected` is dispatched on the main thread.

--- a/kotlin/android/app/src/main/java/dev/firezone/android/cli/CliProvider.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/cli/CliProvider.kt
@@ -1,17 +1,13 @@
 // Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
 package dev.firezone.android.cli
 
-import android.content.ComponentName
 import android.content.ContentProvider
 import android.content.ContentValues
 import android.content.Context
-import android.content.Intent
-import android.content.ServiceConnection
 import android.database.Cursor
 import android.net.Uri
 import android.os.Binder
 import android.os.Bundle
-import android.os.IBinder
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
@@ -19,8 +15,6 @@ import dagger.hilt.components.SingletonComponent
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.core.data.TokenStore
 import dev.firezone.android.tunnel.TunnelService
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 internal const val CLI_AUTHORITY = "dev.firezone.android.cli"
 internal const val HANDSHAKE_METHOD = "handshake"
@@ -32,7 +26,6 @@ private const val PROTOCOL_VERSION = 1
 // supports 26.
 private const val SHELL_UID = 2000
 private const val ROOT_UID = 0
-private const val BIND_TIMEOUT_MS = 5_000L
 
 // Providers are created before `Application.onCreate`, so `@AndroidEntryPoint` cannot inject one.
 // The graph is up by the time a transaction arrives, which is why this is resolved per call.
@@ -102,67 +95,20 @@ class CliProvider : ContentProvider() {
         selectionArgs: Array<out String>?,
     ): Int = 0
 
+    // The provider shares its process with the tunnel, so it reads the live service rather than
+    // binding to reach an object this process already holds. Nothing here can start the tunnel,
+    // which is the point: asking after it must not be what brings it up.
     private fun report(context: Context): Status {
         val app = EntryPointAccessors.fromApplication(context, CliEntryPoint::class.java)
-        val config = app.repository().getConfigSync()
-        val signedIn = app.tokenStore().get() != null
-        val accountSlug = config.accountSlug.ifEmpty { null }
+        val service = TunnelService.running()
+        val accountSlug = app.repository().getConfigSync().accountSlug
 
-        // Who we are signed in as and which addresses we hold are the only fields the service
-        // knows, so nothing else pays for the binding.
-        if (!TunnelService.isRunning(context)) {
-            return Status(
-                signedIn = signedIn,
-                accountSlug = accountSlug,
-                actorName = null,
-                tunnelIpv4 = null,
-                tunnelIpv6 = null,
-            )
-        }
-
-        val connection = TunnelConnection()
-
-        // Flags 0 rather than `BIND_AUTO_CREATE`: asking after the tunnel must never be what
-        // starts it.
-        if (!context.bindService(Intent(context, TunnelService::class.java), connection, 0)) {
-            throw IllegalStateException("The tunnel service is running but refused the binding")
-        }
-
-        try {
-            val service =
-                connection.await()
-                    ?: throw IllegalStateException("The tunnel service did not answer within ${BIND_TIMEOUT_MS}ms")
-
-            return Status(
-                signedIn = signedIn,
-                accountSlug = accountSlug,
-                actorName = service.actorNameState.value,
-                tunnelIpv4 = service.tunnelIpv4State.value,
-                tunnelIpv6 = service.tunnelIpv6State.value,
-            )
-        } finally {
-            context.unbindService(connection)
-        }
-    }
-
-    // The AIDL call arrives on a binder thread, which is the only one allowed to wait here:
-    // `onServiceConnected` is dispatched on the main thread.
-    private class TunnelConnection : ServiceConnection {
-        private val connected = CountDownLatch(1)
-
-        @Volatile
-        private var service: TunnelService? = null
-
-        override fun onServiceConnected(
-            name: ComponentName?,
-            binder: IBinder?,
-        ) {
-            service = (binder as TunnelService.LocalBinder).getService()
-            connected.countDown()
-        }
-
-        override fun onServiceDisconnected(name: ComponentName?) {}
-
-        fun await(): TunnelService? = if (connected.await(BIND_TIMEOUT_MS, TimeUnit.MILLISECONDS)) service else null
+        return Status(
+            signedIn = app.tokenStore().get() != null,
+            accountSlug = accountSlug.ifEmpty { null },
+            actorName = service?.actorNameState?.value,
+            tunnelIpv4 = service?.tunnelIpv4State?.value,
+            tunnelIpv6 = service?.tunnelIpv6State?.value,
+        )
     }
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/cli/CliProvider.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/cli/CliProvider.kt
@@ -12,7 +12,6 @@ import android.net.Uri
 import android.os.Binder
 import android.os.Bundle
 import android.os.IBinder
-import android.os.Process
 import dev.firezone.android.tunnel.TunnelService
 import dev.firezone.android.tunnel.model.Resource
 import java.util.concurrent.CountDownLatch
@@ -23,6 +22,11 @@ internal const val HANDSHAKE_METHOD = "handshake"
 internal const val BINDER_KEY = "binder"
 
 private const val PROTOCOL_VERSION = 1
+
+// `Process.SHELL_UID` and `Process.ROOT_UID` name these, but only since API 29, and the app
+// supports 26.
+private const val SHELL_UID = 2000
+private const val ROOT_UID = 0
 private const val BIND_TIMEOUT_MS = 5_000L
 private const val TUNNEL_DOWN = "Tunnel: DOWN"
 
@@ -45,7 +49,7 @@ class CliProvider : ContentProvider() {
     ): Bundle {
         val uid = Binder.getCallingUid()
 
-        if (uid != Process.SHELL_UID && uid != Process.ROOT_UID) {
+        if (uid != SHELL_UID && uid != ROOT_UID) {
             throw SecurityException("uid $uid may not talk to the Firezone CLI")
         }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/cli/Main.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/cli/Main.kt
@@ -1,0 +1,120 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.cli
+
+import android.content.AttributionSource
+import android.os.Binder
+import android.os.Build
+import android.os.Bundle
+import android.os.IBinder
+import android.os.Looper
+import android.os.Process
+import java.lang.reflect.InvocationTargetException
+
+private const val USAGE = "usage: firezone status"
+
+// `adb shell` runs as the primary user and this prototype offers no way to name another one.
+private const val USER_ID = 0
+
+private const val CALLING_PACKAGE = "com.android.shell"
+
+object Main {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val code = run(args)
+
+        // The binder threads this process picked up are not daemons, so returning from `main`
+        // would leave it running.
+        System.exit(code)
+    }
+
+    private fun run(args: Array<String>): Int {
+        if (args.size != 1 || args[0] != "status") {
+            System.err.println(USAGE)
+
+            return 2
+        }
+
+        // `app_process` starts a bare VM, and the framework code below expects to run on a thread
+        // that has the main looper.
+        Looper.prepareMainLooper()
+
+        return try {
+            println(status())
+
+            0
+        } catch (e: Exception) {
+            // Reflection reports whatever the app threw wrapped, and the wrapper carries no message.
+            val failure = (e as? InvocationTargetException)?.cause ?: e
+
+            System.err.println("firezone: ${failure.message ?: failure}")
+
+            1
+        }
+    }
+
+    // The same route AOSP's `content` tool takes: `IActivityManager` needs no `Context`, which this
+    // process has none of, and it starts the app if it is not already running.
+    private fun status(): String {
+        val activityManager =
+            Class
+                .forName("android.app.ActivityManager")
+                .getMethod("getService")
+                .invoke(null)
+        val iActivityManager = Class.forName("android.app.IActivityManager")
+        val token = Binder()
+
+        val holder =
+            iActivityManager
+                .getMethod(
+                    "getContentProviderExternal",
+                    String::class.java,
+                    Int::class.javaPrimitiveType,
+                    IBinder::class.java,
+                    String::class.java,
+                ).invoke(activityManager, CLI_AUTHORITY, USER_ID, token, "firezone")
+                ?: throw IllegalStateException("No provider for $CLI_AUTHORITY. Is the Firezone app installed?")
+
+        try {
+            val provider = holder.javaClass.getField("provider").get(holder)
+            val handshake = handshake(provider) ?: throw IllegalStateException("The app refused the handshake")
+            val cli =
+                IFirezoneCli.Stub.asInterface(handshake.getBinder(BINDER_KEY))
+                    ?: throw IllegalStateException("The handshake carried no binder")
+
+            return cli.status()
+        } finally {
+            iActivityManager
+                .getMethod(
+                    "removeContentProviderExternalAsUser",
+                    String::class.java,
+                    IBinder::class.java,
+                    Int::class.javaPrimitiveType,
+                ).invoke(activityManager, CLI_AUTHORITY, token, USER_ID)
+        }
+    }
+
+    private fun handshake(provider: Any): Bundle? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            throw IllegalStateException(
+                "`IContentProvider#call` takes an `AttributionSource` only since API 31, this device is API ${Build.VERSION.SDK_INT}",
+            )
+        }
+
+        val attributionSource =
+            AttributionSource
+                .Builder(Process.myUid())
+                .setPackageName(CALLING_PACKAGE)
+                .build()
+
+        return Class
+            .forName("android.content.IContentProvider")
+            .getMethod(
+                "call",
+                AttributionSource::class.java,
+                String::class.java,
+                String::class.java,
+                String::class.java,
+                Bundle::class.java,
+            ).invoke(provider, attributionSource, CLI_AUTHORITY, HANDSHAKE_METHOD, null, null) as Bundle?
+    }
+}

--- a/kotlin/android/app/src/main/java/dev/firezone/android/cli/Main.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/cli/Main.kt
@@ -9,50 +9,78 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Looper
 import android.os.Process
-import com.github.ajalt.clikt.core.CliktError
-import com.github.ajalt.clikt.core.Context
-import com.github.ajalt.clikt.core.CoreCliktCommand
-import com.github.ajalt.clikt.core.main
-import com.github.ajalt.clikt.core.subcommands
 
 // `adb shell` runs as the primary user and this prototype offers no way to name another one.
 private const val USER_ID = 0
 
 private const val CALLING_PACKAGE = "com.android.shell"
 
+// A new command is an entry here plus an arm in `execute`, which the compiler asks for because
+// the `when` over this is exhaustive. The usage text is built from these, so it cannot fall behind.
+private enum class Subcommand(
+    val label: String,
+    val description: String,
+) {
+    STATUS("status", "Report who this device is signed in as and which addresses it holds"),
+}
+
 object Main {
     @JvmStatic
     fun main(args: Array<String>) {
-        // Clikt exits by itself on a usage error, but returns here on success, and the binder
-        // threads this process picked up are not daemons.
-        Firezone().subcommands(StatusCommand()).main(args)
-
-        System.exit(0)
+        // The binder threads this process picked up are not daemons, so returning from `main`
+        // would leave it running.
+        System.exit(dispatch(args))
     }
-}
 
-private class Firezone : CoreCliktCommand(name = "firezone") {
-    override fun run() = Unit
-}
+    private fun dispatch(args: Array<String>): Int {
+        // No command takes arguments of its own yet, so its name is the whole command line.
+        val argument = args.singleOrNull()
 
-private class StatusCommand : CoreCliktCommand(name = "status") {
-    override fun help(context: Context): String = "Report who this device is signed in as and which addresses it holds"
+        if (argument == "--help") {
+            println(usage())
 
-    override fun run() {
+            return 0
+        }
+
+        val command =
+            Subcommand.entries.firstOrNull { it.label == argument }
+                ?: run {
+                    System.err.println(usage())
+
+                    return 2
+                }
+
         // `app_process` starts a bare VM, so nothing has set up the looper the framework calls
         // below expect to find on this thread. The deprecation is aimed at apps, whose main looper
         // the framework prepares for them.
         @Suppress("DEPRECATION")
         Looper.prepareMainLooper()
 
-        val status =
-            try {
-                fetchStatus()
-            } catch (e: Exception) {
-                throw CliktError("firezone: ${e.message ?: e}")
-            }
+        return try {
+            println(execute(command))
 
-        echo(render(status))
+            0
+        } catch (e: Exception) {
+            System.err.println("firezone: ${e.message ?: e}")
+
+            1
+        }
+    }
+
+    private fun execute(command: Subcommand): String =
+        when (command) {
+            Subcommand.STATUS -> render(fetchStatus())
+        }
+
+    private fun usage(): String {
+        val column = Subcommand.entries.maxOf { it.label.length } + 2
+
+        return buildString {
+            appendLine("usage: firezone <command>")
+            appendLine()
+            appendLine("commands:")
+            Subcommand.entries.forEach { appendLine("  ${it.label.padEnd(column)}${it.description}") }
+        }.trimEnd()
     }
 
     // The same route AOSP's `content` tool takes: `IActivityManager` needs no `Context`, which this

--- a/kotlin/android/app/src/main/java/dev/firezone/android/cli/Main.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/cli/Main.kt
@@ -8,9 +8,12 @@ import android.os.Bundle
 import android.os.IBinder
 import android.os.Looper
 import android.os.Process
+import com.github.ajalt.clikt.core.CliktError
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.CoreCliktCommand
+import com.github.ajalt.clikt.core.parse
+import com.github.ajalt.clikt.core.subcommands
 import java.lang.reflect.InvocationTargetException
-
-private const val USAGE = "usage: firezone status"
 
 // `adb shell` runs as the primary user and this prototype offers no way to name another one.
 private const val USER_ID = 0
@@ -20,43 +23,61 @@ private const val CALLING_PACKAGE = "com.android.shell"
 object Main {
     @JvmStatic
     fun main(args: Array<String>) {
-        val code = execute(args)
+        val firezone = Firezone().subcommands(StatusCommand())
+
+        val code =
+            try {
+                firezone.parse(args)
+
+                0
+            } catch (e: CliktError) {
+                val message = firezone.getFormattedHelp(e)
+
+                if (e.statusCode == 0) {
+                    println(message)
+                } else {
+                    System.err.println(message)
+                }
+
+                e.statusCode
+            }
 
         // The binder threads this process picked up are not daemons, so returning from `main`
         // would leave it running.
         System.exit(code)
     }
+}
 
-    private fun execute(args: Array<String>): Int {
-        if (args.size != 1 || args[0] != "status") {
-            System.err.println(USAGE)
+private class Firezone : CoreCliktCommand(name = "firezone") {
+    override fun run() = Unit
+}
 
-            return 2
-        }
+private class StatusCommand : CoreCliktCommand(name = "status") {
+    override fun help(context: Context): String = "Report who this device is signed in as and which addresses it holds"
 
+    override fun run() {
         // `app_process` starts a bare VM, so nothing has set up the looper the framework calls
         // below expect to find on this thread. The deprecation is aimed at apps, whose main looper
         // the framework prepares for them.
         @Suppress("DEPRECATION")
         Looper.prepareMainLooper()
 
-        return try {
-            println(render(status()))
+        val status =
+            try {
+                fetchStatus()
+            } catch (e: Exception) {
+                // Reflection reports whatever the app threw wrapped, and the wrapper carries no message.
+                val failure = (e as? InvocationTargetException)?.cause ?: e
 
-            0
-        } catch (e: Exception) {
-            // Reflection reports whatever the app threw wrapped, and the wrapper carries no message.
-            val failure = (e as? InvocationTargetException)?.cause ?: e
+                throw CliktError("firezone: ${failure.message ?: failure}")
+            }
 
-            System.err.println("firezone: ${failure.message ?: failure}")
-
-            1
-        }
+        echo(render(status))
     }
 
     // The same route AOSP's `content` tool takes: `IActivityManager` needs no `Context`, which this
     // process does not have, and it starts the app if it is not already running.
-    private fun status(): Status {
+    private fun fetchStatus(): Status {
         val activityManager =
             Class
                 .forName("android.app.ActivityManager")

--- a/kotlin/android/app/src/main/java/dev/firezone/android/cli/Main.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/cli/Main.kt
@@ -1,11 +1,12 @@
 // Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
 package dev.firezone.android.cli
 
+import android.app.IActivityManager
 import android.content.AttributionSource
+import android.content.IContentProvider
 import android.os.Binder
 import android.os.Build
 import android.os.Bundle
-import android.os.IBinder
 import android.os.Looper
 import android.os.Process
 import com.github.ajalt.clikt.core.CliktError
@@ -13,7 +14,6 @@ import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.CoreCliktCommand
 import com.github.ajalt.clikt.core.parse
 import com.github.ajalt.clikt.core.subcommands
-import java.lang.reflect.InvocationTargetException
 
 // `adb shell` runs as the primary user and this prototype offers no way to name another one.
 private const val USER_ID = 0
@@ -66,10 +66,7 @@ private class StatusCommand : CoreCliktCommand(name = "status") {
             try {
                 fetchStatus()
             } catch (e: Exception) {
-                // Reflection reports whatever the app threw wrapped, and the wrapper carries no message.
-                val failure = (e as? InvocationTargetException)?.cause ?: e
-
-                throw CliktError("firezone: ${failure.message ?: failure}")
+                throw CliktError("firezone: ${e.message ?: e}")
             }
 
         echo(render(status))
@@ -78,28 +75,16 @@ private class StatusCommand : CoreCliktCommand(name = "status") {
     // The same route AOSP's `content` tool takes: `IActivityManager` needs no `Context`, which this
     // process does not have, and it starts the app if it is not already running.
     private fun fetchStatus(): Status {
-        val activityManager =
-            Class
-                .forName("android.app.ActivityManager")
-                .getMethod("getService")
-                .invoke(null)
-        val iActivityManager = Class.forName("android.app.IActivityManager")
+        val activityManager = activityManager()
         val token = Binder()
 
         val holder =
-            iActivityManager
-                .getMethod(
-                    "getContentProviderExternal",
-                    String::class.java,
-                    Int::class.javaPrimitiveType,
-                    IBinder::class.java,
-                    String::class.java,
-                ).invoke(activityManager, CLI_AUTHORITY, USER_ID, token, "firezone")
+            activityManager.getContentProviderExternal(CLI_AUTHORITY, USER_ID, token, "firezone")
                 ?: throw IllegalStateException("No provider for $CLI_AUTHORITY. Is the Firezone app installed?")
 
         try {
             val provider =
-                holder.javaClass.getField("provider").get(holder)
+                holder.provider
                     ?: throw IllegalStateException("$CLI_AUTHORITY published no provider")
             val reply = handshake(provider) ?: throw IllegalStateException("The app refused the handshake")
             val cli =
@@ -108,17 +93,19 @@ private class StatusCommand : CoreCliktCommand(name = "status") {
 
             return cli.status()
         } finally {
-            iActivityManager
-                .getMethod(
-                    "removeContentProviderExternalAsUser",
-                    String::class.java,
-                    IBinder::class.java,
-                    Int::class.javaPrimitiveType,
-                ).invoke(activityManager, CLI_AUTHORITY, token, USER_ID)
+            activityManager.removeContentProviderExternalAsUser(CLI_AUTHORITY, token, USER_ID)
         }
     }
 
-    private fun handshake(provider: Any): Bundle? {
+    // A hidden static on a public class is the one shape the compile-time stubs cannot describe:
+    // `android.app.ActivityManager` itself comes from `android.jar`, which omits this method.
+    private fun activityManager(): IActivityManager =
+        Class
+            .forName("android.app.ActivityManager")
+            .getMethod("getService")
+            .invoke(null) as IActivityManager
+
+    private fun handshake(provider: IContentProvider): Bundle? {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             throw IllegalStateException(
                 "`IContentProvider#call` takes an `AttributionSource` only since API 31, this device is API ${Build.VERSION.SDK_INT}",
@@ -131,16 +118,7 @@ private class StatusCommand : CoreCliktCommand(name = "status") {
                 .setPackageName(CALLING_PACKAGE)
                 .build()
 
-        return Class
-            .forName("android.content.IContentProvider")
-            .getMethod(
-                "call",
-                AttributionSource::class.java,
-                String::class.java,
-                String::class.java,
-                String::class.java,
-                Bundle::class.java,
-            ).invoke(provider, attributionSource, CLI_AUTHORITY, HANDSHAKE_METHOD, null, null) as Bundle?
+        return provider.call(attributionSource, CLI_AUTHORITY, HANDSHAKE_METHOD, null, null)
     }
 
     private fun render(status: Status): String =

--- a/kotlin/android/app/src/main/java/dev/firezone/android/cli/Main.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/cli/Main.kt
@@ -12,7 +12,7 @@ import android.os.Process
 import com.github.ajalt.clikt.core.CliktError
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.CoreCliktCommand
-import com.github.ajalt.clikt.core.parse
+import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.core.subcommands
 
 // `adb shell` runs as the primary user and this prototype offers no way to name another one.
@@ -23,28 +23,11 @@ private const val CALLING_PACKAGE = "com.android.shell"
 object Main {
     @JvmStatic
     fun main(args: Array<String>) {
-        val firezone = Firezone().subcommands(StatusCommand())
+        // Clikt exits by itself on a usage error, but returns here on success, and the binder
+        // threads this process picked up are not daemons.
+        Firezone().subcommands(StatusCommand()).main(args)
 
-        val code =
-            try {
-                firezone.parse(args)
-
-                0
-            } catch (e: CliktError) {
-                val message = firezone.getFormattedHelp(e)
-
-                if (e.statusCode == 0) {
-                    println(message)
-                } else {
-                    System.err.println(message)
-                }
-
-                e.statusCode
-            }
-
-        // The binder threads this process picked up are not daemons, so returning from `main`
-        // would leave it running.
-        System.exit(code)
+        System.exit(0)
     }
 }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/cli/Main.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/cli/Main.kt
@@ -41,7 +41,7 @@ object Main {
         Looper.prepareMainLooper()
 
         return try {
-            println(status())
+            println(render(status()))
 
             0
         } catch (e: Exception) {
@@ -56,7 +56,7 @@ object Main {
 
     // The same route AOSP's `content` tool takes: `IActivityManager` needs no `Context`, which this
     // process does not have, and it starts the app if it is not already running.
-    private fun status(): String {
+    private fun status(): Status {
         val activityManager =
             Class
                 .forName("android.app.ActivityManager")
@@ -121,4 +121,13 @@ object Main {
                 Bundle::class.java,
             ).invoke(provider, attributionSource, CLI_AUTHORITY, HANDSHAKE_METHOD, null, null) as Bundle?
     }
+
+    private fun render(status: Status): String =
+        buildString {
+            appendLine("signed-in: ${if (status.signedIn) "yes" else "no"}")
+            status.accountSlug?.let { appendLine("account: $it") }
+            status.actorName?.let { appendLine("actor: $it") }
+            status.tunnelIpv4?.let { appendLine("tunnel-ipv4: $it") }
+            status.tunnelIpv6?.let { appendLine("tunnel-ipv6: $it") }
+        }.trimEnd()
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/cli/Main.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/cli/Main.kt
@@ -20,22 +20,24 @@ private const val CALLING_PACKAGE = "com.android.shell"
 object Main {
     @JvmStatic
     fun main(args: Array<String>) {
-        val code = run(args)
+        val code = execute(args)
 
         // The binder threads this process picked up are not daemons, so returning from `main`
         // would leave it running.
         System.exit(code)
     }
 
-    private fun run(args: Array<String>): Int {
+    private fun execute(args: Array<String>): Int {
         if (args.size != 1 || args[0] != "status") {
             System.err.println(USAGE)
 
             return 2
         }
 
-        // `app_process` starts a bare VM, and the framework code below expects to run on a thread
-        // that has the main looper.
+        // `app_process` starts a bare VM, so nothing has set up the looper the framework calls
+        // below expect to find on this thread. The deprecation is aimed at apps, whose main looper
+        // the framework prepares for them.
+        @Suppress("DEPRECATION")
         Looper.prepareMainLooper()
 
         return try {
@@ -53,7 +55,7 @@ object Main {
     }
 
     // The same route AOSP's `content` tool takes: `IActivityManager` needs no `Context`, which this
-    // process has none of, and it starts the app if it is not already running.
+    // process does not have, and it starts the app if it is not already running.
     private fun status(): String {
         val activityManager =
             Class
@@ -75,10 +77,12 @@ object Main {
                 ?: throw IllegalStateException("No provider for $CLI_AUTHORITY. Is the Firezone app installed?")
 
         try {
-            val provider = holder.javaClass.getField("provider").get(holder)
-            val handshake = handshake(provider) ?: throw IllegalStateException("The app refused the handshake")
+            val provider =
+                holder.javaClass.getField("provider").get(holder)
+                    ?: throw IllegalStateException("$CLI_AUTHORITY published no provider")
+            val reply = handshake(provider) ?: throw IllegalStateException("The app refused the handshake")
             val cli =
-                IFirezoneCli.Stub.asInterface(handshake.getBinder(BINDER_KEY))
+                IFirezoneCli.Stub.asInterface(reply.getBinder(BINDER_KEY))
                     ?: throw IllegalStateException("The handshake carried no binder")
 
             return cli.status()

--- a/kotlin/android/app/src/main/java/dev/firezone/android/cli/Status.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/cli/Status.kt
@@ -1,0 +1,14 @@
+// Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
+package dev.firezone.android.cli
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class Status(
+    val signedIn: Boolean,
+    val accountSlug: String?,
+    val actorName: String?,
+    val tunnelIpv4: String?,
+    val tunnelIpv6: String?,
+) : Parcelable

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -95,8 +95,6 @@ class TunnelService : VpnService() {
     @Inject
     internal lateinit var x509Identity: X509Identity
 
-    private var tunnelIpv4Address: String? = null
-    private var tunnelIpv6Address: String? = null
     private var tunnelDnsAddresses: MutableList<String> = mutableListOf()
     private var tunnelSearchDomain: String? = null
     private var tunnelRoutes: MutableList<Cidr> = mutableListOf()
@@ -125,12 +123,16 @@ class TunnelService : VpnService() {
     private val _resourcesState = MutableStateFlow<List<Resource>>(emptyList())
     private val _connectedDevicesState = MutableStateFlow<List<ConnectedDevice>>(emptyList())
     private val _actorNameState = MutableStateFlow<String?>(null)
+    private val _tunnelIpv4State = MutableStateFlow<String?>(null)
+    private val _tunnelIpv6State = MutableStateFlow<String?>(null)
 
     // A `StateFlow` replays its current value to every new collector, so a newly bound SessionActivity catches up on its own.
     val serviceState: StateFlow<State> = _serviceState.asStateFlow()
     val resourcesState: StateFlow<List<Resource>> = _resourcesState.asStateFlow()
     val connectedDevicesState: StateFlow<List<ConnectedDevice>> = _connectedDevicesState.asStateFlow()
     val actorNameState: StateFlow<String?> = _actorNameState.asStateFlow()
+    val tunnelIpv4State: StateFlow<String?> = _tunnelIpv4State.asStateFlow()
+    val tunnelIpv6State: StateFlow<String?> = _tunnelIpv6State.asStateFlow()
 
     var tunnelResources: List<Resource>
         get() = _resourcesState.value
@@ -220,8 +222,8 @@ class TunnelService : VpnService() {
                     addSearchDomain(it)
                 }
 
-                addAddress(tunnelIpv4Address!!, 32)
-                addAddress(tunnelIpv6Address!!, 128)
+                addAddress(tunnelIpv4State.value!!, 32)
+                addAddress(tunnelIpv6State.value!!, 128)
             }.runCatching { establish() }
             .onFailure { Log.e(TAG, "Error establishing VPN service", it) }
             .onSuccess { fd ->
@@ -696,8 +698,8 @@ class TunnelService : VpnService() {
                                 is Event.TunInterfaceUpdated -> {
                                     tunnelDnsAddresses = event.dns.toMutableList()
                                     tunnelSearchDomain = event.searchDomain
-                                    tunnelIpv4Address = event.ipv4
-                                    tunnelIpv6Address = event.ipv6
+                                    _tunnelIpv4State.value = event.ipv4
+                                    _tunnelIpv6State.value = event.ipv6
                                     tunnelRoutes.clear()
                                     tunnelRoutes.addAll(
                                         event.ipv4Routes.map { cidr ->

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -876,6 +876,8 @@ class TunnelService : VpnService() {
         @Volatile
         private var activeService: TunnelService? = null
 
+        fun running(): TunnelService? = activeService
+
         // Protects through the one live service; the session, telemetry, and
         // flow-log drains all share it. Without a running service our VPN cannot
         // be up, so the no-op is the correct bypass then too.

--- a/kotlin/android/cli/firezone
+++ b/kotlin/android/cli/firezone
@@ -1,0 +1,4 @@
+#!/system/bin/sh
+CLASSPATH=$(pm path dev.firezone.android | grep base.apk | sed 's/^package://' | tr -d '\r')
+export CLASSPATH
+exec app_process /system/bin dev.firezone.android.cli.Main "$@"

--- a/kotlin/android/mise-tasks/emulator-tests.sh
+++ b/kotlin/android/mise-tasks/emulator-tests.sh
@@ -32,6 +32,10 @@ adb install -r -g -t "$app_apk"
 echo "==> Installing ${test_apk}"
 adb install -r -g -t "$test_apk"
 
+echo "==> Pushing the CLI wrapper"
+adb push cli/firezone /data/local/tmp/firezone
+adb shell chmod 755 /data/local/tmp/firezone
+
 # Flags are AndroidJUnitRunner's own argument names, so `--notAnnotation X` reaches it as
 # `-e notAnnotation X` and its documentation reads across. Read positionally rather than through
 # `#USAGE`, which only binds under `mise run` and would leave a filter silently unset when a


### PR DESCRIPTION
Android gives a tunnel only to an app that holds VPN consent, so a headless Client in the shape of the Linux and Windows ones is not possible there. A management CLI is: the app keeps owning the tunnel and the CLI becomes another way to ask it things, alongside the UI.

This prototype proves the mechanism end to end with a single `status` command, reporting whether the device is signed in, as whom, to which account, and which tunnel addresses it holds. The CLI ships inside the APK and runs under `app_process`, so it reuses the app's own classes, and it reaches the app the way AOSP's `content` tool does, by acquiring an exported provider through `IActivityManager`. That is also what starts the app process on demand. The provider answers a handshake with a binder and everything after it is AIDL, carrying state as a parcelable so presentation stays in the CLI, which is where a `--json` flag belongs. The provider shares its process with the tunnel and reads the service the tunnel already publishes, so answering takes no binding at all: asking after the tunnel cannot start it, cannot keep it up, and works with it down.

Only shell and root may talk to it, which suits the rooted IoT fleet this came from and leaves room for a signature-level permission before it ships.

Commands are an enum dispatched through an exhaustive `when`, with the usage text built from the same entries, rather than an argument-parsing library: one command is not worth a few hundred KiB of dex that every Android user carries whether or not they ever run the CLI.

One choice worth a reviewer's attention: the hidden framework interfaces behind the handshake are declared as `compileOnly` stubs rather than reached by reflection. The boot classpath always wins on a device, so nothing ships, and the compiler checks calls a reader otherwise cannot.

Related: #15175
Related: #15074