### PR TITLE
ci: gate winget publish on a manual fork sync

### DIFF
--- a/.github/actions/winget-releaser/action.yml
+++ b/.github/actions/winget-releaser/action.yml
@@ -73,39 +73,9 @@ runs:
         GITHUB_TOKEN: ${{ inputs.token }}
       id: version-and-urls
       shell: pwsh
-    - run: |
-        # Pre-sync the fork through its own sync-upstream workflow. That
-        # workflow runs with a token that may update workflow files, which
-        # the token here may not (see the WINGET_TOKEN notes in
-        # publish-release.yml), so it can move the fork across upstream
-        # changes to .github/workflows/* that would make `komac sync-fork`
-        # below fail. Non-fatal: `komac sync-fork` remains the gate.
-        try {
-          $Fork = '${{ inputs.fork-user }}/winget-pkgs'
-          $DispatchedAt = (Get-Date).ToUniversalTime()
-          gh workflow run sync-upstream.yml --repo $Fork --ref master
-          if (-not $?) {
-            Write-Output "::warning::Could not dispatch sync-upstream.yml in $Fork; relying on komac sync-fork."
-            exit 0
-          }
-          foreach ($i in 1..36) {
-            Start-Sleep -Seconds 5
-            $Run = gh run list --repo $Fork --workflow sync-upstream.yml --limit 1 --json status,conclusion,createdAt | ConvertFrom-Json | Select-Object -First 1
-            if ($Run -and ([DateTime]::Parse($Run.createdAt).ToUniversalTime() -ge $DispatchedAt.AddSeconds(-10)) -and ($Run.status -eq 'completed')) {
-              if ($Run.conclusion -ne 'success') {
-                Write-Output "::warning::Fork sync concluded with '$($Run.conclusion)'; relying on komac sync-fork."
-              }
-              exit 0
-            }
-          }
-          Write-Output "::warning::Fork sync did not complete within 3 minutes; relying on komac sync-fork."
-        } catch {
-          Write-Output "::warning::Pre-sync failed unexpectedly: $($_.Exception.Message); relying on komac sync-fork."
-        }
-        exit 0
-      env:
-        GH_TOKEN: ${{ inputs.token }}
-      shell: pwsh
+    # Fast-forwards the fork to upstream's HEAD, which only works while the
+    # fork's `master` is a plain mirror: a commit of our own on that branch
+    # makes the update non-fast-forward and fails every release after it.
     - run: komac sync-fork
       env:
         KOMAC_FORK_OWNER: ${{ inputs.fork-user }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -121,14 +121,16 @@ jobs:
   # scope, and `firezone-bot` must be a write collaborator on the fork
   # `firezone/winget-pkgs`.
   #
-  # We deliberately do NOT grant the `workflow` scope. That means
-  # `komac sync-fork` will fail ("UpdateRef" denied) whenever upstream
-  # microsoft/winget-pkgs has new commits touching `.github/workflows/*`,
-  # because syncing the fork would require writing workflow files. When that
-  # happens, sync `firezone/winget-pkgs` manually (e.g. via the GitHub "Sync
-  # fork" button on the repo page) and re-run this job. The tradeoff: adding
-  # `workflow` scope would grant the bot write access to workflow files in
-  # every repo where it is a collaborator, which we consider too broad.
+  # We deliberately do NOT grant the `workflow` scope: it would give the bot
+  # write access to workflow files in every repo where it is a collaborator,
+  # which we consider too broad. The cost is that `komac sync-fork` fails
+  # ("UpdateRef" denied) whenever upstream microsoft/winget-pkgs has new
+  # commits touching `.github/workflows/*`, because fast-forwarding the fork
+  # then rewrites workflow files. The `winget-publish` environment below
+  # covers that: its required reviewers hold this job and get notified, which
+  # is the prompt to hit "Sync fork" on firezone/winget-pkgs and then approve.
+  # GitHub creates a referenced-but-missing environment with no protection
+  # rules, so that hold only exists while `winget-publish` has reviewers.
   #
   # Do NOT switch to a fine-grained PAT: komac opens the winget PR from
   # `firezone/winget-pkgs` into `microsoft/winget-pkgs`, and fine-grained PATs
@@ -136,28 +138,35 @@ jobs:
   # succeeds but `komac update --submit` fails with "Resource not accessible
   # by personal access token / failed to create pull request".
   publish-clients-to-winget:
-    name: Publish ${{ matrix.identifier }} to winget
+    if: >-
+      ${{
+        startsWith(inputs.release_name || github.event.release.name, 'gui-client') ||
+        startsWith(inputs.release_name || github.event.release.name, 'headless-client')
+      }}
     runs-on: windows-latest
-    strategy:
-      matrix:
-        include:
-          - identifier: Firezone.Client.GUI
-            tag_prefix: gui-client
-          - identifier: Firezone.Client.Headless
-            tag_prefix: headless-client
+    environment:
+      name: winget-publish
+      url: https://github.com/firezone/winget-pkgs
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - id: get-version
+      - id: package
+        env:
+          release_name: ${{ inputs.release_name || github.event.release.name }}
         run: |
-          version=${{ inputs.release_name || github.event.release.name }}
-          version=${version#${{ matrix.tag_prefix }}-}
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+
+          if [[ "$release_name" == gui-client-* ]]; then
+            echo "identifier=Firezone.Client.GUI" >> "$GITHUB_OUTPUT"
+            echo "version=${release_name#gui-client-}" >> "$GITHUB_OUTPUT"
+          else
+            echo "identifier=Firezone.Client.Headless" >> "$GITHUB_OUTPUT"
+            echo "version=${release_name#headless-client-}" >> "$GITHUB_OUTPUT"
+          fi
         shell: bash
       - uses: ./.github/actions/winget-releaser
-        if: ${{ startsWith((inputs.release_name || github.event.release.name), matrix.tag_prefix) }}
         with:
-          identifier: ${{ matrix.identifier }}
-          version: ${{ steps.get-version.outputs.version }}
+          identifier: ${{ steps.package.outputs.identifier }}
+          version: ${{ steps.package.outputs.version }}
           token: ${{ secrets.WINGET_TOKEN }}
           release-notes-url: https://www.firezone.dev/changelog
           release-tag: ${{ inputs.release_name || github.event.release.tag_name || github.ref_name }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -126,11 +126,11 @@ jobs:
   # which we consider too broad. The cost is that `komac sync-fork` fails
   # ("UpdateRef" denied) whenever upstream microsoft/winget-pkgs has new
   # commits touching `.github/workflows/*`, because fast-forwarding the fork
-  # then rewrites workflow files. The `winget-publish` environment below
+  # then rewrites workflow files. The `winget-pkgs` environment below
   # covers that: its required reviewers hold this job and get notified, which
   # is the prompt to hit "Sync fork" on firezone/winget-pkgs and then approve.
   # GitHub creates a referenced-but-missing environment with no protection
-  # rules, so that hold only exists while `winget-publish` has reviewers.
+  # rules, so that hold only exists while the environment has reviewers.
   #
   # Do NOT switch to a fine-grained PAT: komac opens the winget PR from
   # `firezone/winget-pkgs` into `microsoft/winget-pkgs`, and fine-grained PATs
@@ -145,7 +145,7 @@ jobs:
       }}
     runs-on: windows-latest
     environment:
-      name: winget-publish
+      name: winget-pkgs
       url: https://github.com/firezone/winget-pkgs
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
`komac sync-fork` can only fast-forward `firezone/winget-pkgs`, and `WINGET_TOKEN` deliberately lacks the `workflow` scope, so a client release fails whenever upstream has moved across a change under `.github/workflows/*` and nobody has synced the fork by hand. The pre-sync workflow meant to cover that lived on the fork's `master` and made it permanently diverge from upstream, which turned an occasional failure into every release failing at `komac sync-fork`. The fork is a plain mirror again and that file is gone, so the step that dispatched it goes too.

Hold the publish job behind a `winget-pkgs` environment instead: its required reviewers get notified, sync the fork, then approve.