### PR TITLE
fix(portal): reject binary API UUID inputs

### DIFF
--- a/elixir/lib/portal/repo/filter.ex
+++ b/elixir/lib/portal/repo/filter.ex
@@ -256,8 +256,9 @@ defmodule Portal.Repo.Filter do
   defp value_type_valid?({:string, :websearch_wide}, value), do: is_binary(value)
   defp value_type_valid?({:string, :protocol_port}, value), do: is_binary(value)
   defp value_type_valid?({:string, :select}, value), do: is_binary(value)
+  # UUID filters must be textual: cast/1 also accepts arbitrary 16-byte binaries.
   defp value_type_valid?({:string, :uuid}, value) when is_binary(value) do
-    match?({:ok, _}, Ecto.UUID.cast(value))
+    match?({:ok, _}, Ecto.UUID.dump(value))
   end
 
   defp value_type_valid?({:string, :uuid}, _value), do: false
@@ -267,7 +268,7 @@ defmodule Portal.Repo.Filter do
   defp value_type_valid?({:string, :uuid_or_blank}, ""), do: true
 
   defp value_type_valid?({:string, :uuid_or_blank}, value) when is_binary(value) do
-    match?({:ok, _}, Ecto.UUID.cast(value))
+    match?({:ok, _}, Ecto.UUID.dump(value))
   end
 
   defp value_type_valid?({:string, :uuid_or_blank}, _value), do: false

--- a/elixir/lib/portal_api/controllers/log_controller.ex
+++ b/elixir/lib/portal_api/controllers/log_controller.ex
@@ -260,8 +260,8 @@ defmodule PortalAPI.LogController do
 
   defp parse_uuid(value, name) when is_binary(value) do
     case Ecto.UUID.cast(value) do
-      {:ok, uuid} -> {:ok, uuid}
-      :error -> {:error, :bad_request, reason: "`#{name}` must be a UUID"}
+      {:ok, uuid} when byte_size(value) == 36 -> {:ok, uuid}
+      _ -> {:error, :bad_request, reason: "`#{name}` must be a UUID"}
     end
   end
 

--- a/elixir/lib/portal_api/controllers/membership_controller.ex
+++ b/elixir/lib/portal_api/controllers/membership_controller.ex
@@ -221,7 +221,7 @@ defmodule PortalAPI.MembershipController do
   end
 
   defp valid_actor_id?(value) when is_binary(value) do
-    match?({:ok, _uuid}, Ecto.UUID.cast(value))
+    match?({:ok, _uuid}, Ecto.UUID.dump(value))
   end
 
   defp valid_actor_id?(_value), do: false

--- a/elixir/test/portal/repo/filter_test.exs
+++ b/elixir/test/portal/repo/filter_test.exs
@@ -139,6 +139,23 @@ defmodule Portal.Repo.FilterTest do
       assert validate_value(filter, Ecto.UUID.generate()) == :ok
     end
 
+    test "UUID filters require a textual UUID" do
+      for type <- [{:string, :uuid}, {:string, :uuid_or_blank}] do
+        filter = %Filter{type: type}
+        uuid = Ecto.UUID.generate()
+
+        assert validate_value(filter, uuid) == :ok
+        assert validate_value(filter, String.upcase(uuid)) == :ok
+
+        for value <- ["warehouse worker", Ecto.UUID.dump!(uuid)] do
+          assert validate_value(filter, value) ==
+                   {:error, {:invalid_type, type: type, value: value}}
+        end
+      end
+
+      assert validate_value(%Filter{type: {:string, :uuid_or_blank}}, "") == :ok
+    end
+
     test "validates that value is whitelisted" do
       filter = %Filter{
         type: :string,

--- a/elixir/test/portal_api/controllers/log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/log_controller_test.exs
@@ -121,7 +121,7 @@ defmodule PortalAPI.LogControllerTest do
       conn1 =
         conn
         |> authorize_conn(actor)
-        |> get(~p"/logs?type=change&actor_id=#{actor_id}")
+        |> get(~p"/logs?type=change&actor_id=#{String.upcase(actor_id)}")
 
       assert %{"data" => [%{"log_id" => log_id}]} = json_response(conn1, 200)
       assert log_id == matching.log_id
@@ -656,6 +656,16 @@ defmodule PortalAPI.LogControllerTest do
 
       assert %{"detail" => detail} = json_response(conn, 400)
       assert detail =~ "`actor_id` must be a UUID"
+    end
+
+    test "rejects 16-byte actor IDs for every log type", %{conn: conn, actor: actor} do
+      conn = authorize_conn(conn, actor)
+
+      for type <- ["change", "session", "flow", "api_request"] do
+        response = get(conn, "/logs", type: type, actor_id: "warehouse worker")
+
+        assert %{"detail" => "`actor_id` must be a UUID"} = json_response(response, 400)
+      end
     end
 
     test "treats empty filter params as absent", %{conn: conn, actor: actor} do

--- a/elixir/test/portal_api/controllers/membership_controller_test.exs
+++ b/elixir/test/portal_api/controllers/membership_controller_test.exs
@@ -629,6 +629,41 @@ defmodule PortalAPI.MembershipControllerTest do
   end
 
   describe "input validation" do
+    test "rejects 16-byte actor IDs in PUT and both PATCH lists", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      group = group_fixture(account: account)
+      actor = actor_fixture(account: account)
+      membership = membership_fixture(account: account, actor: actor, group: group)
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+
+      response =
+        put(conn, "/groups/#{group.id}/memberships",
+          memberships: [%{"actor_id" => "warehouse worker"}]
+        )
+
+      assert %{"validation_errors" => %{"0" => %{"actor_id" => ["is invalid"]}}} =
+               json_response(response, 422)
+
+      for field <- ["add", "remove"] do
+        response =
+          patch(conn, "/groups/#{group.id}/memberships",
+            memberships: %{field => ["warehouse worker"]}
+          )
+
+        assert %{"validation_errors" => %{^field => %{"0" => ["is invalid"]}}} =
+                 json_response(response, 422)
+      end
+
+      assert Repo.get_by!(Portal.Membership, account_id: account.id, id: membership.id).actor_id == actor.id
+    end
+
     test "PATCH rejects a malformed uuid in remove", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_api/controllers/policy_controller_test.exs
+++ b/elixir/test/portal_api/controllers/policy_controller_test.exs
@@ -126,6 +126,17 @@ defmodule PortalAPI.PolicyControllerTest do
       assert data["id"] == policy.id
     end
 
+    test "rejects 16-byte UUID filter values", %{conn: conn, actor: actor} do
+      conn = authorize_conn(conn, actor)
+
+      for filter <- ["group_id", "resource_id"],
+          value <- ["warehouse worker", URI.decode("%5CVf%C2%8E%C2%8C%F2%A9%A1%B8F%F4%8F%B8%8B")] do
+        response = get(conn, "/policies", %{filter => value, "limit" => "45"})
+
+        assert %{"status" => 400} = json_response(response, 400)
+      end
+    end
+
     test "rejects a malformed group_id filter value", %{conn: conn, actor: actor} do
       conn =
         conn

--- a/elixir/test/portal_web/live/settings/directory_sync_test.exs
+++ b/elixir/test/portal_web/live/settings/directory_sync_test.exs
@@ -519,6 +519,9 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
       |> element("button[phx-click='start_verification']")
       |> render_click()
 
+      # Wait for the queued :do_verification message before checking its event.
+      render(lv)
+
       assert_push_event(lv, "open_url", %{url: url})
       params = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
 


### PR DESCRIPTION
Require textual UUIDs in shared query filters, log actor filters, and membership controller validation. Arbitrary 16-byte strings previously passed UUID validation; policy filters could return an empty 200 response with a null pagination count, violating the API schema. Regression coverage checks rejection and preserves uppercase textual UUID support.

Also synchronize the directory verification test with its queued LiveView message to avoid the CI timing race.

Related: #15201
