### PR TITLE
feat(portal): send founder follow-up email after sign-up

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -324,6 +324,8 @@ config :portal, Portal.Analytics.PostHog,
   project_api_key: nil,
   req_opts: [receive_timeout: 5_000, retry: :transient]
 
+config :portal, Portal.Workers.SignUpFollowUp, from_email: nil, bcc_email: nil
+
 config :portal, Portal.Splunk.APIClient, req_opts: []
 
 config :portal, Portal.Datadog.APIClient, req_opts: []

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -733,6 +733,10 @@ if config_env() == :prod do
     endpoint: "https://bzr.openai.com/v1/events",
     req_opts: [receive_timeout: 5_000, retry: false]
 
+  config :portal, Portal.Workers.SignUpFollowUp,
+    from_email: env_var_to_config(:sign_up_follow_up_from_email),
+    bcc_email: env_var_to_config(:sign_up_follow_up_bcc_email)
+
   posthog_project_api_key = env_var_to_config(:posthog_project_api_key)
 
   config :portal, Portal.Analytics.PostHog,

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -877,6 +877,31 @@ defmodule Portal.Config.Definitions do
   )
 
   @doc """
+  Sender address of the founder follow-up email sent 15 minutes after a web sign-up.
+
+  The follow-up email is disabled when this is unset or blank. The address must be
+  allowed as a sender on the outbound email adapter.
+  """
+  defconfig(:sign_up_follow_up_from_email, :string,
+    default: nil,
+    dump: fn
+      value when is_binary(value) -> if String.trim(value) == "", do: nil, else: String.trim(value)
+      value -> value
+    end
+  )
+
+  @doc """
+  BCC address for the founder follow-up email, such as the HubSpot BCC logging address.
+  """
+  defconfig(:sign_up_follow_up_bcc_email, :string,
+    default: nil,
+    dump: fn
+      value when is_binary(value) -> if String.trim(value) == "", do: nil, else: String.trim(value)
+      value -> value
+    end
+  )
+
+  @doc """
   Enable or disable the Firezone telemetry collection.
   """
   defconfig(:instrumentation_client_logs_enabled, :boolean, default: true)

--- a/elixir/lib/portal/mailer/sign_up_follow_up_email.ex
+++ b/elixir/lib/portal/mailer/sign_up_follow_up_email.ex
@@ -1,0 +1,32 @@
+defmodule Portal.Mailer.SignUpFollowUpEmail do
+  @moduledoc false
+
+  import Portal.Mailer
+  import Swoosh.Email
+
+  @from_name "Jamil Bou Kheir"
+  @subject "Tell me what you think of Firezone"
+
+  @paragraphs [
+    "Hi there,",
+    "I'm Jamil, Firezone's founder.",
+    "I noticed you recently signed up for an account. Can I answer any questions or help you get set up?",
+    "How's it working for you so far? Initial thoughts?",
+    "I read every reply and do my best to respond. Thanks so much!",
+    "Jamil"
+  ]
+
+  def follow_up_email(%Portal.Actor{account: %Portal.Account{} = account} = actor, config) do
+    new()
+    |> from({@from_name, Keyword.fetch!(config, :from_email)})
+    |> to(actor.email)
+    |> maybe_bcc(config[:bcc_email])
+    |> subject(@subject)
+    |> with_account_id(account.id)
+    |> text_body(Enum.join(@paragraphs, "\n\n") <> "\n")
+    |> html_body(Enum.map_join(@paragraphs, &"<p>#{Plug.HTML.html_escape(&1)}</p>"))
+  end
+
+  defp maybe_bcc(email, bcc_email) when is_binary(bcc_email), do: bcc(email, bcc_email)
+  defp maybe_bcc(email, _bcc_email), do: email
+end

--- a/elixir/lib/portal/workers/sign_up_follow_up.ex
+++ b/elixir/lib/portal/workers/sign_up_follow_up.ex
@@ -1,0 +1,87 @@
+defmodule Portal.Workers.SignUpFollowUp do
+  @moduledoc """
+  Sends the founder follow-up email 15 minutes after a web sign-up.
+
+  The job carries only IDs. The recipient is loaded at send time so a disabled
+  account or admin is skipped. A BCC to the HubSpot logging address attaches the
+  email to the CRM contact.
+  """
+
+  use Oban.Worker,
+    queue: :default,
+    max_attempts: 10,
+    unique: [period: :infinity, keys: [:account_id]]
+
+  alias Portal.Mailer
+  alias __MODULE__.Database
+  require Logger
+
+  @delay {15, :minutes}
+
+  def enabled? do
+    from_email = config()[:from_email]
+    is_binary(from_email) and String.trim(from_email) != ""
+  end
+
+  def schedule(account, actor) do
+    if enabled?() do
+      %{"account_id" => account.id, "actor_id" => actor.id}
+      |> new(schedule_in: @delay)
+      |> Oban.insert()
+      |> case do
+        {:ok, _job} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning("Could not schedule sign-up follow-up email",
+            account_id: account.id,
+            reason: inspect(reason)
+          )
+      end
+    end
+
+    :ok
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"account_id" => account_id, "actor_id" => actor_id}}) do
+    case Database.fetch_recipient(account_id, actor_id) do
+      %Portal.Actor{} = actor -> deliver(actor)
+      nil -> :ok
+    end
+  end
+
+  defp deliver(actor) do
+    if enabled?() do
+      actor
+      |> Mailer.SignUpFollowUpEmail.follow_up_email(config())
+      |> Mailer.deliver_with_rate_limit(rate_limit_key: {:sign_up_follow_up, actor.account_id})
+      |> case do
+        {:ok, _result} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      :ok
+    end
+  end
+
+  defp config, do: Portal.Config.get_env(:portal, __MODULE__, [])
+
+  defmodule Database do
+    import Ecto.Query
+    alias Portal.Safe
+
+    def fetch_recipient(account_id, actor_id) do
+      from(actor in Portal.Actor,
+        join: account in assoc(actor, :account),
+        where: actor.id == ^actor_id,
+        where: actor.account_id == ^account_id,
+        where: actor.is_disabled == false,
+        where: account.is_disabled == false,
+        preload: [account: account]
+      )
+      |> Safe.unscoped()
+      |> Safe.one()
+    end
+  end
+end

--- a/elixir/lib/portal_web/live/sign_up.ex
+++ b/elixir/lib/portal_web/live/sign_up.ex
@@ -1236,6 +1236,7 @@ defmodule PortalWeb.SignUp do
        ) do
     Portal.Analytics.PostHog.identify_actor(actor, account, website_attribution)
     Portal.Analytics.registration_completed(account, actor)
+    Portal.Workers.SignUpFollowUp.schedule(account, actor)
 
     assign(socket,
       step: :account_created,

--- a/elixir/test/portal/workers/sign_up_follow_up_test.exs
+++ b/elixir/test/portal/workers/sign_up_follow_up_test.exs
@@ -1,0 +1,88 @@
+defmodule Portal.Workers.SignUpFollowUpTest do
+  use Portal.DataCase, async: true
+  use Oban.Testing, repo: Portal.Repo
+
+  alias Portal.Workers.SignUpFollowUp
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+
+  setup do
+    Portal.Config.put_env_override(:portal, SignUpFollowUp,
+      from_email: "jamil@firezone.dev",
+      bcc_email: "23723443@bcc.na2.hubspot.com"
+    )
+
+    account = account_fixture()
+    actor = actor_fixture(account: account, type: :account_admin_user)
+    %{account: account, actor: actor}
+  end
+
+  test "schedules one job per account 15 minutes out", %{account: account, actor: actor} do
+    assert :ok = SignUpFollowUp.schedule(account, actor)
+    assert :ok = SignUpFollowUp.schedule(account, actor)
+
+    assert [job] = all_enqueued(worker: SignUpFollowUp)
+    assert job.args == %{"account_id" => account.id, "actor_id" => actor.id}
+    delay = DateTime.diff(job.scheduled_at, DateTime.utc_now(), :second)
+    assert_in_delta delay, 15 * 60, 60
+  end
+
+  test "does not schedule when the sender is not configured", %{account: account, actor: actor} do
+    Portal.Config.put_env_override(:portal, SignUpFollowUp, from_email: " ")
+    assert :ok = SignUpFollowUp.schedule(account, actor)
+    assert [] == all_enqueued(worker: SignUpFollowUp)
+  end
+
+  test "sends the founder email with the HubSpot BCC", %{account: account, actor: actor} do
+    assert :ok = perform_job(SignUpFollowUp, %{"account_id" => account.id, "actor_id" => actor.id})
+
+    assert_email_sent(fn email ->
+      assert email.from == {"Jamil Bou Kheir", "jamil@firezone.dev"}
+      assert email.to == [{"", actor.email}]
+      assert email.bcc == [{"", "23723443@bcc.na2.hubspot.com"}]
+      assert email.subject == "Tell me what you think of Firezone"
+      assert email.text_body =~ "I'm Jamil, Firezone's founder."
+      assert email.html_body =~ "<p>I&#39;m Jamil, Firezone&#39;s founder.</p>"
+      assert email.private[:account_id] == account.id
+      true
+    end)
+  end
+
+  test "sends without a BCC when no logging address is configured", %{
+    account: account,
+    actor: actor
+  } do
+    Portal.Config.put_env_override(:portal, SignUpFollowUp,
+      from_email: "jamil@firezone.dev",
+      bcc_email: nil
+    )
+
+    assert :ok = perform_job(SignUpFollowUp, %{"account_id" => account.id, "actor_id" => actor.id})
+
+    assert_email_sent(fn email ->
+      assert email.bcc == []
+      true
+    end)
+  end
+
+  test "skips a disabled admin", %{account: account, actor: actor} do
+    {:ok, _} = actor |> Ecto.Changeset.change(is_disabled: true) |> Portal.Repo.update()
+    assert :ok = perform_job(SignUpFollowUp, %{"account_id" => account.id, "actor_id" => actor.id})
+    refute_email_sent()
+  end
+
+  test "skips a disabled account", %{account: account, actor: actor} do
+    {:ok, _} = account |> Ecto.Changeset.change(is_disabled: true) |> Portal.Repo.update()
+    assert :ok = perform_job(SignUpFollowUp, %{"account_id" => account.id, "actor_id" => actor.id})
+    refute_email_sent()
+  end
+
+  test "skips delivery when the sender was removed after scheduling", %{
+    account: account,
+    actor: actor
+  } do
+    Portal.Config.put_env_override(:portal, SignUpFollowUp, from_email: nil)
+    assert :ok = perform_job(SignUpFollowUp, %{"account_id" => account.id, "actor_id" => actor.id})
+    refute_email_sent()
+  end
+end

--- a/elixir/test/portal_web/live/sign_up_test.exs
+++ b/elixir/test/portal_web/live/sign_up_test.exs
@@ -154,6 +154,7 @@ defmodule PortalWeb.SignUpTest do
 
     test "submitting creates the account with Google and email providers", %{conn: conn} do
       Portal.Config.put_env_override(:portal, Portal.Analytics.OpenAI, api_key: "test-key")
+      enable_follow_up_email()
       attribution = %{"marketing_allowed" => true, "captured_at" => System.os_time(:second)}
       conn = init_test_session(conn, website_attribution: %{"marketing" => attribution})
       Stripe.stub(
@@ -191,6 +192,7 @@ defmodule PortalWeb.SignUpTest do
       assert [%{args: %{"event" => event}}] = all_enqueued(worker: Portal.Analytics.OpenAI)
       assert event["type"] == "registration_completed"
       assert event["user"]["emails_sha256"] == [Portal.Analytics.hash_email("ada@example.com")]
+      assert_follow_up_scheduled(account, "ada@example.com")
 
       google_provider = Portal.Repo.get_by!(Portal.Google.AuthProvider, account_id: account.id)
       assert google_provider.issuer == "https://accounts.google.com"
@@ -804,6 +806,7 @@ defmodule PortalWeb.SignUpTest do
   describe "verify action (handle_params with token)" do
     test "valid token for new email creates account and shows welcome step", %{conn: conn} do
       Portal.Config.put_env_override(:portal, Portal.Analytics.OpenAI, api_key: "test-key")
+      enable_follow_up_email()
       attribution = %{"marketing_allowed" => true, "captured_at" => System.os_time(:second)}
       Stripe.stub(
         [
@@ -835,6 +838,7 @@ defmodule PortalWeb.SignUpTest do
       # Reopening the verification link must not emit another conversion.
       assert {:error, {:redirect, _}} = live(conn, ~p"/verify_sign_up?token=#{token}")
       assert [_] = all_enqueued(worker: Portal.Analytics.OpenAI)
+      assert_follow_up_scheduled(account, "newuser@example.com")
       provider = Portal.Repo.get_by!(Portal.X509.AuthProvider, account_id: account.id)
       assert provider.name == "X.509"
       assert provider.context == :clients_only
@@ -902,5 +906,18 @@ defmodule PortalWeb.SignUpTest do
     }
 
     Plug.Test.init_test_session(conn, %{"google_sign_up" => identity})
+  end
+  defp enable_follow_up_email do
+    Portal.Config.put_env_override(:portal, Portal.Workers.SignUpFollowUp,
+      from_email: "jamil@firezone.dev"
+    )
+  end
+
+  defp assert_follow_up_scheduled(account, email) do
+    actor = Portal.Repo.get_by!(Portal.Actor, account_id: account.id, email: email)
+    assert [job] = all_enqueued(worker: Portal.Workers.SignUpFollowUp)
+    assert job.args == %{"account_id" => account.id, "actor_id" => actor.id}
+    delay = DateTime.diff(job.scheduled_at, DateTime.utc_now(), :second)
+    assert_in_delta delay, 15 * 60, 60
   end
 end


### PR DESCRIPTION
New accounts created through the sign-up web UI now get a short personal email from the founder 15 minutes later, asking how things are going and offering help.

At sign-up, the portal schedules an Oban job. When the job runs, it loads the admin again, skips a disabled account or admin, and sends the email through the portal mailer. The email can BCC a HubSpot logging address so it is attached to the CRM contact. Two new settings control this: `SIGN_UP_FOLLOW_UP_FROM_EMAIL` turns the feature on, and `SIGN_UP_FOLLOW_UP_BCC_EMAIL` is the optional BCC.

Related: firezone/infra#856
