### PR TITLE
fix(portal): retry intermittent Okta 403 responses

### DIFF
--- a/elixir/lib/portal/okta/api_client.ex
+++ b/elixir/lib/portal/okta/api_client.ex
@@ -569,7 +569,7 @@ defmodule Portal.Okta.ReqDPoP do
       429 ->
         {:delay, delay_from_rate_limit_headers(resp.headers)}
 
-      408 when method_safe? ->
+      status when status in [403, 408] and method_safe? ->
         true
 
       status when status in [500, 502, 503, 504] and method_safe? ->

--- a/elixir/lib/portal/okta/error_handler.ex
+++ b/elixir/lib/portal/okta/error_handler.ex
@@ -12,11 +12,10 @@ defmodule Portal.Okta.ErrorHandler do
 
   @non_disabling_steps [:batch_upsert_identities, :batch_upsert_memberships]
 
-  # Req has already retried these before the response reaches us, so an
-  # exhausted throttle means the provider is busy, not that the directory is
-  # misconfigured. Disabling on one would make the admin re-verify to recover
-  # from rate limiting.
-  @throttled_statuses [408, 429]
+  # Okta can return intermittent 403s as well as timeouts and rate limits.
+  # Treat these as transient even after HTTP retries are exhausted so a single
+  # failure does not disable the directory.
+  @transient_statuses [403, 408, 429]
 
   def handle(%Okta.SyncError{error: error, step: step}, directory_id) do
     type = classify(error, step)
@@ -37,7 +36,7 @@ defmodule Portal.Okta.ErrorHandler do
 
   # Classification
 
-  defp classify(%Req.Response{status: status}) when status in @throttled_statuses,
+  defp classify(%Req.Response{status: status}) when status in @transient_statuses,
     do: :transient
 
   defp classify(%Req.Response{status: status}) when status >= 400 and status < 500 do

--- a/elixir/test/portal/directory_sync/error_handler_test.exs
+++ b/elixir/test/portal/directory_sync/error_handler_test.exs
@@ -213,7 +213,7 @@ defmodule Portal.DirectorySync.ErrorHandlerTest do
       assert updated_directory.error_email_count == 0
     end
 
-    test "classifies HTTP 403 errors as client_error and disables directory",
+    test "classifies HTTP 403 errors as transient and keeps directory enabled",
          %{directory: directory} do
       job = %Oban.Job{
         worker: "Portal.Okta.Sync",
@@ -234,12 +234,13 @@ defmodule Portal.DirectorySync.ErrorHandlerTest do
 
       ErrorHandler.handle_error(%{reason: error, job: job})
 
-      # Reload directory and verify it was disabled
+      # Reload directory and verify it remains enabled
       updated_directory = Portal.Repo.get!(Portal.Okta.Directory, directory.id)
 
-      assert updated_directory.is_disabled == true
-      assert updated_directory.disabled_reason == "Sync error"
-      assert updated_directory.is_verified == false
+      assert updated_directory.is_disabled == false
+      assert updated_directory.disabled_reason == nil
+      assert updated_directory.is_verified == directory.is_verified
+      assert updated_directory.errored_at != nil
       assert updated_directory.error_message =~ "Access denied"
     end
 

--- a/elixir/test/portal/directory_sync/throttle_classification_test.exs
+++ b/elixir/test/portal/directory_sync/throttle_classification_test.exs
@@ -98,8 +98,8 @@ defmodule Portal.DirectorySync.ThrottleClassificationTest do
   end
 
   describe "Okta" do
-    test "keeps the directory enabled when the provider throttles" do
-      for status <- @throttled do
+    test "keeps the directory enabled on transient HTTP errors" do
+      for status <- [403 | @throttled] do
         directory = okta_directory_fixture()
 
         Portal.Okta.ErrorHandler.handle(
@@ -117,14 +117,14 @@ defmodule Portal.DirectorySync.ThrottleClassificationTest do
       end
     end
 
-    test "still disables the directory when access is denied" do
+    test "still disables the directory when authentication fails" do
       directory = okta_directory_fixture()
 
       Portal.Okta.ErrorHandler.handle(
         Portal.Okta.SyncError.exception(
           directory_id: directory.id,
           step: :list_users,
-          error: %Req.Response{status: 403, body: ""}
+          error: %Req.Response{status: 401, body: ""}
         ),
         directory.id
       )

--- a/elixir/test/portal/okta/api_client_test.exs
+++ b/elixir/test/portal/okta/api_client_test.exs
@@ -493,6 +493,43 @@ defmodule Portal.Okta.APIClientTest do
       assert Agent.get(agent, & &1) == 2
     end
 
+    test "retries on 403 for GET requests and succeeds", %{client: client} do
+      # Enable retry for this test
+      Portal.Config.put_env_override(Portal.Okta.APIClient,
+        req_opts: [
+          plug: {Req.Test, Portal.Okta.APIClient},
+          retry_delay: fn _n -> 1 end,
+          max_retries: 1
+        ]
+      )
+
+      {:ok, agent} = Agent.start_link(fn -> 0 end)
+
+      Req.Test.stub(APIClient, fn conn ->
+        call_count = Agent.get_and_update(agent, fn count -> {count, count + 1} end)
+
+        case call_count do
+          0 ->
+            # First call fails with 403
+            conn
+            |> Plug.Conn.put_status(403)
+            |> Req.Test.json(%{"errorCode" => "E0000006", "errorSummary" => "Access denied"})
+
+          _ ->
+            # Second call succeeds
+            Req.Test.json(conn, [%{"id" => "user1", "name" => "Test User"}])
+        end
+      end)
+
+      results =
+        APIClient.stream_app_users("app_123", client, "test_token")
+        |> Enum.to_list()
+
+      assert [{:ok, %{"id" => "user1"}}] = results
+      # Verify retry happened
+      assert Agent.get(agent, & &1) == 2
+    end
+
     test "retries on 429 rate limit with delay from headers", %{client: client} do
       # Enable retry for this test - no retry_delay since custom retry returns {:delay, ms}
       Portal.Config.put_env_override(Portal.Okta.APIClient,

--- a/elixir/test/portal/okta/sync_test.exs
+++ b/elixir/test/portal/okta/sync_test.exs
@@ -1466,7 +1466,7 @@ defmodule Portal.Okta.SyncTest do
       assert updated_directory.errored_at != nil
     end
 
-    test "ErrorHandler classifies 403 as client_error and disables directory" do
+    test "ErrorHandler classifies 403 as transient and keeps directory enabled" do
       account = account_fixture(features: %{idp_sync: true})
 
       directory =
@@ -1520,9 +1520,10 @@ defmodule Portal.Okta.SyncTest do
       Portal.DirectorySync.ErrorHandler.handle_error(meta)
 
       updated_directory = Repo.get(Portal.Okta.Directory, directory.id)
-      assert updated_directory.is_disabled == true
-      assert updated_directory.disabled_reason == "Sync error"
-      assert updated_directory.is_verified == false
+      assert updated_directory.is_disabled == false
+      assert updated_directory.disabled_reason == nil
+      assert updated_directory.is_verified == directory.is_verified
+      assert updated_directory.errored_at != nil
       assert updated_directory.error_message =~ "Access denied"
     end
   end


### PR DESCRIPTION
Okta intermittently returns HTTP 403 (`E0000006`) during directory syncs. Previously, these responses skipped HTTP retries and immediately disabled the directory.

Retry 403 responses for safe GET/HEAD requests and classify remaining 403 sync failures as transient, allowing subsequent scheduled syncs to recover. Persistent failures still use the existing 24-hour disable threshold.

Validation: all 140 targeted Okta API client, sync, and directory error-handler tests passed. The 28 API client tests also passed after final test cleanup. Formatting and `git diff --check` passed. Coverage includes recovery from a 403 while streaming app users, keeping the directory enabled after a 403, and continuing to disable on 401.
