### PR TITLE
fix(portal): validate sign-up on blur and refresh survey

### DIFF
--- a/elixir/lib/portal/account.ex
+++ b/elixir/lib/portal/account.ex
@@ -102,7 +102,8 @@ defmodule Portal.Account do
 
   def changeset(changeset) do
     changeset
-    |> validate_length(:name, min: 3, max: 64)
+    |> validate_length(:name, min: 3, message: "too short")
+    |> validate_length(:name, max: 64, message: "too long")
     |> validate_length(:slug, min: 3, max: 100)
     |> validate_length(:key, is: 6)
     |> validate_key_format()
@@ -195,20 +196,26 @@ defmodule Portal.Account.Metadata.SignUpSurvey do
   import Ecto.Changeset
   import Portal.Changeset
 
-  @motivations ~w[performance access_controls simplicity security open_source cost other]
-  @previous_solutions ~w[tailscale twingate cloudflare openvpn wireguard zerotier cisco zscaler other]
   @referral_sources ~w[search github reddit hacker_news word_of_mouth blog social_media event other]
+  @motivations ~w[performance access_controls simplicity security open_source cost other]
+  @use_cases ~w[personal servers internal_apps employees contractors other]
+  @roles ~w[it security devops software_engineer network_engineer founder consultant other]
+  @previous_solutions ~w[tailscale twingate cloudflare openvpn wireguard zerotier cisco zscaler other]
   @other_max_length 255
 
   @primary_key false
   embedded_schema do
+    field :referral_source, :string
+    field :referral_source_other, :string
     field :motivation, :string
     field :motivation_other, :string
+    field :use_case, :string
+    field :use_case_other, :string
+    field :role, :string
+    field :role_other, :string
     field :switching, :boolean
     field :previous_solution, :string
     field :previous_solution_other, :string
-    field :referral_source, :string
-    field :referral_source_other, :string
   end
 
   def other_max_length, do: @other_max_length
@@ -216,21 +223,29 @@ defmodule Portal.Account.Metadata.SignUpSurvey do
   def changeset(survey \\ %__MODULE__{}, attrs) do
     survey
     |> cast(attrs, [
+      :referral_source,
+      :referral_source_other,
       :motivation,
       :motivation_other,
+      :use_case,
+      :use_case_other,
+      :role,
+      :role_other,
       :switching,
       :previous_solution,
-      :previous_solution_other,
-      :referral_source,
-      :referral_source_other
+      :previous_solution_other
     ])
-    |> validate_required([:motivation, :switching, :referral_source])
-    |> validate_inclusion(:motivation, @motivations)
+    |> validate_required([:referral_source, :motivation, :use_case, :role, :switching])
     |> validate_inclusion(:referral_source, @referral_sources)
+    |> validate_inclusion(:motivation, @motivations)
+    |> validate_inclusion(:use_case, @use_cases)
+    |> validate_inclusion(:role, @roles)
     |> validate_previous_solution()
-    |> validate_other(:motivation, :motivation_other)
-    |> validate_other(:previous_solution, :previous_solution_other)
     |> validate_other(:referral_source, :referral_source_other)
+    |> validate_other(:motivation, :motivation_other)
+    |> validate_other(:use_case, :use_case_other)
+    |> validate_other(:role, :role_other)
+    |> validate_other(:previous_solution, :previous_solution_other)
   end
 
   defp validate_previous_solution(changeset) do
@@ -250,7 +265,7 @@ defmodule Portal.Account.Metadata.SignUpSurvey do
       changeset
       |> trim_change(other_field)
       |> validate_required([other_field])
-      |> validate_length(other_field, max: @other_max_length)
+      |> validate_length(other_field, max: @other_max_length, message: "too long")
     else
       put_change(changeset, other_field, nil)
     end

--- a/elixir/lib/portal/changeset.ex
+++ b/elixir/lib/portal/changeset.ex
@@ -354,9 +354,11 @@ defmodule Portal.Changeset do
 
   def valid_email?(_), do: false
 
-  def validate_email(%Ecto.Changeset{} = changeset, field) do
+  def validate_email(%Ecto.Changeset{} = changeset, field, opts \\ []) do
+    message = Keyword.get(opts, :message, "is an invalid email address")
+
     changeset
-    |> validate_format(field, @email_regex, message: "is an invalid email address")
+    |> validate_format(field, @email_regex, message: message)
     |> validate_length(field, max: @email_max_length)
   end
 

--- a/elixir/lib/portal_web/components/form_components.ex
+++ b/elixir/lib/portal_web/components/form_components.ex
@@ -194,13 +194,14 @@ defmodule PortalWeb.FormComponents do
         class={[
           "text-sm py-2 pl-3 pr-8 rounded",
           "bg-raised text-body",
-          "border border-border",
+          "border",
           "outline-none transition-colors cursor-pointer",
           "hover:border-border-emphasis hover:text-heading",
-          "focus:border-border-focus focus:ring-1 focus:ring-border-focus/30",
+          "focus:ring-1",
           "block",
           !@inline_errors && "w-full",
-          @errors != [] && "border-error focus:border-error",
+          @errors == [] && "border-border focus:border-border-focus focus:ring-border-focus/30",
+          @errors != [] && "border-error focus:border-error focus:ring-error/30",
           @class
         ]}
         multiple={@multiple}
@@ -244,13 +245,14 @@ defmodule PortalWeb.FormComponents do
           class={[
             "text-sm py-2 pl-3 pr-8 rounded",
             "bg-raised text-body",
-            "border border-border",
+            "border",
             "outline-none transition-colors cursor-pointer",
             "hover:border-border-emphasis hover:text-heading",
-            "focus:border-border-focus focus:ring-1 focus:ring-border-focus/30",
+            "focus:ring-1",
             "block",
             field_width_class(assigns),
-            @errors != [] && "border-error focus:border-error",
+            @errors == [] && "border-border focus:border-border-focus focus:ring-border-focus/30",
+            @errors != [] && "border-error focus:border-error focus:ring-error/30",
             @class
           ]}
           multiple={@multiple}
@@ -275,12 +277,13 @@ defmodule PortalWeb.FormComponents do
         class={[
           "block rounded-md text-sm px-3 py-2",
           "bg-input text-heading placeholder:text-muted",
-          "border border-input-border",
+          "border",
           "outline-none transition-colors",
-          "focus:border-border-focus focus:ring-1 focus:ring-border-focus/30",
+          "focus:ring-1",
           "min-h-[6rem]",
           !@inline_errors && "w-full",
-          @errors != [] && "border-error focus:border-error",
+          @errors == [] && "border-input-border focus:border-border-focus focus:ring-border-focus/30",
+          @errors != [] && "border-error focus:border-error focus:ring-error/30",
           @class
         ]}
         {@rest}
@@ -341,11 +344,12 @@ defmodule PortalWeb.FormComponents do
             field_width_class(assigns),
             "px-3 py-2 rounded text-sm",
             "bg-input text-heading placeholder:text-muted",
-            "border border-input-border",
+            "border",
             "outline-none transition-colors",
-            "focus:border-border-focus focus:ring-1 focus:ring-border-focus/30",
+            "focus:ring-1",
             "disabled:opacity-40 disabled:cursor-not-allowed",
-            @errors != [] && "border-error focus:border-error",
+            @errors == [] && "border-input-border focus:border-border-focus focus:ring-border-focus/30",
+            @errors != [] && "border-error focus:border-error focus:ring-error/30",
             @class
           ]}
           {@rest}

--- a/elixir/lib/portal_web/components/form_components.ex
+++ b/elixir/lib/portal_web/components/form_components.ex
@@ -48,6 +48,10 @@ defmodule PortalWeb.FormComponents do
     default: false,
     doc: "whether to display errors inline instead of below the input"
 
+  attr :beside_errors, :boolean,
+    default: false,
+    doc: "whether to display errors to the right of the input so the form height does not change"
+
   attr :checked, :boolean, doc: "the checked flag for checkbox and radio inputs"
 
   attr :unchecked_value, :any,
@@ -233,30 +237,30 @@ defmodule PortalWeb.FormComponents do
         name={@name}
         value={@value}
       />
-      <select
-        id={@id}
-        name={@name}
-        class={[
-          "text-sm py-2 pl-3 pr-8 rounded",
-          "bg-raised text-body",
-          "border border-border",
-          "outline-none transition-colors cursor-pointer",
-          "hover:border-border-emphasis hover:text-heading",
-          "focus:border-border-focus focus:ring-1 focus:ring-border-focus/30",
-          "block",
-          !@inline_errors && "w-full",
-          @errors != [] && "border-error focus:border-error",
-          @class
-        ]}
-        multiple={@multiple}
-        {@rest}
-      >
-        <option :if={@prompt} value="" selected={is_nil(@value)}>{@prompt}</option>
-        {Phoenix.HTML.Form.options_for_select(@options, @value)}
-      </select>
-      <.error :for={msg <- @errors} inline={@inline_errors} data-validation-error-for={@name}>
-        {msg}
-      </.error>
+      <div class={field_row_class(assigns)}>
+        <select
+          id={@id}
+          name={@name}
+          class={[
+            "text-sm py-2 pl-3 pr-8 rounded",
+            "bg-raised text-body",
+            "border border-border",
+            "outline-none transition-colors cursor-pointer",
+            "hover:border-border-emphasis hover:text-heading",
+            "focus:border-border-focus focus:ring-1 focus:ring-border-focus/30",
+            "block",
+            field_width_class(assigns),
+            @errors != [] && "border-error focus:border-error",
+            @class
+          ]}
+          multiple={@multiple}
+          {@rest}
+        >
+          <option :if={@prompt} value="" selected={is_nil(@value)}>{@prompt}</option>
+          {Phoenix.HTML.Form.options_for_select(@options, @value)}
+        </select>
+        <.field_errors errors={@errors} name={@name} inline={@inline_errors} beside={@beside_errors} />
+      </div>
     </div>
     """
   end
@@ -326,31 +330,72 @@ defmodule PortalWeb.FormComponents do
     ~H"""
     <div class={@inline_errors && "flex flex-row items-center"}>
       <.label :if={@label} for={@id}>{@label}</.label>
-      <input
-        type={@type}
-        name={@name}
-        id={@id}
-        value={Phoenix.HTML.Form.normalize_value(@type, @value)}
-        class={[
-          "block",
-          !@inline_errors && "w-full",
-          "px-3 py-2 rounded text-sm",
-          "bg-input text-heading placeholder:text-muted",
-          "border border-input-border",
-          "outline-none transition-colors",
-          "focus:border-border-focus focus:ring-1 focus:ring-border-focus/30",
-          "disabled:opacity-40 disabled:cursor-not-allowed",
-          @errors != [] && "border-error focus:border-error",
-          @class
-        ]}
-        {@rest}
-      />
-      <.error :for={msg <- @errors} inline={@inline_errors} data-validation-error-for={@name}>
+      <div class={field_row_class(assigns)}>
+        <input
+          type={@type}
+          name={@name}
+          id={@id}
+          value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+          class={[
+            "block",
+            field_width_class(assigns),
+            "px-3 py-2 rounded text-sm",
+            "bg-input text-heading placeholder:text-muted",
+            "border border-input-border",
+            "outline-none transition-colors",
+            "focus:border-border-focus focus:ring-1 focus:ring-border-focus/30",
+            "disabled:opacity-40 disabled:cursor-not-allowed",
+            @errors != [] && "border-error focus:border-error",
+            @class
+          ]}
+          {@rest}
+        />
+        <.field_errors errors={@errors} name={@name} inline={@inline_errors} beside={@beside_errors} />
+      </div>
+    </div>
+    """
+  end
+
+  attr :errors, :list, required: true
+  attr :name, :string, required: true
+  attr :inline, :boolean, required: true
+  attr :beside, :boolean, required: true
+
+  # The auth layout's left panel appears at lg and takes the gutter the error
+  # overflows into, so the input shrinks again at lg and stops shrinking at xl.
+  defp field_errors(%{beside: true} = assigns) do
+    ~H"""
+    <div
+      :if={@errors != []}
+      class={[
+        "shrink-0 whitespace-nowrap",
+        "md:absolute md:left-full md:top-1/2 md:-translate-y-1/2",
+        "lg:static lg:translate-y-0",
+        "xl:absolute xl:left-full xl:top-1/2 xl:-translate-y-1/2"
+      ]}
+    >
+      <.error :for={msg <- @errors} inline data-validation-error-for={@name}>
         {msg}
       </.error>
     </div>
     """
   end
+
+  defp field_errors(assigns) do
+    ~H"""
+    <.error :for={msg <- @errors} inline={@inline} data-validation-error-for={@name}>
+      {msg}
+    </.error>
+    """
+  end
+
+  defp field_row_class(%{beside_errors: true}), do: "relative flex flex-row items-center"
+  defp field_row_class(%{inline_errors: true}), do: "flex flex-row items-center"
+  defp field_row_class(_assigns), do: nil
+
+  defp field_width_class(%{beside_errors: true}), do: "min-w-0 flex-1"
+  defp field_width_class(%{inline_errors: true}), do: nil
+  defp field_width_class(_assigns), do: "w-full"
 
   defp resolve_field_value(field, value_id) do
     Enum.map(field.value, fn

--- a/elixir/lib/portal_web/live/sign_up.ex
+++ b/elixir/lib/portal_web/live/sign_up.ex
@@ -38,7 +38,7 @@ defmodule PortalWeb.SignUp do
       |> validate_required([:email])
       |> trim_change(:email)
       |> trim_change(:phone)
-      |> validate_email(:email)
+      |> validate_email(:email, message: "invalid email")
       |> validate_email_allowed()
       |> cast_embed(:account, with: fn _account, a -> create_account_changeset(a) end)
       |> cast_embed(:actor, with: fn _actor, a -> create_actor_changeset(a) end)
@@ -56,7 +56,7 @@ defmodule PortalWeb.SignUp do
       validate_change(changeset, :email, fn :email, email ->
         if email_allowed?(email, whitelisted_domains),
           do: [],
-          else: [email: "this email domain is not allowed at this time"]
+          else: [email: "domain not allowed"]
       end)
     end
 
@@ -79,7 +79,7 @@ defmodule PortalWeb.SignUp do
       %Actor{}
       |> cast(attrs, [:name])
       |> validate_required([:name])
-      |> validate_length(:name, min: 1, max: 255)
+      |> validate_length(:name, max: 255, message: "too long")
     end
   end
 
@@ -257,21 +257,23 @@ defmodule PortalWeb.SignUp do
       <.input
         field={@form[:email]}
         type="email"
+        beside_errors
         label="Work Email"
         placeholder="E.g. foo@example.com"
         required
         autofocus
-        phx-debounce="300"
+        phx-debounce="blur"
       />
 
       <.inputs_for :let={account} field={@form[:account]}>
         <.input
           field={account[:name]}
           type="text"
+          beside_errors
           label="Organization Name"
           placeholder="E.g. Example Corp"
           required
-          phx-debounce="300"
+          phx-debounce="blur"
         />
       </.inputs_for>
 
@@ -279,10 +281,11 @@ defmodule PortalWeb.SignUp do
         <.input
           field={actor[:name]}
           type="text"
+          beside_errors
           label="Your Name"
           placeholder="E.g. John Smith"
           required
-          phx-debounce="300"
+          phx-debounce="blur"
         />
         <.input field={actor[:type]} type="hidden" />
       </.inputs_for>
@@ -293,6 +296,7 @@ defmodule PortalWeb.SignUp do
         <.input
           field={@form[:phone]}
           type="text"
+          beside_errors
           label="Phone"
           placeholder="123-456-7890"
           tabindex="-1"
@@ -382,11 +386,12 @@ defmodule PortalWeb.SignUp do
         <.input
           field={account[:name]}
           type="text"
+          beside_errors
           label="Organization Name"
           placeholder="E.g. Example Corp"
           required
           autofocus
-          phx-debounce="300"
+          phx-debounce="blur"
         />
       </.inputs_for>
 
@@ -394,10 +399,11 @@ defmodule PortalWeb.SignUp do
         <.input
           field={actor[:name]}
           type="text"
+          beside_errors
           label="Your Name"
           placeholder="E.g. John Smith"
           required
-          phx-debounce="300"
+          phx-debounce="blur"
         />
       </.inputs_for>
 
@@ -423,14 +429,46 @@ defmodule PortalWeb.SignUp do
     """
   end
 
+  @referral_source_options [
+    {"Google / web search", "search"},
+    {"GitHub", "github"},
+    {"Reddit", "reddit"},
+    {"Hacker News", "hacker_news"},
+    {"Friend or colleague", "word_of_mouth"},
+    {"Blog or article", "blog"},
+    {"Social media", "social_media"},
+    {"Conference or event", "event"},
+    {"Other", "other"}
+  ]
+
   @motivation_options [
     {"Better speed / performance", "performance"},
-    {"More granular access controls", "access_controls"},
-    {"Simpler to set up and manage", "simplicity"},
+    {"More control over who can access what", "access_controls"},
+    {"Easier to set up and manage", "simplicity"},
     {"Better security", "security"},
     {"Open source", "open_source"},
     {"Lower cost", "cost"},
-    {"Something else", "other"}
+    {"Other", "other"}
+  ]
+
+  @use_case_options [
+    {"Personal use / homelab", "personal"},
+    {"Access to servers or infrastructure", "servers"},
+    {"Access to internal apps", "internal_apps"},
+    {"Remote access for employees", "employees"},
+    {"Access for contractors or partners", "contractors"},
+    {"Other", "other"}
+  ]
+
+  @role_options [
+    {"IT / Infrastructure", "it"},
+    {"Security", "security"},
+    {"DevOps / SRE", "devops"},
+    {"Software Engineer", "software_engineer"},
+    {"Network Engineer", "network_engineer"},
+    {"Founder / Executive", "founder"},
+    {"Consultant / MSP", "consultant"},
+    {"Other", "other"}
   ]
 
   @previous_solution_options [
@@ -445,97 +483,110 @@ defmodule PortalWeb.SignUp do
     {"Other", "other"}
   ]
 
-  @referral_source_options [
-    {"Google / web search", "search"},
-    {"GitHub", "github"},
-    {"Reddit", "reddit"},
-    {"Hacker News", "hacker_news"},
-    {"Word of mouth", "word_of_mouth"},
-    {"Blog / article", "blog"},
-    {"Social media", "social_media"},
-    {"Conference / event", "event"},
-    {"Other", "other"}
-  ]
-
   attr :form, :any, required: true
 
   defp survey_fields(assigns) do
     assigns =
       assign(assigns,
-        motivation_options: @motivation_options,
-        previous_solution_options: @previous_solution_options,
         referral_source_options: @referral_source_options,
+        motivation_options: @motivation_options,
+        use_case_options: @use_case_options,
+        role_options: @role_options,
+        previous_solution_options: @previous_solution_options,
         other_max_length: Portal.Account.Metadata.SignUpSurvey.other_max_length()
       )
 
     ~H"""
     <.inputs_for :let={survey} field={@form[:sign_up_survey]}>
-      <.input
+      <.survey_question
+        field={survey[:referral_source]}
+        other_field={survey[:referral_source_other]}
+        label="How did you hear about Firezone?"
+        options={@referral_source_options}
+        other_label="Where did you hear about us?"
+        other_placeholder="Tell us in a few words"
+        other_max_length={@other_max_length}
+      />
+      <.survey_question
         field={survey[:motivation]}
-        type="select"
-        label="What prompted you to try Firezone?"
-        prompt="Select one"
+        other_field={survey[:motivation_other]}
+        label="Why are you trying Firezone?"
         options={@motivation_options}
-        required
+        other_label="What are you hoping to get?"
+        other_placeholder="Tell us in a few words"
+        other_max_length={@other_max_length}
       />
-      <.input
-        :if={survey[:motivation].value == "other"}
-        field={survey[:motivation_other]}
-        type="text"
-        label="What prompted you?"
-        placeholder="Tell us in a few words"
-        maxlength={@other_max_length}
-        required
-        phx-debounce="300"
+      <.survey_question
+        field={survey[:use_case]}
+        other_field={survey[:use_case_other]}
+        label="What are you planning to use Firezone for?"
+        options={@use_case_options}
+        other_label="What will you use it for?"
+        other_placeholder="Tell us in a few words"
+        other_max_length={@other_max_length}
       />
-
+      <.survey_question
+        field={survey[:role]}
+        other_field={survey[:role_other]}
+        label="What best describes your role?"
+        options={@role_options}
+        other_label="What is your role?"
+        other_placeholder="E.g. Product Manager"
+        other_max_length={@other_max_length}
+      />
       <.input
         field={survey[:switching]}
         type="select"
-        label="Are you switching from another VPN or ZTNA solution?"
+        beside_errors
+        label="Are you replacing another VPN or ZTNA tool?"
         prompt="Select one"
         options={[{"Yes", "true"}, {"No", "false"}]}
         required
       />
-      <.input
+      <.survey_question
         :if={survey[:switching].value in [true, "true"]}
         field={survey[:previous_solution]}
-        type="select"
+        other_field={survey[:previous_solution_other]}
         label="Which one?"
-        prompt="Select one"
         options={@previous_solution_options}
-        required
-      />
-      <.input
-        :if={survey[:switching].value in [true, "true"] and survey[:previous_solution].value == "other"}
-        field={survey[:previous_solution_other]}
-        type="text"
-        label="Which solution?"
-        placeholder="E.g. Example VPN"
-        maxlength={@other_max_length}
-        required
-        phx-debounce="300"
-      />
-
-      <.input
-        field={survey[:referral_source]}
-        type="select"
-        label="How did you first hear about Firezone?"
-        prompt="Select one"
-        options={@referral_source_options}
-        required
-      />
-      <.input
-        :if={survey[:referral_source].value == "other"}
-        field={survey[:referral_source_other]}
-        type="text"
-        label="Where did you hear about us?"
-        placeholder="Tell us in a few words"
-        maxlength={@other_max_length}
-        required
-        phx-debounce="300"
+        other_label="Which tool?"
+        other_placeholder="E.g. Example VPN"
+        other_max_length={@other_max_length}
       />
     </.inputs_for>
+    """
+  end
+
+  attr :field, Phoenix.HTML.FormField, required: true
+  attr :other_field, Phoenix.HTML.FormField, required: true
+  attr :label, :string, required: true
+  attr :options, :list, required: true
+  attr :other_label, :string, required: true
+  attr :other_placeholder, :string, required: true
+  attr :other_max_length, :integer, required: true
+
+  defp survey_question(assigns) do
+    ~H"""
+    <.input
+      field={@field}
+      type="select"
+      beside_errors
+      label={@label}
+      prompt="Select one"
+      options={@options}
+      required
+    />
+    <.input
+      :if={@field.value == "other"}
+      field={@other_field}
+      type="text"
+      beside_errors
+      label={@other_label}
+      placeholder={@other_placeholder}
+      maxlength={@other_max_length}
+      required
+      phx-debounce="blur"
+    />
     """
   end
 

--- a/elixir/test/portal/account_test.exs
+++ b/elixir/test/portal/account_test.exs
@@ -23,7 +23,7 @@ defmodule Portal.AccountTest do
 
     test "rejects name exceeding maximum length" do
       changeset = build_changeset(%{name: String.duplicate("a", 65)})
-      assert %{name: ["should be at most 64 character(s)"]} = errors_on(changeset)
+      assert %{name: ["too long"]} = errors_on(changeset)
     end
 
     test "inserts slug at maximum length" do

--- a/elixir/test/portal_web/live/settings/account_test.exs
+++ b/elixir/test/portal_web/live/settings/account_test.exs
@@ -152,7 +152,7 @@ defmodule PortalWeb.Settings.AccountTest do
         |> form("form[phx-submit='submit_account_name']", %{account: %{name: "ab"}})
         |> render_change()
 
-      assert html =~ "should be at least 3 character(s)"
+      assert html =~ "too short"
     end
 
     test "saves updated account name", %{conn: conn, account: account, actor: actor} do

--- a/elixir/test/portal_web/live/sign_up_test.exs
+++ b/elixir/test/portal_web/live/sign_up_test.exs
@@ -7,7 +7,13 @@ defmodule PortalWeb.SignUpTest do
   alias Portal.Mocks.Stripe
 
   @sign_up_token_salt "sign_up_email_v1"
-  @survey %{motivation: "security", switching: "false", referral_source: "github"}
+  @survey %{
+    referral_source: "github",
+    motivation: "security",
+    use_case: "servers",
+    role: "devops",
+    switching: "false"
+  }
 
   describe "direct signup conversions" do
     for {country, allowed} <- [{"US", true}, {"DE", false}] do
@@ -148,7 +154,7 @@ defmodule PortalWeb.SignUpTest do
         )
         |> render_submit()
 
-      assert html =~ "at least 3 character"
+      assert html =~ "too short"
       refute html =~ "Your account has been created!"
     end
 
@@ -301,9 +307,11 @@ defmodule PortalWeb.SignUpTest do
             "account" => %{"name" => "Honest Corp"},
             "actor" => %{"name" => "Ada Lovelace"},
             "sign_up_survey" => %{
+              "referral_source" => "github",
               "motivation" => "security",
-              "switching" => "false",
-              "referral_source" => "github"
+              "use_case" => "servers",
+              "role" => "devops",
+              "switching" => "false"
             }
           }
         })
@@ -394,7 +402,7 @@ defmodule PortalWeb.SignUpTest do
         )
         |> render_submit()
 
-      assert html =~ "at least 3 character"
+      assert html =~ "too short"
       refute html =~ "Check your email"
     end
 
@@ -451,7 +459,7 @@ defmodule PortalWeb.SignUpTest do
         |> form("form", registration: %{email: "not-an-email"})
         |> render_change()
 
-      assert html =~ "is an invalid email address"
+      assert html =~ "invalid email"
     end
   end
 
@@ -538,14 +546,16 @@ defmodule PortalWeb.SignUpTest do
   describe "sign-up survey" do
     test "renders the survey questions on both forms", %{conn: conn} do
       {:ok, _lv, html} = live(conn, ~p"/sign_up/email")
-      assert html =~ "What prompted you to try Firezone?"
-      assert html =~ "Are you switching from another VPN or ZTNA solution?"
-      assert html =~ "How did you first hear about Firezone?"
+      assert html =~ "How did you hear about Firezone?"
+      assert html =~ "Why are you trying Firezone?"
+      assert html =~ "What are you planning to use Firezone for?"
+      assert html =~ "What best describes your role?"
+      assert html =~ "Are you replacing another VPN or ZTNA tool?"
       refute html =~ "Which one?"
 
       {:ok, _lv, html} = live(with_google_identity(conn), ~p"/sign_up/google")
-      assert html =~ "What prompted you to try Firezone?"
-      assert html =~ "How did you first hear about Firezone?"
+      assert html =~ "How did you hear about Firezone?"
+      assert html =~ "What best describes your role?"
     end
 
     test "unanswered questions keep the form with errors", %{conn: conn} do
@@ -558,7 +568,7 @@ defmodule PortalWeb.SignUpTest do
             email: "survey@example.com",
             account: %{name: "Survey Corp"},
             actor: %{name: "Survey User"},
-            sign_up_survey: %{motivation: "", switching: "", referral_source: ""}
+            sign_up_survey: %{referral_source: "", motivation: "", use_case: "", role: "", switching: ""}
           }
         )
         |> render_submit()
@@ -586,7 +596,7 @@ defmodule PortalWeb.SignUpTest do
             email: "switcher@example.com",
             account: %{name: "Switcher Corp"},
             actor: %{name: "Switcher"},
-            sign_up_survey: %{motivation: "cost", switching: "true", referral_source: "reddit"}
+            sign_up_survey: %{@survey | switching: "true"}
           }
         )
         |> render_submit()
@@ -613,19 +623,14 @@ defmodule PortalWeb.SignUpTest do
             email: "other@example.com",
             account: %{name: "Other Corp"},
             actor: %{name: "Other User"},
-            sign_up_survey: %{
-              motivation: "other",
-              motivation_other: other,
-              switching: "false",
-              referral_source: "github"
-            }
+            sign_up_survey: Map.merge(@survey, %{motivation: "other", motivation_other: other})
           }
         )
         |> render_submit()
       end
 
       assert submit.("   ") =~ "can&#39;t be blank"
-      assert submit.(String.duplicate("a", 256)) =~ "should be at most 255 character"
+      assert submit.(String.duplicate("a", 256)) =~ "too long"
       refute_email_sent()
       assert submit.("Needed IPv6 support") =~ "Check your email"
       assert_email_sent()
@@ -643,7 +648,9 @@ defmodule PortalWeb.SignUpTest do
 
       lv
       |> form("#google-sign-up-form",
-        registration: %{sign_up_survey: %{switching: "true", referral_source: "other"}}
+        registration: %{
+          sign_up_survey: %{referral_source: "other", use_case: "other", role: "other", switching: "true"}
+        }
       )
       |> render_change()
 
@@ -663,12 +670,16 @@ defmodule PortalWeb.SignUpTest do
             account: %{name: "Survey Corp"},
             actor: %{name: "Ada Lovelace"},
             sign_up_survey: %{
+              referral_source: "other",
+              referral_source_other: "A podcast",
               motivation: "open_source",
+              use_case: "other",
+              use_case_other: "Lab network",
+              role: "other",
+              role_other: "Hobbyist",
               switching: "true",
               previous_solution: "other",
-              previous_solution_other: "  Homegrown WireGuard  ",
-              referral_source: "other",
-              referral_source_other: "A podcast"
+              previous_solution_other: "  Homegrown WireGuard  "
             }
           }
         )
@@ -679,13 +690,17 @@ defmodule PortalWeb.SignUpTest do
       account = Portal.Repo.get_by!(Portal.Account, name: "Survey Corp")
 
       assert %Portal.Account.Metadata.SignUpSurvey{
+               referral_source: "other",
+               referral_source_other: "A podcast",
                motivation: "open_source",
                motivation_other: nil,
+               use_case: "other",
+               use_case_other: "Lab network",
+               role: "other",
+               role_other: "Hobbyist",
                switching: true,
                previous_solution: "other",
-               previous_solution_other: "Homegrown WireGuard",
-               referral_source: "other",
-               referral_source_other: "A podcast"
+               previous_solution_other: "Homegrown WireGuard"
              } = account.metadata.sign_up_survey
     end
 
@@ -707,9 +722,11 @@ defmodule PortalWeb.SignUpTest do
           account: %{name: "Token Corp"},
           actor: %{name: "Token User"},
           sign_up_survey: %{
+            referral_source: "hacker_news",
             motivation: "simplicity",
-            switching: "false",
-            referral_source: "hacker_news"
+            use_case: "personal",
+            role: "software_engineer",
+            switching: "false"
           }
         }
       )


### PR DESCRIPTION
The sign-up form validated every field 300 ms after each keystroke and showed errors below the input. The form jumped around while the user was still typing.

Fields now validate when they lose focus. Errors show on one line to the right of the input, so the form keeps its height. On narrow screens the input shrinks to make room. On wide screens the error sits in the space next to the card.

The validation messages on this form are shortened so they fit on one line. The account name length messages become "too short" and "too long" everywhere the account changeset is used.

The sign-up survey is updated to the new question list. It adds a use case question and a role question, and reorders the questions. Stored values for the existing questions are unchanged.
