### PR TITLE
fix(apple): carry the error description across the XPC boundary

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/PacketTunnelProviderError.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/PacketTunnelProviderError.swift
@@ -23,14 +23,24 @@ public enum PacketTunnelProviderError: Error, CustomNSError, LocalizedError {
     }
   }
 
-  public var errorDescription: String? {
+  public var errorDescription: String? { message }
+
+  /// `LocalizedError` is a Swift witness, so it is lost when the error crosses to
+  /// another process: the network extension hands one to its completion handler and
+  /// the app receives an `NSError` carrying only the domain and code, which Foundation
+  /// renders as "The operation couldn't be completed." User info survives the trip.
+  public var errorUserInfo: [String: Any] {
+    [NSLocalizedDescriptionKey: message]
+  }
+
+  private var message: String {
     switch self {
     case .providerConfigurationIsInvalid:
-      return "The VPN profile is missing the settings the tunnel needs to start."
+      "The VPN profile is missing the settings the tunnel needs to start."
     case .firezoneIdIsInvalid:
-      return "The device identifier could not be read."
+      "The device identifier could not be read."
     case .credentialNotConfigured:
-      return "A sign-in token is not configured."
+      "A sign-in token is not configured."
     }
   }
 }


### PR DESCRIPTION
`PacketTunnelProviderError` already spells out what went wrong, but only through `LocalizedError`, which is a Swift protocol witness rather than data on the error. The network extension's errors reach the app over XPC as an `NSError` carrying just a domain and a code, so the app has nothing to render and Foundation falls back to its own wording. Starting the tunnel without a token showed "The operation couldn't be completed. (FirezoneKit.PacketTunnelProviderError error 2.)" instead of saying a sign-in token was missing.

`CustomNSError.errorUserInfo` does survive the crossing, so the description now travels in the user info as well.