### PR TITLE
fix(gateway): repair `/var/lib/firezone` ownership recursively

### DIFF
--- a/rust/gateway/debian/firezone-gateway.tmpfiles
+++ b/rust/gateway/debian/firezone-gateway.tmpfiles
@@ -4,3 +4,4 @@ d /etc/firezone 0755 firezone firezone
 f /etc/firezone/gateway-env 0644 firezone firezone -
 f /etc/firezone/gateway-token 0400 root root -
 f /etc/firezone/gateway-preset-env 0644 firezone firezone -
+Z /var/lib/firezone ~0700 firezone firezone -


### PR DESCRIPTION
`StateDirectory=` takes a shortcut documented in `systemd.exec(5)` and implemented in `chown-recursive.c`: when the top-level directory already has the right owner it skips the recursive chown entirely, assuming the tree below it is fine. A `/var/lib/firezone` whose spool was left root-owned by a Gateway that once ran as root therefore stays broken across upgrades, and flow-log writes keep failing with `Permission denied`.

The tmpfiles `Z` type has no such shortcut, and the package's `postinst` already activates the tmpfiles config, so the repair lands at install time on both fresh installs and upgrades. The `~` mode prefix holds directories at `0700` while masking the executable bits off files, matching the `0700` and `0600` the spool writes for itself.

Related: #14827
