### PR TITLE
fix(ci): serialize API fuzzing to avoid Schemathesis race

### DIFF
--- a/scripts/tests/openapi-fuzz.sh
+++ b/scripts/tests/openapi-fuzz.sh
@@ -15,6 +15,10 @@
 # Connections are not reused: for binary request bodies the client can send
 # a Content-Length shorter than the body, and the leftover bytes then corrupt
 # the next request on the same connection and show up as bogus failures.
+#
+# Use one worker: Schemathesis 4.25.2 iterates its shared resource repository
+# while other workers mutate it, causing "dictionary changed size during
+# iteration" during example generation.
 
 set -euo pipefail
 
@@ -58,7 +62,7 @@ fi
   --checks not_a_server_error,status_code_conformance,content_type_conformance,response_schema_conformance,negative_data_rejection,ignored_auth \
   --max-examples "${SCHEMATHESIS_MAX_EXAMPLES:-25}" \
   --max-failures 25 \
-  --workers 2 \
+  --workers 1 \
   --request-timeout 30 \
   --request-retries 3 \
   --generation-database none \


### PR DESCRIPTION
Schemathesis 4.25.2 can crash during example generation when one worker iterates its shared resource repository while another updates it. The linked run failed on `GET /policies` with `RuntimeError: dictionary changed size during iteration`; coverage, fuzzing, and stateful checks passed.

Run the API fuzzer with one worker to avoid the race. All phases, checks, and example counts remain enabled. This trades some runtime for reliable execution until the upstream concurrency issue is resolved.

Validation: `bash -n`, ShellCheck, `git diff --check`, and a CLI smoke check confirming one worker, all six checks, default phases, and 25 examples passed. Full integration fuzzing was not run locally because Docker is unavailable.

Related failure: https://github.com/firezone/firezone/actions/runs/34377587148/job/102555978880?pr=15185
