### PR TITLE
fix(android): let the fake session own the tun descriptor

### DIFF
--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/FakeSession.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/FakeSession.kt
@@ -1,6 +1,7 @@
 // Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
 package dev.firezone.android.tunnel
 
+import android.os.ParcelFileDescriptor
 import kotlinx.coroutines.channels.Channel
 import uniffi.connlib.AndroidSessionConfig
 import uniffi.connlib.ClientTlsIdentity
@@ -13,6 +14,11 @@ class FakeSession(
     val tlsIdentity: ClientTlsIdentity?,
 ) : TunnelSession {
     private val events = Channel<Event>(Channel.UNLIMITED)
+
+    // connlib owns the descriptor it is handed. Leaving it open keeps the interface the
+    // service established alive, and the framework holds the service bound while one is up,
+    // which no amount of stopping the service undoes.
+    private var tun: ParcelFileDescriptor? = null
 
     val commands = Channel<String>(Channel.UNLIMITED)
 
@@ -52,10 +58,14 @@ class FakeSession(
 
     override fun setTun(fd: Int) {
         commands.trySend("setTun")
+        tun?.close()
+        tun = ParcelFileDescriptor.adoptFd(fd)
     }
 
     override fun close() {
         events.close()
         commands.close()
+        tun?.close()
+        tun = null
     }
 }


### PR DESCRIPTION
`TunnelService` hands `setTun` a descriptor it has detached, which the real connlib owns and closes when the session ends. The fake session dropped it, so an interface the service established under test stayed up, and the framework keeps a service bound for as long as one is. A bound service never leaves `getRunningServices`, so `stopTunnelService` could not return the device to a state the next test could use, and the whole suite after it timed out waiting.