### PR TITLE
test: fix flaky Google sign-up expiry tests and schema warnings

### DIFF
--- a/elixir/test/portal_api/schemas/contract_test.exs
+++ b/elixir/test/portal_api/schemas/contract_test.exs
@@ -20,7 +20,11 @@ defmodule PortalAPI.Schemas.ContractTest do
     %{schema: PortalAPI.Schemas.Site.Schema, struct: Portal.Site},
     %{schema: PortalAPI.Schemas.Group.Schema, struct: Portal.Group, attrs: %{sync_state: nil}},
     %{schema: PortalAPI.Schemas.Policy.Schema, struct: Portal.Policy},
-    %{schema: PortalAPI.Schemas.Resource.Schema, struct: Portal.Resource},
+    %{
+      schema: PortalAPI.Schemas.Resource.Schema,
+      struct: Portal.Resource,
+      omittable: [:ip_stack, :site_id]
+    },
     %{
       schema: PortalAPI.Schemas.Client.GetSchema,
       struct: Portal.Device,
@@ -94,7 +98,7 @@ defmodule PortalAPI.Schemas.ContractTest do
   ]
 
   for contract <- @contracts do
-    @contract Map.merge(%{aliases: [], attrs: %{}}, contract)
+    @contract Map.merge(%{aliases: [], attrs: %{}, omittable: []}, contract)
 
     describe "#{inspect(contract.schema)} against #{inspect(contract.struct)}" do
       test "encodes exactly the documented properties" do
@@ -139,9 +143,8 @@ defmodule PortalAPI.Schemas.ContractTest do
       test "marks every property required unless the payload may omit it" do
         schema = @contract.schema.schema()
         not_required = Map.keys(schema.properties) -- List.wrap(schema.required)
-        omittable = Map.get(%{PortalAPI.Schemas.Resource.Schema => [:ip_stack, :site_id]}, @contract.schema, [])
 
-        assert Enum.sort(not_required) == Enum.sort(omittable),
+        assert Enum.sort(not_required) == Enum.sort(@contract.omittable),
                "#{inspect(@contract.schema)} must list every property the payload always " <>
                  "carries as required. Not required: #{inspect(Enum.sort(not_required))}"
       end

--- a/elixir/test/portal_web/live/sign_up_test.exs
+++ b/elixir/test/portal_web/live/sign_up_test.exs
@@ -198,12 +198,12 @@ defmodule PortalWeb.SignUpTest do
     end
 
     test "patching back to the Google form after expiry shows error state", %{conn: conn} do
-      conn = with_google_identity(conn, expires_at: System.os_time(:second) + 1)
+      conn = with_google_identity(conn)
 
       {:ok, lv, html} = live(conn, ~p"/sign_up/google")
       assert html =~ "Almost there"
 
-      Process.sleep(1_100)
+      expire_google_identity(lv)
 
       html = render_patch(lv, ~p"/sign_up/google")
 
@@ -264,12 +264,12 @@ defmodule PortalWeb.SignUpTest do
     end
 
     test "submitting after the Google session expires shows error state", %{conn: conn} do
-      conn = with_google_identity(conn, expires_at: System.os_time(:second) + 1)
+      conn = with_google_identity(conn)
 
       {:ok, lv, html} = live(conn, ~p"/sign_up/google")
       assert html =~ "Almost there"
 
-      Process.sleep(1_100)
+      expire_google_identity(lv)
 
       html =
         lv
@@ -621,6 +621,13 @@ defmodule PortalWeb.SignUpTest do
       assert html =~ "Something went wrong"
       assert html =~ "invalid or has expired"
     end
+  end
+
+  defp expire_google_identity(lv) do
+    # Expire the mounted identity without racing the clock during LiveView startup.
+    :sys.replace_state(lv.pid, fn state ->
+      put_in(state.socket.assigns.google_identity.expires_at, System.os_time(:second) - 1)
+    end)
   end
 
   defp with_google_identity(conn, attrs \\ []) do


### PR DESCRIPTION
The Google sign-up expiry tests gave the session only until the next wall-clock second to mount. On CI, the session could already be expired at the initial “Almost there” assertion. Mount with the normal valid session, then explicitly expire the LiveView's stored identity before patching or submitting. Both tests retain their expiry assertions without sleeps or a startup race.

Also move the resource schema's omittable fields into the contract test data, avoiding the repeated Elixir type warnings from looking up known-absent keys in a literal map.

Validation: all 142 tests in `sign_up_test.exs` and `contract_test.exs` pass; formatting and `git diff --check` pass.
