### PR TITLE
fix(portal): keep the site dropdown open during validation

### DIFF
--- a/elixir/lib/portal_web/components/form_components.ex
+++ b/elixir/lib/portal_web/components/form_components.ex
@@ -173,6 +173,8 @@ defmodule PortalWeb.FormComponents do
   end
 
   def input(%{type: "group_select"} = assigns) do
+    assigns = assign(assigns, :value, select_value(assigns))
+
     ~H"""
     <div>
       <.label :if={@label} for={@id}>{@label}</.label>
@@ -200,7 +202,7 @@ defmodule PortalWeb.FormComponents do
         multiple={@multiple}
         {@rest}
       >
-        <option :if={@prompt} value="">{@prompt}</option>
+        <option :if={@prompt} value="" selected={is_nil(@value)}>{@prompt}</option>
 
         <%= for {label, options} <- @options do %>
           <%= if label == nil do %>
@@ -220,6 +222,8 @@ defmodule PortalWeb.FormComponents do
   end
 
   def input(%{type: "select"} = assigns) do
+    assigns = assign(assigns, :value, select_value(assigns))
+
     ~H"""
     <div>
       <.label :if={@label} for={@id}>{@label}</.label>
@@ -247,7 +251,7 @@ defmodule PortalWeb.FormComponents do
         multiple={@multiple}
         {@rest}
       >
-        <option :if={@prompt} value="">{@prompt}</option>
+        <option :if={@prompt} value="" selected={is_nil(@value)}>{@prompt}</option>
         {Phoenix.HTML.Form.options_for_select(@options, @value)}
       </select>
       <.error :for={msg <- @errors} inline={@inline_errors} data-validation-error-for={@name}>
@@ -1159,5 +1163,51 @@ defmodule PortalWeb.FormComponents do
     }
 
     [icon_size[size]]
+  end
+
+  # morphdom stamps `selected` on the option the browser picks; render it on the same
+  # option or LiveView sees a focused select as changed on every patch and blurs it.
+  defp select_value(%{multiple: true} = assigns), do: assigns[:value]
+
+  defp select_value(assigns) do
+    value = assigns[:value]
+    options = assigns[:options] || []
+
+    cond do
+      option_value?(options, value) -> value
+      assigns[:prompt] -> nil
+      true -> first_option_value(options)
+    end
+  end
+
+  defp option_value?(_options, nil), do: false
+
+  defp option_value?(options, value) do
+    escaped = escape_option_value(value)
+    options |> option_values() |> Enum.any?(&(escape_option_value(&1) == escaped))
+  end
+
+  defp escape_option_value(value) do
+    value |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
+  end
+
+  defp first_option_value(options) do
+    case option_values(options) do
+      [nil | _] -> ""
+      [value | _] -> value
+      [] -> nil
+    end
+  end
+
+  defp option_values(options) do
+    Enum.flat_map(options, fn
+      {:hr, nil} -> []
+      :hr -> []
+      {_key, group} when is_list(group) -> option_values(group)
+      {_key, group} when is_map(group) and not is_struct(group) -> option_values(group)
+      {_key, value} -> [value]
+      option when is_list(option) -> [Keyword.get(option, :value)]
+      option -> [option]
+    end)
   end
 end

--- a/elixir/lib/portal_web/live_table.ex
+++ b/elixir/lib/portal_web/live_table.ex
@@ -568,7 +568,9 @@ defmodule PortalWeb.LiveTable do
           )
         ]}
       >
-        <option value="">All {pluralize(String.downcase(@filter.title))}</option>
+        <option value="" selected={@form[@filter.name].value in [nil, ""]}>
+          All {pluralize(String.downcase(@filter.title))}
+        </option>
         <option
           :for={{label, value} <- @filter.values}
           value={value}

--- a/elixir/test/portal_web/components/form_components_test.exs
+++ b/elixir/test/portal_web/components/form_components_test.exs
@@ -45,6 +45,89 @@ defmodule PortalWeb.FormComponentsTest do
     assert Floki.attribute(back, "href") == ["/groups"]
   end
 
+  describe "select" do
+    test "marks the prompt selected when no value is set" do
+      assert [option] = selected_options(select_html(value: nil, prompt: "Select a Site"))
+      assert Floki.text(option) == "Select a Site"
+    end
+
+    test "marks the matching option selected instead of the prompt" do
+      assert [option] = selected_options(select_html(value: "b", prompt: "Select a Site"))
+      assert Floki.attribute(option, "value") == ["b"]
+    end
+
+    test "marks the prompt selected when the value matches no option" do
+      assert [option] = selected_options(select_html(value: "missing", prompt: "Select a Site"))
+      assert Floki.text(option) == "Select a Site"
+    end
+
+    test "marks the first option selected when there is no prompt and no value" do
+      assert [option] = selected_options(select_html(value: nil))
+      assert Floki.attribute(option, "value") == ["a"]
+    end
+
+    test "marks the matching option selected when there is no prompt" do
+      assert [option] = selected_options(select_html(value: "b"))
+      assert Floki.attribute(option, "value") == ["b"]
+    end
+
+    test "keeps every chosen option selected for a multiple select" do
+      html = select_html(value: ["a", "b"], multiple: true)
+      assert ["a", "b"] = html |> selected_options() |> Floki.attribute("value")
+    end
+
+    test "marks the prompt of a group select selected when no value is set" do
+      html =
+        select_html(
+          type: "group_select",
+          value: nil,
+          prompt: "Select a Site",
+          options: [{"Group", [{"A", "a"}, {"B", "b"}]}]
+        )
+
+      assert [option] = selected_options(html)
+      assert Floki.text(option) == "Select a Site"
+    end
+
+    test "keeps a nil-valued first option of a group select selected when no value is set" do
+      html =
+        select_html(
+          type: "group_select",
+          value: nil,
+          options: [{nil, [{"For any Site", nil}]}, {"Sites", [{"A", "a"}, {"B", "b"}]}]
+        )
+
+      assert [option] = selected_options(html)
+      assert Floki.text(option) == "For any Site"
+    end
+
+    test "marks the first grouped option selected when there is no prompt and no value" do
+      html =
+        select_html(type: "group_select", value: nil, options: [{"Group", [{"A", "a"}, {"B", "b"}]}])
+
+      assert [option] = selected_options(html)
+      assert Floki.attribute(option, "value") == ["a"]
+    end
+  end
+
+  defp select_html(opts) do
+    {value, opts} = Keyword.pop(opts, :value)
+    form = Phoenix.Component.to_form(%{"site_id" => value}, as: :resource)
+
+    assigns =
+      Enum.into(opts, %{
+        field: form[:site_id],
+        type: "select",
+        options: [{"A", "a"}, {"B", "b"}]
+      })
+
+    render_component(&PortalWeb.FormComponents.input/1, assigns)
+  end
+
+  defp selected_options(html) do
+    html |> Floki.parse_fragment!() |> Floki.find("option[selected]")
+  end
+
   defp classes(element) do
     element
     |> Floki.attribute("class")

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -1541,9 +1541,48 @@ defmodule PortalWeb.ResourcesTest do
     end
   end
 
+  describe "new resource form site select" do
+    test "keeps the site select markup stable across validation", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site_fixture(account: account)
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/new")
+
+      before = site_select(html)
+      assert [option] = Floki.find(before, "option[selected]")
+      assert Floki.attribute(option, "value") == [""]
+
+      html =
+        render_change(lv, "change_resource_form", %{
+          "_target" => ["resource", "address"],
+          "resource" => %{
+            "type" => "dns",
+            "name" => "My App",
+            "address" => "app.example.com",
+            "_unused_address_description" => "",
+            "address_description" => "",
+            "_unused_site_id" => "",
+            "site_id" => ""
+          }
+        })
+
+      assert Floki.raw_html(site_select(html)) == Floki.raw_html(before)
+    end
+  end
+
   defp count_occurrences(haystack, needle) do
     haystack
     |> :binary.matches(needle)
     |> length()
+  end
+
+  defp site_select(html) do
+    html |> Floki.parse_document!() |> Floki.find("#resource_site_id")
   end
 end

--- a/elixir/test/portal_web/live_table_test.exs
+++ b/elixir/test/portal_web/live_table_test.exs
@@ -296,7 +296,7 @@ defmodule PortalWeb.LiveTableTest do
       assert Floki.attribute(select, "name") == ["table-id[select]"]
 
       assert select |> List.first() |> elem(2) == [
-               {"option", [{"value", ""}], ["For any Select"]},
+               {"option", [{"value", ""}, {"selected", "selected"}], ["For any Select"]},
                {"option", [{"value", "1"}], ["One"]},
                {"option", [{"value", "2"}], ["Two"]},
                {"option", [{"value", "3"}], ["Three"]},


### PR DESCRIPTION
Filling out the new Resource form, the Site dropdown closed on its own as soon as a validation reply came back from the server. On a slow connection this happened while the user was still picking a site.

The cause is in how LiveView patches a focused `<select>`. The browser marks the option it shows as `selected` in the DOM, but the server HTML had no `selected` attribute when nothing was chosen yet. LiveView compared the two, believed the options had changed, and blurred the select before patching it. The blur closed the dropdown.

The shared select components now render `selected` on the option the browser shows (the matching option, else the prompt, else the first option). The live DOM and the server HTML stay equal, so the select is left alone while it has focus. The live table filter select does the same by hand. Every other native select in the portal uses the shared component, so they are covered too.

Fixes: #15192
