### PR TITLE
fix(gui-client): let the Tunnel service clean up its own logs

### DIFF
--- a/rust/gui-client/src-tauri/src/logging.rs
+++ b/rust/gui-client/src-tauri/src/logging.rs
@@ -92,14 +92,9 @@ pub fn setup_gui(directives: &str) -> Result<Handles> {
         "`gui-client` started logging"
     );
 
-    // Start background log cleanup thread
-    let log_dirs = log_paths()
-        .context("Can't compute log paths for cleanup")?
-        .into_iter()
-        .map(|lp| lp.src)
-        .collect();
+    // Not the Tunnel service's log dir: only it has the privileges to delete those.
     let cleanup = logging::start_log_cleanup_thread(
-        log_dirs,
+        vec![log_path],
         logging::DEFAULT_MAX_SIZE_MB,
         logging::DEFAULT_CLEANUP_INTERVAL,
     )?;
@@ -121,6 +116,7 @@ pub fn setup_tunnel(
     logging::file::Handle,
     logging::FilterReloadHandle,
     Option<flow_log_writer::Guard>,
+    logging::CleanupHandle,
 )> {
     // If `log_dir` is Some, use that. Else call `tunnel_service_logs`
     let log_path = log_path.map_or_else(
@@ -164,10 +160,17 @@ pub fn setup_tunnel(
         "`tunnel service` started logging"
     );
 
+    let cleanup = logging::start_log_cleanup_thread(
+        vec![log_path],
+        logging::DEFAULT_MAX_SIZE_MB,
+        logging::DEFAULT_CLEANUP_INTERVAL,
+    )?;
+
     Ok((
         file_handle,
         file_reloader.merge(stdout_reloader),
         flow_log_guard,
+        cleanup,
     ))
 }
 

--- a/rust/gui-client/src-tauri/src/service/linux.rs
+++ b/rust/gui-client/src-tauri/src/service/linux.rs
@@ -9,7 +9,8 @@ use crate::ipc::SocketId;
 ///
 /// Linux uses the CLI args from here, Windows does not
 pub fn run(log_dir: Option<PathBuf>, dns_control: DnsControlMethod) -> Result<()> {
-    let (_handle, log_filter_reloader, _flow_log_guard) = crate::logging::setup_tunnel(log_dir)?;
+    let (_handle, log_filter_reloader, _flow_log_guard, _cleanup) =
+        crate::logging::setup_tunnel(log_dir)?;
     if !elevation_check()? {
         bail!("Tunnel service failed its elevation check, try running as admin / root");
     }

--- a/rust/gui-client/src-tauri/src/service/macos.rs
+++ b/rust/gui-client/src-tauri/src/service/macos.rs
@@ -4,7 +4,8 @@ use std::path::PathBuf;
 
 pub fn run(log_dir: Option<PathBuf>, _dns_control: DnsControlMethod) -> Result<()> {
     // We call this here to avoid a dead-code warning.
-    let (_handle, _log_filter_reloader, _flow_log_guard) = crate::logging::setup_tunnel(log_dir)?;
+    let (_handle, _log_filter_reloader, _flow_log_guard, _cleanup) =
+        crate::logging::setup_tunnel(log_dir)?;
 
     bail!("not implemented")
 }

--- a/rust/gui-client/src-tauri/src/service/windows.rs
+++ b/rust/gui-client/src-tauri/src/service/windows.rs
@@ -255,7 +255,7 @@ windows_service::define_windows_service!(run_service_ffi, run_service);
 fn run_service(arguments: Vec<OsString>) {
     // `arguments` doesn't seem to work right when running as a Windows service
     // (even though it's meant for that) so just use the default log dir.
-    let (_handle, log_filter_reloader, _flow_log_guard) =
+    let (_handle, log_filter_reloader, _flow_log_guard, _cleanup) =
         crate::logging::setup_tunnel(None).expect("Should be able to set up logging");
 
     tracing::info!(?arguments, "run_service");

--- a/rust/libs/logging/src/cleanup.rs
+++ b/rust/libs/logging/src/cleanup.rs
@@ -204,7 +204,7 @@ pub fn enforce_size_cap(log_dirs: &[&Path], max_size_mb: u32) -> u64 {
                         tracing::debug!(path = %path.display(), "Log file already deleted");
                     }
                     ErrorKind::PermissionDenied => {
-                        tracing::warn!(path = %path.display(), "Permission denied deleting old log file");
+                        tracing::debug!(path = %path.display(), "Permission denied deleting old log file");
                     }
                     _ => {
                         tracing::warn!(path = %path.display(), error = %e, "Failed to delete old log file");


### PR DESCRIPTION
The GUI client's log cleanup thread swept the Tunnel service's log directory as well as its own. Those files belong to SYSTEM on Windows and root on Linux, so the desktop user could never delete them and the hourly pass retried the same files forever.

The Tunnel service now enforces the size cap on its own log directory, where it has the privileges to do so, and the GUI client only sweeps its own. As a consequence the cap applies to each directory separately rather than to their sum, so a large Tunnel service log directory no longer evicts the GUI client's own logs.