### PR TITLE
chore(android): trim the Play Store screenshot listing

### DIFF
--- a/kotlin/android/screenshots/play-store.txt
+++ b/kotlin/android/screenshots/play-store.txt
@@ -1,8 +1,5 @@
 kotlin/android/screenshots/sign-in.png
 kotlin/android/screenshots/session-screen.png
 kotlin/android/screenshots/resource-details.png
-kotlin/android/screenshots/session-screen-favorites.png
-kotlin/android/screenshots/resource-details-internet.png
-kotlin/android/screenshots/device-details.png
 kotlin/android/screenshots/settings-general.png
 kotlin/android/screenshots/settings-advanced.png


### PR DESCRIPTION
Narrows the phone screenshots uploaded to the Play Store listing to the sign-in screen, the resource list, a resource detail sheet and the two settings screens.

The favourites, Internet Resource and connected device captures stay in the repo, where the screenshot tests keep covering them.