### PR TITLE
fix(apple): check the submenu is still open once photographed

### DIFF
--- a/swift/apple/FirezoneUITests/AppScreenshotTests.swift
+++ b/swift/apple/FirezoneUITests/AppScreenshotTests.swift
@@ -143,6 +143,17 @@
         let submenu = try openedSubmenu(of: row)
 
         capture([menuFrame, submenu.frame], as: "menu", in: appearance)
+
+        // Only the pointer resting on the row holds the submenu open, and the
+        // capture waits seconds for the screen to hold still. A submenu that
+        // closed in that time leaves the plain menu behind, which holds still
+        // perfectly and photographs as a screen this test never asked for.
+        guard submenuIsOpen(of: row) else {
+          print("The submenu closed while it was photographed; the row presents:")
+          print(row.debugDescription)
+
+          throw AppScreenshotError.menuDidNotStayOpen
+        }
       }
     }
 
@@ -197,18 +208,27 @@
       return menu
     }
 
+    /// Whether the submenu the hovered `row` opens is on screen.
+    ///
+    /// Hittable rather than present: every resource carries a submenu and they are
+    /// all in the tree before any of them is shown.
+    private func submenuIsOpen(of row: XCUIElement) -> Bool {
+      let item = row.menuItems["Copy address"].firstMatch
+
+      return item.exists && item.isHittable
+    }
+
     /// Waits for the submenu the hovered `row` opens, and hands it back.
     ///
     /// The row's own, rather than the tallest menu that is not the menu: every resource
     /// carries a submenu and they are all in the tree before any of them is shown, so
     /// that handed back menus that were never on screen, whose frame the capture was
-    /// then cropped to. Hittable rather than present, for the same reason.
+    /// then cropped to.
     private func openedSubmenu(of row: XCUIElement) throws -> XCUIElement {
-      let item = row.menuItems["Copy address"].firstMatch
       let deadline = Date().addingTimeInterval(10)
 
       while Date() < deadline {
-        if item.exists, item.isHittable { return row.menus.firstMatch }
+        if submenuIsOpen(of: row) { return row.menus.firstMatch }
 
         Thread.sleep(forTimeInterval: 0.5)
       }
@@ -332,6 +352,7 @@
     case windowDidNotAppear
     case statusItemNotFound
     case menuDidNotOpen
+    case menuDidNotStayOpen
     case tabNotFound(String)
     case tabDidNotOpen(String)
   }


### PR DESCRIPTION
Only the pointer resting on the row holds the resource submenu open, and the capture then waits up to twenty seconds for the screen to hold still. A submenu that closes in that window leaves the plain menu behind, which holds still perfectly, so the settle loop accepts it and the gallery gets a menu with no submenu under the name of one that has it. The frames were measured while it was still open, so the region it occupied is photographed as desktop. #15075 committed a `menu-dark.png` like that, while its `menu-light.png` in the same run kept its submenu.

The check that waits for the submenu now also runs after the capture, so a submenu that did not stay open fails the test where it happened rather than passing as a picture. Why the hover is lost is still unknown; nothing in the settle loop moves the pointer, and this makes CI say so instead of committing the result.

This is the same shape as #15182: a screen that holds still is not necessarily the right screen, and it bites hardest where an interaction is the only thing holding the screen open.

Related: #15075