### PR TITLE
fix(api): render nested validation errors without crashing

### DIFF
--- a/elixir/lib/portal_api/plugs/request_validation_error.ex
+++ b/elixir/lib/portal_api/plugs/request_validation_error.ex
@@ -21,7 +21,7 @@ defmodule PortalAPI.Plugs.RequestValidationError do
 
     if request_errors == [] do
       PortalAPI.ProblemDetails.send(conn, 422, "The request body failed validation.", %{
-        validation_errors: Enum.reduce(field_errors, %{}, &put_field_error/2)
+        validation_errors: field_errors |> Enum.reduce(%{}, &put_field_error/2) |> render()
       })
     else
       PortalAPI.ProblemDetails.send(
@@ -32,12 +32,30 @@ defmodule PortalAPI.Plugs.RequestValidationError do
     end
   end
 
-  defp put_field_error(%Error{} = error, acc) do
+  # Errors are collected in a tree first because a schema built with allOf or
+  # oneOf reports a failure on the property as a whole as well as on the field
+  # inside it that caused it, so one path can be both a leaf and a parent.
+  defp put_field_error(%Error{} = error, tree) do
     [_wrapper | path] = path(error)
-    {parents, [leaf]} = Enum.split(path, -1)
-    keys = Enum.map(parents, &Access.key(&1, %{})) ++ [Access.key(leaf, [])]
-    update_in(acc, keys, &[message(error) | &1])
+    put_message(tree, path, message(error))
   end
+
+  defp put_message(node, [], message) do
+    Map.update(node, :messages, [message], &[message | &1])
+  end
+
+  defp put_message(node, [key | rest], message) do
+    child = node |> Map.get(:children, %{}) |> Map.get(key, %{}) |> put_message(rest, message)
+    Map.update(node, :children, %{key => child}, &Map.put(&1, key, child))
+  end
+
+  # The message on the property as a whole says less than the ones on the
+  # fields inside it, so a node with children renders the children alone.
+  defp render(%{children: children}) do
+    Map.new(children, fn {key, child} -> {key, render(child)} end)
+  end
+
+  defp render(node), do: Map.get(node, :messages, [])
 
   defp path(%Error{path: path}), do: Enum.map(path, &to_string/1)
 

--- a/elixir/test/portal_api/plugs/request_validation_error_test.exs
+++ b/elixir/test/portal_api/plugs/request_validation_error_test.exs
@@ -1,0 +1,50 @@
+defmodule PortalAPI.Plugs.RequestValidationErrorTest do
+  use PortalAPI.ConnCase, async: true
+
+  alias OpenApiSpex.Cast.Error
+  alias PortalAPI.Plugs.RequestValidationError
+
+  defp render(conn, errors) do
+    conn
+    |> Phoenix.Controller.put_format("json")
+    |> RequestValidationError.call(errors)
+  end
+
+  test "renders a field error under its path", %{conn: conn} do
+    errors = [%Error{reason: :invalid_format, format: :uuid, path: [:policy, :group_id], value: "x"}]
+
+    assert %{"status" => 422, "validation_errors" => %{"group_id" => ["is invalid"]}} =
+             json_response(render(conn, errors), 422)
+  end
+
+  test "renders list indexes as keys", %{conn: conn} do
+    errors = [%Error{reason: :invalid_enum, path: [:policy, :conditions, 0, :operator], value: "x"}]
+
+    assert %{"validation_errors" => %{"conditions" => %{"0" => %{"operator" => ["is invalid"]}}}} =
+             json_response(render(conn, errors), 422)
+  end
+
+  test "keeps the field messages when the property as a whole also failed", %{conn: conn} do
+    whole = %Error{reason: :all_of, path: [:policy, :postures], meta: %{invalid_schema: "PolicyPostureNode"}}
+    field = %Error{reason: :invalid_type, type: :string, path: [:policy, :postures, :rows], value: %{}}
+
+    for errors <- [[whole, field], [field, whole]] do
+      assert %{"validation_errors" => %{"postures" => %{"rows" => ["is invalid"]}}} =
+               json_response(render(conn, errors), 422)
+    end
+  end
+
+  test "renders the property's own message when nothing inside it failed", %{conn: conn} do
+    errors = [%Error{reason: :all_of, path: [:policy, :postures], meta: %{invalid_schema: "PolicyPostureNode"}}]
+
+    assert %{"validation_errors" => %{"postures" => [message]}} = json_response(render(conn, errors), 422)
+    assert message =~ "PolicyPostureNode"
+  end
+
+  test "renders a problem with the request itself as a 400", %{conn: conn} do
+    errors = [%Error{reason: :missing_field, name: :policy, path: [:policy]}]
+
+    assert %{"status" => 400, "detail" => "The request could not be processed: `policy` is required"} =
+             json_response(render(conn, errors), 400)
+  end
+end


### PR DESCRIPTION
When a request body failed OpenAPI validation, the error renderer nested each message under its field path as it went. A schema built with `allOf` or `oneOf` reports two errors for one bad value: one on the property as a whole and one on the field inside it that caused it. The second write then landed on a list of messages instead of a map and the request ended in a 500 instead of a 422.

The renderer now collects errors in a tree first and renders it in one pass. A property that failed as a whole and also has field errors shows the field errors, since they say more. The flow log ingestion request schemas use `oneOf`, so this was reachable on main; the API fuzzer surfaced it on the policy posture schema in #15234.

Related: #15234
