### PR TITLE
fix(android): report when the VPN interface cannot be built

### DIFF
--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
@@ -22,6 +22,7 @@ import dev.firezone.android.tunnel.FakeSession
 import dev.firezone.android.tunnel.FakeSessionFactory
 import dev.firezone.android.tunnel.TestRestrictions
 import dev.firezone.android.tunnel.TunnelNotification
+import dev.firezone.android.tunnel.UNASSIGNABLE_IPV6
 import dev.firezone.android.tunnel.benchController
 import dev.firezone.android.tunnel.engineeringWiki
 import dev.firezone.android.tunnel.finishAllActivities
@@ -32,6 +33,7 @@ import dev.firezone.android.tunnel.launchApp
 import dev.firezone.android.tunnel.resumedActivity
 import dev.firezone.android.tunnel.startTunnelService
 import dev.firezone.android.tunnel.stopTunnelService
+import dev.firezone.android.tunnel.tunInterface
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
@@ -230,6 +232,28 @@ class TunnelE2eTest {
         assertEquals("Managed Pixel", session.config.deviceName)
     }
 
+    @Test
+    fun theTunnelInterfaceReachesConnlib() {
+        val session = signInAndConnect()
+
+        session.emit(tunInterface())
+
+        awaitCommand(session, "setTun")
+    }
+
+    @Test
+    fun anInterfaceTheDeviceRefusesIsReportedAndEndsTheSession() {
+        val session = signInAndConnect()
+
+        session.emit(tunInterface(ipv6 = UNASSIGNABLE_IPV6))
+
+        assertEquals(
+            "This device rejected Firezone's tunnel configuration. Contact your administrator for support.",
+            awaitErrorNotification(),
+        )
+        awaitCommand(session, "disconnect")
+    }
+
     private fun signInAndConnect(): FakeSession {
         signIn()
         startTunnelService()
@@ -262,6 +286,17 @@ class TunnelE2eTest {
         return disconnectedNotification()
     }
 
+    private fun awaitErrorNotification(): String? {
+        await("the error notification") { errorNotification() != null }
+
+        return errorNotification()
+    }
+
+    private fun awaitCommand(
+        session: FakeSession,
+        command: String,
+    ) = runBlocking { withTimeout(TIMEOUT_MS) { session.awaitCommand(command) } }
+
     private fun await(
         what: String,
         condition: () -> Boolean,
@@ -277,10 +312,14 @@ class TunnelE2eTest {
         }
     }
 
-    private fun disconnectedNotification(): String? =
+    private fun disconnectedNotification(): String? = notificationText(TunnelNotification.DISCONNECTED_NOTIFICATION_ID)
+
+    private fun errorNotification(): String? = notificationText(TunnelNotification.ERROR_NOTIFICATION_ID)
+
+    private fun notificationText(id: Int): String? =
         notificationManager()
             .activeNotifications
-            .firstOrNull { it.id == TunnelNotification.DISCONNECTED_NOTIFICATION_ID }
+            .firstOrNull { it.id == id }
             ?.notification
             ?.extras
             ?.getString(Notification.EXTRA_TEXT)

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Connlib.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/tunnel/Connlib.kt
@@ -1,9 +1,11 @@
 // Licensed under Apache 2.0 (C) 2026 Firezone, Inc.
 package dev.firezone.android.tunnel
 
+import uniffi.connlib.Cidr
 import uniffi.connlib.ConnectedDevice
 import uniffi.connlib.DisconnectError
 import uniffi.connlib.DnsResource
+import uniffi.connlib.Event
 import uniffi.connlib.InternetResource
 import uniffi.connlib.NoHandle
 import uniffi.connlib.Resource
@@ -57,3 +59,22 @@ val benchController =
         tunIpv6 = "fd00:2021:1111::12",
         pools = listOf("Lab hardware", "Shared storage"),
     )
+
+// The interface connlib hands the service once the portal has assigned this Client its addresses.
+// The routes deliberately exclude a default route so the tunnel a test establishes cannot take the
+// emulator's own connectivity with it.
+fun tunInterface(
+    ipv4: String = "100.64.0.1",
+    ipv6: String = "fd00:2021:1111::1",
+) = Event.TunInterfaceUpdated(
+    ipv4 = ipv4,
+    ipv6 = ipv6,
+    dns = listOf("100.100.111.1"),
+    searchDomain = null,
+    ipv4Routes = listOf(Cidr("100.64.0.0", 11u), Cidr("100.100.111.0", 24u)),
+    ipv6Routes = listOf(Cidr("fd00:2021:1111::", 107u), Cidr("fd00:2021:1111:8000::", 107u)),
+)
+
+// Multicast passes `VpnService.Builder`'s own validation and the kernel then refuses it, which is
+// how a device that will not take one of our addresses fails the entire interface.
+const val UNASSIGNABLE_IPV6 = "ff02::1"

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -169,7 +169,7 @@ class TunnelService : VpnService() {
             binder
         }
 
-    private fun buildVpnService() {
+    private fun vpnBuilder(): Builder {
         fun handleApplications(
             appRestrictions: Bundle,
             key: String,
@@ -180,7 +180,7 @@ class TunnelService : VpnService() {
             }
         }
 
-        Builder()
+        return Builder()
             .apply {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     setMetered(false) // Inherit the metered status from the underlying networks.
@@ -222,16 +222,43 @@ class TunnelService : VpnService() {
 
                 addAddress(tunnelIpv4Address!!, 32)
                 addAddress(tunnelIpv6Address!!, 128)
-            }.runCatching { establish() }
-            .onFailure { Log.e(TAG, "Error establishing VPN service", it) }
-            .onSuccess { fd ->
-                if (fd == null) {
-                    Log.d(TAG, "VpnService.Builder.establish() returned null")
-                    return@onSuccess
-                }
-
-                sendTunnelCommand(TunnelCommand.SetTun(fd.detachFd()))
             }
+    }
+
+    private fun buildVpnService() {
+        if (tunnelIpv4Address == null || tunnelIpv6Address == null) {
+            // A managed-configuration change can land before connlib has handed us an interface.
+            Log.d(TAG, "Not building the VPN interface: connlib has not configured one yet")
+            return
+        }
+
+        // Both assembling the interface and handing it to the system can be rejected, and either
+        // way connlib is left without a TUN device and moves no traffic at all.
+        val fd =
+            try {
+                vpnBuilder().establish()
+            } catch (e: Exception) {
+                Log.e(TAG, "Cannot establish the VPN interface", e)
+                showErrorNotification(
+                    "Could not create the VPN interface",
+                    "This device rejected Firezone's tunnel configuration. Contact your administrator for support.",
+                )
+                disconnect()
+                return
+            }
+
+        if (fd == null) {
+            // `establish` only returns null once our VPN consent is gone.
+            Log.e(TAG, "VpnService.Builder.establish() returned null")
+            showErrorNotification(
+                "VPN permission required",
+                "Firezone is no longer allowed to set up a VPN on this device. Open Firezone to grant the permission again.",
+            )
+            disconnect()
+            return
+        }
+
+        sendTunnelCommand(TunnelCommand.SetTun(fd.detachFd()))
     }
 
     private val restrictionsFilter = IntentFilter(Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED)


### PR DESCRIPTION
Failing to establish the VPN interface was only logged. connlib was left without a TUN device while the session stayed open, so the app went on reporting itself as connected over a tunnel that carried nothing, and the user was never told why.

Report the failure and end the session instead.