### PR TITLE
fix(flow-logs): widen the cluster size on 32-bit Android ABIs

### DIFF
--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -625,7 +625,8 @@ fn cluster_bytes(path: &Path) -> Option<u64> {
         .inspect_err(|e| tracing::debug!(path = %path.display(), "Failed to stat volume: {e}"))
         .ok()?;
 
-    Some(stats.fragment_size())
+    // `c_ulong` is 32-bit on Android's 32-bit ABIs.
+    Some(stats.fragment_size() as u64)
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
`nix` types `fragment_size()` as `c_ulong`, which is 32-bit on the `armeabi-v7a` and `x86` ABIs, so the Android build stopped compiling once the flow-log spool started sizing itself against the file system's cluster size. A cast rather than `u64::from`, because on the 64-bit ABIs that conversion is a no-op and clippy rejects it.

Related: #15211