### PR TITLE
feat(portal): ask three survey questions at sign-up

### DIFF
--- a/elixir/lib/portal/account.ex
+++ b/elixir/lib/portal/account.ex
@@ -173,12 +173,81 @@ defmodule Portal.Account.Metadata do
   embedded_schema do
     field :marketing_attribution, :map
     embeds_one :stripe, Portal.Account.Metadata.Stripe, on_replace: :update
+    embeds_one :sign_up_survey, Portal.Account.Metadata.SignUpSurvey, on_replace: :update
   end
 
   def changeset(metadata \\ %__MODULE__{}, attrs) do
     metadata
     |> cast(attrs, [:marketing_attribution])
     |> cast_embed(:stripe, with: &Portal.Account.Metadata.Stripe.changeset/2)
+    |> cast_embed(:sign_up_survey, with: &Portal.Account.Metadata.SignUpSurvey.changeset/2)
+  end
+end
+
+defmodule Portal.Account.Metadata.SignUpSurvey do
+  use Ecto.Schema
+  import Ecto.Changeset
+  import Portal.Changeset
+
+  @motivations ~w[performance access_controls simplicity security open_source cost other]
+  @previous_solutions ~w[tailscale twingate cloudflare openvpn wireguard zerotier cisco zscaler other]
+  @referral_sources ~w[search github reddit hacker_news word_of_mouth blog social_media event other]
+  @other_max_length 255
+
+  @primary_key false
+  embedded_schema do
+    field :motivation, :string
+    field :motivation_other, :string
+    field :switching, :boolean
+    field :previous_solution, :string
+    field :previous_solution_other, :string
+    field :referral_source, :string
+    field :referral_source_other, :string
+  end
+
+  def other_max_length, do: @other_max_length
+
+  def changeset(survey \\ %__MODULE__{}, attrs) do
+    survey
+    |> cast(attrs, [
+      :motivation,
+      :motivation_other,
+      :switching,
+      :previous_solution,
+      :previous_solution_other,
+      :referral_source,
+      :referral_source_other
+    ])
+    |> validate_required([:motivation, :switching, :referral_source])
+    |> validate_inclusion(:motivation, @motivations)
+    |> validate_inclusion(:referral_source, @referral_sources)
+    |> validate_previous_solution()
+    |> validate_other(:motivation, :motivation_other)
+    |> validate_other(:previous_solution, :previous_solution_other)
+    |> validate_other(:referral_source, :referral_source_other)
+  end
+
+  defp validate_previous_solution(changeset) do
+    if get_field(changeset, :switching) do
+      changeset
+      |> validate_required([:previous_solution])
+      |> validate_inclusion(:previous_solution, @previous_solutions)
+    else
+      changeset
+      |> put_change(:previous_solution, nil)
+      |> put_change(:previous_solution_other, nil)
+    end
+  end
+
+  defp validate_other(changeset, field, other_field) do
+    if get_field(changeset, field) == "other" do
+      changeset
+      |> trim_change(other_field)
+      |> validate_required([other_field])
+      |> validate_length(other_field, max: @other_max_length)
+    else
+      put_change(changeset, other_field, nil)
+    end
   end
 end
 

--- a/elixir/lib/portal_web/controllers/home_html.ex
+++ b/elixir/lib/portal_web/controllers/home_html.ex
@@ -61,7 +61,7 @@ defmodule PortalWeb.HomeHTML do
         </div>
         <div class="flex-1 min-w-0">
           <p class="text-sm font-semibold text-heading group-hover:text-brand transition-colors">
-            My company uses Firezone
+            My organization uses Firezone
           </p>
           <p class="text-xs text-subtle mt-0.5 leading-relaxed">
             Find your organization's sign-in page.

--- a/elixir/lib/portal_web/live/find_account.ex
+++ b/elixir/lib/portal_web/live/find_account.ex
@@ -82,7 +82,7 @@ defmodule PortalWeb.FindAccount do
       </div>
       <div>
         <h1 class="text-xl font-bold text-heading tracking-tight">
-          Find your company's account
+          Find your organization's account
         </h1>
         <p class="text-xs text-subtle mt-0.5">
           We'll send you a link to your organization's sign-in page.

--- a/elixir/lib/portal_web/live/sign_up.ex
+++ b/elixir/lib/portal_web/live/sign_up.ex
@@ -268,7 +268,7 @@ defmodule PortalWeb.SignUp do
         <.input
           field={account[:name]}
           type="text"
-          label="Company Name"
+          label="Organization Name"
           placeholder="E.g. Example Corp"
           required
           phx-debounce="300"
@@ -382,7 +382,7 @@ defmodule PortalWeb.SignUp do
         <.input
           field={account[:name]}
           type="text"
-          label="Company Name"
+          label="Organization Name"
           placeholder="E.g. Example Corp"
           required
           autofocus

--- a/elixir/lib/portal_web/live/sign_up.ex
+++ b/elixir/lib/portal_web/live/sign_up.ex
@@ -28,6 +28,7 @@ defmodule PortalWeb.SignUp do
       field(:phone, :string)
       embeds_one(:account, Portal.Account)
       embeds_one(:actor, Actor)
+      embeds_one(:sign_up_survey, Portal.Account.Metadata.SignUpSurvey)
     end
 
     @spec changeset(map()) :: Ecto.Changeset.t()
@@ -41,6 +42,7 @@ defmodule PortalWeb.SignUp do
       |> validate_email_allowed()
       |> cast_embed(:account, with: fn _account, a -> create_account_changeset(a) end)
       |> cast_embed(:actor, with: fn _actor, a -> create_actor_changeset(a) end)
+      |> cast_embed(:sign_up_survey, required: true)
     end
 
     defp validate_email_allowed(changeset) do
@@ -285,6 +287,8 @@ defmodule PortalWeb.SignUp do
         <.input field={actor[:type]} type="hidden" />
       </.inputs_for>
 
+      <.survey_fields form={@form} />
+
       <div class="absolute -left-[10000px] top-auto w-px h-px overflow-hidden" aria-hidden="true">
         <.input
           field={@form[:phone]}
@@ -397,6 +401,8 @@ defmodule PortalWeb.SignUp do
         />
       </.inputs_for>
 
+      <.survey_fields form={@form} />
+
       <button
         type="submit"
         phx-disable-with="Creating..."
@@ -414,6 +420,122 @@ defmodule PortalWeb.SignUp do
         <.link href={~p"/sign_up"} class={[link_style()]}>Start over.</.link>
       </p>
     </.footer>
+    """
+  end
+
+  @motivation_options [
+    {"Better speed / performance", "performance"},
+    {"More granular access controls", "access_controls"},
+    {"Simpler to set up and manage", "simplicity"},
+    {"Better security", "security"},
+    {"Open source", "open_source"},
+    {"Lower cost", "cost"},
+    {"Something else", "other"}
+  ]
+
+  @previous_solution_options [
+    {"Tailscale", "tailscale"},
+    {"Twingate", "twingate"},
+    {"Cloudflare Zero Trust", "cloudflare"},
+    {"OpenVPN", "openvpn"},
+    {"WireGuard", "wireguard"},
+    {"ZeroTier", "zerotier"},
+    {"Cisco / AnyConnect", "cisco"},
+    {"Zscaler", "zscaler"},
+    {"Other", "other"}
+  ]
+
+  @referral_source_options [
+    {"Google / web search", "search"},
+    {"GitHub", "github"},
+    {"Reddit", "reddit"},
+    {"Hacker News", "hacker_news"},
+    {"Word of mouth", "word_of_mouth"},
+    {"Blog / article", "blog"},
+    {"Social media", "social_media"},
+    {"Conference / event", "event"},
+    {"Other", "other"}
+  ]
+
+  attr :form, :any, required: true
+
+  defp survey_fields(assigns) do
+    assigns =
+      assign(assigns,
+        motivation_options: @motivation_options,
+        previous_solution_options: @previous_solution_options,
+        referral_source_options: @referral_source_options,
+        other_max_length: Portal.Account.Metadata.SignUpSurvey.other_max_length()
+      )
+
+    ~H"""
+    <.inputs_for :let={survey} field={@form[:sign_up_survey]}>
+      <.input
+        field={survey[:motivation]}
+        type="select"
+        label="What prompted you to try Firezone?"
+        prompt="Select one"
+        options={@motivation_options}
+        required
+      />
+      <.input
+        :if={survey[:motivation].value == "other"}
+        field={survey[:motivation_other]}
+        type="text"
+        label="What prompted you?"
+        placeholder="Tell us in a few words"
+        maxlength={@other_max_length}
+        required
+        phx-debounce="300"
+      />
+
+      <.input
+        field={survey[:switching]}
+        type="select"
+        label="Are you switching from another VPN or ZTNA solution?"
+        prompt="Select one"
+        options={[{"Yes", "true"}, {"No", "false"}]}
+        required
+      />
+      <.input
+        :if={survey[:switching].value in [true, "true"]}
+        field={survey[:previous_solution]}
+        type="select"
+        label="Which one?"
+        prompt="Select one"
+        options={@previous_solution_options}
+        required
+      />
+      <.input
+        :if={survey[:switching].value in [true, "true"] and survey[:previous_solution].value == "other"}
+        field={survey[:previous_solution_other]}
+        type="text"
+        label="Which solution?"
+        placeholder="E.g. Example VPN"
+        maxlength={@other_max_length}
+        required
+        phx-debounce="300"
+      />
+
+      <.input
+        field={survey[:referral_source]}
+        type="select"
+        label="How did you first hear about Firezone?"
+        prompt="Select one"
+        options={@referral_source_options}
+        required
+      />
+      <.input
+        :if={survey[:referral_source].value == "other"}
+        field={survey[:referral_source_other]}
+        type="text"
+        label="Where did you hear about us?"
+        placeholder="Tell us in a few words"
+        maxlength={@other_max_length}
+        required
+        phx-debounce="300"
+      />
+    </.inputs_for>
     """
   end
 
@@ -786,7 +908,8 @@ defmodule PortalWeb.SignUp do
           account: %{name: registration.account.name},
           actor: %{name: registration.actor.name},
           identity: socket.assigns.google_identity,
-          marketing_attribution: get_in(socket.assigns.website_attribution || %{}, ["marketing"])
+          marketing_attribution: get_in(socket.assigns.website_attribution || %{}, ["marketing"]),
+          sign_up_survey: survey_attrs(registration.sign_up_survey)
         }
 
         handle_registration_result(
@@ -854,6 +977,7 @@ defmodule PortalWeb.SignUp do
           registration.email,
           registration.account.name,
           registration.actor.name,
+          survey_attrs(registration.sign_up_survey),
           socket.assigns.website_attribution
         )
       else
@@ -900,6 +1024,8 @@ defmodule PortalWeb.SignUp do
 
   defp honeypot_filled?(attrs), do: Map.get(attrs, "phone", "") != ""
 
+  defp survey_attrs(%Portal.Account.Metadata.SignUpSurvey{} = survey), do: Map.from_struct(survey)
+
   defp log_honeypot_hit(attrs, user_agent, real_ip) do
     Logger.warning("Sign-up honeypot triggered",
       email: normalize_log_value(Map.get(attrs, "email")),
@@ -924,13 +1050,14 @@ defmodule PortalWeb.SignUp do
     )
   end
 
-  @spec send_verification_email(String.t(), String.t(), String.t(), map() | nil) ::
+  @spec send_verification_email(String.t(), String.t(), String.t(), map(), map() | nil) ::
           {:ok, any()} | {:error, any()}
-  defp send_verification_email(email, company_name, actor_name, website_attribution) do
+  defp send_verification_email(email, company_name, actor_name, sign_up_survey, website_attribution) do
     payload = %{
       email: email,
       company_name: company_name,
       actor_name: actor_name,
+      sign_up_survey: sign_up_survey,
       website_attribution: website_attribution
     }
 
@@ -1090,7 +1217,8 @@ defmodule PortalWeb.SignUp do
           email: email,
           account: %{name: company_name},
           actor: %{name: actor_name},
-          marketing_attribution: get_in(registration_claims, [:website_attribution, "marketing"])
+          marketing_attribution: get_in(registration_claims, [:website_attribution, "marketing"]),
+          sign_up_survey: Map.get(registration_claims, :sign_up_survey)
         }
 
         handle_registration_result(
@@ -1243,7 +1371,8 @@ defmodule PortalWeb.SignUp do
           name: registration.account.name,
           metadata: %{
             stripe: stripe_metadata,
-            marketing_attribution: registration[:marketing_attribution]
+            marketing_attribution: registration[:marketing_attribution],
+            sign_up_survey: registration[:sign_up_survey]
           }
         }
 

--- a/elixir/test/portal_web/controllers/home_controller_test.exs
+++ b/elixir/test/portal_web/controllers/home_controller_test.exs
@@ -106,7 +106,7 @@ defmodule PortalWeb.HomeControllerTest do
 
       assert html =~ "Let's get started!"
       assert html =~ "Which best describes why you're here?"
-      assert html =~ "My company uses Firezone"
+      assert html =~ "My organization uses Firezone"
       refute html =~ "Sign in to Firezone"
     end
 

--- a/elixir/test/portal_web/live/find_account_test.exs
+++ b/elixir/test/portal_web/live/find_account_test.exs
@@ -8,7 +8,7 @@ defmodule PortalWeb.FindAccountTest do
     test "renders email input form", %{conn: conn} do
       {:ok, _lv, html} = live(conn, ~p"/find_account")
 
-      assert html =~ "Find your company&#39;s account"
+      assert html =~ "Find your organization&#39;s account"
       assert html =~ "Work email"
       assert html =~ "Find"
     end

--- a/elixir/test/portal_web/live/sign_up_test.exs
+++ b/elixir/test/portal_web/live/sign_up_test.exs
@@ -75,7 +75,7 @@ defmodule PortalWeb.SignUpTest do
       assert_patch(lv, ~p"/sign_up/email")
       assert html =~ ~s(name="registration[phone]")
       assert html =~ "Work Email"
-      assert html =~ "Company Name"
+      assert html =~ "Organization Name"
       assert html =~ "Your Name"
       assert html =~ "Create Account"
     end
@@ -86,7 +86,7 @@ defmodule PortalWeb.SignUpTest do
       assert html =~ "Create your organization"
       assert html =~ ~s(name="registration[phone]")
       assert html =~ "Work Email"
-      assert html =~ "Company Name"
+      assert html =~ "Organization Name"
       assert html =~ "Your Name"
       assert html =~ "Create Account"
     end
@@ -118,7 +118,7 @@ defmodule PortalWeb.SignUpTest do
       assert html =~ "ada@example.com"
       assert html =~ "Verified by Google"
       assert html =~ ~s(value="Ada Lovelace")
-      assert html =~ "Company Name"
+      assert html =~ "Organization Name"
       refute html =~ ~s(name="registration[email]")
     end
 

--- a/elixir/test/portal_web/live/sign_up_test.exs
+++ b/elixir/test/portal_web/live/sign_up_test.exs
@@ -7,6 +7,7 @@ defmodule PortalWeb.SignUpTest do
   alias Portal.Mocks.Stripe
 
   @sign_up_token_salt "sign_up_email_v1"
+  @survey %{motivation: "security", switching: "false", referral_source: "github"}
 
   describe "direct signup conversions" do
     for {country, allowed} <- [{"US", true}, {"DE", false}] do
@@ -20,7 +21,7 @@ defmodule PortalWeb.SignUpTest do
         ] ++ Stripe.mock_create_subscription_endpoint())
         conn = conn |> put_req_header("x-geo-location-region", @country) |> with_google_identity(email: email)
         {:ok, lv, _} = live(conn, ~p"/sign_up/google")
-        html = lv |> form("#google-sign-up-form", registration: %{account: %{name: "Direct Corp"}, actor: %{name: "Direct User"}}) |> render_submit()
+        html = lv |> form("#google-sign-up-form", registration: %{account: %{name: "Direct Corp"}, actor: %{name: "Direct User"}, sign_up_survey: @survey}) |> render_submit()
         assert html =~ "Your account has been created!"
         account = Portal.Repo.get_by!(Portal.Account, name: "Direct Corp")
         assert account.metadata.marketing_attribution["marketing_allowed"] == @allowed
@@ -34,7 +35,7 @@ defmodule PortalWeb.SignUpTest do
           {"POST", "/v1/customers", 200, Stripe.customer_object("cus_direct", "Direct Corp", email)}
         ] ++ Stripe.mock_create_subscription_endpoint())
         {:ok, lv, _} = live(put_req_header(conn, "x-geo-location-region", @country), ~p"/sign_up/email")
-        lv |> form("form", registration: %{email: email, phone: "", account: %{name: "Direct Corp"}, actor: %{name: "Direct User"}}) |> render_submit()
+        lv |> form("form", registration: %{email: email, phone: "", account: %{name: "Direct Corp"}, actor: %{name: "Direct User"}, sign_up_survey: @survey}) |> render_submit()
         test_pid = self()
         assert_email_sent(fn email ->
           [_, token] = Regex.run(~r/verify_sign_up\?token=([^\s]+)/, email.text_body)
@@ -143,7 +144,7 @@ defmodule PortalWeb.SignUpTest do
       html =
         lv
         |> form("#google-sign-up-form",
-          registration: %{account: %{name: "AB"}, actor: %{name: "Ada Lovelace"}}
+          registration: %{account: %{name: "AB"}, actor: %{name: "Ada Lovelace"}, sign_up_survey: @survey}
         )
         |> render_submit()
 
@@ -176,7 +177,7 @@ defmodule PortalWeb.SignUpTest do
       html =
         lv
         |> form("#google-sign-up-form",
-          registration: %{account: %{name: "Google Corp"}, actor: %{name: "Ada Lovelace"}}
+          registration: %{account: %{name: "Google Corp"}, actor: %{name: "Ada Lovelace"}, sign_up_survey: @survey}
         )
         |> render_submit()
 
@@ -232,7 +233,7 @@ defmodule PortalWeb.SignUpTest do
       html =
         lv
         |> form("#google-sign-up-form",
-          registration: %{account: %{name: "Raced Corp"}, actor: %{name: "Ada Lovelace"}}
+          registration: %{account: %{name: "Raced Corp"}, actor: %{name: "Ada Lovelace"}, sign_up_survey: @survey}
         )
         |> render_submit()
 
@@ -296,7 +297,12 @@ defmodule PortalWeb.SignUpTest do
           "registration" => %{
             "email" => "victim@example.com",
             "account" => %{"name" => "Honest Corp"},
-            "actor" => %{"name" => "Ada Lovelace"}
+            "actor" => %{"name" => "Ada Lovelace"},
+            "sign_up_survey" => %{
+              "motivation" => "security",
+              "switching" => "false",
+              "referral_source" => "github"
+            }
           }
         })
 
@@ -318,7 +324,7 @@ defmodule PortalWeb.SignUpTest do
       html =
         lv
         |> form("#google-sign-up-form",
-          registration: %{account: %{name: "Late Corp"}, actor: %{name: "Ada Lovelace"}}
+          registration: %{account: %{name: "Late Corp"}, actor: %{name: "Ada Lovelace"}, sign_up_survey: @survey}
         )
         |> render_submit()
 
@@ -336,7 +342,7 @@ defmodule PortalWeb.SignUpTest do
       html =
         lv
         |> form("#google-sign-up-form",
-          registration: %{account: %{name: "Test Corp"}, actor: %{name: "Ada Lovelace"}}
+          registration: %{account: %{name: "Test Corp"}, actor: %{name: "Ada Lovelace"}, sign_up_survey: @survey}
         )
         |> render_submit()
 
@@ -358,7 +364,7 @@ defmodule PortalWeb.SignUpTest do
           registration: %{
             email: email,
             account: %{name: "Another Corp"},
-            actor: %{name: "Another User"}
+            actor: %{name: "Another User"}, sign_up_survey: @survey
           }
         )
         |> render_submit()
@@ -381,7 +387,7 @@ defmodule PortalWeb.SignUpTest do
           registration: %{
             email: "someone@example.com",
             account: %{name: "AB"},
-            actor: %{name: "Test User"}
+            actor: %{name: "Test User"}, sign_up_survey: @survey
           }
         )
         |> render_submit()
@@ -399,7 +405,7 @@ defmodule PortalWeb.SignUpTest do
           registration: %{
             email: "not-an-email",
             account: %{name: "Test Corp"},
-            actor: %{name: "Test User"}
+            actor: %{name: "Test User"}, sign_up_survey: @survey
           }
         )
         |> render_submit()
@@ -414,7 +420,7 @@ defmodule PortalWeb.SignUpTest do
       email = "ratelimit@example.com"
 
       attrs = %{
-        registration: %{email: email, account: %{name: "Test Corp"}, actor: %{name: "Test User"}}
+        registration: %{email: email, account: %{name: "Test Corp"}, actor: %{name: "Test User"}, sign_up_survey: @survey}
       }
 
       {:ok, lv, _} = live(conn, ~p"/sign_up/email")
@@ -458,7 +464,7 @@ defmodule PortalWeb.SignUpTest do
             email: "newuser@example.com",
             phone: "",
             account: %{name: "Test Corp"},
-            actor: %{name: "Test User"}
+            actor: %{name: "Test User"}, sign_up_survey: @survey
           }
         )
         |> render_submit()
@@ -485,7 +491,7 @@ defmodule PortalWeb.SignUpTest do
           email: "attributed@example.com",
           phone: "",
           account: %{name: "Attributed Corp"},
-          actor: %{name: "Attributed User"}
+          actor: %{name: "Attributed User"}, sign_up_survey: @survey
         }
       )
       |> render_submit()
@@ -516,7 +522,7 @@ defmodule PortalWeb.SignUpTest do
             email: "bot@example.com",
             phone: "555-0100",
             account: %{name: "Bot Corp"},
-            actor: %{name: "Bot User"}
+            actor: %{name: "Bot User"}, sign_up_survey: @survey
           }
         )
         |> render_submit()
@@ -525,6 +531,214 @@ defmodule PortalWeb.SignUpTest do
       refute_email_sent()
     end
 
+  end
+
+  describe "sign-up survey" do
+    test "renders the survey questions on both forms", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/sign_up/email")
+      assert html =~ "What prompted you to try Firezone?"
+      assert html =~ "Are you switching from another VPN or ZTNA solution?"
+      assert html =~ "How did you first hear about Firezone?"
+      refute html =~ "Which one?"
+
+      {:ok, _lv, html} = live(with_google_identity(conn), ~p"/sign_up/google")
+      assert html =~ "What prompted you to try Firezone?"
+      assert html =~ "How did you first hear about Firezone?"
+    end
+
+    test "unanswered questions keep the form with errors", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/sign_up/email")
+
+      html =
+        lv
+        |> form("form",
+          registration: %{
+            email: "survey@example.com",
+            account: %{name: "Survey Corp"},
+            actor: %{name: "Survey User"},
+            sign_up_survey: %{motivation: "", switching: "", referral_source: ""}
+          }
+        )
+        |> render_submit()
+
+      assert html =~ "can&#39;t be blank"
+      refute html =~ "Check your email"
+      refute_email_sent()
+    end
+
+    test "switching to another solution reveals and requires the previous solution", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/sign_up/email")
+
+      html =
+        lv
+        |> form("form", registration: %{sign_up_survey: %{switching: "true"}})
+        |> render_change()
+
+      assert html =~ "Which one?"
+      assert html =~ "Tailscale"
+
+      html =
+        lv
+        |> form("form",
+          registration: %{
+            email: "switcher@example.com",
+            account: %{name: "Switcher Corp"},
+            actor: %{name: "Switcher"},
+            sign_up_survey: %{motivation: "cost", switching: "true", referral_source: "reddit"}
+          }
+        )
+        |> render_submit()
+
+      assert html =~ "can&#39;t be blank"
+      refute html =~ "Check your email"
+    end
+
+    test "other answers reveal a bounded free-text field", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/sign_up/email")
+
+      html =
+        lv
+        |> form("form", registration: %{sign_up_survey: %{motivation: "other"}})
+        |> render_change()
+
+      assert html =~ ~s(name="registration[sign_up_survey][motivation_other]")
+      assert html =~ ~s(maxlength="255")
+
+      submit = fn other ->
+        lv
+        |> form("form",
+          registration: %{
+            email: "other@example.com",
+            account: %{name: "Other Corp"},
+            actor: %{name: "Other User"},
+            sign_up_survey: %{
+              motivation: "other",
+              motivation_other: other,
+              switching: "false",
+              referral_source: "github"
+            }
+          }
+        )
+        |> render_submit()
+      end
+
+      assert submit.("   ") =~ "can&#39;t be blank"
+      assert submit.(String.duplicate("a", 256)) =~ "should be at most 255 character"
+      refute_email_sent()
+      assert submit.("Needed IPv6 support") =~ "Check your email"
+      assert_email_sent()
+    end
+
+    test "Google signup stores the survey in account metadata", %{conn: conn} do
+      Stripe.stub(
+        [
+          {"POST", "/v1/customers", 200,
+           Stripe.customer_object("cus_test", "Survey Corp", "ada@example.com")}
+        ] ++ Stripe.mock_create_subscription_endpoint()
+      )
+
+      {:ok, lv, _html} = live(with_google_identity(conn), ~p"/sign_up/google")
+
+      lv
+      |> form("#google-sign-up-form",
+        registration: %{sign_up_survey: %{switching: "true", referral_source: "other"}}
+      )
+      |> render_change()
+
+      html =
+        lv
+        |> form("#google-sign-up-form",
+          registration: %{sign_up_survey: %{previous_solution: "other"}}
+        )
+        |> render_change()
+
+      assert html =~ ~s(name="registration[sign_up_survey][previous_solution_other]")
+
+      html =
+        lv
+        |> form("#google-sign-up-form",
+          registration: %{
+            account: %{name: "Survey Corp"},
+            actor: %{name: "Ada Lovelace"},
+            sign_up_survey: %{
+              motivation: "open_source",
+              switching: "true",
+              previous_solution: "other",
+              previous_solution_other: "  Homegrown WireGuard  ",
+              referral_source: "other",
+              referral_source_other: "A podcast"
+            }
+          }
+        )
+        |> render_submit()
+
+      assert html =~ "Your account has been created!"
+
+      account = Portal.Repo.get_by!(Portal.Account, name: "Survey Corp")
+
+      assert %Portal.Account.Metadata.SignUpSurvey{
+               motivation: "open_source",
+               motivation_other: nil,
+               switching: true,
+               previous_solution: "other",
+               previous_solution_other: "Homegrown WireGuard",
+               referral_source: "other",
+               referral_source_other: "A podcast"
+             } = account.metadata.sign_up_survey
+    end
+
+    test "email signup carries the survey through the verification token", %{conn: conn} do
+      Stripe.stub(
+        [
+          {"POST", "/v1/customers", 200,
+           Stripe.customer_object("cus_test", "Token Corp", "token@example.com")}
+        ] ++ Stripe.mock_create_subscription_endpoint()
+      )
+
+      {:ok, lv, _html} = live(conn, ~p"/sign_up/email")
+
+      lv
+      |> form("form",
+        registration: %{
+          email: "token@example.com",
+          phone: "",
+          account: %{name: "Token Corp"},
+          actor: %{name: "Token User"},
+          sign_up_survey: %{
+            motivation: "simplicity",
+            switching: "false",
+            referral_source: "hacker_news"
+          }
+        }
+      )
+      |> render_submit()
+
+      test_pid = self()
+
+      assert_email_sent(fn email ->
+        [_, token] = Regex.run(~r/verify_sign_up\?token=([^\s]+)/, email.text_body)
+        send(test_pid, {:verification_token, token})
+        true
+      end)
+
+      assert_receive {:verification_token, token}
+
+      assert {:ok, %{sign_up_survey: %{motivation: "simplicity", previous_solution: nil}}} =
+               Phoenix.Token.verify(PortalWeb.Endpoint, @sign_up_token_salt, token)
+
+      {:ok, _lv, html} = live(build_conn(), ~p"/verify_sign_up?token=#{token}")
+      assert html =~ "Your account has been created!"
+
+      account = Portal.Repo.get_by!(Portal.Account, name: "Token Corp")
+
+      assert %Portal.Account.Metadata.SignUpSurvey{
+               motivation: "simplicity",
+               switching: false,
+               previous_solution: nil,
+               referral_source: "hacker_news",
+               referral_source_other: nil
+             } = account.metadata.sign_up_survey
+    end
   end
 
   describe "verify action — mount" do


### PR DESCRIPTION
The sign-up form only collected an email, a company name, and the admin's name. It now also asks three short questions: what prompted the visitor to try Firezone, whether they are switching from another VPN or ZTNA product and which one, and how they first heard about Firezone.

Every answer comes from a fixed list. Picking "Other" reveals a text box that is trimmed and capped at 255 characters, so the free-text answers stay bounded. The "Which one?" question only appears after answering "Yes" to switching, and a stale answer is cleared if the visitor flips back to "No".

The answers are stored under `sign_up_survey` in the account metadata. The Google path stores them directly. The email path carries them inside the signed verification link, so they still land when the link is opened in a different browser. Links signed before this change have no survey and still create the account.
