### PR TITLE
fix(gateway): stop restarting when the portal refuses the token

### DIFF
--- a/rust/gateway/debian/firezone-gateway.service
+++ b/rust/gateway/debian/firezone-gateway.service
@@ -33,6 +33,9 @@ TimeoutStartSec=15s
 TimeoutStopSec=15s
 Restart=always
 RestartSec=7
+# 78 is `EX_CONFIG` from `sysexits.h`: the portal refused the token, so restarting
+# cannot help until an operator installs a new one.
+RestartPreventExitStatus=78
 
 #####################
 # HARDENING OPTIONS #

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -45,6 +45,11 @@ const DEFAULT_MAX_PARTITION_TIME: Duration = Duration::from_secs(60 * 60 * 24); 
 /// with 0700/0600 permissions.
 const FLOW_LOGS_DIR: &str = "/var/lib/firezone/flow_logs";
 
+/// Exit code that tells systemd this failure needs an operator, so restarting cannot fix it.
+///
+/// `EX_CONFIG` from `sysexits.h`; `firezone-gateway.service` lists it in `RestartPreventExitStatus`.
+const EX_CONFIG: u8 = 78;
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
@@ -88,9 +93,20 @@ fn main() -> ExitCode {
         }
         Err(e) if e.any_is::<EventloopFailed>() => {
             tracing::error!("{e:#}");
+
+            let exit_code = if needs_new_token(&e) {
+                tracing::info!(
+                    "Replace the token in `/etc/firezone/gateway-token` and start the service again"
+                );
+
+                ExitCode::from(EX_CONFIG)
+            } else {
+                ExitCode::FAILURE
+            };
+
             telemetry::stop();
 
-            ExitCode::FAILURE
+            exit_code
         }
         Err(e) => {
             tracing::info!("{e:#}");
@@ -302,6 +318,12 @@ async fn try_main(cli: Cli) -> Result<()> {
 #[derive(thiserror::Error, Debug)]
 #[error("Eventloop failed")]
 struct EventloopFailed;
+
+/// Returns whether the portal refused our token and will keep refusing it.
+fn needs_new_token(e: &anyhow::Error) -> bool {
+    e.any_downcast_ref::<phoenix_channel::Error>()
+        .is_some_and(phoenix_channel::Error::requires_sign_in)
+}
 
 fn tonic_otlp_exporter(
     endpoint: String,
@@ -604,6 +626,16 @@ mod tests {
         unsafe {
             std::env::remove_var("CREDENTIALS_DIRECTORY");
         }
+    }
+
+    #[test]
+    fn only_an_invalid_token_needs_a_new_one() {
+        let invalid_token =
+            anyhow::Error::new(phoenix_channel::Error::InvalidToken).context(EventloopFailed);
+        let unrelated = anyhow::Error::msg("TUN device disappeared").context(EventloopFailed);
+
+        assert!(needs_new_token(&invalid_token));
+        assert!(!needs_new_token(&unrelated));
     }
 
     #[test]

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -639,19 +639,14 @@ mod tests {
     }
 
     #[test]
-    fn systemd_units_prevent_restart_on_ex_config() {
+    fn packaged_unit_prevents_restart_on_ex_config() {
         let unit = include_str!("../debian/firezone-gateway.service");
-        let install_script = include_str!("../../../scripts/gateway-systemd-install.sh");
 
         let directive = format!("RestartPreventExitStatus={EX_CONFIG}");
 
         assert!(
             unit.contains(&directive),
             "`firezone-gateway.service` must carry `{directive}`"
-        );
-        assert!(
-            install_script.contains(&directive),
-            "`gateway-systemd-install.sh` must carry `{directive}`"
         );
     }
 

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -639,6 +639,23 @@ mod tests {
     }
 
     #[test]
+    fn systemd_units_prevent_restart_on_ex_config() {
+        let unit = include_str!("../debian/firezone-gateway.service");
+        let install_script = include_str!("../../../scripts/gateway-systemd-install.sh");
+
+        let directive = format!("RestartPreventExitStatus={EX_CONFIG}");
+
+        assert!(
+            unit.contains(&directive),
+            "`firezone-gateway.service` must carry `{directive}`"
+        );
+        assert!(
+            install_script.contains(&directive),
+            "`gateway-systemd-install.sh` must carry `{directive}`"
+        );
+    }
+
+    #[test]
     fn adds_flow_logs_directive_to_default() {
         let directives = make_directives(None, true);
 

--- a/scripts/gateway-systemd-install.sh
+++ b/scripts/gateway-systemd-install.sh
@@ -131,6 +131,9 @@ TimeoutStartSec=15s
 TimeoutStopSec=15s
 Restart=always
 RestartSec=7
+# 78 is \`EX_CONFIG\` from \`sysexits.h\`: the portal refused the token, so restarting
+# cannot help until an operator installs a new one.
+RestartPreventExitStatus=78
 
 #####################
 # HARDENING OPTIONS #


### PR DESCRIPTION
The portal refuses an invalid or revoked token outright, so a Gateway holding one exits within seconds of starting. `Restart=always` then brings it back seven seconds later, forever, and every attempt reports the same login failure. No restart can turn a refused token into a valid one: that needs an operator to install a new one.

The Gateway now reports that failure with a distinct exit code and the unit declines to restart on it, so the service stays failed and quiet until the token is replaced. Every other failure keeps restarting as before.