### PR TITLE
feat(portal): ask for feedback when an account is deleted

### DIFF
--- a/elixir/lib/portal/account.ex
+++ b/elixir/lib/portal/account.ex
@@ -169,16 +169,22 @@ defmodule Portal.Account.Metadata do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @deletion_feedback_max_length 2000
+
   @primary_key false
   embedded_schema do
     field :marketing_attribution, :map
+    field :deletion_feedback, :string
     embeds_one :stripe, Portal.Account.Metadata.Stripe, on_replace: :update
     embeds_one :sign_up_survey, Portal.Account.Metadata.SignUpSurvey, on_replace: :update
   end
 
+  def deletion_feedback_max_length, do: @deletion_feedback_max_length
+
   def changeset(metadata \\ %__MODULE__{}, attrs) do
     metadata
-    |> cast(attrs, [:marketing_attribution])
+    |> cast(attrs, [:marketing_attribution, :deletion_feedback])
+    |> validate_length(:deletion_feedback, max: @deletion_feedback_max_length)
     |> cast_embed(:stripe, with: &Portal.Account.Metadata.Stripe.changeset/2)
     |> cast_embed(:sign_up_survey, with: &Portal.Account.Metadata.SignUpSurvey.changeset/2)
   end

--- a/elixir/lib/portal/accounts/deletion.ex
+++ b/elixir/lib/portal/accounts/deletion.ex
@@ -23,6 +23,14 @@ defmodule Portal.Accounts.Deletion do
     end
   end
 
+  def change_deletion_feedback(%Account{} = account, feedback \\ nil) do
+    Database.change_deletion_feedback(account, feedback)
+  end
+
+  def save_deletion_feedback(%Account{} = account, feedback, subject) do
+    Database.save_deletion_feedback(account, feedback, subject)
+  end
+
   defp enqueue_deletion_notification(%Account{} = account, subject) do
     notify_admins(
       account,
@@ -81,6 +89,7 @@ defmodule Portal.Accounts.Deletion do
 
   defmodule Database do
     import Ecto.Query
+    import Ecto.Changeset
 
     alias Portal.Account
     alias Portal.Actor
@@ -113,6 +122,26 @@ defmodule Portal.Accounts.Deletion do
         end
       end)
     end
+
+    def change_deletion_feedback(%Account{} = account, feedback) do
+      account
+      |> cast(%{metadata: %{deletion_feedback: feedback}}, [])
+      |> cast_embed(:metadata)
+      |> Account.changeset()
+    end
+
+    def save_deletion_feedback(
+          %Account{id: account_id} = account,
+          feedback,
+          %{account: %{id: account_id}} = subject
+        ) do
+      account
+      |> change_deletion_feedback(feedback)
+      |> Safe.scoped(subject)
+      |> Safe.update()
+    end
+
+    def save_deletion_feedback(_account, _feedback, _subject), do: {:error, :unauthorized}
 
     defp fetch_account(account_id, subject) do
       from(a in Account, where: a.id == ^account_id)

--- a/elixir/lib/portal_web/live/settings/account.ex
+++ b/elixir/lib/portal_web/live/settings/account.ex
@@ -19,6 +19,7 @@ defmodule PortalWeb.Settings.Account do
         error: nil,
         slug_confirmation: "",
         confirm_delete_account: false,
+        deletion_feedback_form: nil,
         edit_account_open: false,
         name_form: to_form(Database.change_account_name(account)),
         admins_count: Database.count_account_admin_users_for_account(subject),
@@ -158,6 +159,38 @@ defmodule PortalWeb.Settings.Account do
               {@error}
             </.flash>
           </div>
+
+          <.modal
+            :if={@deletion_feedback_form}
+            id="deletion-feedback-modal"
+            on_close="skip_deletion_feedback"
+            on_back="skip_deletion_feedback"
+          >
+            <:title>Sorry Firezone didn't work out</:title>
+            <:body>
+              <p class="mb-4">Anything you'd like to share about your experience?</p>
+              <.form
+                id="deletion-feedback-form"
+                for={@deletion_feedback_form}
+                phx-change="validate_deletion_feedback"
+                phx-submit="submit_deletion_feedback"
+              >
+                <.inputs_for :let={metadata} field={@deletion_feedback_form[:metadata]}>
+                  <.input
+                    field={metadata[:deletion_feedback]}
+                    type="textarea"
+                    placeholder="Your feedback (optional)"
+                    maxlength={Portal.Account.Metadata.deletion_feedback_max_length()}
+                    phx-debounce="300"
+                  />
+                </.inputs_for>
+              </.form>
+            </:body>
+            <:back_button>Skip</:back_button>
+            <:confirm_button form="deletion-feedback-form" type="submit">
+              Send feedback
+            </:confirm_button>
+          </.modal>
 
           <%!-- Danger Zone (active, unlocked accounts only) --%>
           <div :if={Account.active?(@account) and not Account.locked?(@account)} class="mt-6">
@@ -575,6 +608,7 @@ defmodule PortalWeb.Settings.Account do
                account: updated_account,
                confirm_delete_account: false,
                slug_confirmation: "",
+               deletion_feedback_form: deletion_feedback_form(updated_account),
                error: nil
              )}
 
@@ -586,6 +620,54 @@ defmodule PortalWeb.Settings.Account do
       true ->
         {:noreply,
          assign(socket, slug_confirmation: "", error: "Slug does not match, please try again.")}
+    end
+  end
+
+  def handle_event("validate_deletion_feedback", params, socket) do
+    form =
+      socket.assigns.account
+      |> Deletion.change_deletion_feedback(deletion_feedback_param(params))
+      |> Map.put(:action, :validate)
+      |> to_form(as: :account)
+
+    {:noreply, assign(socket, deletion_feedback_form: form)}
+  end
+
+  def handle_event("submit_deletion_feedback", params, socket) do
+    account = socket.assigns.account
+
+    case params |> deletion_feedback_param() |> String.trim() do
+      "" ->
+        {:noreply, assign(socket, deletion_feedback_form: nil)}
+
+      feedback ->
+        case Deletion.save_deletion_feedback(account, feedback, socket.assigns.subject) do
+          {:ok, updated_account} ->
+            {:noreply, assign(socket, account: updated_account, deletion_feedback_form: nil)}
+
+          {:error, %Ecto.Changeset{} = changeset} ->
+            {:noreply, assign(socket, deletion_feedback_form: to_form(changeset, as: :account))}
+
+          {:error, _reason} ->
+            {:noreply, assign(socket, deletion_feedback_form: nil)}
+        end
+    end
+  end
+
+  def handle_event("skip_deletion_feedback", _params, socket) do
+    {:noreply, assign(socket, deletion_feedback_form: nil)}
+  end
+
+  defp deletion_feedback_form(account) do
+    account
+    |> Deletion.change_deletion_feedback()
+    |> to_form(as: :account)
+  end
+
+  defp deletion_feedback_param(params) do
+    case get_in(params, ["account", "metadata", "deletion_feedback"]) do
+      feedback when is_binary(feedback) -> feedback
+      _ -> ""
     end
   end
 

--- a/elixir/test/portal/accounts/deletion_test.exs
+++ b/elixir/test/portal/accounts/deletion_test.exs
@@ -53,6 +53,62 @@ defmodule Portal.Accounts.DeletionTest do
     end
   end
 
+  describe "save_deletion_feedback/3" do
+    test "stores the feedback in the account metadata" do
+      account = account_fixture()
+      actor = admin_actor_fixture(account: account)
+      subject = subject_fixture(account: account, actor: actor)
+
+      assert {:ok, account} =
+               Deletion.save_deletion_feedback(account, "Too hard to set up", subject)
+
+      assert account.metadata.deletion_feedback == "Too hard to set up"
+      assert fetch_account!(account.id).metadata.deletion_feedback == "Too hard to set up"
+    end
+
+    test "keeps the other metadata fields" do
+      account = account_fixture()
+      actor = admin_actor_fixture(account: account)
+      subject = subject_fixture(account: account, actor: actor)
+
+      account =
+        update_account(account, %{
+          metadata: %{marketing_attribution: %{"source" => "github"}}
+        })
+
+      assert {:ok, account} = Deletion.save_deletion_feedback(account, "Bye", subject)
+
+      assert account.metadata.marketing_attribution == %{"source" => "github"}
+      assert account.metadata.deletion_feedback == "Bye"
+    end
+
+    test "rejects feedback longer than 2000 characters" do
+      account = account_fixture()
+      actor = admin_actor_fixture(account: account)
+      subject = subject_fixture(account: account, actor: actor)
+
+      feedback = String.duplicate("a", 2001)
+
+      assert {:error, changeset} = Deletion.save_deletion_feedback(account, feedback, subject)
+
+      assert %{metadata: %{deletion_feedback: ["should be at most 2000 character(s)"]}} =
+               errors_on(changeset)
+
+      refute fetch_account!(account.id).metadata.deletion_feedback
+    end
+
+    test "rejects a subject from another account" do
+      account = account_fixture()
+      other_account = account_fixture()
+      actor = admin_actor_fixture(account: other_account)
+      subject = subject_fixture(account: other_account, actor: actor)
+
+      assert {:error, _reason} = Deletion.save_deletion_feedback(account, "Bye", subject)
+
+      refute fetch_account!(account.id).metadata.deletion_feedback
+    end
+  end
+
   describe "cancel_account_deletion/3" do
     test "cancels both delete and reminder jobs" do
       account = account_fixture()

--- a/elixir/test/portal_web/live/settings/account_test.exs
+++ b/elixir/test/portal_web/live/settings/account_test.exs
@@ -246,6 +246,118 @@ defmodule PortalWeb.Settings.AccountTest do
       assert email.text_body =~ Calendar.strftime(account.scheduled_deletion_at, "%B %-d, %Y")
     end
 
+    test "prompts for feedback after scheduling deletion", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/account")
+
+      render_click(lv, "confirm_delete_account")
+      render_click(lv, "update_slug_confirmation", %{"slug_confirmation" => account.slug})
+
+      html =
+        lv
+        |> form("form[phx-submit='delete_account']", %{slug_confirmation: account.slug})
+        |> render_submit()
+
+      assert html =~ "Sorry Firezone didn&#39;t work out"
+      assert html =~ "Anything you&#39;d like to share about your experience?"
+
+      html =
+        lv
+        |> form("#deletion-feedback-form", %{
+          account: %{metadata: %{deletion_feedback: "  Too hard to set up  "}}
+        })
+        |> render_submit()
+
+      refute html =~ "Sorry Firezone didn&#39;t work out"
+      assert fetch_account!(account.id).metadata.deletion_feedback == "Too hard to set up"
+    end
+
+    test "skipping the feedback prompt stores nothing", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/account")
+
+      render_click(lv, "confirm_delete_account")
+      render_click(lv, "update_slug_confirmation", %{"slug_confirmation" => account.slug})
+
+      lv
+      |> form("form[phx-submit='delete_account']", %{slug_confirmation: account.slug})
+      |> render_submit()
+
+      html = render_click(lv, "skip_deletion_feedback")
+
+      refute html =~ "Sorry Firezone didn&#39;t work out"
+      refute fetch_account!(account.id).metadata.deletion_feedback
+    end
+
+    test "submitting empty feedback closes the prompt without storing", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/account")
+
+      render_click(lv, "confirm_delete_account")
+      render_click(lv, "update_slug_confirmation", %{"slug_confirmation" => account.slug})
+
+      lv
+      |> form("form[phx-submit='delete_account']", %{slug_confirmation: account.slug})
+      |> render_submit()
+
+      html =
+        lv
+        |> form("#deletion-feedback-form", %{
+          account: %{metadata: %{deletion_feedback: "   "}}
+        })
+        |> render_submit()
+
+      refute html =~ "Sorry Firezone didn&#39;t work out"
+      refute fetch_account!(account.id).metadata.deletion_feedback
+    end
+
+    test "shows an error when feedback is longer than 2000 characters", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/account")
+
+      render_click(lv, "confirm_delete_account")
+      render_click(lv, "update_slug_confirmation", %{"slug_confirmation" => account.slug})
+
+      lv
+      |> form("form[phx-submit='delete_account']", %{slug_confirmation: account.slug})
+      |> render_submit()
+
+      html =
+        lv
+        |> form("#deletion-feedback-form", %{
+          account: %{metadata: %{deletion_feedback: String.duplicate("a", 2001)}}
+        })
+        |> render_submit()
+
+      assert html =~ "Sorry Firezone didn&#39;t work out"
+      assert html =~ "should be at most 2000 character(s)"
+      refute fetch_account!(account.id).metadata.deletion_feedback
+    end
+
     test "sends aborted deletion email when cancellation restores the account", %{
       conn: conn,
       account: account,


### PR DESCRIPTION
When an admin scheduled their account for deletion, the portal disabled the account and showed the deletion date. We learned nothing about why they left.

Now a modal opens right after the 7-day deletion timer is set. It says "Sorry Firezone didn't work out" and asks if they want to share anything about their experience. The answer is optional, limited to 2000 characters, and is stored in the account metadata so we can read it before the data is gone. Skipping or sending an empty answer stores nothing.