### PR TITLE
fix(android): narrow the TUN to the families Android accepts

### DIFF
--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/e2e/TunnelE2eTest.kt
@@ -242,10 +242,22 @@ class TunnelE2eTest {
     }
 
     @Test
-    fun anInterfaceTheDeviceRefusesIsReportedAndEndsTheSession() {
+    fun anAddressTheDeviceRefusesLeavesTheFamilyItAccepts() {
         val session = signInAndConnect()
 
         session.emit(tunInterface(ipv6 = UNASSIGNABLE_IPV6))
+
+        awaitCommand(session, "setTun")
+        assertNull(errorNotification())
+    }
+
+    @Test
+    fun anInterfaceTheDeviceRefusesEntirelyIsReportedAndEndsTheSession() {
+        val session = signInAndConnect()
+
+        // `VpnService.Builder` rejects loopback outright, so no address family is left to fall
+        // back to.
+        session.emit(tunInterface(ipv4 = "127.0.0.1", ipv6 = "::1"))
 
         assertEquals(
             "This device rejected Firezone's tunnel configuration. Contact your administrator for support.",

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -100,6 +100,7 @@ class TunnelService : VpnService() {
     private var tunnelDnsAddresses: MutableList<String> = mutableListOf()
     private var tunnelSearchDomain: String? = null
     private var tunnelRoutes: MutableList<Cidr> = mutableListOf()
+    private var acceptedFamilies: Set<AddressFamily>? = null
     private var resourceState: ResourceState = ResourceState.UNSET
 
     // For reacting to changes to the network
@@ -169,7 +170,7 @@ class TunnelService : VpnService() {
             binder
         }
 
-    private fun vpnBuilder(): Builder {
+    private fun vpnBuilder(families: Set<AddressFamily>): Builder {
         fun handleApplications(
             appRestrictions: Bundle,
             key: String,
@@ -180,13 +181,15 @@ class TunnelService : VpnService() {
             }
         }
 
+        val routes = tunnelRoutes.filter { familyOf(it.address) in families }
+
         return Builder()
             .apply {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     setMetered(false) // Inherit the metered status from the underlying networks.
                 }
 
-                if (tunnelRoutes.all { it.prefix != 0 }) {
+                if (routes.all { it.prefix != 0 }) {
                     // Allow traffic to bypass the VPN interface when Always-on VPN is enabled only
                     // if full-route is not enabled.
                     allowBypass()
@@ -208,11 +211,11 @@ class TunnelService : VpnService() {
                 addDisallowedApplication("com.google.firebase.messaging") // Firebase Cloud Messaging
                 addDisallowedApplication("com.google.android.gsf") // Google Services Framework
 
-                tunnelRoutes.forEach {
+                routes.forEach {
                     addRoute(it.address, it.prefix)
                 }
 
-                tunnelDnsAddresses.forEach { dns ->
+                tunnelDnsAddresses.filter { familyOf(it) in families }.forEach { dns ->
                     addDnsServer(dns)
                 }
 
@@ -220,8 +223,13 @@ class TunnelService : VpnService() {
                     addSearchDomain(it)
                 }
 
-                addAddress(tunnelIpv4Address!!, 32)
-                addAddress(tunnelIpv6Address!!, 128)
+                if (AddressFamily.V4 in families) {
+                    addAddress(tunnelIpv4Address!!, 32)
+                }
+
+                if (AddressFamily.V6 in families) {
+                    addAddress(tunnelIpv6Address!!, 128)
+                }
             }
     }
 
@@ -232,33 +240,55 @@ class TunnelService : VpnService() {
             return
         }
 
-        // Both assembling the interface and handing it to the system can be rejected, and either
-        // way connlib is left without a TUN device and moves no traffic at all.
-        val fd =
-            try {
-                vpnBuilder().establish()
-            } catch (e: Exception) {
-                Log.e(TAG, "Cannot establish the VPN interface", e)
+        // Android hands the addresses to the kernel one at a time and discards the ones it already
+        // applied as soon as one is rejected, so a device that refuses IPv6 fails the entire
+        // interface. Dropping the family it will not take is the only way to get a TUN device there.
+        //
+        // A rejected `establish` also tears down the interface we already have, so stay on the
+        // families this device accepted rather than re-running the doomed attempts on every update.
+        val attempts = acceptedFamilies?.let { listOf(it) } ?: ADDRESS_FAMILY_ATTEMPTS
+        var lastFailure: Throwable? = null
+
+        for (families in attempts) {
+            val fd =
+                try {
+                    vpnBuilder(families).establish()
+                } catch (e: Exception) {
+                    Log.d(TAG, "Cannot establish the VPN interface for $families", e)
+                    lastFailure = e
+                    continue
+                }
+
+            if (fd == null) {
+                // `establish` only returns null once our VPN consent is gone, and no narrower
+                // interface wins it back.
+                Log.e(TAG, "VpnService.Builder.establish() returned null")
                 showErrorNotification(
-                    "Could not create the VPN interface",
-                    "This device rejected Firezone's tunnel configuration. Contact your administrator for support.",
+                    "VPN permission required",
+                    "Firezone is no longer allowed to set up a VPN on this device. Open Firezone to grant the permission again.",
                 )
                 disconnect()
                 return
             }
 
-        if (fd == null) {
-            // `establish` only returns null once our VPN consent is gone.
-            Log.e(TAG, "VpnService.Builder.establish() returned null")
-            showErrorNotification(
-                "VPN permission required",
-                "Firezone is no longer allowed to set up a VPN on this device. Open Firezone to grant the permission again.",
-            )
-            disconnect()
+            if (families != ALL_ADDRESS_FAMILIES) {
+                Log.i(TAG, "Established the VPN interface with $families only")
+            }
+
+            acceptedFamilies = families
+            sendTunnelCommand(TunnelCommand.SetTun(fd.detachFd()))
             return
         }
 
-        sendTunnelCommand(TunnelCommand.SetTun(fd.detachFd()))
+        // Whatever we learned about this device no longer holds, so start over next time.
+        acceptedFamilies = null
+
+        Log.e(TAG, "Cannot establish the VPN interface", checkNotNull(lastFailure))
+        showErrorNotification(
+            "Could not create the VPN interface",
+            "This device rejected Firezone's tunnel configuration. Contact your administrator for support.",
+        )
+        disconnect()
     }
 
     private val restrictionsFilter = IntentFilter(Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED)
@@ -871,6 +901,23 @@ class TunnelService : VpnService() {
             UP,
             DOWN,
         }
+
+        enum class AddressFamily {
+            V4,
+            V6,
+        }
+
+        private val ALL_ADDRESS_FAMILIES = setOf(AddressFamily.V4, AddressFamily.V6)
+
+        // Ordered from the interface we want to the ones we settle for.
+        private val ADDRESS_FAMILY_ATTEMPTS =
+            listOf(
+                ALL_ADDRESS_FAMILIES,
+                setOf(AddressFamily.V4),
+                setOf(AddressFamily.V6),
+            )
+
+        private fun familyOf(address: String): AddressFamily = if (address.contains(':')) AddressFamily.V6 else AddressFamily.V4
 
         private const val SESSION_NAME: String = "Firezone Connection"
         private const val MTU: Int = 1280


### PR DESCRIPTION
Android applies the tunnel's addresses one at a time and throws away the ones it already set as soon as it rejects one, so a device that will not take our IPv6 address fails the entire interface and never gets a TUN device at all. Devices without kernel IPv6 support can therefore never connect.

Retry with a narrower set of address families, keeping the routes and DNS servers the surviving families can carry.