### PR TITLE
fix(gui-client): derive telemetry environment in the service

### DIFF
--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -127,8 +127,8 @@ fn try_main(cli: Cli, rt: &Runtime, log_guard: &mut Option<LogGuard>) -> Result<
     // owned by the privileged Tunnel service and arrive over the `Hello` IPC
     // message. Telemetry stays in `entrypoint` mode (started in `main`) and the
     // log filter is `RUST_LOG` or a hardcoded `info` until then; once `Hello`
-    // lands the controller re-applies the effective log filter and sends the
-    // real environment to the service via `StartTelemetry`.
+    // lands the controller re-applies the effective log filter and re-points
+    // telemetry at the effective API URL.
     let log_filter = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_owned());
 
     *log_guard = None;

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -426,16 +426,13 @@ impl<I: GuiIntegration> Controller<I> {
     }
 
     async fn update_telemetry_context(&mut self) -> Result<()> {
-        let environment = self.api_url().to_string();
-
         if !self.telemetry_allowed {
             return Ok(());
         }
 
-        telemetry::start(&environment, crate::RELEASE, telemetry::GUI_DSN);
+        telemetry::start(self.api_url().as_str(), crate::RELEASE, telemetry::GUI_DSN);
 
         self.send_ipc(&service::ClientMsg::StartTelemetry {
-            environment: environment.clone(),
             release: crate::RELEASE.to_string(),
         })
         .await?;

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -68,7 +68,6 @@ pub enum ClientMsg {
     ApplyAdvancedSettings(AdvancedSettings),
     SetInternetResourceState(bool),
     StartTelemetry {
-        environment: String,
         release: String,
     },
     #[cfg(debug_assertions)]
@@ -660,19 +659,11 @@ impl<'a> Handler<'a> {
         Poll::Pending
     }
 
-    /// Re-points telemetry to the neutral environment so events emitted while
-    /// disconnected aren't attributed to the ended session.
-    fn reset_telemetry_environment(&mut self) {
-        if let Some(release) = &self.telemetry_release {
-            telemetry::start("entrypoint", release, telemetry::GUI_DSN);
-        }
-    }
-
     async fn handle_connlib_event(&mut self, msg: client_shared::Event) -> Result<()> {
         match msg {
             client_shared::Event::Disconnected(error) => {
                 self.session = Session::None;
-                self.reset_telemetry_environment();
+                telemetry::set_account_slug(None);
                 self.dns_controller.deactivate()?;
                 self.send_ipc(ServerMsg::OnDisconnect {
                     user_msg: error.user_message(),
@@ -772,7 +763,7 @@ impl<'a> Handler<'a> {
             }
             ClientMsg::Disconnect => {
                 self.session = Session::None;
-                self.reset_telemetry_environment();
+                telemetry::set_account_slug(None);
                 self.dns_controller.deactivate()?;
 
                 // Always send `DisconnectedGracefully` even if we weren't connected,
@@ -806,10 +797,7 @@ impl<'a> Handler<'a> {
 
                 connlib.set_internet_resource_state(state);
             }
-            ClientMsg::StartTelemetry {
-                environment,
-                release,
-            } => {
+            ClientMsg::StartTelemetry { release } => {
                 // This is a bit hacky.
                 // It would be cleaner to pass it down from the `Cli` struct.
                 // However, the service can be run in many different ways and adapting all of those
@@ -821,8 +809,7 @@ impl<'a> Handler<'a> {
 
                 if !no_telemetry {
                     self.telemetry_release = Some(release.clone());
-                    telemetry::start(&environment, &release, telemetry::GUI_DSN);
-                    telemetry::set_firezone_id(self.device_id.id.clone());
+                    self.point_telemetry_at_api_url();
 
                     opentelemetry::global::set_meter_provider(
                         telemetry::SentryMeterProvider::default(),
@@ -845,6 +832,19 @@ impl<'a> Handler<'a> {
             .as_ref()
             .map(|u| u.as_str())
             .unwrap_or_else(|| self.advanced_settings.api_url.as_str())
+    }
+
+    /// Points telemetry at the API URL we would dial.
+    ///
+    /// Deriving the environment here instead of accepting one from the GUI is what keeps
+    /// telemetry off for unofficial deployments: it cannot name a portal we never talk to.
+    fn point_telemetry_at_api_url(&self) {
+        let Some(release) = &self.telemetry_release else {
+            return;
+        };
+
+        telemetry::start(self.api_url(), release, telemetry::GUI_DSN);
+        telemetry::set_firezone_id(self.device_id.id.clone()); // Re-pointing clears the identity.
     }
 
     /// One keystore read serves the whole attempt: the certificate presented to the portal and
@@ -872,6 +872,9 @@ impl<'a> Handler<'a> {
             },
             Ok(None) | Err(_) => None,
         };
+
+        // The settings may have moved since the GUI last asked us to start telemetry.
+        self.point_telemetry_at_api_url();
 
         let api_url = self.api_url().to_string();
         let url = LoginUrl::client(


### PR DESCRIPTION
The GUI process computed the telemetry environment from its own copy of the advanced settings and pushed it to the Tunnel service over IPC, while the service connected to the portal using its own copy. Nothing kept the two in step, so the service could report against an environment it never talked to, defeating the gating that keeps telemetry off for unofficial deployments.

The service now derives the environment from the same `api_url()` that builds the `LoginUrl`, both when the GUI asks it to start telemetry and on every connect, so the two cannot disagree. Disconnecting no longer re-points to the neutral `entrypoint` environment, which started a session regardless of the configured portal; it now just forgets the account the ended session belonged to.