### PR TITLE
fix(portal): keep live table filters across panel operations

### DIFF
--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -148,27 +148,22 @@ defmodule PortalWeb.Actors do
         _params,
         %{assigns: %{actor_panel: %{creating_actor: true}}} = socket
       ) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/actors?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/actors"))}
   end
 
   def handle_event("close_panel", _params, socket) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/actors?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/actors"))}
   end
 
   def handle_event("handle_keydown", _params, %{assigns: %{live_action: :edit}} = socket)
       when not is_nil(socket.assigns.selected_actor) do
     {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/actors/#{socket.assigns.selected_actor.id}"
-     )}
+     push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/actors/#{socket.assigns.selected_actor.id}"))}
   end
 
   def handle_event("handle_keydown", _params, socket)
       when not is_nil(socket.assigns.selected_actor) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/actors?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/actors"))}
   end
 
   def handle_event(
@@ -176,8 +171,7 @@ defmodule PortalWeb.Actors do
         _params,
         %{assigns: %{actor_panel: %{creating_actor: true}}} = socket
       ) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/actors?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/actors"))}
   end
 
   def handle_event("handle_keydown", _params, socket) do
@@ -185,7 +179,7 @@ defmodule PortalWeb.Actors do
   end
 
   def handle_event("open_new_actor_panel", _params, socket) do
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/actors/new")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/actors/new"))}
   end
 
   def handle_event("select_new_actor_type", %{"type" => "user"}, socket) do
@@ -209,16 +203,12 @@ defmodule PortalWeb.Actors do
 
   def handle_event("open_actor_edit_form", _params, socket) do
     {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/actors/#{socket.assigns.selected_actor.id}/edit"
-     )}
+     push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/actors/#{socket.assigns.selected_actor.id}/edit"))}
   end
 
   def handle_event("cancel_actor_edit_form", _params, socket) do
     {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/actors/#{socket.assigns.selected_actor.id}"
-     )}
+     push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/actors/#{socket.assigns.selected_actor.id}"))}
   end
 
   def handle_event("validate", %{"actor" => attrs} = params, socket) do
@@ -357,7 +347,7 @@ defmodule PortalWeb.Actors do
               |> apply_group_membership_changes(actor, socket.assigns.subject)
               |> put_flash(:success, "User created successfully")
               |> reload_live_table!("actors")
-              |> push_patch(to: ~p"/#{socket.assigns.account}/actors/#{actor.id}")
+              |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/actors/#{actor.id}"))
 
             {:noreply, socket}
 
@@ -390,7 +380,7 @@ defmodule PortalWeb.Actors do
             socket
             |> apply_group_membership_changes(actor, socket.assigns.subject)
             |> reload_live_table!("actors")
-            |> push_patch(to: ~p"/#{socket.assigns.account}/actors/#{actor.id}")
+            |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/actors/#{actor.id}"))
 
           {:noreply, socket}
 
@@ -400,7 +390,7 @@ defmodule PortalWeb.Actors do
             |> apply_group_membership_changes(actor, socket.assigns.subject)
             |> reload_live_table!("actors")
             |> merge_state(:actor_related, created_token: encoded_token)
-            |> push_patch(to: ~p"/#{socket.assigns.account}/actors/#{actor.id}")
+            |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/actors/#{actor.id}"))
 
           {:noreply, socket}
 
@@ -475,7 +465,7 @@ defmodule PortalWeb.Actors do
        socket
        |> put_flash(:success, "Actor deleted successfully")
        |> reload_live_table!("actors")
-       |> push_patch(to: ~p"/#{socket.assigns.account}/actors")}
+       |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/actors"))}
     else
       {:error, :not_found} ->
         {:noreply, put_flash(socket, :error, "Actor not found")}
@@ -559,12 +549,7 @@ defmodule PortalWeb.Actors do
         %{"tab" => tab},
         %{assigns: %{selected_actor: %Actor{} = actor}} = socket
       ) do
-    params = Map.put(socket.assigns.query_params, "tab", tab)
-
-    {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/actors/#{actor}?#{params}"
-     )}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/actors/#{actor}", tab: tab))}
   end
 
   def handle_event("change_tab", _params, %{assigns: %{selected_actor: nil}} = socket) do
@@ -886,7 +871,7 @@ defmodule PortalWeb.Actors do
          socket
          |> put_flash(:success, flash_message)
          |> reload_live_table!("actors")
-         |> push_patch(to: ~p"/#{socket.assigns.account}/actors/#{actor.id}")}
+         |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/actors/#{actor.id}"))}
 
       {:error, changeset} ->
         {:noreply, assign(socket, actor_form: actor_form_state(to_form(changeset)))}

--- a/elixir/lib/portal_web/live/devices.ex
+++ b/elixir/lib/portal_web/live/devices.ex
@@ -313,8 +313,7 @@ defmodule PortalWeb.Devices do
       do: handle_live_table_event(event, params, socket)
 
   def handle_event("close_panel", _params, socket) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/devices?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/devices"))}
   end
 
   def handle_event(
@@ -322,15 +321,7 @@ defmodule PortalWeb.Devices do
         %{"tab" => tab},
         %{assigns: %{selected_device: %Device{} = device}} = socket
       ) do
-    params =
-      socket.assigns.query_params
-      |> Map.put("tab", tab)
-      |> Map.delete("page")
-
-    {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/devices/#{device}?#{params}"
-     )}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/devices/#{device}", tab: tab))}
   end
 
   def handle_event("switch_device_tab", _params, %{assigns: %{selected_device: nil}} = socket) do
@@ -338,11 +329,9 @@ defmodule PortalWeb.Devices do
   end
 
   def handle_event("change_policy_authorizations_page", %{"page" => page}, socket) do
-    params = Map.put(socket.assigns.query_params, "page", page)
-
     {:noreply,
      push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/devices/#{socket.assigns.selected_device.id}?#{params}"
+       to: live_table_path(socket, ~p"/#{socket.assigns.account}/devices/#{socket.assigns.selected_device.id}", tab: "authorizations", page: page)
      )}
   end
 
@@ -355,16 +344,12 @@ defmodule PortalWeb.Devices do
 
   def handle_event("open_device_edit_form", _params, socket) do
     {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/devices/#{socket.assigns.selected_device.id}/edit"
-     )}
+     push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/devices/#{socket.assigns.selected_device.id}/edit"))}
   end
 
   def handle_event("cancel_device_edit_form", _params, socket) do
     {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/devices/#{socket.assigns.selected_device.id}"
-     )}
+     push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/devices/#{socket.assigns.selected_device.id}"))}
   end
 
   def handle_event("change_device_edit_form", %{"device" => attrs}, socket) do
@@ -384,7 +369,7 @@ defmodule PortalWeb.Devices do
          socket
          |> put_flash(:success, "Device updated successfully.")
          |> reload_live_table!("devices")
-         |> push_patch(to: ~p"/#{socket.assigns.account}/devices/#{updated_client.id}")}
+         |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/devices/#{updated_client.id}"))}
 
       {:error, changeset} ->
         {:noreply,
@@ -397,15 +382,12 @@ defmodule PortalWeb.Devices do
   def handle_event("handle_keydown", _params, socket)
       when socket.assigns.device_panel.view == :edit_device do
     {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/devices/#{socket.assigns.selected_device.id}"
-     )}
+     push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/devices/#{socket.assigns.selected_device.id}"))}
   end
 
   def handle_event("handle_keydown", _params, socket)
       when not is_nil(socket.assigns.selected_device) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/devices?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/devices"))}
   end
 
   def handle_event("handle_keydown", _params, socket) do
@@ -475,7 +457,7 @@ defmodule PortalWeb.Devices do
          |> put_flash(:success, "Device \"#{device.name}\" was deleted.")
          |> merge_state(:device_confirm, delete?: false)
          |> reload_live_table!("devices")
-         |> push_patch(to: ~p"/#{socket.assigns.account}/devices")}
+         |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/devices"))}
 
       {:error, _} ->
         {:noreply, merge_state(socket, :device_confirm, delete?: false)}
@@ -508,7 +490,7 @@ defmodule PortalWeb.Devices do
     {:noreply,
      socket
      |> put_flash(:error, message)
-     |> push_patch(to: ~p"/#{socket.assigns.account}/devices?#{socket.assigns.query_params}")}
+     |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/devices"))}
   end
 
   def handle_info(%Change{op: :insert, struct: %Device{type: :client}} = change, socket) do

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -137,8 +137,7 @@ defmodule PortalWeb.Groups do
       do: handle_live_table_event(event, params, socket)
 
   def handle_event("close_panel", _params, socket) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/groups?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/groups"))}
   end
 
   def handle_event("confirm_delete_group", _params, socket) do
@@ -152,21 +151,17 @@ defmodule PortalWeb.Groups do
   def handle_event("handle_keydown", %{"key" => "Escape"}, socket)
       when socket.assigns.group_panel.view == :edit_form do
     {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/groups/#{socket.assigns.selected_group.id}"
-     )}
+     push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/groups/#{socket.assigns.selected_group.id}"))}
   end
 
   def handle_event("handle_keydown", %{"key" => "Escape"}, socket)
       when socket.assigns.group_panel.view == :new_form do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/groups?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/groups"))}
   end
 
   def handle_event("handle_keydown", %{"key" => "Escape"}, socket)
       when not is_nil(socket.assigns.selected_group) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/groups?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/groups"))}
   end
 
   def handle_event("handle_keydown", _params, socket) do
@@ -283,12 +278,7 @@ defmodule PortalWeb.Groups do
         %{"tab" => tab},
         %{assigns: %{selected_group: %Group{} = group}} = socket
       ) do
-    params = Map.put(socket.assigns.query_params, "tab", tab)
-
-    {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/groups/#{group}?#{params}"
-     )}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/groups/#{group}", tab: tab))}
   end
 
   def handle_event("switch_group_tab", _params, %{assigns: %{selected_group: nil}} = socket) do
@@ -653,7 +643,7 @@ defmodule PortalWeb.Groups do
             socket
             |> put_flash(:success, "Group deleted successfully")
             |> reload_live_table!("groups")
-            |> push_patch(to: ~p"/#{socket.assigns.account}/groups")
+            |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/groups"))
 
           {:noreply, socket}
 
@@ -682,7 +672,7 @@ defmodule PortalWeb.Groups do
           |> assign(selected_group: group)
           |> put_flash(:success, "Group created successfully")
           |> reload_live_table!("groups")
-          |> push_patch(to: ~p"/#{socket.assigns.account}/groups/#{group.id}")
+          |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/groups/#{group.id}"))
 
         {:noreply, socket}
 
@@ -718,7 +708,7 @@ defmodule PortalWeb.Groups do
             |> assign(selected_group: updated_group)
             |> put_flash(:success, "Group updated successfully")
             |> reload_live_table!("groups")
-            |> push_patch(to: ~p"/#{socket.assigns.account}/groups/#{group.id}")
+            |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/groups/#{group.id}"))
 
           {:noreply, socket}
 
@@ -741,7 +731,7 @@ defmodule PortalWeb.Groups do
     {:noreply,
      socket
      |> put_flash(:error, message)
-     |> push_patch(to: ~p"/#{socket.assigns.account}/groups?#{socket.assigns.query_params}")}
+     |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/groups"))}
   end
 
   defp edit_group_panel(socket, group, id) do
@@ -762,7 +752,7 @@ defmodule PortalWeb.Groups do
       {:noreply,
        socket
        |> put_flash(:error, "This group cannot be edited")
-       |> push_patch(to: ~p"/#{socket.assigns.account}/groups/#{id}")}
+       |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/groups/#{id}"))}
     end
   end
 
@@ -823,7 +813,7 @@ defmodule PortalWeb.Groups do
           <.button
             style="primary"
             icon="ri-add-line"
-            patch={~p"/#{@account}/groups/new"}
+            patch={live_table_path(assigns, ~p"/#{@account}/groups/new")}
           >
             New Group
           </.button>
@@ -902,7 +892,7 @@ defmodule PortalWeb.Groups do
                 </p>
               </div>
               <.link
-                patch={~p"/#{@account}/groups/new"}
+                patch={live_table_path(assigns, ~p"/#{@account}/groups/new")}
                 class="flex items-center gap-1 px-2.5 py-1 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
               >
                 <.icon name="ri-add-line" class="w-3 h-3" /> Add a Group
@@ -914,7 +904,7 @@ defmodule PortalWeb.Groups do
       <.group_panel
         account={@account}
         group={@selected_group}
-        query_params={@query_params}
+        edit_path={@selected_group && live_table_path(assigns, ~p"/#{@account}/groups/#{@selected_group.id}/edit")}
         flash={@flash}
         panel={@group_panel}
         form_state={@group_form}
@@ -1145,8 +1135,7 @@ defmodule PortalWeb.Groups do
     if return_to = handle_return_to(socket) do
       push_navigate(socket, to: return_to)
     else
-      params = Map.drop(socket.assigns.query_params, ["tab"])
-      push_patch(socket, to: ~p"/#{socket.assigns.account}/groups?#{params}")
+      push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/groups"))
     end
   end
 

--- a/elixir/lib/portal_web/live/groups/components.ex
+++ b/elixir/lib/portal_web/live/groups/components.ex
@@ -12,7 +12,7 @@ defmodule PortalWeb.Groups.Components do
   attr :account, :any, required: true
   attr :group, :any, default: nil
   attr :flash, :map, required: true
-  attr :query_params, :map, default: %{}
+  attr :edit_path, :string, default: nil
   attr :panel, :map, required: true
   attr :form_state, :map, required: true
   attr :members_state, :map, required: true
@@ -57,6 +57,7 @@ defmodule PortalWeb.Groups.Components do
         :if={@group && @view == :list}
         account={@account}
         group={@group}
+        edit_path={@edit_path}
         flash={@flash}
         panel={@panel}
         members_state={@members_state}
@@ -233,6 +234,7 @@ defmodule PortalWeb.Groups.Components do
 
   attr :account, :any, required: true
   attr :group, :any, required: true
+  attr :edit_path, :string, required: true
   attr :flash, :map, required: true
   attr :panel, :map, required: true
   attr :members_state, :map, required: true
@@ -249,7 +251,12 @@ defmodule PortalWeb.Groups.Components do
 
     ~H"""
     <div class="flex flex-col h-full overflow-hidden">
-      <.group_details_header account={@account} group={@group} confirm_delete?={@confirm_delete?} />
+      <.group_details_header
+        account={@account}
+        group={@group}
+        edit_path={@edit_path}
+        confirm_delete?={@confirm_delete?}
+      />
 
       <div class="flex flex-1 min-h-0 divide-x divide-border">
         <div class="flex-1 flex flex-col overflow-hidden">
@@ -288,6 +295,7 @@ defmodule PortalWeb.Groups.Components do
 
   attr :account, :any, required: true
   attr :group, :any, required: true
+  attr :edit_path, :string, required: true
   attr :confirm_delete?, :boolean, required: true
 
   def group_details_header(assigns) do
@@ -318,7 +326,7 @@ defmodule PortalWeb.Groups.Components do
         <div class="flex items-center gap-1.5 shrink-0">
           <.link
             :if={editable_group?(@group) and not @confirm_delete?}
-            patch={~p"/#{@account}/groups/#{@group.id}/edit"}
+            patch={@edit_path}
             class="flex items-center gap-1 px-2.5 py-1.5 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
           >
             <.icon name="ri-pencil-line" class="w-3.5 h-3.5" /> Edit

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -152,7 +152,7 @@ defmodule PortalWeb.Policies do
     {:noreply,
      socket
      |> put_flash(:error, message)
-     |> push_patch(to: ~p"/#{socket.assigns.account}/policies?#{socket.assigns.query_params}")}
+     |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/policies"))}
   end
 
   defp parse_page(params) do
@@ -336,7 +336,7 @@ defmodule PortalWeb.Policies do
                 </p>
               </div>
               <.link
-                patch={~p"/#{@account}/policies/new"}
+                patch={live_table_path(assigns, ~p"/#{@account}/policies/new")}
                 class="flex items-center gap-1 px-2.5 py-1 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
               >
                 <.icon name="ri-add-line" class="w-3 h-3" /> Add a Policy
@@ -474,8 +474,7 @@ defmodule PortalWeb.Policies do
       do: handle_live_table_event(event, params, socket)
 
   def handle_event("close_panel", _params, socket) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/policies?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/policies"))}
   end
 
   def handle_event(
@@ -483,15 +482,7 @@ defmodule PortalWeb.Policies do
         %{"tab" => tab},
         %{assigns: %{selected_policy: %Policy{} = policy}} = socket
       ) do
-    params =
-      socket.assigns.query_params
-      |> Map.put("tab", tab)
-      |> Map.delete("page")
-
-    {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/policies/#{policy}?#{params}"
-     )}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/policies/#{policy}", tab: tab))}
   end
 
   def handle_event("switch_policy_tab", _params, %{assigns: %{selected_policy: nil}} = socket) do
@@ -499,11 +490,9 @@ defmodule PortalWeb.Policies do
   end
 
   def handle_event("change_policy_authorizations_page", %{"page" => page}, socket) do
-    params = Map.put(socket.assigns.query_params, "page", page)
-
     {:noreply,
      push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/policies/#{socket.assigns.selected_policy.id}?#{params}"
+       to: live_table_path(socket, ~p"/#{socket.assigns.account}/policies/#{socket.assigns.selected_policy.id}", tab: "authorizations", page: page)
      )}
   end
 
@@ -522,13 +511,12 @@ defmodule PortalWeb.Policies do
         _ -> ~p"/#{socket.assigns.account}/policies"
       end
 
-    {:noreply, push_patch(socket, to: path)}
+    {:noreply, push_patch(socket, to: live_table_path(socket, path))}
   end
 
   def handle_event("handle_keydown", %{"key" => "Escape"}, socket)
       when not is_nil(socket.assigns.selected_policy) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/policies?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/policies"))}
   end
 
   def handle_event("handle_keydown", _params, socket) do
@@ -585,14 +573,12 @@ defmodule PortalWeb.Policies do
      |> put_flash(:success, "Policy deleted successfully.")
      |> merge_state(:policy_confirm, delete?: false)
      |> reload_live_table!("policies")
-     |> push_patch(to: ~p"/#{socket.assigns.account}/policies")}
+     |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/policies"))}
   end
 
   def handle_event("open_edit_form", _params, socket) do
     {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/policies/#{socket.assigns.selected_policy.id}/edit"
-     )}
+     push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/policies/#{socket.assigns.selected_policy.id}/edit"))}
   end
 
   def handle_event("cancel_policy_form", _params, socket) do
@@ -602,11 +588,11 @@ defmodule PortalWeb.Policies do
         _ -> ~p"/#{socket.assigns.account}/policies"
       end
 
-    {:noreply, push_patch(socket, to: path)}
+    {:noreply, push_patch(socket, to: live_table_path(socket, path))}
   end
 
   def handle_event("open_new_policy_form", _params, socket) do
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/policies/new")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/policies/new"))}
   end
 
   def handle_event("change_policy_form", %{"policy" => params}, socket) do
@@ -639,7 +625,7 @@ defmodule PortalWeb.Policies do
            socket
            |> put_flash(:success, "Policy created successfully.")
            |> reload_live_table!("policies")
-           |> push_patch(to: ~p"/#{socket.assigns.account}/policies/#{policy.id}")}
+           |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/policies/#{policy.id}"))}
 
         {:error, changeset} ->
           {:noreply, merge_state(socket, :policy_panel, form: to_form(changeset))}
@@ -661,7 +647,7 @@ defmodule PortalWeb.Policies do
            socket
            |> put_flash(:success, "Policy updated successfully.")
            |> reload_live_table!("policies")
-           |> push_patch(to: ~p"/#{socket.assigns.account}/policies/#{updated.id}")}
+           |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/policies/#{updated.id}"))}
 
         {:error, changeset} ->
           {:noreply, merge_state(socket, :policy_panel, form: to_form(changeset))}

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -315,17 +315,20 @@ defmodule PortalWeb.Resources do
     {:noreply,
      socket
      |> put_flash(:error, message)
-     |> push_patch(to: ~p"/#{socket.assigns.account}/resources?#{socket.assigns.query_params}")}
+     |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/resources"))}
   end
 
-  defp resources_index_path(socket), do: ~p"/#{socket.assigns.account}/resources"
-  defp new_resource_path(socket), do: ~p"/#{socket.assigns.account}/resources/new"
+  defp resources_index_path(socket),
+    do: live_table_path(socket, ~p"/#{socket.assigns.account}/resources")
+
+  defp new_resource_path(socket),
+    do: live_table_path(socket, ~p"/#{socket.assigns.account}/resources/new")
 
   defp resource_show_path(socket, resource_id),
-    do: ~p"/#{socket.assigns.account}/resources/#{resource_id}"
+    do: live_table_path(socket, ~p"/#{socket.assigns.account}/resources/#{resource_id}")
 
   defp edit_resource_path(socket, resource_id),
-    do: ~p"/#{socket.assigns.account}/resources/#{resource_id}/edit"
+    do: live_table_path(socket, ~p"/#{socket.assigns.account}/resources/#{resource_id}/edit")
 
   defp cancel_resource_form_path(socket) do
     case socket.assigns.resource_panel.view do
@@ -569,7 +572,7 @@ defmodule PortalWeb.Resources do
                 </p>
               </div>
               <.link
-                patch={~p"/#{@account}/resources/new"}
+                patch={live_table_path(assigns, ~p"/#{@account}/resources/new")}
                 class="flex items-center gap-1 px-2.5 py-1 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
               >
                 <.icon name="ri-add-line" class="w-3 h-3" /> Add a Resource
@@ -627,8 +630,7 @@ defmodule PortalWeb.Resources do
       do: handle_live_table_event(event, params, socket)
 
   def handle_event("close_panel", _params, socket) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/resources?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/resources"))}
   end
 
   def handle_event("open_new_form", _params, socket) do
@@ -658,15 +660,7 @@ defmodule PortalWeb.Resources do
         %{"tab" => tab},
         %{assigns: %{selected_resource: %Resource{} = resource}} = socket
       ) do
-    params =
-      socket.assigns.query_params
-      |> Map.put("tab", tab)
-      |> Map.delete("page")
-
-    {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/resources/#{resource}?#{params}"
-     )}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/resources/#{resource}", tab: tab))}
   end
 
   def handle_event(
@@ -678,11 +672,9 @@ defmodule PortalWeb.Resources do
   end
 
   def handle_event("change_policy_authorizations_page", %{"page" => page}, socket) do
-    params = Map.put(socket.assigns.query_params, "page", page)
-
     {:noreply,
      push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/resources/#{socket.assigns.selected_resource.id}?#{params}"
+       to: live_table_path(socket, ~p"/#{socket.assigns.account}/resources/#{socket.assigns.selected_resource.id}", tab: "authorizations", page: page)
      )}
   end
 
@@ -738,7 +730,7 @@ defmodule PortalWeb.Resources do
           {:noreply,
            socket
            |> reload_live_table!("resources")
-           |> push_patch(to: ~p"/#{socket.assigns.account}/resources/#{resource.id}")}
+           |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/resources/#{resource.id}"))}
 
         {:error, changeset} ->
           changeset = Map.put(changeset, :action, :validate)
@@ -760,7 +752,7 @@ defmodule PortalWeb.Resources do
           {:noreply,
            socket
            |> reload_live_table!("resources")
-           |> push_patch(to: ~p"/#{socket.assigns.account}/resources/#{updated_resource.id}")}
+           |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/resources/#{updated_resource.id}"))}
 
         {:error, changeset} ->
           changeset = Map.put(changeset, :action, :validate)
@@ -776,8 +768,7 @@ defmodule PortalWeb.Resources do
 
   def handle_event("handle_keydown", %{"key" => "Escape"}, socket)
       when not is_nil(socket.assigns.selected_resource) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/resources?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/resources"))}
   end
 
   def handle_event("handle_keydown", _params, socket) do
@@ -1173,7 +1164,7 @@ defmodule PortalWeb.Resources do
          socket
          |> put_flash(:success, "Resource \"#{resource.name}\" was deleted.")
          |> reload_live_table!("resources")
-         |> push_patch(to: ~p"/#{socket.assigns.account}/resources")}
+         |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/resources"))}
 
       {:error, _} ->
         {:noreply,

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -132,27 +132,22 @@ defmodule PortalWeb.ServiceAccounts do
       do: handle_live_table_event(event, params, socket)
 
   def handle_event("close_panel", _params, %{assigns: %{actor_panel: %{creating_actor: true}}} = socket) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/service_accounts?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/service_accounts"))}
   end
 
   def handle_event("close_panel", _params, socket) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/service_accounts?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/service_accounts"))}
   end
 
   def handle_event("handle_keydown", _params, %{assigns: %{live_action: :edit}} = socket)
       when not is_nil(socket.assigns.selected_actor) do
     {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/service_accounts/#{socket.assigns.selected_actor.id}"
-     )}
+     push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/service_accounts/#{socket.assigns.selected_actor.id}"))}
   end
 
   def handle_event("handle_keydown", _params, socket)
       when not is_nil(socket.assigns.selected_actor) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/service_accounts?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/service_accounts"))}
   end
 
   def handle_event(
@@ -160,8 +155,7 @@ defmodule PortalWeb.ServiceAccounts do
         _params,
         %{assigns: %{actor_panel: %{creating_actor: true}}} = socket
       ) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/service_accounts?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/service_accounts"))}
   end
 
   def handle_event("handle_keydown", _params, socket) do
@@ -169,22 +163,17 @@ defmodule PortalWeb.ServiceAccounts do
   end
 
   def handle_event("open_new_actor_panel", _params, socket) do
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/service_accounts/new")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/service_accounts/new"))}
   end
 
   def handle_event("open_actor_edit_form", _params, socket) do
     {:noreply,
-     push_patch(socket,
-       to:
-         ~p"/#{socket.assigns.account}/service_accounts/#{socket.assigns.selected_actor.id}/edit"
-     )}
+     push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/service_accounts/#{socket.assigns.selected_actor.id}/edit"))}
   end
 
   def handle_event("cancel_actor_edit_form", _params, socket) do
     {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/service_accounts/#{socket.assigns.selected_actor.id}"
-     )}
+     push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/service_accounts/#{socket.assigns.selected_actor.id}"))}
   end
 
   def handle_event("validate", %{"actor" => attrs} = params, socket) do
@@ -320,9 +309,7 @@ defmodule PortalWeb.ServiceAccounts do
             socket
             |> apply_group_membership_changes(actor, socket.assigns.subject)
             |> reload_live_table!("actors")
-            |> push_patch(
-              to: ~p"/#{socket.assigns.account}/service_accounts/#{actor.id}"
-            )
+            |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/service_accounts/#{actor.id}"))
 
           {:noreply, socket}
 
@@ -332,9 +319,7 @@ defmodule PortalWeb.ServiceAccounts do
             |> apply_group_membership_changes(actor, socket.assigns.subject)
             |> reload_live_table!("actors")
             |> merge_state(:actor_related, created_token: encoded_token)
-            |> push_patch(
-              to: ~p"/#{socket.assigns.account}/service_accounts/#{actor.id}"
-            )
+            |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/service_accounts/#{actor.id}"))
 
           {:noreply, socket}
 
@@ -373,9 +358,7 @@ defmodule PortalWeb.ServiceAccounts do
          socket
          |> put_flash(:success, "Service account updated successfully.")
          |> reload_live_table!("actors")
-         |> push_patch(
-           to: ~p"/#{socket.assigns.account}/service_accounts/#{updated_actor.id}"
-         )}
+         |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/service_accounts/#{updated_actor.id}"))}
 
       {:error, changeset} ->
         {:noreply, assign(socket, actor_form: actor_form_state(to_form(changeset)))}
@@ -405,7 +388,7 @@ defmodule PortalWeb.ServiceAccounts do
        socket
        |> put_flash(:success, "Service account deleted successfully")
        |> reload_live_table!("actors")
-       |> push_patch(to: ~p"/#{socket.assigns.account}/service_accounts")}
+       |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/service_accounts"))}
     else
       {:error, :not_found} ->
         {:noreply, put_flash(socket, :error, "Service account not found")}
@@ -482,12 +465,7 @@ defmodule PortalWeb.ServiceAccounts do
         %{"tab" => tab},
         %{assigns: %{selected_actor: %Actor{} = actor}} = socket
       ) do
-    params = Map.put(socket.assigns.query_params, "tab", tab)
-
-    {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/service_accounts/#{actor}?#{params}"
-     )}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/service_accounts/#{actor}", tab: tab))}
   end
 
   def handle_event("change_tab", _params, %{assigns: %{selected_actor: nil}} = socket) do
@@ -705,7 +683,7 @@ defmodule PortalWeb.ServiceAccounts do
                 </p>
               </div>
               <.link
-                patch={~p"/#{@account}/service_accounts/new"}
+                patch={live_table_path(assigns, ~p"/#{@account}/service_accounts/new")}
                 class="flex items-center gap-1 px-2.5 py-1 rounded text-xs border border-border-strong text-body hover:text-heading hover:border-border-emphasis bg-surface transition-colors"
               >
                 <.icon name="ri-add-line" class="w-3 h-3" /> Add a Service Account

--- a/elixir/lib/portal_web/live/sites.ex
+++ b/elixir/lib/portal_web/live/sites.ex
@@ -111,7 +111,7 @@ defmodule PortalWeb.Sites do
     {:noreply,
      socket
      |> put_flash(:error, message)
-     |> push_patch(to: ~p"/#{socket.assigns.account}/sites?#{socket.assigns.query_params}")}
+     |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/sites"))}
   end
 
   defp site_panel_assigns(site, params, socket) do
@@ -410,7 +410,7 @@ defmodule PortalWeb.Sites do
                 Create a Site in order to deploy Gateways and attach Resources.
               </p>
             </div>
-            <.button patch={~p"/#{@account}/sites/new"} icon="ri-add-line" size="xs">Add a Site</.button>
+            <.button patch={live_table_path(assigns, ~p"/#{@account}/sites/new")} icon="ri-add-line" size="xs">Add a Site</.button>
           </div>
         </div>
       </div>
@@ -533,12 +533,11 @@ defmodule PortalWeb.Sites do
   # ---- Events ----
 
   def handle_event("select_site", %{"id" => id}, socket) do
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/sites/#{id}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/sites/#{id}"))}
   end
 
   def handle_event("close_panel", _params, socket) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/sites?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/sites"))}
   end
 
   def handle_event(
@@ -546,9 +545,8 @@ defmodule PortalWeb.Sites do
         %{"tab" => tab},
         %{assigns: %{selected_site: %Portal.Site{} = site}} = socket
       ) do
-    params = Map.put(socket.assigns.query_params, "tab", tab)
-
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/sites/#{site}?#{params}")}
+    {:noreply,
+     push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/sites/#{site}", tab: tab))}
   end
 
   def handle_event("switch_panel_tab", _params, %{assigns: %{selected_site: nil}} = socket) do
@@ -558,15 +556,12 @@ defmodule PortalWeb.Sites do
   def handle_event("handle_keydown", _params, socket)
       when socket.assigns.site_panel.view == :edit_site do
     {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/sites/#{socket.assigns.selected_site.id}"
-     )}
+     push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/sites/#{socket.assigns.selected_site.id}"))}
   end
 
   def handle_event("handle_keydown", _params, socket)
       when socket.assigns.new_site.open do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/sites?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/sites"))}
   end
 
   def handle_event("handle_keydown", _params, socket)
@@ -584,8 +579,7 @@ defmodule PortalWeb.Sites do
 
   def handle_event("handle_keydown", _params, socket)
       when not is_nil(socket.assigns.selected_site) do
-    params = Map.drop(socket.assigns.query_params, ["tab"])
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/sites?#{params}")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/sites"))}
   end
 
   def handle_event("handle_keydown", _params, socket) do
@@ -593,11 +587,11 @@ defmodule PortalWeb.Sites do
   end
 
   def handle_event("open_new_site_panel", _params, socket) do
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/sites/new")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/sites/new"))}
   end
 
   def handle_event("close_new_site_panel", _params, socket) do
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/sites")}
+    {:noreply, push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/sites"))}
   end
 
   def handle_event("new_site_change", %{"site" => attrs}, socket) do
@@ -621,7 +615,7 @@ defmodule PortalWeb.Sites do
        |> put_flash(:success, "Site #{site.name} created successfully.")
        |> put_state(:new_site, base_new_site_state())
        |> assign(sites: sites)
-       |> push_patch(to: ~p"/#{account}/sites/#{site.id}")}
+       |> push_patch(to: live_table_path(socket, ~p"/#{account}/sites/#{site.id}"))}
     else
       false ->
         changeset =
@@ -1010,7 +1004,7 @@ defmodule PortalWeb.Sites do
          socket
          |> put_flash(:success, "Site #{socket.assigns.selected_site.name} deleted successfully.")
          |> assign(sites: sites)
-         |> push_patch(to: ~p"/#{socket.assigns.account}/sites")}
+         |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/sites"))}
 
       {:error, _changeset} ->
         {:noreply,
@@ -1022,16 +1016,12 @@ defmodule PortalWeb.Sites do
 
   def handle_event("open_site_edit_form", _params, socket) do
     {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/sites/#{socket.assigns.selected_site.id}/edit"
-     )}
+     push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/sites/#{socket.assigns.selected_site.id}/edit"))}
   end
 
   def handle_event("cancel_site_edit_form", _params, socket) do
     {:noreply,
-     push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/sites/#{socket.assigns.selected_site.id}"
-     )}
+     push_patch(socket, to: live_table_path(socket, ~p"/#{socket.assigns.account}/sites/#{socket.assigns.selected_site.id}"))}
   end
 
   def handle_event("change_site_edit_form", %{"site" => attrs}, socket) do
@@ -1058,7 +1048,7 @@ defmodule PortalWeb.Sites do
            sites: sites,
            resources_counts: resources_counts
          )
-         |> push_patch(to: ~p"/#{socket.assigns.account}/sites/#{updated_site.id}")}
+         |> push_patch(to: live_table_path(socket, ~p"/#{socket.assigns.account}/sites/#{updated_site.id}"))}
 
       {:error, changeset} ->
         {:noreply,

--- a/elixir/lib/portal_web/live_table.ex
+++ b/elixir/lib/portal_web/live_table.ex
@@ -1346,6 +1346,47 @@ defmodule PortalWeb.LiveTable do
     {:noreply, push_patch(socket, to: String.trim_trailing("#{path}?#{query}", "?"))}
   end
 
+  @doc """
+  Builds a patch path that carries the state of every live table on the socket
+  (filters, ordering, pagination) so that opening, closing or submitting a panel
+  does not reset the table.
+
+  Panel-local query keys such as `tab` and `page` are dropped; pass them in
+  `extra` when the target panel needs them. `return_to` is kept so a panel can
+  still navigate back to where it was opened from.
+
+  Accepts either a socket or the template assigns.
+  """
+  def live_table_path(socket_or_assigns, path, extra \\ [])
+
+  def live_table_path(%Phoenix.LiveView.Socket{assigns: assigns}, path, extra) do
+    live_table_path(assigns, path, extra)
+  end
+
+  def live_table_path(assigns, path, extra) when is_map(assigns) do
+    table_ids = Map.get(assigns, :live_table_ids, [])
+
+    query =
+      assigns
+      |> Map.get(:query_params, %{})
+      |> Map.filter(fn {key, _value} -> live_table_key?(key, table_ids) end)
+      |> Map.merge(Map.new(extra, fn {key, value} -> {to_string(key), value} end))
+      |> Map.reject(fn {_key, value} -> is_nil(value) end)
+      |> Plug.Conn.Query.encode()
+
+    if query == "" do
+      path
+    else
+      "#{path}?#{query}"
+    end
+  end
+
+  defp live_table_key?("return_to", _table_ids), do: true
+
+  defp live_table_key?(key, table_ids) do
+    Enum.any?(table_ids, &String.starts_with?(key, "#{&1}_"))
+  end
+
   defp put_page_to_params(params, id, page) do
     params
     |> delete_page_from_params(id)

--- a/elixir/test/portal_web/live/actors_test.exs
+++ b/elixir/test/portal_web/live/actors_test.exs
@@ -1637,4 +1637,93 @@ defmodule PortalWeb.ActorsTest do
       refute_receive {:DOWN, ^ref, :process, ^pid, _reason}, 500
     end
   end
+  describe "live table filters across panel operations" do
+    setup %{account: account} do
+      matching = actor_fixture(account: account, name: "Johnny Appleseed")
+      other = actor_fixture(account: account, name: "Zelda Fitzgerald")
+      filter = %{"actors_filter[name_or_email]" => "johnny"}
+      %{matching: matching, other: other, filter: filter}
+    end
+
+    test "are kept when creating a user", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      other: other,
+      filter: filter
+    } do
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors?#{filter}")
+
+      refute html =~ other.name
+
+      render_click(lv, "open_new_actor_panel")
+      assert_patch(lv, ~p"/#{account}/actors/new?#{filter}")
+
+      render_click(lv, "close_panel")
+      assert_patch(lv, ~p"/#{account}/actors?#{filter}")
+
+      render_click(lv, "open_new_actor_panel")
+      render_click(lv, "select_new_actor_type", %{"type" => "user"})
+
+      lv
+      |> form("form[phx-submit='create_user']",
+        actor: %{
+          name: "Johnny Cash",
+          email: "johnny.cash@example.com",
+          type: "account_user",
+          allow_email_otp_sign_in: "true"
+        }
+      )
+      |> render_submit()
+
+      created = Portal.Repo.get_by!(Actor, account_id: account.id, name: "Johnny Cash")
+      assert_patch(lv, ~p"/#{account}/actors/#{created.id}?#{filter}")
+
+      html = render(lv)
+      assert html =~ "Johnny Cash"
+      refute html =~ other.name
+    end
+
+    test "are kept when editing a user", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      matching: matching,
+      other: other,
+      filter: filter
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/#{matching}?#{filter}")
+
+      render_click(lv, "open_actor_edit_form")
+      assert_patch(lv, ~p"/#{account}/actors/#{matching}/edit?#{filter}")
+
+      render_click(lv, "cancel_actor_edit_form")
+      assert_patch(lv, ~p"/#{account}/actors/#{matching}?#{filter}")
+
+      render_click(lv, "open_actor_edit_form")
+
+      lv
+      |> form("form[phx-submit='save']",
+        actor: %{
+          name: "Johnny Renamed",
+          email: matching.email,
+          type: "account_user",
+          allow_email_otp_sign_in: "true"
+        }
+      )
+      |> render_submit()
+
+      assert_patch(lv, ~p"/#{account}/actors/#{matching}?#{filter}")
+
+      html = render(lv)
+      assert html =~ "Johnny Renamed"
+      refute html =~ other.name
+    end
+  end
 end

--- a/elixir/test/portal_web/live/devices_test.exs
+++ b/elixir/test/portal_web/live/devices_test.exs
@@ -1535,4 +1535,49 @@ defmodule PortalWeb.DevicesTest do
        [[{:AttributeTypeAndValue, {2, 5, 4, 3}, {:utf8String, common_name}}]]}
     )
   end
+  describe "live table filters across panel operations" do
+    setup %{account: account, actor: actor} do
+      matching = client_fixture(account: account, actor: actor, name: "laptop-alpha")
+      other = client_fixture(account: account, actor: actor, name: "desktop-beta")
+      filter = %{"devices_filter[search]" => "laptop"}
+      %{matching: matching, other: other, filter: filter}
+    end
+
+    test "are kept when editing a device", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      matching: matching,
+      other: other,
+      filter: filter
+    } do
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/devices/#{matching.id}?#{filter}")
+
+      refute html =~ other.name
+
+      render_click(lv, "open_device_edit_form")
+      assert_patch(lv, ~p"/#{account}/devices/#{matching.id}/edit?#{filter}")
+
+      render_click(lv, "cancel_device_edit_form")
+      assert_patch(lv, ~p"/#{account}/devices/#{matching.id}?#{filter}")
+
+      render_click(lv, "open_device_edit_form")
+
+      lv
+      |> form("[phx-submit='submit_device_edit_form']", device: %{name: "laptop-renamed"})
+      |> render_submit()
+
+      assert_patch(lv, ~p"/#{account}/devices/#{matching.id}?#{filter}")
+
+      html = render(lv)
+      assert html =~ "laptop-renamed"
+      refute html =~ other.name
+
+      render_click(lv, "close_panel")
+      assert_patch(lv, ~p"/#{account}/devices?#{filter}")
+    end
+  end
 end

--- a/elixir/test/portal_web/live/groups_test.exs
+++ b/elixir/test/portal_web/live/groups_test.exs
@@ -774,4 +774,110 @@ defmodule PortalWeb.GroupsTest do
       assert html =~ "Total"
     end
   end
+  describe "live table filters across panel operations" do
+    setup %{account: account} do
+      matching = group_fixture(account: account, name: "Engineering Team")
+      other = group_fixture(account: account, name: "Marketing Team")
+      filter = %{"groups_filter[name]" => "Engineering"}
+      %{matching: matching, other: other, filter: filter}
+    end
+
+    test "are kept when creating a group", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      other: other,
+      filter: filter
+    } do
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/groups?#{filter}")
+
+      refute html =~ other.name
+
+      new_link = "a[href='#{~p"/#{account}/groups/new?#{filter}"}']"
+
+      lv |> element(new_link) |> render_click()
+      assert_patch(lv, ~p"/#{account}/groups/new?#{filter}")
+
+      render_click(lv, "close_panel")
+      assert_patch(lv, ~p"/#{account}/groups?#{filter}")
+
+      lv |> element(new_link) |> render_click()
+
+      lv
+      |> form("#group-form", group: %{name: "Engineering Ops", member_search: ""})
+      |> render_submit()
+
+      group = Portal.Repo.get_by!(Group, account_id: account.id, name: "Engineering Ops")
+      assert_patch(lv, ~p"/#{account}/groups/#{group.id}?#{filter}")
+
+      html = render(lv)
+      assert html =~ "Engineering Ops"
+      refute html =~ other.name
+    end
+
+    test "are kept when editing a group", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      matching: matching,
+      other: other,
+      filter: filter
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/groups/#{matching}?#{filter}")
+
+      lv
+      |> element("a[href='#{~p"/#{account}/groups/#{matching}/edit?#{filter}"}']")
+      |> render_click()
+
+      assert_patch(lv, ~p"/#{account}/groups/#{matching}/edit?#{filter}")
+
+      lv
+      |> form("#group-form", group: %{name: "Engineering Renamed", member_search: ""})
+      |> render_submit()
+
+      assert_patch(lv, ~p"/#{account}/groups/#{matching}?#{filter}")
+
+      html = render(lv)
+      assert html =~ "Engineering Renamed"
+      refute html =~ other.name
+    end
+
+    test "are kept when granting access to a resource", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      matching: matching,
+      other: other,
+      filter: filter
+    } do
+      resource = resource_fixture(account: account, name: "Private API")
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/groups/#{matching}?#{filter}")
+
+      render_click(lv, "switch_group_tab", %{"tab" => "resources"})
+      assert_patch(lv, ~p"/#{account}/groups/#{matching}?#{Map.put(filter, "tab", "resources")}")
+
+      render_click(lv, "open_grant_resource_form")
+      render_click(lv, "toggle_grant_resource", %{"resource_id" => resource.id})
+
+      html =
+        lv
+        |> form("#grant-resource-form")
+        |> render_submit()
+
+      assert Portal.Repo.get_by!(Policy, group_id: matching.id, resource_id: resource.id)
+      assert html =~ resource.name
+      refute html =~ other.name
+      assert has_element?(lv, "input[name='groups[name]'][value='Engineering']")
+    end
+  end
 end

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -1625,4 +1625,108 @@ defmodule PortalWeb.PoliciesTest do
       assert html =~ "Total"
     end
   end
+  describe "live table filters across panel operations" do
+    setup %{account: account} do
+      group = group_fixture(account: account, name: "Engineering Team")
+      other_group = group_fixture(account: account, name: "Marketing Team")
+      resource = resource_fixture(account: account)
+      other_resource = resource_fixture(account: account)
+      matching = policy_fixture(group: group, resource: resource)
+      policy_fixture(group: other_group, resource: other_resource)
+      filter = %{"policies_filter[group_name]" => "Engineering"}
+
+      %{
+        group: group,
+        other_group: other_group,
+        resource: resource,
+        other_resource: other_resource,
+        matching: matching,
+        filter: filter
+      }
+    end
+
+    test "are kept when creating a policy", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      group: group,
+      other_group: other_group,
+      other_resource: other_resource,
+      filter: filter
+    } do
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies?#{filter}")
+
+      refute html =~ other_group.name
+
+      render_click(lv, "open_new_policy_form")
+      assert_patch(lv, ~p"/#{account}/policies/new?#{filter}")
+
+      render_click(lv, "cancel_policy_form")
+      assert_patch(lv, ~p"/#{account}/policies?#{filter}")
+
+      render_click(lv, "open_new_policy_form")
+
+      lv
+      |> form("[phx-submit='submit_policy_form']",
+        policy: %{
+          group_id: group.id,
+          resource_id: other_resource.id,
+          description: "Engineering access"
+        }
+      )
+      |> render_submit()
+
+      policy =
+        Portal.Repo.get_by!(Portal.Policy, group_id: group.id, resource_id: other_resource.id)
+
+      assert_patch(lv, ~p"/#{account}/policies/#{policy.id}?#{filter}")
+
+      html = render(lv)
+      assert html =~ "Engineering access"
+      refute html =~ other_group.name
+    end
+
+    test "are kept when editing a policy", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      group: group,
+      other_group: other_group,
+      resource: resource,
+      matching: matching,
+      filter: filter
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies/#{matching.id}?#{filter}")
+
+      render_click(lv, "open_edit_form")
+      assert_patch(lv, ~p"/#{account}/policies/#{matching.id}/edit?#{filter}")
+
+      render_click(lv, "cancel_policy_form")
+      assert_patch(lv, ~p"/#{account}/policies/#{matching.id}?#{filter}")
+
+      render_click(lv, "open_edit_form")
+
+      lv
+      |> form("[phx-submit='submit_policy_form']",
+        policy: %{
+          group_id: group.id,
+          resource_id: resource.id,
+          description: "Updated description"
+        }
+      )
+      |> render_submit()
+
+      assert_patch(lv, ~p"/#{account}/policies/#{matching.id}?#{filter}")
+
+      html = render(lv)
+      assert html =~ "Updated description"
+      refute html =~ other_group.name
+    end
+  end
 end

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -1585,4 +1585,124 @@ defmodule PortalWeb.ResourcesTest do
   defp site_select(html) do
     html |> Floki.parse_document!() |> Floki.find("#resource_site_id")
   end
+  describe "live table filters across panel operations" do
+    setup %{account: account} do
+      site = site_fixture(account: account)
+      matching = resource_fixture(account: account, site: site, name: "alpha-server")
+      other = resource_fixture(account: account, site: site, name: "beta-server")
+      filter = %{"resources_filter[name_or_address]" => "alpha"}
+      %{site: site, matching: matching, other: other, filter: filter}
+    end
+
+    test "are kept when creating a resource", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      site: site,
+      other: other,
+      filter: filter
+    } do
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources?#{filter}")
+
+      refute html =~ other.name
+
+      render_click(lv, "open_new_form")
+      assert_patch(lv, ~p"/#{account}/resources/new?#{filter}")
+
+      render_click(lv, "cancel_resource_form")
+      assert_patch(lv, ~p"/#{account}/resources?#{filter}")
+
+      render_click(lv, "open_new_form")
+
+      lv
+      |> form("[phx-submit='submit_resource_form']", resource: %{type: "dns"})
+      |> render_change()
+
+      lv
+      |> form("[phx-submit='submit_resource_form']",
+        resource: %{
+          type: "dns",
+          name: "alpha-two",
+          address: "alpha2.example.com",
+          site_id: site.id
+        }
+      )
+      |> render_submit()
+
+      resource = Repo.get_by!(Resource, account_id: account.id, name: "alpha-two")
+      assert_patch(lv, ~p"/#{account}/resources/#{resource.id}?#{filter}")
+
+      html = render(lv)
+      assert html =~ "alpha-two"
+      refute html =~ other.name
+    end
+
+    test "are kept when editing and deleting a resource", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      matching: matching,
+      other: other,
+      filter: filter
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{matching.id}?#{filter}")
+
+      render_click(lv, "open_edit_form")
+      assert_patch(lv, ~p"/#{account}/resources/#{matching.id}/edit?#{filter}")
+
+      render_click(lv, "cancel_resource_form")
+      assert_patch(lv, ~p"/#{account}/resources/#{matching.id}?#{filter}")
+
+      render_click(lv, "open_edit_form")
+
+      lv
+      |> form("[phx-submit='submit_resource_form']", resource: %{name: "alpha-renamed"})
+      |> render_submit()
+
+      assert_patch(lv, ~p"/#{account}/resources/#{matching.id}?#{filter}")
+
+      html = render(lv)
+      assert html =~ "alpha-renamed"
+      refute html =~ other.name
+
+      render_click(lv, "confirm_delete_resource")
+      render_click(lv, "delete_resource")
+      assert_patch(lv, ~p"/#{account}/resources?#{filter}")
+    end
+
+    test "are kept when granting access to a resource", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      matching: matching,
+      other: other,
+      filter: filter
+    } do
+      group = group_fixture(account: account, name: "Engineering")
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{matching.id}?#{filter}")
+
+      render_click(lv, "open_grant_form")
+      render_click(lv, "toggle_grant_group", %{"group_id" => group.id})
+
+      html =
+        lv
+        |> form("#grant-form")
+        |> render_submit()
+
+      assert Repo.get_by!(Policy, resource_id: matching.id, group_id: group.id)
+      assert html =~ group.name
+      refute html =~ other.name
+      assert has_element?(lv, "input[name='resources[name_or_address]'][value='alpha']")
+    end
+  end
 end

--- a/elixir/test/portal_web/live/service_accounts_test.exs
+++ b/elixir/test/portal_web/live/service_accounts_test.exs
@@ -1140,4 +1140,83 @@ defmodule PortalWeb.ServiceAccountsTest do
       assert render(lv) =~ "Renamed Service Account"
     end
   end
+  describe "live table filters across panel operations" do
+    setup %{account: account} do
+      matching = service_account_fixture(account: account, name: "ci-runner")
+      other = service_account_fixture(account: account, name: "backup-bot")
+      filter = %{"actors_filter[name_or_email]" => "ci-"}
+      %{matching: matching, other: other, filter: filter}
+    end
+
+    test "are kept when creating a service account", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      other: other,
+      filter: filter
+    } do
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/service_accounts?#{filter}")
+
+      refute html =~ other.name
+
+      render_click(lv, "open_new_actor_panel")
+      assert_patch(lv, ~p"/#{account}/service_accounts/new?#{filter}")
+
+      render_click(lv, "close_panel")
+      assert_patch(lv, ~p"/#{account}/service_accounts?#{filter}")
+
+      render_click(lv, "open_new_actor_panel")
+
+      lv
+      |> form("form[phx-submit='create_service_account']",
+        actor: %{name: "ci-deployer"},
+        token_expiration: ""
+      )
+      |> render_submit()
+
+      created =
+        Repo.get_by!(Actor, account_id: account.id, type: :service_account, name: "ci-deployer")
+
+      assert_patch(lv, ~p"/#{account}/service_accounts/#{created.id}?#{filter}")
+
+      html = render(lv)
+      assert html =~ "ci-deployer"
+      refute html =~ other.name
+    end
+
+    test "are kept when editing a service account", %{
+      conn: conn,
+      account: account,
+      actor: actor,
+      matching: matching,
+      other: other,
+      filter: filter
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/service_accounts/#{matching}?#{filter}")
+
+      render_click(lv, "open_actor_edit_form")
+      assert_patch(lv, ~p"/#{account}/service_accounts/#{matching}/edit?#{filter}")
+
+      render_click(lv, "cancel_actor_edit_form")
+      assert_patch(lv, ~p"/#{account}/service_accounts/#{matching}?#{filter}")
+
+      render_click(lv, "open_actor_edit_form")
+
+      lv
+      |> form("form[phx-submit='save']", actor: %{name: "ci-renamed"})
+      |> render_submit()
+
+      assert_patch(lv, ~p"/#{account}/service_accounts/#{matching}?#{filter}")
+
+      html = render(lv)
+      assert html =~ "ci-renamed"
+      refute html =~ other.name
+    end
+  end
 end

--- a/elixir/test/portal_web/live_table_test.exs
+++ b/elixir/test/portal_web/live_table_test.exs
@@ -858,6 +858,63 @@ defmodule PortalWeb.LiveTableTest do
     end
   end
 
+  describe "live_table_path/3" do
+    setup do
+      socket =
+        %Phoenix.LiveView.Socket{
+          assigns: %{__changed__: %{}, live_table_ids: ["actors", "groups"]}
+        }
+        |> put_uri_assigns(
+          "/acc/actors/1?actors_page=2" <>
+            "&actors_filter%5Bname%5D=buz" <>
+            "&actors_order_by=actors%3Aasc%3Aname" <>
+            "&groups_page_size=25" <>
+            "&tab=groups&page=3&return_to=%2Facc%2Fgroups"
+        )
+
+      %{socket: socket}
+    end
+
+    test "keeps table state and return_to but drops panel keys", %{socket: socket} do
+      assert {"/acc/actors/new", query} = split_path(live_table_path(socket, "/acc/actors/new"))
+
+      assert query == %{
+               "actors_page" => "2",
+               "actors_filter[name]" => "buz",
+               "actors_order_by" => "actors:asc:name",
+               "groups_page_size" => "25",
+               "return_to" => "/acc/groups"
+             }
+    end
+
+    test "merges extra params and drops nil values", %{socket: socket} do
+      {_path, query} =
+        split_path(live_table_path(socket, "/acc/actors/1", tab: "groups", page: nil))
+
+      assert query["tab"] == "groups"
+      refute Map.has_key?(query, "page")
+      assert query["actors_filter[name]"] == "buz"
+    end
+
+    test "returns the bare path when there is nothing to carry" do
+      socket =
+        %Phoenix.LiveView.Socket{assigns: %{__changed__: %{}, live_table_ids: ["actors"]}}
+        |> put_uri_assigns("/acc/actors?tab=groups")
+
+      assert live_table_path(socket, "/acc/actors/new") == "/acc/actors/new"
+    end
+
+    test "accepts template assigns", %{socket: socket} do
+      assert live_table_path(socket.assigns, "/acc/actors/new") ==
+               live_table_path(socket, "/acc/actors/new")
+    end
+  end
+
+  defp split_path(path) do
+    %URI{path: path, query: query} = URI.parse(path)
+    {path, URI.decode_query(query || "")}
+  end
+
   defp fetch_patched_query_params!(socket) do
     assert {:noreply, %{redirected: {:live, :patch, %{kind: :push, to: to}}}} = socket
     uri = URI.parse(to)


### PR DESCRIPTION
The live tables keep their filters, sort order, and page in the URL. Opening a new or edit panel, saving, cancelling, or deleting patched to a bare path, so the table saw an empty filter and reset. Row clicks and tab switches already carried the query string, so this was an inconsistency between call sites rather than a design problem.

This adds one helper, `live_table_path`, that builds a patch path carrying every table key on the socket. All panel transitions in the resources, sites, actors, groups, policies, service accounts, and devices views now go through it. Panel-only keys like `tab` and `page` are dropped and passed back explicitly where a panel needs them, which replaces the ad hoc `Map.drop` calls.

Fixes #15206
