### PR TITLE
feat(portal): add API option to create disabled policy

### DIFF
--- a/elixir/lib/portal_api/controllers/policy_controller.ex
+++ b/elixir/lib/portal_api/controllers/policy_controller.ex
@@ -75,6 +75,12 @@ defmodule PortalAPI.PolicyController do
   # coveralls-ignore-start - OpenApiSpex operation specs are compile-time, not executable
   operation :create,
     summary: "Create Policy",
+    description: """
+    Creates a Policy.
+
+    A Policy is enabled by default. Pass `is_disabled: true` to create it \
+    disabled, so it grants no access until enabled.
+    """,
     parameters: [],
     request_body:
       {"Policy Attributes", "application/json", PortalAPI.Schemas.Policy.CreateRequest,
@@ -316,7 +322,7 @@ defmodule PortalAPI.PolicyController do
     # so we only do the request-specific casting here.
     defp create_changeset(attrs, %Authentication.Subject{} = subject) do
       %Policy{}
-      |> cast(attrs, ~w[description group_id resource_id flow_log_uploads_enabled]a)
+      |> cast(attrs, ~w[description group_id resource_id flow_log_uploads_enabled is_disabled]a)
       |> validate_required(~w[group_id resource_id]a)
       |> cast_embed(:conditions, with: &Portal.Policies.Condition.changeset/3)
       |> put_change(:account_id, subject.account.id)

--- a/elixir/lib/portal_api/schemas/policy_schema.ex
+++ b/elixir/lib/portal_api/schemas/policy_schema.ex
@@ -108,6 +108,14 @@ defmodule PortalAPI.Schemas.Policy do
               "Defaults to true. Always false for Internet Resource policies.",
           default: true
         },
+        is_disabled: %Schema{
+          example: false,
+          type: :boolean,
+          description:
+            "Whether the Policy is disabled. A disabled Policy grants no access but is " <>
+              "otherwise retained. Defaults to false.",
+          default: false
+        },
         conditions: %Schema{
           example: [
             %{

--- a/elixir/priv/static/openapi.json
+++ b/elixir/priv/static/openapi.json
@@ -249,6 +249,12 @@
             "format": "uuid",
             "type": "string"
           },
+          "is_disabled": {
+            "default": false,
+            "description": "Whether the Policy is disabled. A disabled Policy grants no access but is otherwise retained. Defaults to false.",
+            "example": false,
+            "type": "boolean"
+          },
           "resource_id": {
             "description": "Resource ID",
             "example": "a9f60587-793c-46ae-8525-597f43ab2fb1",
@@ -18264,6 +18270,7 @@
       },
       "post": {
         "callbacks": {},
+        "description": "Creates a Policy.\n\nA Policy is enabled by default. Pass `is_disabled: true` to create it disabled, so it grants no access until enabled.\n",
         "operationId": "PortalAPI.PolicyController.create",
         "parameters": [],
         "requestBody": {

--- a/elixir/test/portal_api/controllers/policy_controller_test.exs
+++ b/elixir/test/portal_api/controllers/policy_controller_test.exs
@@ -315,6 +315,69 @@ defmodule PortalAPI.PolicyControllerTest do
       assert resp["data"]["conditions"] == []
     end
 
+    test "creates an enabled policy by default", %{conn: conn, account: account, actor: actor} do
+      resource = resource_fixture(account: account)
+      group = group_fixture(account: account)
+
+      attrs = %{"group_id" => group.id, "resource_id" => resource.id}
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/policies", policy: attrs)
+
+      assert %{"data" => %{"id" => id, "is_disabled" => false}} = json_response(conn, 201)
+
+      assert %Policy{is_disabled: false} = Repo.get_by(Policy, id: id, account_id: account.id)
+    end
+
+    test "creates a disabled policy", %{conn: conn, account: account, actor: actor} do
+      resource = resource_fixture(account: account)
+      group = group_fixture(account: account)
+
+      attrs = %{
+        "group_id" => group.id,
+        "resource_id" => resource.id,
+        "is_disabled" => true
+      }
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/policies", policy: attrs)
+
+      assert %{"data" => %{"id" => id, "is_disabled" => true}} = json_response(conn, 201)
+
+      assert %Policy{is_disabled: true} = Repo.get_by(Policy, id: id, account_id: account.id)
+    end
+
+    test "creates an enabled policy when is_disabled is false", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      resource = resource_fixture(account: account)
+      group = group_fixture(account: account)
+
+      attrs = %{
+        "group_id" => group.id,
+        "resource_id" => resource.id,
+        "is_disabled" => false
+      }
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/policies", policy: attrs)
+
+      assert %{"data" => %{"id" => id, "is_disabled" => false}} = json_response(conn, 201)
+
+      assert %Policy{is_disabled: false} = Repo.get_by(Policy, id: id, account_id: account.id)
+    end
+
     test "creates a policy with conditions", %{conn: conn, account: account, actor: actor} do
       resource = resource_fixture(account: account)
       group = group_fixture(account: account)


### PR DESCRIPTION
The REST API could only create Policies in an enabled state; disabling one required a second request. 

Policy creation now accepts `is_disabled`, defaulting to enabled when omitted.