### PR TITLE
fix(android): only mark the tunnel up once connlib has the TUN

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/NetworkMonitor.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/NetworkMonitor.kt
@@ -16,11 +16,6 @@ class NetworkMonitor(
         network: Network,
         linkProperties: LinkProperties,
     ) {
-        if (tunnelService.tunnelState != TunnelService.Companion.State.UP) {
-            tunnelService.tunnelState = TunnelService.Companion.State.UP
-            tunnelService.startConnectedNotification()
-        }
-
         if (lastDns != linkProperties.dnsServers) {
             lastDns = linkProperties.dnsServers
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -562,7 +562,7 @@ class TunnelService : VpnService() {
         return deviceId
     }
 
-    fun startConnectedNotification() {
+    private fun startConnectedNotification() {
         val notification = TunnelNotification.createConnectedNotification(this)
         startForeground(TunnelNotification.CONNECTED_NOTIFICATION_ID, notification)
     }
@@ -676,6 +676,13 @@ class TunnelService : VpnService() {
 
                             is TunnelCommand.SetTun -> {
                                 session.setTun(command.fd)
+
+                                // connlib only moves packets once it holds the TUN device, so this
+                                // is the first moment the tunnel is actually carrying traffic.
+                                if (tunnelState != State.UP) {
+                                    tunnelState = State.UP
+                                    startConnectedNotification()
+                                }
                             }
 
                             is TunnelCommand.Reset -> {


### PR DESCRIPTION
The network callback flipped the service to `UP` and posted the connected notification off the underlying network's link properties, which says nothing about whether the tunnel exists. Any failure to establish the VPN interface therefore still left the app reporting itself as connected while it carried no traffic at all.