### PR TITLE
feat(gateway): seed telemetry with cached account slug

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2461,6 +2461,7 @@ name = "firezone-gateway"
 version = "1.6.2"
 dependencies = [
  "anyhow-ext",
+ "atomicfs",
  "backoff",
  "bin-shared",
  "caps",
@@ -2471,6 +2472,7 @@ dependencies = [
  "flow-log-writer",
  "futures",
  "futures-bounded",
+ "hex",
  "hickory-resolver",
  "humantime",
  "ip-packet",
@@ -2488,6 +2490,9 @@ dependencies = [
  "rpassword",
  "rustls",
  "secrecy",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
  "snownet",
  "socket-factory",
  "telemetry",

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -25,6 +25,7 @@ depends = 'iptables,systemd'
 
 [dependencies]
 anyhow = { workspace = true }
+atomicfs = { workspace = true }
 backoff = { workspace = true }
 bin-shared = { workspace = true }
 clap = { workspace = true }
@@ -34,6 +35,7 @@ flow-log-upload = { workspace = true }
 flow-log-writer = { workspace = true }
 futures = { workspace = true }
 futures-bounded = { workspace = true }
+hex = { workspace = true }
 hickory-resolver = { workspace = true }
 humantime = { workspace = true }
 ip-packet = { workspace = true }
@@ -50,6 +52,9 @@ resolv-conf = { workspace = true }
 rpassword = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
 snownet = { workspace = true }
 socket-factory = { workspace = true }
 telemetry = { workspace = true }

--- a/rust/gateway/src/account_slug.rs
+++ b/rust/gateway/src/account_slug.rs
@@ -1,0 +1,132 @@
+//! Caches the account slug reported by the portal, so it is available before the next login.
+
+use anyhow::{Context as _, Result};
+use secrecy::{ExposeSecret as _, SecretString};
+use sha2::Digest as _;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// The account slug of the most recent successful login, cached on disk.
+///
+/// The cache is keyed by a hash of the token it was written with.
+/// That keeps the token itself off the disk and invalidates the slug when the Gateway is pointed at a different account.
+pub(crate) struct Cache {
+    path: PathBuf,
+    token_hash: String,
+    slug: Option<String>,
+}
+
+impl Cache {
+    /// Loads the cache from `/var/lib/firezone/account_slug`.
+    pub(crate) fn new(token: &SecretString) -> Self {
+        const CACHE_PATH: &str = "/var/lib/firezone/account_slug";
+
+        Self::at(PathBuf::from(CACHE_PATH), token)
+    }
+
+    /// Returns the cached account slug, if there is one for the current token.
+    pub(crate) fn get(&self) -> Option<&str> {
+        self.slug.as_deref()
+    }
+
+    /// Caches `slug` on disk, doing nothing if it is already cached.
+    ///
+    /// # Errors
+    ///
+    /// If the cache file cannot be written.
+    pub(crate) fn set(&mut self, slug: &str) -> Result<()> {
+        if self.slug.as_deref() == Some(slug) {
+            return Ok(());
+        }
+
+        let dir = self
+            .path
+            .parent()
+            .context("Account slug path should always have a parent")?;
+        fs::create_dir_all(dir).context("Failed to create dir for account slug")?;
+
+        let content = serde_json::to_string(&CacheJson {
+            token_hash: self.token_hash.clone(),
+            account_slug: slug.to_owned(),
+        })
+        .context("Impossible: Failed to serialize account slug")?;
+
+        atomicfs::write(&self.path, content).context("Failed to write account slug file")?;
+
+        self.slug = Some(slug.to_owned());
+
+        Ok(())
+    }
+
+    fn at(path: PathBuf, token: &SecretString) -> Self {
+        let token_hash = hex::encode(sha2::Sha256::digest(token.expose_secret()));
+
+        let slug = match read_at(&path, &token_hash) {
+            Ok(slug) => Some(slug),
+            Err(e) => {
+                tracing::debug!("No cached account slug: {e:#}");
+
+                None
+            }
+        };
+
+        Self {
+            path,
+            token_hash,
+            slug,
+        }
+    }
+}
+
+fn read_at(path: &Path, token_hash: &str) -> Result<String> {
+    let content = fs::read_to_string(path).context("Failed to read file")?;
+    let cache = serde_json::from_str::<CacheJson>(&content)
+        .context("Failed to deserialize content as JSON")?;
+
+    anyhow::ensure!(
+        cache.token_hash == token_hash,
+        "Cache belongs to a different token"
+    );
+
+    Ok(cache.account_slug)
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct CacheJson {
+    token_hash: String,
+    account_slug: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn slug_is_read_back_for_the_same_token() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("account_slug");
+        let mut cache = Cache::at(path.clone(), &token("some-token"));
+
+        cache.set("acme").unwrap();
+
+        assert_eq!(Cache::at(path, &token("some-token")).get(), Some("acme"));
+    }
+
+    #[test]
+    fn slug_is_discarded_for_a_different_token() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("account_slug");
+        let mut cache = Cache::at(path.clone(), &token("some-token"));
+
+        cache.set("acme").unwrap();
+
+        assert_eq!(Cache::at(path, &token("another-token")).get(), None);
+    }
+
+    fn token(token: &str) -> SecretString {
+        SecretString::from(token)
+    }
+}

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -27,7 +27,7 @@ use tunnel::{
     GatewayEvent, GatewayTunnel, IPV4_TUNNEL, IPV6_TUNNEL, IpConfig, ResolveDnsRequest, TunnelError,
 };
 
-use crate::RELEASE;
+use crate::{RELEASE, account_slug};
 
 pub const PHOENIX_TOPIC: &str = "gateway";
 
@@ -46,6 +46,8 @@ pub struct Eventloop {
 
     /// The `--flow-logs` flag.
     local_flow_logs: bool,
+
+    account_slug: account_slug::Cache,
 
     resolve_tasks: futures_bounded::FuturesTupleSet<
         Result<Vec<IpAddr>, Arc<anyhow::Error>>,
@@ -85,6 +87,7 @@ impl Eventloop {
         resolver: TokioResolver,
         flow_logs_dir: std::path::PathBuf,
         local_flow_logs: bool,
+        account_slug: account_slug::Cache,
     ) -> Result<Self> {
         let (portal_event_tx, portal_event_rx) = mpsc::channel(128);
         let (portal_cmd_tx, portal_cmd_rx) = mpsc::channel(128);
@@ -104,6 +107,7 @@ impl Eventloop {
             resolver,
             flow_logs_dir,
             local_flow_logs,
+            account_slug,
             resolve_tasks: futures_bounded::FuturesTupleSet::new(
                 || futures_bounded::Delay::tokio(DNS_RESOLUTION_TIMEOUT),
                 1000,
@@ -428,6 +432,10 @@ impl Eventloop {
             }) => {
                 if let Some(account_slug) = account_slug {
                     telemetry::set_account_slug(account_slug.clone());
+
+                    if let Err(e) = self.account_slug.set(&account_slug) {
+                        tracing::debug!("Failed to cache account slug: {e:#}");
+                    }
 
                     analytics::identify(RELEASE.to_owned(), account_slug, None, None)
                 }

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -31,6 +31,7 @@ use tracing_subscriber::layer;
 use tun::Tun;
 use url::Url;
 
+mod account_slug;
 mod eventloop;
 mod manage;
 mod otel;
@@ -172,9 +173,15 @@ async fn try_main(cli: Cli) -> Result<()> {
             .context("Failed to read `FIREZONE_TOKEN` systemd credential")?,
     };
 
+    let account_slug = account_slug::Cache::new(&token);
+
     if cli.is_telemetry_allowed() {
         telemetry::start(cli.api_url.as_str(), RELEASE, telemetry::GATEWAY_DSN);
         telemetry::set_firezone_id(firezone_id.clone());
+
+        if let Some(slug) = account_slug.get() {
+            telemetry::set_account_slug(slug.to_owned());
+        }
     }
 
     if let Some(backend) = cli.metrics {
@@ -291,6 +298,7 @@ async fn try_main(cli: Cli) -> Result<()> {
         resolver,
         flow_logs_dir,
         cli.flow_logs,
+        account_slug,
     )?
     .run()
     .await


### PR DESCRIPTION
A Gateway learns which account it belongs to from the portal's init message, so a Gateway that never gets past login reports its errors with no account attached and we cannot tell whose deployment is broken.

Caching the slug on disk, keyed by a hash of the token it was learned with, lets telemetry name the account from process start rather than from the first successful login. Keying on the token means the cache invalidates itself when a Gateway is pointed at a different account, and hashing it keeps the token off the disk.