### PR TITLE
fix: accept iru-id as a device attestation SAN alias

### DIFF
--- a/elixir/lib/portal_api/client/device_trust.ex
+++ b/elixir/lib/portal_api/client/device_trust.ex
@@ -57,7 +57,8 @@ defmodule PortalAPI.Client.DeviceTrust do
     "intune-id" => :last_attested_mdm_device_id,
     "ws1-uuid" => :last_attested_mdm_device_id,
     "jamf-id" => :last_attested_mdm_device_id,
-    "kandji-id" => :last_attested_mdm_device_id
+    "kandji-id" => :last_attested_mdm_device_id,
+    "iru-id" => :last_attested_mdm_device_id
   }
 
   @typed_uri_regex ~r{^firezone://([^/]+)/(.+)$}i

--- a/elixir/test/portal_api/client/device_trust_test.exs
+++ b/elixir/test/portal_api/client/device_trust_test.exs
@@ -474,6 +474,18 @@ defmodule PortalAPI.Client.DeviceTrustTest do
   end
 
   describe "extract_identifiers/1" do
+    test "accepts iru-id and kandji-id as MDM device identifiers" do
+      for idtype <- ["iru-id", "kandji-id"] do
+        uri = ~c"firezone://#{idtype}/5F2E7B7A-9D54-4BD2-9D4F-8F6C2A01F9D3"
+
+        assert DeviceTrust.extract_identifiers(
+                 otp(sans: [{:uniformResourceIdentifier, uri}])
+               ) == %{
+                 last_attested_mdm_device_id: "5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3"
+               }
+      end
+    end
+
     test "reads every typed URI SAN into its column" do
       identifiers = DeviceTrust.extract_identifiers(otp(:rsa))
       assert identifiers.last_attested_device_serial == "C02XK1ZGJGH5"

--- a/rust/libs/x509-claims/src/lib.rs
+++ b/rust/libs/x509-claims/src/lib.rs
@@ -645,7 +645,7 @@ fn mdm_attribute(attribute: &str) -> bool {
 fn device_id_attribute(attribute: &str) -> bool {
     matches!(
         attribute,
-        "intune-id" | "entra-id" | "ws1-uuid" | "jamf-id" | "kandji-id"
+        "intune-id" | "entra-id" | "ws1-uuid" | "jamf-id" | "kandji-id" | "iru-id"
     )
 }
 

--- a/rust/libs/x509-claims/tests/parse_certificate.rs
+++ b/rust/libs/x509-claims/tests/parse_certificate.rs
@@ -92,6 +92,22 @@ fn extracts_typed_mdm_device_id_like_the_portal() {
 }
 
 #[test]
+fn accepts_iru_and_kandji_mdm_device_ids() {
+    for attribute in ["iru-id", "kandji-id"] {
+        let uri = format!("firezone://{attribute}/5F2E7B7A-9D54-4BD2-9D4F-8F6C2A01F9D3");
+        let der = certificate_with_uri_sans(&[&uri]);
+        let metadata = parse_certificate(&der, now()).expect("generated certificate should parse");
+
+        assert_eq!(
+            metadata.mdm_device_id.valid(),
+            Some("5f2e7b7a-9d54-4bd2-9d4f-8f6c2a01f9d3")
+        );
+        assert!(metadata.is_device_certificate());
+        assert!(metadata.unrecognised_claims.is_empty());
+    }
+}
+
+#[test]
 fn percent_decodes_typed_mdm_identifiers() {
     // The portal runs every typed claim through `URI.decode`, so a client that reported the
     // escape sequence verbatim would name a device the portal has never heard of.


### PR DESCRIPTION
Accept `firezone://iru-id/<value>` as an alias for `firezone://kandji-id/<value>` in attested SAN attributes. Both names map to the same MDM device ID in the portal and Rust certificate parser, preserving support for existing Kandji certificates.

Regression tests cover both names, identifier normalization, and recognition as a device certificate without unknown-claim warnings.

Validation:
- `mix test test/portal_api/client/device_trust_test.exs` — 49 passed.
- `cargo test -p x509-claims` — 27 passed.
- Elixir and Rust formatting checks passed.
